### PR TITLE
skip pipelines that don't exist

### DIFF
--- a/tools/notification-configuration/common/Services/AzureDevOpsService.cs
+++ b/tools/notification-configuration/common/Services/AzureDevOpsService.cs
@@ -91,7 +91,18 @@ namespace NotificationConfiguration.Services
         public async Task<BuildDefinition> GetPipelineAsync(string projectName, int pipelineId)
         {
             var client = await GetClientAsync<BuildHttpClient>();
-            return await client.GetDefinitionAsync(projectName, pipelineId);
+            BuildDefinition result;
+            try
+            {
+                result = await client.GetDefinitionAsync(projectName, pipelineId);
+            }
+            catch (DefinitionNotFoundException)
+            {
+                result = default;
+            }
+
+
+            return result;
         }
 
         /// <summary>

--- a/tools/notification-configuration/github-codeowner-subscriber/Program.cs
+++ b/tools/notification-configuration/github-codeowner-subscriber/Program.cs
@@ -86,7 +86,7 @@ namespace GitHubCodeownerSubscriber
                     });
 
                 var pipelineGroups = await Task.WhenAll(pipelineGroupTasks);
-                var filteredGroups = pipelineGroups.Where(group => group.Pipeline.Path.StartsWith(pathPrefix));
+                var filteredGroups = pipelineGroups.Where(group => group.Pipeline != default && group.Pipeline.Path.StartsWith(pathPrefix));
 
                 foreach (var group in filteredGroups)
                 {


### PR DESCRIPTION
This code more gracefully handles the case where a pipeline is deleted but its notification teams are not deleted. Because these applications run independently this should handle the edge case more gracefully than it currently does. 

The pipelines that run this do not complete successfully under these conditions until a fix is merged. 