### PR TITLE
Add and remove namespaces from .NET analyzers

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
@@ -23,7 +23,7 @@ namespace /*MM*/RandomNamespace
             var diagnostic = Assert.Single(diagnostics);
             Assert.Equal("AZC0001", diagnostic.Id);
             Assert.Equal("Namespace 'RandomNamespace' shouldn't contain public types. Use one of the following pre-approved namespace groups: " +
-                         "Azure.ApplicationModel, Azure.Analytics, Azure.Data, Azure.Iot, Azure.Media, Azure.Messaging, Azure.ML, Azure.Security, Azure.Storage", diagnostic.GetMessage());
+                         "Azure.AI, Azure.Analytics, Azure.Data, Azure.Iot, Azure.Media, Azure.Messaging, Azure.Security, Azure.Storage", diagnostic.GetMessage());
 
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
@@ -12,13 +12,12 @@ namespace Azure.ClientSdk.Analyzers
     {
         internal static readonly string[] AllowedNamespacePrefix = new[]
         {
-            "Azure.ApplicationModel",
+            "Azure.AI",
             "Azure.Analytics",
             "Azure.Data",
             "Azure.Iot",
             "Azure.Media",
             "Azure.Messaging",
-            "Azure.ML",
             "Azure.Security",
             "Azure.Storage"
         };


### PR DESCRIPTION
Add Azure.AI to namespace prefixes in static analyzers.  Remove Azure.ApplicationModel.

Fixes Azure/azure-sdk-for-net#7384.