### PR TITLE
Check Enforcer fixes.

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer.Tests/Azure.Sdk.Tools.CheckEnforcer.Tests.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer.Tests/Azure.Sdk.Tools.CheckEnforcer.Tests.csproj
@@ -1,0 +1,19 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="nunit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azure.Sdk.Tools.CheckEnforcer\Azure.Sdk.Tools.CheckEnforcer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer.Tests/Integrations/GitHub/GitHubWebhookSignatureValidatorTest.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer.Tests/Integrations/GitHub/GitHubWebhookSignatureValidatorTest.cs
@@ -1,0 +1,27 @@
+﻿using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Tests.Integrations.GitHub
+{
+    public class GitHubWebhookSignatureValidatorTest
+    {
+        [Test]
+        public void VerifyMatchesGitHubTestCase()
+        {
+            var signature = "sha1=d03207e4b030cf234e3447bac4d93add4c6643d8";
+            var secret = "mysecret";
+            var payload = "{\"foo\":\"bar\"}";
+
+            var payloadBytes = Encoding.UTF8.GetBytes(payload);
+
+            var isValid = GitHubWebhookSignatureValidator.IsValid(payloadBytes, signature, secret);
+
+            Assert.IsTrue(isValid);
+        }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/CheckEnforcerSecurityException.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/CheckEnforcerSecurityException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.CheckEnforcer
+{
+
+    [Serializable]
+    public class CheckEnforcerSecurityException : CheckEnforcerException
+    {
+        public CheckEnforcerSecurityException(string message) : base(message) { }
+        public CheckEnforcerSecurityException(string message, Exception inner) : base(message, inner) { }
+        protected CheckEnforcerSecurityException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/CheckEnforcerConfigurationException.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/CheckEnforcerConfigurationException.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Azure.Sdk.Tools.CheckEnforcer
+namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
 {
 
     [Serializable]

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/GlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/GlobalConfigurationProvider.cs
@@ -1,12 +1,12 @@
-﻿using System;
+﻿using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace Azure.Sdk.Tools.CheckEnforcer
 {
-    public class GlobalConfiguration
+    public class GlobalConfigurationProvider : IGlobalConfigurationProvider
     {
-
         public string GetApplicationID()
         {
             var id = Environment.GetEnvironmentVariable("GITHUBAPP_ID");
@@ -18,7 +18,5 @@ namespace Azure.Sdk.Tools.CheckEnforcer
             var applicationName = Environment.GetEnvironmentVariable("CHECK_NAME");
             return applicationName;
         }
-
-        public const int ApplicationTokenLifetimeInMinutes = 10;
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/GlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/GlobalConfigurationProvider.cs
@@ -18,5 +18,23 @@ namespace Azure.Sdk.Tools.CheckEnforcer
             var applicationName = Environment.GetEnvironmentVariable("CHECK_NAME");
             return applicationName;
         }
+
+        public string GetKeyVaultUri()
+        {
+            var keyVaultUri = Environment.GetEnvironmentVariable("KEYVAULT_URI");
+            return keyVaultUri;
+        }
+
+        public string GetGitHubAppPrivateKeyName()
+        {
+            var gitHubAppPrivateKeyName = Environment.GetEnvironmentVariable("KEYVAULT_GITHUBAPP_KEY_NAME");
+            return gitHubAppPrivateKeyName;
+        }
+
+        public string GetGitHubAppWebhookSecretName()
+        {
+            var gitHubAppWebhookSecretName = Environment.GetEnvironmentVariable("GITHUBAPP_WEBHOOK_SECRET");
+            return gitHubAppWebhookSecretName;
+        }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
+{
+    public interface IGlobalConfigurationProvider
+    {
+        string GetApplicationID();
+        string GetApplicationName();
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
@@ -8,5 +8,9 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
     {
         string GetApplicationID();
         string GetApplicationName();
+        string GetGitHubAppPrivateKeyName();
+        string GetGitHubAppWebhookSecretName();
+        string GetKeyVaultUri();
+
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IRepositoryConfiguration.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IRepositoryConfiguration.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Text;
 
-namespace Azure.Sdk.Tools.CheckEnforcer
+namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
 {
     public interface IRepositoryConfiguration
     {

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IRepositoryConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IRepositoryConfigurationProvider.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
+{
+    public interface IRepositoryConfigurationProvider
+    {
+        Task<IRepositoryConfiguration> GetRepositoryConfigurationAsync(long installationId, long repositoryId, string pullRequestSha, CancellationToken cancellationToken);
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfiguration.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfiguration.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Text;
 using YamlDotNet.Serialization;
 
-namespace Azure.Sdk.Tools.CheckEnforcer
+namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
 {
     public class RepositoryConfiguration : IRepositoryConfiguration
     {

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfigurationProvider.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Build.Utilities;
+﻿using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Microsoft.Build.Utilities;
 using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using Octokit;
@@ -15,16 +16,16 @@ using YamlDotNet.RepresentationModel;
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NodeDeserializers;
 
-namespace Azure.Sdk.Tools.CheckEnforcer
+namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
 {
-    public class ConfigurationStore
+    public class RepositoryConfigurationProvider : IRepositoryConfigurationProvider
     {
-        public ConfigurationStore(GitHubClientFactory clientFactory)
+        public RepositoryConfigurationProvider(IGitHubClientProvider gitHubClientProvider)
         {
-            this.clientFactory = clientFactory;
+            this.gitHubClientProvider = gitHubClientProvider;
         }
 
-        private GitHubClientFactory clientFactory;
+        private IGitHubClientProvider gitHubClientProvider;
 
         private ConcurrentDictionary<string, IRepositoryConfiguration> cachedConfigurations = new ConcurrentDictionary<string, IRepositoryConfiguration>();
 
@@ -32,7 +33,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         {
             try
             {
-                var client = await clientFactory.GetInstallationClientAsync(installationId, cancellationToken);
+                var client = await gitHubClientProvider.GetInstallationClientAsync(installationId, cancellationToken);
                 var searchResults = await client.Repository.Content.GetAllContents(repositoryId, "eng/CHECKENFORCER");
                 var configurationFile = searchResults.Single();
                 ThrowIfInvalidFormat(configurationFile);

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Constants.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Constants.cs
@@ -4,10 +4,8 @@ using System.Text;
 
 namespace Azure.Sdk.Tools.CheckEnforcer
 {
-    internal static class Constants
+    public class Constants
     {
-        public const int ApplicationID = 41380;
-        public const string ApplicationName = "check-enforcer";
         public const int ApplicationTokenLifetimeInMinutes = 10;
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubClientFactory.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubClientFactory.cs
@@ -17,9 +17,12 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public class GitHubClientFactory
     {
-        public GitHubClientFactory()
+        public GitHubClientFactory(GlobalConfiguration globalConfiguration)
         {
+            this.globalConfiguration = globalConfiguration;
         }
+
+        private GlobalConfiguration globalConfiguration;
 
         private Tuple<DateTimeOffset, string> cachedApplicationToken;
 
@@ -83,7 +86,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
             jwtHeader["alg"] = "RS256";
 
             var jwtPayload = new JwtPayload(
-                issuer: Constants.ApplicationID.ToString(),
+                issuer: globalConfiguration.GetApplicationID(),
                 audience: null,
                 claims: null,
                 notBefore: DateTime.UtcNow,
@@ -154,7 +157,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         {
             var token = await GetTokenAsync(cancellationToken);
 
-            var appClient = new GitHubClient(new ProductHeaderValue(Constants.ApplicationName))
+            var appClient = new GitHubClient(new ProductHeaderValue(this.globalConfiguration.GetApplicationName()))
             {
                 Credentials = new Credentials(token, AuthenticationType.Bearer)
             };
@@ -185,7 +188,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         public async Task<GitHubClient> GetInstallationClientAsync(long installationId, CancellationToken cancellationToken)
         {
             var installationToken = await GetInstallationTokenAsync(installationId, cancellationToken);
-            var installationClient = new GitHubClient(new ProductHeaderValue($"{Constants.ApplicationName}-{installationId}"))
+            var installationClient = new GitHubClient(new ProductHeaderValue($"{this.globalConfiguration.GetApplicationName()}-{installationId}"))
             {
                 Credentials = new Credentials(installationToken)
             };

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
@@ -31,8 +31,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public static class GitHubWebhookFunction
     {
-        private static GlobalConfiguration globalConfiguration = new GlobalConfiguration();
-        private static IGitHubClientProvider gitHubClientProvider = new GitHubClientProvider(globalConfiguration);
+        private static IGlobalConfigurationProvider globalConfigurationProvider = new GlobalConfigurationProvider();
+        private static IGitHubClientProvider gitHubClientProvider = new GitHubClientProvider(globalConfigurationProvider);
         private static IRepositoryConfigurationProvider repositoryConfigurationPrivider = new RepositoryConfigurationProvider(gitHubClientProvider);
 
         [FunctionName("webhook")]
@@ -42,7 +42,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         {
             try
             {
-                var processor = new GitHubWebhookProcessor(log, gitHubClientProvider, repositoryConfigurationPrivider, globalConfiguration);
+                var processor = new GitHubWebhookProcessor(log, gitHubClientProvider, repositoryConfigurationPrivider, globalConfigurationProvider);
                 await processor.ProcessWebhookAsync(req, cancellationToken);
                 return new OkResult();
             }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
@@ -24,14 +24,16 @@ using System.Security.Cryptography;
 using Azure.Core;
 using System.Web.Http;
 using System.Runtime.CompilerServices;
+using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
 
 namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public static class GitHubWebhookFunction
     {
         private static GlobalConfiguration globalConfiguration = new GlobalConfiguration();
-        private static GitHubClientFactory clientFactory = new GitHubClientFactory(globalConfiguration);
-        private static ConfigurationStore configurationStore = new ConfigurationStore(clientFactory);
+        private static IGitHubClientProvider gitHubClientProvider = new GitHubClientProvider(globalConfiguration);
+        private static IRepositoryConfigurationProvider repositoryConfigurationPrivider = new RepositoryConfigurationProvider(gitHubClientProvider);
 
         [FunctionName("webhook")]
         public static async Task<IActionResult> Run(
@@ -40,7 +42,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         {
             try
             {
-                var processor = new GitHubWebhookProcessor(log, clientFactory, configurationStore, globalConfiguration);
+                var processor = new GitHubWebhookProcessor(log, gitHubClientProvider, repositoryConfigurationPrivider, globalConfiguration);
                 await processor.ProcessWebhookAsync(req, cancellationToken);
                 return new OkResult();
             }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
@@ -29,7 +29,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public static class GitHubWebhookFunction
     {
-        private static GitHubClientFactory clientFactory = new GitHubClientFactory();
+        private static GlobalConfiguration globalConfiguration = new GlobalConfiguration();
+        private static GitHubClientFactory clientFactory = new GitHubClientFactory(globalConfiguration);
         private static ConfigurationStore configurationStore = new ConfigurationStore(clientFactory);
 
         [FunctionName("webhook")]
@@ -39,7 +40,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         {
             try
             {
-                var processor = new GitHubWebhookProcessor(log, clientFactory, configurationStore);
+                var processor = new GitHubWebhookProcessor(log, clientFactory, configurationStore, globalConfiguration);
                 await processor.ProcessWebhookAsync(req, cancellationToken);
                 return new OkResult();
             }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
@@ -33,7 +33,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
     {
         private static IGlobalConfigurationProvider globalConfigurationProvider = new GlobalConfigurationProvider();
         private static IGitHubClientProvider gitHubClientProvider = new GitHubClientProvider(globalConfigurationProvider);
-        private static IRepositoryConfigurationProvider repositoryConfigurationPrivider = new RepositoryConfigurationProvider(gitHubClientProvider);
+        private static IRepositoryConfigurationProvider repositoryConfigurationProvider = new RepositoryConfigurationProvider(gitHubClientProvider);
 
         [FunctionName("webhook")]
         public static async Task<IActionResult> Run(
@@ -42,8 +42,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         {
             try
             {
-                var processor = new GitHubWebhookProcessor(log, gitHubClientProvider, repositoryConfigurationPrivider, globalConfigurationProvider);
-                await processor.ProcessWebhookAsync(req, cancellationToken);
+                var processor = new GitHubWebhookProcessor(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider);
+                await processor.ProcessWebhookAsync(req, log, cancellationToken);
                 return new OkResult();
             }
             catch (CheckEnforcerUnsupportedEventException ex)

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
@@ -34,17 +34,22 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         private static IGlobalConfigurationProvider globalConfigurationProvider = new GlobalConfigurationProvider();
         private static IGitHubClientProvider gitHubClientProvider = new GitHubClientProvider(globalConfigurationProvider);
         private static IRepositoryConfigurationProvider repositoryConfigurationProvider = new RepositoryConfigurationProvider(gitHubClientProvider);
+        private static GitHubWebhookProcessor gitHubWebhookProcessor = new GitHubWebhookProcessor(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider);
 
         [FunctionName("webhook")]
         public static async Task<IActionResult> Run(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = null)] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequest req,
             ILogger log, CancellationToken cancellationToken)
         {
             try
             {
-                var processor = new GitHubWebhookProcessor(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider);
-                await processor.ProcessWebhookAsync(req, log, cancellationToken);
+                await gitHubWebhookProcessor.ProcessWebhookAsync(req, log, cancellationToken);
                 return new OkResult();
+            }
+            catch (CheckEnforcerSecurityException ex)
+            {
+                log.LogError(ex, "Webhook failed to pass security checks.");
+                return new BadRequestResult();
             }
             catch (CheckEnforcerUnsupportedEventException ex)
             {

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
@@ -147,6 +147,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
                 }
                 else if (eventName == "check_suite")
                 {
+                    Log.LogWarning("We got here!");
                     var rawPayload = request.Body;
                     var payload = await DeserializePayloadAsync<CheckSuiteEventPayload>(rawPayload);
 

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
@@ -123,6 +123,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
                 long repositoryId;
                 string pullRequestSha;
 
+
                 if (eventName == "check_run")
                 {
                     var rawPayload = request.Body;

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
@@ -5,6 +5,7 @@ using Azure.Sdk.Tools.CheckEnforcer.Handlers;
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
+using Azure.Security.KeyVault.Secrets;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
@@ -35,30 +36,74 @@ namespace Azure.Sdk.Tools.CheckEnforcer
             this.repositoryConfigurationProvider = repositoryConfigurationProvider;
         }
         
-        public IGitHubClientProvider gitHubClientProvider;
         public IGlobalConfigurationProvider globalConfigurationProvider;
+        public IGitHubClientProvider gitHubClientProvider;
         private IRepositoryConfigurationProvider repositoryConfigurationProvider;
 
         private const string GitHubEventHeader = "X-GitHub-Event";
+        private const string GitHubSignatureHeader = "X-Hub-Signature";
+
+        private async Task<string> GetGitHubAppWebhookSecretAsync(CancellationToken cancellationToken)
+        {
+            var keyVaultUri = globalConfigurationProvider.GetKeyVaultUri();
+            var gitHubAppWebhookSecretName = globalConfigurationProvider.GetGitHubAppWebhookSecretName();
+
+            var credential = new DefaultAzureCredential();
+            var client = new SecretClient(new Uri(keyVaultUri), credential);
+            var response = await client.GetAsync(gitHubAppWebhookSecretName, cancellationToken: cancellationToken);
+            var secret = response.Value;
+
+            return secret.Value;
+        }
+
+        private async Task<string> ReadAndVerifyBodyAsync(HttpRequest request, CancellationToken cancellationToken)
+        {
+            using (var reader = new StreamReader(request.Body))
+            {
+                var json = await reader.ReadToEndAsync();
+                var jsonBytes = Encoding.UTF8.GetBytes(json);
+
+                if (request.Headers.TryGetValue(GitHubSignatureHeader, out StringValues signature))
+                {
+                    var secret = await GetGitHubAppWebhookSecretAsync(cancellationToken);
+
+                    var isValid = GitHubWebhookSignatureValidator.IsValid(jsonBytes, signature, secret);
+                    if (isValid)
+                    {
+                        return json;
+                    }
+                    else
+                    {
+                        throw new CheckEnforcerSecurityException("Webhook signature validation failed.");
+                    }
+                }
+                else
+                {
+                    throw new CheckEnforcerSecurityException("Webhook missing event signature.");
+                }
+            }
+        }
 
         public async Task ProcessWebhookAsync(HttpRequest request, ILogger logger, CancellationToken cancellationToken)
         {
+            var json = await ReadAndVerifyBodyAsync(request, cancellationToken);
+
             if (request.Headers.TryGetValue(GitHubEventHeader, out StringValues eventName))
             {
                 if (eventName == "check_run")
                 {
                     var handler = new CheckRunHandler(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger);
-                    await handler.HandleAsync(request.Body, cancellationToken);
+                    await handler.HandleAsync(json, cancellationToken);
                 }
                 else if (eventName == "check_suite")
                 {
                     var handler = new CheckSuiteHandler(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger);
-                    await handler.HandleAsync(request.Body, cancellationToken);
+                    await handler.HandleAsync(json, cancellationToken);
                 }
                 else if (eventName == "issue_comment")
                 {
                     var handler = new IssueCommentHandler(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger);
-                    await handler.HandleAsync(request.Body, cancellationToken);
+                    await handler.HandleAsync(json, cancellationToken);
                 }
                 else
                 {

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.IdentityModel.Tokens.Jwt;
 using System.IO;
 using System.Linq;
+using System.Reflection.Metadata;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading;
@@ -27,152 +28,37 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public class GitHubWebhookProcessor
     {
-        public GitHubWebhookProcessor(ILogger log, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, IGlobalConfigurationProvider globalConfigurationProvider)
+        public GitHubWebhookProcessor(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider)
         {
-            this.Log = log;
             this.globalConfigurationProvider = globalConfigurationProvider;
             this.gitHubClientProvider = gitHubClientProvider;
             this.repositoryConfigurationProvider = repositoryConfigurationProvider;
         }
-
-        public ILogger Log { get; private set; }
-
+        
         public IGitHubClientProvider gitHubClientProvider;
         public IGlobalConfigurationProvider globalConfigurationProvider;
         private IRepositoryConfigurationProvider repositoryConfigurationProvider;
 
         private const string GitHubEventHeader = "X-GitHub-Event";
 
-        private async Task<TEvent> DeserializePayloadAsync<TEvent>(Stream stream)
-        {
-            using (var reader = new StreamReader(stream))
-            {
-                var rawPayload = await reader.ReadToEndAsync();
-                Log.LogInformation("Received payload from GitHub: {rawPayload}", rawPayload);
-
-                var serializer = new SimpleJsonSerializer();
-                var payload = serializer.Deserialize<TEvent>(rawPayload);
-
-                return payload;
-            }
-        }
-
-        private async Task<CheckRun> CreateCheckEnforcerRunAsync(GitHubClient client, long repositoryId, string headSha, bool recreate)
-        {
-            var response = await client.Check.Run.GetAllForReference(repositoryId, headSha);
-            var runs = response.CheckRuns;
-            var checkRun = runs.SingleOrDefault(r => r.Name == globalConfigurationProvider.GetApplicationName());
-
-            if (checkRun == null || recreate)
-            {
-                checkRun = await client.Check.Run.Create(
-                    repositoryId,
-                    new NewCheckRun(globalConfigurationProvider.GetApplicationName(), headSha)
-                    {
-                        Status = new StringEnum<CheckStatus>(CheckStatus.InProgress)
-                    }
-                );
-            }
-
-            return checkRun;
-        }
-
-        private async Task EvaluateAndUpdateCheckEnforcerRunStatusAsync(IRepositoryConfiguration configuration, long installationId, long repositoryId, string pullRequestSha, CancellationToken cancellationToken)
-        {
-            var client = await gitHubClientProvider.GetInstallationClientAsync(installationId, cancellationToken);
-
-            var runsResponse = await client.Check.Run.GetAllForReference(repositoryId, pullRequestSha);
-            var runs = runsResponse.CheckRuns;
-
-            // NOTE: If this blows up it means that we didn't receive the check_suite request.
-            var checkEnforcerRun = await CreateCheckEnforcerRunAsync(client, repositoryId, pullRequestSha, false);
-
-            var otherRuns = from run in runs
-                            where run.Name != globalConfigurationProvider.GetApplicationName()
-                            select run;
-
-            var totalOtherRuns = otherRuns.Count();
-
-            var outstandingOtherRuns = from run in otherRuns
-                                       where run.Conclusion != new StringEnum<CheckConclusion>(CheckConclusion.Success)
-                                       select run;
-
-            var totalOutstandingOtherRuns = outstandingOtherRuns.Count();
-
-            if (totalOtherRuns >= configuration.MinimumCheckRuns && totalOutstandingOtherRuns == 0 && checkEnforcerRun.Conclusion != new StringEnum<CheckConclusion>(CheckConclusion.Success))
-            {
-                await client.Check.Run.Update(repositoryId, checkEnforcerRun.Id, new CheckRunUpdate()
-                {
-                    Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Success),
-                    Status = new StringEnum<CheckStatus>(CheckStatus.Completed)
-                });
-            }
-            else if (checkEnforcerRun.Conclusion == new StringEnum<CheckConclusion>(CheckConclusion.Success))
-            {
-                // NOTE: We do this when we need to go back from a conclusion of success to a status of in-progress.
-                await CreateCheckEnforcerRunAsync(client, repositoryId, pullRequestSha, true);
-            }
-        }
-
-        public async Task ProcessWebhookAsync(HttpRequest request, CancellationToken cancellationToken)
+        public async Task ProcessWebhookAsync(HttpRequest request, ILogger logger, CancellationToken cancellationToken)
         {
             if (request.Headers.TryGetValue(GitHubEventHeader, out StringValues eventName))
             {
-                long installationId;
-                long repositoryId;
-                string pullRequestSha;
-
-
                 if (eventName == "check_run")
                 {
-                    var rawPayload = request.Body;
-                    var payload = await DeserializePayloadAsync<CheckRunEventPayload>(rawPayload);
-
-                    if (payload.CheckRun.Name != globalConfigurationProvider.GetApplicationName())
-                    {
-                        // Extract critical info for payload.
-                        installationId = payload.Installation.Id;
-                        repositoryId = payload.Repository.Id;
-                        pullRequestSha = payload.CheckRun.CheckSuite.HeadSha;
-
-                        var configuration = await repositoryConfigurationProvider.GetRepositoryConfigurationAsync(
-                            installationId, repositoryId, pullRequestSha, cancellationToken
-                            );
-
-                        if (configuration.IsEnabled)
-                        {
-                            await EvaluateAndUpdateCheckEnforcerRunStatusAsync(
-                                configuration, installationId, repositoryId, pullRequestSha, cancellationToken
-                                );
-                        }
-                    }
+                    var handler = new CheckRunHandler(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger);
+                    await handler.HandleAsync(request.Body, cancellationToken);
                 }
                 else if (eventName == "check_suite")
                 {
-                    Log.LogWarning("We got here!");
-                    var rawPayload = request.Body;
-                    var payload = await DeserializePayloadAsync<CheckSuiteEventPayload>(rawPayload);
-
-                    if (payload.Action == "requested" || payload.Action == "rerequested")
-                    {
-                        // Extract critical info for payload.
-                        installationId = payload.Installation.Id;
-                        repositoryId = payload.Repository.Id;
-                        pullRequestSha = payload.CheckSuite.HeadSha;
-
-                        var client = await gitHubClientProvider.GetInstallationClientAsync(installationId, cancellationToken);
-                        await CreateCheckEnforcerRunAsync(client, repositoryId, pullRequestSha, true);
-                    }
-                    return;
+                    var handler = new CheckSuiteHandler(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger);
+                    await handler.HandleAsync(request.Body, cancellationToken);
                 }
                 else if (eventName == "issue_comment")
                 {
-                    var rawPayload = request.Body;
-                    var payload = await DeserializePayloadAsync<IssueCommentPayload>(rawPayload);
-
-                    var handler = new IssueCommentHandler(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, Log);
-                    await handler.HandleAsync(payload, cancellationToken);
-
+                    var handler = new IssueCommentHandler(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger);
+                    await handler.HandleAsync(request.Body, cancellationToken);
                 }
                 else
                 {

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GobalConfiguration.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GobalConfiguration.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.CheckEnforcer
+{
+    public class GlobalConfiguration
+    {
+
+        public string GetApplicationID()
+        {
+            var id = Environment.GetEnvironmentVariable("GITHUBAPP_ID");
+            return id;
+        }
+
+        public string GetApplicationName()
+        {
+            var applicationName = Environment.GetEnvironmentVariable("CHECK_NAME");
+            return applicationName;
+        }
+
+        public const int ApplicationTokenLifetimeInMinutes = 10;
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
@@ -1,0 +1,38 @@
+﻿using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Microsoft.Extensions.Logging;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
+{
+    public class CheckRunHandler : Handler<CheckRunEventPayload>
+    {
+        public CheckRunHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubCLientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, ILogger logger) : base(globalConfigurationProvider, gitHubCLientProvider, repositoryConfigurationProvider, logger)
+        {
+        }
+
+
+        protected override async Task HandleCoreAsync(HandlerContext<CheckRunEventPayload> context, CancellationToken cancellationToken)
+        {
+            var payload = context.Payload;
+
+            if (payload.CheckRun.Name != this.GlobalConfigurationProvider.GetApplicationName())
+            {
+                // Extract critical info for payload.
+                var installationId = payload.Installation.Id;
+                var repositoryId = payload.Repository.Id;
+                var sha = payload.CheckRun.CheckSuite.HeadSha;
+
+                await EvaluatePullRequestAsync(
+                    context.Client, installationId, repositoryId, sha, cancellationToken
+                    );
+            }
+        }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckSuiteHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckSuiteHandler.cs
@@ -22,12 +22,16 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
             if (payload.Action == "requested" || payload.Action == "rerequested")
             {
-                // Extract critical info for payload.
                 var installationId = payload.Installation.Id;
                 var repositoryId = payload.Repository.Id;
                 var sha = payload.CheckSuite.HeadSha;
 
-                await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
+                var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
+
+                if (configuration.IsEnabled)
+                {
+                    await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
+                }
             }
         }
     }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckSuiteHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckSuiteHandler.cs
@@ -1,0 +1,34 @@
+﻿using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Microsoft.Extensions.Logging;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
+{
+    public class CheckSuiteHandler : Handler<CheckSuiteEventPayload>
+    {
+        public CheckSuiteHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, ILogger logger) : base(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger)
+        {
+        }
+
+        protected override async Task HandleCoreAsync(HandlerContext<CheckSuiteEventPayload> context, CancellationToken cancellationToken)
+        {
+            var payload = context.Payload;
+
+            if (payload.Action == "requested" || payload.Action == "rerequested")
+            {
+                // Extract critical info for payload.
+                var installationId = payload.Installation.Id;
+                var repositoryId = payload.Repository.Id;
+                var sha = payload.CheckSuite.HeadSha;
+
+                await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
+            }
+        }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
+{
+    public abstract class Handler<T>
+    {
+        public abstract Task HandleAsync(T payload, CancellationToken cancellationToken);
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
@@ -1,13 +1,156 @@
-﻿using System;
+﻿using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Microsoft.Extensions.Logging;
+using Octokit;
+using Octokit.Internal;
+using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 {
-    public abstract class Handler<T>
+    public abstract class Handler<T> where T: ActivityPayload
     {
-        public abstract Task HandleAsync(T payload, CancellationToken cancellationToken);
+        public Handler(IGlobalConfigurationProvider globalConfiguratoinProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, ILogger logger)
+        {
+            this.GlobalConfigurationProvider = globalConfiguratoinProvider;
+            this.GitHubClientProvider = gitHubClientProvider;
+            this.RepositoryConfigurationProvider = repositoryConfigurationProvider;
+            this.Logger = logger;
+        }
+
+        protected IGlobalConfigurationProvider GlobalConfigurationProvider { get; private set; }
+        protected IGitHubClientProvider GitHubClientProvider { get; private set; }
+        protected IRepositoryConfigurationProvider RepositoryConfigurationProvider { get; private set; }
+
+
+        protected ILogger Logger { get; private set; }
+
+        protected async Task SetSuccessAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
+        {
+            var response = await client.Check.Run.GetAllForReference(repositoryId, sha);
+            var runs = response.CheckRuns;
+            var run = runs.Single(r => r.Name == this.GlobalConfigurationProvider.GetApplicationName());
+
+            await client.Check.Run.Update(repositoryId, run.Id, new CheckRunUpdate()
+            {
+                Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Success)
+            });
+        }
+
+        protected async Task SetInProgressAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
+        {
+            var response = await client.Check.Run.GetAllForReference(repositoryId, sha);
+            var runs = response.CheckRuns;
+            var run = runs.Single(r => r.Name == this.GlobalConfigurationProvider.GetApplicationName());
+
+            await client.Check.Run.Update(repositoryId, run.Id, new CheckRunUpdate()
+            {
+                Status = new StringEnum<CheckStatus>(CheckStatus.InProgress)
+            }); ;
+        }
+
+        protected async Task SetQueuedAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
+        {
+            var response = await client.Check.Run.GetAllForReference(repositoryId, sha);
+            var runs = response.CheckRuns;
+            var run = runs.Single(r => r.Name == this.GlobalConfigurationProvider.GetApplicationName());
+
+            await client.Check.Run.Update(repositoryId, run.Id, new CheckRunUpdate()
+            {
+                Status = new StringEnum<CheckStatus>(CheckStatus.Queued)
+            }); ;
+        }
+
+        protected async Task<CheckRun> CreateCheckAsync(GitHubClient client, long repositoryId, string headSha, bool recreate, CancellationToken cancellationToken)
+        {
+            var response = await client.Check.Run.GetAllForReference(repositoryId, headSha);
+            var runs = response.CheckRuns;
+            var checkRun = runs.SingleOrDefault(r => r.Name == this.GlobalConfigurationProvider.GetApplicationName());
+
+            if (checkRun == null || recreate)
+            {
+                checkRun = await client.Check.Run.Create(
+                    repositoryId,
+                    new NewCheckRun(this.GlobalConfigurationProvider.GetApplicationName(), headSha)
+                    {
+                        Status = new StringEnum<CheckStatus>(CheckStatus.InProgress)
+                    }
+                );
+            }
+
+            return checkRun;
+        }
+
+        protected async Task EvaluatePullRequestAsync(GitHubClient client, long installationId, long repositoryId, string sha, CancellationToken cancellationToken)
+        {
+            var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
+
+            if (configuration.IsEnabled)
+            {
+                var runsResponse = await client.Check.Run.GetAllForReference(repositoryId, sha);
+                var runs = runsResponse.CheckRuns;
+
+                // NOTE: If this blows up it means that we didn't receive the check_suite request.
+                var checkEnforcerRun = await CreateCheckAsync(client, repositoryId, sha, false, cancellationToken);
+
+                var otherRuns = from run in runs
+                                where run.Name != this.GlobalConfigurationProvider.GetApplicationName()
+                                select run;
+
+                var totalOtherRuns = otherRuns.Count();
+
+                var outstandingOtherRuns = from run in otherRuns
+                                           where run.Conclusion != new StringEnum<CheckConclusion>(CheckConclusion.Success)
+                                           select run;
+
+                var totalOutstandingOtherRuns = outstandingOtherRuns.Count();
+
+                if (totalOtherRuns >= configuration.MinimumCheckRuns && totalOutstandingOtherRuns == 0 && checkEnforcerRun.Conclusion != new StringEnum<CheckConclusion>(CheckConclusion.Success))
+                {
+                    await client.Check.Run.Update(repositoryId, checkEnforcerRun.Id, new CheckRunUpdate()
+                    {
+                        Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Success),
+                        Status = new StringEnum<CheckStatus>(CheckStatus.Completed)
+                    });
+                }
+                else if (checkEnforcerRun.Conclusion == new StringEnum<CheckConclusion>(CheckConclusion.Success))
+                {
+                    // NOTE: We do this when we need to go back from a conclusion of success to a status of in-progress.
+                    await CreateCheckAsync(client, repositoryId, sha, true, cancellationToken);
+                }
+            }
+        }
+
+        private async Task<T> DeserializePayloadAsync(Stream stream)
+        {
+            using (var reader = new StreamReader(stream))
+            {
+                var rawPayload = await reader.ReadToEndAsync();
+                Logger.LogInformation("Received payload from GitHub: {rawPayload}", rawPayload);
+
+                var serializer = new SimpleJsonSerializer();
+                var payload = serializer.Deserialize<T>(rawPayload);
+
+                return payload;
+            }
+        }
+
+        public async Task HandleAsync(Stream payload, CancellationToken cancellationToken)
+        {
+            var deserializedPayload = await DeserializePayloadAsync(payload);
+            var installationId = deserializedPayload.Installation.Id;
+
+            var client = await this.GitHubClientProvider.GetInstallationClientAsync(installationId, cancellationToken);
+            var context = new HandlerContext<T>(deserializedPayload, client);
+
+            await HandleCoreAsync(context, cancellationToken);
+        }
+
+        protected abstract Task HandleCoreAsync(HandlerContext<T> context, CancellationToken cancellationToken);
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
@@ -71,7 +71,17 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
         {
             var response = await client.Check.Run.GetAllForReference(repositoryId, headSha);
             var runs = response.CheckRuns;
-            var checkRun = runs.SingleOrDefault(r => r.Name == this.GlobalConfigurationProvider.GetApplicationName());
+            var checkEnforcerRuns = runs.Where(r => r.Name == this.GlobalConfigurationProvider.GetApplicationName());
+            
+            if (checkEnforcerRuns.Count() > 1)
+            {
+                var serializer = new SimpleJsonSerializer();
+                var serializedRuns = serializer.Serialize(checkEnforcerRuns);
+                Logger.LogWarning("Duplicate check-enforcer runs found: {serializedRuns}", serializedRuns);
+            }
+
+            var checkRun = checkEnforcerRuns.SingleOrDefault();
+
 
             if (checkRun == null || recreate)
             {

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
@@ -129,23 +129,16 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
             }
         }
 
-        private async Task<T> DeserializePayloadAsync(Stream stream)
+        private T DeserializePayload(string json)
         {
-            using (var reader = new StreamReader(stream))
-            {
-                var rawPayload = await reader.ReadToEndAsync();
-                Logger.LogInformation("Received payload from GitHub: {rawPayload}", rawPayload);
-
-                var serializer = new SimpleJsonSerializer();
-                var payload = serializer.Deserialize<T>(rawPayload);
-
-                return payload;
-            }
+            SimpleJsonSerializer serializer = new SimpleJsonSerializer();
+            var payload = serializer.Deserialize<T>(json);
+            return payload;
         }
 
-        public async Task HandleAsync(Stream payload, CancellationToken cancellationToken)
+        public async Task HandleAsync(string json, CancellationToken cancellationToken)
         {
-            var deserializedPayload = await DeserializePayloadAsync(payload);
+            var deserializedPayload = DeserializePayload(json);
             var installationId = deserializedPayload.Installation.Id;
 
             var client = await this.GitHubClientProvider.GetInstallationClientAsync(installationId, cancellationToken);

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
@@ -38,7 +38,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
             await client.Check.Run.Update(repositoryId, run.Id, new CheckRunUpdate()
             {
-                Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Success)
+                Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Success),
+                CompletedAt = DateTimeOffset.UtcNow
             });
         }
 
@@ -51,7 +52,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
             await client.Check.Run.Update(repositoryId, run.Id, new CheckRunUpdate()
             {
                 Status = new StringEnum<CheckStatus>(CheckStatus.InProgress)
-            }); ;
+            });
         }
 
         protected async Task SetQueuedAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
@@ -63,7 +64,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
             await client.Check.Run.Update(repositoryId, run.Id, new CheckRunUpdate()
             {
                 Status = new StringEnum<CheckStatus>(CheckStatus.Queued)
-            }); ;
+            });
         }
 
         protected async Task<CheckRun> CreateCheckAsync(GitHubClient client, long repositoryId, string headSha, bool recreate, CancellationToken cancellationToken)
@@ -78,7 +79,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
                     repositoryId,
                     new NewCheckRun(this.GlobalConfigurationProvider.GetApplicationName(), headSha)
                     {
-                        Status = new StringEnum<CheckStatus>(CheckStatus.InProgress)
+                        Status = new StringEnum<CheckStatus>(CheckStatus.InProgress),
+                        StartedAt = DateTimeOffset.UtcNow
                     }
                 );
             }
@@ -115,7 +117,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
                     await client.Check.Run.Update(repositoryId, checkEnforcerRun.Id, new CheckRunUpdate()
                     {
                         Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Success),
-                        Status = new StringEnum<CheckStatus>(CheckStatus.Completed)
+                        Status = new StringEnum<CheckStatus>(CheckStatus.Completed),
+                        CompletedAt = DateTimeOffset.UtcNow
                     });
                 }
                 else if (checkEnforcerRun.Conclusion == new StringEnum<CheckConclusion>(CheckConclusion.Success))

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
@@ -72,16 +72,17 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
             var response = await client.Check.Run.GetAllForReference(repositoryId, headSha);
             var runs = response.CheckRuns;
             var checkEnforcerRuns = runs.Where(r => r.Name == this.GlobalConfigurationProvider.GetApplicationName());
-            
+
             if (checkEnforcerRuns.Count() > 1)
             {
-                var serializer = new SimpleJsonSerializer();
-                var serializedRuns = serializer.Serialize(checkEnforcerRuns);
-                Logger.LogWarning("Duplicate check-enforcer runs found: {serializedRuns}", serializedRuns);
+                var firstRun = checkEnforcerRuns.First();
+                SimpleJsonSerializer serializer = new SimpleJsonSerializer();
+                var serializedFirstRun = serializer.Serialize(firstRun);
+
+                Logger.LogTrace("Duplicated run: {serializedFirstRun}", serializedFirstRun);
             }
 
             var checkRun = checkEnforcerRuns.SingleOrDefault();
-
 
             if (checkRun == null || recreate)
             {
@@ -141,6 +142,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
         private T DeserializePayload(string json)
         {
+            Logger.LogTrace("Payload: {json}", json);
+
             SimpleJsonSerializer serializer = new SimpleJsonSerializer();
             var payload = serializer.Deserialize<T>(json);
             return payload;

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/HandlerContext.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/HandlerContext.cs
@@ -1,0 +1,19 @@
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
+{
+    public class HandlerContext<T> where T: ActivityPayload
+    {
+        public HandlerContext(T payload, GitHubClient client)
+        {
+            this.Payload = payload;
+            this.Client = client;
+        }
+
+        public T Payload { get; private set; }
+        public GitHubClient Client { get; private set; }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
@@ -1,0 +1,98 @@
+﻿using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
+{
+    public class IssueCommentHandler : Handler<IssueCommentPayload>
+    {
+        public IssueCommentHandler(IRepositoryConfigurationProvider repositoryConfigurationProvider, IGitHubClientProvider gitHubClientProvider, ILogger logger)
+        {
+            this.repositoryConfigurationProvider = repositoryConfigurationProvider;
+            this.gitHubClientProvider = gitHubClientProvider;
+            this.logger = logger;
+        }
+
+        private IRepositoryConfigurationProvider repositoryConfigurationProvider;
+        private IGitHubClientProvider gitHubClientProvider;
+        private ILogger logger;
+
+        private async Task SetSuccessAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
+        {
+            var response = await client.Check.Run.GetAllForReference(repositoryId, sha);
+            var runs = response.CheckRuns;
+            var run = runs.Single(r => r.Name == "check-enforcer-dev"); // HACK!
+
+            await client.Check.Run.Update(repositoryId, run.Id, new CheckRunUpdate()
+            {
+                Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Success)
+            });
+        }
+
+        private async Task CreateCheckAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
+        {
+            var response = await client.Check.Run.GetAllForReference(repositoryId, sha);
+            var runs = response.CheckRuns;
+            var checkEnforcerRuns = runs.Where(r => r.Name == "check-enforcer-dev"); // HACK!
+
+            foreach (var checkEnforcerRun in checkEnforcerRuns)
+            {
+                await client.Check.Run.Update(repositoryId, checkEnforcerRun.Id, new CheckRunUpdate()
+                {
+                    Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Cancelled)
+                });
+            }
+
+            await client.Check.Run.Create(repositoryId, new NewCheckRun("check-enforcer-dev", sha));
+        }
+
+        public override async Task HandleAsync(IssueCommentPayload payload, CancellationToken cancellationToken)
+        {
+            var installationId = payload.Installation.Id;
+            var repositoryId = payload.Repository.Id;
+            var comment = payload.Comment.Body.ToLower();
+            var issueId = payload.Issue.Number;
+
+            var client = await gitHubClientProvider.GetInstallationClientAsync(installationId, cancellationToken);
+            var pullRequest = await client.PullRequest.Get(repositoryId, issueId);
+            var sha = pullRequest.Head.Sha;
+
+            var configuration = await repositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
+            
+            switch (comment)
+            {
+                case "/check-enforcer evaluate":
+                    logger.LogTrace("Comment command received: {comment}", comment);
+                    break;
+
+                case "/check-enforcer queued":
+                    logger.LogTrace("Comment command received: {comment}", comment);
+                    break;
+
+                case "/check-enforcer inprogress":
+                    logger.LogTrace("Comment command received: {comment}", comment);
+                    break;
+
+                case "/check-enforcer success":
+                    await SetSuccessAsync(client, repositoryId, sha, cancellationToken);
+                    break;
+
+                case "/check-enforcer reset":
+                    await CreateCheckAsync(client, repositoryId, sha, cancellationToken);
+                    break;
+
+                default:
+                    logger.LogTrace("Unrecognized command: {comment}", comment);
+                    break;
+            }
+        }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
@@ -2,6 +2,7 @@
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
+using Microsoft.Identity.Client;
 using Octokit;
 using System;
 using System.Collections.Generic;
@@ -14,108 +15,45 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 {
     public class IssueCommentHandler : Handler<IssueCommentPayload>
     {
-        public IssueCommentHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, ILogger logger)
+        public IssueCommentHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, ILogger logger) : base(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger)
         {
-            this.globalConfigurationProvider = globalConfigurationProvider;
-            this.gitHubClientProvider = gitHubClientProvider;
-            this.repositoryConfigurationProvider = repositoryConfigurationProvider;
-            this.logger = logger;
         }
 
-        private IGlobalConfigurationProvider globalConfigurationProvider;
-        private IGitHubClientProvider gitHubClientProvider;
-        private IRepositoryConfigurationProvider repositoryConfigurationProvider;
-        private ILogger logger;
-
-        private async Task SetSuccessAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
+        protected override async Task HandleCoreAsync(HandlerContext<IssueCommentPayload> context, CancellationToken cancellationToken)
         {
-            var response = await client.Check.Run.GetAllForReference(repositoryId, sha);
-            var runs = response.CheckRuns;
-            var run = runs.Single(r => r.Name == globalConfigurationProvider.GetApplicationName());
-
-            await client.Check.Run.Update(repositoryId, run.Id, new CheckRunUpdate()
-            {
-                Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Success)
-            });
-        }
-
-        private async Task CreateCheckAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
-        {
-            var response = await client.Check.Run.GetAllForReference(repositoryId, sha);
-            var runs = response.CheckRuns;
-            var checkEnforcerRuns = runs.Where(r => r.Name == globalConfigurationProvider.GetApplicationName());
-
-            foreach (var checkEnforcerRun in checkEnforcerRuns)
-            {
-                await client.Check.Run.Update(repositoryId, checkEnforcerRun.Id, new CheckRunUpdate()
-                {
-                    Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Cancelled)
-                });
-            }
-
-            await client.Check.Run.Create(
-                repositoryId,
-                new NewCheckRun(globalConfigurationProvider.GetApplicationName(), sha)
-                );
-        }
-
-        private async Task SetInProgressAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
-        {
-            var response = await client.Check.Run.GetAllForReference(repositoryId, sha);
-            var runs = response.CheckRuns;
-            var run = runs.Single(r => r.Name == globalConfigurationProvider.GetApplicationName());
-
-            await client.Check.Run.Update(repositoryId, run.Id, new CheckRunUpdate()
-            {
-                Status = new StringEnum<CheckStatus>(CheckStatus.InProgress)
-            }); ;
-        }
-
-        private async Task SetQueuedAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
-        {
-            var response = await client.Check.Run.GetAllForReference(repositoryId, sha);
-            var runs = response.CheckRuns;
-            var run = runs.Single(r => r.Name == globalConfigurationProvider.GetApplicationName());
-
-            await client.Check.Run.Update(repositoryId, run.Id, new CheckRunUpdate()
-            {
-                Status = new StringEnum<CheckStatus>(CheckStatus.Queued)
-            }); ;
-        }
-
-        public override async Task HandleAsync(IssueCommentPayload payload, CancellationToken cancellationToken)
-        {
+            var payload = context.Payload;
             var installationId = payload.Installation.Id;
             var repositoryId = payload.Repository.Id;
             var comment = payload.Comment.Body.ToLower();
             var issueId = payload.Issue.Number;
 
-            var client = await gitHubClientProvider.GetInstallationClientAsync(installationId, cancellationToken);
-            var pullRequest = await client.PullRequest.Get(repositoryId, issueId);
+            var pullRequest = await context.Client.PullRequest.Get(repositoryId, issueId);
             var sha = pullRequest.Head.Sha;
 
-            var configuration = await repositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
-            
             switch (comment)
             {
                 case "/check-enforcer queued":
-                    await SetQueuedAsync(client, repositoryId, sha, cancellationToken);
+                    await SetQueuedAsync(context.Client, repositoryId, sha, cancellationToken);
                     break;
 
                 case "/check-enforcer inprogress":
-                    await SetInProgressAsync(client, repositoryId, sha, cancellationToken);
+                    await SetInProgressAsync(context.Client, repositoryId, sha, cancellationToken);
                     break;
 
                 case "/check-enforcer success":
-                    await SetSuccessAsync(client, repositoryId, sha, cancellationToken);
+                    await SetSuccessAsync(context.Client, repositoryId, sha, cancellationToken);
                     break;
 
                 case "/check-enforcer reset":
-                    await CreateCheckAsync(client, repositoryId, sha, cancellationToken);
+                    await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
+                    break;
+
+                case "/check-enforcer evaluate":
+                    await EvaluatePullRequestAsync(context.Client, installationId, repositoryId, sha, cancellationToken);
                     break;
 
                 default:
-                    logger.LogTrace("Unrecognized command: {comment}", comment);
+                    this.Logger.LogTrace("Unrecognized command: {comment}", comment);
                     break;
             }
         }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubClientProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubClientProvider.cs
@@ -1,5 +1,7 @@
 ﻿using Azure.Core;
 using Azure.Identity;
+using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using Microsoft.IdentityModel.Tokens;
@@ -15,9 +17,9 @@ using System.Threading.Tasks;
 
 namespace Azure.Sdk.Tools.CheckEnforcer
 {
-    public class GitHubClientFactory
+    public class GitHubClientProvider : IGitHubClientProvider
     {
-        public GitHubClientFactory(GlobalConfiguration globalConfiguration)
+        public GitHubClientProvider(GlobalConfiguration globalConfiguration)
         {
             this.globalConfiguration = globalConfiguration;
         }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubClientProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubClientProvider.cs
@@ -19,12 +19,12 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public class GitHubClientProvider : IGitHubClientProvider
     {
-        public GitHubClientProvider(GlobalConfiguration globalConfiguration)
+        public GitHubClientProvider(IGlobalConfigurationProvider globalConfigurationProvider)
         {
-            this.globalConfiguration = globalConfiguration;
+            this.globalConfigurationProvider = globalConfigurationProvider;
         }
 
-        private GlobalConfiguration globalConfiguration;
+        private IGlobalConfigurationProvider globalConfigurationProvider;
 
         private Tuple<DateTimeOffset, string> cachedApplicationToken;
 
@@ -88,7 +88,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
             jwtHeader["alg"] = "RS256";
 
             var jwtPayload = new JwtPayload(
-                issuer: globalConfiguration.GetApplicationID(),
+                issuer: globalConfigurationProvider.GetApplicationID(),
                 audience: null,
                 claims: null,
                 notBefore: DateTime.UtcNow,
@@ -159,7 +159,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         {
             var token = await GetTokenAsync(cancellationToken);
 
-            var appClient = new GitHubClient(new ProductHeaderValue(this.globalConfiguration.GetApplicationName()))
+            var appClient = new GitHubClient(new ProductHeaderValue(globalConfigurationProvider.GetApplicationName()))
             {
                 Credentials = new Credentials(token, AuthenticationType.Bearer)
             };
@@ -190,7 +190,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         public async Task<GitHubClient> GetInstallationClientAsync(long installationId, CancellationToken cancellationToken)
         {
             var installationToken = await GetInstallationTokenAsync(installationId, cancellationToken);
-            var installationClient = new GitHubClient(new ProductHeaderValue($"{this.globalConfiguration.GetApplicationName()}-{installationId}"))
+            var installationClient = new GitHubClient(new ProductHeaderValue($"{globalConfigurationProvider.GetApplicationName()}-{installationId}"))
             {
                 Credentials = new Credentials(installationToken)
             };

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubClientProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubClientProvider.cs
@@ -129,10 +129,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 
         private async Task<Key> GetKey(KeyClient keyClient, CancellationToken cancellationToken)
         {
-            var keyVaultGitHubKeyName = Environment.GetEnvironmentVariable("KEYVAULT_GITHUBAPP_KEY_NAME");
-
             var keyResponse = await keyClient.GetKeyAsync(
-                keyVaultGitHubKeyName,
+                globalConfigurationProvider.GetGitHubAppPrivateKeyName(),
                 cancellationToken: cancellationToken
                 );
 
@@ -142,15 +140,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 
         private KeyClient GetKeyClient(TokenCredential credential)
         {
-
-            // We need a variable that tells Check Enforcer which KeyVault to talk to,
-            // this is currently done via an environment variable.
-            //
-            //      KEYVAULT_URI
-            //
-            var keyVaultUriEnvironmentVariable = Environment.GetEnvironmentVariable("KEYVAULT_URI");
-
-            var keyVaultUri = new Uri(keyVaultUriEnvironmentVariable);
+            var keyVaultUri = new Uri(globalConfigurationProvider.GetKeyVaultUri());
             var keyClient = new KeyClient(keyVaultUri, credential);
             return keyClient;
         }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubWebhookSignatureValidator.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubWebhookSignatureValidator.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub
+{
+    public static class GitHubWebhookSignatureValidator
+    {
+        public static bool IsValid(byte[] body, string signature, string secret)
+        {
+            var key = Encoding.UTF8.GetBytes(secret);
+            var sha1 = new HMACSHA1(key);
+
+            var digest = sha1.ComputeHash(body);
+            var hex = BitConverter.ToString(digest).Replace("-", "").ToLower();
+            var generatedSignature = $"sha1={hex}";
+
+            return signature == generatedSignature;
+        }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/IGitHubClientProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/IGitHubClientProvider.cs
@@ -1,0 +1,15 @@
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub
+{
+    public interface IGitHubClientProvider
+    {
+        Task<GitHubClient> GetApplicationClientAsync(CancellationToken cancellationToken);
+        Task<GitHubClient> GetInstallationClientAsync(long installationId, CancellationToken cancellationToken);
+    }
+}

--- a/tools/check-enforcer/CheckEnforcer.sln
+++ b/tools/check-enforcer/CheckEnforcer.sln
@@ -3,7 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Sdk.Tools.CheckEnforcer", "Azure.Sdk.Tools.CheckEnforcer\Azure.Sdk.Tools.CheckEnforcer.csproj", "{97850C3F-0A6C-446B-B00B-B1E571426661}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CheckEnforcer", "Azure.Sdk.Tools.CheckEnforcer\Azure.Sdk.Tools.CheckEnforcer.csproj", "{97850C3F-0A6C-446B-B00B-B1E571426661}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Sdk.Tools.CheckEnforcer.Tests", "Azure.Sdk.Tools.CheckEnforcer.Tests\Azure.Sdk.Tools.CheckEnforcer.Tests.csproj", "{4C33C118-A3C1-4742-B407-57D032497769}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{97850C3F-0A6C-446B-B00B-B1E571426661}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{97850C3F-0A6C-446B-B00B-B1E571426661}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{97850C3F-0A6C-446B-B00B-B1E571426661}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C33C118-A3C1-4742-B407-57D032497769}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C33C118-A3C1-4742-B407-57D032497769}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C33C118-A3C1-4742-B407-57D032497769}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C33C118-A3C1-4742-B407-57D032497769}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This PR does some restructuring to the code to try and work around some of the error states we were getting into in production. It also adds the ability re-evaluate Check Enforcer. It also moves the app ID and check name into environmental configuration.