### PR TITLE
Bump doc-warden version for release.

### DIFF
--- a/packages/python-packages/doc-warden/warden/version.py
+++ b/packages/python-packages/doc-warden/warden/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.4.2'
+VERSION = '0.5.0'


### PR DESCRIPTION
This PR bumps the ```doc-warden``` version. I'm going to insta merge this one since I need to publish the new version of the package. If any pipelines break then it means that they had a bug which was not specifying the version of ```doc-warden``` that they are using ;)