### PR TITLE
Add analyzer that checks type name - file name consistency

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC1002Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC1002Tests.cs
@@ -33,7 +33,23 @@ namespace RandomNamespace
 namespace RandomNamespace/*MM*/     
 {
 }
+",          @"
+class C
+{
+    public void Main(int a,/*MM*/
+                     int b){}
+}
+",          @"
+class C
+{
+    public void Main(int a)
+    {
+        a.ToString();/*MM*/
+    }
+}
 ",
+
+
 
         }.Select(s => new object[] { s }).ToArray();
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC1002Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC1002Tests.cs
@@ -16,27 +16,27 @@ namespace Azure.ClientSdk.Analyzers.Tests
             @"
 namespace RandomNamespace
 {
-/*MM*/    
+/*MM*/____
 }
 ",
             @"
 namespace RandomNamespace
 {
-}/*MM*/    
+}/*MM*/____
 ",
             @"
 namespace RandomNamespace
-{/*MM*/    
+{/*MM*/____
 }
 ",
             @"
-namespace RandomNamespace/*MM*/     
+namespace RandomNamespace/*MM*/____
 {
 }
 ",          @"
 class C
 {
-    public void Main(int a,/*MM*/
+    public void Main(int a,/*MM*/____
                      int b){}
 }
 ",          @"
@@ -44,7 +44,7 @@ class C
 {
     public void Main(int a)
     {
-        a.ToString();/*MM*/
+        a.ToString();/*MM*/____
     }
 }
 ",
@@ -57,7 +57,7 @@ class C
         [MemberData(nameof(TestCases))]
         public async Task AZC1002ProducedForWhitespaceInTheEndOfTheLine(string testCase)
         {
-            var testSource = TestSource.Read(testCase);
+            var testSource = TestSource.Read(testCase.Replace("_", " "));
             var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
 
             var diagnostic = Assert.Single(diagnostics);

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC1003Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC1003Tests.cs
@@ -1,0 +1,85 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Linq;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC1003Tests
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new FileTypeNameAnalyzer());
+
+        [Fact]
+        public async Task AZC1003ProducedForMissnamedFiles()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    public class /*MM*/SomeClient
+    {
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+
+            Assert.Equal("AZC1003", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+        }
+
+        [Fact]
+        public async Task AZC1003NotProducedForNonPublicTypes()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    class SomeClient
+    {
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC1003NotProducedForCorrectlyNamedFiles()
+        {
+            var testSource = TestSource.Read(
+                $@"
+namespace RandomNamespace
+{{
+    public class {DiagnosticProject.DefaultFilePathPrefix}<T>
+    {{
+    }}
+}}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC1003NotProducedForNestedTypes()
+        {
+            var testSource = TestSource.Read(
+                $@"
+namespace RandomNamespace
+{{
+    public class {DiagnosticProject.DefaultFilePathPrefix}
+    {{
+        public class Nested {{}}
+    }}
+}}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            Assert.Empty(diagnostics);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -55,5 +55,8 @@ namespace Azure.ClientSdk.Analyzers
         public static DiagnosticDescriptor AZC1002 = new DiagnosticDescriptor(
             "AZC1002", "Avoid whitespace in the end of the line",
             "Avoid whitespace in the end of the line", "Usage", DiagnosticSeverity.Warning, true);
+        public static DiagnosticDescriptor AZC1003 = new DiagnosticDescriptor(
+            "AZC1003", "File name differs from the type name",
+            "File name differs from the type name. File name should contain '{0}'", "Usage", DiagnosticSeverity.Warning, true);
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/FileTypeNameAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/FileTypeNameAnalyzer.cs
@@ -1,0 +1,53 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Immutable;
+using System.IO;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.ClientSdk.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class FileTypeNameAnalyzer : DiagnosticAnalyzer
+    {
+        public override void Initialize(AnalysisContext context)
+        {
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(
+                analysisContext => {
+                    analysisContext.RegisterSymbolAction(
+                        symbolAnalysisContext => {
+                            var symbol = symbolAnalysisContext.Symbol;
+
+                            if (symbol.DeclaredAccessibility != Accessibility.Public)
+                            {
+                                return;
+                            }
+
+                            // Skip nested types
+                            if (symbol.ContainingType != null)
+                            {
+                                return;
+                            }
+
+                            foreach (var symbolLocation in symbol.Locations)
+                            {
+                                var fileName = Path.GetFileName(symbolLocation.SourceTree.FilePath);
+                                if (fileName.IndexOf(symbol.Name, StringComparison.OrdinalIgnoreCase) == -1)
+                                {
+                                    symbolAnalysisContext.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC1003, symbolLocation, symbol.Name));
+                                }
+                            }
+                        }, SymbolKind.NamedType);
+                });
+        }
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(new[]
+        {
+            Descriptors.AZC1003
+        });
+    }
+}


### PR DESCRIPTION
I'm often guilty of missing the file name and @jsquire has to keep pointing it out.