### PR TITLE
Disable public CI triggers in our pipeline generation

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
@@ -28,21 +28,11 @@ namespace PipelineGenerator.Conventions
 
             var hasChanges = await base.ApplyConventionAsync(definition, component);
 
-            var ciTrigger = definition.Triggers.OfType<ContinuousIntegrationTrigger>().SingleOrDefault();
-
-            if (ciTrigger == null)
+            for (int i = definition.Triggers.Count - 1; i >= 0; i--)
             {
-                definition.Triggers.Add(new ContinuousIntegrationTrigger()
+                if (definition.Triggers[i] is ContinuousIntegrationTrigger)
                 {
-                    SettingsSourceType = 2 // HACK: This is editor invisible, but this is required to inherit branch filters from YAML file.
-                });
-                hasChanges = true;
-            }
-            else
-            {
-                if (ciTrigger.SettingsSourceType != 2)
-                {
-                    ciTrigger.SettingsSourceType = 2;
+                    definition.Triggers.RemoveAt(i);
                     hasChanges = true;
                 }
             }


### PR DESCRIPTION
For now we are cutting out the public CI triggers and letting
the internal CI jobs handle the load to help eliminate some
of the build queuing issues.

@mitchdenny I ran this locally in, js/python/java but until this comes in they will get reset so lets get this merged and published asap