### PR TITLE
Live test resource cleanup

### DIFF
--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -15,7 +15,7 @@ stages:
 
     steps:
       - pwsh: >
-          tools/live-test-cleanup/cleanup.ps1
+          ./tools/live-test-cleanup/cleanup.ps1
           -ProvisionerApplicationId "$(provisioner-aad-id)"
           -ProvisionerApplicationSecret "$(provisioner-aad-secret)"
           -ProvisionerApplicationTenantId "$(provisioner-aad-tenant)"

--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -21,5 +21,4 @@ stages:
           -ProvisionerApplicationTenantId "$(provisioner-aad-tenant)"
           -SubscriptionId "$(provisioner-subscription)"
           -Verbose
-          -WhatIf
         displayName: Clean up subscription resources

--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -1,0 +1,25 @@
+
+trigger: none
+pr: none
+
+stages:
+- stage: Run
+
+  variables:
+  - template: ./templates/variables/globals.yml
+
+  jobs:
+  - job: Run
+    pool:
+      vmImage: ubuntu-16.04
+
+    steps:
+      - pwsh: >
+          tools/live-test-cleanup/cleanup.ps1
+          -ProvisionerApplicationId "$(provisioner-aad-id)"
+          -ProvisionerApplicationSecret "$(provisioner-aad-secret)"
+          -ProvisionerApplicationTenantId "$(provisioner-aad-tenant)"
+          -SubscriptionId "$(provisioner-subscription)"
+          -Verbose
+          -WhatIf
+        displayName: Clean up subscription resources

--- a/tools/live-test-cleanup/README.md
+++ b/tools/live-test-cleanup/README.md
@@ -1,0 +1,26 @@
+# Live Test Resource Cleanup
+
+Removes resource groups from the given subscription. Cleans up resources that
+might be left behind after a normal pipeline's execution encounters an abnormal
+termination (timeout, crash, etc.). This is accomplished by parsing the value in
+the `DeleteAfter` tag using .NET [DateTime.Parse](https://docs.microsoft.com/en-us/dotnet/api/system.datetime.parse?view=netframework-4.8)
+and removing if the current time is later than the `DeleteAfter` time.
+
+Run this script on some cadence (e.g. 1x every 24 hours) to ensure subscriptions
+do not have unused resources lying around. (see
+`eng/pipelines/live-test-cleanup.yml`)
+
+## Requirements
+
+* [az CLI](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest)
+* AAD App with permissions in the subscription to delete resource groups
+
+## Parameters
+
+* `ProvisionerApplicationId` -- AAD Application ID
+* `ProvisionerApplicationSecret` -- AAD Application Secret
+* `ProvisionerApplicationTenantId` -- AAD Tenant ID
+* `SubscriptionId` -- Subscription ID to clean
+* `Verbose` -- Verbose output
+* `WhatIf` -- Outputs destructive operations but does not perform them
+* `Confirm` -- Prompts before destructive operations

--- a/tools/live-test-cleanup/cleanup.ps1
+++ b/tools/live-test-cleanup/cleanup.ps1
@@ -48,6 +48,6 @@ Write-Verbose "Groups to delete: $($toDelete.Length)"
 
 $toDelete | foreach {
     if ($PSCmdlet.ShouldProcess("$($_.Name) (UTC: $($_.tags.DeleteAfter))", "Delete Group")) {
-        az group delete --name $_.Name --yes
+        az group delete --name $_.Name --yes --no-wait
     }
 }

--- a/tools/live-test-cleanup/cleanup.ps1
+++ b/tools/live-test-cleanup/cleanup.ps1
@@ -22,7 +22,10 @@ param (
 
     [Parameter(Mandatory = $true)]
     [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
-    [string] $SubscriptionId
+    [string] $SubscriptionId,
+
+    [Parameter()]
+    [switch] $Force
 )
 
 Write-Verbose "Logging in"
@@ -47,7 +50,8 @@ $toDelete = $allGroups |
 Write-Verbose "Groups to delete: $($toDelete.Length)"
 
 $toDelete | foreach {
-    if ($PSCmdlet.ShouldProcess("$($_.Name) (UTC: $($_.tags.DeleteAfter))", "Delete Group")) {
+    if ($Force -or $PSCmdlet.ShouldProcess("$($_.Name) (UTC: $($_.tags.DeleteAfter))", "Delete Group")) {
+        Write-Verbose "Deleting group: $($_.Name)"
         az group delete --name $_.Name --yes --no-wait
     }
 }

--- a/tools/live-test-cleanup/cleanup.ps1
+++ b/tools/live-test-cleanup/cleanup.ps1
@@ -1,0 +1,53 @@
+#!/usr/bin/env pwsh
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+#Requires -Version 6.0
+#Requires -PSEdition Core
+
+[CmdletBinding(DefaultParameterSetName = 'Default', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
+param (
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+    [string] $ProvisionerApplicationId,
+
+    [Parameter(Mandatory = $true)]
+    [string] $ProvisionerApplicationSecret,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+    [ValidateNotNullOrEmpty()]
+    [string] $ProvisionerApplicationTenantId,
+
+    [Parameter(Mandatory = $true)]
+    [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
+    [string] $SubscriptionId
+)
+
+Write-Verbose "Logging in"
+az login --service-principal --username=$ProvisionerApplicationId --password=$ProvisionerApplicationSecret --tenant=$ProvisionerApplicationTenantId
+Write-Verbose "Setting account"
+az account set --subscription=$SubscriptionId
+
+Write-Verbose "Fetching groups"
+$allGroups = az group list | ConvertFrom-Json
+
+Write-Verbose "Total Resource Groups: $($allGroups.Length)"
+
+$now = [DateTime]::UtcNow
+
+$toDelete = $allGroups |
+    where {
+        $parsedTime = [DateTime]::MaxValue;
+        $canParse = [DateTime]::TryParse($_.tags.DeleteAfter, [ref]$parsedTime);
+        $canParse -and ($now -gt $parsedTime)
+    }
+
+Write-Verbose "Groups to delete: $($toDelete.Length)"
+
+$toDelete | foreach {
+    if ($PSCmdlet.ShouldProcess("$($_.Name) (UTC: $($_.tags.DeleteAfter))", "Delete Group")) {
+        az group delete --name $_.Name --yes
+    }
+}

--- a/tools/live-test-cleanup/cleanup.ps1
+++ b/tools/live-test-cleanup/cleanup.ps1
@@ -39,8 +39,8 @@ $now = [DateTime]::UtcNow
 
 $toDelete = $allGroups |
     where {
-        $parsedTime = [DateTime]::MaxValue;
-        $canParse = [DateTime]::TryParse($_.tags.DeleteAfter, [ref]$parsedTime);
+        $parsedTime = [DateTime]::MaxValue
+        $canParse = [DateTime]::TryParse($_.tags.DeleteAfter, [ref]$parsedTime)
         $canParse -and ($now -gt $parsedTime)
     }
 


### PR DESCRIPTION
Of note: I put the pipeline yml file in eng/pipelines because this seems like a cross-cutting pipeline. However, I could see reasonable arguments for putting the pipeline yml file in the folder with the cleanup script. 

Sample run (with `-WhatIf` flag): https://dev.azure.com/azure-sdk/playground/_build/results?buildId=233831&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=8c98ab76-57b2-59d0-3d3a-18dce788f3ba