### PR TITLE
Change back to windows host

### DIFF
--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -17,7 +17,7 @@ resources:
       name: internal/azure-sdk-build-tools
 
 pool:
-  vmImage: ubuntu-18.04
+  vmImage: windows-2019
 
 jobs:
   - job: SyncEngCommon


### PR DESCRIPTION
Currently there are some script and pwsh steps that don't
work well on linux so we need to stay on windows until those
can be fixed.

Things that don't work well:

- echo commands in script blocks. On windows they don't need quotes
  but on linux they do and escaping quotes is also different
- commands like mkdir on in pwsh scripts don't work consistently
  on windows it will create parent directories because it does
  the create recurisvely and it is just an alias to new-item. On
  linux it is not an alias and you have to pass the "-p" arg to
  get it to create parent directories. In general we should be careful
  with using alias' for cross-platform pwsh because they are not
  consistently alias' on all platforms.


FYI @heaths @mitchdenny 
cc @Azure/azure-sdk-eng 