### PR TITLE
Add versioning support props and targets

### DIFF
--- a/.azure-pipelines/dotnet.yml
+++ b/.azure-pipelines/dotnet.yml
@@ -1,5 +1,6 @@
 # External variables:
 # ProjectFile - The project to build and test. This variable is defined in pipeline web ui because we want to be able to provide it at queue time and that isn't supported in yaml yet.
+# VersioningProps - A collection of extra msbuild versioning properties like OfficialBuildId, PreReleaseVersionLabel, and DotNetFinalVersionKind
 
 trigger:
   - master
@@ -19,7 +20,7 @@ jobs:
         inputs:
           version: '$(DotNetCoreVersion)'
 
-      - script: 'dotnet pack $(ProjectFile) -o $(Build.ArtifactStagingDirectory) -warnaserror'
+      - script: 'dotnet pack $(ProjectFile) -o $(Build.ArtifactStagingDirectory) -warnaserror $(VersioningProps)'
         displayName: 'Build and Package'
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1

--- a/eng/Directory.Build.props
+++ b/eng/Directory.Build.props
@@ -8,6 +8,11 @@
     <SignAssembly>true</SignAssembly>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <!--
+      Disable NuGet Pack warning that the version is SemVer 2.0.
+      SemVer 2.0 is supported by NuGet since 3.0.0 (July 2015) in some capacity, and fully since 3.5.0 (October 2016).
+    -->
+    <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
 
   <!-- TargetFramework default properties -->
@@ -51,4 +56,5 @@
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
 
+  <Import Project="Versioning.props" />
 </Project>

--- a/eng/Directory.Build.targets
+++ b/eng/Directory.Build.targets
@@ -18,4 +18,5 @@
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)AzureSDKToolsKey.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
 
+  <Import Project="Versioning.targets" />
 </Project>

--- a/eng/Versioning.props
+++ b/eng/Versioning.props
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <PropertyGroup>
+    <_BuildNumber>$(OfficialBuildId)</_BuildNumber>
+    <_BuildNumber Condition="'$(OfficialBuildId)' == ''">$([System.DateTime]::Now.ToString(yyyyMMdd)).1</_BuildNumber>
+
+    <_PreReleaseLabel>$(PreReleaseVersionLabel)</_PreReleaseLabel>
+    <_PreReleaseLabel Condition="'$(_PreReleaseLabel)' == ''">dev</_PreReleaseLabel>
+
+    <!--
+      If DotNetFinalVersionKind is specified, overrides the package version produced by the build like so:
+        "release"    -> 1.2.3
+        "prerelease" -> 1.2.3-label
+        ""           -> 1.2.3-label.12345.67
+    -->
+    <VersionSuffix Condition="'$(DotNetFinalVersionKind)' == 'release'"/>
+    <VersionSuffix Condition="'$(DotNetFinalVersionKind)' == 'prerelease'">$(_PreReleaseLabel)</VersionSuffix>
+    <VersionSuffix Condition="'$(DotNetFinalVersionKind)' == ''">$(_PreReleaseLabel).$(_BuildNumber)</VersionSuffix>
+  </PropertyGroup>
+</Project>

--- a/eng/Versioning.targets
+++ b/eng/Versioning.targets
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+  <!--
+    Specification: https://github.com/dotnet/arcade/blob/master/Documentation/CoreVersioning.md
+
+    File version has 4 parts and need to increase every official build. This is especially important when building MSIs.
+    FILEMAJOR.FILEMINOR.FILEPATCH.FILEREVISION
+    FILEMAJOR: Specified in the first part of VersionPrefix property.
+    FILEMINOR: Set to MINOR * 100 + PATCH / 100, where MINOR and PATCH are the 2nd and 3rd parts of VersionPrefix property.
+    FILEPATCH: Set to (PATCH % 100) * 100 + yy.
+    FILEREVISION: Set to (50 * mm + dd) * 100 + r. This algorithm makes it easy to parse the month and date from FILEREVISION while staying in the range of a short which is what a version element uses.
+
+    The versioning scheme defined below imposes the following limits on these version parts:
+    - `MAJOR` version is in range [0-65535]
+    - `MINOR` version is in range [0-654]
+    - `PATCH` version is in range [0-9999]
+  -->
+  <Target Name="_InitializeFileVersion" BeforeTargets="GetAssemblyVersion">
+    <Error Text="Expected _BuildNumber to match OfficialBuildId property!"
+            Condition="'$(OfficialBuildId)' != '' and '$(OfficialBuildId)' != '$(_BuildNumber)'" />
+
+    <Error Text="Invalid format of OfficialBuildId: '$(OfficialBuildId)' should be in form yyyyMMdd.r"
+           Condition="$(OfficialBuildId) != '' and ($(OfficialBuildId.Length) &lt; 10 or '$(OfficialBuildId[8])' != '.')" />
+
+    <!-- Compute an ever increasing build number based on official build id assuming it is passed -->
+    <PropertyGroup Condition="'$(OfficialBuildId)' != ''">
+      <_BuildNumberYY>$(_BuildNumber.Substring(2, 2))</_BuildNumberYY>
+      <_BuildNumberMM>$(_BuildNumber.Substring(4, 2))</_BuildNumberMM>
+      <_BuildNumberDD>$(_BuildNumber.Substring(6, 2))</_BuildNumberDD>
+      <_BuildNumberR>$(_BuildNumber.Substring(9))</_BuildNumberR>
+
+      <_VersionPrefixMajor>$(VersionPrefix.Split('.')[0])</_VersionPrefixMajor>
+      <_VersionPrefixMinor>$(VersionPrefix.Split('.')[1])</_VersionPrefixMinor>
+      <_VersionPrefixPatch>$(VersionPrefix.Split('.')[2])</_VersionPrefixPatch>
+
+      <_FileMajor>$(_VersionPrefixMajor)</_FileMajor>
+
+      <!-- MINOR * 100 + PATCH / 100 -->
+      <_FileMinor>$([MSBuild]::Add(
+                    $([MSBuild]::Multiply($(_VersionPrefixMinor), 100)),
+                    $([System.Convert]::ToInt32($([MSBuild]::Divide($(_VersionPrefixPatch), 100))))
+                  ))</_FileMinor>
+
+      <!-- (PATCH % 100) * 100 + yy -->
+      <_FilePatch>$([MSBuild]::Add(
+                    $([MSBuild]::Multiply(
+                      $([MSBuild]::Modulo($(_VersionPrefixPatch), 100)),
+                      100)),
+                    $(_BuildNumberYY)
+                  ))</_FilePatch>
+
+      <!-- mm * 5000 + dd * 100 + r -->
+      <_FileRevision>$([MSBuild]::Add(
+                        $([MSBuild]::Add(
+                          $([MSBuild]::Multiply($(_BuildNumberMM), 5000)),
+                          $([MSBuild]::Multiply($(_BuildNumberDD), 100))
+                        )),
+                        $(_BuildNumberR)
+                     ))</_FileRevision>
+
+      <FileVersion>$(_FileMajor).$(_FileMinor).$(_FilePatch).$(_FileRevision)</FileVersion>
+    </PropertyGroup>
+  </Target>
+</Project>

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.3</TargetFramework>
     <BuildOutputTargetFolder>analyzers/dotnet/cs/</BuildOutputTargetFolder>
-    <PackageVersion>0.1.1-preview1</PackageVersion>
+    <VersionPrefix>0.1.1</VersionPrefix>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Mostly follows https://github.com/dotnet/arcade/blob/master/Documentation/CoreVersioning.md
but uses the full date for package version instead of the short date we need to use
for file versioning.

Fixes https://github.com/Azure/azure-sdk-tools/issues/27

PTAL @pakrym 