### PR TITLE
Enable Doc Warden Feature - Package Indexing

### DIFF
--- a/packages/python-packages/doc-warden/changelog.md
+++ b/packages/python-packages/doc-warden/changelog.md
@@ -1,3 +1,25 @@
+# 2019-04-30 - 0.3.0
+
+New functionality for indexing packages within a repository has been added. Leverage with the `index` positional argument.
+
+
+```
+ward index <target directory>
+
+```
+
+Additional Details:
+
+ * Can successfully statically index Python, .NET, Java, or Javascript repositories and locate `packages`
+ * Generates a `packages.md` file at the root of each repo
+    * This location can be adjusted.
+
+Check the [readme](readme.md) for more explicit usage details.
+
+Other Changes:
+
+ * Reorganization between `enforce_readme_present.py` and `warden_common.py`
+
 # 2019-04-10 - 0.2.6
 
 Versions 0 -> 0.2.6 have all been various iterations on `base warden functionality`.

--- a/packages/python-packages/doc-warden/setup.py
+++ b/packages/python-packages/doc-warden/setup.py
@@ -53,6 +53,8 @@ setup(
         'docutils', # parsing rst to html
         'pygments', # docutils uses pygments for parsing rst to html
         'beautifulsoup4', # parsing of generated html
+        'jinja2', # used for generation from template for index_packages
+        'requests', # utilized to validate published repository URLs. 
         'pathlib'
     ],
     entry_points = {

--- a/packages/python-packages/doc-warden/warden/PackageInfo.py
+++ b/packages/python-packages/doc-warden/warden/PackageInfo.py
@@ -1,0 +1,66 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from __future__ import print_function
+import argparse
+import yaml
+import os
+import requests
+from requests.exceptions import HTTPError
+
+class PackageInfo():
+    def __init__(self, package_id = '',
+            package_version = '',
+            relative_package_location = '',
+            relative_readme_location = '',
+            relative_changelog_location = '',
+            repository_args = []):
+
+        # variables strictly related to the package itself
+        self.package_id = package_id
+        self.package_version = package_version
+        self.relative_package_location = relative_package_location
+        self.relative_readme_location = relative_readme_location
+        self.relative_changelog_location = relative_changelog_location
+
+        # leveraged for formatting the link out to the appropriate package manager
+        self.repository_args = repository_args
+
+    # is there a changelog present?
+    def show_changelog(self):
+        return len(self.relative_readme_location) > 0
+
+    # is there a readme present?
+    def show_readme(self):
+        return len(self.relative_changelog_location) > 0
+
+    # test a remote URL. True if sucessful
+    def test_url(self, configuration):
+        url = self.get_formatted_repository_url(configuration)
+
+        try:
+            response = requests.get(url)
+            if response.status_code == 200:
+                return True
+        except Exception as err:
+            if config.verbose_output:
+                print(err)
+        return False
+
+    # get the base template URL from the configuration, then fill in the elements 
+    # from repository_args if necessary
+    def get_formatted_repository_url(self, configuration):
+        repo_url_template = configuration.get_repository_details()['URL']
+
+        # pull in the package id
+        repo_url_template = repo_url_template.format(package_id = self.package_id)
+
+        # pull in any additional elements through repository_args
+        for index, additional_argument in enumerate(self.repository_args):
+            repo_url_template = repo_url_template.replace('[' + str(index) + ']', self.repository_args[index])
+
+        # possibly need to url encode here.
+        return repo_url_template
+
+    def get_repository_link_text(self, configuration):
+        return configuration.get_repository_details()['Text']

--- a/packages/python-packages/doc-warden/warden/WardenConfiguration.py
+++ b/packages/python-packages/doc-warden/warden/WardenConfiguration.py
@@ -10,8 +10,11 @@ class WardenConfiguration():
     REPOSITORY_SETS = {
         # 0 = groupId
         'java': { 
-            'URL': 'https://search.maven.org/classic/#search%7Cga%7C1%7Cg:%22[0]%22%20AND%20a:%22{package_id}%22',
-            'Text': 'Maven'
+            'TestUrl': 'https://oss.sonatype.org/content/repositories/releases/[0]/{package_id}/{package_version}/{package_id}-{package_version}.pom',
+            'TestUrlTransformationFunction': lambda input_string: input_string.replace('.','/'),
+            'URL': 'https://search.maven.org/artifact/[0]/{package_id}',
+            'UrlTransformationFunction': lambda input_string: input_string,
+            'Text': 'Maven',
         },
         'python': { 
             'URL': 'https://pypi.org/project/{package_id}',

--- a/packages/python-packages/doc-warden/warden/WardenConfiguration.py
+++ b/packages/python-packages/doc-warden/warden/WardenConfiguration.py
@@ -10,7 +10,7 @@ class WardenConfiguration():
     REPOSITORY_SETS = {
         # 0 = groupId
         'java': { 
-            'URL': 'https://search.maven.org/search?q=g:[0]%20AND%20a:{packageId}',
+            'URL': 'https://search.maven.org/classic/#search%7Cga%7C1%7Cg:%22[0]%22%20AND%20a:%22{package_id}%22',
             'Text': 'Maven'
         },
         'python': { 

--- a/packages/python-packages/doc-warden/warden/__init__.py
+++ b/packages/python-packages/doc-warden/warden/__init__.py
@@ -3,14 +3,19 @@
 
 from .version import VERSION
 
+from .WardenConfiguration import WardenConfiguration
+from .PackageInfo import PackageInfo
+
 from .enforce_readme_presence import find_missing_readmes
 from .enforce_readme_content import verify_readme_content
-from .WardenConfiguration import WardenConfiguration
 from .warden_common import walk_directory_for_pattern, get_omitted_files
 from .cmd_entry import console_entry_point 
+from .index_packages import index_packages
 
 __all__ = [
            'WardenConfiguration',
+           'PackageInfo',
+           'index_packages'
            'find_missing_readmes',
            'verify_readme_content',
            'console_entry_point',

--- a/packages/python-packages/doc-warden/warden/cmd_entry.py
+++ b/packages/python-packages/doc-warden/warden/cmd_entry.py
@@ -4,7 +4,9 @@ from __future__ import print_function
 
 from .enforce_readme_presence import find_missing_readmes
 from .enforce_readme_content import verify_readme_content
+from .index_packages import index_packages, render
 from .WardenConfiguration import WardenConfiguration
+from .PackageInfo import PackageInfo
 import os
 
 # CONFIGURATION. ENTRY POINT. EXECUTION.
@@ -17,7 +19,8 @@ def console_entry_point():
     command_selector = {
         'scan': all_operations,
         'content': verify_content,
-        'presence': verify_presence
+        'presence': verify_presence,
+        'index': index
     }
     
     if cfg.command in command_selector:
@@ -25,6 +28,16 @@ def console_entry_point():
     else:
         print('Unrecognized command invocation {}.'.format(cfg.command))
         exit(1)
+
+# index the packages present in the repository
+def index(config):
+    packages = index_packages(config)
+    render(config, packages)
+
+    if config.verbose_output:
+        print('Warden located the following packages: ')
+        for pkg in packages:
+            print(pkg.package_id)
 
 # verify the content of the readmes only
 def verify_content(config):

--- a/packages/python-packages/doc-warden/warden/enforce_readme_presence.py
+++ b/packages/python-packages/doc-warden/warden/enforce_readme_presence.py
@@ -6,10 +6,9 @@ from __future__ import print_function
 import pathlib
 import os
 import glob
-import xml.etree.ElementTree as ET
 import fnmatch
 import zipfile
-from .warden_common import check_match, walk_directory_for_pattern, get_omitted_files
+from .warden_common import get_java_package_roots, get_net_package_roots, get_python_package_roots, get_js_package_roots, find_alongside_file
 
 # python 3 transitioned StringIO to be part of `io` module. 
 # python 2 needs the old version however
@@ -44,9 +43,17 @@ def find_missing_readmes(configuration):
 
     return missing_readme_paths, ignored_missing_readme_paths
 
+# check the root of the target_directory for a master README 
+def check_repo_root(configuration):
+    if configuration.root_check_enabled:
+        # check root for readme.md
+        present_files = [f for f in os.listdir(configuration.target_directory) if os.path.isfile(os.path.join(configuration.target_directory, f))]
+        return  any(x in [f.lower() for f in present_files] for x in ['readme.md', 'readme.rst'])
+    return true
+
 # return all missing readmes for a PYTHON repostiroy
 def check_python_readmes(configuration):
-    expected_readmes, omitted_readmes = get_file_sets(configuration, '*/setup.py')
+    expected_readmes, omitted_readmes = get_python_package_roots(configuration)
     missing_expected_readme_locations = []
 
     for expected_location in expected_readmes:
@@ -58,7 +65,7 @@ def check_python_readmes(configuration):
 
 # return all missing readmes for a JAVASCRIPT repository
 def check_js_readmes(configuration):
-    expected_readmes, omitted_readmes = get_file_sets(configuration, '*/package.json')
+    expected_readmes, omitted_readmes = get_js_package_roots(configuration)
     missing_expected_readme_locations = []
 
     for expected_location in expected_readmes:
@@ -70,7 +77,7 @@ def check_js_readmes(configuration):
 
 # return all missing readmes for a .NET repostory
 def check_net_readmes(configuration):
-    expected_readmes, omitted_readmes = get_file_sets(configuration, '*.sln', is_net_csproj_package)
+    expected_readmes, omitted_readmes = get_net_package_roots(configuration)
     missing_expected_readme_locations = []
 
     for expected_location in expected_readmes:
@@ -79,13 +86,9 @@ def check_net_readmes(configuration):
             missing_expected_readme_locations.append(os.path.dirname(expected_location))
     return missing_expected_readme_locations
 
-# convention. omit test projects
-def is_net_csproj_package(file_path):
-    return "tests.csproj" not in file_path.lower()
-
 # returns all missing readmes for a JAVA repo
 def check_java_readmes(configuration):
-    expected_readmes, omitted_readmes = get_file_sets(configuration, "*/pom.xml", is_java_pom_package_pom)
+    expected_readmes, omitted_readmes = get_java_package_roots(configuration)
     missing_expected_readmes = []
 
     for expected_location in expected_readmes:
@@ -94,60 +97,3 @@ def check_java_readmes(configuration):
             missing_expected_readmes.append(os.path.dirname(expected_location))
 
     return missing_expected_readmes
-
-# given a pom.xml, crack it open and ensure that it is actually a package pom (versus a parent pom)
-def is_java_pom_package_pom(file_path):
-    root = parse_pom(file_path)
-    jar_tag = root.find('packaging')
-
-    if jar_tag is not None:
-        return jar_tag.text == 'jar'
-    return False
-
-# check the root of the target_directory for a master README 
-def check_repo_root(configuration):
-    if configuration.root_check_enabled:
-        # check root for readme.md
-        present_files = [f for f in os.listdir(configuration.target_directory) if os.path.isfile(os.path.join(configuration.target_directory, f))]
-        return  any(x in [f.lower() for f in present_files] for x in ['readme.md', 'readme.rst'])
-    return true
-
-# given a file location or folder, check within or alongside for a target file
-# case insensitive
-def find_alongside_file(file_location, target_file_name):
-    if not os.path.exists(file_location) or not target_file_name:
-        return False
-    containing_folder = ''
-    if os.path.isdir(file_location):
-        # we're already looking at a file location. just check for presence of target_file_name in listdir
-        containing_folder = file_location
-    else:
-        # os.path.listdir(os.path.dirname(file_location))
-        containing_folder = os.path.dirname(file_location)
-
-    for x in os.listdir(containing_folder):
-        if x.lower() == target_file_name.lower():
-            return os.path.normpath(os.path.join(containing_folder, x))
-    return False
-
-# returns the two sets:
-    # the set of files where we expect a readme to be present
-    # and the set of files that we expect a readme to be present that have been explicitly omitted
-def get_file_sets(configuration, target_pattern, lambda_check = None):
-    expected_locations = walk_directory_for_pattern(configuration.target_directory, [target_pattern], lambda_check)
-    
-    omitted_files = get_omitted_files(configuration)
-
-    return list(set(expected_locations) - set(omitted_files)), set(omitted_files).intersection(expected_locations) 
-
-# namespaces in xml really mess with xmlTree: https://bugs.python.org/issue18304
-# this function provides a workaround for both parsing an xml file as well as REMOVING said namespaces
-def parse_pom(file_path):
-    with open(file_path) as f:
-        xml = f.read()
-
-    it = ET.iterparse(StringIO(xml))
-    for _, el in it:
-        if '}' in el.tag:
-            el.tag = el.tag.split('}', 1)[1]
-    return it.root

--- a/packages/python-packages/doc-warden/warden/index_packages.py
+++ b/packages/python-packages/doc-warden/warden/index_packages.py
@@ -32,7 +32,7 @@ REPO_COL = ' `[Repo Link]( {{ pkg.relative_package_location }}` )'
 PUBLISH_COL = ' {% if pkg.test_url(config) %}[{{ pkg.get_repository_link_text(config) }}]( {{ pkg.get_formatted_repository_url(config) }} ){% else %} N/A {% endif %} '
 COLUMN_LOOP = '{% for pkg in packages %}'
 COLUMN_TEMPLATE = '{0}|{1}|{2}|{3}|{4}|'.format(COLUMN_LOOP, PKGID_COL, RM_COL, CL_COL, PUBLISH_COL)
-JAVA_COLUMN_TEMPLATE = '{0}|{1}|{2}|{3}|{4}|{5}|'.format(COLUMN_LOOP, PKGID_COL, GROUPID_COL, RM_COL, CL_COL, PUBLISH_COL)
+JAVA_COLUMN_TEMPLATE = '{0}|{1}|{2}|{3}|{4}|'.format(COLUMN_LOOP, PKGID_COL, GROUPID_COL, RM_COL, PUBLISH_COL)
 
 OUTPUT_HEADER = """
 # Package Index - {{ title }}
@@ -44,8 +44,8 @@ OUTPUT_HEADER = """
 JAVA_OUTPUT_HEADER = """
 # Package Index - {{ title }}
 
-| Package Id     | GroupId   | Readme    | Changelog                 | Published Url       |
-|----------------|-----------|-----------|---------------------------|---------------------|
+| Package Id     | GroupId   | Readme    | Published Url       |
+|----------------|-----------|-----------|---------------------|
 """
 
 COLUMN_OUTPUT_FOOTER = """

--- a/packages/python-packages/doc-warden/warden/index_packages.py
+++ b/packages/python-packages/doc-warden/warden/index_packages.py
@@ -1,0 +1,350 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+from __future__ import print_function
+
+from .warden_common import check_match, walk_directory_for_pattern, get_omitted_files, get_java_package_roots, get_net_packages, get_python_package_roots, get_js_package_roots, find_alongside_file, find_below_file, parse_pom, is_java_pom_package_pom, find_above_file
+from .PackageInfo import PackageInfo
+import json
+import os
+import ast
+from jinja2 import Template
+import xml.etree.ElementTree as ET
+import textwrap
+import re
+import fnmatch
+
+# python 3 transitioned StringIO to be part of `io` module. 
+# python 2 needs the old version however
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+# chose to go with in-line templates. reasoning here is that the whitespace is a bit more important for markdown
+# given that all the content fitting on a single line is important, leveraging the format string method makes for a 
+# much simpler to maintain template
+PKGID_COL = ' [`{{ pkg.package_id }}`]( {{ pkg.relative_package_location }} )'
+RM_COL = ' {% if len(pkg.relative_readme_location) > 0 %}[Readme]({{ pkg.relative_readme_location }}){% else %} N/A {% endif %} '
+CL_COL = ' {% if len(pkg.relative_changelog_location) > 0 %}[Changelog]({{ pkg.relative_changelog_location }}){% else %} N/A {% endif %} '
+GROUPID_COL = ' `{{ pkg.repository_args[0] }}` '
+REPO_COL = ' `[Repo Link]( {{ pkg.relative_package_location }}` )'
+PUBLISH_COL = ' {% if pkg.test_url(config) %}[{{ pkg.get_repository_link_text(config) }}]( {{ pkg.get_formatted_repository_url(config) }} ){% else %} N/A {% endif %} '
+COLUMN_LOOP = '{% for pkg in packages %}'
+COLUMN_TEMPLATE = '{0}|{1}|{2}|{3}|{4}|'.format(COLUMN_LOOP, PKGID_COL, RM_COL, CL_COL, PUBLISH_COL)
+JAVA_COLUMN_TEMPLATE = '{0}|{1}|{2}|{3}|{4}|{5}|'.format(COLUMN_LOOP, PKGID_COL, GROUPID_COL, RM_COL, CL_COL, PUBLISH_COL)
+
+OUTPUT_HEADER = """
+# Package Index - {{ title }}
+
+| Package Id     | Readme    | Changelog                 | Published Url       |
+|----------------|-----------|---------------------------|---------------------|
+"""
+
+JAVA_OUTPUT_HEADER = """
+# Package Index - {{ title }}
+
+| Package Id     | GroupId   | Readme    | Changelog                 | Published Url       |
+|----------------|-----------|-----------|---------------------------|---------------------|
+"""
+
+COLUMN_OUTPUT_FOOTER = """
+{% endfor %}
+"""
+
+# model for "context" of the output template
+#  title = <repo-name> (target directory dirname() perhaps
+#  packages = [ PackageInfo, PackageInfo, ... ]
+#  len = wrapper for len(string)
+OUTPUT_TEMPLATE = OUTPUT_HEADER + COLUMN_TEMPLATE + COLUMN_OUTPUT_FOOTER
+JAVA_OUTPUT_TEMPLATE = JAVA_OUTPUT_HEADER + JAVA_COLUMN_TEMPLATE + COLUMN_OUTPUT_FOOTER
+
+# given a set of package roots (omitted packages are included for indexing), extract a set of common metadata
+# to use when generated a package index.
+def index_packages(configuration):
+    language_selector = {
+        'python': get_python_package_info,
+        'js': get_js_package_info,
+        'java': get_java_package_info,
+        'net': get_net_packages_info
+    }
+
+    return language_selector.get(configuration.scan_language.lower(), unrecognized_option)(configuration)
+
+# leverages python AST to parse arguments to `setup.py` and return a list of all indexed packages 
+# within the target directory
+def get_python_package_info(config):
+    pkg_list = []
+    pkg_locations, ignored_pkg_locations = get_python_package_roots(config)
+
+    for pkg_file in (pkg_locations + ignored_pkg_locations):
+        pkg_id, version = parse_setup(config, pkg_file)
+
+        # package is badly formatted setup. ignore.
+        if pkg_id is None:
+            continue
+
+        changelog = find_below_file('changelog.md', pkg_file)
+        if changelog is None:
+            changelog = find_below_file('history.rst', pkg_file)
+
+        readme = find_below_file('readme.md', pkg_file)
+        if readme is None:
+            readme = find_below_file('readme.rst', pkg_file)
+
+        if changelog:
+            changelog_relpath = webify_relative_path(os.path.relpath(changelog, config.target_directory))
+        else:
+            changelog_relpath = ''
+
+        if readme:
+            readme_relpath = webify_relative_path(os.path.relpath(readme, config.target_directory))
+        else:
+            readme_relpath = ''
+
+        pkg_location = webify_relative_path(os.path.relpath(pkg_file, config.target_directory))
+
+        if(pkg_id not in config.package_indexing_exclusion_list):
+            pkg_list.append(PackageInfo(
+                package_id = pkg_id, 
+                package_version = version, 
+                relative_package_location = pkg_location,
+                relative_readme_location = readme_relpath or '',
+                relative_changelog_location = changelog_relpath or '',
+                repository_args = []
+                ))
+
+    return pkg_list
+
+# leverages JSON parsing of any packages.json files and returns a list of all indexed packages found
+# within the target directory
+def get_js_package_info(config):
+    pkg_list = []
+    pkg_locations, ignored_pkg_locations = get_js_package_roots(config)
+
+    for pkg_file in (pkg_locations + ignored_pkg_locations):
+        with open(pkg_file, 'r') as read_file:
+            pkg_json = json.load(read_file)
+
+        target_directory = os.path.dirname(pkg_file)
+
+        changelog = find_below_file('changelog.md', pkg_file)
+        readme = find_below_file('readme.md', pkg_file)
+
+        if changelog:
+            changelog_relpath = webify_relative_path(os.path.relpath(changelog, config.target_directory))
+        else:
+            changelog_relpath = ''
+
+        if readme:
+            readme_relpath = webify_relative_path(os.path.relpath(readme, config.target_directory))
+        else:
+            readme_relpath = ''
+
+        pkg_location = webify_relative_path(os.path.relpath(pkg_file, config.target_directory))
+
+        if(pkg_json['name'] not in config.package_indexing_exclusion_list):
+            pkg_list.append(PackageInfo(
+                package_id = pkg_json['name'], 
+                package_version = pkg_json['version'], 
+                relative_package_location = pkg_location,
+                relative_readme_location = readme_relpath or '',
+                relative_changelog_location = changelog_relpath or '',
+                repository_args = []
+                ))
+
+    return pkg_list
+
+# given a pom file, maven `groupId` is usually present at the same level as the `artifactId`
+# however, this is not always the case. When this instance occurs, we instead look for the parent `groupId`
+def resolve_java_group_id(pom_root):
+    parent_id_root = pom_root.find('parent')
+    group_id_root = pom_root.find('groupId')
+
+    # there isn't a groupId at the same level as version and artifactId
+    if group_id_root is None:
+        if parent_id_root:
+            parent_group_id = parent_id_root.find('groupId')
+            if parent_group_id:
+                return parent_group_id.text
+    else:
+        return group_id_root.text
+    return ''
+
+# parses all pom files within the target directory, and returns a list of `jar` packages found within
+def get_java_package_info(config):
+    pkg_list = []
+    pkg_locations, ignored_pkg_locations = get_java_package_roots(config)
+    for pkg_file in (pkg_locations + ignored_pkg_locations):
+        with open(pkg_file, 'r') as read_file:
+            root = parse_pom(pkg_file)
+
+        target_directory = os.path.dirname(pkg_file)
+
+        changelog = find_below_file('changelog.md', pkg_file)
+        readme = find_below_file('readme.md', pkg_file)
+
+        if changelog:
+            changelog_relpath = webify_relative_path(os.path.relpath(changelog, config.target_directory))
+        else:
+            changelog_relpath = ''
+
+        if readme:
+            readme_relpath = webify_relative_path(os.path.relpath(readme, config.target_directory))
+        else:
+            readme_relpath = ''
+
+        pkg_location = webify_relative_path(os.path.relpath(pkg_file, config.target_directory))
+
+        artifact_root = root.find('artifactId')
+        version_root = root.find('version')
+        group_id = resolve_java_group_id(root)
+
+        if artifact_root is None or version_root is None or not group_id:
+            if config.verbose_output:
+                print("{} has is missing a version, artifactId, or groupId".format(pkg_file))
+            continue
+
+        if(artifact_root.text not in config.package_indexing_exclusion_list):
+            pkg_list.append(PackageInfo(
+                package_id = artifact_root.text,
+                package_version = version_root.text,
+                relative_package_location = pkg_location,
+                relative_readme_location = readme_relpath or '',
+                relative_changelog_location = changelog_relpath or '',
+                repository_args = [group_id]
+                ))
+    return pkg_list
+
+# finds .net packages (non-test CSProjs) and attempts to correlate the packageinfo details
+# returns a list of all `packages` found within the target directory.
+def get_net_packages_info(config):
+    pkg_list = []
+    pkg_locations, ignored_pkg_locations = get_net_packages(config)
+
+    for pkg_file in (pkg_locations + ignored_pkg_locations):
+        pkg_name = os.path.splitext(os.path.basename(pkg_file))[0]
+        if(pkg_name not in config.package_indexing_exclusion_list):
+            changelog = find_above_file('changelog.md', pkg_file, config.get_package_indexing_traversal_stops() + [os.path.normpath(config.target_directory)], net_early_exit)
+            readme = find_above_file('readme.md', pkg_file, config.get_package_indexing_traversal_stops() + [os.path.normpath(config.target_directory)], net_early_exit)
+
+            if changelog:
+                changelog_relpath = webify_relative_path(os.path.relpath(changelog, config.target_directory))
+            else:
+                changelog_relpath = ''
+
+            if readme:
+                readme_relpath = webify_relative_path(os.path.relpath(readme, config.target_directory))
+            else:
+                readme_relpath = ''
+
+            pkg_location = webify_relative_path(os.path.relpath(pkg_file, config.target_directory))
+
+            pkg_list.append(PackageInfo(
+                package_id = pkg_name, 
+                package_version = '', 
+                relative_package_location = pkg_location,
+                relative_readme_location = readme_relpath or '',
+                relative_changelog_location = changelog_relpath or '',
+                repository_args = []
+                ))
+
+    return pkg_list
+
+# used after scanning a directory for readme. If this returns true,
+# we shouldn't traverse higher up the tree.
+def net_early_exit(path):
+    if path is None:
+        return False
+
+    rule = re.compile(fnmatch.translate('*.sln'))
+
+    for file in os.listdir(path):
+        if rule.match(file):
+            return True
+
+    return False
+
+# windows outputs paths with `\`, but that really needs to be `/` to work as a url
+# given that this is a cross-platform package, we will manually handle this here.
+def webify_relative_path(path):
+    path_corrected = path.replace('\\', '/')
+    return path_corrected
+
+# entrypoint for rendering the packages.md
+# handles the template selection and execution
+def render(config, pkg_list):
+    language_selector = {
+        'python': OUTPUT_TEMPLATE,
+        'js': OUTPUT_TEMPLATE,
+        'java': JAVA_OUTPUT_TEMPLATE,
+        'net': OUTPUT_TEMPLATE
+    }
+
+    template = language_selector.get(config.scan_language.lower(), unrecognized_option)
+    render_template(config, pkg_list, template)
+
+# implementation of the jinja2 template substitution. given a packagelist, generates
+# packages.md rows.
+def render_template(config, pkg_list, template):
+    template = Template(template)
+    pkg_list.sort(key=lambda x: x.package_id)
+
+    get_len = lambda string: len(string)
+
+    rendered_template = template.render(title=os.path.basename(config.target_directory), packages=pkg_list, config=config, len=get_len)
+
+    with open(config.package_index_output_location, 'w') as packages_file:
+        packages_file.write(rendered_template)
+
+def unrecognized_option(configuration):
+    print('Argument {} provided is not a supported language.'.format(configuration.scan_language))
+    exit(1)
+
+# opens setup.py and leverages AST to intercept the parameters TO setup.py 
+# this easily allows us to examine the values that may originate from outside this file (like VERSION)
+def parse_setup(config, setup_filename):
+    mock_setup = textwrap.dedent('''\
+    def setup(*args, **kwargs):
+        __setup_calls__.append((args, kwargs))
+    ''')
+
+    parsed_mock_setup = ast.parse(mock_setup, filename=setup_filename)
+    with open(setup_filename, 'rt') as setup_file:
+        try:
+            parsed = ast.parse(setup_file.read())
+        except:
+            if config.verbose_output:
+                print('{} was unparsable.'.format(setup_filename))
+            return None, None
+        for index, node in enumerate(parsed.body[:]):
+            if (
+                not isinstance(node, ast.Expr) or
+                not isinstance(node.value, ast.Call) or
+                not hasattr(node.value.func, 'id') or
+                node.value.func.id != 'setup'
+            ):
+                continue
+            parsed.body[index:index] = parsed_mock_setup.body
+            break
+
+    fixed = ast.fix_missing_locations(parsed)
+    codeobj = compile(fixed, setup_filename, 'exec')
+    local_vars = {}
+    global_vars = {'__setup_calls__': []}
+    current_dir = os.getcwd()
+    working_dir = os.path.dirname(setup_filename)
+    os.chdir(working_dir)
+    exec(codeobj, global_vars, local_vars)
+    os.chdir(current_dir)
+    try:
+        _, kwargs = global_vars['__setup_calls__'][0]
+    except:
+        if config.verbose_output:
+            print('{} had no kwargs'.format(setup_filename))
+        return None, None
+
+    version = kwargs['version']
+    pkg_id = kwargs['name']
+
+    return pkg_id, version

--- a/packages/python-packages/doc-warden/warden/index_packages.py
+++ b/packages/python-packages/doc-warden/warden/index_packages.py
@@ -44,7 +44,7 @@ OUTPUT_HEADER = """
 JAVA_OUTPUT_HEADER = """
 # Package Index - {{ title }}
 
-| Package Id     | GroupId   | Readme    | Published Url       |
+| Artifact Id    | Group Id  | Readme    | Published Url       |
 |----------------|-----------|-----------|---------------------|
 """
 
@@ -225,8 +225,8 @@ def get_net_packages_info(config):
     for pkg_file in (pkg_locations + ignored_pkg_locations):
         pkg_name = os.path.splitext(os.path.basename(pkg_file))[0]
         if(pkg_name not in config.package_indexing_exclusion_list):
-            changelog = find_above_file('changelog.md', pkg_file, config.get_package_indexing_traversal_stops() + [os.path.normpath(config.target_directory)], net_early_exit)
-            readme = find_above_file('readme.md', pkg_file, config.get_package_indexing_traversal_stops() + [os.path.normpath(config.target_directory)], net_early_exit)
+            changelog = find_above_file('changelog.md', pkg_file, config.get_package_indexing_traversal_stops(), net_early_exit, os.path.normpath(config.target_directory))
+            readme = find_above_file('readme.md', pkg_file, config.get_package_indexing_traversal_stops(), net_early_exit, os.path.normpath(config.target_directory))
 
             if changelog:
                 changelog_relpath = webify_relative_path(os.path.relpath(changelog, config.target_directory))

--- a/packages/python-packages/doc-warden/warden/version.py
+++ b/packages/python-packages/doc-warden/warden/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.2.6'
+VERSION = '0.3.0'

--- a/packages/python-packages/doc-warden/warden/warden_common.py
+++ b/packages/python-packages/doc-warden/warden/warden_common.py
@@ -3,23 +3,51 @@
 
 import os
 import fnmatch
+import re
+import xml.etree.ElementTree as ET
 
-# Returns a list of files under a target directory. The files included will match any of the
-# target_patterns AND the lambda_check function. 
-def walk_directory_for_pattern(target_directory, target_patterns, lambda_check = None):
-    expected_locations = []
-    target_directory = os.path.normpath(target_directory)
-    normalized_target_patterns = [os.path.normpath(pattern) for pattern in target_patterns]
-    check_function = lambda_check or return_true
+# python 3 transitioned StringIO to be part of `io` module. 
+# python 2 needs the old version however
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
-    # walk the folders, filter to the patterns established
-    for folder, subfolders, files in os.walk(target_directory): 
-        for file in files:
-            file_path = os.path.join(folder, file)
-            if check_match(file_path, normalized_target_patterns) and check_function(file_path):
-                expected_locations.append(file_path)
+JS_PACKAGE_DISCOVERY_PATTERN = '*/package.json'
+PYTHON_PACKAGE_DISCOVERY_PATTERN = '*/setup.py'
+NET_PACKAGE_ROOT_DISCOVERY_PATTERN = '*.sln'
+NET_PACKAGE_DISCOVERY_PATTERN = '*.csproj'
+JAVA_PACKAGE_DISCOVERY_PATTERN = '*/pom.xml'
 
-    return expected_locations
+# we want to walk the files as few times as possible. as such, for omitted_files, we provide a SET 
+# of patterns that we want to omit. This function simply checks 
+def check_match(file_path, normalized_target_patterns):
+    return any([fnmatch.fnmatch(file_path, normalized_target_pattern) 
+                for normalized_target_pattern in normalized_target_patterns])
+
+def get_java_package_roots(configuration):
+    return get_file_sets(configuration, JAVA_PACKAGE_DISCOVERY_PATTERN, is_java_pom_package_pom)
+
+def get_net_package_roots(configuration):
+    return get_file_sets(configuration, NET_PACKAGE_ROOT_DISCOVERY_PATTERN)
+
+def get_net_packages(configuration):
+    return get_file_sets(configuration, NET_PACKAGE_DISCOVERY_PATTERN, is_net_csproj_package)
+
+def get_python_package_roots(configuration):
+    return get_file_sets(configuration, PYTHON_PACKAGE_DISCOVERY_PATTERN)
+    
+def get_js_package_roots(configuration):
+    return get_file_sets(configuration, JS_PACKAGE_DISCOVERY_PATTERN)
+
+# returns the two sets:
+    # the set of files where we expect a readme to be present
+    # and the set of files that we expect a readme to be present that have been explicitly omitted
+def get_file_sets(configuration, target_pattern, lambda_check = None):
+    expected_locations = walk_directory_for_pattern(configuration.target_directory, [target_pattern], lambda_check)
+    omitted_files = get_omitted_files(configuration)
+
+    return list(set(expected_locations) - set(omitted_files)), list(set(omitted_files).intersection(expected_locations))
 
 # gets the set of files in the target directory that have explicitly been omitted in the config settings
 def get_omitted_files(configuration):
@@ -33,11 +61,124 @@ def get_omitted_files(configuration):
 
     return omitted_paths
 
-# we want to walk the files as few times as possible. as such, for omitted_files, we provide a SET 
-# of patterns that we want to omit. This function simply checks 
-def check_match(file_path, normalized_target_patterns):
-    return any([fnmatch.fnmatch(file_path, normalized_target_pattern) 
-                for normalized_target_pattern in normalized_target_patterns])
+# convention. omit test projects
+def is_net_csproj_package(file_path):
+    test_proj_exclude = re.compile('.*tests.csproj|.*test.csproj', re.IGNORECASE)
+    sample_project_exclude = re.compile('.*TestProject.csproj', re.IGNORECASE)
 
-def return_true(param):
+    if test_proj_exclude.match(file_path) or sample_project_exclude.match(file_path):
+        return False
+    
     return True
+    
+# Returns a list of files under a target directory. The files included will match any of the
+# target_patterns AND the lambda_check function. 
+def walk_directory_for_pattern(target_directory, target_patterns, lambda_check = None):
+    expected_locations = []
+    target_directory = os.path.normpath(target_directory)
+    normalized_target_patterns = [os.path.normpath(pattern) for pattern in target_patterns]
+    return_true = lambda x: True
+    check_function = lambda_check or return_true
+
+    # walk the folders, filter to the patterns established
+    for folder, subfolders, files in os.walk(target_directory): 
+        for file in files:
+            file_path = os.path.join(folder, file)
+            if check_match(file_path, normalized_target_patterns) and check_function(file_path):
+                expected_locations.append(file_path)
+    return expected_locations
+
+# given a file location or folder, check within or alongside for a target file
+# case insensitive
+def find_alongside_file(file_location, target):
+    if not os.path.exists(file_location) or not target:
+        return False
+
+    rule = re.compile(fnmatch.translate(target), re.IGNORECASE)
+    containing_folder = ''
+
+    if os.path.isdir(file_location):
+        # we're already looking at a file location. just check for presence of target in listdir
+        containing_folder = file_location
+    else:
+        # os.path.listdir(os.path.dirname(file_location))
+        containing_folder = os.path.dirname(file_location)
+
+    for file in os.listdir(containing_folder):
+        if file.lower() == target.lower():
+            return os.path.normpath(os.path.join(containing_folder, file))
+    return False
+
+# find's the first file that matches a glob pattern under a target file's location
+# case insensitive
+def find_below_file(glob_pattern, file):
+    if not os.path.exists(file) or not glob_pattern or os.path.isdir(file):
+        return None
+    rule = re.compile(fnmatch.translate(glob_pattern), re.IGNORECASE)
+
+    target_directory = os.path.dirname(file)
+
+    for folder, subfolders, files in os.walk(target_directory): 
+        for file in files:
+            file_path = os.path.join(folder, file)
+            if rule.match(file):
+                return file_path
+
+# searches upwards along from a specified file for a pattern
+# glob pattern is the pattern we're matching against. often just a filename
+# file is the file we're starting from
+# path_exclusion_list the list of paths we should hard stop traversing up on if we haven't already exited
+# early_exit_lambda_check a specific check that isn't only based on file. for .net we check to see of a .sln is present in the directory
+def find_above_file(glob_pattern, file, path_exclusion_list, early_exit_lambda_check):
+    if not os.path.exists(file) or not glob_pattern or os.path.isdir(file):
+        return None
+
+    if (path_exclusion_list is None or len(path_exclusion_list) == 0) and early_exit_lambda_check is None:
+        print('Using find_above_file without at least one member set for package_indexing_traversal_stops in .docsettings OR setting an early_exit_lambda_check is disallowed. Exiting.')
+        exit(1)
+
+    if early_exit_lambda_check is None:
+        early_exit_lambda_check = lambda path: True
+
+    target_rule = re.compile(fnmatch.translate(glob_pattern), re.IGNORECASE)
+
+    file_dir = os.path.dirname(file)
+
+    while not check_folder_against_exclusion_list(file_dir, path_exclusion_list):
+        for file in os.listdir(file_dir):
+            if target_rule.match(file):
+                return os.path.normpath(os.path.join(file_dir, file))
+        # the early_exit_lambda check runs after we're done scanning the current directory for matches
+        if early_exit_lambda_check(file_dir):
+            return None
+        file_dir = os.path.abspath(os.path.join(file_dir, '../'))
+    return None
+
+# True if folder matches anything in the exclusion list
+# False if not
+def check_folder_against_exclusion_list(folder, path_exclusion_list):
+    if not os.path.isdir(folder):
+        return True
+
+    return os.path.normpath(folder) in path_exclusion_list
+
+# given a pom.xml, crack it open and ensure that it is actually a package pom (versus a parent pom)
+def is_java_pom_package_pom(file_path):
+    root = parse_pom(file_path)
+    jar_tag = root.find('packaging')
+
+    if jar_tag is not None:
+        return jar_tag.text == 'jar'
+    return False
+
+# namespaces in xml really mess with xmlTree: https://bugs.python.org/issue18304
+# this function provides a workaround for both parsing an xml file as well as REMOVING said namespaces
+def parse_pom(file_path):
+    with open(file_path) as f:
+        xml = f.read()
+
+    it = ET.iterparse(StringIO(xml))
+    for _, el in it:
+        if '}' in el.tag:
+            el.tag = el.tag.split('}', 1)[1]
+    return it.root

--- a/packages/python-packages/doc-warden/warden/warden_common.py
+++ b/packages/python-packages/doc-warden/warden/warden_common.py
@@ -129,13 +129,15 @@ def find_below_file(glob_pattern, file):
 # file is the file we're starting from
 # path_exclusion_list the list of paths we should hard stop traversing up on if we haven't already exited
 # early_exit_lambda_check a specific check that isn't only based on file. for .net we check to see of a .sln is present in the directory
-def find_above_file(glob_pattern, file, path_exclusion_list, early_exit_lambda_check):
+def find_above_file(glob_pattern, file, path_exclusion_list, early_exit_lambda_check, root_directory):
     if not os.path.exists(file) or not glob_pattern or os.path.isdir(file):
         return None
 
     if (path_exclusion_list is None or len(path_exclusion_list) == 0) and early_exit_lambda_check is None:
         print('Using find_above_file without at least one member set for package_indexing_traversal_stops in .docsettings OR setting an early_exit_lambda_check is disallowed. Exiting.')
         exit(1)
+
+    complete_exclusion_list = path_exclusion_list + [root_directory]
 
     if early_exit_lambda_check is None:
         early_exit_lambda_check = lambda path: True
@@ -144,7 +146,7 @@ def find_above_file(glob_pattern, file, path_exclusion_list, early_exit_lambda_c
 
     file_dir = os.path.dirname(file)
 
-    while not check_folder_against_exclusion_list(file_dir, path_exclusion_list):
+    while not check_folder_against_exclusion_list(file_dir, complete_exclusion_list):
         for file in os.listdir(file_dir):
             if target_rule.match(file):
                 return os.path.normpath(os.path.join(file_dir, file))


### PR DESCRIPTION
New Functionality
 * `ward index` outputs a `packages.md` file at the root of the repository. Location can be overrided via `-p` or `--package-output` arguments.

ToDo:
 - Respond to Feedback on individual `packages.md` per repo

@Azure/azure-sdk-eng 