### PR TITLE
Add swift to the list of supported languages

### DIFF
--- a/packages/python-packages/doc-warden/warden/enforce_changelog_content.py
+++ b/packages/python-packages/doc-warden/warden/enforce_changelog_content.py
@@ -12,7 +12,7 @@ from docutils.writers.html4css1 import Writer,HTMLTranslator
 import pathlib
 import logging
 
-from .index_packages import get_python_package_info, get_js_package_info, get_java_package_info, get_net_packages_info
+from .index_packages import get_python_package_info, get_js_package_info, get_java_package_info, get_net_package_info
 
 # entry point
 def verify_changelog_content(config, pkg_list):

--- a/packages/python-packages/doc-warden/warden/enforce_target_file_presence.py
+++ b/packages/python-packages/doc-warden/warden/enforce_target_file_presence.py
@@ -9,7 +9,7 @@ import glob
 import fnmatch
 import zipfile
 from pathlib import Path
-from .warden_common import get_java_package_roots, get_net_packages, get_python_package_roots, get_js_package_roots, find_alongside_file
+from .warden_common import get_java_package_roots, get_net_package, get_python_package_roots, get_swift_package_roots, get_js_package_roots, find_alongside_file
 
 # python 3 transitioned StringIO to be part of `io` module. 
 # python 2 needs the old version however
@@ -29,7 +29,8 @@ def find_missing_target_files(configuration):
         'python': check_python_target_files,
         'js': check_js_target_files,
         'java': check_java_target_files,
-        'net': check_net_target_files
+        'net': check_net_target_files,
+        'swift': check_swift_target_files
     }
     missing_target_file_paths = []
     ignored_missing_target_file_paths = []
@@ -51,6 +52,18 @@ def check_repo_root(configuration):
         present_files = [f for f in os.listdir(configuration.target_directory) if os.path.isfile(os.path.join(configuration.target_directory, f))]
         return  any(x in [f.lower() for f in present_files] for x in configuration.target_files)
     return true
+
+def check_swift_target_files(configuration):
+    expected_target_files, omitted_target_files = get_swift_package_roots(configuration)
+    missing_expected_target_file_locations = []
+
+    for expected_location in expected_target_files:
+        result = False
+        for target_file in configuration.target_files:
+            result = result or find_alongside_file(expected_location, target_file)
+        if not result:
+            missing_expected_target_file_locations.append(os.path.dirname(expected_location))
+    return missing_expected_target_file_locations
 
 # return all missing target_files for a PYTHON repostiroy
 def check_python_target_files(configuration):
@@ -80,7 +93,7 @@ def check_js_target_files(configuration):
 
 # return all missing target_files for a .NET repostory
 def check_net_target_files(configuration):
-    expected_target_files, omitted_target_files = get_net_packages(configuration)
+    expected_target_files, omitted_target_files = get_net_package(configuration)
     missing_expected_target_file_locations = []
 
     for expected_location in expected_target_files:

--- a/packages/python-packages/doc-warden/warden/index_packages.py
+++ b/packages/python-packages/doc-warden/warden/index_packages.py
@@ -3,7 +3,7 @@
 
 from __future__ import print_function
 
-from .warden_common import check_match, walk_directory_for_pattern, get_omitted_files, get_java_package_roots, get_net_package, get_python_package_roots, get_js_package_roots, find_alongside_file, find_below_file, parse_pom, parse_csproj, is_java_pom_package_pom, find_above_file
+from .warden_common import check_match, walk_directory_for_pattern, get_omitted_files, get_java_package_roots, get_net_package, get_swift_package_roots, get_python_package_roots, get_js_package_roots, find_alongside_file, find_below_file, parse_pom, parse_csproj, is_java_pom_package_pom, find_above_file
 from .PackageInfo import PackageInfo
 import json
 import os
@@ -66,10 +66,26 @@ def index_packages(configuration):
         'python': get_python_package_info,
         'js': get_js_package_info,
         'java': get_java_package_info,
-        'net': get_net_package_info
+        'net': get_net_package_info,
+        'swift': get_swift_package_info
     }
 
     return language_selector.get(configuration.scan_language.lower(), unrecognized_option)(configuration)
+
+def get_swift_package_info(config):
+    pkg_list = []
+    pkg_locations, ignored_pkg_locations = get_swift_package_roots(config)
+
+    for pkg_file in (pkg_locations + ignored_pkg_locations):
+        # TODOprint("Found *.pbxproj file: {}".format(pkg_file))
+        pkg_list.append(PackageInfo(
+            package_id = 'AzureCore',
+            package_version = '1.0.0-beta.1',
+            relative_package_location = 'x',
+            relative_readme_location = 'y',
+            relative_changelog_location = 'z',
+            repository_args = []
+            ))
 
 # leverages python AST to parse arguments to `setup.py` and return a list of all indexed packages 
 # within the target directory
@@ -87,6 +103,7 @@ def get_python_package_info(config):
         changelog = find_below_file('history.md', pkg_file)
         if changelog is None:
             changelog = find_below_file('history.rst', pkg_file)
+
 
         readme = find_below_file('readme.md', pkg_file)
         if readme is None:
@@ -276,6 +293,7 @@ def webify_relative_path(path):
 # entrypoint for rendering the packages.md
 # handles the template selection and execution
 def render(config, pkg_list):
+
     language_selector = {
         'python': OUTPUT_TEMPLATE,
         'js': OUTPUT_TEMPLATE,

--- a/packages/python-packages/doc-warden/warden/index_packages.py
+++ b/packages/python-packages/doc-warden/warden/index_packages.py
@@ -281,6 +281,7 @@ def render(config, pkg_list):
         'js': OUTPUT_TEMPLATE,
         'java': JAVA_OUTPUT_TEMPLATE,
         'net': OUTPUT_TEMPLATE,
+        'android': OUTPUT_TEMPLATE,
         'ios': OUTPUT_TEMPLATE
     }
 

--- a/packages/python-packages/doc-warden/warden/index_packages.py
+++ b/packages/python-packages/doc-warden/warden/index_packages.py
@@ -280,7 +280,8 @@ def render(config, pkg_list):
         'python': OUTPUT_TEMPLATE,
         'js': OUTPUT_TEMPLATE,
         'java': JAVA_OUTPUT_TEMPLATE,
-        'net': OUTPUT_TEMPLATE
+        'net': OUTPUT_TEMPLATE,
+        'ios': OUTPUT_TEMPLATE
     }
 
     template = language_selector.get(config.scan_language.lower(), unrecognized_option)

--- a/packages/python-packages/doc-warden/warden/index_packages.py
+++ b/packages/python-packages/doc-warden/warden/index_packages.py
@@ -3,7 +3,7 @@
 
 from __future__ import print_function
 
-from .warden_common import check_match, walk_directory_for_pattern, get_omitted_files, get_java_package_roots, get_net_packages, get_python_package_roots, get_js_package_roots, find_alongside_file, find_below_file, parse_pom, parse_csproj, is_java_pom_package_pom, find_above_file
+from .warden_common import check_match, walk_directory_for_pattern, get_omitted_files, get_java_package_roots, get_net_package, get_python_package_roots, get_js_package_roots, find_alongside_file, find_below_file, parse_pom, parse_csproj, is_java_pom_package_pom, find_above_file
 from .PackageInfo import PackageInfo
 import json
 import os
@@ -66,7 +66,7 @@ def index_packages(configuration):
         'python': get_python_package_info,
         'js': get_js_package_info,
         'java': get_java_package_info,
-        'net': get_net_packages_info
+        'net': get_net_package_info
     }
 
     return language_selector.get(configuration.scan_language.lower(), unrecognized_option)(configuration)
@@ -218,9 +218,9 @@ def get_java_package_info(config):
 
 # finds .net packages (non-test CSProjs) and attempts to correlate the packageinfo details
 # returns a list of all `packages` found within the target directory.
-def get_net_packages_info(config):
+def get_net_package_info(config):
     pkg_list = []
-    pkg_locations, ignored_pkg_locations = get_net_packages(config)
+    pkg_locations, ignored_pkg_locations = get_net_package(config)
 
     for pkg_file in (pkg_locations + ignored_pkg_locations):
         pkg_version = parse_csproj(pkg_file)
@@ -280,9 +280,7 @@ def render(config, pkg_list):
         'python': OUTPUT_TEMPLATE,
         'js': OUTPUT_TEMPLATE,
         'java': JAVA_OUTPUT_TEMPLATE,
-        'net': OUTPUT_TEMPLATE,
-        'android': OUTPUT_TEMPLATE,
-        'ios': OUTPUT_TEMPLATE
+        'net': OUTPUT_TEMPLATE
     }
 
     template = language_selector.get(config.scan_language.lower(), unrecognized_option)

--- a/packages/python-packages/doc-warden/warden/warden_common.py
+++ b/packages/python-packages/doc-warden/warden/warden_common.py
@@ -5,6 +5,7 @@ import os
 import fnmatch
 import re
 import xml.etree.ElementTree as ET
+import pathlib
 
 # python 3 transitioned StringIO to be part of `io` module. 
 # python 2 needs the old version however
@@ -17,6 +18,7 @@ JS_PACKAGE_DISCOVERY_PATTERN = '*/package.json'
 PYTHON_PACKAGE_DISCOVERY_PATTERN = '*/setup.py'
 NET_PACKAGE_DISCOVERY_PATTERN = '*.csproj'
 JAVA_PACKAGE_DISCOVERY_PATTERN = '*/pom.xml'
+SWIFT_PACKAGE_DISCOVERY_PATTERN = '*/project.pbxproj'
 
 # we want to walk the files as few times as possible. as such, for omitted_files, we provide a SET 
 # of patterns that we want to omit. This function simply checks 
@@ -36,6 +38,29 @@ def get_java_package_roots(configuration):
 def get_net_package(configuration):
     file_set =  get_file_sets(configuration, NET_PACKAGE_DISCOVERY_PATTERN, is_net_csproj_package)
     
+    if configuration.verbose_output:
+        print(file_set)
+
+    return file_set
+
+def get_project_roots_from_pbxproj_paths(pbxproj_file_set):
+    project_roots = []
+    for pbxproj_file in pbxproj_file_set:
+        pbxproj_file_path = pathlib.Path(pbxproj_file)
+        project_root_path = pbxproj_file_path.parents[1]
+        project_roots.append(str(project_root_path))
+
+    return project_roots
+
+
+def get_swift_package_roots(configuration):
+    project_files, omitted_project_files = get_file_sets(configuration, SWIFT_PACKAGE_DISCOVERY_PATTERN)
+
+    project_roots = get_project_roots_from_pbxproj_paths(project_files)
+    omitted_project_roots = get_project_roots_from_pbxproj_paths(omitted_project_files)
+
+    file_set = project_roots, omitted_project_roots
+
     if configuration.verbose_output:
         print(file_set)
 

--- a/packages/python-packages/doc-warden/warden/warden_common.py
+++ b/packages/python-packages/doc-warden/warden/warden_common.py
@@ -33,7 +33,7 @@ def get_java_package_roots(configuration):
 
     return list(set(file_set[0]).union(defined_packages)) , file_set[1]
 
-def get_net_packages(configuration):
+def get_net_package(configuration):
     file_set =  get_file_sets(configuration, NET_PACKAGE_DISCOVERY_PATTERN, is_net_csproj_package)
     
     if configuration.verbose_output:


### PR DESCRIPTION
DocWarden needs an iOS and Android option. Its kinda strange to cause this a language value when it generally appears to map to the repository name.