### PR TITLE
Fix an overflow error caused by not calling against base class.

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/ContinuousIntegrationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/ContinuousIntegrationPipelineConvention.cs
@@ -19,7 +19,7 @@ namespace PipelineGenerator.Conventions
             // NOTE: Not happy with this code at all, I'm going to look for a reasonable
             // API that can do equality comparisons (without having to do all the checks myself).
 
-            var hasChanges = await ApplyConventionAsync(definition, component);
+            var hasChanges = await base.ApplyConventionAsync(definition, component);
 
             var ciTrigger = definition.Triggers.OfType<ContinuousIntegrationTrigger>().SingleOrDefault();
 


### PR DESCRIPTION
I had this in a local change and forgot to push it before merging. Just putting it in now to unblock the pipeline generation automation.