### PR TITLE
Setup for NPM release.

### DIFF
--- a/tools/eslint-plugin-azure-sdk/ci.yml
+++ b/tools/eslint-plugin-azure-sdk/ci.yml
@@ -63,7 +63,7 @@ stages:
             condition: succeededOrFailed()
 
   # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
-  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))}}
+  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))}}:
     - stage: Prerelease
       dependsOn: Build
       jobs:

--- a/tools/eslint-plugin-azure-sdk/ci.yml
+++ b/tools/eslint-plugin-azure-sdk/ci.yml
@@ -62,7 +62,7 @@ stages:
             artifact: packages
             condition: succeededOrFailed()
 
-  - stage: Release
+  - stage: Prerelease
     dependsOn: Build
     condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
     jobs:
@@ -82,10 +82,37 @@ stages:
                   displayName: Detecting package archive
 
                 - task: Npm@1
-                  displayName: Publish package to feed
                   inputs:
                     command: 'custom'
                     workingDir: '$(Pipeline.Workspace)/packages'
                     customCommand: 'publish $(Package.Archive)'
                     customRegistry: 'useFeed'
                     customFeed: '7a8a7255-a1aa-48df-a904-c77c0b78cb03'
+                  displayName: 'Publish package to azure-sdk public feed'
+
+  - stage: Release
+    dependsOn: Prerelease
+    condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
+    jobs:
+      - deployment: PublishPackage
+        environment: npm
+        
+        pool:
+          vmImage: ubuntu-16.04
+
+        strategy:
+          runOnce:
+            deploy:
+              steps:
+                - script: |
+                    export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/packages/*.tgz`
+                    echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
+                  displayName: Detecting package archive
+
+                - task: Npm@1
+                  inputs:
+                    command: 'custom'
+                    workingDir: '$(Pipeline.Workspace)/packages'
+                    customCommand: 'publish $(Package.Archive)'
+                    customEndpoint: 'NPM @azure'
+                  displayName: 'Publish to npmjs.org'

--- a/tools/eslint-plugin-azure-sdk/ci.yml
+++ b/tools/eslint-plugin-azure-sdk/ci.yml
@@ -62,57 +62,57 @@ stages:
             artifact: packages
             condition: succeededOrFailed()
 
-  - stage: Prerelease
-    dependsOn: Build
-    condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-    jobs:
-      - deployment: PublishPackage
-        environment: azure-sdk
-        
-        pool:
-          vmImage: ubuntu-16.04
+  # The Prerelease and Release stages are conditioned on whether we are building a pull request and the branch.
+  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))}}
+    - stage: Prerelease
+      dependsOn: Build
+      jobs:
+        - deployment: PublishPackage
+          environment: azure-sdk
+          
+          pool:
+            vmImage: ubuntu-16.04
 
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - script: |
-                    export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/packages/*.tgz`
-                    echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
-                  displayName: Detecting package archive
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - script: |
+                      export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/packages/*.tgz`
+                      echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
+                    displayName: Detecting package archive
 
-                - task: Npm@1
-                  inputs:
-                    command: 'custom'
-                    workingDir: '$(Pipeline.Workspace)/packages'
-                    customCommand: 'publish $(Package.Archive)'
-                    customRegistry: 'useFeed'
-                    customFeed: '7a8a7255-a1aa-48df-a904-c77c0b78cb03'
-                  displayName: 'Publish package to azure-sdk public feed'
+                  - task: Npm@1
+                    inputs:
+                      command: 'custom'
+                      workingDir: '$(Pipeline.Workspace)/packages'
+                      customCommand: 'publish $(Package.Archive)'
+                      customRegistry: 'useFeed'
+                      customFeed: '7a8a7255-a1aa-48df-a904-c77c0b78cb03'
+                    displayName: 'Publish package to azure-sdk public feed'
 
-  - stage: Release
-    dependsOn: Prerelease
-    condition: and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Build.SourceBranch'], 'refs/heads/master'))
-    jobs:
-      - deployment: PublishPackage
-        environment: npm
-        
-        pool:
-          vmImage: ubuntu-16.04
+    - stage: Release
+      dependsOn: Prerelease
+      jobs:
+        - deployment: PublishPackage
+          environment: npm
+          
+          pool:
+            vmImage: ubuntu-16.04
 
-        strategy:
-          runOnce:
-            deploy:
-              steps:
-                - script: |
-                    export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/packages/*.tgz`
-                    echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
-                  displayName: Detecting package archive
+          strategy:
+            runOnce:
+              deploy:
+                steps:
+                  - script: |
+                      export DETECTED_PACKAGE_NAME=`ls $(Pipeline.Workspace)/packages/*.tgz`
+                      echo "##vso[task.setvariable variable=Package.Archive]$DETECTED_PACKAGE_NAME"
+                    displayName: Detecting package archive
 
-                - task: Npm@1
-                  inputs:
-                    command: 'custom'
-                    workingDir: '$(Pipeline.Workspace)/packages'
-                    customCommand: 'publish $(Package.Archive)'
-                    customEndpoint: 'NPM @azure'
-                  displayName: 'Publish to npmjs.org'
+                  - task: Npm@1
+                    inputs:
+                      command: 'custom'
+                      workingDir: '$(Pipeline.Workspace)/packages'
+                      customCommand: 'publish $(Package.Archive)'
+                      customEndpoint: 'NPM @azure'
+                    displayName: 'Publish to npmjs.org'


### PR DESCRIPTION
This PR adds a release stage that publishes to NPM. It retains the old release stage as pre-release. Eventually we'll break these stages out into a separate template. But for now this is just to get the eslint-plug-azure-sdk process unblocked and we can then iterate to refine this NPM release pipeline and make it more reusable.