### PR TITLE
Remove dependency on AST_NODE_TYPES

### DIFF
--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.3.0-preview.1",
+  "version": "1.3.0-preview.2",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "keywords": [
     "eslint",

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-drop-noun.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-drop-noun.ts
@@ -3,10 +3,7 @@
  * @author Arpan Laha
  */
 
-import {
-  TSESTree,
-  AST_NODE_TYPES
-} from "@typescript-eslint/experimental-utils";
+import { TSESTree } from "@typescript-eslint/experimental-utils";
 import { Rule } from "eslint";
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
 import { getPublicMethods, getRuleMetaData } from "../utils";
@@ -34,8 +31,7 @@ export = {
           // check for proper return type configuration
           if (
             TSFunction.returnType !== undefined &&
-            TSFunction.returnType.typeAnnotation.type ===
-              AST_NODE_TYPES.TSTypeReference
+            TSFunction.returnType.typeAnnotation.type === "TSTypeReference"
           ) {
             const typeIdentifier = TSFunction.returnType.typeAnnotation
               .typeName as Identifier;

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-subclients.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-naming-subclients.ts
@@ -3,10 +3,7 @@
  * @author Arpan Laha
  */
 
-import {
-  TSESTree,
-  AST_NODE_TYPES
-} from "@typescript-eslint/experimental-utils";
+import { TSESTree } from "@typescript-eslint/experimental-utils";
 import { Rule } from "eslint";
 import { ClassDeclaration, Identifier, MethodDefinition } from "estree";
 import { getPublicMethods, getRuleMetaData } from "../utils";
@@ -33,8 +30,7 @@ export = {
           // check for proper return type configuration
           if (
             TSFunction.returnType !== undefined &&
-            TSFunction.returnType.typeAnnotation.type ===
-              AST_NODE_TYPES.TSTypeReference
+            TSFunction.returnType.typeAnnotation.type === "TSTypeReference"
           ) {
             const typeIdentifier = TSFunction.returnType.typeAnnotation
               .typeName as Identifier;

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-pagination-list.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-pagination-list.ts
@@ -3,10 +3,7 @@
  * @author Arpan Laha
  */
 
-import {
-  TSESTree,
-  AST_NODE_TYPES
-} from "@typescript-eslint/experimental-utils";
+import { TSESTree } from "@typescript-eslint/experimental-utils";
 import { Rule } from "eslint";
 import { Identifier, MethodDefinition } from "estree";
 import { getRuleMetaData } from "../utils";
@@ -32,8 +29,7 @@ export = {
         const TSFunction = node.value as TSESTree.FunctionExpression;
         if (
           TSFunction.returnType === undefined ||
-          TSFunction.returnType.typeAnnotation.type !==
-            AST_NODE_TYPES.TSTypeReference
+          TSFunction.returnType.typeAnnotation.type !== "TSTypeReference"
         ) {
           context.report({
             node: node,


### PR DESCRIPTION
A few rules depend on `AST_NODE_TYPES`, an enum used in `@typescript-eslint/experimental-utils` - however, this dependency does not disappear on compilation unlike all other imports from any `@typescript-eslint` package. To resolve this, this PR uses the enum strings literally and bumps the version to `1.3.0-preview.2`