### PR TITLE
Publish to azure-sdk public feed.

### DIFF
--- a/tools/eslint-plugin-azure-sdk/ci.yml
+++ b/tools/eslint-plugin-azure-sdk/ci.yml
@@ -88,7 +88,7 @@ stages:
                       workingDir: '$(Pipeline.Workspace)/packages'
                       customCommand: 'publish $(Package.Archive)'
                       customRegistry: 'useFeed'
-                      customFeed: '7a8a7255-a1aa-48df-a904-c77c0b78cb03'
+                      customFeed: '29ec6040-b234-4e31-b139-33dc4287b756/8bea7e97-84ed-4421-9a37-2bbf3200662b'
                     displayName: 'Publish package to azure-sdk public feed'
 
     - stage: Release

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.1.0-preview.2",
+  "version": "1.1.0-preview.3",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "keywords": [
     "eslint",


### PR DESCRIPTION
This PR swaps the prerelease process over to publish to the azure-sdk public feed instead of the internal feed.