### PR TITLE
Fix #328: Analyze async using statement without braces.

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0012Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0012Tests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis.CSharp;
 using Xunit;
@@ -439,6 +440,74 @@ namespace RandomNamespace
         }
 
         [Fact]
+        public async Task AZC0012WarningOnAsyncUsingNoBraces()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public class MyClass
+    {
+        public static async Task Foo()
+        {
+            await using IAsyncDisposable x = /*MM0*/CreateAsyncDisposable(),
+                                         y = /*MM1*/new AsyncDisposable();
+        }
+
+        private static IAsyncDisposable CreateAsyncDisposable() => new AsyncDisposable();
+
+        private class AsyncDisposable : IAsyncDisposable
+        {
+            public ValueTask DisposeAsync() => new ValueTask();
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            Assert.Equal(2, diagnostics.Length);
+
+            Assert.Equal("AZC0012", diagnostics[0].Id);
+            Assert.Equal("AZC0012", diagnostics[1].Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
+            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
+        }
+
+        [Fact]
+        public async Task AZC0012WarningOnAsyncUsingVariableNoBraces()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public class MyClass
+    {
+        public static async Task Foo()
+        {
+            var ad = new AsyncDisposable();
+            await using var _ = /*MM*/ad;
+        }
+    
+        private class AsyncDisposable : IAsyncDisposable
+        {
+            public ValueTask DisposeAsync() => new ValueTask();
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0012", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+        }
+
+        [Fact]
         public async Task AZC0012NoWarningOnAsyncUsingExistingConfigureAwaitFalse()
         {
             var testSource = TestSource.Read(@"
@@ -455,6 +524,37 @@ namespace RandomNamespace
             await using(ad.ConfigureAwait(false)) { }
         }
     
+        private class AsyncDisposable : IAsyncDisposable
+        {
+            public ValueTask DisposeAsync() => new ValueTask();
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0012NoWarningOnAsyncUsingNoBracesExistingConfigureAwaitFalse()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+
+    public class MyClass
+    {
+        public static async Task Foo()
+        {
+            var ad = new AsyncDisposable();
+            await using ConfiguredAsyncDisposable x = CreateAsyncDisposable().ConfigureAwait(false), y = ad.ConfigureAwait(false);
+        }
+
+        private static IAsyncDisposable CreateAsyncDisposable() => new AsyncDisposable();
+
         private class AsyncDisposable : IAsyncDisposable
         {
             public ValueTask DisposeAsync() => new ValueTask();
@@ -494,7 +594,34 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnCSharp7()
+        public async Task AZC0012NoWarningOnUsingNoBraces()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading.Tasks;
+
+    public class MyClass
+    {
+        public static async Task Foo()
+        {
+            using var _ = new Disposable();
+        }
+    
+        private class Disposable : IDisposable
+        {
+            public void Dispose() { }
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0012NoWarningOnCSharp7() 
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -522,6 +649,36 @@ namespace RandomNamespace
 ");
             var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source, LanguageVersion.CSharp7);
             Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0012NonCompilableCode() 
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
+    public class MyClass
+    {
+        public static async Task M00() => await Task.Foo();
+        public static async Task M01() => await Task.Foo().ConfigureAwait(false);
+        public static async Task M02() => await Task.Delay(0).ConfigureAwait(0);
+        public static async Task M03() => await Task.Foo();
+        public static async Task M10() { await foreach () { } }
+        public static async Task M11() { await foreach (var x in ) { } }
+        public static async Task M12() { await foreach (var x in enum.ConfigureAwait(false)) { } }
+        public static async Task M20() { await using var ; }
+        public static async Task M21() { await using var a = ; }
+        public static async Task M22() { await using(){} }
+        public static async Task M23() { await using(var ){} }
+        public static async Task M24() { await using(var a = ){} }
+    }
+}
+");
+            await _runner.GetDiagnosticsAsync(testSource.Source);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
@@ -9,7 +9,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.4.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" PrivateAssets="All" />


### PR DESCRIPTION
Also:
- Collapse multiple tests for disabling AZC0013 into one
- Add test for non-compilable code
- Remove dependency on Microsoft.Bcl.AsyncInterfaces