### PR TITLE
Add distributed locking to Check Enforcer

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Azure.Identity" Version="1.0.0-preview.4" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.0.0-preview.4" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.0-preview.4" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0-preview.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -1,15 +1,15 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.0.0-preview.4" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.0.0-preview.4" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.0-preview.4" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0-preview.3" />
+    <PackageReference Include="Azure.Identity" Version="1.0.0-preview.5" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.0.0-preview.5" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.0-preview.5" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0-preview.4" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
-    <PackageReference Include="Octokit" Version="0.32.0" />
+    <PackageReference Include="Octokit" Version="0.36.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />
     <PackageReference Include="YamlDotNet" Version="6.1.2" />
   </ItemGroup>

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <AzureFunctionsVersion>v2</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.0.0-preview.5" />
-    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.0.0-preview.5" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.0-preview.5" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0-preview.4" />
+    <PackageReference Include="Azure.Identity" Version="1.0.0-preview.4" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.0.0-preview.4" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.0-preview.4" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.0.0-preview.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="1.0.29" />
     <PackageReference Include="Octokit" Version="0.36.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="5.5.0" />

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/GlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/GlobalConfigurationProvider.cs
@@ -36,5 +36,17 @@ namespace Azure.Sdk.Tools.CheckEnforcer
             var gitHubAppWebhookSecretName = Environment.GetEnvironmentVariable("GITHUBAPP_WEBHOOK_SECRET");
             return gitHubAppWebhookSecretName;
         }
+
+        public string GetDistributedLockStorageUri()
+        {
+            var distributedLockStorageUri = Environment.GetEnvironmentVariable("DISTRIBUTED_LOCK_STORAGE_URI");
+            return distributedLockStorageUri;
+        }
+
+        public string GetDistributedLockContainerName()
+        {
+            var distributedLockContainerName = Environment.GetEnvironmentVariable("DISTRIBUTED_LOCK_CONTAINER_NAME");
+            return distributedLockContainerName;
+        }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
@@ -11,6 +11,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
         string GetGitHubAppPrivateKeyName();
         string GetGitHubAppWebhookSecretName();
         string GetKeyVaultUri();
+        string GetDistributedLockStorageUri();
+        string GetDistributedLockContainerName();
 
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfigurationCacheEntry.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfigurationCacheEntry.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
+{
+    public class RepositoryConfigurationCacheEntry
+    {
+        public RepositoryConfigurationCacheEntry(DateTimeOffset fetched, IRepositoryConfiguration repositoryConfiguration)
+        {
+            this.Fetched = fetched;
+            this.Configuration = repositoryConfiguration;
+        }
+
+        public IRepositoryConfiguration Configuration { get; }
+        public DateTimeOffset Fetched { get; }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookFunction.cs
@@ -26,6 +26,7 @@ using System.Web.Http;
 using System.Runtime.CompilerServices;
 using Azure.Sdk.Tools.CheckEnforcer.Configuration;
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Azure.Sdk.Tools.CheckEnforcer.Locking;
 
 namespace Azure.Sdk.Tools.CheckEnforcer
 {
@@ -34,7 +35,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer
         private static IGlobalConfigurationProvider globalConfigurationProvider = new GlobalConfigurationProvider();
         private static IGitHubClientProvider gitHubClientProvider = new GitHubClientProvider(globalConfigurationProvider);
         private static IRepositoryConfigurationProvider repositoryConfigurationProvider = new RepositoryConfigurationProvider(gitHubClientProvider);
-        private static GitHubWebhookProcessor gitHubWebhookProcessor = new GitHubWebhookProcessor(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider);
+        private static IDistributedLockProvider distributedLockProvider = new DistributedLockProvider(globalConfigurationProvider);
+        private static GitHubWebhookProcessor gitHubWebhookProcessor = new GitHubWebhookProcessor(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, distributedLockProvider);
 
         [FunctionName("webhook")]
         public static async Task<IActionResult> Run(

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
@@ -57,7 +57,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
                 var gitHubAppWebhookSecretName = globalConfigurationProvider.GetGitHubAppWebhookSecretName();
 
                 var client = GetSecretClient();
-                var response = await client.GetSecretAsync(gitHubAppWebhookSecretName, cancellationToken: cancellationToken);
+                var response = await client.GetAsync(gitHubAppWebhookSecretName, cancellationToken: cancellationToken);
                 var secret = response.Value;
 
                 gitHubAppWebhookSecretExpiry = DateTimeOffset.UtcNow.AddSeconds(30);

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
@@ -57,7 +57,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
                 var gitHubAppWebhookSecretName = globalConfigurationProvider.GetGitHubAppWebhookSecretName();
 
                 var client = GetSecretClient();
-                var response = await client.GetAsync(gitHubAppWebhookSecretName, cancellationToken: cancellationToken);
+                var response = await client.GetSecretAsync(gitHubAppWebhookSecretName, cancellationToken: cancellationToken);
                 var secret = response.Value;
 
                 gitHubAppWebhookSecretExpiry = DateTimeOffset.UtcNow.AddSeconds(30);

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
@@ -30,6 +30,16 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
                 var repositoryId = payload.Repository.Id;
                 var sha = payload.CheckRun.CheckSuite.HeadSha;
 
+                if (payload.CheckRun.Status != new StringEnum<CheckStatus>(CheckStatus.Completed))
+                {
+                    // TODO: Need to evaluate whether this is the best thing to do
+                    //       here. Strictly speaking if a check is requequed this means
+                    //       that we wouldn't react to it. But this is useful as a way
+                    //       of reducing load. You can't get throttled on requeusts you
+                    //       don't make!
+                    return;
+                }
+
                 var distributedLockIdentifier = $"{installationId}/{repositoryId}/{sha}";
 
                 var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
@@ -4,6 +4,7 @@ using Azure.Sdk.Tools.CheckEnforcer.Locking;
 using Microsoft.Extensions.Logging;
 using Octokit;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using System.Text;
@@ -14,50 +15,243 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 {
     public class CheckRunHandler : Handler<CheckRunEventPayload>
     {
+        private static readonly EventId AcquiringSemaphoreEventId = new EventId(0, "Acquring Semaphore");
+        private static readonly EventId AcquiredSemaphoreEventId = new EventId(1, "Acquired Semaphore");
+        private static readonly EventId ReleasingSemaphoreEventId = new EventId(2, "Releasing Semaphore");
+        private static readonly EventId ReleasedSemaphoreEventId = new EventId(3, "Released Semaphore");
+        private static readonly EventId SkippedProcessingTrapSemaphoreEventId = new EventId(4, "Skipped Processing (Trap Semaphore)");
+        private static readonly EventId WaitingOnTrapSemaphoreEventId = new EventId(5, "Waiting on Trap Semaphore");
+        private static readonly EventId WaitOnTrapSemaphoreTimeoutEventId = new EventId(6, "Wait on Trap Semaphore Timeout");
+        private static readonly EventId WaitingOnQueueSemaphoreEventId = new EventId(7, "Waiting on Queue Semaphore");
+        private static readonly EventId WaitOnQueueSemaphoreTimeoutEventId = new EventId(8, "Wait on Queue Semaphore Timeout");
+        private static readonly EventId CheckEnforcerEnabledEventId = new EventId(9, "Check Enforcer Enabled");
+        private static readonly EventId CheckEnforcerDisabledEventId = new EventId(10, "Check Enforcer Disabled");
+        private static readonly EventId AcquiringDistributedLockEventId = new EventId(11, "Acquiring Distributed Lock");
+        private static readonly EventId AcquiredDistributedLockEventId = new EventId(12, "Acquired Distributed Lock");
+        private static readonly EventId ReleasingDistributedLockEventId = new EventId(13, "Releasing Distributed Lock");
+        private static readonly EventId ReleasedDistributedLockEventId = new EventId(14, "Released Distributed Lock");
+        private static readonly EventId EvaluatingCheckRunEventId = new EventId(15, "Evalating Check Run");
+        private static readonly EventId EvaluatedCheckRunEventId = new EventId(16, "Evaluated Check Run");
+        private static readonly EventId CheckRunEventProcessingFailedEventId = new EventId(17, "Check Run Event Processing Failed");
+        private static readonly EventId SkippedProcessingCheckEnforcerCheckRunEventEventId = new EventId(18, "Skipped Processing Check Enforcer Check Run Event");
+        private static readonly EventId SkippedProcessingIncompleteCheckRunEventEventId = new EventId(19, "Skipped Processing Incomplete Check Run Event");
+        private static readonly EventId FailedToAcquiredDistributedLockEventId = new EventId(20, "Failed to acquired distributed lock, giving up.");
+
         public CheckRunHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubCLientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, IDistributedLockProvider distributedLockProvider, ILogger logger) : base(globalConfigurationProvider, gitHubCLientProvider, repositoryConfigurationProvider, distributedLockProvider, logger)
         {
         }
 
+        private static ConcurrentDictionary<string, SemaphoreSlim> semaphores = new ConcurrentDictionary<string, SemaphoreSlim>();
+
+        private SemaphoreSlim GetSemaphore(string semaphoreName)
+        {
+            Logger.LogDebug(AcquiringSemaphoreEventId, "Acquiring semaphore: {semaphoreName}.", semaphoreName);
+            var semaphore = semaphores.GetOrAdd(semaphoreName, new SemaphoreSlim(1, 1));
+            var currentCount = semaphore.CurrentCount;
+            Logger.LogDebug(
+                AcquiredSemaphoreEventId,
+                "Acquired semaphore: {semaphoreName} with current count of: {currentCount}.",
+                semaphoreName,
+                currentCount
+                );
+            return semaphore;
+        }
 
         protected override async Task HandleCoreAsync(HandlerContext<CheckRunEventPayload> context, CancellationToken cancellationToken)
         {
             var payload = context.Payload;
 
-            if (payload.CheckRun.Name != this.GlobalConfigurationProvider.GetApplicationName())
+            var installationId = payload.Installation.Id;
+            var repositoryId = payload.Repository.Id;
+            var sha = payload.CheckRun.CheckSuite.HeadSha;
+            var distributedLockIdentifier = $"{installationId}/{repositoryId}/{sha}";
+
+            using (var scope = Logger.BeginScope("Processing check-run event on: {distributedLockIdentifier}", distributedLockIdentifier))
             {
-                // Extract critical info for payload.
-                var installationId = payload.Installation.Id;
-                var repositoryId = payload.Repository.Id;
-                var sha = payload.CheckRun.CheckSuite.HeadSha;
-
-                if (payload.CheckRun.Status != new StringEnum<CheckStatus>(CheckStatus.Completed))
+                if (payload.CheckRun.Name == this.GlobalConfigurationProvider.GetApplicationName())
                 {
-                    // TODO: Need to evaluate whether this is the best thing to do
-                    //       here. Strictly speaking if a check is requequed this means
-                    //       that we wouldn't react to it. But this is useful as a way
-                    //       of reducing load. You can't get throttled on requeusts you
-                    //       don't make!
-                    return;
+                    Logger.LogDebug(
+                        SkippedProcessingCheckEnforcerCheckRunEventEventId,
+                        "Skipping processing event for: {distributedLockIdentifier}",
+                        distributedLockIdentifier
+                        );
                 }
-
-                var distributedLockIdentifier = $"{installationId}/{repositoryId}/{sha}";
-
-                var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
-
-                if (configuration.IsEnabled)
+                else
                 {
-                    using (var distributedLock = DistributedLockProvider.Create(distributedLockIdentifier))
+                    try
                     {
-                        await distributedLock.AcquireAsync();
+                        if (payload.CheckRun.Status != new StringEnum<CheckStatus>(CheckStatus.Completed))
+                        {
+                            Logger.LogDebug(
+                                SkippedProcessingIncompleteCheckRunEventEventId,
+                                "Skipping processing event for: {distributedLockIdentifier}",
+                                distributedLockIdentifier
+                                );
+                            return;
+                        }
 
-                        await EvaluatePullRequestAsync(
-                            context.Client, installationId, repositoryId, sha, cancellationToken
+                        var trapSemaphore = GetSemaphore($"trap/{distributedLockIdentifier}");
+                        var queueSemaphore = GetSemaphore($"queue/{distributedLockIdentifier}");
+
+                        if (trapSemaphore.CurrentCount == 0)
+                        {
+                            Logger.LogDebug(
+                                SkippedProcessingTrapSemaphoreEventId,
+                                "Skipped processing check-run event: {distributedLockIdentifier} because semaphore current count was zero."
+                                );
+                            return;
+                        }
+
+                        Logger.LogDebug(
+                            WaitingOnTrapSemaphoreEventId,
+                            "Waiting on trap semaphore for: {distributedLockIdentifier}",
+                            distributedLockIdentifier
+                            );
+
+                        var trapWaitSuccessful = await trapSemaphore.WaitAsync(10000, cancellationToken);
+
+                        if (!trapWaitSuccessful)
+                        {
+                            Logger.LogWarning(
+                                WaitOnTrapSemaphoreTimeoutEventId,
+                                "Timed out waiting in trap semaphore for: {distributedLockIdentifier}.",
+                                distributedLockIdentifier
+                                );
+                            return;
+                        }
+
+                        Logger.LogDebug(
+                            WaitingOnQueueSemaphoreEventId,
+                            "Waiting on queue semaphore for: {distributedLockIdentifier}",
+                            distributedLockIdentifier
+                            );
+
+                        var queueWaitSuccessful = await queueSemaphore.WaitAsync(10000, cancellationToken);
+
+                        if (!queueWaitSuccessful)
+                        {
+                            Logger.LogWarning(
+                                WaitOnQueueSemaphoreTimeoutEventId,
+                                "Timed out waiting in queue semaphore for: {distributedLockIdentifier}.",
+                                distributedLockIdentifier
+                                );
+                            return;
+                        }
+
+                        var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
+                        if (configuration.IsEnabled)
+                        {
+                            Logger.LogInformation(
+                                CheckEnforcerEnabledEventId,
+                                "Check Enforcer was enabled for: {distributedLockIdentifier}.",
+                                distributedLockIdentifier
+                                );
+                        }
+                        else
+                        {
+                            Logger.LogInformation(
+                                CheckEnforcerDisabledEventId,
+                                "Check Enforcer was disabled for: {distributedLockIdentifier}.",
+                                distributedLockIdentifier
+                                );
+                            return;
+                        }
+
+                        Logger.LogDebug(
+                            AcquiringDistributedLockEventId,
+                            "Acquiring distributed lock for: {distributedLockIdentifier}.",
+                            distributedLockIdentifier
+                            );
+
+                        var distributedLock = this.DistributedLockProvider.Create(distributedLockIdentifier);
+                        var distributedLockAquired = await distributedLock.AcquireAsync();
+
+                        if (!distributedLockAquired)
+                        {
+                            Logger.LogWarning(
+                                FailedToAcquiredDistributedLockEventId,
+                                "Failed to acquire distributed lock for: {distributedLockIdentifier}.",
+                                distributedLockIdentifier
+                                );
+
+                            // Quickly clean up and get out of here.
+                            trapSemaphore.Release();
+                            queueSemaphore.Release();
+                            return;
+                        }
+
+                        Logger.LogDebug(
+                            ReleasingSemaphoreEventId,
+                            "Releasing trap semaphore for: {distributedLockIdentifier}.",
+                            distributedLockIdentifier
+                            );
+
+                        trapSemaphore.Release();
+
+                        Logger.LogDebug(
+                            ReleasedSemaphoreEventId,
+                            "Released trap semaphore for: {distributedLockIdentifier}.",
+                            distributedLockIdentifier
+                            );
+
+                        Logger.LogInformation(
+                            EvaluatingCheckRunEventId,
+                            "Evaluating check-run for: {distributedLockIdentifier}.",
+                            distributedLockIdentifier
+                            );
+
+                        await EvaluatePullRequestAsync(context.Client, installationId, repositoryId, sha, cancellationToken);
+
+                        Logger.LogInformation(
+                            EvaluatedCheckRunEventId,
+                            "Evaluated check-run for: {distributedLockIdentifier}.",
+                            distributedLockIdentifier
+                            );
+
+                        Logger.LogDebug(
+                            ReleasingDistributedLockEventId,
+                            "Releasing distributed lock for: {distributedLockIdentifier}.",
+                            distributedLockIdentifier
                             );
 
                         await distributedLock.ReleaseAsync();
+
+                        Logger.LogDebug(
+                            ReleasedDistributedLockEventId,
+                            "Released distributed lock for: {distributedLockIdentifier}.",
+                            distributedLockIdentifier
+                            );
+
+                        Logger.LogDebug(
+                            ReleasingSemaphoreEventId,
+                            "Releasing queue semaphore for: {distributedLockIdentifier}.",
+                            distributedLockIdentifier
+                            );
+
+                        queueSemaphore.Release();
+
+                        Logger.LogDebug(
+                            ReleasingSemaphoreEventId,
+                            "Released queue semaphore for: {distributedLockIdentifier}.",
+                            distributedLockIdentifier
+                            );
+                    }
+                    catch (Exception ex)
+                    {
+                        Logger.LogError(
+                            CheckRunEventProcessingFailedEventId,
+                            ex,
+                            "Failed to process check-run event for: {distributedLockIdentifier}",
+                            distributedLockIdentifier
+                            );
+
+                        // Clear the semaphores.
+                        semaphores.TryRemove($"trap/{distributedLockIdentifier}", out SemaphoreSlim _);
+                        semaphores.TryRemove($"queue/{distributedLockIdentifier}", out SemaphoreSlim _);
+
+                        throw ex;
                     }
                 }
-
             }
         }
     }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckSuiteHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckSuiteHandler.cs
@@ -35,7 +35,9 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
                     using (var distributedLock = DistributedLockProvider.Create(distributedLockIdentifier))
                     {
-                        await distributedLock.AcquireAsync();
+                        var distributedLockAcquired = await distributedLock.AcquireAsync();
+                        if (!distributedLockAcquired) return;
+
                         await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
                         await distributedLock.ReleaseAsync();
                     }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckSuiteHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckSuiteHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Sdk.Tools.CheckEnforcer.Configuration;
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Azure.Sdk.Tools.CheckEnforcer.Locking;
 using Microsoft.Extensions.Logging;
 using Octokit;
 using System;
@@ -12,7 +13,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 {
     public class CheckSuiteHandler : Handler<CheckSuiteEventPayload>
     {
-        public CheckSuiteHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, ILogger logger) : base(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger)
+        public CheckSuiteHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, IDistributedLockProvider distributedLockProvider, ILogger logger) : base(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, distributedLockProvider, logger)
         {
         }
 
@@ -30,7 +31,14 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
                 if (configuration.IsEnabled)
                 {
-                    await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
+                    var distributedLockIdentifier = $"{installationId}/{repositoryId}/{sha}";
+
+                    using (var distributedLock = DistributedLockProvider.Create(distributedLockIdentifier))
+                    {
+                        await distributedLock.AcquireAsync();
+                        await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
+                        await distributedLock.ReleaseAsync();
+                    }
                 }
             }
         }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
@@ -1,10 +1,12 @@
 ﻿using Azure.Sdk.Tools.CheckEnforcer.Configuration;
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Azure.Sdk.Tools.CheckEnforcer.Locking;
 using Microsoft.Extensions.Logging;
 using Octokit;
 using Octokit.Internal;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -15,19 +17,19 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 {
     public abstract class Handler<T> where T: ActivityPayload
     {
-        public Handler(IGlobalConfigurationProvider globalConfiguratoinProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, ILogger logger)
+        public Handler(IGlobalConfigurationProvider globalConfiguratoinProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, IDistributedLockProvider distrbutedLockProvider, ILogger logger)
         {
             this.GlobalConfigurationProvider = globalConfiguratoinProvider;
             this.GitHubClientProvider = gitHubClientProvider;
             this.RepositoryConfigurationProvider = repositoryConfigurationProvider;
+            this.DistributedLockProvider = distrbutedLockProvider;
             this.Logger = logger;
         }
 
         protected IGlobalConfigurationProvider GlobalConfigurationProvider { get; private set; }
         protected IGitHubClientProvider GitHubClientProvider { get; private set; }
         protected IRepositoryConfigurationProvider RepositoryConfigurationProvider { get; private set; }
-
-
+        public IDistributedLockProvider DistributedLockProvider { get; }
         protected ILogger Logger { get; private set; }
 
         protected async Task SetSuccessAsync(GitHubClient client, long repositoryId, string sha, CancellationToken cancellationToken)
@@ -71,18 +73,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
         {
             var response = await client.Check.Run.GetAllForReference(repositoryId, headSha);
             var runs = response.CheckRuns;
-            var checkEnforcerRuns = runs.Where(r => r.Name == this.GlobalConfigurationProvider.GetApplicationName());
-
-            if (checkEnforcerRuns.Count() > 1)
-            {
-                var firstRun = checkEnforcerRuns.First();
-                SimpleJsonSerializer serializer = new SimpleJsonSerializer();
-                var serializedFirstRun = serializer.Serialize(firstRun);
-
-                Logger.LogTrace("Duplicated run: {serializedFirstRun}", serializedFirstRun);
-            }
-
-            var checkRun = checkEnforcerRuns.SingleOrDefault();
+            var checkRun = runs.SingleOrDefault(r => r.Name == this.GlobalConfigurationProvider.GetApplicationName());
 
             if (checkRun == null || recreate)
             {
@@ -103,40 +94,37 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
         {
             var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
 
-            if (configuration.IsEnabled)
+            var runsResponse = await client.Check.Run.GetAllForReference(repositoryId, sha);
+            var runs = runsResponse.CheckRuns;
+
+            // NOTE: If this blows up it means that we didn't receive the check_suite request.
+            var checkEnforcerRun = await CreateCheckAsync(client, repositoryId, sha, false, cancellationToken);
+
+            var otherRuns = from run in runs
+                            where run.Name != this.GlobalConfigurationProvider.GetApplicationName()
+                            select run;
+
+            var totalOtherRuns = otherRuns.Count();
+
+            var outstandingOtherRuns = from run in otherRuns
+                                        where run.Conclusion != new StringEnum<CheckConclusion>(CheckConclusion.Success)
+                                        select run;
+
+            var totalOutstandingOtherRuns = outstandingOtherRuns.Count();
+
+            if (totalOtherRuns >= configuration.MinimumCheckRuns && totalOutstandingOtherRuns == 0 && checkEnforcerRun.Conclusion != new StringEnum<CheckConclusion>(CheckConclusion.Success))
             {
-                var runsResponse = await client.Check.Run.GetAllForReference(repositoryId, sha);
-                var runs = runsResponse.CheckRuns;
-
-                // NOTE: If this blows up it means that we didn't receive the check_suite request.
-                var checkEnforcerRun = await CreateCheckAsync(client, repositoryId, sha, false, cancellationToken);
-
-                var otherRuns = from run in runs
-                                where run.Name != this.GlobalConfigurationProvider.GetApplicationName()
-                                select run;
-
-                var totalOtherRuns = otherRuns.Count();
-
-                var outstandingOtherRuns = from run in otherRuns
-                                           where run.Conclusion != new StringEnum<CheckConclusion>(CheckConclusion.Success)
-                                           select run;
-
-                var totalOutstandingOtherRuns = outstandingOtherRuns.Count();
-
-                if (totalOtherRuns >= configuration.MinimumCheckRuns && totalOutstandingOtherRuns == 0 && checkEnforcerRun.Conclusion != new StringEnum<CheckConclusion>(CheckConclusion.Success))
+                await client.Check.Run.Update(repositoryId, checkEnforcerRun.Id, new CheckRunUpdate()
                 {
-                    await client.Check.Run.Update(repositoryId, checkEnforcerRun.Id, new CheckRunUpdate()
-                    {
-                        Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Success),
-                        Status = new StringEnum<CheckStatus>(CheckStatus.Completed),
-                        CompletedAt = DateTimeOffset.UtcNow
-                    });
-                }
-                else if (checkEnforcerRun.Conclusion == new StringEnum<CheckConclusion>(CheckConclusion.Success))
-                {
-                    // NOTE: We do this when we need to go back from a conclusion of success to a status of in-progress.
-                    await CreateCheckAsync(client, repositoryId, sha, true, cancellationToken);
-                }
+                    Conclusion = new StringEnum<CheckConclusion>(CheckConclusion.Success),
+                    Status = new StringEnum<CheckStatus>(CheckStatus.Completed),
+                    CompletedAt = DateTimeOffset.UtcNow
+                });
+            }
+            else if (totalOtherRuns < configuration.MinimumCheckRuns || totalOutstandingOtherRuns != 0 && checkEnforcerRun.Status != new StringEnum<CheckStatus>(CheckStatus.InProgress))
+            {
+                // NOTE: We do this when we need to go back from a conclusion of success to a status of in-progress.
+                await CreateCheckAsync(client, repositoryId, sha, true, cancellationToken);
             }
         }
 

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
@@ -38,7 +38,9 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
             using (var distributedLock = DistributedLockProvider.Create(distributedLockIdentifier))
             {
-                await distributedLock.AcquireAsync();
+                var distributedLockAcquired = await distributedLock.AcquireAsync();
+                if (!distributedLockAcquired) return;
+
                 switch (comment)
                 {
                     case "/check-enforcer queued":

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Sdk.Tools.CheckEnforcer.Configuration;
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Azure.Sdk.Tools.CheckEnforcer.Locking;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using Microsoft.Identity.Client;
@@ -15,7 +16,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 {
     public class IssueCommentHandler : Handler<IssueCommentPayload>
     {
-        public IssueCommentHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, ILogger logger) : base(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger)
+        public IssueCommentHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, IDistributedLockProvider distributedLockProvider, ILogger logger) : base(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, distributedLockProvider, logger)
         {
         }
 
@@ -30,31 +31,38 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
             var pullRequest = await context.Client.PullRequest.Get(repositoryId, issueId);
             var sha = pullRequest.Head.Sha;
 
-            switch (comment)
+            var distributedLockIdentifier = $"{installationId}/{repositoryId}/{sha}";
+
+            using (var distributedLock = DistributedLockProvider.Create(distributedLockIdentifier))
             {
-                case "/check-enforcer queued":
-                    await SetQueuedAsync(context.Client, repositoryId, sha, cancellationToken);
-                    break;
+                await distributedLock.AcquireAsync();
+                switch (comment)
+                {
+                    case "/check-enforcer queued":
+                        await SetQueuedAsync(context.Client, repositoryId, sha, cancellationToken);
+                        break;
 
-                case "/check-enforcer inprogress":
-                    await SetInProgressAsync(context.Client, repositoryId, sha, cancellationToken);
-                    break;
+                    case "/check-enforcer inprogress":
+                        await SetInProgressAsync(context.Client, repositoryId, sha, cancellationToken);
+                        break;
 
-                case "/check-enforcer success":
-                    await SetSuccessAsync(context.Client, repositoryId, sha, cancellationToken);
-                    break;
+                    case "/check-enforcer success":
+                        await SetSuccessAsync(context.Client, repositoryId, sha, cancellationToken);
+                        break;
 
-                case "/check-enforcer reset":
-                    await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
-                    break;
+                    case "/check-enforcer reset":
+                        await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
+                        break;
 
-                case "/check-enforcer evaluate":
-                    await EvaluatePullRequestAsync(context.Client, installationId, repositoryId, sha, cancellationToken);
-                    break;
+                    case "/check-enforcer evaluate":
+                        await EvaluatePullRequestAsync(context.Client, installationId, repositoryId, sha, cancellationToken);
+                        break;
 
-                default:
-                    this.Logger.LogTrace("Unrecognized command: {comment}", comment);
-                    break;
+                    default:
+                        this.Logger.LogTrace("Unrecognized command: {comment}", comment);
+                        break;
+                }
+                await distributedLock.ReleaseAsync();
             }
         }
     }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
@@ -28,6 +28,9 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
             var comment = payload.Comment.Body.ToLower();
             var issueId = payload.Issue.Number;
 
+            // Bail early if we aren't even a check enforcer comment. Reduces exception noise.
+            if (!comment.StartsWith("/check-enforcer")) return;
+
             var pullRequest = await context.Client.PullRequest.Get(repositoryId, issueId);
             var sha = pullRequest.Head.Sha;
 

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Locking/CheckEnforcerDistributedLockException.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Locking/CheckEnforcerDistributedLockException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Locking
+{
+
+    [Serializable]
+    public class CheckEnforcerDistributedLockException : Exception
+    {
+        public CheckEnforcerDistributedLockException(string message) : base(message) { }
+        public CheckEnforcerDistributedLockException(string message, Exception inner) : base(message, inner) { }
+        protected CheckEnforcerDistributedLockException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Locking/DistributedLock.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Locking/DistributedLock.cs
@@ -1,0 +1,88 @@
+﻿using Azure.Storage;
+using Azure.Storage.Blobs;
+using Azure.Storage.Blobs.Specialized;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Locking
+{
+    public class DistributedLock : IDisposable
+    {
+        private BlobContainerClient containerClient;
+        private string lockIdentifier;
+        private int maxRetries;
+        private TimeSpan backoffInterval;
+        private TimeSpan lockDuration;
+        private TimeSpan acquisitionTimeout;
+        private int attempts;
+        private LeaseClient leaseClient;
+        private static Random random = new Random();
+
+        public DistributedLock(BlobContainerClient containerClient, string lockIdentifier, int maxRetries, TimeSpan backoffInterval, TimeSpan lockDuration, TimeSpan acquisitionTimeout)
+        {
+            this.containerClient = containerClient;
+            this.lockIdentifier = lockIdentifier;
+            this.maxRetries = maxRetries;
+            this.backoffInterval = backoffInterval;
+            this.lockDuration = lockDuration;
+            this.acquisitionTimeout = acquisitionTimeout;
+        }
+
+        public async Task AcquireAsync()
+        {
+            var acquisitionStarted = DateTimeOffset.UtcNow;
+
+            do
+            {
+                attempts++;
+
+                var blobClient = containerClient.GetBlobClient(lockIdentifier);
+                leaseClient = blobClient.GetLeaseClient();
+
+                try
+                {
+                    await leaseClient.AcquireAsync(lockDuration);
+                    return;
+                }
+                catch (StorageRequestFailedException ex) when (ex.ErrorCode == "BlobNotFound")
+                {
+                    var contentBytes = Encoding.UTF8.GetBytes(lockIdentifier);
+                    var contentStream = new MemoryStream(contentBytes);
+                    await blobClient.UploadAsync(contentStream);
+                }
+                catch (StorageRequestFailedException ex) when (ex.ErrorCode == "LeaseAlreadyPresent")
+                {
+                    // Simple backoff logic.
+                    var immediateMultiplier = random.Next(0, 2);
+                    int delay = immediateMultiplier * attempts * ((int)backoffInterval.TotalMilliseconds);
+                    await Task.Delay(delay);
+                }
+                catch (Exception ex)
+                {
+                    throw ex;
+                }
+
+            } while (attempts < maxRetries || DateTimeOffset.UtcNow > acquisitionStarted + acquisitionTimeout);
+
+            throw new CheckEnforcerDistributedLockException($"Failed to acquire lock for {lockIdentifier}.");
+        }
+
+        public async Task ReleaseAsync()
+        {
+            if (leaseClient != null)
+            {
+                await leaseClient.ReleaseAsync();
+                leaseClient = null;
+            }
+        }
+
+        public void Dispose()
+        {
+            ReleaseAsync().Wait(10000);
+        }
+    }
+
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Locking/DistributedLockProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Locking/DistributedLockProvider.cs
@@ -39,10 +39,10 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Locking
             var containerClient = client.GetBlobContainerClient(containerName);
 
             // TOOD: Consider replacing these with con
-            var maxRetries = 200;
-            var backoffInterval = TimeSpan.FromMilliseconds(250);
+            var maxRetries = 3;
+            var backoffInterval = TimeSpan.FromMilliseconds(2000);
             var lockDuration = TimeSpan.FromSeconds(20);
-            var acquisitionTimeout = TimeSpan.FromSeconds(60);
+            var acquisitionTimeout = TimeSpan.FromSeconds(10);
 
             var distributedLock = new DistributedLock(
                 containerClient,

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Locking/DistributedLockProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Locking/DistributedLockProvider.cs
@@ -1,0 +1,59 @@
+﻿using Azure.Identity;
+using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Azure.Storage.Blobs;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Locking
+{
+    public class DistributedLockProvider : IDistributedLockProvider
+    {
+        public DistributedLockProvider(IGlobalConfigurationProvider globalConfigurationProvider)
+        {
+            this.globalConfigurationProvider = globalConfigurationProvider;
+        }
+
+        private IGlobalConfigurationProvider globalConfigurationProvider;
+        private BlobServiceClient client;
+        private object clientLock = new object();
+
+
+        public DistributedLock Create(string identifier)
+        {
+            if (client == null)
+            {
+                lock(clientLock)
+                {
+                    if (client == null)
+                    {
+                        var uri = new Uri(globalConfigurationProvider.GetDistributedLockStorageUri());
+                        var credential = new DefaultAzureCredential();
+                        client = new BlobServiceClient(uri, credential);
+
+                    }
+                }
+            }
+
+            var containerName = globalConfigurationProvider.GetDistributedLockContainerName();
+            var containerClient = client.GetBlobContainerClient(containerName);
+
+            // TOOD: Consider replacing these with con
+            var maxRetries = 200;
+            var backoffInterval = TimeSpan.FromMilliseconds(250);
+            var lockDuration = TimeSpan.FromSeconds(20);
+            var acquisitionTimeout = TimeSpan.FromSeconds(60);
+
+            var distributedLock = new DistributedLock(
+                containerClient,
+                identifier,
+                maxRetries,
+                backoffInterval,
+                lockDuration,
+                acquisitionTimeout
+                );
+
+            return distributedLock;
+        }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Locking/IDistributedLockProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Locking/IDistributedLockProvider.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Locking
+{
+    public interface IDistributedLockProvider
+    {
+        DistributedLock Create(string identifier);
+    }
+}


### PR DESCRIPTION
This PR adds distributed locking (via Azure Storage blob leases) to serialize operations against GitHub. This is a MVP of this approach. If this works and we don't have any further issues with GitHub getting into an inconsistent state then we can look at optimizing this more.