### PR TITLE
Put semicolon at the end of the method declaration instead of "{…

### DIFF
--- a/src/dotnet/APIView/APIView/Languages/CodeFileBuilder.cs
+++ b/src/dotnet/APIView/APIView/Languages/CodeFileBuilder.cs
@@ -49,7 +49,7 @@ namespace ApiView
 
         public ICodeFileBuilderSymbolOrderProvider SymbolOrderProvider { get; set; } = new CodeFileBuilderSymbolOrderProvider();
 
-        public const string CurrentVersion = "12";
+        public const string CurrentVersion = "13";
 
         private IEnumerable<INamespaceSymbol> EnumerateNamespaces(IAssemblySymbol assemblySymbol)
         {

--- a/src/dotnet/APIView/APIView/Languages/CodeFileBuilder.cs
+++ b/src/dotnet/APIView/APIView/Languages/CodeFileBuilder.cs
@@ -319,9 +319,7 @@ namespace ApiView
                 !member.IsAbstract &&
                 member.ContainingType.TypeKind != TypeKind.Interface)
             {
-                builder.Space();
-                builder.Punctuation(SyntaxKind.OpenBraceToken);
-                builder.Punctuation(SyntaxKind.CloseBraceToken);
+                builder.Punctuation(SyntaxKind.SemicolonToken);
             }
             else if (member.Kind == SymbolKind.Field && member.ContainingType.TypeKind == TypeKind.Enum)
             {

--- a/src/dotnet/APIView/APIView/Languages/CodeFileBuilder.cs
+++ b/src/dotnet/APIView/APIView/Languages/CodeFileBuilder.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -98,7 +99,7 @@ namespace ApiView
             {
                 Text = assemblySymbol.Name + ".dll",
                 ChildItems = navigationItems.ToArray(),
-                Tags = { {"TypeKind", "assembly"} }
+                Tags = { { "TypeKind", "assembly" } }
             };
 
             var node = new CodeFile()
@@ -107,7 +108,7 @@ namespace ApiView
                 Language = "C#",
                 Tokens = builder.Tokens.ToArray(),
                 VersionString = CurrentVersion,
-                Navigation = new [] { assemblyNavigationItem },
+                Navigation = new[] { assemblyNavigationItem },
                 Diagnostics = analyzer.Results.ToArray()
             };
 
@@ -138,7 +139,7 @@ namespace ApiView
                 NavigationId = namespaceSymbol.GetId(),
                 Text = namespaceSymbol.ToDisplayString(),
                 ChildItems = namespaceItems.ToArray(),
-                Tags = { {"TypeKind", "namespace"} }
+                Tags = { { "TypeKind", "namespace" } }
             };
             navigationItems.Add(namespaceItem);
         }
@@ -315,6 +316,7 @@ namespace ApiView
 
             builder.WriteIndent();
             NodeFromSymbol(builder, member);
+
             if (member.Kind == SymbolKind.Method &&
                 !member.IsAbstract &&
                 member.ContainingType.TypeKind != TypeKind.Interface)
@@ -520,7 +522,7 @@ namespace ApiView
                 DefinitionId = definedSymbol?.Equals(symbol) == true ? definedSymbol.GetId() : null,
                 NavigateToId = navigateToId,
                 Value = symbolDisplayPart.ToString(),
-                Kind =  kind
+                Kind = kind
             };
         }
 

--- a/src/dotnet/APIView/APIView/Languages/CodeFileBuilder.cs
+++ b/src/dotnet/APIView/APIView/Languages/CodeFileBuilder.cs
@@ -317,13 +317,7 @@ namespace ApiView
             builder.WriteIndent();
             NodeFromSymbol(builder, member);
 
-            if (member.Kind == SymbolKind.Method &&
-                !member.IsAbstract &&
-                member.ContainingType.TypeKind != TypeKind.Interface)
-            {
-                builder.Punctuation(SyntaxKind.SemicolonToken);
-            }
-            else if (member.Kind == SymbolKind.Field && member.ContainingType.TypeKind == TypeKind.Enum)
+            if (member.Kind == SymbolKind.Field && member.ContainingType.TypeKind == TypeKind.Enum)
             {
                 builder.Punctuation(SyntaxKind.CommaToken);
             }

--- a/src/dotnet/APIView/APIViewTest/ExactFormatting/Attributes.cs
+++ b/src/dotnet/APIView/APIViewTest/ExactFormatting/Attributes.cs
@@ -12,7 +12,7 @@ namespace A {
     public class Class {
         [Conditional("string")]
         [Conditional("string2")]
-        public void M() {}
+        public void M()/*-*/{/*-*/;/*-*/}/*-*/
         /*-*/
         // Skipped attributes
         [DebuggerStepThrough]
@@ -24,12 +24,12 @@ namespace A {
         [Public("s")]
         [Public("s", Property = "a")]
         [Public(null, Property = null)]
-        public void M1() {}
+        public void M1()/*-*/{/*-*/;/*-*/}/*-*/
     }
     [AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
     public class PublicAttribute : Attribute {
-        public PublicAttribute(int i) {}
-        public PublicAttribute(string s) {}
+        public PublicAttribute(int i)/*-*/{/*-*/;/*-*/}/*-*/
+        public PublicAttribute(string s)/*-*/{/*-*/;/*-*/}/*-*/
         public string Property { get; set; }
     }
 }

--- a/src/dotnet/APIView/APIViewTest/ExactFormatting/Inheritance.cs
+++ b/src/dotnet/APIView/APIViewTest/ExactFormatting/Inheritance.cs
@@ -7,6 +7,6 @@
         public abstract void M();
     }
     public class LClass : K, I1, I2<K> {
-        public override sealed void M() {}
+        public override sealed void M()/*-*/{/*-*/;/*-*/}/*-*/
     }
 }

--- a/src/dotnet/APIView/APIViewTest/ExactFormatting/Methods.cs
+++ b/src/dotnet/APIView/APIViewTest/ExactFormatting/Methods.cs
@@ -1,12 +1,12 @@
 ﻿/*-*/using System;/*-*/
 namespace A {
     public class Class {
-        public static void K() {}
-        public void M0(string s) {}
-        public void M1(string s = null) {}
-        public virtual void M2(string s = "s") {}
-        public void M3(string s, int m = 3) {}
-        public Class M3(string s, int m = 3, DateTime d = default) {/*-*/return null;/*-*/}
-        public void M4<T>() {}
+        public static void K()/*-*/{/*-*/;/*-*/}/*-*/
+        public void M0(string s)/*-*/{/*-*/;/*-*/}/*-*/
+        public void M1(string s = null)/*-*/{/*-*/;/*-*/}/*-*/
+        public virtual void M2(string s = "s")/*-*/{/*-*/;/*-*/}/*-*/
+        public void M3(string s, int m = 3)/*-*/{/*-*/;/*-*/}/*-*/
+        public Class M3(string s, int m = 3, DateTime d = default)/*-*/{ return null/*-*/;/*-*/}/*-*/
+        public void M4<T>()/*-*/{/*-*/;/*-*/}/*-*/
     }
 }

--- a/src/dotnet/APIView/APIViewTest/ExactFormatting/Struct.cs
+++ b/src/dotnet/APIView/APIViewTest/ExactFormatting/Struct.cs
@@ -1,6 +1,6 @@
 ﻿namespace A {
     public struct S {
-        public S(int a) {/*-*/ A = a; Str = null; /*-*/}
+        public S(int a)/*-*/{ A = a; Str = null/*-*/;/*-*/}/*-*/
         public int A;
         public string Str { get; }
     }


### PR DESCRIPTION
…hat is now.

The original intention was to have code that compiles, however having readable code is more important for the tool.

Fixes #231 

/cc @pakrym @KrzysztofCwalina 