### PR TITLE
Ignore rules on certain files

### DIFF
--- a/tools/eslint-plugin-azure-sdk/package-lock.json
+++ b/tools/eslint-plugin-azure-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.1.0-preview.1",
+  "version": "1.1.0-preview.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -58,16 +58,45 @@
       "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
       "dev": true
     },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
+      "dev": true
+    },
+    "@types/glob": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+      "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+      "dev": true,
+      "requires": {
+        "@types/events": "*",
+        "@types/minimatch": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/json-schema": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.3.tgz",
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
       "dev": true
     },
+    "@types/minimatch": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
+      "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
+      "dev": true
+    },
     "@types/mocha": {
       "version": "5.2.7",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-5.2.7.tgz",
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ==",
+      "dev": true
+    },
+    "@types/node": {
+      "version": "12.6.8",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.8.tgz",
+      "integrity": "sha512-aX+gFgA5GHcDi89KG5keey2zf0WfZk/HAQotEamsK2kbey+8yGKcson0hbK8E+v0NArlCJQCqMP161YhV6ZXLg==",
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
@@ -190,8 +219,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bluebird": {
       "version": "3.5.5",
@@ -203,7 +231,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -323,8 +350,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "cross-spawn": {
       "version": "6.0.5",
@@ -672,8 +698,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -718,7 +743,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -808,7 +832,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1112,7 +1135,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -1292,7 +1314,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -1406,8 +1427,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -1848,8 +1868,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.1.0-preview.2",
+  "version": "1.1.0-preview.3",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "keywords": [
     "eslint",

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -43,6 +43,7 @@
     "test": "npm run clean && tsc -p tsconfig.json && mocha --timeout 10000 --recursive dist/tests"
   },
   "dependencies": {
+    "glob": "^7.1.4",
     "path": "^0.12.7",
     "typescript": "^3.4.5"
   },
@@ -51,6 +52,7 @@
     "@types/chai": "^4.1.7",
     "@types/eslint": "^4.16.6",
     "@types/estree": "0.0.39",
+    "@types/glob": "^7.1.1",
     "@types/mocha": "^5.2.7",
     "@typescript-eslint/eslint-plugin": "^1.12.0",
     "@typescript-eslint/experimental-utils": "^1.12.0",

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
@@ -6,13 +6,28 @@
 import { Rule } from "eslint";
 import { getLocalExports } from "../utils";
 import { Node } from "estree";
-import { Node as TSNode, TypeChecker } from "typescript";
+import {
+  ArrayLiteralExpression,
+  createCompilerHost,
+  JsonObjectExpressionStatement,
+  JsonSourceFile,
+  Node as TSNode,
+  NodeArray,
+  ObjectLiteralExpression,
+  PropertyAssignment,
+  ScriptTarget,
+  StringLiteral,
+  TypeChecker
+} from "typescript";
 import { ParserWeakMap } from "@typescript-eslint/typescript-estree/dist/parser-options";
 import {
   ParserServices,
   TSESTree
 } from "@typescript-eslint/experimental-utils";
 import { getRuleMetaData } from "../utils";
+// @ts-ignore
+import { relative } from "path";
+import { sync } from "glob";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -61,6 +76,49 @@ const reportInternal = (
   }
 };
 
+/**
+ * Determine whether this rule should examine a given file
+ * @param fileName the filename of the file in question
+ * @param exclude the list of files excluded by TypeDoc (other than those in node_modues)
+ * @returns false if not in src or is excluded by TypeDoc
+ */
+const shouldExamineFile = (fileName: string, exclude: string[]): boolean => {
+  if (!/src/.test(fileName)) {
+    return false;
+  }
+  const relativePath = relative("", fileName).replace(/\\/g, "/");
+  return !exclude.includes(relativePath);
+};
+
+let exclude: string[] = [];
+const JSONHost = createCompilerHost({});
+const typeDoc = JSONHost.getSourceFile("typedoc.json", ScriptTarget.JSON) as
+  | JsonSourceFile
+  | undefined;
+
+if (typeDoc !== undefined) {
+  typeDoc.statements.forEach(
+    (statement: JsonObjectExpressionStatement): void => {
+      const expression = statement.expression as ObjectLiteralExpression;
+      const properties = expression.properties as NodeArray<PropertyAssignment>;
+      properties.forEach((property: PropertyAssignment): void => {
+        const name = property.name as StringLiteral;
+        if (name.text === "exclude") {
+          const initializer = property.initializer as ArrayLiteralExpression;
+          const elements = initializer.elements as NodeArray<StringLiteral>;
+          elements.forEach((element: StringLiteral): void => {
+            exclude = exclude.concat(
+              sync(element.text).filter((excludeFile: string): boolean => {
+                return !/node_modules/.test(excludeFile);
+              })
+            );
+          });
+        }
+      });
+    }
+  );
+}
+
 export = {
   meta: getRuleMetaData(
     "ts-doc-internal",
@@ -68,7 +126,16 @@ export = {
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const fileName = context.getFilename();
-    if (/\.ts$/.test(fileName) && !context.settings.exported) {
+    const parserServices = context.parserServices as ParserServices;
+    if (
+      parserServices.program === undefined ||
+      parserServices.esTreeNodeToTSNodeMap === undefined ||
+      parserServices.tsNodeToESTreeNodeMap === undefined
+    ) {
+      return {};
+    }
+
+    if (context.settings.exported === undefined && /\.ts$/.test(fileName)) {
       const packageExports = getLocalExports(context);
       if (packageExports !== undefined) {
         context.settings.exported = packageExports;
@@ -77,18 +144,11 @@ export = {
         return {};
       }
     }
-    const parserServices: ParserServices = context.parserServices as ParserServices;
-    if (
-      parserServices.program === undefined ||
-      parserServices.esTreeNodeToTSNodeMap === undefined
-    ) {
-      return {};
-    }
 
     const typeChecker = parserServices.program.getTypeChecker();
     const converter = parserServices.esTreeNodeToTSNodeMap;
 
-    return /src/.test(fileName)
+    return shouldExamineFile(fileName, exclude)
       ? {
           // callback functions
           ":matches(TSInterfaceDeclaration, ClassDeclaration, TSModuleDeclaration)": (

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
@@ -126,14 +126,6 @@ export = {
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const fileName = context.getFilename();
-    const parserServices = context.parserServices as ParserServices;
-    if (
-      parserServices.program === undefined ||
-      parserServices.esTreeNodeToTSNodeMap === undefined ||
-      parserServices.tsNodeToESTreeNodeMap === undefined
-    ) {
-      return {};
-    }
 
     if (context.settings.exported === undefined && /\.ts$/.test(fileName)) {
       const packageExports = getLocalExports(context);
@@ -143,6 +135,14 @@ export = {
         context.settings.exported = [];
         return {};
       }
+    }
+
+    const parserServices = context.parserServices as ParserServices;
+    if (
+      parserServices.program === undefined ||
+      parserServices.esTreeNodeToTSNodeMap === undefined
+    ) {
+      return {};
     }
 
     const typeChecker = parserServices.program.getTypeChecker();

--- a/tools/eslint-plugin-azure-sdk/tests/rules/ts-use-interface-parameters.ts
+++ b/tools/eslint-plugin-azure-sdk/tests/rules/ts-use-interface-parameters.ts
@@ -51,87 +51,113 @@ ruleTester.run("ts-use-interface-parameters", rule, {
     // single parameter
     {
       // function declaration
-      code: example + "function func3(b: B): void { console.log(b); }"
+      code: example + "function func3(b: B): void { console.log(b); }",
+      filename: "src/test.ts"
     },
     {
       // class method
-      code: example + "class C { method1(b: B): void { console.log(b); } }"
+      code: example + "class C { method1(b: B): void { console.log(b); } }",
+      filename: "src/test.ts"
     },
     // multiple parameters
     {
       // function declaration
-      code: example + "function func6(b1: B, b2: B): void { console.log(b); }"
+      code: example + "function func6(b1: B, b2: B): void { console.log(b); }",
+      filename: "src/test.ts"
     },
     {
       // class method
       code:
-        example + "class C { method2(b1: B, b2: B): void { console.log(b); } }"
+        example + "class C { method2(b1: B, b2: B): void { console.log(b); } }",
+      filename: "src/test.ts"
     },
     // overloads
     {
       // class methods
       code:
         example +
-        "class C { overloadMethod(a: A): void { console.log(a); }; overloadMethod(b: B): void { console.log(b); }; }"
+        "class C { overloadMethod(a: A): void { console.log(a); }; overloadMethod(b: B): void { console.log(b); }; }",
+      filename: "src/test.ts"
     },
     {
       // function declaration
       code:
         example +
-        "function overloadDeclaration(a: A): void { console.log(a); }; function overloadDeclaration(b: B): void { console.log(b); }"
+        "function overloadDeclaration(a: A): void { console.log(a); }; function overloadDeclaration(b: B): void { console.log(b); }",
+      filename: "src/test.ts"
     },
     // nested objects
     {
       // class methods
       code:
-        example + "class C { nestedMethod(b: B2): void { console.log(b); }; }"
+        example + "class C { nestedMethod(b: B2): void { console.log(b); }; }",
+      filename: "src/test.ts"
     },
     {
       // function declaration
       code:
-        example + "function nestedDeclaration(b: B2): void { console.log(b); }"
+        example + "function nestedDeclaration(b: B2): void { console.log(b); }",
+      filename: "src/test.ts"
     },
     // optional parameters
     {
       // class methods
       code:
         example +
-        "class C { nestedMethod(b: B, a?: A): void { console.log(b); a && console.log(a); }; }"
+        "class C { nestedMethod(b: B, a?: A): void { console.log(b); a && console.log(a); }; }",
+      filename: "src/test.ts"
     },
     {
       // function declaration
       code:
         example +
-        "function nestedDeclaration(b: B, a?: A): void { console.log(b); a && console.log(a); }"
+        "function nestedDeclaration(b: B, a?: A): void { console.log(b); a && console.log(a); }",
+      filename: "src/test.ts"
     },
     // array parameters []
     {
       // class method
       code:
-        example + "class C { arrayMethod(b: B[]): void { console.log(b); }; }"
+        example + "class C { arrayMethod(b: B[]): void { console.log(b); }; }",
+      filename: "src/test.ts"
     },
     {
       // function declaration
       code:
-        example + "function arrayDeclaration(b: B[]): void { console.log(b); }"
+        example + "function arrayDeclaration(b: B[]): void { console.log(b); }",
+      filename: "src/test.ts"
     },
     // array parameters Array<>
     {
       // class method
       code:
         example +
-        "class C { array2Method(b: Array<B>): void { console.log(b); }; }"
+        "class C { array2Method(b: Array<B>): void { console.log(b); }; }",
+      filename: "src/test.ts"
     },
     {
       // function declaration
       code:
         example +
-        "function array2Declaration(b: Array<B>): void { console.log(b); }"
+        "function array2Declaration(b: Array<B>): void { console.log(b); }",
+      filename: "src/test.ts"
     },
     // private method
     {
       code:
-        example + "class { private pMethod(a: A): void { console.log(a); } }"
+        example + "class { private pMethod(a: A): void { console.log(a); } }",
+      filename: "src/test.ts"
+    },
+    // not in src
+    {
+      // function declaration
+      code: example + "function func3(a: A): void { console.log(a); }",
+      filename: "tests/test.ts"
+    },
+    {
+      // class method
+      code: example + "class C { method1(b: A): void { console.log(a); } }",
+      filename: "tests/test.ts"
     }
   ],
   invalid: [
@@ -139,6 +165,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
     {
       // function declaration
       code: example + "function func9(a: A): void { console.log(a); }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -149,6 +176,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
     {
       // class method
       code: example + "class { method3(a: A): void { console.log(a); } }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -161,6 +189,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       // function declaration
       code:
         example + "function func12(a: A, b: B): void { console.log(a, b); }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -172,6 +201,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       // class method
       code:
         example + "class { method4(a: A, b: B): void { console.log(a, b); } }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -185,6 +215,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "function func15(a1: A, a2: A): void { console.log(a1, a2); }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -201,6 +232,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "class { method3(a1: A, a2: A): void { console.log(a1, a2); } }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -218,6 +250,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "class C { overloadMethodBad(a: A): void { console.log(a); } overloadMethodBad(a1: A, a2: A): void { console.log(a1, a2); }; }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -238,6 +271,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "function overloadDeclarationBad(a: A): void { console.log(a); } function overloadDeclarationBad(a1: A, a2: A): void { console.log(a1, a2); }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -259,6 +293,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "class C { nestedMethodBad(b: B3): void { console.log(b); }; }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -271,6 +306,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "function nestedDeclarationBad(b: B3): void { console.log(b); }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -284,6 +320,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "class C { arrayMethodBad(a: A[]): void { console.log(a); }; }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -296,6 +333,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "function arrayDeclarationBad(a: A[]): void { console.log(a); }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -309,6 +347,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "class C { nestedArrayMethodBad(a: B4): void { console.log(a); }; }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -321,6 +360,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "function nestedArrayDeclarationBad(a: B4): void { console.log(a); }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -334,6 +374,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "class C { array2MethodBad(a: Array<A>): void { console.log(a); }; }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -346,6 +387,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "function array2DeclarationBad(a: Array<A>): void { console.log(a); }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -359,6 +401,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "class C { nestedArray2MethodBad(a: B5): void { console.log(a); }; }",
+      filename: "src/test.ts",
       errors: [
         {
           message:
@@ -371,6 +414,7 @@ ruleTester.run("ts-use-interface-parameters", rule, {
       code:
         example +
         "function nestedArray2DeclarationBad(a: B5): void { console.log(a); }",
+      filename: "src/test.ts",
       errors: [
         {
           message:


### PR DESCRIPTION
# `ts-doc-internal`

Files that are marked as excluded by `typedoc.json` are being flagged for errors, which is not what we want.

To fix this, we define a list of excluded files as follows:

- If `typedoc.json` does not exist, the list is empty
- Otherwise, the list corresponds to all files matching the glob patterns specified in the `exclude` field in `typedoc.json` if found (excluding files in `node_modules`

# `ts-use-interface-parameters`

Files in test directories were being flagged, which doesn't make sense for this rule as it exists to protect users of the library from having to deal with class-based conflicts. As test files are not user-facing, we can simply only have the rule operate on files in `src`.

