### PR TITLE
Remove dependency on path

### DIFF
--- a/tools/eslint-plugin-azure-sdk/package-lock.json
+++ b/tools/eslint-plugin-azure-sdk/package-lock.json
@@ -1155,9 +1155,9 @@
       }
     },
     "mocha": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
-      "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.0.tgz",
+      "integrity": "sha512-qwfFgY+7EKAAUAdv7VYMZQknI7YJSGesxHyhn6qD52DV8UcSZs5XwCifcZGMVIE4a5fbmhvbotxC0DLQ0oKohQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",

--- a/tools/eslint-plugin-azure-sdk/package-lock.json
+++ b/tools/eslint-plugin-azure-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.1.0-preview.5",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1409,15 +1409,6 @@
         "callsites": "^3.0.0"
       }
     },
-    "path": {
-      "version": "0.12.7",
-      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
-      "integrity": "sha1-1NwqUGxM4hl+tIHr/NWzbAFAsQ8=",
-      "requires": {
-        "process": "^0.11.1",
-        "util": "^0.10.3"
-      }
-    },
     "path-exists": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
@@ -1458,11 +1449,6 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
       "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==",
       "dev": true
-    },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "progress": {
       "version": "2.0.3",
@@ -1778,14 +1764,6 @@
       "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "util": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
-      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
-      "requires": {
-        "inherits": "2.0.3"
       }
     },
     "which": {

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -44,7 +44,6 @@
   },
   "dependencies": {
     "glob": "^7.1.4",
-    "path": "^0.12.7",
     "typescript": "^3.4.5"
   },
   "devDependencies": {

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -62,7 +62,7 @@
     "chai": "^4.2.0",
     "eslint": "^5.16.0",
     "markdownlint-cli": "^0.17.0",
-    "mocha": "^6.1.4",
+    "mocha": "^6.2.0",
     "prettier": "^1.18.2"
   },
   "peerDependencies": {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-doc-internal.ts
@@ -12,11 +12,9 @@ import { Rule } from "eslint";
 import { Node } from "estree";
 import { readFileSync } from "fs";
 import { sync } from "glob";
+import { relative } from "path";
 import { Node as TSNode, TypeChecker } from "typescript";
 import { getLocalExports, getRuleMetaData } from "../utils";
-
-// @ts-ignore
-import { relative } from "path";
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-modules-only-named.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-modules-only-named.ts
@@ -5,10 +5,8 @@
 
 import { Rule } from "eslint";
 import { ExportDefaultDeclaration } from "estree";
-import { getRuleMetaData } from "../utils";
-
-// @ts-ignore (path has no typings)
 import { normalize, relative } from "path";
+import { getRuleMetaData } from "../utils";
 
 //------------------------------------------------------------------------------
 // Rule Definition


### PR DESCRIPTION
`eslint-plugin-azure-sdk` had a dependency on [path](https://www.npmjs.com/package/path), when it could have just used the inbuilt node path module.

This PR removes the external dependency and allows for the removal of all `@ts-ignore` tags in `eslint-plugin-azure-sdk`.

Also bumps `mocha` to latest version.