### PR TITLE
Fix a typo in artifact name.

### DIFF
--- a/tools/eslint-plugin-azure-sdk/ci.yml
+++ b/tools/eslint-plugin-azure-sdk/ci.yml
@@ -75,5 +75,5 @@ stages:
         DependsOn: Build
         ArtifactName: packages
         Artifacts:
-          - name: azure-eslink-plugin-azure-sdk
-            safeName: azureeslinkpluginazuresdk
+          - name: azure-eslint-plugin-azure-sdk
+            safeName: azureeslintpluginazuresdk


### PR DESCRIPTION
This PR fixes a typo in the artifact name. Reminder that I need to do some artifact presence checks in the PR phase to pick up these issues earlier.