### PR TITLE
Add ability to fix rule violations where possible

### DIFF
--- a/tools/eslint-plugin-azure-sdk/README.md
+++ b/tools/eslint-plugin-azure-sdk/README.md
@@ -76,47 +76,51 @@ For example, if you are not targeting Node, disable `ts-config-moduleresolution`
 }
 ```
 
+Some rules (see table below) are fixable using the `--fix` ESLint option.
+
 ## Supported Rules
 
-- [github-source-headers](/tools/eslint-plugin-azure-sdk/docs/rules/github-source-headers.md)
-- [ts-apisurface-standardized-verbs](/tools/eslint-plugin-azure-sdk/docs/rules/ts-apisurface-standardized-verbs.md)
-- [ts-apisurface-supportcancellation](/tools/eslint-plugin-azure-sdk/docs/rules/ts-apisurface-supportcancellation.md)
-- [ts-config-allowsyntheticdefaultimports](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md)
-- [ts-config-declaration](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md)
-- [ts-config-esmoduleinterop](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md)
-- [ts-config-exclude](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md)
-- [ts-config-forceconsistentcasinginfilenames](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md)
-- [ts-config-importhelpers](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md)
-- [ts-config-lib](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md)
-- [ts-config-module](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md)
-- [ts-config-moduleresolution](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-moduleresolution.md)
-- [ts-config-no-experimentaldecorators](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md)
-- [ts-config-sourcemap](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md)
-- [ts-config-strict](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md)
-- [ts-config-target](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-target.md)
-- [ts-doc-internal](/tools/eslint-plugin-azure-sdk/docs/rules/ts-doc-internal.md)
-- [ts-error-handling](/tools/eslint-plugin-azure-sdk/docs/rules/ts-error-handling.md)
-- [ts-modules-only-named](/tools/eslint-plugin-azure-sdk/docs/rules/ts-modules-only-named.md)
-- [ts-naming-drop-noun](/tools/eslint-plugin-azure-sdk/docs/rules/ts-naming-drop-noun.md)
-- [ts-naming-options](/tools/eslint-plugin-azure-sdk/docs/rules/ts-naming-options.md)
-- [ts-naming-subclients](/tools/eslint-plugin-azure-sdk/docs/rules/ts-naming-subclients.md)
-- [ts-no-const-enums](/tools/eslint-plugin-azure-sdk/docs/rules/ts-no-const-enums.md)
-- [ts-no-namespaces](/tools/eslint-plugin-azure-sdk/docs/rules/ts-no-namespaces.md)
-- [ts-package-json-author](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md)
-- [ts-package-json-bugs](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md)
-- [ts-package-json-engine-is-present](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-engine-is-present.md)
-- [ts-package-json-files-required](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-files-required.md)
-- [ts-package-json-homepage](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md)
-- [ts-package-json-keywords](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md)
-- [ts-package-json-license](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md)
-- [ts-package-json-main-is-cjs](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-main-is-cjs.md)
-- [ts-package-json-module](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-module.md)
-- [ts-package-json-name](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md)
-- [ts-package-json-repo](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md)
-- [ts-package-json-required-scripts](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-required-scripts.md)
-- [ts-package-json-sideeffects](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-sideeffects.md)
-- [ts-package-json-types](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-types.md)
-- [ts-pagination-list](/tools/eslint-plugin-azure-sdk/docs/rules/ts-pagination-list.md)
-- [ts-use-interface-parameters](/tools/eslint-plugin-azure-sdk/docs/rules/ts-use-interface-parameters.md)
-- [ts-use-promises](/tools/eslint-plugin-azure-sdk/docs/rules/ts-use-promises.md)
-- [ts-versioning-semver](/tools/eslint-plugin-azure-sdk/docs/rules/ts-versioning-semver.md)
+| Rule                                                                                                                                  | Fixable |
+| ------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| [github-source-headers](/tools/eslint-plugin-azure-sdk/docs/rules/github-source-headers.md)                                           | Yes     |
+| [ts-apisurface-standardized-verbs](/tools/eslint-plugin-azure-sdk/docs/rules/ts-apisurface-standardized-verbs.md)                     | No      |
+| [ts-apisurface-supportcancellation](/tools/eslint-plugin-azure-sdk/docs/rules/ts-apisurface-supportcancellation.md)                   | No      |
+| [ts-config-allowsyntheticdefaultimports](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md)         | Yes     |
+| [ts-config-declaration](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md)                                           | Yes     |
+| [ts-config-esmoduleinterop](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md)                                   | Yes     |
+| [ts-config-exclude](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md)                                                   | Yes     |
+| [ts-config-forceconsistentcasinginfilenames](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md) | Yes     |
+| [ts-config-importhelpers](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md)                                       | Yes     |
+| [ts-config-lib](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md)                                                           | Yes     |
+| [ts-config-module](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md)                                                     | Yes     |
+| [ts-config-moduleresolution](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-moduleresolution.md)                                 | Yes     |
+| [ts-config-no-experimentaldecorators](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md)               | Yes     |
+| [ts-config-sourcemap](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md)                                               | Yes     |
+| [ts-config-strict](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md)                                                     | Yes     |
+| [ts-config-target](/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-target.md)                                                     | No      |
+| [ts-doc-internal](/tools/eslint-plugin-azure-sdk/docs/rules/ts-doc-internal.md)                                                       | No      |
+| [ts-error-handling](/tools/eslint-plugin-azure-sdk/docs/rules/ts-error-handling.md)                                                   | No      |
+| [ts-modules-only-named](/tools/eslint-plugin-azure-sdk/docs/rules/ts-modules-only-named.md)                                           | No      |
+| [ts-naming-drop-noun](/tools/eslint-plugin-azure-sdk/docs/rules/ts-naming-drop-noun.md)                                               | No      |
+| [ts-naming-options](/tools/eslint-plugin-azure-sdk/docs/rules/ts-naming-options.md)                                                   | No      |
+| [ts-naming-subclients](/tools/eslint-plugin-azure-sdk/docs/rules/ts-naming-subclients.md)                                             | No      |
+| [ts-no-const-enums](/tools/eslint-plugin-azure-sdk/docs/rules/ts-no-const-enums.md)                                                   | Yes     |
+| [ts-no-namespaces](/tools/eslint-plugin-azure-sdk/docs/rules/ts-no-namespaces.md)                                                     | No      |
+| [ts-package-json-author](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md)                                         | Yes     |
+| [ts-package-json-bugs](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md)                                             | Yes     |
+| [ts-package-json-engine-is-present](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-engine-is-present.md)                   | Yes     |
+| [ts-package-json-files-required](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-files-required.md)                         | Yes     |
+| [ts-package-json-homepage](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-homepage.md)                                     | No      |
+| [ts-package-json-keywords](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md)                                     | Yes     |
+| [ts-package-json-license](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md)                                       | Yes     |
+| [ts-package-json-main-is-cjs](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-main-is-cjs.md)                               | Yes     |
+| [ts-package-json-module](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-module.md)                                         | Yes     |
+| [ts-package-json-name](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-name.md)                                             | No      |
+| [ts-package-json-repo](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md)                                             | Yes     |
+| [ts-package-json-required-scripts](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-required-scripts.md)                     | No      |
+| [ts-package-json-sideeffects](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-sideeffects.md)                               | Yes     |
+| [ts-package-json-types](/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-types.md)                                           | No      |
+| [ts-pagination-list](/tools/eslint-plugin-azure-sdk/docs/rules/ts-pagination-list.md)                                                 | No      |
+| [ts-use-interface-parameters](/tools/eslint-plugin-azure-sdk/docs/rules/ts-use-interface-parameters.md)                               | No      |
+| [ts-use-promises](/tools/eslint-plugin-azure-sdk/docs/rules/ts-use-promises.md)                                                       | No      |
+| [ts-versioning-semver](/tools/eslint-plugin-azure-sdk/docs/rules/ts-versioning-semver.md)                                             | No      |

--- a/tools/eslint-plugin-azure-sdk/docs/rules/github-source-headers.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/github-source-headers.md
@@ -9,6 +9,8 @@ Copyright (c) Microsoft Corporation.
 Licensed under the MIT license.
 ```
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-allowsyntheticdefaultimports.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.allowSyntheticDefaultImports` in `tsconfig.json` to be set to `true`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-declaration.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.declaration` in `tsconfig.json` to be set to `true`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-esmoduleinterop.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.esModuleInterop` in `tsconfig.json` to be set to `true`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-exclude.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.exclude` in `tsconfig.json` to include `node_modules`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-forceconsistentcasinginfilenames.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.forceConsistentCasingInFileNames` in `tsconfig.json` to be set to `true`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-importhelpers.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.importHelpers` in `tsconfig.json` to be set to `true`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-lib.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.lib` in `tsconfig.json` to be set to an empty array.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-module.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.module` in `tsconfig.json` to be set to `"es6"`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-moduleresolution.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-moduleresolution.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.moduleResolution` in `tsconfig.json` to be set to `"node"`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-no-experimentaldecorators.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.experimentalDecorators` in `tsconfig.json` to be set to `false`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-sourcemap.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.sourceMap` and `compilerOptions.declarationMap` in `tsconfig.json` to be set to `true`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-config-strict.md
@@ -2,6 +2,8 @@
 
 Requires `compilerOptions.strict` in `tsconfig.json` to be set to `false`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-no-const-enums.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-no-const-enums.md
@@ -2,6 +2,8 @@
 
 Recommends against the usage of TypeScript's const enums.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-author.md
@@ -2,6 +2,8 @@
 
 Requires `author` in `package.json` to be set to `"Microsoft Corporation"`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-bugs.md
@@ -2,6 +2,8 @@
 
 Requires `bugs` in `package.json` to be set to `"https://github.com/Azure/azure-sdk-for-js/issues"`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-engine-is-present.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-engine-is-present.md
@@ -4,6 +4,8 @@ Requires support for all Node LTS version.
 
 Currently, this requires `engine` in `package.json` to be set to `">=8.0.0"`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-files-required.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-files-required.md
@@ -4,6 +4,8 @@ Requires `files` in `package.json` to contain paths to the package contents.
 
 Specifically, this rule looks for inclusion of `dist`, `dist-esm/src`, and `src` as either just those directories or specific subdirectories
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-keywords.md
@@ -2,6 +2,8 @@
 
 Requires `keywords` in `package.json` to include `"Azure"` and `"cloud"`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-license.md
@@ -2,6 +2,8 @@
 
 Requires `license` in `package.json` to be set to `"MIT"`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-main-is-cjs.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-main-is-cjs.md
@@ -2,6 +2,8 @@
 
 Requires `main` in `package.json` to be point to a CommonJS or UMD module. In this case, its assumed that it points to `"dist/index.js"`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-module.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-module.md
@@ -2,6 +2,8 @@
 
 Requires `module` in `package.json` to be set to the ES6 entrypoint of the package. It is assumed that this is `"dist-esm/src/index.js"`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-repo.md
@@ -2,6 +2,8 @@
 
 Requires `repository` in `package.json` to be set to `"github:Azure/azure-sdk-for-js"`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-sideeffects.md
+++ b/tools/eslint-plugin-azure-sdk/docs/rules/ts-package-json-sideeffects.md
@@ -2,6 +2,8 @@
 
 Requires `sideEffects` in `package.json` to be set to `false`.
 
+This rule is fixable using the `--fix` option.
+
 ## Examples
 
 ### Good

--- a/tools/eslint-plugin-azure-sdk/package-lock.json
+++ b/tools/eslint-plugin-azure-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.2.0-preview.1",
+  "version": "1.3.0-preview.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.2.0-preview.1",
+  "version": "1.3.0-preview.1",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "keywords": [
     "eslint",

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -39,8 +39,7 @@
     "format": "prettier --write \"./**/*.{ts,json,md}\"",
     "format:check": "prettier --check \"./**/*.{ts,json,md}\"",
     "lint": "eslint src tests --ext .ts && markdownlint README.md docs",
-    "test": "npm run clean && tsc -p tsconfig.json && mocha --timeout 10000 --recursive dist/tests",
-    "test-temp": "npm run clean && tsc -p tsconfig.json && mocha --timeout 10000 --recursive dist/tests/rules/ts-config-declaration.js"
+    "test": "npm run clean && tsc -p tsconfig.json && mocha --timeout 10000 --recursive dist/tests"
   },
   "dependencies": {
     "glob": "^7.1.4",

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -39,7 +39,8 @@
     "format": "prettier --write \"./**/*.{ts,json,md}\"",
     "format:check": "prettier --check \"./**/*.{ts,json,md}\"",
     "lint": "eslint src tests --ext .ts && markdownlint README.md docs",
-    "test": "npm run clean && tsc -p tsconfig.json && mocha --timeout 10000 --recursive dist/tests"
+    "test": "npm run clean && tsc -p tsconfig.json && mocha --timeout 10000 --recursive dist/tests",
+    "test-temp": "npm run clean && tsc -p tsconfig.json && mocha --timeout 10000 --recursive dist/tests/rules/ts-config-declaration.js"
   },
   "dependencies": {
     "glob": "^7.1.4",

--- a/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
@@ -11,10 +11,14 @@ import { getRuleMetaData } from "../utils";
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const expectedComments =
+  "// Copyright (c) Microsoft Corporation.\n// Licensed under the MIT license.";
+
 export = {
   meta: getRuleMetaData(
     "github-source-headers",
-    "require copyright headers in every source file"
+    "require copyright headers in every source file",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener =>
     /\.ts$/.test(context.getFilename())
@@ -31,7 +35,9 @@ export = {
             if (headerComments.length === 0) {
               context.report({
                 node: node,
-                message: "no copyright header found"
+                message: "no copyright header found",
+                fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+                  fixer.insertTextBefore(node, expectedComments)
               });
               return;
             }
@@ -53,7 +59,9 @@ export = {
                 node: node,
                 message:
                   "copyright header not properly configured - expected value:\n" +
-                  "Copyright (c) Microsoft Corporation.\nLicensed under the MIT license.\n"
+                  "Copyright (c) Microsoft Corporation.\nLicensed under the MIT license.\n",
+                fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+                  fixer.insertTextBefore(node, expectedComments)
               });
             }
           }

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-supportcancellation.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-apisurface-supportcancellation.ts
@@ -4,8 +4,8 @@
  */
 
 import {
-  TSESTree,
-  ParserServices
+  ParserServices,
+  TSESTree
 } from "@typescript-eslint/experimental-utils";
 import { Rule } from "eslint";
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-allowsyntheticdefaultimports.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-allowsyntheticdefaultimports.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-allowsyntheticdefaultimports",
-    "force tsconfig.json's compilerOptions.allowSyntheticDefaultImports value to be true"
+    "force tsconfig.json's compilerOptions.allowSyntheticDefaultImports value to be true",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-declaration.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-declaration.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-declaration",
-    "force tsconfig.json's compilerOptions.declaration value to be true"
+    "force tsconfig.json's compilerOptions.declaration value to be true",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-esmoduleinterop.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-esmoduleinterop.ts
@@ -15,7 +15,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-esmoduleinterop",
-    "force tsconfig.json's compilerOptions.esModuleOnterop value to be true"
+    "force tsconfig.json's compilerOptions.esModuleOnterop value to be true",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-exclude.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-exclude.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-exclude",
-    "force tsconfig.json's compilerOptions.exclude value to at least contain 'node_modules'"
+    "force tsconfig.json's compilerOptions.exclude value to at least contain 'node_modules'",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-forceconsistentcasinginfilenames.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-forceconsistentcasinginfilenames.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-forceconsistentcasinginfilenames",
-    "force tsconfig.json's compilerOptions.forceConsistentCasingInFileNames value to be true"
+    "force tsconfig.json's compilerOptions.forceConsistentCasingInFileNames value to be true",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-importhelpers.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-importhelpers.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-importhelpers",
-    "force tsconfig.json's compilerOptions.importHelpers value to be true"
+    "force tsconfig.json's compilerOptions.importHelpers value to be true",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-lib.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-lib.ts
@@ -14,7 +14,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-lib",
-    "force tsconfig.json's compilerOptions.lib value to be an empty array"
+    "force tsconfig.json's compilerOptions.lib value to be an empty array",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {
@@ -41,13 +42,17 @@ export = {
               if (nodeValue.elements.length !== 0) {
                 context.report({
                   node: nodeValue,
-                  message: "compilerOptions.lib is not set to an empty array"
+                  message: "compilerOptions.lib is not set to an empty array",
+                  fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+                    fixer.replaceText(nodeValue, "[]")
                 });
               }
             } else {
               context.report({
                 node: node.value,
-                message: "compilerOptions.lib is not set to an empty array"
+                message: "compilerOptions.lib is not set to an empty array",
+                fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+                  fixer.replaceText(node.value, "[]")
               });
             }
           }

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-module.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-module.ts
@@ -44,7 +44,7 @@ export = {
                 message:
                   "compilerOptions.module is not set to a literal (string | boolean | null | number | RegExp)",
                 fix: (fixer: Rule.RuleFixer): Rule.Fix =>
-                  fixer.replaceText(node.value, "es6")
+                  fixer.replaceText(node.value, `"es6"`)
               });
             }
 
@@ -57,7 +57,7 @@ export = {
                 node: node,
                 message: `compilerOptions.module is set to ${module} when it should be set to ES6`,
                 fix: (fixer: Rule.RuleFixer): Rule.Fix =>
-                  fixer.replaceText(nodeValue, "es6")
+                  fixer.replaceText(nodeValue, `"es6"`)
               });
             }
           }

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-module.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-module.ts
@@ -14,7 +14,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-module",
-    "force tsconfig.json's compilerOptions.module value to be set to 'es6'"
+    "force tsconfig.json's compilerOptions.module value to be set to 'es6'",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {
@@ -41,7 +42,9 @@ export = {
               context.report({
                 node: node.value,
                 message:
-                  "compilerOptions.module is not set to a literal (string | boolean | null | number | RegExp)"
+                  "compilerOptions.module is not set to a literal (string | boolean | null | number | RegExp)",
+                fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+                  fixer.replaceText(node.value, "es6")
               });
             }
 
@@ -52,11 +55,9 @@ export = {
             if (!/^es6$/i.test(module)) {
               context.report({
                 node: node,
-                message:
-                  "compilerOptions.module is set to {{ identifier }} when it should be set to ES6",
-                data: {
-                  identifier: module
-                }
+                message: `compilerOptions.module is set to ${module} when it should be set to ES6`,
+                fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+                  fixer.replaceText(nodeValue, "es6")
               });
             }
           }

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-moduleresolution.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-moduleresolution.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-moduleresolution",
-    "force tsconfig.json's compilerOptions.strict value to be true"
+    "force tsconfig.json's compilerOptions.strict value to be true",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-no-experimentaldecorators.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-no-experimentaldecorators.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-no-experimentaldecorators",
-    "force tsconfig.json's compilerOptions.experimentalDecorators value to be false"
+    "force tsconfig.json's compilerOptions.experimentalDecorators value to be false",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-sourcemap.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-sourcemap.ts
@@ -14,7 +14,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-sourcemap",
-    "force tsconfig.json's compilerOptions.sourceMap and compilerOptions.declarationMap values to both be true"
+    "force tsconfig.json's compilerOptions.sourceMap and compilerOptions.declarationMap values to both be true",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const sourceMapVerifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-config-strict.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-config-strict.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-config-strict",
-    "force tsconfig.json's compilerOptions.strict value to be true"
+    "force tsconfig.json's compilerOptions.strict value to be true",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-error-handling.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-error-handling.ts
@@ -58,11 +58,7 @@ export = {
             if (!["TypeError", "RangeError", "Error", "any"].includes(type)) {
               context.report({
                 node: thrown,
-                message:
-                  "type {{ type }} of thrown error is not one of the allowed error types: TypeError, RangeError, Error",
-                data: {
-                  type: type
-                }
+                message: `type ${type} of thrown error is not one of the allowed error types: TypeError, RangeError, Error`
               });
             }
           },
@@ -77,11 +73,7 @@ export = {
             if (!["TypeError", "RangeError", "Error"].includes(callee.name)) {
               context.report({
                 node: callee,
-                message:
-                  "type {{ type }} of thrown error is not one of the allowed error types: TypeError, RangeError, Error",
-                data: {
-                  type: callee.name
-                }
+                message: `type ${callee.name} of thrown error is not one of the allowed error types: TypeError, RangeError, Error`
               });
             }
           }

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-no-const-enums.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-no-const-enums.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-no-const-enums",
-    "forbid usage of TypeScript's const enums"
+    "forbid usage of TypeScript's const enums",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener =>
     ({
@@ -24,7 +25,12 @@ export = {
         if (node.const !== undefined) {
           context.report({
             node: node,
-            message: "const enums should not be used"
+            message: "const enums should not be used",
+            fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+              fixer.removeRange([
+                node.range[0],
+                node.range[0] + "const ".length
+              ])
           });
         }
       }

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-author.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-author.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-package-json-author",
-    "force package.json's author value to be 'Microsoft Corporation'"
+    "force package.json's author value to be 'Microsoft Corporation'",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-bugs.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-bugs.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-package-json-bugs",
-    "force package.json's bugs.url value to be 'https://github.com/Azure/azure-sdk-for-js/issues'"
+    "force package.json's bugs.url value to be 'https://github.com/Azure/azure-sdk-for-js/issues'",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-engine-is-present.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-engine-is-present.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-package-json-engine-is-present",
-    "force Node support for all LTS versions"
+    "force Node support for all LTS versions",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     /**

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-files-required.ts
@@ -14,7 +14,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-package-json-files-required",
-    "requires package.json's files value to contain paths to the package contents"
+    "requires package.json's files value to contain paths to the package contents",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {
@@ -42,6 +43,9 @@ export = {
 
             const nodeValue = node.value;
             const elements = nodeValue.elements as Literal[];
+            const elementValues = elements.map(
+              (element: Literal): unknown => element.value
+            );
 
             // looks for 'dist' with optional leading './' and optional trailing '/'
             if (
@@ -52,7 +56,11 @@ export = {
             ) {
               context.report({
                 node: nodeValue,
-                message: "dist is not included in files"
+                message: "dist is not included in files",
+                fix: (fixer: Rule.RuleFixer): Rule.Fix => {
+                  elementValues.push("dist");
+                  return fixer.replaceText(nodeValue, elementValues.toString());
+                }
               });
             }
 
@@ -67,7 +75,11 @@ export = {
             ) {
               context.report({
                 node: nodeValue,
-                message: "dist-esm/src is not included in files"
+                message: "dist-esm/src is not included in files",
+                fix: (fixer: Rule.RuleFixer): Rule.Fix => {
+                  elementValues.push("dist/src");
+                  return fixer.replaceText(nodeValue, elementValues.toString());
+                }
               });
             }
 
@@ -80,7 +92,11 @@ export = {
             ) {
               context.report({
                 node: nodeValue,
-                message: "src is not included in files"
+                message: "src is not included in files",
+                fix: (fixer: Rule.RuleFixer): Rule.Fix => {
+                  elementValues.push("src");
+                  return fixer.replaceText(nodeValue, elementValues.toString());
+                }
               });
             }
           }

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-keywords.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-keywords.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-package-json-keywords",
-    "force package.json's keywords value to contain at least 'Azure' and 'cloud'"
+    "force package.json's keywords value to contain at least 'Azure' and 'cloud'",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-license.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-license.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-packge-json-license",
-    "force package.json's license value to be 'MIT'"
+    "force package.json's license value to be 'MIT'",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-main-is-cjs.ts
@@ -14,7 +14,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-package-json-main-is-cjs",
-    "force package.json's main value to point to a CommonJS or UMD module"
+    "force package.json's main value to point to a CommonJS or UMD module",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {
@@ -44,11 +45,9 @@ export = {
             if (!/^(\.\/)?dist\/index\.js$/.test(main)) {
               context.report({
                 node: nodeValue,
-                message:
-                  "main is set to {{ identifier }} when it should be set to dist/index.js",
-                data: {
-                  identifier: main
-                }
+                message: `main is set to ${main} when it should be set to dist/index.js`,
+                fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+                  fixer.replaceText(nodeValue, `"dist/index.js"`)
               });
             }
           }

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-module.ts
@@ -14,7 +14,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-package-json-module",
-    "force package.json's module value to be the ES6 entrypoint to the application"
+    "force package.json's module value to be the ES6 entrypoint to the application",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {
@@ -39,16 +40,14 @@ export = {
             }
 
             const nodeValue = node.value as Literal;
-            const module = nodeValue.value as string;
+            const moduleValue = nodeValue.value as string;
 
-            if (!/^(\.\/)?dist-esm\/src\/index\.js$/.test(module)) {
+            if (!/^(\.\/)?dist-esm\/src\/index\.js$/.test(moduleValue)) {
               context.report({
                 node: nodeValue,
-                message:
-                  "module is set to {{ identifier }} when it should be set to dist-esm/src/index.js",
-                data: {
-                  identifier: module
-                }
+                message: `module is set to ${moduleValue} when it should be set to dist-esm/src/index.js`,
+                fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+                  fixer.replaceText(nodeValue, `"dist-esm/src/index.js"`)
               });
             }
           }

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-repo.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-package-json-repo",
-    "force package.json's repository value to be 'github:Azure/azure-sdk-for-js'"
+    "force package.json's repository value to be 'github:Azure/azure-sdk-for-js'",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sideeffects.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-package-json-sideeffects.ts
@@ -13,7 +13,8 @@ import { getRuleMetaData, getVerifiers, stripPath } from "../utils";
 export = {
   meta: getRuleMetaData(
     "ts-package-json-sideeffects",
-    "force package.json's sideEffects value to be false"
+    "force package.json's sideEffects value to be false",
+    "code"
   ),
   create: (context: Rule.RuleContext): Rule.RuleListener => {
     const verifiers = getVerifiers(context, {

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
@@ -224,15 +224,11 @@ const evaluateOverloads = (
   const identifier = getParamAsIdentifier(param);
   context.report({
     node: identifier,
-    message:
-      "type {{ type }} of parameter {{ param }} of function {{ func }} is a class or contains a class as a member",
-    data: {
-      type: typeChecker.typeToString(
-        getTypeOfParam(param, converter, typeChecker)
-      ),
-      param: identifier.name,
-      func: name
-    }
+    message: `type ${typeChecker.typeToString(
+      getTypeOfParam(param, converter, typeChecker)
+    )} of parameter ${
+      identifier.name
+    } of function ${name} is a class or contains a class as a member`
   });
 };
 

--- a/tools/eslint-plugin-azure-sdk/src/utils/metadata.ts
+++ b/tools/eslint-plugin-azure-sdk/src/utils/metadata.ts
@@ -7,13 +7,17 @@ import { Rule } from "eslint";
 
 export const getRuleMetaData = (
   ruleName: string,
-  ruleDescription: string
-): Rule.RuleMetaData => ({
-  docs: {
-    description: ruleDescription,
-    category: "Best Practices",
-    recommended: true,
-    url: `"https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/${ruleName}.md`
-  },
-  schema: []
-});
+  ruleDescription: string,
+  fix?: "code" | "whitespace"
+): Rule.RuleMetaData => {
+  const required = {
+    docs: {
+      description: ruleDescription,
+      category: "Best Practices",
+      recommended: true,
+      url: `"https://github.com/Azure/azure-sdk-tools/blob/master/tools/eslint-plugin-azure-sdk/docs/rules/${ruleName}.md`
+    },
+    schema: []
+  };
+  return fix !== undefined ? { ...required, fixable: fix } : { ...required };
+};

--- a/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
+++ b/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
@@ -197,11 +197,10 @@ export const getVerifiers = (
           context.report({
             node: nodeValue,
             message: `${outer} does not contain ${value}`,
-            fix: (fixer: Rule.RuleFixer): Rule.Fix =>
-              fixer.replaceText(
-                nodeValue,
-                [...candidateValues, value].toString()
-              )
+            fix: (fixer: Rule.RuleFixer): Rule.Fix => {
+              candidateValues.push(value);
+              return fixer.replaceText(nodeValue, candidateValues.toString());
+            }
           });
         }
       });
@@ -210,11 +209,10 @@ export const getVerifiers = (
         context.report({
           node: nodeValue,
           message: `${outer} does not contain ${expected}`,
-          fix: (fixer: Rule.RuleFixer): Rule.Fix =>
-            fixer.replaceText(
-              nodeValue,
-              [...candidateValues, expected].toString()
-            )
+          fix: (fixer: Rule.RuleFixer): Rule.Fix => {
+            candidateValues.push(expected);
+            return fixer.replaceText(nodeValue, candidateValues.toString());
+          }
         });
       }
     }

--- a/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
+++ b/tools/eslint-plugin-azure-sdk/src/utils/verifiers.ts
@@ -84,7 +84,14 @@ export const getVerifiers = (
     if (nodeValue.value !== expected) {
       context.report({
         node: nodeValue,
-        message: `${outer} is set to ${nodeValue.value} when it should be set to ${expected}`
+        message: `${outer} is set to ${nodeValue.value} when it should be set to ${expected}`,
+        fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+          fixer.replaceText(
+            nodeValue,
+            typeof expected === "string"
+              ? `"${expected}"`
+              : (expected as string)
+          )
       });
     }
   },
@@ -138,7 +145,14 @@ export const getVerifiers = (
     if (nodeValue.value !== expected) {
       context.report({
         node: nodeValue,
-        message: `${outer}.${inner} is set to ${nodeValue.value} when it should be set to ${expected}`
+        message: `${outer}.${inner} is set to ${nodeValue.value} when it should be set to ${expected}`,
+        fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+          fixer.replaceText(
+            nodeValue,
+            typeof expected === "string"
+              ? `"${expected}"`
+              : (expected as string)
+          )
       });
     }
   },
@@ -173,29 +187,34 @@ export const getVerifiers = (
     }
 
     const candidateArray = nodeValue.elements as Literal[];
+    const candidateValues = candidateArray.map(
+      (candidate: Literal): unknown => candidate.value
+    );
 
     if (expected instanceof Array) {
       expected.forEach((value: unknown): void => {
-        if (
-          candidateArray.every(
-            (candidate: Literal): boolean => candidate.value !== value
-          )
-        ) {
+        if (!candidateValues.includes(value)) {
           context.report({
             node: nodeValue,
-            message: `${outer} does not contain ${value}`
+            message: `${outer} does not contain ${value}`,
+            fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+              fixer.replaceText(
+                nodeValue,
+                [...candidateValues, value].toString()
+              )
           });
         }
       });
     } else {
-      if (
-        candidateArray.every(
-          (candidate: Literal): boolean => candidate.value !== expected
-        )
-      ) {
+      if (!candidateValues.includes(expected)) {
         context.report({
           node: nodeValue,
-          message: `${outer} does not contain ${expected}`
+          message: `${outer} does not contain ${expected}`,
+          fix: (fixer: Rule.RuleFixer): Rule.Fix =>
+            fixer.replaceText(
+              nodeValue,
+              [...candidateValues, expected].toString()
+            )
         });
       }
     }


### PR DESCRIPTION
ESLint provides the `--fix` options, where fixes are made to rule violations if that rule has defined a fix function. This PR implements fix functions for all rules where possible - however, not all errors thrown by fixable rules will necessarily have a fix (for example, changing a value vs adding a significant amount of text).

Fixable rules: 
- `github-source-headers`
- `ts-config-allowsyntheticdefaultimports`
- `ts-config-declaration`
- `ts-config-esmoduleinterop`
- `ts-config-exclude`
- `ts-config-forceconsistentcasinginfilenames`
- `ts-config-importhelpers`
- `ts-config-lib`
- `ts-config-module`
- `ts-config-moduleresolution`
- `ts-config-no-experimentaldecorators`
- `ts-config-sourcemap`
- `ts-config-strict`
- `ts-no-const-enums`
- `ts-package-json-author`
- `ts-package-json-bugs`
- `ts-package-json-engine-is-present`
- `ts-package-json-files-required`
- `ts-package-json-keywords`
- `ts-package-json-license`
- `ts-package-json-main-is-cjs`
- `ts-package-json-module`
- `ts-package-json-repo`
- `ts-package-json-sideeffects`

Also replaces usage of the `data` field in ESLint reports with template literals.

This PR will bump `@azure/eslint-plugin-azure-sdk` to `1.3.0-preview.1`.