### PR TITLE
Fix for internal pipelines not being comment triggerable.

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -92,13 +92,13 @@ namespace PipelineGenerator.Conventions
             }
             else
             {
-                if (prTrigger.SettingsSourceType != 2 ||
+                if (prTrigger.SettingsSourceType != 1 ||
                     prTrigger.IsCommentRequiredForPullRequest != true ||
                     !prTrigger.BranchFilters.All(bf => bf == $"+{Context.Branch}") ||
                     prTrigger.Forks.AllowSecrets != true ||
                     prTrigger.Forks.Enabled != true)
                 {
-                    prTrigger.SettingsSourceType = 2;
+                    prTrigger.SettingsSourceType = 1;
                     prTrigger.IsCommentRequiredForPullRequest = true;
                     prTrigger.BranchFilters = new List<string>()
                     {


### PR DESCRIPTION
This PR fixes a bug that triggered after a recent change where internal unified pipelines became untriggerable via an ```/azp run``` comment. The issue was the ```SettingsSourceType``` field value. Upon initial creation it was set to 1 (default), but when a change was detected it got set to 2 -- changing the way that path filters were evaluated. The fix is to make it detect when the unified pipeline convention based pipeline is set incorrectly and flick the value back to 1. When this is merged and we update the pipeline generator all the internal pipelines will be triggerable again after the next generation run.