### PR TITLE
Moved to publish keyword.

### DIFF
--- a/tools/eslint-plugin-azure-sdk/ci.yml
+++ b/tools/eslint-plugin-azure-sdk/ci.yml
@@ -57,11 +57,9 @@ stages:
             condition: eq(variables['RunNpmAudit'], 'true')
             displayName: "Audit package"
 
-          - task: PublishPipelineArtifact@1
+          - publish: $(Build.ArtifactStagingDirectory)
+            artifact: packages
             condition: succeededOrFailed()
-            displayName: "Store package with run"
-            inputs:
-              artifactName: packages
 
   - stage: Release
     dependsOn: Build


### PR DESCRIPTION
This PR swaps from the explicit publish artifacts task to the publish keyword which is a bit easier and will automatically kept current. It also fixes up a path issue where I was uploading too much.