### PR TITLE
Update copyright header definitions

### DIFF
--- a/tools/eslint-plugin-azure-sdk/docs/rules/github-source-headers.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/github-source-headers.md
@@ -44,7 +44,7 @@ class Class {
   /* source code here */
 }
 // Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 ```
 
 ## [Source](https://azuresdkspecs.z5.web.core.windows.net/TypeScriptSpec.html#github-source-headers)

--- a/tools/eslint-plugin-azure-sdk/docs/rules/github-source-headers.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/github-source-headers.md
@@ -5,8 +5,8 @@ Requires copyright headers in every source file.
 Specifically, a source file is defined as any TypeScript file and the expected header text is as follows:
 
 ```fundamental
-Copyright (c) Microsoft Corporation. All rights reserved.
-Licensed under the MIT License.
+Copyright (c) Microsoft Corporation.
+Licensed under the MIT license.
 ```
 
 ## Examples
@@ -16,27 +16,27 @@ Licensed under the MIT License.
 These must be located at the top of every source file.
 
 ```ts
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 ```
 
 ```ts
 /**
- * Copyright (c) Microsoft Corporation. All rights reserved.
- * Licensed under the MIT License.
+ * Copyright (c) Microsoft Corporation.
+ * Licensed under the MIT license.
  */
 ```
 
 ```ts
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
 // Other comment text here.
 ```
 
 ### Bad
 
 ```ts
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 ```
 
 ```ts

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "keywords": [
     "eslint",

--- a/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
@@ -40,7 +40,7 @@ export = {
             if (
               headerComments.every(
                 (comment: Comment): boolean =>
-                  !/Copyright \(c\) Microsoft Corporation\. All rights reserved\./.test(
+                  !/Copyright \(c\) Microsoft Corporation\./.test(
                     comment.value
                   ) ||
                   headerComments.every(
@@ -53,7 +53,7 @@ export = {
                 node: node,
                 message:
                   "copyright header not properly configured - expected value:\n" +
-                  "Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.\n"
+                  "Copyright (c) Microsoft Corporation.\nLicensed under the MIT License.\n"
               });
             }
           }

--- a/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
@@ -45,7 +45,7 @@ export = {
                   ) ||
                   headerComments.every(
                     (comment: Comment): boolean =>
-                      !/Licensed under the MIT License\./.test(comment.value)
+                      !/Licensed under the MIT license\./.test(comment.value)
                   )
               )
             ) {
@@ -53,7 +53,7 @@ export = {
                 node: node,
                 message:
                   "copyright header not properly configured - expected value:\n" +
-                  "Copyright (c) Microsoft Corporation.\nLicensed under the MIT License.\n"
+                  "Copyright (c) Microsoft Corporation.\nLicensed under the MIT license.\n"
               });
             }
           }

--- a/tools/eslint-plugin-azure-sdk/tests/rules/github-source-headers.ts
+++ b/tools/eslint-plugin-azure-sdk/tests/rules/github-source-headers.ts
@@ -18,22 +18,22 @@ const ruleTester = new RuleTester({
 });
 
 const valid = `
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT License.
-console.log("hello")`;
-
-const invalid1 = `
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 console.log("hello")`;
 
+const invalid1 = `
+// Copyright (c) Microsoft.
+// Licensed under the MIT License.
+console.log("hello")`;
+
 const invalid2 = `
-// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation.
 // Licensed under the Apache 2.0 License.
 console.log("hello")`;
 
 const configError = `copyright header not properly configured - expected value:
-Copyright (c) Microsoft Corporation. All rights reserved.
+Copyright (c) Microsoft Corporation.
 Licensed under the MIT License.
 `;
 

--- a/tools/eslint-plugin-azure-sdk/tests/rules/github-source-headers.ts
+++ b/tools/eslint-plugin-azure-sdk/tests/rules/github-source-headers.ts
@@ -19,22 +19,22 @@ const ruleTester = new RuleTester({
 
 const valid = `
 // Copyright (c) Microsoft Corporation.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 console.log("hello")`;
 
 const invalid1 = `
 // Copyright (c) Microsoft.
-// Licensed under the MIT License.
+// Licensed under the MIT license.
 console.log("hello")`;
 
 const invalid2 = `
 // Copyright (c) Microsoft Corporation.
-// Licensed under the Apache 2.0 License.
+// Licensed under the Apache 2.0 license.
 console.log("hello")`;
 
 const configError = `copyright header not properly configured - expected value:
 Copyright (c) Microsoft Corporation.
-Licensed under the MIT License.
+Licensed under the MIT license.
 `;
 
 ruleTester.run("github-source-headers", rule, {


### PR DESCRIPTION
`github-source-headers` previously assumed that the correct copyright header was the following:

```fundamental
Copyright (c) Microsoft Corporation. All rights reserved.
Licensed under the MIT license.
```

However, this has changed to the following:

```fundamental
Copyright (c) Microsoft Corporation.
Licensed under the MIT license.
```

This PR updates the rule definition to accommodate these changes, bumping the package version to `1.1.1`.