### PR TITLE
Rescope eslint-plugin-azure-sdk to @azure

### DIFF
--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -10,21 +10,21 @@ You'll first need to install [ESLint](http://eslint.org):
 npm i eslint --save-dev
 ```
 
-Next, install `@azuresdktools/eslint-plugin-azure-sdk`:
+Next, install `@azure/eslint-plugin-azure-sdk`:
 
 ```shell
-npm install @azuresdktools/eslint-plugin-azure-sdk --save-dev
+npm install @azure/eslint-plugin-azure-sdk --save-dev
 ```
 
-**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `@azuresdktools/eslint-plugin-azure-sdk` globally.
+**Note:** If you installed ESLint globally (using the `-g` flag) then you must also install `@azure/eslint-plugin-azure-sdk` globally.
 
 ## Usage
 
-Add `@azuresdktools/azure-sdk` to the `plugins` section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
+Add `@azure/azure-sdk` to the `plugins` section of your `.eslintrc` configuration file. You can omit the `eslint-plugin-` prefix:
 
 ```json
 {
-  "plugins": ["@azuresdktools/azure-sdk"]
+  "plugins": ["@azure/azure-sdk"]
 }
 ```
 
@@ -42,7 +42,7 @@ For all rules to be enforced according to the standards set by the Design Guidel
 
 ```json
 {
-  "extends": ["plugin:@azuresdktools/azure-sdk/recommended"]
+  "extends": ["plugin:@azure/azure-sdk/recommended"]
 }
 ```
 
@@ -51,7 +51,7 @@ If you need to modify or disable specific rules, you can do so in the `rules` se
 ```json
 {
   "rules": {
-    "@azuresdktools/azure-sdk/rule-name": "off"
+    "@azure/azure-sdk/rule-name": "off"
   }
 }
 ```

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
@@ -8,9 +8,9 @@ Requires `compilerOptions.allowSyntheticDefaultImports` in `tsconfig.json` to be
 
 ```json
 {
-    "compilerOptions": {
-        "allowSyntheticDefaultImports": true
-    }
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true
+  }
 }
 ```
 
@@ -18,15 +18,15 @@ Requires `compilerOptions.allowSyntheticDefaultImports` in `tsconfig.json` to be
 
 ```json
 {
-    "compilerOptions": {
-        "allowSyntheticDefaultImports": false
-    }
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": false
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md
@@ -8,9 +8,9 @@ Requires `compilerOptions.declaration` in `tsconfig.json` to be set to `true`.
 
 ```json
 {
-    "compilerOptions": {
-        "declaration": true
-    }
+  "compilerOptions": {
+    "declaration": true
+  }
 }
 ```
 
@@ -18,15 +18,15 @@ Requires `compilerOptions.declaration` in `tsconfig.json` to be set to `true`.
 
 ```json
 {
-    "compilerOptions": {
-        "declaration": false
-    }
+  "compilerOptions": {
+    "declaration": false
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md
@@ -8,9 +8,9 @@ Requires `compilerOptions.esModuleInterop` in `tsconfig.json` to be set to `true
 
 ```json
 {
-    "compilerOptions": {
-        "esModuleInterop": true
-    }
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
 }
 ```
 
@@ -18,15 +18,15 @@ Requires `compilerOptions.esModuleInterop` in `tsconfig.json` to be set to `true
 
 ```json
 {
-    "compilerOptions": {
-        "esModuleInterop": false
-    }
+  "compilerOptions": {
+    "esModuleInterop": false
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
@@ -8,17 +8,17 @@ Requires `compilerOptions.exclude` in `tsconfig.json` to include `node_modules`.
 
 ```json
 {
-    "compilerOptions": {
-        "exclude": ["node_modules"]
-    }
+  "compilerOptions": {
+    "exclude": ["node_modules"]
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {
-        "exclude": ["node_modules", "test"]
-    }
+  "compilerOptions": {
+    "exclude": ["node_modules", "test"]
+  }
 }
 ```
 
@@ -26,15 +26,15 @@ Requires `compilerOptions.exclude` in `tsconfig.json` to include `node_modules`.
 
 ```json
 {
-    "compilerOptions": {
-        "exclude": []
-    }
+  "compilerOptions": {
+    "exclude": []
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md
@@ -8,9 +8,9 @@ Requires `compilerOptions.forceConsistentCasingInFileNames` in `tsconfig.json` t
 
 ```json
 {
-    "compilerOptions": {
-        "forceConsistentCasingInFileNames": true
-    }
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": true
+  }
 }
 ```
 
@@ -18,15 +18,15 @@ Requires `compilerOptions.forceConsistentCasingInFileNames` in `tsconfig.json` t
 
 ```json
 {
-    "compilerOptions": {
-        "forceConsistentCasingInFileNames": false
-    }
+  "compilerOptions": {
+    "forceConsistentCasingInFileNames": false
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md
@@ -8,9 +8,9 @@ Requires `compilerOptions.importHelpers` in `tsconfig.json` to be set to `true`.
 
 ```json
 {
-    "compilerOptions": {
-        "importHelpers": true
-    }
+  "compilerOptions": {
+    "importHelpers": true
+  }
 }
 ```
 
@@ -18,15 +18,15 @@ Requires `compilerOptions.importHelpers` in `tsconfig.json` to be set to `true`.
 
 ```json
 {
-    "compilerOptions": {
-        "importHelpers": false
-    }
+  "compilerOptions": {
+    "importHelpers": false
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-isolatedmodules.md
@@ -8,9 +8,9 @@ Requires `compilerOptions.isolatedModules` in `tsconfig.json` to be set to `true
 
 ```json
 {
-    "compilerOptions": {
-        "isolatedModules": true
-    }
+  "compilerOptions": {
+    "isolatedModules": true
+  }
 }
 ```
 
@@ -18,15 +18,15 @@ Requires `compilerOptions.isolatedModules` in `tsconfig.json` to be set to `true
 
 ```json
 {
-    "compilerOptions": {
-        "isolatedModules": false
-    }
+  "compilerOptions": {
+    "isolatedModules": false
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md
@@ -8,9 +8,9 @@ Requires `compilerOptions.lib` in `tsconfig.json` to be set to an empty array.
 
 ```json
 {
-    "compilerOptions": {
-        "lib": []
-    }
+  "compilerOptions": {
+    "lib": []
+  }
 }
 ```
 
@@ -18,23 +18,23 @@ Requires `compilerOptions.lib` in `tsconfig.json` to be set to an empty array.
 
 ```json
 {
-    "compilerOptions": {
-        "lib": "exnext"
-    }
+  "compilerOptions": {
+    "lib": "exnext"
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {
-        "lib": ["esnext", "dom"]
-    }
+  "compilerOptions": {
+    "lib": ["esnext", "dom"]
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md
@@ -8,9 +8,9 @@ Requires `compilerOptions.module` in `tsconfig.json` to be set to `"es6"`.
 
 ```json
 {
-    "compilerOptions": {
-        "module": "es6"
-    }
+  "compilerOptions": {
+    "module": "es6"
+  }
 }
 ```
 
@@ -18,15 +18,15 @@ Requires `compilerOptions.module` in `tsconfig.json` to be set to `"es6"`.
 
 ```json
 {
-    "compilerOptions": {
-        "module": "es5"
-    }
+  "compilerOptions": {
+    "module": "es5"
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md
@@ -8,9 +8,9 @@ Requires `compilerOptions.experimentalDecorators` in `tsconfig.json` to be set t
 
 ```json
 {
-    "compilerOptions": {
-        "experimentalDecorators": false
-    }
+  "compilerOptions": {
+    "experimentalDecorators": false
+  }
 }
 ```
 
@@ -18,15 +18,15 @@ Requires `compilerOptions.experimentalDecorators` in `tsconfig.json` to be set t
 
 ```json
 {
-    "compilerOptions": {
-        "experimentalDecorators": true
-    }
+  "compilerOptions": {
+    "experimentalDecorators": true
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md
@@ -8,10 +8,10 @@ Requires `compilerOptions.sourceMap` and `compilerOptions.declarationMap` in `ts
 
 ```json
 {
-    "compilerOptions": {
-        "declarationMap": true,
-        "sourceMap": true
-    }
+  "compilerOptions": {
+    "declarationMap": true,
+    "sourceMap": true
+  }
 }
 ```
 
@@ -19,14 +19,14 @@ Requires `compilerOptions.sourceMap` and `compilerOptions.declarationMap` in `ts
 
 ```json
 {
-    "compilerOptions": {
-        "declarationMap": false,
-        "sourceMap": true
-    }
+  "compilerOptions": {
+    "declarationMap": false,
+    "sourceMap": true
+  }
 }
 ```
 
-```json
+````json
 {
     "compilerOptions": {
         "sourceMap": true
@@ -37,7 +37,7 @@ Requires `compilerOptions.sourceMap` and `compilerOptions.declarationMap` in `ts
 {
     "compilerOptions": {}
 }
-```
+````
 
 ```json
 {}

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md
@@ -8,9 +8,9 @@ Requires `compilerOptions.strict` in `tsconfig.json` to be set to `false`.
 
 ```json
 {
-    "compilerOptions": {
-        "strict": false
-    }
+  "compilerOptions": {
+    "strict": false
+  }
 }
 ```
 
@@ -18,15 +18,15 @@ Requires `compilerOptions.strict` in `tsconfig.json` to be set to `false`.
 
 ```json
 {
-    "compilerOptions": {
-        "strict": true
-    }
+  "compilerOptions": {
+    "strict": true
+  }
 }
 ```
 
 ```json
 {
-    "compilerOptions": {}
+  "compilerOptions": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md
@@ -8,7 +8,7 @@ Requires `author` in `package.json` to be set to `"Microsoft Corporation"`.
 
 ```json
 {
-    "author": "Microsoft Corporation"
+  "author": "Microsoft Corporation"
 }
 ```
 
@@ -16,7 +16,7 @@ Requires `author` in `package.json` to be set to `"Microsoft Corporation"`.
 
 ```json
 {
-    "author": "Microsoft"
+  "author": "Microsoft"
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md
@@ -8,9 +8,9 @@ Requires `bugs` in `package.json` to be set to `"https://github.com/Azure/azure-
 
 ```json
 {
-    "bugs": {
-        "url": "https://github.com/Azure/azure-sdk-for-js/issues"
-    }
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-js/issues"
+  }
 }
 ```
 
@@ -18,15 +18,15 @@ Requires `bugs` in `package.json` to be set to `"https://github.com/Azure/azure-
 
 ```json
 {
-    "bugs": {
-        "url": "https://github.com/Azure/azure-sdk-for-java/issues"
-    }
+  "bugs": {
+    "url": "https://github.com/Azure/azure-sdk-for-java/issues"
+  }
 }
 ```
 
 ```json
 {
-    "bugs": {}
+  "bugs": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md
@@ -8,13 +8,13 @@ Requires `homepage` in `package.json` to be set to the library's readme.
 
 ```json
 {
-    "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/README.md"
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus/README.md"
 }
 ```
 
 ```json
 {
-    "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus"
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/sdk/servicebus/service-bus"
 }
 ```
 
@@ -22,19 +22,19 @@ Requires `homepage` in `package.json` to be set to the library's readme.
 
 ```json
 {
-    "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/README.md"
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master/README.md"
 }
 ```
 
 ```json
 {
-    "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master"
+  "homepage": "https://github.com/Azure/azure-sdk-for-js/blob/master"
 }
 ```
 
 ```json
 {
-    "homepage": "https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/servicebus/service-bus/README.md"
+  "homepage": "https://github.com/Azure/azure-sdk-for-java/blob/master/sdk/servicebus/service-bus/README.md"
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md
@@ -8,13 +8,13 @@ Requires `keywords` in `package.json` to include `"Azure"` and `"cloud"`.
 
 ```json
 {
-    "keywords": ["Azure", "cloud"]
+  "keywords": ["Azure", "cloud"]
 }
 ```
 
 ```json
 {
-    "keywords": ["Azure", "cloud", "sdk"]
+  "keywords": ["Azure", "cloud", "sdk"]
 }
 ```
 
@@ -22,13 +22,13 @@ Requires `keywords` in `package.json` to include `"Azure"` and `"cloud"`.
 
 ```json
 {
-    "keywords": ["Azure"]
+  "keywords": ["Azure"]
 }
 ```
 
 ```json
 {
-    "keywords": []
+  "keywords": []
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md
@@ -8,7 +8,7 @@ Requires `license` in `package.json` to be set to `"MIT"`.
 
 ```json
 {
-    "license": "MIT"
+  "license": "MIT"
 }
 ```
 
@@ -16,7 +16,7 @@ Requires `license` in `package.json` to be set to `"MIT"`.
 
 ```json
 {
-    "license": "ISC"
+  "license": "ISC"
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md
@@ -8,7 +8,7 @@ Requires `name` in `package.json` to be set to `"@azure/<service-name>"`, with t
 
 ```json
 {
-    "name": "@azure/service-bus"
+  "name": "@azure/service-bus"
 }
 ```
 
@@ -16,19 +16,19 @@ Requires `name` in `package.json` to be set to `"@azure/<service-name>"`, with t
 
 ```json
 {
-    "name": "@microsoft/service-bus"
+  "name": "@microsoft/service-bus"
 }
 ```
 
 ```json
 {
-    "name": "service-bus"
+  "name": "service-bus"
 }
 ```
 
 ```json
 {
-    "name": "@azure/serviceBus"
+  "name": "@azure/serviceBus"
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md
@@ -8,7 +8,7 @@ Requires `repository` in `package.json` to be set to `"github:Azure/azure-sdk-fo
 
 ```json
 {
-    "repository": "github:Azure/azure-sdk-for-js"
+  "repository": "github:Azure/azure-sdk-for-js"
 }
 ```
 
@@ -16,7 +16,7 @@ Requires `repository` in `package.json` to be set to `"github:Azure/azure-sdk-fo
 
 ```json
 {
-    "repository": "github:Azure/azure-sdk-for-java"
+  "repository": "github:Azure/azure-sdk-for-java"
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-required-scripts.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-required-scripts.md
@@ -8,20 +8,20 @@ Requires `scripts` in `package.json` to be contain `"build"` and `"test"`.
 
 ```json
 {
-    "scripts": {
-        "build": "...",
-        "test": "..."
-    }
+  "scripts": {
+    "build": "...",
+    "test": "..."
+  }
 }
 ```
 
 ```json
 {
-    "scripts": {
-        "build": "...",
-        "lint": "...",
-        "test": "..."
-    }
+  "scripts": {
+    "build": "...",
+    "lint": "...",
+    "test": "..."
+  }
 }
 ```
 
@@ -29,15 +29,15 @@ Requires `scripts` in `package.json` to be contain `"build"` and `"test"`.
 
 ```json
 {
-    "scripts": {
-        "build": "..."
-    }
+  "scripts": {
+    "build": "..."
+  }
 }
 ```
 
 ```json
 {
-    "scripts": {}
+  "scripts": {}
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-sideeffects.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-sideeffects.md
@@ -8,7 +8,7 @@ Requires `sideEffects` in `package.json` to be set to `false`.
 
 ```json
 {
-    "sideEffects": false
+  "sideEffects": false
 }
 ```
 
@@ -16,7 +16,7 @@ Requires `sideEffects` in `package.json` to be set to `false`.
 
 ```json
 {
-    "sideEffects": true
+  "sideEffects": true
 }
 ```
 

--- a/tools/eslint-plugin-azure-sdk/package-lock.json
+++ b/tools/eslint-plugin-azure-sdk/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azuresdktools/eslint-plugin-azure-sdk",
+  "name": "@azure/eslint-plugin-azure-sdk",
   "version": "1.0.0-preview.1",
   "lockfileVersion": 1,
   "requires": true,

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@azuresdktools/eslint-plugin-azure-sdk",
+  "name": "@azure/eslint-plugin-azure-sdk",
   "version": "1.0.1-preview.2",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "keywords": [

--- a/tools/eslint-plugin-azure-sdk/src/configs/index.ts
+++ b/tools/eslint-plugin-azure-sdk/src/configs/index.ts
@@ -5,35 +5,33 @@
 
 export = {
   recommended: {
-    plugins: ["@azuresdktools/azure-sdk"],
+    plugins: ["@azure/azure-sdk"],
     env: {
       node: true
     },
     parser: "@typescript-eslint/parser",
     rules: {
-      "@azuresdktools/azure-sdk/ts-config-allowsyntheticdefaultimports":
-        "error",
-      "@azuresdktools/azure-sdk/ts-config-declaration": "error",
-      "@azuresdktools/azure-sdk/ts-config-esmoduleinterop": "error",
-      "@azuresdktools/azure-sdk/ts-config-exclude": "error",
-      "@azuresdktools/azure-sdk/ts-config-forceconsistentcasinginfilenames":
-        "error",
-      "@azuresdktools/azure-sdk/ts-config-importhelpers": "error",
-      "@azuresdktools/azure-sdk/ts-config-isolatedmodules": "warn",
-      "@azuresdktools/azure-sdk/ts-config-lib": "error",
-      "@azuresdktools/azure-sdk/ts-config-module": "error",
-      "@azuresdktools/azure-sdk/ts-config-no-experimentaldecorators": "error",
-      "@azuresdktools/azure-sdk/ts-config-sourcemap": "error",
-      "@azuresdktools/azure-sdk/ts-config-strict": "error",
-      "@azuresdktools/azure-sdk/ts-package-json-author": "error",
-      "@azuresdktools/azure-sdk/ts-package-json-bugs": "error",
-      "@azuresdktools/azure-sdk/ts-package-json-homepage": "error",
-      "@azuresdktools/azure-sdk/ts-package-json-keywords": "error",
-      "@azuresdktools/azure-sdk/ts-package-json-license": "error",
-      "@azuresdktools/azure-sdk/ts-package-json-name": "error",
-      "@azuresdktools/azure-sdk/ts-package-json-repo": "error",
-      "@azuresdktools/azure-sdk/ts-package-json-required-scripts": "error",
-      "@azuresdktools/azure-sdk/ts-package-json-sideeffects": "error"
+      "@azure/azure-sdk/ts-config-allowsyntheticdefaultimports": "error",
+      "@azure/azure-sdk/ts-config-declaration": "error",
+      "@azure/azure-sdk/ts-config-esmoduleinterop": "error",
+      "@azure/azure-sdk/ts-config-exclude": "error",
+      "@azure/azure-sdk/ts-config-forceconsistentcasinginfilenames": "error",
+      "@azure/azure-sdk/ts-config-importhelpers": "error",
+      "@azure/azure-sdk/ts-config-isolatedmodules": "warn",
+      "@azure/azure-sdk/ts-config-lib": "error",
+      "@azure/azure-sdk/ts-config-module": "error",
+      "@azure/azure-sdk/ts-config-no-experimentaldecorators": "error",
+      "@azure/azure-sdk/ts-config-sourcemap": "error",
+      "@azure/azure-sdk/ts-config-strict": "error",
+      "@azure/azure-sdk/ts-package-json-author": "error",
+      "@azure/azure-sdk/ts-package-json-bugs": "error",
+      "@azure/azure-sdk/ts-package-json-homepage": "error",
+      "@azure/azure-sdk/ts-package-json-keywords": "error",
+      "@azure/azure-sdk/ts-package-json-license": "error",
+      "@azure/azure-sdk/ts-package-json-name": "error",
+      "@azure/azure-sdk/ts-package-json-repo": "error",
+      "@azure/azure-sdk/ts-package-json-required-scripts": "error",
+      "@azure/azure-sdk/ts-package-json-sideeffects": "error"
     }
   }
 };

--- a/tools/eslint-plugin-azure-sdk/tests/plugin.ts
+++ b/tools/eslint-plugin-azure-sdk/tests/plugin.ts
@@ -223,11 +223,11 @@ describe("plugin", (): void => {
         it("plugins should be an array", (): void => {
           assert.isArray(plugins, "plugins is not an array");
         });
-        it("plugins should contain '@azuresdktools/azure-sdk'", (): void => {
+        it("plugins should contain '@azure/azure-sdk'", (): void => {
           assert.include(
             plugins,
-            "@azuresdktools/azure-sdk",
-            "plugins does not contain '@azuresdktools/azure-sdk'"
+            "@azure/azure-sdk",
+            "plugins does not contain '@azure/azure-sdk'"
           );
         });
       });
@@ -274,7 +274,7 @@ describe("plugin", (): void => {
           ruleList.forEach((rule: string): void => {
             assert.property(
               rules,
-              "@azuresdktools/azure-sdk/" + rule,
+              "@azure/azure-sdk/" + rule,
               "rules does not contain a setting for " + rule
             );
           });


### PR DESCRIPTION
For publishing to NPM, `eslint-plugin-azure-sdk` will be rescoped from `@azuresdktools` to `@azure`.

I also re-ran a format script that caused a bunch of changes in the documentation, making the PR size a bit larger than it would be otherwise.