### PR TITLE
Feed cleaner

### DIFF
--- a/tools/feed-cleaner/Clean-Feeds.ps1
+++ b/tools/feed-cleaner/Clean-Feeds.ps1
@@ -1,0 +1,67 @@
+param(
+    [Parameter(Mandatory=$true)][string]$Organization,
+    [Parameter(Mandatory=$true)][string]$FeedProject,
+    [Parameter(Mandatory=$true)][string]$RunProject,
+    [Parameter(Mandatory=$true)][string]$AccessToken    
+)
+
+$ErrorActionPreference = "$Stop"
+
+function Get-Feeds([string]$Organization, [string]$Project, [PSCredential]$Credential) {
+    $url = "https://feeds.dev.azure.com/$Organization/$Project/_apis/packaging/feeds?api-version=4.1-preview"
+    
+    Write-Information "Requesting list of feeds from: $url"
+    $response = Invoke-RestMethod -Uri $url -Method GET -Credential $Credential -Authentication Basic
+
+    Write-Information "Found $($response.value.Length) feeds."
+
+    return $response.value
+}
+
+function Get-FilteredFeeds([string]$Organization, [string]$Project, [PSCredential]$Credential) {
+    $feeds = Get-Feeds -Organization $Organization -Project $Project -Credential $Credential
+
+    # Filter the list of feeds to those in the form azure-sdk-{runid} as those are the ones
+    # that we want to evaluate for deletion.
+    Write-Information "Filtering down to burner feeds with the form azure-sdk-{runid}."
+    $filteredFeeds = @($feeds | Where-Object { $_.name -match "^azure-sdk-([0-9]+)$" })
+    Write-Information "Found $($filteredFeeds.Length) burner feeds."
+
+    return $filteredFeeds
+}
+
+function Get-Run([string]$Organization, [string]$Project, [int]$RunID, [PSCredential]$Credential) {
+    $url = "https://dev.azure.com/$Organization/$Project/_apis/build/builds/$($RunID)?api-version=5.1"
+    $response = Invoke-RestMethod -Uri $url -Method GET -Credential $Credential -Authentication Basic
+    return $response
+}
+
+function Delete-Feed([string]$Organization, [string]$Project, $Feed, [PSCredential]$Credential) {
+    $url = "https://feeds.dev.azure.com/$Organization/$Project/_apis/packaging/feeds/$($Feed.id)?api-version=5.1-preview.1"
+    Write-Host "Deleting feed: $($Feed.id) ($($Feed.name))"
+    $response = Invoke-RestMethod -Uri $url -Method DELETE -Credential $Credential -Authentication Basic
+}
+
+$filteredFeeds = Get-FilteredFeeds -Organization $Organization -Project $FeedProject -Credential $Credential
+
+[RegEx]$expressionToExtractRunID = "^azure-sdk-(?<RunID>([0-9]+))$"
+foreach ($filteredFeed in $filteredFeeds) {
+    $match = $expressionToExtractRunID.Match($filteredFeed.name)
+    $runID = [System.Int32]::Parse($match.Groups["RunID"].Value)
+
+    $shouldDeleteFeed = $false
+    try {
+        $run = Get-Run -Organization $Organization -Project $RunProject -RunID $runID -Credential $Credential
+        $shouldDeleteFeed = $run.status -ne "inProgress"
+    }
+    catch {
+        $shouldDeleteFeed = $true
+    }
+
+    if ($shouldDeleteFeed) {
+        Delete-Feed -Organization $Organization -Project $FeedProject -Feed $filteredFeed -Credential $Credential
+    }
+    else {
+        Write-Host "Skipping: $($run._links.web)"
+    }
+}


### PR DESCRIPTION
This PR includes a script that I created to remove old ```azure-sdk-{runid}``` feeds. It determines that the feed is eligible for deletion by first listing all the feeds that match that format, then using the run ID looking up the pipeline run to see whether the pipeline is still active. If the pipeline is still in-progress then it removes the feed.

This script will be run by a scheduled pipeline every day. Generally we shouldn't have too many but this will stop them accumulating.