### PR TITLE
Bump version number

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
@@ -7,7 +7,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pipeline-generator</ToolCommandName>
 
-    <VersionPrefix>1.0.1</VersionPrefix>
+    <VersionPrefix>1.0.2</VersionPrefix>
 
     <AssemblyName>Azure.Sdk.Tools.PipelineGenerator</AssemblyName>
   </PropertyGroup>


### PR DESCRIPTION
The automated version numbering isn't working correctly. To get unblocked for my current task I'm going to bump the patch number on the tool then come back and have a closer look as to why the build number didn't increment.