### PR TITLE
Fix ts-doc-internal

### DIFF
--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.1.0-preview.1",
+  "version": "1.1.0-preview.2",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "keywords": [
     "eslint",

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
@@ -67,7 +67,8 @@ export = {
     "require TSDoc comments to include an '@internal' or '@ignore' tag if the object is not public-facing"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
-    if (!context.settings.exported) {
+    const fileName = context.getFilename();
+    if (/\.ts$/.test(fileName) && !context.settings.exported) {
       const packageExports = getLocalExports(context);
       if (packageExports !== undefined) {
         context.settings.exported = packageExports;
@@ -87,7 +88,7 @@ export = {
     const typeChecker = parserServices.program.getTypeChecker();
     const converter = parserServices.esTreeNodeToTSNodeMap;
 
-    return /src/.test(context.getFilename())
+    return /src/.test(fileName)
       ? {
           // callback functions
           ":matches(TSInterfaceDeclaration, ClassDeclaration, TSModuleDeclaration)": (


### PR DESCRIPTION
The `ts-doc-internal` rule fetches type information about all exports from the main entrypoint of a package - to do so, if exports have not been fetched yet it uses the parser services to fetch the SourceFile corresponding to the main entrypoint and proceed from there.

However, running this rule on the scripts I set up in the [demo PR](https://github.com/Azure/azure-sdk-for-js/pull/4330) results in more lint errors than there should be, and upon examination it seems that `getSourceFile` in `src/utils/exports.ts` fails. This is because the first files executed on by ESLint in the scripts I ran on are `package.json` and `tsconfig.json`, and the compiler settings are likely different, leading to a failure to fetch a `SourceFile`. Without any changes, this could be solved by ensuring that TypeScript files are examined first.

This PR makes sure that a file is a TypeScript file before attempting to fetch information about exports so that the order that files are examined does not affect the lint errors in the output.