### PR TITLE
Fixes for Java - Resolve Paths to Folders

### DIFF
--- a/scripts/python/util/replace_relative_links.py
+++ b/scripts/python/util/replace_relative_links.py
@@ -143,6 +143,11 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
+    logging.info("Root Folder: {}".format(args.root_folder))
+    logging.info("Target Folder: {}".format(args.target_folder))
+    logging.info("Repository Id: {}".format(args.repo_id))
+    logging.info("Build SHA: {}".format(args.build_sha))
+
     readme_files = locate_readmes(args.target_folder)
 
     for readme_location in readme_files:

--- a/scripts/python/util/replace_relative_links.py
+++ b/scripts/python/util/replace_relative_links.py
@@ -34,7 +34,7 @@ def locate_readmes(directory):
 
 def is_relative_link(link_value, readme_location):
     try:
-        return os.path.isfile(
+        return os.path.exists(
             os.path.abspath(os.path.join(os.path.dirname(readme_location), link_value))
         )
     except:


### PR DESCRIPTION
We wanted to also resolve absolute _folders_.

`os.path.exists` only differs from `os.path.isfile` in that the latter ensures it's not a directory. 