### PR TITLE
Disable distributed lock and recreation on Check Enforcer

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckSuiteHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckSuiteHandler.cs
@@ -31,16 +31,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
                 if (configuration.IsEnabled)
                 {
-                    var distributedLockIdentifier = $"{installationId}/{repositoryId}/{sha}";
-
-                    using (var distributedLock = DistributedLockProvider.Create(distributedLockIdentifier))
-                    {
-                        var distributedLockAcquired = await distributedLock.AcquireAsync();
-                        if (!distributedLockAcquired) return;
-
-                        await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
-                        await distributedLock.ReleaseAsync();
-                    }
+                    await CreateCheckAsync(context.Client, repositoryId, sha, true, cancellationToken);
                 }
             }
         }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/Handler.cs
@@ -142,11 +142,6 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
                 });
                 Logger.LogTrace("Updated check-run.");
             }
-            else if (totalOtherRuns < configuration.MinimumCheckRuns || totalOutstandingOtherRuns != 0 && checkEnforcerRun.Status != new StringEnum<CheckStatus>(CheckStatus.InProgress))
-            {
-                // NOTE: We do this when we need to go back from a conclusion of success to a status of in-progress.
-                await CreateCheckAsync(client, repositoryId, sha, true, cancellationToken);
-            }
         }
 
         private T DeserializePayload(string json)


### PR DESCRIPTION
This PR disables use of the distributed lock for Check Enforcer (it is possible that in a future PR I'll be able to rip it out completely. I also disabled the recreation logic since that could cause problems.