### PR TITLE
Fix to handle links with location

### DIFF
--- a/eng/pipelines/templates/scripts/replace-relative-links.yml
+++ b/eng/pipelines/templates/scripts/replace-relative-links.yml
@@ -42,9 +42,13 @@ steps:
 
 
         def is_relative_link(link_value, readme_location):
+            link_without_location = link_value
+            if link_without_location.find('#') > 0:
+                link_without_location = link_without_location[0:link_without_location.find('#')]
+
             try:
                 return os.path.exists(
-                    os.path.abspath(os.path.join(os.path.dirname(readme_location), link_value))
+                    os.path.abspath(os.path.join(os.path.dirname(readme_location), link_without_location))
                 )
             except:
                 return False


### PR DESCRIPTION
This is a minor fix to the relative link replacement.

What was happening is that it wasn't correctly handling a relative link with a location.  For example: foo.md would get it's relative link replaced just fine but foo.md#bar wouldn't. The is_relative_link was checks whether or not something is a relative link by seeing if the combined path exists which would never pass due to the "#location" being part of the link. The fix here is to check if the link contains a # sign, not as the first character, and if so strip it off before checking the path.