### PR TITLE
add notification-configuration tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -454,3 +454,6 @@ tools/LocalNugetFeed/Microsoft.Internal.NetSdkBuild.Mgmt.Tools.*.nupkg
 restoredPackages/
 src/dotnet/Mgmt.CI.BuildTools/NugetToolsPackage/CI.Tools.Package/build/tasks/net461/
 src/dotnet/Mgmt.CI.BuildTools/NugetToolsPackage/CI.Tools.Package/build/tasks/netstandard2.0
+
+# Visual Studio launch settings (frequently user-specific)
+launchSettings.json

--- a/tools/notification-configuration/.gitignore
+++ b/tools/notification-configuration/.gitignore
@@ -1,0 +1,1 @@
+launchSettings.json

--- a/tools/notification-configuration/.gitignore
+++ b/tools/notification-configuration/.gitignore
@@ -1,1 +1,0 @@
-launchSettings.json

--- a/tools/notification-configuration/Enums/TeamPurpose.cs
+++ b/tools/notification-configuration/Enums/TeamPurpose.cs
@@ -1,0 +1,29 @@
+﻿namespace NotificationConfiguration.Enums
+{
+    /// <summary>
+    /// Purpose of a DevOps team
+    /// </summary>
+    public enum TeamPurpose
+    {
+        /// <summary>
+        /// A team assigned to receive notification for build failures. This
+        /// team can be manually managed.
+        /// </summary>
+        /// <remarks>
+        /// Explicitly set value because YAML serialization does not emit 
+        /// default values (i.e. 0)
+        /// </remarks>
+        ParentNotificationTeam = 1,
+
+        /// <summary>
+        /// A team that lives within a ParentNotificationTeam, its members are
+        /// synchronized from external data sources. Automation may overwrite
+        /// changes made to this group.
+        /// </summary>
+        /// <remarks>
+        /// Explicitly set value because YAML serialization does not emit 
+        /// default values (i.e. 0)
+        /// </remarks>
+        SynchronizedNotificationTeam = 2,
+    }
+}

--- a/tools/notification-configuration/Models/TeamMetadata.cs
+++ b/tools/notification-configuration/Models/TeamMetadata.cs
@@ -1,0 +1,23 @@
+﻿using NotificationConfiguration.Enums;
+
+namespace NotificationConfiguration.Models
+{
+    /// <summary>
+    /// Object describing a Team in DevOps
+    /// </summary>
+    /// <remarks>
+    /// This field is serialized into YAML and stored in the team description
+    /// </remarks>
+    public class TeamMetadata
+    {
+        /// <summary>
+        /// ID of associated alert pipeline
+        /// </summary>
+        public int PipelineId { get; set; }
+
+        /// <summary>
+        /// Team's purpose
+        /// </summary>
+        public TeamPurpose Purpose { get; set; }
+    }
+}

--- a/tools/notification-configuration/NotificationConfigurator.cs
+++ b/tools/notification-configuration/NotificationConfigurator.cs
@@ -1,0 +1,157 @@
+﻿using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.VisualStudio.Services.Notifications.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+using NotificationConfiguration.Enums;
+using NotificationConfiguration.Models;
+using NotificationConfiguration.Services;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace NotificationConfiguration
+{
+    class NotificationConfigurator
+    {
+        private readonly AzureDevOpsService service;
+        private readonly ILogger<NotificationConfigurator> logger;
+
+        public NotificationConfigurator(AzureDevOpsService service, ILogger<NotificationConfigurator> logger)
+        {
+            this.service = service;
+            this.logger = logger;
+        }
+
+        public async Task ConfigureNotifications(string projectName, string projectPath, bool persistChanges = true)
+        {
+            var pipelines = await service.GetScheduledPipelinesAsync(projectName, projectPath);
+            var teams = await service.GetTeamsAsync(projectName);
+
+            foreach (var pipeline in pipelines)
+            {
+                using (logger.BeginScope("Evaluate Pipeline Name = {0}, Path = {1}, Id = {2}", pipeline.Name, pipeline.Path, pipeline.Id))
+                {
+                    var parentTeam = await EnsureTeamExists(pipeline, "Notifications", TeamPurpose.ParentNotificationTeam, teams, persistChanges);
+                    var childTeam = await EnsureTeamExists(pipeline, "Sync Notifications", TeamPurpose.SynchronizedNotificationTeam, teams, persistChanges);
+
+                    if (!persistChanges && (parentTeam == default || childTeam == default))
+                    {
+                        // Skip team nesting and notification work if 
+                        logger.LogInformation("Skipping Teams and Notifications because parent or child team does not exist");
+                        continue;
+                    }
+
+                    await EnsureSynchronizedNotificationTeamIsChild(parentTeam, childTeam, persistChanges);
+                    await EnsureScheduledBuildFailSubscriptionExists(pipeline, parentTeam, persistChanges);
+                }
+            }
+        }
+
+        private async Task<WebApiTeam> EnsureTeamExists(
+            BuildDefinition pipeline,
+            string suffix,
+            TeamPurpose purpose,
+            IEnumerable<WebApiTeam> teams, 
+            bool persistChanges)
+        {
+            var result = teams.FirstOrDefault(
+                team =>
+                {
+                    // Swallowing exceptions because parse errors on
+                    // free form text fields which might be non-yaml text
+                    // are not exceptional
+                    var metadata = YamlHelper.Deserialize<TeamMetadata>(team.Description, swallowExceptions: true);
+                    return metadata?.PipelineId == pipeline.Id && metadata?.Purpose == purpose;
+                });
+
+            if (result == default)
+            {
+                logger.LogInformation("Team Not Found Suffix = {0}", suffix);
+                var teamMetadata = new TeamMetadata
+                {
+                    PipelineId = pipeline.Id,
+                    Purpose = TeamPurpose.ParentNotificationTeam,
+                };
+                var newTeam = new WebApiTeam
+                {
+                    Description = YamlHelper.Serialize(teamMetadata),
+                    Name = $"{pipeline.Name} -- {suffix}",
+                };
+
+                logger.LogInformation("Create Team for Pipeline PipelineId = {0} Purpose = {1}", pipeline.Id, purpose);
+                if (persistChanges)
+                {
+                    result = await service.CreateTeamForProjectAsync(pipeline.Project.Id.ToString(), newTeam);
+                }
+            }
+
+            return result;
+        }
+
+        private async Task EnsureSynchronizedNotificationTeamIsChild(WebApiTeam parent, WebApiTeam child, bool persistChanges)
+        {
+            var parentDescriptor = await service.GetDescriptorAsync(parent.Id);
+            var childDescriptor = await service.GetDescriptorAsync(child.Id);
+
+            var isInTeam = await service.CheckMembershipAsync(parentDescriptor, childDescriptor);
+
+            logger.LogInformation("Child In Parent ParentId = {0}, ChildId = {1}, IsInTeam = {2}", parent.Id, child.Id, isInTeam);
+
+            if (!isInTeam)
+            {
+                logger.LogInformation("Adding Child Team");
+
+                if (persistChanges)
+                {
+                    await service.AddTeamToTeamAsync(parentDescriptor, childDescriptor);
+                }
+            }
+        }
+
+        private async Task EnsureScheduledBuildFailSubscriptionExists(BuildDefinition pipeline, WebApiTeam team, bool persistChanges)
+        {
+            const string BuildFailureNotificationTag = "#AutomaticBuildFailureNotification";
+            var subscriptions = await service.GetSubscriptionsAsync(team.Id);
+
+            var hasSubscription = subscriptions.Any(sub => sub.Description.Contains(BuildFailureNotificationTag));
+
+            logger.LogInformation("Team Is Subscribed TeamId = {0} PipelineId = {1} HasSubscription = {2}", team.Id, pipeline.Id, hasSubscription);
+
+            if (!hasSubscription)
+            {
+                var filterModel = new ExpressionFilterModel
+                {
+                    Clauses = new ExpressionFilterClause[]
+                    {
+                        new ExpressionFilterClause { Index = 1, LogicalOperator = "", FieldName = "Status", Operator = "=", Value = "Failed" },
+                        new ExpressionFilterClause { Index = 2, LogicalOperator = "And", FieldName = "Definition name", Operator = "=", Value = $"\\{pipeline.Project.Name}\\{pipeline.Name}" },
+                        new ExpressionFilterClause { Index = 3, LogicalOperator = "And", FieldName = "Build reason", Operator = "=", Value = "Scheduled" }
+                    }
+                };
+                var filter = new ExpressionFilter("ms.vss-build.build-completed-event", filterModel);
+
+                var identity = new IdentityRef
+                {
+                    Id = team.Id.ToString(),
+                    Url = team.IdentityUrl
+                };
+
+                var newSubscription = new NotificationSubscriptionCreateParameters
+                {
+                    Channel = new UserSubscriptionChannel { UseCustomAddress = false },
+                    Description = $"A build fails {BuildFailureNotificationTag}",
+                    Filter = filter,
+                    Scope = new SubscriptionScope { Type = "none", Id = pipeline.Project.Id },
+                    Subscriber = identity,
+                };
+
+                logger.LogInformation("Creating Subscription PipelineId = {0}, TeamId = {1}", pipeline.Id, team.Id);
+                if (persistChanges)
+                {
+                    var subscription = await service.CreateSubscriptionAsync(newSubscription);
+                }
+            }
+        }
+    }
+}

--- a/tools/notification-configuration/Program.cs
+++ b/tools/notification-configuration/Program.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.WebApi;
+using NotificationConfiguration.Services;
+
+namespace NotificationConfiguration
+{
+    class Program
+    {
+        /// <summary>
+        /// Create notification groups for failures in scheduled builds
+        /// </summary>
+        /// <param name="organization">Azure DevOps Organization</param>
+        /// <param name="project">Name of the DevOps project</param>
+        /// <param name="pathPrefix">Path prefix to include pipelines (e.g. "\net")</param>
+        /// <param name="tokenVaraibleName">Environment variable token name (e.g. "SYSTEM_ACCESSTOKEN")</param>
+        /// <param name="dryRun">Prints changes but does not alter any objects</param>
+        /// <returns></returns>
+        static async Task Main(
+            string organization,
+            string project, 
+            string pathPrefix, 
+            string tokenVaraibleName, 
+            bool dryRun = false)
+        {
+            var devOpsToken = Environment.GetEnvironmentVariable(tokenVaraibleName);
+            var devOpsCreds = new VssBasicCredential("nobody", devOpsToken);
+            var devOpsConnection = new VssConnection(new Uri($"https://dev.azure.com/{organization}/"), devOpsCreds);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+            var loggerFactory = new LoggerFactory().AddConsole(includeScopes: true);
+#pragma warning restore CS0618 // Type or member is obsolete
+            var devOpsServiceLogger = loggerFactory.CreateLogger<AzureDevOpsService>();
+            var notificationConfiguratorLogger = loggerFactory.CreateLogger<NotificationConfigurator>();
+
+            var devOpsService = new AzureDevOpsService(devOpsConnection, devOpsServiceLogger);
+
+
+            var configurator = new NotificationConfigurator(devOpsService, notificationConfiguratorLogger);
+            await configurator.ConfigureNotifications(project, pathPrefix, !dryRun);
+        }
+    }
+}

--- a/tools/notification-configuration/Services/AzureDevOpsService.cs
+++ b/tools/notification-configuration/Services/AzureDevOpsService.cs
@@ -1,0 +1,181 @@
+
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.VisualStudio.Services.Graph.Client;
+using Microsoft.VisualStudio.Services.WebApi;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.Services.Notifications.WebApi.Clients;
+using Microsoft.VisualStudio.Services.Notifications.WebApi;
+using System;
+using Microsoft.Extensions.Logging;
+
+namespace NotificationConfiguration.Services
+{
+    /// <summary>
+    /// Provides access to DevOps entities
+    /// </summary>
+    public class AzureDevOpsService
+    {
+
+        private readonly VssConnection connection;
+        private readonly ILogger<AzureDevOpsService> logger;
+        private Dictionary<Type, VssHttpClientBase> clientCache = new Dictionary<Type, VssHttpClientBase>();
+
+        /// <summary>
+        /// Creates a new AzureDevOpsService
+        /// </summary>
+        /// <param name="connection">VssConnection to use</param>
+        /// <param name="logger">Logger</param>
+        public AzureDevOpsService(VssConnection connection, ILogger<AzureDevOpsService> logger)
+        {
+            this.connection = connection;
+            this.logger = logger;
+        }
+
+        private async Task<T> GetClientAsync<T>() 
+            where T : VssHttpClientBase
+        {
+            var type = typeof(T);
+            if (clientCache.ContainsKey(type))
+            {
+                return (T)clientCache[type];
+            }
+
+            var result = await connection.GetClientAsync<T>();
+            clientCache.Add(type, result);
+            return result;
+        }
+
+        /// <summary>
+        /// Returns build definitions that have at least one schedule trigger
+        /// </summary>
+        /// <param name="projectName">Name of the project</param>
+        /// <param name="pathPrefix">Prefix of the path in the build folder tree</param>
+        /// <returns>IEnumerable of build definitions that satisfy the given criteria</returns>
+        public async Task<IEnumerable<BuildDefinition>> GetScheduledPipelinesAsync(string projectName, string pathPrefix = null)
+        {
+            var client = await GetClientAsync<BuildHttpClient>();
+
+            logger.LogInformation("GetScheduledPipelinesAsync ProjectName = {0} PathPrefix = {1}", projectName, pathPrefix);
+            var definitions = await client.GetFullDefinitionsAsync2(project: projectName, path: pathPrefix);
+
+            var filteredDefinitions = definitions.Where(
+                def => def.Triggers.Any(
+                    trigger => trigger.TriggerType == DefinitionTriggerType.Schedule));
+
+            return filteredDefinitions;
+        }
+
+        /// <summary>
+        /// Returns teams in the given project
+        /// </summary>
+        /// <param name="projectName">Name of the project</param>
+        /// <returns>Teams that satisfy given criteria</returns>
+        public async Task<IEnumerable<WebApiTeam>> GetTeamsAsync(string projectName)
+        {
+            var client = await GetClientAsync<TeamHttpClient>();
+
+            logger.LogInformation("GetTeamsAsync ProjectName = {0}", projectName);
+            var teams = await client.GetTeamsAsync(projectName);
+
+            return teams;
+        }
+        
+        /// <summary>
+        /// Creates a team in the given project
+        /// </summary>
+        /// <param name="projectId">ID of project to associate with team</param>
+        /// <param name="team">Team to create</param>
+        /// <returns>Team with properties set from creation</returns>
+        public async Task<WebApiTeam> CreateTeamForProjectAsync(string projectId, WebApiTeam team)
+        {
+            var client = await GetClientAsync<TeamHttpClient>();
+
+            logger.LogInformation("CreateTeamForProjectAsync TeamName = {0} ProjectId = {1}", team.Name, projectId);
+            var result = await client.CreateTeamAsync(team, projectId);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Checks whether a child is a member of the parent enttiy
+        /// </summary>
+        /// <param name="parent">Parent descriptor</param>
+        /// <param name="child">Child descriptor</param>
+        /// <returns>True if the child is a member of the parent</returns>
+        public async Task<bool> CheckMembershipAsync(string parent, string child)
+        {
+            var client = await GetClientAsync<GraphHttpClient>();
+            
+            logger.LogInformation("CheckMembership ParentId = {0} ChildId = {1}", parent, child);
+            var result = await client.CheckMembershipExistenceAsync(child, parent);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the descriptor for an object
+        /// </summary>
+        /// <param name="id">GUID of the object</param>
+        /// <returns>A descriptor string suitable for use in some Graph queries</returns>
+        public async Task<string> GetDescriptorAsync(Guid id)
+        {
+            var client = await GetClientAsync<GraphHttpClient>();
+
+            logger.LogInformation("GetDescriptor Id = {0}", id);
+            var descriptor = await client.GetDescriptorAsync(id);
+            return descriptor.Value;
+        }
+
+        /// <summary>
+        /// Adds a child item to a parent item
+        /// </summary>
+        /// <param name="parent">Parent descriptor</param>
+        /// <param name="child">Child descriptor</param>
+        /// <returns>GraphMembership object resulting from adding the child to the parent</returns>
+        public async Task<GraphMembership> AddTeamToTeamAsync(string parent, string child)
+        {
+            var client = await GetClientAsync<GraphHttpClient>();
+
+            logger.LogInformation("AddTeamToTeamAsync ParentId = {0} ChildId = {1}", parent, child);
+            var result = await client.AddMembershipAsync(child, parent);
+            return result;
+        }
+
+        /// <summary>
+        /// Gets subscriptions for a given target GUID
+        /// </summary>
+        /// <remarks>
+        /// Some properties of the NotificationSubscription (like "Filter") are
+        /// not resolved in this API call. Expansion with a followup call may
+        /// be required
+        /// </remarks>
+        /// <param name="targetId">GUID of the subscription target</param>
+        /// <returns>Complete subscription objects</returns>
+        public async Task<IEnumerable<NotificationSubscription>> GetSubscriptionsAsync(Guid targetId)
+        {
+            var client = await GetClientAsync<NotificationHttpClient>();
+
+            logger.LogInformation("GetSubscriptionsAsync TargetId = {0}", targetId);
+            var result = await client.ListSubscriptionsAsync(targetId);
+
+            return result;
+        }
+
+        /// <summary>
+        /// Creates a subscription
+        /// </summary>
+        /// <param name="newSubscription">Subscription to create</param>
+        /// <returns>The newly created subscription</returns>
+        public async Task<NotificationSubscription> CreateSubscriptionAsync(NotificationSubscriptionCreateParameters newSubscription)
+        {
+            var client = await GetClientAsync<NotificationHttpClient>();
+
+            logger.LogInformation("CreateSubscriptionAsync Description = {0}", newSubscription.Description);
+            var result = await client.CreateSubscriptionAsync(newSubscription);
+            return result;
+        }
+    }
+}

--- a/tools/notification-configuration/YamlHelper.cs
+++ b/tools/notification-configuration/YamlHelper.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace NotificationConfiguration
+{
+    static class YamlHelper
+    {
+        private static ISerializer serializer = 
+            new SerializerBuilder().WithNamingConvention(new CamelCaseNamingConvention()).Build();
+
+        private static IDeserializer deserializer =
+            new DeserializerBuilder().WithNamingConvention(new CamelCaseNamingConvention()).Build();
+
+
+        public static T Deserialize<T>(string input, bool swallowExceptions = false)
+            where T : class
+        {
+            T result; 
+            try
+            {
+                result = deserializer.Deserialize<T>(input);
+            }
+            catch
+            {
+                if (!swallowExceptions)
+                {
+                    throw;
+                }
+
+                result = null;
+            }
+
+            return result;
+        }
+
+        public static string Serialize<T>(T input)
+        {
+            return serializer.Serialize(input);
+        }
+    }
+}

--- a/tools/notification-configuration/notification-configuration.csproj
+++ b/tools/notification-configuration/notification-configuration.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <RootNamespace>NotificationConfiguration</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0-preview" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.ExtendedClient" Version="16.153.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Notifications.WebApi" Version="16.153.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi" Version="16.153.0-preview" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19317.1" />
+    <PackageReference Include="YamlDotNet" Version="6.1.1" />
+  </ItemGroup>
+
+</Project>

--- a/tools/notification-configuration/notification-configuration.sln
+++ b/tools/notification-configuration/notification-configuration.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "notification-configuration", "notification-configuration.csproj", "{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Debug|x64.Build.0 = Debug|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Debug|x86.Build.0 = Debug|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Release|x64.ActiveCfg = Release|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Release|x64.Build.0 = Release|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Release|x86.ActiveCfg = Release|Any CPU
+		{9D316AD9-A6C3-46E9-A5C7-38F2AFC4174A}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
A command line tool that generates teams and subscribes them to scheduled build failures for pipelines that have scheduled builds.