### PR TITLE
Update PackageNameDiagnosticRule.java

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/PackageNameDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/PackageNameDiagnosticRule.java
@@ -19,7 +19,7 @@ public class PackageNameDiagnosticRule implements DiagnosticRule {
             getClassName(cu).map(listing.getKnownTypes()::get).ifPresent(typeId -> {
                 if (!regex.matcher(packageName).matches()) {
                     listing.addDiagnostic(new Diagnostic(typeId,
-                            "Package name must start with 'com.azure', and it must be lower-case, with no underscores or hyphens."));
+                            "Package name must start with 'com.azure.<group>.', and it must be lower-case, with no underscores or hyphens."));
                 }
             });
         });


### PR DESCRIPTION
Make it clear in error message that all libraries must have the package name structure com.azure.<group>, e.g. `com.azure.cosmos` is not valid.