### PR TITLE
Fix ts-use-interface-params

### DIFF
--- a/tools/eslint-plugin-azure-sdk/package-lock.json
+++ b/tools/eslint-plugin-azure-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "2.0.0",
+  "version": "2.0.0-preview.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tools/eslint-plugin-azure-sdk/package.json
+++ b/tools/eslint-plugin-azure-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure/eslint-plugin-azure-sdk",
-  "version": "2.0.0",
+  "version": "2.0.0-preview.2",
   "description": "An ESLint plugin enforcing design guidelines for the JavaScript/TypeScript Azure SDK",
   "keywords": [
     "eslint",

--- a/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
+++ b/tools/eslint-plugin-azure-sdk/src/rules/ts-use-interface-parameters.ts
@@ -299,14 +299,19 @@ export = {
                   .getSymbol();
                 const overloads =
                   symbol !== undefined
-                    ? symbol.declarations.map(
-                        (declaration: Declaration): FunctionExpression => {
-                          const method = reverter.get(
-                            declaration as TSNode
-                          ) as MethodDefinition;
-                          return method.value;
-                        }
-                      )
+                    ? symbol.declarations
+                        .filter(
+                          (declaration: Declaration): boolean =>
+                            reverter.get(declaration as TSNode) !== undefined
+                        )
+                        .map(
+                          (declaration: Declaration): FunctionExpression => {
+                            const method = reverter.get(
+                              declaration as TSNode
+                            ) as MethodDefinition;
+                            return method.value;
+                          }
+                        )
                     : [];
                 evaluateOverloads(
                   overloads,


### PR DESCRIPTION
Reading `method.value` on line `307` of `src/rules/ts-use-interface-parameters` results in an error where method occasionally returns undefined.

This PR patches this bug and changes `@azure/eslint-plugin-azure-sdk` to `2.0.0-preview.2`.