### PR TITLE
Fixing a bug when generating a repo index for .net

### DIFF
--- a/packages/python-packages/doc-warden/warden/warden_common.py
+++ b/packages/python-packages/doc-warden/warden/warden_common.py
@@ -45,7 +45,9 @@ def get_net_packages(configuration):
     file_set =  get_file_sets(configuration, NET_PACKAGE_DISCOVERY_PATTERN, is_net_csproj_package)
     
     if configuration.verbose_output:
-        print(sets)
+        print(file_set)
+
+    return file_set
 
 def get_python_package_roots(configuration):
     file_set = get_file_sets(configuration, PYTHON_PACKAGE_DISCOVERY_PATTERN)


### PR DESCRIPTION
@chidozieononiwu 

This is the solution we were looking for.

Lacking a return meant that for the `indexing` action, .NET wasn't finding any packages due to not _returning them_ from the function that finds them!