### PR TITLE
Remove trailing slash as Url parsing code doesn't expect it.

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -181,7 +181,7 @@ namespace APIViewWeb
             foreach (var email in emails)
             {
                 var address = email["email"]?.Value<string>();
-                if (address != null && address.EndsWith("microsoft.com", StringComparison.OrdinalIgnoreCase))
+                if (address != null && address.EndsWith("@microsoft.com", StringComparison.OrdinalIgnoreCase))
                 {
                     return address;
                 }

--- a/src/dotnet/APIView/APIViewWeb/appsettings.json
+++ b/src/dotnet/APIView/APIViewWeb/appsettings.json
@@ -8,5 +8,5 @@
   "Github": {
     "RequiredOrganization": [ "Azure", "Microsoft" ]
   },
-  "EndPoint": "https://apiview.dev/"
+  "EndPoint": "https://apiview.dev"
 }


### PR DESCRIPTION
Also add @ symbol for email lookup.