### PR TITLE
Check enforcer: fix for issue blocking PR merging

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
@@ -111,8 +111,13 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
             var runsResponse = await client.Check.Run.GetAllForReference(repositoryId, sha);
             var runs = runsResponse.CheckRuns;
 
-            // NOTE: If this blows up it means that we didn't receive the check_suite request.
-            var checkEnforcerRun = await CreateCheckAsync(client, repositoryId, sha, false, cancellationToken);
+            var checkEnforcerRun = runs.SingleOrDefault(r => r.Name == this.GlobalConfigurationProvider.GetApplicationName());
+
+            if (checkEnforcerRun == null)
+            {
+                 Logger.LogTrace("Check-run for enforcer doesn't exist.");
+                 return;
+            }
 
             var otherRuns = from run in runs
                             where run.Name != this.GlobalConfigurationProvider.GetApplicationName()


### PR DESCRIPTION
This fixes the problem that is preventing Check Enforcer from being made a required check. The problem manifests as **_Required statuses must pass before merging_** even though all checks show as "successful".

The root cause appears to be a bug in Azure Pipelines. Azure Pipelines is incorrectly creating/completing a check run against the **_merge_** commit of the PR (not the head commit). This happens in the scenario where no jobs get run due to there being no files in the PR that match the pipeline's PR trigger file path filters.

The fix avoids creating a new check run on every check completion because, as mentioned above, a check run is being incorrectly created against the merge commit SHA. GitHub show all checks as passed, but the check associated with the merge commit SHA is still pending, which is preventing the PR from being merged.