### PR TITLE
Add scheduled triggers to unified pipelines.

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
@@ -9,22 +9,6 @@ namespace PipelineGenerator.Conventions
 {
     public class IntegrationTestingPipelineConvention : PipelineConvention
     {
-        /// <summary>
-        /// Key in repository properties dictionary for reporting build status
-        /// </summary>
-        private const string ReportBuildStatusKey = "reportBuildStatus";
-
-        /// <summary>
-        /// Start hour (3AM)
-        /// </summary>
-        private const int StartHourOffset = 3;
-
-        /// <summary>
-        /// Number of buckets for hour hashing
-        /// </summary>
-        private const int HourBuckets = 3;
-
-
         public override string SearchPattern => "tests.yml";
 
         public IntegrationTestingPipelineConvention(ILogger logger, PipelineGenerationContext context) : base(logger, context)
@@ -83,11 +67,6 @@ namespace PipelineGenerator.Conventions
             }
 
             return hasChanges;
-        }
-
-        private int HashBucket(string pipelineName)
-        {
-            return pipelineName.GetHashCode() % HourBuckets;
         }
 
         private PullRequestTrigger GetDefaultPrTrigger()

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -241,6 +241,21 @@ namespace PipelineGenerator.Conventions
             return hasChanges;
         }
 
+        /// <summary>
+        /// Start hour (3AM)
+        /// </summary>
+        protected const int StartHourOffset = 3;
+
+        /// <summary>
+        /// Number of buckets for hour hashing
+        /// </summary>
+        protected const int HourBuckets = 3;
+
+        protected int HashBucket(string pipelineName)
+        {
+            return pipelineName.GetHashCode() % HourBuckets;
+        }
+
         protected virtual Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)
         {
             bool hasChanges = true;

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -28,6 +28,29 @@ namespace PipelineGenerator.Conventions
 
             var hasChanges = await base.ApplyConventionAsync(definition, component);
 
+            // Ensure Schedule Trigger
+            var scheduleTriggers = definition.Triggers.OfType<ScheduleTrigger>();
+
+            if (scheduleTriggers == default || !scheduleTriggers.Any())
+            {
+                var schedule = new Schedule
+                {
+                    DaysToBuild = ScheduleDays.All,
+                    ScheduleOnlyWithChanges = false,
+                    StartHours = StartHourOffset + HashBucket(definition.Name),
+                    StartMinutes = 0,
+                    TimeZoneId = "Pacific Standard Time",
+                };
+                schedule.BranchFilters.Add("+master");
+
+                definition.Triggers.Add(new ScheduleTrigger
+                {
+                    Schedules = new List<Schedule> { schedule }
+                });
+
+                hasChanges = true;
+            }
+
             var ciTrigger = definition.Triggers.OfType<ContinuousIntegrationTrigger>().SingleOrDefault();
 
             if (ciTrigger == null)


### PR DESCRIPTION
Lifted the schedule bucketing technique into the base pipeline convention class and implemented the same logic for the unified pipelines convention that is used in the integration tests (which makes sense since the unified pipelines will ultimately take over for running these live tests).