### PR TITLE
missing sapce after type parameter

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -466,6 +466,7 @@ public class ASTAnalyser implements Analyser {
                 }
             }
             tokens.add(new Token(PUNCTUATION, ">"));
+            tokens.add(new Token(WHITESPACE, " "));
         }
 
         private void getGenericTypeParameter(TypeParameter typeParameter, List<Token> tokens) {


### PR DESCRIPTION
Missing a space after the generic type <T> on methods.
https://apiview.azurewebsites.net/Assemblies/Review/bf57bf1f08a3443bb5c66a4f56248178