### PR TITLE
Fix github-source-header comment interactions

### DIFF
--- a/tools/eslint-plugin-azure-sdk/package-lock.json
+++ b/tools/eslint-plugin-azure-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.3.0-preview.5",
+  "version": "1.3.0-preview.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.3.0",
+  "version": "1.3.0-preview.6",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "keywords": [
     "eslint",

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "1.3.0-preview.5",
+  "version": "1.3.0",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "keywords": [
     "eslint",


### PR DESCRIPTION
ESLint autofix interactions with `Comment` nodes aren't immediately intuitive and the previous implementation didn't work properly. This PR addresses this issue and bumps the version to `1.3.0-preview.6`.