### PR TITLE
Readme Pixel Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ This repository contains useful tools that the Azure SDK team utilizes across th
 
 # Index
 
-| Package or Intent | Path                                    | Description                                                     | Status   |
-|-------------------|-----------------------------------------|-----------------------------------------------------------------|----------|
-| doc-warden        | [Readme](packages/python-packages/doc-warden/README.md) | A tool used to enforce readme standards across Azure SDK Repos. |[![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/108?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=108&branchName=master) |
-| pixel-server      | [Readme](packages/web/pixel-server/README.md) | A tiny ASP.NET Core site used to serve a pixel and record impressions. | Not Yet Enabled |
+| Package or Intent    | Path                                    | Description                                                     | Status   |
+|----------------------|-----------------------------------------|-----------------------------------------------------------------|----------|
+| doc-warden           | [Readme](packages/python-packages/doc-warden/README.md) | A tool used to enforce readme standards across Azure SDK Repos. |[![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/108?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=108&branchName=master) |
+| pixel-server         | [Readme](packages/web/pixel-server/README.md) | A tiny ASP.NET Core site used to serve a pixel and record impressions. | Not Yet Enabled |
+| pixel insertion tool | [Readme](scripts/python/readme_tracking/README.md) | A tool used to insert the image reference. Served by `pixel server`.  | Not Yet Enabled |
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This repository contains useful tools that the Azure SDK team utilizes across th
 |----------------------|-----------------------------------------|-----------------------------------------------------------------|----------|
 | doc-warden           | [Readme](packages/python-packages/doc-warden/README.md) | A tool used to enforce readme standards across Azure SDK Repos. |[![Build Status](https://dev.azure.com/azure-sdk/public/_apis/build/status/108?branchName=master)](https://dev.azure.com/azure-sdk/public/_build/latest?definitionId=108&branchName=master) |
 | pixel-server         | [Readme](packages/web/pixel-server/README.md) | A tiny ASP.NET Core site used to serve a pixel and record impressions. | Not Yet Enabled |
-| pixel insertion tool | [Readme](scripts/python/readme_tracking/README.md) | A tool used to insert the image reference. Served by `pixel server`.  | Not Yet Enabled |
+| pixel insertion tool | [Readme](scripts/python/readme_tracking/README.md) | A tool used to insert the requests for images served by `pixel server`.  | Not Yet Enabled |
 
 # Contributing
 

--- a/scripts/python/readme_tracking/readme.md
+++ b/scripts/python/readme_tracking/readme.md
@@ -1,0 +1,62 @@
+# This Script Inserts Pixels Into Your Readme Files
+
+### Context
+Github currently doesn't offer a method to see visitor traffic patterns. The `PATHS` API merely returns the _top 10_ most popular paths on your repository. There is no guarantee of coverage. So, what happens if you want to see whether location `A` in your repository is more popular than location `B`?. Only way that we've found is to insert an image who's number of loads can be counted. 
+
+This python script inserts a pixel image whos _name corresponds to the location of the rendered readme in the repository_.
+
+### Before Running, Some Details
+This script was built and tested on Python 3.6/
+
+[This project](../../../web/pixel-server/README.md) is the code involved for counting the number of impressions per rendered readme view. Update it however you want to store the data. Currently it leverages `Application Insights` as the data store.
+
+So there are prep steps before running this tool:
+
+1. Go [host the code](https://docs.microsoft.com/en-us/aspnet/core/host-and-deploy/?view=aspnetcore-2.2) from the [folder above](../../../web/pixel-server/README.md) in a publically accessible location.
+2. Update the `HOSTNAME` variable to point at wherever your site is hosted.
+3. Run the script against your repository
+
+### Running the Script
+`python <script_location> -d <target_directory> -i <rep_identifier>`
+
+**Target Directory**:
+The top level directory that the tool will search _below_ for all `readme.rst` or `readme.md` files.
+
+**Repo Identifier**:
+If this is run on multiple repositories, some way needs to be maintained to tell readmes apart when the requests are being fired from the same relative URL within each repository. The tool places this `repo identifier` as a lead value before the relative URL.
+
+### Example Usage and Results
+Given the below repository structure:
+
+```
+<repo-root, located at C:/repo/cool-repo>
+│   README.md
+│
+└───<folder1>
+    └───README.rst
+└───<other files and folders>
+```
+
+Let's walk through an example usage. The `repo id` used here will be `cool-repo`.
+
+```
+/:> python <script_location> -d C:/repo/cool-repo -i cool-repo
+```
+
+With the sample repo structure above and the inputs provided, `/README.md` and `/folder1/README.rst` would be affected after the script run. A new image would appear in both of them.
+
+For markdown, like `/README.md`:
+```
+![Impressions](<your HOSTNAME>/api/impressions/cool-repo%2FREADME.png)
+```
+
+
+For restructured text, like `/folder1/README.rst`:
+```
+.. image::  <your HOSTNAME>/api/impressions/cool-repo%2Ffolder1%2FREADME.png
+```
+
+
+
+
+

--- a/scripts/python/readme_tracking/update_readmes_for_tracking.py
+++ b/scripts/python/readme_tracking/update_readmes_for_tracking.py
@@ -1,0 +1,119 @@
+from __future__ import print_function
+import os
+import fnmatch
+import re
+import sys
+import urllib.parse
+import argparse
+
+
+HOSTNAME = 'https://azure-sdk-impressions.azurewebsites.net'
+
+README_PATTERNS = ['*/readme.md', '*/readme.rst']
+MARKDOWN_REGEX = r'!\[Impressions\]\([^\)]+\)'
+RST_REGEX = r'\.\. image::  https://' + HOSTNAME + r'/api/impressions/[^\s]+'
+
+TRACKING_PIXEL_MD_FORMAT_STRING = '![Impressions](' + HOSTNAME + '/api/impressions/{0}{1})'
+TRACKING_PIXEL_RST_FORMAT_STRING = '.. image::  ' + HOSTNAME + '/api/impressions/{0}{1}'
+
+# walks a target directory with support for multiple glob patterns
+def walk_directory_for_pattern(target_directory, target_patterns):
+    expected_locations = []
+    target_directory = os.path.normpath(target_directory)
+    normalized_target_patterns = [os.path.normpath(pattern) for pattern in target_patterns]
+
+    # walk the folders, filter to the patterns established
+    for folder, subfolders, files in os.walk(target_directory): 
+        for file in files:
+            file_path = os.path.join(folder, file)
+            if check_match(file_path, normalized_target_patterns):
+                expected_locations.append(file_path)
+
+    return expected_locations
+
+# a set of glob patterns against a single file path
+def check_match(file_path, normalized_target_patterns):
+    return any([fnmatch.fnmatch(file_path, normalized_target_pattern) 
+                for normalized_target_pattern in normalized_target_patterns])
+
+# returns all readmes that match either of the readme patterns.
+def get_all_readme_files(folder_location):
+    return walk_directory_for_pattern(folder_location, README_PATTERNS)
+
+# runs across provided set of readmes, inserts or updates pixels in all
+def update_readmes_with_tracking(readme_files, target_directory, repo_id):
+    for file_path in readme_files:
+        with open(file_path, 'r') as f:
+            data = f.read()
+
+        md_regex = re.compile(MARKDOWN_REGEX, re.IGNORECASE | re.MULTILINE)
+        rs_regex = re.compile(RST_REGEX, re.IGNORECASE | re.MULTILINE)
+        try:
+            extension = os.path.splitext(file_path)[1]
+        except e:
+            print('No file extension present.')
+            print(e)
+            exit(1)
+
+        if (extension == '.rst'):
+            updated_content = replace_tracking_pixel_rst(file_path, data, rs_regex, target_directory, repo_id)
+        if (extension == '.md'):
+            updated_content = replace_tracking_pixel_md(file_path, data, md_regex, target_directory, repo_id)
+
+        if updated_content != data:
+            with open(file_path, 'w') as f:
+                f.write(updated_content)
+
+# insert/update tracking pixel, rst specific
+def replace_tracking_pixel_rst(file_path, file_content, compiled_regex, target_directory, repo_id):
+    existing_matches = compiled_regex.search(file_content)
+
+    if existing_matches:
+        return compiled_regex.sub(get_tracking_pixel(TRACKING_PIXEL_RST_FORMAT_STRING, file_path, target_directory, repo_id), file_content)
+    else:
+        return file_content + '\n\n' + get_tracking_pixel(TRACKING_PIXEL_RST_FORMAT_STRING, file_path, target_directory, repo_id) + '\n'
+
+# insert/update tracking pixel, markdown specific
+def replace_tracking_pixel_md(file_path, file_content, compiled_regex, target_directory, repo_id):
+    existing_matches = compiled_regex.search(file_content)
+
+    if existing_matches:
+        return compiled_regex.sub(get_tracking_pixel(TRACKING_PIXEL_MD_FORMAT_STRING, file_path, target_directory, repo_id), file_content)
+    else:
+        return file_content + '\n\n' + get_tracking_pixel(TRACKING_PIXEL_MD_FORMAT_STRING, file_path, target_directory, repo_id) + '\n'
+
+# creates the pixel tag
+def get_tracking_pixel(fmt_string, file_path, target_directory, repo_id):
+    # remove leading folders
+    relative_path = file_path.replace(os.path.normpath(target_directory), '')
+
+    # rename to an image
+    relative_path = os.path.splitext(relative_path)[0] + '.png'
+
+    # ensure that windows doesn't mess up anything
+    slash_path = relative_path.replace('\\', '/')
+
+    # uri encode
+    url_encoded_path = urllib.parse.quote_plus(slash_path)
+
+    return fmt_string.format(repo_id, url_encoded_path)
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description ='Script that will take any repository + identifier as input, and add or update a tracking pixel image in all readme files contained within the input directory.')
+
+    parser.add_argument(
+        '-d',
+        '--scan-directory',
+        dest = 'scan_directory',
+        help = 'The repo directory that this tool should be scanning.',
+        required = True)
+    parser.add_argument(
+        '-i',
+        '--id',
+        dest = 'repo_id',
+        help = 'The repository identifier. Will be prefixed onto the readme path.',
+        required = True)
+    args = parser.parse_args()
+
+    target_readme_files = get_all_readme_files(args.scan_directory)
+    update_readmes_with_tracking(target_readme_files, args.scan_directory, args.repo_id)

--- a/web/pixel-server/PixelServer/Controllers/TrackingController.cs
+++ b/web/pixel-server/PixelServer/Controllers/TrackingController.cs
@@ -11,7 +11,6 @@ using Microsoft.Extensions.Caching.Memory;
 
 namespace PixelServer.Controllers
 {
-    [Route("api/impressions")]
     [ApiController]
     public class TrackingController : ControllerBase
     {
@@ -31,6 +30,7 @@ namespace PixelServer.Controllers
         /// </summary>
         /// <param name="path"></param>
         /// <returns></returns>
+        [Route("api/impressions/{*path}")]
         [HttpGet]
         public IActionResult Get(string path)
         {
@@ -42,7 +42,7 @@ namespace PixelServer.Controllers
 
             return new ImageActionResult();
         }
-
+        
         private string getCachedVisitorStatus(System.Net.IPAddress address)
         {
             if (!_cache.TryGetValue(address, out _))


### PR DESCRIPTION
Adding a script that can be pointed at a repository to generate and insert the `md` or `rst` tags necessary to so that we can find out what readmes people are looking at.

This will be pulled into `doc-warden` when we want to make this part of our regular build automation. This is pending, as we don't currently have patterns for "add another commit for X".

For now, we want to see how valuable this data is, hence the tool checkin + associated PRs.

Additionally, this PR includes an update to how we HANDLE the requests as well. Turns out that any trailing `?blahblah` added to an image request will be *blocked* by adblockers and the like. Instead we handle the path as the image name itself.

@Azure/azure-sdk-eng 
