### PR TITLE
Add documentation to each existing rule

### DIFF
--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -72,7 +72,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-strict](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md)
 - [ts-package-json-author](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md)
 - [ts-package-json-bugs](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md)
-- [ts-package-json-homepage](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-homepage)
+- [ts-package-json-homepage](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md)
 - [ts-package-json-keywords](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-keywords)
 - [ts-package-json-license](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-license)
 - [ts-package-json-name](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-name)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -67,7 +67,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-isolatedmodules](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md)
 - [ts-config-lib](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md)
 - [ts-config-module](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md)
-- [ts-config-no-experimentaldecorators](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-no-experimentaldecorators)
+- [ts-config-no-experimentaldecorators](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md)
 - [ts-config-sourcemap](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-sourcemap)
 - [ts-config-strict](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-strict)
 - [ts-package-json-author](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-author)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -71,7 +71,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-sourcemap](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md)
 - [ts-config-strict](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md)
 - [ts-package-json-author](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md)
-- [ts-package-json-bugs](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-bugs)
+- [ts-package-json-bugs](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md)
 - [ts-package-json-homepage](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-homepage)
 - [ts-package-json-keywords](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-keywords)
 - [ts-package-json-license](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-license)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -70,7 +70,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-no-experimentaldecorators](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md)
 - [ts-config-sourcemap](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md)
 - [ts-config-strict](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md)
-- [ts-package-json-author](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-author)
+- [ts-package-json-author](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md)
 - [ts-package-json-bugs](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-bugs)
 - [ts-package-json-homepage](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-homepage)
 - [ts-package-json-keywords](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-keywords)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -63,7 +63,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-esmoduleinterop](/docs/rules/ts-config-esmoduleinterop.md)
 - [ts-config-exclude](/docs/rules/ts-config-exclude.md)
 - [ts-config-forceconsistentcasinginfilenames](/docs/rules/ts-config-forceconsistentcasinginfilenames.md)
-- [ts-config-importhelpers](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-importhelpers)
+- [ts-config-importhelpers](/docs/rules/ts-config-importhelpers.md)
 - [ts-config-isolatedmodules](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-isolatedmodules)
 - [ts-config-lib](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-lib)
 - [ts-config-module](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-module)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -58,7 +58,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 
 ## Supported Rules
 
-- [ts-config-allowsyntheticdefaultimports](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-allowsyntheticdefaultimports)
+- [ts-config-allowsyntheticdefaultimports](/docs/rules/ts-config-allowsyntheticdefaultimports.md)
 - [ts-config-declaration](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-declaration)
 - [ts-config-esmoduleinterop](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-esmoduleinterop)
 - [ts-config-exclude](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-exclude)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -66,7 +66,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-importhelpers](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md)
 - [ts-config-isolatedmodules](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md)
 - [ts-config-lib](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md)
-- [ts-config-module](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-module)
+- [ts-config-module](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md)
 - [ts-config-no-experimentaldecorators](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-no-experimentaldecorators)
 - [ts-config-sourcemap](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-sourcemap)
 - [ts-config-strict](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-strict)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -78,4 +78,4 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-package-json-name](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md)
 - [ts-package-json-repo](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md)
 - [ts-package-json-required-scripts](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-required-scripts.md)
-- [ts-package-json-sideeffects](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-sideeffects)
+- [ts-package-json-sideeffects](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-sideeffects.md)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -75,7 +75,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-package-json-homepage](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md)
 - [ts-package-json-keywords](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md)
 - [ts-package-json-license](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md)
-- [ts-package-json-name](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-name)
+- [ts-package-json-name](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md)
 - [ts-package-json-repo](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-repo)
 - [ts-package-json-required-scripts](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-required-scripts)
 - [ts-package-json-sideeffects](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-sideeffects)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -77,5 +77,5 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-package-json-license](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md)
 - [ts-package-json-name](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md)
 - [ts-package-json-repo](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md)
-- [ts-package-json-required-scripts](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-required-scripts)
+- [ts-package-json-required-scripts](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-required-scripts.md)
 - [ts-package-json-sideeffects](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-sideeffects)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -61,7 +61,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-allowsyntheticdefaultimports](/docs/rules/ts-config-allowsyntheticdefaultimports.md)
 - [ts-config-declaration](/docs/rules/ts-config-declaration.md)
 - [ts-config-esmoduleinterop](/docs/rules/ts-config-esmoduleinterop.md)
-- [ts-config-exclude](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-exclude)
+- [ts-config-exclude](/docs/rules/ts-config-exclude.md)
 - [ts-config-forceconsistentcasinginfilenames](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-forceconsistentcasinginfilenames)
 - [ts-config-importhelpers](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-importhelpers)
 - [ts-config-isolatedmodules](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-isolatedmodules)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -62,7 +62,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-declaration](/docs/rules/ts-config-declaration.md)
 - [ts-config-esmoduleinterop](/docs/rules/ts-config-esmoduleinterop.md)
 - [ts-config-exclude](/docs/rules/ts-config-exclude.md)
-- [ts-config-forceconsistentcasinginfilenames](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-forceconsistentcasinginfilenames)
+- [ts-config-forceconsistentcasinginfilenames](/docs/rules/ts-config-forceconsistentcasinginfilenames.md)
 - [ts-config-importhelpers](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-importhelpers)
 - [ts-config-isolatedmodules](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-isolatedmodules)
 - [ts-config-lib](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-lib)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -69,7 +69,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-module](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md)
 - [ts-config-no-experimentaldecorators](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md)
 - [ts-config-sourcemap](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md)
-- [ts-config-strict](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-strict)
+- [ts-config-strict](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md)
 - [ts-package-json-author](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-author)
 - [ts-package-json-bugs](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-bugs)
 - [ts-package-json-homepage](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-homepage)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -73,7 +73,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-package-json-author](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md)
 - [ts-package-json-bugs](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md)
 - [ts-package-json-homepage](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md)
-- [ts-package-json-keywords](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-keywords)
+- [ts-package-json-keywords](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md)
 - [ts-package-json-license](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-license)
 - [ts-package-json-name](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-name)
 - [ts-package-json-repo](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-repo)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -60,7 +60,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 
 - [ts-config-allowsyntheticdefaultimports](/docs/rules/ts-config-allowsyntheticdefaultimports.md)
 - [ts-config-declaration](/docs/rules/ts-config-declaration.md)
-- [ts-config-esmoduleinterop](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-esmoduleinterop)
+- [ts-config-esmoduleinterop](/docs/rules/ts-config-esmoduleinterop.md)
 - [ts-config-exclude](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-exclude)
 - [ts-config-forceconsistentcasinginfilenames](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-forceconsistentcasinginfilenames)
 - [ts-config-importhelpers](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-importhelpers)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -64,7 +64,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-exclude](/docs/rules/ts-config-exclude.md)
 - [ts-config-forceconsistentcasinginfilenames](/docs/rules/ts-config-forceconsistentcasinginfilenames.md)
 - [ts-config-importhelpers](/docs/rules/ts-config-importhelpers.md)
-- [ts-config-isolatedmodules](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-isolatedmodules)
+- [ts-config-isolatedmodules](/docs/rules/ts-config-isolatedmodules.md)
 - [ts-config-lib](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-lib)
 - [ts-config-module](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-module)
 - [ts-config-no-experimentaldecorators](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-no-experimentaldecorators)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -74,7 +74,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-package-json-bugs](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md)
 - [ts-package-json-homepage](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md)
 - [ts-package-json-keywords](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md)
-- [ts-package-json-license](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-license)
+- [ts-package-json-license](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md)
 - [ts-package-json-name](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-name)
 - [ts-package-json-repo](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-repo)
 - [ts-package-json-required-scripts](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-required-scripts)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -58,14 +58,14 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 
 ## Supported Rules
 
-- [ts-config-allowsyntheticdefaultimports](/docs/rules/ts-config-allowsyntheticdefaultimports.md)
-- [ts-config-declaration](/docs/rules/ts-config-declaration.md)
-- [ts-config-esmoduleinterop](/docs/rules/ts-config-esmoduleinterop.md)
-- [ts-config-exclude](/docs/rules/ts-config-exclude.md)
-- [ts-config-forceconsistentcasinginfilenames](/docs/rules/ts-config-forceconsistentcasinginfilenames.md)
-- [ts-config-importhelpers](/docs/rules/ts-config-importhelpers.md)
-- [ts-config-isolatedmodules](/docs/rules/ts-config-isolatedmodules.md)
-- [ts-config-lib](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-lib)
+- [ts-config-allowsyntheticdefaultimports](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md)
+- [ts-config-declaration](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md)
+- [ts-config-esmoduleinterop](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md)
+- [ts-config-exclude](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md)
+- [ts-config-forceconsistentcasinginfilenames](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md)
+- [ts-config-importhelpers](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md)
+- [ts-config-isolatedmodules](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md)
+- [ts-config-lib](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md)
 - [ts-config-module](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-module)
 - [ts-config-no-experimentaldecorators](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-no-experimentaldecorators)
 - [ts-config-sourcemap](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-sourcemap)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -59,7 +59,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 ## Supported Rules
 
 - [ts-config-allowsyntheticdefaultimports](/docs/rules/ts-config-allowsyntheticdefaultimports.md)
-- [ts-config-declaration](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-declaration)
+- [ts-config-declaration](/docs/rules/ts-config-declaration.md)
 - [ts-config-esmoduleinterop](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-esmoduleinterop)
 - [ts-config-exclude](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-exclude)
 - [ts-config-forceconsistentcasinginfilenames](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-forceconsistentcasinginfilenames)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -76,6 +76,6 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-package-json-keywords](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md)
 - [ts-package-json-license](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md)
 - [ts-package-json-name](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md)
-- [ts-package-json-repo](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-repo)
+- [ts-package-json-repo](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md)
 - [ts-package-json-required-scripts](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-required-scripts)
 - [ts-package-json-sideeffects](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-sideeffects)

--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -68,7 +68,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 - [ts-config-lib](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md)
 - [ts-config-module](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md)
 - [ts-config-no-experimentaldecorators](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md)
-- [ts-config-sourcemap](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-sourcemap)
+- [ts-config-sourcemap](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md)
 - [ts-config-strict](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-strict)
 - [ts-package-json-author](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-author)
 - [ts-package-json-bugs](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-bugs)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
@@ -1,6 +1,6 @@
 # ts-config-allowsyntheticdefaultimports
 
-Requires `compilerOptions.allowSyntheticDefaultImports` in `tsconfig.json` to be set to true.
+Requires `compilerOptions.allowSyntheticDefaultImports` in `tsconfig.json` to be set to `true`.
 
 ## Examples
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
@@ -1,4 +1,4 @@
-# ts-config-allow-syntheticdefaultimports
+# ts-config-allowsyntheticdefaultimports
 
 Requires `compilerOptions.allowSyntheticDefaultImports` in `tsconfig.json` to be set to true.
 
@@ -29,3 +29,5 @@ Requires `compilerOptions.allowSyntheticDefaultImports` in `tsconfig.json` to be
     "compilerOptions": {}
 }
 ```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-allowsyntheticdefaultimports)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
@@ -30,4 +30,8 @@ Requires `compilerOptions.allowSyntheticDefaultImports` in `tsconfig.json` to be
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-allowsyntheticdefaultimports)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
@@ -1,0 +1,31 @@
+# ts-config-allow-syntheticdefaultimports
+
+Requires `compilerOptions.allowSyntheticDefaultImports` in `tsconfig.json` to be set to true.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": true
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "allowSyntheticDefaultImports": false
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md
@@ -1,0 +1,33 @@
+# ts-config-declaration
+
+Requires `compilerOptions.declaration` in `tsconfig.json` to be set to true.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "declaration": true
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "declaration": false
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-declaration)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md
@@ -30,4 +30,8 @@ Requires `compilerOptions.declaration` in `tsconfig.json` to be set to `true`.
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-declaration)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md
@@ -1,6 +1,6 @@
 # ts-config-declaration
 
-Requires `compilerOptions.declaration` in `tsconfig.json` to be set to true.
+Requires `compilerOptions.declaration` in `tsconfig.json` to be set to `true`.
 
 ## Examples
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md
@@ -30,4 +30,8 @@ Requires `compilerOptions.esModuleInterop` in `tsconfig.json` to be set to `true
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-esmoduleinterop)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md
@@ -1,0 +1,33 @@
+# ts-config-esmoduleinterop
+
+Requires `compilerOptions.esModuleInterop` in `tsconfig.json` to be set to true.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "esModuleInterop": true
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "esModuleInterop": false
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-esmoduleinterop)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md
@@ -1,6 +1,6 @@
 # ts-config-esmoduleinterop
 
-Requires `compilerOptions.esModuleInterop` in `tsconfig.json` to be set to true.
+Requires `compilerOptions.esModuleInterop` in `tsconfig.json` to be set to `true`.
 
 ## Examples
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
@@ -1,0 +1,33 @@
+# ts-config-exclude
+
+Requires `compilerOptions.exclude` in `tsconfig.json` to include `node_modules`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "exclude": ["node_modules"]
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "exclude": []]
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-exclude)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
@@ -27,7 +27,7 @@ Requires `compilerOptions.exclude` in `tsconfig.json` to include `node_modules`.
 ```json
 {
     "compilerOptions": {
-        "exclude": []]
+        "exclude": []
     }
 }
 ```

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
@@ -14,6 +14,14 @@ Requires `compilerOptions.exclude` in `tsconfig.json` to include `node_modules`.
 }
 ```
 
+```json
+{
+    "compilerOptions": {
+        "exclude": ["node_modules", "test"]
+    }
+}
+```
+
 ### Bad
 
 ```json

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
@@ -30,4 +30,8 @@ Requires `compilerOptions.exclude` in `tsconfig.json` to include `node_modules`.
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-exclude)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md
@@ -30,4 +30,8 @@ Requires `compilerOptions.forceConsistentCasingInFileNames` in `tsconfig.json` t
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-forceconsistentcasinginfilenames)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md
@@ -1,0 +1,33 @@
+# ts-config-forceconsistentcasinginfilenames
+
+Requires `compilerOptions.forceConsistentCasingInFileNames` in `tsconfig.json` to be set to true.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "forceConsistentCasingInFileNames": true
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "forceConsistentCasingInFileNames": false
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-forceconsistentcasinginfilenames)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md
@@ -1,6 +1,6 @@
 # ts-config-forceconsistentcasinginfilenames
 
-Requires `compilerOptions.forceConsistentCasingInFileNames` in `tsconfig.json` to be set to true.
+Requires `compilerOptions.forceConsistentCasingInFileNames` in `tsconfig.json` to be set to `true`.
 
 ## Examples
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md
@@ -1,6 +1,6 @@
 # ts-config-importhelpers
 
-Requires `compilerOptions.importHelpers` in `tsconfig.json` to be set to true.
+Requires `compilerOptions.importHelpers` in `tsconfig.json` to be set to `true`.
 
 ## Examples
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md
@@ -1,0 +1,33 @@
+# ts-config-importhelpers
+
+Requires `compilerOptions.importHelpers` in `tsconfig.json` to be set to true.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "importHelpers": true
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "importHelpers": false
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-importhelpers)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md
@@ -30,4 +30,8 @@ Requires `compilerOptions.importHelpers` in `tsconfig.json` to be set to `true`.
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-importhelpers)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md
@@ -1,0 +1,33 @@
+# ts-config-isolatedmodules
+
+Requires `compilerOptions.isolatedModules` in `tsconfig.json` to be set to true.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "isolatedModules": true
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "isolatedModules": false
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-isolatedmodules)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md
@@ -30,4 +30,8 @@ Requires `compilerOptions.isolatedModules` in `tsconfig.json` to be set to `true
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-isolatedmodules)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md
@@ -1,6 +1,6 @@
 # ts-config-isolatedmodules
 
-Requires `compilerOptions.isolatedModules` in `tsconfig.json` to be set to true.
+Requires `compilerOptions.isolatedModules` in `tsconfig.json` to be set to `true`.
 
 ## Examples
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md
@@ -27,7 +27,7 @@ Requires `compilerOptions.lib` in `tsconfig.json` to be set to an empty array.
 ```json
 {
     "compilerOptions": {
-        "lib": ["esnext", "dom]
+        "lib": ["esnext", "dom"]
     }
 }
 ```
@@ -36,6 +36,10 @@ Requires `compilerOptions.lib` in `tsconfig.json` to be set to an empty array.
 {
     "compilerOptions": {}
 }
+```
+
+```json
+{}
 ```
 
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-lib)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md
@@ -1,0 +1,41 @@
+# ts-config-lib
+
+Requires `compilerOptions.lib` in `tsconfig.json` to be set to an empty array.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "lib": []
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "lib": "exnext"
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {
+        "lib": ["esnext", "dom]
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-lib)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md
@@ -1,6 +1,6 @@
 # ts-config-module
 
-Requires `compilerOptions.module` in `tsconfig.json` to be set to es6.
+Requires `compilerOptions.module` in `tsconfig.json` to be set to `"es6"`.
 
 ## Examples
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md
@@ -30,4 +30,8 @@ Requires `compilerOptions.module` in `tsconfig.json` to be set to `"es6"`.
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-module)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md
@@ -1,0 +1,33 @@
+# ts-config-module
+
+Requires `compilerOptions.module` in `tsconfig.json` to be set to es6.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "module": "es6"
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "module": "es5"
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-module)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md
@@ -1,0 +1,33 @@
+# ts-config-no-experimentaldecorators
+
+Requires `compilerOptions.experimentalDecorators` in `tsconfig.json` to be set to `false`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "experimentalDecorators": false
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "experimentalDecorators": true
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-no-experimentaldecorators)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md
@@ -30,4 +30,8 @@ Requires `compilerOptions.experimentalDecorators` in `tsconfig.json` to be set t
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-no-experimentaldecorators)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md
@@ -39,4 +39,8 @@ Requires `compilerOptions.sourceMap` and `compilerOptions.declarationMap` in `ts
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-sourcemap)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md
@@ -1,0 +1,42 @@
+# ts-config-sourcmap
+
+Requires `compilerOptions.sourceMap` and `compilerOptions.declarationMap` in `tsconfig.json` to be set to `true`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "declarationMap": true,
+        "sourceMap": true
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "declarationMap": false,
+        "sourceMap": true
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {
+        "sourceMap": true
+    }
+}
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-sourcemap)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md
@@ -1,0 +1,33 @@
+# ts-config-strict
+
+Requires `compilerOptions.strict` in `tsconfig.json` to be set to `false`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "compilerOptions": {
+        "strict": false
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "compilerOptions": {
+        "strict": true
+    }
+}
+```
+
+```json
+{
+    "compilerOptions": {}
+}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-strict)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md
@@ -30,4 +30,8 @@ Requires `compilerOptions.strict` in `tsconfig.json` to be set to `false`.
 }
 ```
 
+```json
+{}
+```
+
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-strict)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md
@@ -1,0 +1,27 @@
+# ts-package-json-author
+
+Requires `author` in `package.json` to be set to `"Microsoft Corporation"`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "author": "Microsoft Corporation"
+}
+```
+
+### Bad
+
+```json
+{
+    "author": "Microsoft"
+}
+```
+
+```json
+{}}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-author)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md
@@ -21,7 +21,7 @@ Requires `author` in `package.json` to be set to `"Microsoft Corporation"`.
 ```
 
 ```json
-{}}
+{}
 ```
 
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-author)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md
@@ -1,0 +1,37 @@
+# ts-package-json-bugs
+
+Requires `bugs` in `package.json` to be set to `"https://github.com/Azure/azure-sdk-for-js/issues"`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "bugs": {
+        "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "bugs": {
+        "url": "https://github.com/Azure/azure-sdk-for-java/issues"
+    }
+}
+```
+
+```json
+{
+    "bugs": {}
+}
+```
+
+```json
+{}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-bugs)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md
@@ -1,0 +1,45 @@
+# ts-package-json-homepage
+
+Requires `homepage` in `package.json` to be set to the library's readme.
+
+## Examples
+
+### Good
+
+```json
+{
+    "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/README.md"
+}
+```
+
+```json
+{
+    "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus"
+}
+```
+
+### Bad
+
+```json
+{
+    "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/README.md"
+}
+```
+
+```json
+{
+    "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master"
+}
+```
+
+```json
+{
+    "homepage": "https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/servicebus/service-bus/README.md"
+}
+```
+
+```json
+{}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-homepage)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md
@@ -1,0 +1,39 @@
+# ts-package-json-keywords
+
+Requires `keywords` in `package.json` to include `"Azure"` and `"cloud"`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "keywords": ["Azure", "cloud"]
+}
+```
+
+```json
+{
+    "keywords": ["Azure", "cloud", "sdk"]
+}
+```
+
+### Bad
+
+```json
+{
+    "keywords": ["Azure"]
+}
+```
+
+```json
+{
+    "keywords": []
+}
+```
+
+```json
+{}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-keywords)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md
@@ -1,0 +1,27 @@
+# ts-package-json-license
+
+Requires `license` in `package.json` to be set to `"MIT"`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "license": "MIT"
+}
+```
+
+### Bad
+
+```json
+{
+    "license": "ISC"
+}
+```
+
+```json
+{}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-license)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md
@@ -1,0 +1,39 @@
+# ts-package-json-name
+
+Requires `name` in `package.json` to be set to `"@azure/<service-name>"`, with the service name in kebab-case.
+
+## Examples
+
+### Good
+
+```json
+{
+    "name": "@azure/service-bus"
+}
+```
+
+### Bad
+
+```json
+{
+    "name": "@microsoft/service-bus"
+}
+```
+
+```json
+{
+    "name": "service-bus"
+}
+```
+
+```json
+{
+    "name": "@azure/serviceBus"
+}
+```
+
+```json
+{}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-name)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md
@@ -1,0 +1,27 @@
+# ts-package-json-repo
+
+Requires `repository` in `package.json` to be set to `"github:Azure/azure-sdk-for-js"`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "repository": "github:Azure/azure-sdk-for-js"
+}
+```
+
+### Bad
+
+```json
+{
+    "repository": "github:Azure/azure-sdk-for-java"
+}
+```
+
+```json
+{}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-repo)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-required-scripts.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-required-scripts.md
@@ -1,0 +1,48 @@
+# ts-package-json-required-scripts
+
+Requires `scripts` in `package.json` to be contain `"build"` and `"test"`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "scripts": {
+        "build": "...",
+        "test": "..."
+    }
+}
+```
+
+```json
+{
+    "scripts": {
+        "build": "...",
+        "lint": "...",
+        "test": "..."
+    }
+}
+```
+
+### Bad
+
+```json
+{
+    "scripts": {
+        "build": "..."
+    }
+}
+```
+
+```json
+{
+    "scripts": {}
+}
+```
+
+```json
+{}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-required-scripts)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-sideeffects.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-sideeffects.md
@@ -1,0 +1,27 @@
+# ts-package-json-sideeffects
+
+Requires `sideEffects` in `package.json` to be set to `false`.
+
+## Examples
+
+### Good
+
+```json
+{
+    "sideEffects": false
+}
+```
+
+### Bad
+
+```json
+{
+    "sideEffects": true
+}
+```
+
+```json
+{}
+```
+
+## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-sideeffects)

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -23,7 +23,8 @@
   "homepage": "https://github.com/Azure/azure-sdk-tools/src/ts/eslint-plugin-azure-sdk",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Azure/azure-sdk-tools"
+    "url": "https://github.com/Azure/azure-sdk-tools.git",
+    "directory": "tools/eslint-plugin-azure-sdk"
   },
   "bugs": {
     "url": "https://github.com/Azure/azure-sdk-tools/issues"

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -30,7 +30,8 @@
   },
   "main": "dist/index.js",
   "files": [
-    "dist"
+    "dist",
+    "docs"
   ],
   "scripts": {
     "build": "npm run clean && npm run format && tsc -p tsconfig.build.json",

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-allowsyntheticdefaultimports.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-allowsyntheticdefaultimports.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-allowsyntheticdefaultimports"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-declaration.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-declaration.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-declaration"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-esmoduleinterop.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-esmoduleinterop.ts
@@ -22,7 +22,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-esmoduleinterop"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-exclude.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-exclude.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-exclude"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-forceconsistentcasinginfilenames.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-forceconsistentcasinginfilenames.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-forceconsistentcasinginfilenames"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-importhelpers.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-importhelpers.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-importhelpers"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-importhelpers.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-importhelpers.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-isolatedmodules.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-isolatedmodules.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-isolatedmodules.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-isolatedmodules.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-isolatedModules"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-lib.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-lib.ts
@@ -21,7 +21,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-lib"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-module.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-module.ts
@@ -21,7 +21,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-module"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-module.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-module.ts
@@ -21,7 +21,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-no-experimentaldecorators.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-no-experimentaldecorators.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-experimentaldecorators"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-no-experimentaldecorators.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-no-experimentaldecorators.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-sourcemap.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-sourcemap.ts
@@ -21,7 +21,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.m"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-sourcemap.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-sourcemap.ts
@@ -21,7 +21,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-sourcemap"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.m"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-strict.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-strict.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-config-strict"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-strict.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-strict.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-author.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-author.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-author"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-bugs.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-bugs.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-bugs"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-homepage.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-homepage.ts
@@ -21,7 +21,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-homepage"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md"
     },
     schema: [] // no options
   },
@@ -40,7 +40,7 @@ export = {
           "ExpressionStatement > ObjectExpression > Property[key.value='homepage']": (
             node: Property
           ): void => {
-            const regex = /^https:\/\/github.com\/Azure\/azure-sdk-for-js\/blob\/master\/sdk\/(([a-z]+-)*[a-z]+\/)+README\.md$/;
+            const regex = /^https:\/\/github.com\/Azure\/azure-sdk-for-js\/blob\/master\/sdk\/(([a-z]+-)*[a-z]+\/)+(README\.md)?$/;
 
             const nodeValue: Literal = node.value as Literal;
             const value: string = nodeValue.value as string;

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-keywords.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-keywords.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-author"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-license.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-license.ts
@@ -19,7 +19,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-license"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-name.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-name.ts
@@ -21,7 +21,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-name"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
@@ -20,7 +20,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-repo"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-required-scripts.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-required-scripts.ts
@@ -21,7 +21,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-required-scripts"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-required-scripts.md"
     },
     schema: [] // no options
   },

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sideeffects.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sideeffects.ts
@@ -19,7 +19,7 @@ export = {
       category: "Best Practices",
       recommended: true,
       url:
-        "https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#ts-package-json-sideeffects"
+        "https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-sideeffects.md"
     },
     schema: [] // no options
   },


### PR DESCRIPTION
Standard ESLint procedure is for rule files to exist in three places:

- `docs/rules/<rule-name>`: Definition
- `src/rules/<rule-name>`: Implementation
- `tests/rules/<rule-name>`: Testing

I only included the latter two since our definitions are also included in the [guidelines](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html), but some rules have functionality that's only a subset or a superset of what's described in the guidelines, or (later on) may not be in the guidelines at all.

Standard rule documentation structure will be an explanation with both good and bad examples. 