### PR TITLE
expand scope of notifications 

### DIFF
--- a/tools/notification-configuration/github-codeowner-subscriber/CodeOwnersParser.cs
+++ b/tools/notification-configuration/github-codeowner-subscriber/CodeOwnersParser.cs
@@ -37,11 +37,14 @@ namespace NotificationConfiguration
         public List<string> GetContactsForPath(string path)
         {
             var result = expressionContacts
-                .LastOrDefault(expr => path.StartsWith(expr.GlobExpression));
+                .Where(expr => path.StartsWith(expr.GlobExpression))
+                .SelectMany(item => item.Contacts)
+                .ToHashSet()
+                .ToList();
 
             return result == default
                 ? new List<string>()
-                : result.Contacts;
+                : result;
         }
 
         /// <summary>


### PR DESCRIPTION
expand scope of notifications to include all matching expressions instead of last matching expression

@Azure/azure-sdk-eng 