### PR TITLE
Add Client type analyzers

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
@@ -23,7 +23,7 @@ namespace /*MM*/RandomNamespace
             var diagnostic = Assert.Single(diagnostics);
             Assert.Equal("AZC0001", diagnostic.Id);
             Assert.Equal("Namespace 'RandomNamespace' shouldn't contain public types. Use one of the following pre-approved namespace groups: " +
-                         "Azure.Analytics, Azure.Data, Azure.Iot, Azure.Media, Azure.Messaging, Azure.ML, Azure.Security, Azure.Storage", diagnostic.GetMessage());
+                         "Azure.ApplicationModel, Azure.Analytics, Azure.Data, Azure.Iot, Azure.Media, Azure.Messaging, Azure.ML, Azure.Security, Azure.Storage", diagnostic.GetMessage());
 
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
@@ -22,8 +22,8 @@ namespace /*MM*/RandomNamespace
             var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
             var diagnostic = Assert.Single(diagnostics);
             Assert.Equal("AZC0001", diagnostic.Id);
-            Assert.Equal("Namespace 'RandomNamespace' shouldn't contain public types. Use one of the following pre-approved namespace groups:" +
-                         " Azure.Diagnostics, Azure.Cognitive, Azure.Iot, Azure.Networking, Azure.Runtime, Azure.Security, Azure.Storage, Azure.ApplicationModel", diagnostic.GetMessage());
+            Assert.Equal("Namespace 'RandomNamespace' shouldn't contain public types. Use one of the following pre-approved namespace groups: " +
+                         "Azure.Analytics, Azure.Data, Azure.Iot, Azure.Media, Azure.Messaging, Azure.ML, Azure.Security, Azure.Storage", diagnostic.GetMessage());
 
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
@@ -1,0 +1,108 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC0002Tests
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientMethodsAnalyzer());
+
+        [Fact]
+        public async Task AZC0002ProducedForMethodsWithoutCancellationToken()
+        {
+            var testSource = TestSource.Read(@"
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public virtual Task /*MM0*/GetAsync()
+        {
+            return null;
+        }
+
+        public virtual void /*MM1*/Get()
+        {
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            Assert.Equal(2, diagnostics.Length);
+
+            Assert.Equal("AZC0002", diagnostics[0].Id);
+            Assert.Equal("AZC0002", diagnostics[1].Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
+        }
+
+        [Fact]
+        public async Task AZC0002ProducedForMethodsWithNonOptionalCancellationToken()
+        {
+            var testSource = TestSource.Read(@"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public virtual Task /*MM0*/GetAsync(CancellationToken cancellationToken)
+        {
+            return null;
+        }
+
+        public virtual void /*MM1*/Get(CancellationToken cancellationToken)
+        {
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            Assert.Equal(2, diagnostics.Length);
+
+            Assert.Equal("AZC0002", diagnostics[0].Id);
+            Assert.Equal("AZC0002", diagnostics[1].Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
+        }
+
+        [Fact]
+        public async Task AZC0003ProducedForMethodsWithWrongNameParameter()
+        {
+            var testSource = TestSource.Read(@"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public virtual Task /*MM0*/GetAsync(CancellationToken cancellation = default)
+        {
+            return null;
+        }
+
+        public virtual void /*MM1*/Get(CancellationToken cancellation = default)
+        {
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            Assert.Equal(2, diagnostics.Length);
+
+            Assert.Equal("AZC0002", diagnostics[0].Id);
+            Assert.Equal("AZC0002", diagnostics[1].Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0003Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0003Tests.cs
@@ -41,5 +41,32 @@ namespace RandomNamespace
             AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
             AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
         }
+
+        [Fact]
+        public async Task AZC0002SkippedForPrivateMethods()
+        {
+            var testSource = TestSource.Read(@"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        private Task GetAsync(CancellationToken cancellationToken = default)
+        {
+            return null;
+        }
+
+        private void Get(CancellationToken cancellationToken = default)
+        {
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            Assert.Empty(diagnostics);
+        }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0003Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0003Tests.cs
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC0003Tests
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientMethodsAnalyzer());
+
+        [Fact]
+        public async Task AZC0002ProducedForNonVirtualMethods()
+        {
+            var testSource = TestSource.Read(@"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public Task /*MM0*/GetAsync(CancellationToken cancellationToken = default)
+        {
+            return null;
+        }
+
+        public void /*MM1*/Get(CancellationToken cancellationToken = default)
+        {
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            Assert.Equal(2, diagnostics.Length);
+
+            Assert.Equal("AZC0003", diagnostics[0].Id);
+            Assert.Equal("AZC0003", diagnostics[1].Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0004Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0004Tests.cs
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC0004Tests
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientMethodsAnalyzer());
+
+        [Fact]
+        public async Task AZC0004ProducedForMethodsWithoutSyncAlternative()
+        {
+            var testSource = TestSource.Read(@"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public virtual Task /*MM0*/GetAsync(CancellationToken cancellationToken = default)
+        {
+            return null;
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0004", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0005Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0005Tests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC0005Tests
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientConstructorAnalyzer());
+
+        [Fact]
+        public async Task AZC0005ProducedForClientTypesWithoutProtectedCtor()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    public class SomeClientOptions { }
+
+    public class /*MM*/SomeClient
+    {
+        public SomeClient(string connectionString) {}
+        public SomeClient(string connectionString, SomeClientOptions options) {}
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0005", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0006Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0006Tests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC0006Tests
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientConstructorAnalyzer());
+
+        [Fact]
+        public async Task AZC0006ProducedForClientsWithoutOptionsCtor()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    public class SomeClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public /*MM*/SomeClient(SomeClientOptions options) {}
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0006", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+        }
+
+        [Fact]
+        public async Task AZC0006ProducedForClientsWithoutOptionsCtorWithArguments()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    public class SomeClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public /*MM*/SomeClient(string connectionString, SomeClientOptions options) {}
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0006", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0007Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0007Tests.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC0007Tests
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientConstructorAnalyzer());
+
+        [Fact]
+        public async Task AZC0007ProducedForClientsWithoutOptionsCtor()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public /*MM*/SomeClient() {}
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0007", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+        }
+
+        [Fact]
+        public async Task AZC0006ProducedForClientsWithoutOptionsCtorWithArguments()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public /*MM*/SomeClient(string connectionString) {}
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0007", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/DiagnosticAnalyzerRunner.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/DiagnosticAnalyzerRunner.cs
@@ -6,6 +6,7 @@ using System.Collections.Immutable;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Xunit;
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/DiagnosticProject.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/DiagnosticProject.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.Extensions.DependencyModel;
 using Microsoft.Extensions.DependencyModel.Resolution;
@@ -36,7 +37,8 @@ namespace Azure.ClientSdk.Analyzers.Tests
                     var projectId = ProjectId.CreateNewId(debugName: TestProjectName);
                     solution = new AdhocWorkspace()
                         .CurrentSolution
-                        .AddProject(projectId, TestProjectName, TestProjectName, LanguageNames.CSharp);
+                        .AddProject(projectId, TestProjectName, TestProjectName, LanguageNames.CSharp)
+                        .WithProjectParseOptions(projectId, new CSharpParseOptions(LanguageVersion.Latest));
 
                     foreach (var defaultCompileLibrary in DependencyContext.Load(testAssembly).CompileLibraries)
                     {

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAnalyzerBase.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAnalyzerBase.cs
@@ -1,0 +1,75 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.ClientSdk.Analyzers
+{
+    public abstract class ClientAnalyzerBase : DiagnosticAnalyzer
+    {
+        protected const string ClientSuffix = "Client";
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(
+                analysisContext => {
+                    analysisContext.RegisterSymbolAction(symbolAnalysisContext => {
+
+                        var typeSymbol = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
+                        if (typeSymbol.TypeKind != TypeKind.Class || !typeSymbol.Name.EndsWith(ClientSuffix) || typeSymbol.DeclaredAccessibility != Accessibility.Public)
+                        {
+                            return;
+                        }
+
+                        AnalyzeClientType(symbolAnalysisContext);
+                    }, SymbolKind.NamedType);
+                });
+        }
+
+        protected abstract void AnalyzeClientType(SymbolAnalysisContext context);
+
+
+        protected class ParameterEquivalenceComparer: IEqualityComparer<IParameterSymbol>
+        {
+            public static ParameterEquivalenceComparer Default { get; } = new ParameterEquivalenceComparer();
+
+            public bool Equals(IParameterSymbol x, IParameterSymbol y)
+            {
+                return x.Type.Equals(y.Type) && x.Name.Equals(y.Name);
+            }
+
+            public int GetHashCode(IParameterSymbol obj)
+            {
+                return obj.Type.GetHashCode() ^ obj.Name.GetHashCode();
+            }
+        }
+
+        protected IMethodSymbol FindMethod(IEnumerable<IMethodSymbol> methodSymbols, ImmutableArray<IParameterSymbol> parameters)
+        {
+            return methodSymbols.SingleOrDefault(symbol => parameters.SequenceEqual(symbol.Parameters, ParameterEquivalenceComparer.Default));
+        }
+
+        protected IMethodSymbol FindMethod(IEnumerable<IMethodSymbol> methodSymbols, ImmutableArray<IParameterSymbol> parameters, Func<IParameterSymbol, bool> lastParameter)
+        {
+
+            return methodSymbols.SingleOrDefault(symbol => {
+
+                if (!symbol.Parameters.Any())
+                {
+                    return false;
+                }
+
+                var allButLast = symbol.Parameters.RemoveAt(symbol.Parameters.Length - 1);
+
+                return allButLast.SequenceEqual(parameters, ParameterEquivalenceComparer.Default) && lastParameter(symbol.Parameters.Last());
+            });
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
@@ -12,14 +12,14 @@ namespace Azure.ClientSdk.Analyzers
     {
         internal static readonly string[] AllowedNamespacePrefix = new[]
         {
-            "Azure.Diagnostics",
-            "Azure.Cognitive",
+            "Azure.Analytics",
+            "Azure.Data",
             "Azure.Iot",
-            "Azure.Networking",
-            "Azure.Runtime",
+            "Azure.Media",
+            "Azure.Messaging",
+            "Azure.ML",
             "Azure.Security",
-            "Azure.Storage",
-            "Azure.ApplicationModel"
+            "Azure.Storage"
         };
 
         public ClientAssemblyNamespaceAnalyzer()

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
@@ -12,6 +12,7 @@ namespace Azure.ClientSdk.Analyzers
     {
         internal static readonly string[] AllowedNamespacePrefix = new[]
         {
+            "Azure.ApplicationModel",
             "Azure.Analytics",
             "Azure.Data",
             "Azure.Iot",

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientConstructorAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientConstructorAnalyzer.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.ClientSdk.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ClientConstructorAnalyzer : ClientAnalyzerBase
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(new[]
+        {
+            Descriptors.AZC0005,
+            Descriptors.AZC0006,
+            Descriptors.AZC0007
+        });
+
+        protected override void AnalyzeClientType(SymbolAnalysisContext context)
+        {
+            var typeSymbol = (INamedTypeSymbol)context.Symbol;
+            if (!typeSymbol.Constructors.Any(c => (c.DeclaredAccessibility == Accessibility.Protected || c.DeclaredAccessibility == Accessibility.Public) && c.Parameters.Length == 0))
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0005, typeSymbol.Locations.First()));
+            }
+
+            foreach (var constructor in typeSymbol.Constructors)
+            {
+                if (constructor.DeclaredAccessibility == Accessibility.Public)
+                {
+                    if (IsClientOptionsParameter(constructor.Parameters.LastOrDefault()))
+                    {
+                        var nonOptionsMethod = FindMethod(
+                            typeSymbol.Constructors, constructor.Parameters.RemoveAt(constructor.Parameters.Length - 1));
+
+                        if (nonOptionsMethod == null || nonOptionsMethod.DeclaredAccessibility != Accessibility.Public)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0006, constructor.Locations.First(), GetOptionsTypeName(typeSymbol)));
+                        }
+                    }
+                    else
+                    {
+                        var optionsMethod = FindMethod(
+                            typeSymbol.Constructors, constructor.Parameters, IsClientOptionsParameter);
+
+                        if (optionsMethod == null || optionsMethod.DeclaredAccessibility != Accessibility.Public)
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0007, constructor.Locations.First(), GetOptionsTypeName(typeSymbol)));
+                        }
+                    }
+                }
+            }
+        }
+
+        private bool IsClientOptionsParameter(IParameterSymbol symbol)
+        {
+            if (symbol == null)
+            {
+                return false;
+            }
+            var clientOptionsType = GetOptionsTypeName(symbol.ContainingType);
+            return symbol.Type.Name == clientOptionsType;
+        }
+
+        private static string GetOptionsTypeName(INamedTypeSymbol symbol)
+        {
+            return symbol.Name + "Options";
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Azure.ClientSdk.Analyzers
             var typeSymbol = (INamedTypeSymbol)context.Symbol;
             foreach (var member in typeSymbol.GetMembers())
             {
-                if (member is IMethodSymbol methodSymbol && methodSymbol.Name.EndsWith(AsyncSuffix))
+                if (member is IMethodSymbol methodSymbol && methodSymbol.Name.EndsWith(AsyncSuffix) && methodSymbol.DeclaredAccessibility == Accessibility.Public)
                 {
                     CheckClientMethod(context, methodSymbol);
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.ClientSdk.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class ClientMethodsAnalyzer : ClientAnalyzerBase
+    {
+        private const string AsyncSuffix = "Async";
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(new[]
+        {
+            Descriptors.AZC0002,
+            Descriptors.AZC0003,
+            Descriptors.AZC0004
+        });
+
+        protected override void AnalyzeClientType(SymbolAnalysisContext context)
+        {
+            var typeSymbol = (INamedTypeSymbol)context.Symbol;
+            foreach (var member in typeSymbol.GetMembers())
+            {
+                if (member is IMethodSymbol methodSymbol && methodSymbol.Name.EndsWith(AsyncSuffix))
+                {
+                    CheckClientMethod(context, methodSymbol);
+
+                    var syncMemberName = member.Name.Substring(0, member.Name.Length - AsyncSuffix.Length);
+
+                    var syncMember = FindMethod(typeSymbol.GetMembers(syncMemberName).OfType<IMethodSymbol>(), methodSymbol.Parameters);
+
+                    if (syncMember == null)
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0004, member.Locations.First()));
+                    }
+                    else
+                    {
+                        CheckClientMethod(context, syncMember);
+                    }
+                }
+            }
+        }
+
+        private static void CheckClientMethod(SymbolAnalysisContext context, IMethodSymbol member)
+        {
+            if (!member.IsVirtual)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0003, member.Locations.First()));
+            }
+
+            var lastArgument = member.Parameters.LastOrDefault();
+            if (lastArgument == null || lastArgument.Name != "cancellationToken" || lastArgument.Type.Name != "CancellationToken" || !lastArgument.HasExplicitDefaultValue)
+            {
+                context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0002, member.Locations.First()));
+            }
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -11,6 +11,30 @@ namespace Azure.ClientSdk.Analyzers
 
         public static DiagnosticDescriptor AZC0001 = new DiagnosticDescriptor(
             "AZC0001", AZC0001Title,
-            "Namespace '{0}' shouldn't contain public types. " + AZC0001Title, "Usage", DiagnosticSeverity.Error, true);
+            "Namespace '{0}' shouldn't contain public types. " + AZC0001Title, "Usage", DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0002 = new DiagnosticDescriptor(
+            "AZC0002", "Client method should have cancellationToken as the last optional parameter",
+            "Client method should have cancellationToken as the last optional parameter (both name and it being optional matters)", "Usage", DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0003 = new DiagnosticDescriptor(
+            "AZC0003", "Client methods should be virtual",
+            "Client methods should be virtual", "Usage", DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0004 = new DiagnosticDescriptor(
+            "AZC0004", "Async client method should have sync alternative with same arguments",
+            "Async client method should have sync alternative with same arguments", "Usage", DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0005 = new DiagnosticDescriptor(
+            "AZC0005", "Client type should have protected parameterless constructor",
+            "Client type should have protected parameterless constructor", "Usage", DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0006 = new DiagnosticDescriptor(
+            "AZC0006", "Client type should have public constructor with equivalent parameters taking client options",
+            "Client type should have public constructor with equivalent parameters taking '{0}' as last argument", "Usage", DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0007 = new DiagnosticDescriptor(
+            "AZC0007", "Client type should have public constructor with equivalent parameters not taking client options",
+            "Client type should have public constructor with equivalent parameters not taking '{0}' as last argument", "Usage", DiagnosticSeverity.Warning, true);
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-tools/issues/37

Add analyzers for client type methods and constructors.

You can see the list in `Descriptors.cs` diff.