### PR TITLE
Patch --fix option

### DIFF
--- a/tools/eslint-plugin-azure-sdk/src/processors/index.ts
+++ b/tools/eslint-plugin-azure-sdk/src/processors/index.ts
@@ -19,6 +19,7 @@ export = {
       messages[0].filter(
         (message: Linter.LintMessage): boolean =>
           message.ruleId !== "no-unused-expressions"
-      )
+      ),
+    supportsAutofix: false // TODO enable when ESLint is bumped to 6.x.x
   }
 };

--- a/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/github-source-headers.ts
@@ -12,7 +12,7 @@ import { getRuleMetaData } from "../utils";
 //------------------------------------------------------------------------------
 
 const expectedComments =
-  "// Copyright (c) Microsoft Corporation.\n// Licensed under the MIT license.";
+  "// Copyright (c) Microsoft Corporation.\n// Licensed under the MIT license.\n";
 
 export = {
   meta: getRuleMetaData(

--- a/tools/eslint-plugin-azure-sdk/src/utils/metadata.ts
+++ b/tools/eslint-plugin-azure-sdk/src/utils/metadata.ts
@@ -11,6 +11,7 @@ export const getRuleMetaData = (
   fix?: "code" | "whitespace"
 ): Rule.RuleMetaData => {
   const required = {
+    type: "suggestion",
     docs: {
       description: ruleDescription,
       category: "Best Practices",
@@ -19,5 +20,5 @@ export const getRuleMetaData = (
     },
     schema: []
   };
-  return fix !== undefined ? { ...required, fixable: fix } : { ...required };
+  return fix !== undefined ? { ...required, fixable: fix } : required;
 };


### PR DESCRIPTION
`--fix` produces unexpected behavior, such as unexplained crashes and lint error reports where not using `--fix` would not have produced a lint error.