### PR TITLE
Set up JS pipelines

### DIFF
--- a/.azure-pipelines/js.yml
+++ b/.azure-pipelines/js.yml
@@ -84,47 +84,8 @@ jobs:
 
   - job: "Test"
 
-    strategy:
-      matrix:
-        Linux_Node8:
-          OSName: "Linux"
-          OSVmImage: "ubuntu-16.04"
-          NodeVersion: "8.x"
-        Linux_Node10:
-          OSName: "Linux"
-          OSVmImage: "ubuntu-16.04"
-          NodeVersion: "10.x"
-        Linux_Node12:
-          OSName: "Linux"
-          OSVmImage: "ubuntu-16.04"
-          NodeVersion: "12.x"
-        macOS_Node8:
-          OSName: "macOS"
-          OSVmImage: "macOS-10.13"
-          NodeVersion: "8.x"
-        macOS_Node10:
-          OSName: "macOS"
-          OSVmImage: "macOS-10.13"
-          NodeVersion: "10.x"
-        macOS_Node12:
-          OSName: "macOS"
-          OSVmImage: "macOS-10.13"
-          NodeVersion: "12.x"
-        Windows_Node8:
-          OSName: "Windows"
-          OSVmImage: "vs2017-win2016"
-          NodeVersion: "8.x"
-        Windows_Node10:
-          OSName: "Windows"
-          OSVmImage: "vs2017-win2016"
-          NodeVersion: "10.x"
-        Windows_Node12:
-          OSName: "Windows"
-          OSVmImage: "vs2017-win2016"
-          NodeVersion: "12.x"
-
     pool:
-      vmImage: "$(OSVmImage)"
+      vmImage: "ubuntu-16.04"
 
     steps:
       - task: NodeTool@0

--- a/.azure-pipelines/js.yml
+++ b/.azure-pipelines/js.yml
@@ -1,9 +1,3 @@
-# External variables:
-# rushFlags
-#   Flags to pass to Rush for bulk commands. Typically, this is used to limit commands to a subset of packages, or to enable verbose output.
-#   Defined in pipeline web ui because multiple pipelines use this YAML with different packages.
-#   Example: -t @azure/event-hubs --verbose
-#
 trigger:
   - master
 
@@ -24,24 +18,28 @@ jobs:
         displayName: "Install Node.js $(NodeVersion)"
 
       - script: |
+          cd src/ts/eslint-plugin-azure-sdk
+        displayName: "Reach directory"
+
+      - script: |
           npm install -g npm@6.9.0
         displayName: "Install npm version 6.9.0"
 
       - script: |
-          node common/scripts/install-run-rush.js install
+          npm install
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js build $(rushFlags)
-        displayName: "Build libraries"
+          npm run build
+        displayName: "Build library"
 
       - script: |
-          node common/scripts/install-run-rush.js pack $(rushFlags)
+          npm pack
         displayName: "Pack libraries"
 
       - task: CopyFiles@2
         inputs:
-          contents: "src/ts/*.tgz"
+          contents: "src/ts/eslint-plugin-azure-sdk/*.tgz"
           targetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
         displayName: "Copy packages"
@@ -64,36 +62,25 @@ jobs:
         displayName: "Install Node.js $(NodeVersion)"
 
       - script: |
-          node common/scripts/install-run-rush.js install
+          cd src/ts/eslint-plugin-azure-sdk
+        displayName: "Reach directory"
+
+      - script: |
+          npm install -g npm@6.9.0
+        displayName: "Install npm version 6.9.0"
+
+      - script: |
+          npm install
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js lint $(rushFlags)
+          npm run lint
         displayName: "Run lint"
 
-      - task: CopyFiles@2
-        inputs:
-          contents: "sdk/**/**/*lintReport.html"
-          targetFolder: $(Build.ArtifactStagingDirectory)
-          flattenFolders: true
-        displayName: "Copy packages"
-
-      - task: PublishBuildArtifacts@1
-        condition: succeededOrFailed()
-        displayName: "Publish lint reports"
-        inputs:
-          artifactName: reports
-
       - script: |
-          node common/scripts/install-run-rush.js audit $(rushFlags)
+          npm audit
         condition: and(succeeded(), eq(variables['RunNpmAudit'], 'true'))
         displayName: "Audit packages"
-
-      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
-        # ComponentGovernance is currently unable to run on pull requests of public projects. Running on non-PR
-        # builds should be sufficient.
-        condition: and(succeededOrFailed(), ne(variables['Build.Reason'], 'PullRequest'))
-        displayName: "Component Detection"
 
   - job: "Test"
 
@@ -146,16 +133,17 @@ jobs:
         displayName: "Install Node.js $(NodeVersion)"
 
       - script: |
-          node common/scripts/install-run-rush.js install
+          cd src/ts/eslint-plugin-azure-sdk
+        displayName: "Reach directory"
+
+      - script: |
+          npm install -g npm@6.9.0
+        displayName: "Install npm version 6.9.0"
+
+      - script: |
+          npm install
         displayName: "Install dependencies"
 
       - script: |
-          node common/scripts/install-run-rush.js test $(rushFlags)
-        displayName: 'Test libraries"'
-
-      - task: PublishTestResults@2
-        inputs:
-          testResultsFiles: "**/test-results.xml"
-          testRunTitle: "$(OSName) Node $(NodeVersion)"
-        condition: succeededOrFailed()
-        displayName: "Publish test results"
+          npm test
+        displayName: "Test library"

--- a/.azure-pipelines/js.yml
+++ b/.azure-pipelines/js.yml
@@ -1,0 +1,161 @@
+# External variables:
+# rushFlags
+#   Flags to pass to Rush for bulk commands. Typically, this is used to limit commands to a subset of packages, or to enable verbose output.
+#   Defined in pipeline web ui because multiple pipelines use this YAML with different packages.
+#   Example: -t @azure/event-hubs --verbose
+#
+trigger:
+  - master
+
+variables:
+  NodeVersion: "10.x"
+  skipComponentGovernanceDetection: true
+
+jobs:
+  - job: "Build"
+
+    pool:
+      vmImage: "ubuntu-16.04"
+
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: "$(NodeVersion)"
+        displayName: "Install Node.js $(NodeVersion)"
+
+      - script: |
+          npm install -g npm@6.9.0
+        displayName: "Install npm version 6.9.0"
+
+      - script: |
+          node common/scripts/install-run-rush.js install
+        displayName: "Install dependencies"
+
+      - script: |
+          node common/scripts/install-run-rush.js build $(rushFlags)
+        displayName: "Build libraries"
+
+      - script: |
+          node common/scripts/install-run-rush.js pack $(rushFlags)
+        displayName: "Pack libraries"
+
+      - task: CopyFiles@2
+        inputs:
+          contents: "src/ts/*.tgz"
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: true
+        displayName: "Copy packages"
+
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: "Publish artifacts"
+        inputs:
+          artifactName: packages
+
+  - job: "Analyze"
+
+    pool:
+      vmImage: "ubuntu-16.04"
+
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: "$(NodeVersion)"
+        displayName: "Install Node.js $(NodeVersion)"
+
+      - script: |
+          node common/scripts/install-run-rush.js install
+        displayName: "Install dependencies"
+
+      - script: |
+          node common/scripts/install-run-rush.js lint $(rushFlags)
+        displayName: "Run lint"
+
+      - task: CopyFiles@2
+        inputs:
+          contents: "sdk/**/**/*lintReport.html"
+          targetFolder: $(Build.ArtifactStagingDirectory)
+          flattenFolders: true
+        displayName: "Copy packages"
+
+      - task: PublishBuildArtifacts@1
+        condition: succeededOrFailed()
+        displayName: "Publish lint reports"
+        inputs:
+          artifactName: reports
+
+      - script: |
+          node common/scripts/install-run-rush.js audit $(rushFlags)
+        condition: and(succeeded(), eq(variables['RunNpmAudit'], 'true'))
+        displayName: "Audit packages"
+
+      - task: ms.vss-governance-buildtask.governance-build-task-component-detection.ComponentGovernanceComponentDetection@0
+        # ComponentGovernance is currently unable to run on pull requests of public projects. Running on non-PR
+        # builds should be sufficient.
+        condition: and(succeededOrFailed(), ne(variables['Build.Reason'], 'PullRequest'))
+        displayName: "Component Detection"
+
+  - job: "Test"
+
+    strategy:
+      matrix:
+        Linux_Node8:
+          OSName: "Linux"
+          OSVmImage: "ubuntu-16.04"
+          NodeVersion: "8.x"
+        Linux_Node10:
+          OSName: "Linux"
+          OSVmImage: "ubuntu-16.04"
+          NodeVersion: "10.x"
+        Linux_Node12:
+          OSName: "Linux"
+          OSVmImage: "ubuntu-16.04"
+          NodeVersion: "12.x"
+        macOS_Node8:
+          OSName: "macOS"
+          OSVmImage: "macOS-10.13"
+          NodeVersion: "8.x"
+        macOS_Node10:
+          OSName: "macOS"
+          OSVmImage: "macOS-10.13"
+          NodeVersion: "10.x"
+        macOS_Node12:
+          OSName: "macOS"
+          OSVmImage: "macOS-10.13"
+          NodeVersion: "12.x"
+        Windows_Node8:
+          OSName: "Windows"
+          OSVmImage: "vs2017-win2016"
+          NodeVersion: "8.x"
+        Windows_Node10:
+          OSName: "Windows"
+          OSVmImage: "vs2017-win2016"
+          NodeVersion: "10.x"
+        Windows_Node12:
+          OSName: "Windows"
+          OSVmImage: "vs2017-win2016"
+          NodeVersion: "12.x"
+
+    pool:
+      vmImage: "$(OSVmImage)"
+
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: "$(NodeVersion)"
+        displayName: "Install Node.js $(NodeVersion)"
+
+      - script: |
+          node common/scripts/install-run-rush.js install
+        displayName: "Install dependencies"
+
+      - script: |
+          node common/scripts/install-run-rush.js test $(rushFlags)
+        displayName: 'Test libraries"'
+
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFiles: "**/test-results.xml"
+          testRunTitle: "$(OSName) Node $(NodeVersion)"
+        condition: succeededOrFailed()
+        displayName: "Publish test results"

--- a/tools/eslint-plugin-azure-sdk/ci.yml
+++ b/tools/eslint-plugin-azure-sdk/ci.yml
@@ -18,7 +18,7 @@ jobs:
         displayName: "Install Node.js $(NodeVersion)"
 
       - script: |
-          cd src/ts/eslint-plugin-azure-sdk
+          cd tools/eslint-plugin-azure-sdk
         displayName: "Reach directory"
 
       - script: |
@@ -39,7 +39,7 @@ jobs:
 
       - task: CopyFiles@2
         inputs:
-          contents: "src/ts/eslint-plugin-azure-sdk/*.tgz"
+          contents: "tools/eslint-plugin-azure-sdk/*.tgz"
           targetFolder: $(Build.ArtifactStagingDirectory)
           flattenFolders: true
         displayName: "Copy packages"
@@ -62,7 +62,7 @@ jobs:
         displayName: "Install Node.js $(NodeVersion)"
 
       - script: |
-          cd src/ts/eslint-plugin-azure-sdk
+          cd tools/eslint-plugin-azure-sdk
         displayName: "Reach directory"
 
       - script: |
@@ -94,7 +94,7 @@ jobs:
         displayName: "Install Node.js $(NodeVersion)"
 
       - script: |
-          cd src/ts/eslint-plugin-azure-sdk
+          cd tools/eslint-plugin-azure-sdk
         displayName: "Reach directory"
 
       - script: |


### PR DESCRIPTION
Related to #54 - attempt at creating pipeline needed for #53.

To be honest, I have no idea if I'm doing this right but I want to have the following functionality:

- Build - `npm run build` and `npm pack`
- Analyze - `npm run lint` and `npm audit`
- Test - `npm test`

The project defined in #53 will reside in `src/ts/eslint-plugin-azure-sdk`, which I access by `cd`ing in through a script block, but I'm not sure if this is the correct way to do it or how to make it modular to other projects in `src/ts`.

@Azure/azure-sdk-eng 