### PR TITLE
Updating Env Log Outputs

### DIFF
--- a/packages/python-packages/tox-monorepo/tox_monorepo/monorepo.py
+++ b/packages/python-packages/tox-monorepo/tox_monorepo/monorepo.py
@@ -37,12 +37,15 @@ def update_env(old_path, new_path, environment_config):
     environment_config.envtmpdir = py.path.local(
         environment_config.envtmpdir.strpath.replace(old_path, new_path)
     )
+    environment_config.envlogdir = py.path.local(
+        environment_config.envlogdir.strpath.replace(old_path, new_path)
+    )
+
 
     # update the cachedir
     environment_config.setenv["TOX_ENV_DIR"] = environment_config.setenv[
         "TOX_ENV_DIR"
     ].replace(old_path, new_path)
-
 
 @hookimpl
 def tox_configure(config):
@@ -77,6 +80,11 @@ def tox_configure(config):
     if config.sdistsrc:
         config.sdistsrc = py.path.local(
             config.sdistsrc.strpath.replace(original_toxinipath, invocationcwd)
+        )
+
+    if config.logdir:
+        config.logdir = py.path.local(
+            config.logdir.strpath.replace(original_toxinipath, invocationcwd)
         )
 
     for environment_name, environment_config in config.envconfigs.items():

--- a/packages/python-packages/tox-monorepo/tox_monorepo/version.py
+++ b/packages/python-packages/tox-monorepo/tox_monorepo/version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.1.1"
+VERSION = "0.1.2"


### PR DESCRIPTION
Ensuring that they end up in the proper location. This bugfix is a step towards ensuring that multiple `tox` invocations can run at the same time. 

@Azure/azure-sdk-eng 