### PR TITLE
Set/update folder name based on prefix.

### DIFF
--- a/tools/pipeline-generator/PipelineGenerator/PipelineConvention.cs
+++ b/tools/pipeline-generator/PipelineGenerator/PipelineConvention.cs
@@ -160,6 +160,7 @@ namespace PipelineGenerator
 
             var projectReference = await Context.GetProjectReferenceAsync(cancellationToken);
             var agentPoolQueue = await Context.GetAgentPoolQueue(cancellationToken);
+            var normalizedRelativeYamlPath = component.RelativeYamlPath.Replace("\\", "/");
 
             var definition = new BuildDefinition()
             {
@@ -168,7 +169,7 @@ namespace PipelineGenerator
                 Repository = buildRepository,
                 Process = new YamlProcess()
                 {
-                    YamlFilename = component.RelativeYamlPath
+                    YamlFilename = normalizedRelativeYamlPath
                 },
                 Queue = agentPoolQueue
             };

--- a/tools/pipeline-generator/PipelineGenerator/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/PipelineGenerator/PullRequestValidationPipelineConvention.cs
@@ -28,6 +28,12 @@ namespace PipelineGenerator
 
             var hasChanges = false;
 
+            if (definition.Path != $"\\{this.Context.Prefix}")
+            {
+                definition.Path = $"\\{this.Context.Prefix}";
+                hasChanges = true;
+            }
+
             var ciTrigger = definition.Triggers.OfType<ContinuousIntegrationTrigger>().SingleOrDefault();
 
             if (ciTrigger == null)


### PR DESCRIPTION
This change makes it so that when the pipeline generator tool runs it automatically sets/updates the folder on the definition. Also fixed up a bug where the slashes on the YAML path were around the wrong way. It worked, but would cause a few UI glitches in Azure DevOps when you went to edit a pipeline.