### PR TITLE
Introduce a default for enabled flag.

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/RepositoryConfiguration.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/RepositoryConfiguration.cs
@@ -11,6 +11,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         public RepositoryConfiguration()
         {
             MinimumCheckRuns = 1;
+            IsEnabled = true;
         }
 
         [YamlMember(Alias = "minimumCheckRuns")]


### PR DESCRIPTION
This PR is a reaction to some of the conversations we've had about making ```enabled: true``` the default if the ```eng/CHECKENFORCER``` file is present, but it is still visible to have ```enabled: true`` or ```enabled: false```.