### PR TITLE
Thread review Url through login button

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/AccountController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AccountController.cs
@@ -12,6 +12,10 @@ namespace APIViewWeb.Controllers
         public async Task<IActionResult> Login(string returnUrl = "/")
         {
             await HttpContext.SignOutAsync();
+            if (!Url.IsLocalUrl(returnUrl))
+            {
+                returnUrl = "/";
+            }
             return Challenge(new AuthenticationProperties() { RedirectUri = returnUrl }, "GitHub");
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Unauthorized.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Unauthorized.cshtml
@@ -24,7 +24,7 @@
     find yourself under the "People" tab of the organization page and set your visibility to public.
 </p>
 
-<a class="login-button btn btn-outline-dark" asp-action="Login" asp-controller="Account">
+<a class="login-button btn btn-outline-dark" asp-action="Login" asp-controller="Account" asp-route-returnUrl="@HttpContext.Request.Query["returnurl"]">
     <img height="30" width="30" src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" />
     Login with GitHub
 </a>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Unauthorized.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Unauthorized.cshtml
@@ -24,7 +24,7 @@
     find yourself under the "People" tab of the organization page and set your visibility to public.
 </p>
 
-<a class="login-button btn btn-outline-dark" asp-action="Login" asp-controller="Account" asp-route-returnUrl="@HttpContext.Request.Query["returnurl"]">
+<a class="login-button btn btn-outline-dark" asp-action="Login" asp-controller="Account" asp-route-returnUrl="@Model.ReturnUrl">
     <img height="30" width="30" src="https://github.githubassets.com/images/modules/logos_page/GitHub-Mark.png" />
     Login with GitHub
 </a>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Unauthorized.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Unauthorized.cshtml.cs
@@ -9,6 +9,9 @@ namespace APIViewWeb.Pages
     {
         public OrganizationOptions Options { get; }
 
+        [BindProperty(SupportsGet = true)]
+        public string ReturnUrl { get; private set; }
+
         public UnauthorizedModel(IOptions<OrganizationOptions> options)
         {
             Options = options.Value;
@@ -17,7 +20,10 @@ namespace APIViewWeb.Pages
         public IActionResult OnGet()
         {
             if (User.Identity.IsAuthenticated)
+            {
                 return RedirectToPage("./Assemblies/Index");
+            }
+            ReturnUrl = Request.Query["returnurl"];
             return Page();
         }
     }


### PR DESCRIPTION
Links to individual reviews wouldn't work if the user was prompted to login.
Relative links to comments still won't work correctly as the "#" part of Url is not sent to the server, but at least users will get directed to the correct review, instead of the default Api View page listing all reviews.