### PR TITLE
Adding Source Distribution Output to Warden Build

### DIFF
--- a/.azure-pipelines/warden.yml
+++ b/.azure-pipelines/warden.yml
@@ -21,6 +21,7 @@ jobs:
   - script: |
       cd $(Build.SourcesDirectory)/packages/python-packages/doc-warden/
       python setup.py bdist_wheel -d $(Build.ArtifactStagingDirectory)
+      python setup.py sdist -d $(Build.ArtifactStagingDirectory) --format zip
     displayName: 'Build Package'
 
   - script: |


### PR DESCRIPTION
Such that we don't have to specialcase handling `.whl` files during parsing of necessary tags.