### PR TITLE
Test framework migration

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,6 +3,7 @@
 	<packageSources>
 		<add key="NugetOfficialV3" value="https://api.nuget.org/v3/index.json" />
 		<add key="Local" value="tools/LocalNugetFeed" />
+		<add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
 		<add key="AzArtifactsFeed" value="https://azuresdkartifacts.blob.core.windows.net/azure-sdk-tools/index.json" />
 	</packageSources>
 	

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
@@ -2,75 +2,67 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.Testing;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientAssemblyNamespaceAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0001Tests
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientAssemblyNamespaceAnalyzer());
-
         [Fact]
         public async Task AZC0001ProducedForInvalidNamespaces()
         {
-            var testSource = TestSource.Read(@"
-namespace /*MM*/RandomNamespace
+            const string code = @"
+namespace RandomNamespace
 {
     public class Program { }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            var diagnostic = Assert.Single(diagnostics);
-            Assert.Equal("AZC0001", diagnostic.Id);
-            Assert.Equal("Namespace 'RandomNamespace' shouldn't contain public types. Use one of the following pre-approved namespace groups: " +
-                         "Azure.AI, Azure.Analytics, Azure.Data, Azure.Iot, Azure.Media, Azure.Messaging, Azure.Security, Azure.Storage, Microsoft.Extensions.Azure", diagnostic.GetMessage());
+}";
 
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+            var diagnostic = Verifier.Diagnostic("AZC0001")
+                .WithMessage("Namespace 'RandomNamespace' shouldn't contain public types. Use one of the following pre-approved namespace groups: " +
+                             "Azure.AI, Azure.Analytics, Azure.Data, Azure.Iot, Azure.Media, Azure.Messaging, Azure.Security, Azure.Storage, Microsoft.Extensions.Azure")
+                .WithSpan(2, 11, 2, 26);
+
+            await Verifier.VerifyAnalyzerAsync(code, diagnostic);
         }
 
         [Fact]
-        public async Task AZC0001ProducedOneErrorPerNamspaceDefinition()
+        public async Task AZC0001ProducedOneErrorPerNamespaceDefinition()
         {
-            var testSource = TestSource.Read(@"
-namespace RandomNamespace
+            const string code = @"
+namespace [|RandomNamespace|]
 {
     public class Program { }
 }
 
-namespace RandomNamespace
+namespace [|RandomNamespace|]
 {
     public class Program2 { }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            Assert.Equal(2, diagnostics.Length);
-            Assert.All(diagnostics, d => Assert.Equal("AZC0001", d.Id));
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0001");
         }
 
         [Fact]
         public async Task AZC0001NotProducedForNamespacesWithPrivateMembersOnly()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     internal class Program { }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            Assert.Empty(diagnostics);
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
         public async Task AZC0001NotProducedForAllowedNamespaces()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace Azure.Storage.Hello
 {
     public class Program { }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            Assert.Empty(diagnostics);
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
@@ -3,48 +3,39 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientMethodsAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0002Tests
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientMethodsAnalyzer());
-
         [Fact]
         public async Task AZC0002ProducedForMethodsWithoutCancellationToken()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 using System.Threading.Tasks;
 
 namespace RandomNamespace
 {
     public class SomeClient
     {
-        public virtual Task /*MM0*/GetAsync()
+        public virtual Task [|GetAsync|]()
         {
             return null;
         }
 
-        public virtual void /*MM1*/Get()
+        public virtual void [|Get|]()
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            Assert.Equal(2, diagnostics.Length);
-
-            Assert.Equal("AZC0002", diagnostics[0].Id);
-            Assert.Equal("AZC0002", diagnostics[1].Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
-            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0002");
         }
 
         [Fact]
         public async Task AZC0002ProducedForMethodsWithNonOptionalCancellationToken()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -52,31 +43,23 @@ namespace RandomNamespace
 {
     public class SomeClient
     {
-        public virtual Task /*MM0*/GetAsync(CancellationToken cancellationToken)
+        public virtual Task [|GetAsync|](CancellationToken cancellationToken)
         {
             return null;
         }
 
-        public virtual void /*MM1*/Get(CancellationToken cancellationToken)
+        public virtual void [|Get|](CancellationToken cancellationToken)
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            Assert.Equal(2, diagnostics.Length);
-
-            Assert.Equal("AZC0002", diagnostics[0].Id);
-            Assert.Equal("AZC0002", diagnostics[1].Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
-            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0002");
         }
 
         [Fact]
-        public async Task AZC0003ProducedForMethodsWithWrongNameParameter()
+        public async Task AZC0002ProducedForMethodsWithWrongNameParameter()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -84,25 +67,17 @@ namespace RandomNamespace
 {
     public class SomeClient
     {
-        public virtual Task /*MM0*/GetAsync(CancellationToken cancellation = default)
+        public virtual Task [|GetAsync|](CancellationToken cancellation = default)
         {
             return null;
         }
 
-        public virtual void /*MM1*/Get(CancellationToken cancellation = default)
+        public virtual void [|Get|](CancellationToken cancellation = default)
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            Assert.Equal(2, diagnostics.Length);
-
-            Assert.Equal("AZC0002", diagnostics[0].Id);
-            Assert.Equal("AZC0002", diagnostics[1].Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
-            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0002");
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0003Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0003Tests.cs
@@ -3,17 +3,16 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientMethodsAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0003Tests
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientMethodsAnalyzer());
-
         [Fact]
-        public async Task AZC0002ProducedForNonVirtualMethods()
+        public async Task AZC0003ProducedForNonVirtualMethods()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,31 +20,23 @@ namespace RandomNamespace
 {
     public class SomeClient
     {
-        public Task /*MM0*/GetAsync(CancellationToken cancellationToken = default)
+        public Task [|GetAsync|](CancellationToken cancellationToken = default)
         {
             return null;
         }
 
-        public void /*MM1*/Get(CancellationToken cancellationToken = default)
+        public void [|Get|](CancellationToken cancellationToken = default)
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            Assert.Equal(2, diagnostics.Length);
-
-            Assert.Equal("AZC0003", diagnostics[0].Id);
-            Assert.Equal("AZC0003", diagnostics[1].Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
-            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0003");
         }
 
         [Fact]
-        public async Task AZC0002SkippedForPrivateMethods()
+        public async Task AZC0003SkippedForPrivateMethods()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -62,17 +53,14 @@ namespace RandomNamespace
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            Assert.Empty(diagnostics);
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
-        public async Task AZC0002SkippedForOverrides()
+        public async Task AZC0003SkippedForOverrides()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -97,11 +85,8 @@ namespace RandomNamespace
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            Assert.Empty(diagnostics);
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0004Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0004Tests.cs
@@ -3,17 +3,16 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientMethodsAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0004Tests
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientMethodsAnalyzer());
-
         [Fact]
         public async Task AZC0004ProducedForMethodsWithoutSyncAlternative()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -21,19 +20,13 @@ namespace RandomNamespace
 {
     public class SomeClient
     {
-        public virtual Task /*MM0*/GetAsync(CancellationToken cancellationToken = default)
+        public virtual Task [|GetAsync|](CancellationToken cancellationToken = default)
         {
             return null;
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0004", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0004");
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0005Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0005Tests.cs
@@ -3,34 +3,27 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientConstructorAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0005Tests
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientConstructorAnalyzer());
-
         [Fact]
         public async Task AZC0005ProducedForClientTypesWithoutProtectedCtor()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions { }
 
-    public class /*MM*/SomeClient
+    public class [|SomeClient|]
     {
         public SomeClient(string connectionString) {}
         public SomeClient(string connectionString, SomeClientOptions options) {}
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0005", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0005");
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0006Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0006Tests.cs
@@ -3,17 +3,16 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientConstructorAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0006Tests
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientConstructorAnalyzer());
-
         [Fact]
         public async Task AZC0006ProducedForClientsWithoutOptionsCtor()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions { }
@@ -21,22 +20,16 @@ namespace RandomNamespace
     public class SomeClient
     {
         protected SomeClient() {}
-        public /*MM*/SomeClient(SomeClientOptions options) {}
+        public [|SomeClient|](SomeClientOptions options) {}
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0006", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0006");
         }
 
         [Fact]
         public async Task AZC0006ProducedForClientsWithoutOptionsCtorWithArguments()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions { }
@@ -44,16 +37,10 @@ namespace RandomNamespace
     public class SomeClient
     {
         protected SomeClient() {}
-        public /*MM*/SomeClient(string connectionString, SomeClientOptions options) {}
+        public [|SomeClient|](string connectionString, SomeClientOptions options) {}
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0006", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0006");
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0007Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0007Tests.cs
@@ -3,52 +3,39 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientConstructorAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0007Tests
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientConstructorAnalyzer());
-
         [Fact]
         public async Task AZC0007ProducedForClientsWithoutOptionsCtor()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClient
     {
-        public /*MM*/SomeClient() {}
+        public [|SomeClient|]() {}
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0007", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0007");
         }
 
         [Fact]
-        public async Task AZC0006ProducedForClientsWithoutOptionsCtorWithArguments()
+        public async Task AZC0007ProducedForClientsWithoutOptionsCtorWithArguments()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClient
     {
         protected SomeClient() {}
-        public /*MM*/SomeClient(string connectionString) {}
+        public [|SomeClient|](string connectionString) {}
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0007", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0007");
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0008Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0008Tests.cs
@@ -1,38 +1,31 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-using System.Linq;
+
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientOptionsAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0008Tests
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientOptionsAnalyzer());
-
         [Fact]
         public async Task AZC0008ProducedForClientOptionsWithoutServiceVersionEnum()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
-    public class /*MM*/SomeClientOptions { 
+    public class [|SomeClientOptions|] { 
 
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0008", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0008");
         }
 
         [Fact]
         public async Task AZC0008NotProducedForClientOptionsWithServiceVersionEnum()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions { 
@@ -42,10 +35,10 @@ namespace RandomNamespace
             V2018_11_09 = 0
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            Assert.Empty(diagnostics.Where(d => d.Id == "AZC0008"));
+}";
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0009")
+                .RunAsync();
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0009Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0009Tests.cs
@@ -2,40 +2,33 @@
 // Licensed under the MIT License.
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientOptionsAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0009Tests
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientOptionsAnalyzer());
-               
         [Fact]
         public async Task AZC0009ProducedForClientOptionsWithOnlyDefaultCtor()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
-    public class /*MM*/SomeClientOptions {
+    public class [|SomeClientOptions|] {
 
         public enum ServiceVersion
         {
             V2018_11_09 = 0
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0009", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0009");
         }
 
         [Fact]
         public async Task AZC0009ProducedForClientOptionsWithoutServiceVersionInCtor()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions {
@@ -45,24 +38,18 @@ namespace RandomNamespace
             V2018_11_09 = 0
         }
 
-        public /*MM*/SomeClientOptions()
+        public [|SomeClientOptions|]()
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0009", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0009");
         }
 
         [Fact]
         public async Task AZC0009ProducedForClientOptionsCtorWhereServiceVersionNotFirstParam()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions { 
@@ -72,24 +59,18 @@ namespace RandomNamespace
             V2018_11_09 = 0
         }
 
-        public SomeClientOptions(string /*MM*/anOption, ServiceVersion version = ServiceVersion.V2018_11_09)
+        public SomeClientOptions(string [|anOption|], ServiceVersion version = ServiceVersion.V2018_11_09)
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0009", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0009");
         }
 
         [Fact]
         public async Task AZC0009NotProducedForClientOptionsCtorWhereServiceVersionFirstParam()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions { 
@@ -103,10 +84,8 @@ namespace RandomNamespace
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            Assert.Empty(diagnostics);
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0010Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0010Tests.cs
@@ -2,17 +2,16 @@
 // Licensed under the MIT License.
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientOptionsAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0010Tests
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new ClientOptionsAnalyzer());
-
         [Fact]
         public async Task AZC0010ProducedForClientOptionsCtorWithNoServiceVersionDefault()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions { 
@@ -22,24 +21,18 @@ namespace RandomNamespace
             V2018_11_09 = 0
         }
 
-        public SomeClientOptions(ServiceVersion /*MM*/version)
+        public SomeClientOptions(ServiceVersion [|version|])
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0010", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0010");
         }
 
         [Fact]
         public async Task AZC0010ProducedForClientOptionsCtorWithNonMaxVersionExplicit()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions { 
@@ -50,24 +43,18 @@ namespace RandomNamespace
             V2019_03_20 = 1
         }
 
-        public SomeClientOptions(ServiceVersion /*MM*/version = ServiceVersion.V2018_11_09)
+        public SomeClientOptions(ServiceVersion [|version|] = ServiceVersion.V2018_11_09)
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0010", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0010");
         }
 
         [Fact]
         public async Task AZC0010ProducedForClientOptionsCtorWithNonMaxVersionImplicit()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions { 
@@ -78,24 +65,18 @@ namespace RandomNamespace
             V2019_03_20
         }
 
-        public SomeClientOptions(ServiceVersion /*MM*/version = ServiceVersion.V2018_11_09)
+        public SomeClientOptions(ServiceVersion [|version|] = ServiceVersion.V2018_11_09)
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0010", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
+}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0010");
         }
 
         [Fact]
         public async Task AZC0010NotProducedForClientOptionsCtorWithMaxServiceVersionDefault()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     public class SomeClientOptions { 
@@ -110,10 +91,8 @@ namespace RandomNamespace
         {
         }
     }
-}
-");
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            Assert.Empty(diagnostics);
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0100Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0100Tests.cs
@@ -9,14 +9,14 @@ using Xunit;
 
 namespace Azure.ClientSdk.Analyzers.Tests 
 {
-    public class AZC0012Tests 
+    public class AZC0100Tests 
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AddConfigureAwaitAnalyzer());
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
 
         [Theory]
         [InlineData(LanguageVersion.CSharp7)]
         [InlineData(LanguageVersion.Latest)]
-        public async Task AZC0012WarningOnTask(LanguageVersion version)
+        public async Task AZC0100WarningOnTask(LanguageVersion version)
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -34,14 +34,14 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Theory]
         [InlineData(LanguageVersion.CSharp7)]
         [InlineData(LanguageVersion.Latest)]
-        public async Task AZC0012WarningOnTaskOfT(LanguageVersion version) 
+        public async Task AZC0100WarningOnTaskOfT(LanguageVersion version) 
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -59,14 +59,14 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Theory]
         [InlineData(LanguageVersion.CSharp7)]
         [InlineData(LanguageVersion.Latest)]
-        public async Task AZC0012WarningOnValueTask(LanguageVersion version) 
+        public async Task AZC0100WarningOnValueTask(LanguageVersion version) 
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -91,14 +91,14 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Theory]
         [InlineData(LanguageVersion.CSharp7)]
         [InlineData(LanguageVersion.Latest)]
-        public async Task AZC0012WarningOnValueTaskOfT(LanguageVersion version) 
+        public async Task AZC0100WarningOnValueTaskOfT(LanguageVersion version) 
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -121,12 +121,12 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnExistingConfigureAwaitFalse()
+        public async Task AZC0100NoWarningOnExistingConfigureAwaitFalse()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -145,7 +145,7 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012WarningOnTaskDelay()
+        public async Task AZC0100WarningOnTaskDelay()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -163,12 +163,12 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnTaskYield()
+        public async Task AZC0100NoWarningOnTaskYield()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -187,7 +187,7 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnNested()
+        public async Task AZC0100NoWarningOnNested()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -211,7 +211,7 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012WarningOnVariable()
+        public async Task AZC0100WarningOnVariable()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -230,12 +230,12 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0012WarningOnAsyncForeach()
+        public async Task AZC0100WarningOnAsyncForeach()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -259,12 +259,12 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnAsyncForeachExistingConfigureAwaitFalse()
+        public async Task AZC0100NoWarningOnAsyncForeachExistingConfigureAwaitFalse()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -289,7 +289,7 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnForeach()
+        public async Task AZC0100NoWarningOnForeach()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -314,7 +314,7 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012WarningOnAsyncEnumerableVariable()
+        public async Task AZC0100WarningOnAsyncEnumerableVariable()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -339,12 +339,12 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0012WarningOnAsyncForeachOfCustomEnumerable()
+        public async Task AZC0100WarningOnAsyncForeachOfCustomEnumerable()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -372,12 +372,12 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0012WarningOnAsyncUsingVariable()
+        public async Task AZC0100WarningOnAsyncUsingVariable()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -404,12 +404,12 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0012WarningOnAsyncUsing()
+        public async Task AZC0100WarningOnAsyncUsing()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -435,12 +435,12 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0012WarningOnAsyncUsingNoBraces()
+        public async Task AZC0100WarningOnAsyncUsingNoBraces()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -469,14 +469,14 @@ namespace RandomNamespace
 
             Assert.Equal(2, diagnostics.Length);
 
-            Assert.Equal("AZC0012", diagnostics[0].Id);
-            Assert.Equal("AZC0012", diagnostics[1].Id);
+            Assert.Equal("AZC0100", diagnostics[0].Id);
+            Assert.Equal("AZC0100", diagnostics[1].Id);
             AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM0"], diagnostics[0].Location);
             AnalyzerAssert.DiagnosticLocation(testSource.MarkerLocations["MM1"], diagnostics[1].Location);
         }
 
         [Fact]
-        public async Task AZC0012WarningOnAsyncUsingVariableNoBraces()
+        public async Task AZC0100WarningOnAsyncUsingVariableNoBraces()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -503,12 +503,12 @@ namespace RandomNamespace
 
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0012", diagnostic.Id);
+            Assert.Equal("AZC0100", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnAsyncUsingExistingConfigureAwaitFalse()
+        public async Task AZC0100NoWarningOnAsyncUsingExistingConfigureAwaitFalse()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -536,7 +536,7 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnAsyncUsingNoBracesExistingConfigureAwaitFalse()
+        public async Task AZC0100NoWarningOnAsyncUsingNoBracesExistingConfigureAwaitFalse()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -567,7 +567,7 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnUsing()
+        public async Task AZC0100NoWarningOnUsing()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -594,7 +594,7 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnUsingNoBraces()
+        public async Task AZC0100NoWarningOnUsingNoBraces()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -621,7 +621,7 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012NoWarningOnCSharp7() 
+        public async Task AZC0100NoWarningOnCSharp7() 
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -652,7 +652,7 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0012NonCompilableCode() 
+        public async Task AZC0100NonCompilableCode() 
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0101Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0101Tests.cs
@@ -6,12 +6,12 @@ using Xunit;
 
 namespace Azure.ClientSdk.Analyzers.Tests 
 {
-    public class AZC0013Tests 
+    public class AZC0101Tests 
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AddConfigureAwaitAnalyzer());
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
 
         [Fact]
-        public async Task AZC0013WarningOnExistingConfigureAwaitTrue()
+        public async Task AZC0101WarningOnExistingConfigureAwaitTrue()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -28,12 +28,12 @@ namespace RandomNamespace
             var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0013", diagnostic.Id);
+            Assert.Equal("AZC0101", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0013WarningOnAsyncEnumerableExistingConfigureAwaitTrue()
+        public async Task AZC0101WarningOnAsyncEnumerableExistingConfigureAwaitTrue()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -56,12 +56,12 @@ namespace RandomNamespace
             var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0013", diagnostic.Id);
+            Assert.Equal("AZC0101", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0013WarningOnAsyncUsingExistingConfigureAwaitTrue()
+        public async Task AZC0101WarningOnAsyncUsingExistingConfigureAwaitTrue()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -87,12 +87,12 @@ namespace RandomNamespace
             var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0013", diagnostic.Id);
+            Assert.Equal("AZC0101", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0013WarningOnAsyncUsingNoBracesExistingConfigureAwaitTrue()
+        public async Task AZC0101WarningOnAsyncUsingNoBracesExistingConfigureAwaitTrue()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -118,12 +118,12 @@ namespace RandomNamespace
             var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
             var diagnostic = Assert.Single(diagnostics);
 
-            Assert.Equal("AZC0013", diagnostic.Id);
+            Assert.Equal("AZC0101", diagnostic.Id);
             AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostics[0].Location);
         }
 
         [Fact]
-        public async Task AZC0013DisabledNoWarningOnExistingConfigureAwaitTrue()
+        public async Task AZC0101DisabledNoWarningOnExistingConfigureAwaitTrue()
         {
             var testSource = TestSource.Read(@"
 namespace RandomNamespace
@@ -138,12 +138,12 @@ namespace RandomNamespace
         {
             var ad = new AsyncDisposable();
 
-#pragma warning disable AZC0013
+#pragma warning disable AZC0101
             await foreach (var x in GetValuesAsync().ConfigureAwait(true)) { }
             await System.Threading.Tasks.Task.Run(() => {}).ConfigureAwait(true);
             await using var y = ad.ConfigureAwait(true);
             await using(ad.ConfigureAwait(true)) { }
-#pragma warning restore AZC0013
+#pragma warning restore AZC0101
         }
     
         private static async IAsyncEnumerable<int> GetValuesAsync() { yield break; }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0102Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0102Tests.cs
@@ -1,0 +1,203 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public class AZC0102Tests 
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp7)]
+        [InlineData(LanguageVersion.Latest)]
+        public async Task AZC0102WarningOnTask(LanguageVersion version)
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            Task<int> task = Task.Run(() => 10);
+            task./*MM*/GetAwaiter().GetResult();
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source, version);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0102", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Theory]
+        [InlineData(LanguageVersion.CSharp7)]
+        [InlineData(LanguageVersion.Latest)]
+        public async Task AZC0102WarningOnValueTask(LanguageVersion version)
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading.Tasks;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            new ValueTask()./*MM*/GetAwaiter().GetResult();
+        }
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source, version);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0102", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0102WarningOnAwaitable()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            new CustomAwaitable()./*MM*/GetAwaiter().GetResult();
+        }
+    }
+
+    public class CustomAwaitable
+    {
+        public CustomAwaiter GetAwaiter() => new CustomAwaiter();
+    }
+
+    public class CustomAwaiter : ICriticalNotifyCompletion
+    {
+        internal bool IsCompleted => true;
+        protected internal void GetResult() {}
+        public void OnCompleted(Action continuation) {}
+        public void UnsafeOnCompleted(Action continuation) {}
+    }  
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0102", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0102WarningOnExtension()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            new TestStruct()./*MM*/GetAwaiter().GetResult();
+        }
+    }
+
+    public struct TestStruct { }
+
+    public static class Extensions
+    {
+        public static TaskAwaiter GetAwaiter(this TestStruct s) => default;
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0102", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0102NoWarningOnNonAwaiter()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+    
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            new CustomAwaitable()./*MM*/GetAwaiter().GetResult();
+        }
+    }
+
+    public class CustomAwaitable
+    {
+        public FakeAwaiter GetAwaiter() => new FakeAwaiter();
+    }
+
+    public class FakeAwaiter : INotifyCompletion 
+    {
+        protected bool IsCompleted => true;
+        public void GetResult() {}
+        public void OnCompleted(Action continuation) {}
+    } 
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0102NoWarningOnNonAwaitable()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Runtime.CompilerServices;
+    using System.Threading.Tasks;
+    
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            new NonAwaitable().GetAwaiter().GetResult();
+        }
+    }
+
+    public class NonAwaitable
+    {
+        public TaskAwaiter GetAwaiter(int i = default) => default(TaskAwaiter);
+    }
+}
+");
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0103Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0103Tests.cs
@@ -1,0 +1,223 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public class AZC0103Tests 
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
+
+        private const string TaskExtensionsString = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+#pragma warning disable AZC0102
+        public static void EnsureCompleted(this Task task) => task.GetAwaiter().GetResult();
+#pragma warning restore AZC0102
+    }
+}
+";
+
+        [Fact]
+        public async Task AZC0103WarningInAsyncMethod()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public async Task Foo()
+        {
+            await Task.Yield();
+            FooImplAsync(true)./*MM*/EnsureCompleted();
+        }
+
+        private async Task FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0103", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0103WarningInAsyncLambda()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public void Foo()
+        {
+            Func<Task> f = async () => 
+            {
+                await Task.Yield();
+                FooImplAsync(true)./*MM*/EnsureCompleted();
+            };
+        }
+
+        private async Task FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0103", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+        
+        [Fact]
+        public async Task AZC0103WarningInAsyncLambdaField()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private Func<Task> _f = async () => 
+        {
+            await Task.Yield();
+            FooImplAsync(true)./*MM*/EnsureCompleted();
+        };
+
+        private static async Task FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0103", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+        
+        [Fact]
+        public async Task AZC0103NoWarningInAsyncMethodWithAsyncParameter()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private async Task FooAsync(bool async, CancellationToken ct = default(CancellationToken))
+        {
+            await FooImplAsync(true, ct).ConfigureAwait(false);
+        }
+
+        private async Task FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0103NoWarningInAsyncLambdaWithAsyncParameter()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private void Foo(CancellationToken ct = default(CancellationToken))
+        {
+            Func<bool, Task> f = async (async) => 
+            {
+                await FooImplAsync(true, ct).ConfigureAwait(false);
+            };
+        }
+
+        private async Task FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0103NoWarningInAsyncLambdaWithAsyncParameterInClosure()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private async Task FooImpl(bool async, CancellationToken ct = default(CancellationToken))
+        {
+            Func<Task> f = async () => 
+            {
+                await Task.Yield();
+                await FooImplAsync(true, ct).ConfigureAwait(false);
+            };
+
+            await f().ConfigureAwait(false);
+        }
+
+        private async Task FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0104Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0104Tests.cs
@@ -3,14 +3,13 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.AsyncAnalyzer>;
 
-namespace Azure.ClientSdk.Analyzers.Tests 
+namespace Azure.ClientSdk.Analyzers.Tests
 {
     public class AZC0104Tests 
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
-
-        private const string TaskExtensionsString = @"
+        private const string AzureCorePipelineTaskExtensions = @"
 namespace Azure.Core.Pipeline
 {
     using System.Threading.Tasks;
@@ -27,7 +26,7 @@ namespace Azure.Core.Pipeline
         [Fact]
         public async Task AZC0104WarningEnsureCompletedOnField()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     using System;
@@ -38,25 +37,22 @@ namespace RandomNamespace
     {
         public int Foo(Task<int> task)
         {
-            return /*MM*/_task.EnsureCompleted();
+            return [|_task|].EnsureCompleted();
         }
 
         private Task<int> _task = Task.FromResult(42);
     }
-}
-" + TaskExtensionsString);
-
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            var diagnostic = Assert.Single(diagnostics);
+}";
             
-            Assert.Equal("AZC0104", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+            await Verifier.CreateAnalyzer(code, "AZC0104")
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
         }
 
         [Fact]
         public async Task AZC0104WarningEnsureCompletedOnVariable()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     using System;
@@ -71,26 +67,23 @@ namespace RandomNamespace
             {
                 Task<int> task = Task.FromResult(0);
                 task = FooImplAsync();
-                return /*MM*/task.EnsureCompleted();
+                return [|task|].EnsureCompleted();
             };
         }
 
         private static async Task<int> FooImplAsync(CancellationToken ct = default(CancellationToken)) => 42;
     }
-}
-" + TaskExtensionsString);
-
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            var diagnostic = Assert.Single(diagnostics);
+}";
             
-            Assert.Equal("AZC0104", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+            await Verifier.CreateAnalyzer(code, "AZC0104")
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
         }
 
         [Fact]
         public async Task AZC0104WarningEnsureCompletedOnParameter()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     using System;
@@ -101,25 +94,22 @@ namespace RandomNamespace
     {
         public static int Foo(Task<int> task)
         {
-            return /*MM*/task.EnsureCompleted();
+            return [|task|].EnsureCompleted();
         }
 
         private static async Task<int> FooImplAsync(CancellationToken ct = default(CancellationToken)) => 42;
     }
-}
-" + TaskExtensionsString);
-
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            var diagnostic = Assert.Single(diagnostics);
+}";
             
-            Assert.Equal("AZC0104", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+            await Verifier.CreateAnalyzer(code, "AZC0104")
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
         }
 
         [Fact]
         public async Task AZC0104WarningEnsureCompletedOnProperty()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     using System;
@@ -130,19 +120,16 @@ namespace RandomNamespace
     {
         public static int Foo(Task<int> task)
         {
-            return /*MM*/FooImplAsync.EnsureCompleted();
+            return [|FooImplAsync|].EnsureCompleted();
         }
 
         private static Task<int> FooImplAsync => Task.FromResult(42);
     }
-}
-" + TaskExtensionsString);
-
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            var diagnostic = Assert.Single(diagnostics);
+}";
             
-            Assert.Equal("AZC0104", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+            await Verifier.CreateAnalyzer(code, "AZC0104")
+                .WithSources(AzureCorePipelineTaskExtensions)
+                .RunAsync();
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0104Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0104Tests.cs
@@ -1,0 +1,148 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public class AZC0104Tests 
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
+
+        private const string TaskExtensionsString = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+#pragma warning disable AZC0102
+        public static T EnsureCompleted<T>(this Task<T> task) => task.GetAwaiter().GetResult();
+#pragma warning restore AZC0102
+    }
+}
+";
+
+        [Fact]
+        public async Task AZC0104WarningEnsureCompletedOnField()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public int Foo(Task<int> task)
+        {
+            return /*MM*/_task.EnsureCompleted();
+        }
+
+        private Task<int> _task = Task.FromResult(42);
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+            
+            Assert.Equal("AZC0104", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0104WarningEnsureCompletedOnVariable()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static async Task FooAsync()
+        {
+            Func<int, int> a = i => 
+            {
+                Task<int> task = Task.FromResult(0);
+                task = FooImplAsync();
+                return /*MM*/task.EnsureCompleted();
+            };
+        }
+
+        private static async Task<int> FooImplAsync(CancellationToken ct = default(CancellationToken)) => 42;
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+            
+            Assert.Equal("AZC0104", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0104WarningEnsureCompletedOnParameter()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static int Foo(Task<int> task)
+        {
+            return /*MM*/task.EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(CancellationToken ct = default(CancellationToken)) => 42;
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+            
+            Assert.Equal("AZC0104", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0104WarningEnsureCompletedOnProperty()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static int Foo(Task<int> task)
+        {
+            return /*MM*/FooImplAsync.EnsureCompleted();
+        }
+
+        private static Task<int> FooImplAsync => Task.FromResult(42);
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+            
+            Assert.Equal("AZC0104", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0105Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0105Tests.cs
@@ -1,0 +1,99 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public class AZC0105Tests 
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
+
+        [Fact]
+        public async Task AZC0105WarningPublicAsyncMethodWithAsyncParameter()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    public class MyClass
+    {
+        public static async Task /*MM*/FooAsync(bool async, CancellationToken ct)
+        {
+            await Task.Yield();
+        }
+    }
+}");
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0105", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0105WarningPublicSyncMethodWithAsyncParameter()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    public class MyClass
+    {
+        public static void /*MM*/Foo(bool async, CancellationToken ct) { }
+    }
+}");
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0105", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0105NoWarningInternalAsyncMethodWithAsyncParameter()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    internal class MyClass
+    {
+        public static async Task FooAsync(bool async, CancellationToken ct)
+        {
+            await Task.Yield();
+        }
+    }
+}");
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0105NoWarningPrivateSyncMethodWithAsyncParameter()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    public class MyClass
+    {
+        private void Foo(bool async, CancellationToken ct) { }
+    }
+}");
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0105Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0105Tests.cs
@@ -3,64 +3,52 @@
 
 using System.Threading.Tasks;
 using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.AsyncAnalyzer>;
 
 namespace Azure.ClientSdk.Analyzers.Tests 
 {
     public class AZC0105Tests 
     {
-        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
-
         [Fact]
-        public async Task AZC0105WarningPublicAsyncMethodWithAsyncParameter()
-        {
-            var testSource = TestSource.Read(@"
+        public async Task AZC0105WarningPublicAsyncMethodWithAsyncParameter() {
+            const string code = @"
 namespace RandomNamespace
 {
     using System.Threading;
     using System.Threading.Tasks;
     public class MyClass
     {
-        public static async Task /*MM*/FooAsync(bool async, CancellationToken ct)
+        public static async Task FooAsync([|bool async|], CancellationToken ct)
         {
             await Task.Yield();
         }
     }
-}");
+}";
 
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0105", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0105");
         }
 
         [Fact]
         public async Task AZC0105WarningPublicSyncMethodWithAsyncParameter()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     using System.Threading;
     using System.Threading.Tasks;
     public class MyClass
     {
-        public static void /*MM*/Foo(bool async, CancellationToken ct) { }
+        public static void Foo([|bool async|], CancellationToken ct) { }
     }
-}");
+}";
 
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-
-            var diagnostic = Assert.Single(diagnostics);
-
-            Assert.Equal("AZC0105", diagnostic.Id);
-            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0105");
         }
 
         [Fact]
         public async Task AZC0105NoWarningInternalAsyncMethodWithAsyncParameter()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     using System.Threading;
@@ -72,16 +60,15 @@ namespace RandomNamespace
             await Task.Yield();
         }
     }
-}");
+}";
 
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            Assert.Empty(diagnostics);
+            await Verifier.VerifyAnalyzerAsync(code);
         }
 
         [Fact]
         public async Task AZC0105NoWarningPrivateSyncMethodWithAsyncParameter()
         {
-            var testSource = TestSource.Read(@"
+            const string code = @"
 namespace RandomNamespace
 {
     using System.Threading;
@@ -90,10 +77,9 @@ namespace RandomNamespace
     {
         private void Foo(bool async, CancellationToken ct) { }
     }
-}");
+}";
 
-            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
-            Assert.Empty(diagnostics);
+            await Verifier.VerifyAnalyzerAsync(code);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0106Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0106Tests.cs
@@ -1,0 +1,199 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public class AZC0106Tests 
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
+
+        private const string TaskExtensionsString = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+#pragma warning disable AZC0102
+        public static T EnsureCompleted<T>(this Task<T> task) => task.GetAwaiter().GetResult();
+#pragma warning restore AZC0102
+    }
+}
+";
+
+        [Fact]
+        public async Task AZC0106WarningOnAsyncMethodCall()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            /*MM*/FooImplAsync().EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0106", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0106WarningOnAsyncMethodCallInLambda()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public async Task Foo()
+        {
+            Func<int, int> a = i => /*MM*/FooImplAsync().EnsureCompleted();
+            await Task.Yield();
+        }
+
+        private async Task<int> FooImplAsync(CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0106", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0106WarningOnAsyncMethodCallInDelegate()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public async Task Foo()
+        {
+            Action a = delegate
+            {
+                /*MM*/FooImplAsync().EnsureCompleted();
+            };
+            await Task.Yield();
+        }
+
+        private async Task<int> FooImplAsync(CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0106", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0106WarningOnAsyncMethodCallInLocalFunction()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public async Task Foo()
+        {
+            await Task.Yield();
+
+            void FooImpl()
+            {
+                /*MM*/FooImplAsync().EnsureCompleted();
+            }
+        }
+
+        private async Task<int> FooImplAsync(CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0106", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0106NoWarningOnAsyncMethodCallWithAsyncParameter()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0107Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0107Tests.cs
@@ -1,0 +1,479 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public class AZC0107Tests 
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
+
+        private const string TaskExtensionsString = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+#pragma warning disable AZC0102
+        public static T EnsureCompleted<T>(this Task<T> task) => task.GetAwaiter().GetResult();
+#pragma warning restore AZC0102
+    }
+}
+";
+
+        [Fact]
+        public async Task AZC0107WarningInAsyncMethodFalseValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static async Task FooAsync()
+        {
+            await FooImplAsync(/*MM*/false).ConfigureAwait(false);
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0107", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0107WarningInAsyncScopeFalseValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (async)
+            {
+                await FooImplAsync(/*MM*/false).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0107", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0107WarningInAsyncLambdaFalseValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static void Foo(bool async)
+        {
+            Func<Task<int>> fooAsync = async () 
+                => async ? await FooImplAsync(/*MM*/false).ConfigureAwait(false) : 42;
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0107", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0107WarningInSyncMethodTrueValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(/*MM*/true).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0107", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0107WarningInSyncPropertyTrueValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static int Foo { get { return FooImplAsync(/*MM*/true).EnsureCompleted(); } }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0107", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0107WarningInSyncExpressionPropertyTrueValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static int Foo => FooImplAsync(/*MM*/true).EnsureCompleted();
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0107", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0107WarningInSyncScopeTrueValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (!async)
+            {
+                FooImplAsync(/*MM*/true).EnsureCompleted();
+            }
+            else 
+            {
+                await Task.Yield();
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0107", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0107WarningInSyncLambdaTrueValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            Func<Task<int>> fooAsync = async () 
+                => async ? await FooImplAsync(true).ConfigureAwait(false) : FooImplAsync(/*MM*/true).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0107", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0107NoWarningInAsyncMethodTrueValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static async Task FooAsync()
+        {
+            await FooImplAsync(true).ConfigureAwait(false);
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0107NoWarningInAsyncScopeTrueValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (async)
+            {
+                await FooImplAsync(true).ConfigureAwait(false);
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0107NoWarningInAsyncLambdaTrueValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static void Foo(bool async)
+        {
+            Func<Task<int>> fooAsync = async () 
+                => async ? await FooImplAsync(true).ConfigureAwait(false) : 42;
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0107NoWarningInSyncMethodFalseValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0107NoWarningInSyncScopeFalseValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            if (!async)
+            {
+                FooImplAsync(false).EnsureCompleted();
+            }
+            else 
+            {
+                await Task.Yield();
+            }
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0107NoWarningInSyncLambdaFalseValue()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        private static async Task FooAsync(bool async)
+        {
+            Func<Task<int>> fooAsync = async () 
+                => async ? await FooImplAsync(true).ConfigureAwait(false) : FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0108Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0108Tests.cs
@@ -1,0 +1,227 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public class AZC0108Tests 
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
+
+        private const string TaskExtensionsString = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+#pragma warning disable AZC0102
+        public static T EnsureCompleted<T>(this Task<T> task) => task.GetAwaiter().GetResult();
+#pragma warning restore AZC0102
+    }
+}
+";
+
+        [Fact]
+        public async Task AZC0108WarningOnAssignment()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            /*MM*/async = false;
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0108", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0108WarningOnReading()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            var x /*MM*/= async;
+            if (x)
+            {
+                await Task.Yield();
+            }
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0108", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0108WarningOnBinaryOperation()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            var x = false;
+            if (/*MM*/async && x)
+            {
+                await Task.Yield();
+            }
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0108", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0108NoWarningOnUnaryNot()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            if (!async)
+            {
+                return 42;
+            }
+
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0108NoWarningOnTernary()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0108NoWarningOnConditional()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            if (async)
+            {
+                return await Task.FromResult(42).ConfigureAwait(false);
+            }
+            else 
+            {
+                return 42;
+            }
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0109Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0109Tests.cs
@@ -1,0 +1,227 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public class AZC0109Tests 
+    {
+        private readonly DiagnosticAnalyzerRunner _runner = new DiagnosticAnalyzerRunner(new AsyncAnalyzer());
+
+        private const string TaskExtensionsString = @"
+namespace Azure.Core.Pipeline
+{
+    using System.Threading.Tasks;
+
+    internal static class TaskExtensions
+    {
+#pragma warning disable AZC0102
+        public static T EnsureCompleted<T>(this Task<T> task) => task.GetAwaiter().GetResult();
+#pragma warning restore AZC0102
+    }
+}
+";
+
+        [Fact]
+        public async Task AZC0109WarningOnAssignment()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            /*MM*/async = false;
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0109", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0109WarningOnReading()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            var x /*MM*/= async;
+            if (x)
+            {
+                await Task.Yield();
+            }
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0109", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0109WarningOnBinaryOperation()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            var x = false;
+            if (/*MM*/async && x)
+            {
+                await Task.Yield();
+            }
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            var diagnostic = Assert.Single(diagnostics);
+
+            Assert.Equal("AZC0109", diagnostic.Id);
+            AnalyzerAssert.DiagnosticLocation(testSource.DefaultMarkerLocation, diagnostic.Location);
+        }
+
+        [Fact]
+        public async Task AZC0109NoWarningOnUnaryNot()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            if (!async)
+            {
+                return 42;
+            }
+
+            await Task.Yield();
+            return 42;
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0109NoWarningOnTernary()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+            => async ? await Task.FromResult(42).ConfigureAwait(false) : 42;
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+
+        [Fact]
+        public async Task AZC0109NoWarningOnConditional()
+        {
+            var testSource = TestSource.Read(@"
+namespace RandomNamespace
+{
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Core.Pipeline;
+    public class MyClass
+    {
+        public static void Foo()
+        {
+            FooImplAsync(false).EnsureCompleted();
+        }
+
+        private static async Task<int> FooImplAsync(bool async, CancellationToken ct = default(CancellationToken)) 
+        {
+            if (async)
+            {
+                return await Task.FromResult(42).ConfigureAwait(false);
+            }
+            else 
+            {
+                return 42;
+            }
+        }
+    }
+}
+" + TaskExtensionsString);
+
+            var diagnostics = await _runner.GetDiagnosticsAsync(testSource.Source);
+            Assert.Empty(diagnostics);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
@@ -11,7 +11,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing.XUnit" Version="1.0.1-beta1.20113.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
 
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
@@ -1,19 +1,24 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
+using System.Collections.Immutable;
 using System.Linq;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 namespace Azure.ClientSdk.Analyzers.Tests 
 {
     public class AzureAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier> where TAnalyzer : DiagnosticAnalyzer, new() 
     {
+        private static readonly ReferenceAssemblies DefaultReferenceAssemblies =
+            ReferenceAssemblies.Default.AddPackages(ImmutableArray.Create(
+                new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "1.1.0"),
+                new PackageIdentity("System.Threading.Tasks.Extensions", "4.5.3")));
+
         public AzureAnalyzerTest(LanguageVersion languageVersion = LanguageVersion.Latest) 
         {
             SolutionTransforms.Add((solution, projectId) =>
@@ -23,8 +28,7 @@ namespace Azure.ClientSdk.Analyzers.Tests
                 return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
             });
 
-            TestState.AdditionalReferences.Add(typeof(ValueTask).Assembly);
-            TestState.AdditionalReferences.Add(typeof(IAsyncDisposable).Assembly);
+            ReferenceAssemblies = DefaultReferenceAssemblies;
         }
 
         public string DescriptorName { get; set; }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
@@ -1,0 +1,37 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing.Verifiers;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public class AzureAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier> where TAnalyzer : DiagnosticAnalyzer, new() 
+    {
+        public AzureAnalyzerTest(LanguageVersion languageVersion = LanguageVersion.Latest) 
+        {
+            SolutionTransforms.Add((solution, projectId) =>
+            {
+                var project = solution.GetProject(projectId);
+                var parseOptions = (CSharpParseOptions)project.ParseOptions;
+                return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(languageVersion));
+            });
+
+            TestState.AdditionalReferences.Add(typeof(ValueTask).Assembly);
+            TestState.AdditionalReferences.Add(typeof(IAsyncDisposable).Assembly);
+        }
+
+        public string DescriptorName { get; set; }
+
+        protected override DiagnosticDescriptor GetDefaultDiagnostic(DiagnosticAnalyzer[] analyzers) 
+            => string.IsNullOrWhiteSpace(DescriptorName) 
+                ? base.GetDefaultDiagnostic(analyzers)
+                : analyzers.SelectMany(a => a.SupportedDiagnostics).FirstOrDefault(d => d.Id == DescriptorName) ?? base.GetDefaultDiagnostic(analyzers);
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTestExtensions.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTestExtensions.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public static class AzureAnalyzerTestExtensions 
+    {
+        public static AzureAnalyzerTest<TAnalyzer> WithSources<TAnalyzer>(this AzureAnalyzerTest<TAnalyzer> test, params string[] sources)
+            where TAnalyzer : DiagnosticAnalyzer, new() 
+        {
+            foreach (var source in sources) 
+            {
+                test.TestState.Sources.Add(source);
+            }
+            return test;
+        }
+
+        public static AzureAnalyzerTest<TAnalyzer> WithDisabledDiagnostics<TAnalyzer>(this AzureAnalyzerTest<TAnalyzer> test, params string[] diagnostics)
+            where TAnalyzer : DiagnosticAnalyzer, new() 
+        {
+            test.DisabledDiagnostics.AddRange(diagnostics);
+            return test;
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerVerifier.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerVerifier.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Testing.XUnit;
+using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Azure.ClientSdk.Analyzers.Tests 
+{
+    public static class AzureAnalyzerVerifier<TAnalyzer> where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        public static AzureAnalyzerTest<TAnalyzer> CreateAnalyzer(string source, string expectedDescriptor = default, LanguageVersion languageVersion = LanguageVersion.Latest)
+            => new AzureAnalyzerTest<TAnalyzer> (languageVersion)
+            {
+                TestCode = source,
+                DescriptorName = expectedDescriptor,
+                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck
+            };
+
+        public static Task VerifyAnalyzerAsync(string source, string expectedDescriptor = default, LanguageVersion languageVersion = LanguageVersion.Latest) 
+            => CreateAnalyzer(source, expectedDescriptor, languageVersion).RunAsync(CancellationToken.None);
+
+        public static Task VerifyAnalyzerAsync(string source, params DiagnosticResult[] diagnostics) {
+            var test = new AzureAnalyzerTest<TAnalyzer> 
+            {
+                TestCode = source,
+                TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck
+            };
+
+            test.ExpectedDiagnostics.AddRange(diagnostics);
+            return test.RunAsync(CancellationToken.None);
+        }
+
+        public static DiagnosticResult Diagnostic(string expectedDescriptor) => AnalyzerVerifier<TAnalyzer>.Diagnostic(expectedDescriptor);
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/AsyncAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/AsyncAnalyzer.cs
@@ -7,6 +7,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
+using static Azure.ClientSdk.Analyzers.Descriptors;
 
 namespace Azure.ClientSdk.Analyzers
 {
@@ -16,7 +17,7 @@ namespace Azure.ClientSdk.Analyzers
         private AsyncAnalyzerUtilities _asyncUtilities;
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-            ImmutableArray.Create(Descriptors.AZC0100, Descriptors.AZC0101, Descriptors.AZC0102, Descriptors.AZC0103, Descriptors.AZC0104, Descriptors.AZC0105, Descriptors.AZC0106, Descriptors.AZC0107, Descriptors.AZC0108, Descriptors.AZC0109);
+            ImmutableArray.Create(AZC0100, AZC0101, AZC0102, AZC0103, AZC0104, AZC0105, AZC0106, AZC0107, AZC0108, AZC0109);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/AsyncAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/AsyncAnalyzer.cs
@@ -16,7 +16,7 @@ namespace Azure.ClientSdk.Analyzers
         private AsyncAnalyzerUtilities _asyncUtilities;
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } =
-            ImmutableArray.Create(Descriptors.AZC0100, Descriptors.AZC0101, Descriptors.AZC0102, Descriptors.AZC0103, Descriptors.AZC0104, Descriptors.AZC0105, Descriptors.AZC0106, Descriptors.AZC0107, Descriptors.AZC0108);
+            ImmutableArray.Create(Descriptors.AZC0100, Descriptors.AZC0101, Descriptors.AZC0102, Descriptors.AZC0103, Descriptors.AZC0104, Descriptors.AZC0105, Descriptors.AZC0106, Descriptors.AZC0107, Descriptors.AZC0108, Descriptors.AZC0109);
 
         public override void Initialize(AnalysisContext context)
         {

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -129,13 +129,20 @@ namespace Azure.ClientSdk.Analyzers
 
         public static DiagnosticDescriptor AZC0107 = new DiagnosticDescriptor(
             nameof(AZC0107),
-            "Incorrect 'async' parameter value.",
-            "In {0} scope 'async' parameter for the '{1}' method call should be '{2}'.",
+            "DO NOT call public asynchronous method in synchronous scope.",
+            "Public asynchronous method shouldn't be called in synchronous scope. Use synchronous version of the method if it is available.",
             "Usage",
             DiagnosticSeverity.Warning, true);
 
         public static DiagnosticDescriptor AZC0108 = new DiagnosticDescriptor(
             nameof(AZC0108),
+            "Incorrect 'async' parameter value.",
+            "In {0} scope 'async' parameter for the '{1}' method call should be '{2}'.",
+            "Usage",
+            DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0109 = new DiagnosticDescriptor(
+            nameof(AZC0109),
             "Misuse of 'async' parameter.",
             "'async' parameter in asynchronous method can't be changed and can only be used as an exclusive condition in '?:' operator or conditional statement.",
             "Usage",

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -95,7 +95,7 @@ namespace Azure.ClientSdk.Analyzers
         public static DiagnosticDescriptor AZC0102 = new DiagnosticDescriptor(
             nameof(AZC0102),
             "Do not use GetAwaiter().GetResult().",
-            "Do not use GetAwaiter().GetResult(). Use TaskExtensions.EnsureCompleted() extension method instead.",
+            "Do not use GetAwaiter().GetResult(). Use the TaskExtensions.EnsureCompleted() extension method instead.",
             "Usage",
             DiagnosticSeverity.Warning, true);
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -101,8 +101,8 @@ namespace Azure.ClientSdk.Analyzers
 
         public static DiagnosticDescriptor AZC0103 = new DiagnosticDescriptor(
             nameof(AZC0103),
-            "Do not use EnsureCompleted in asynchronous scope.",
-            "Do not use EnsureCompleted in asynchronous scope. Use await keyword instead.",
+            "Do not wait synchronously in asynchronous scope.",
+            "Do not use {0} in asynchronous scope. Use await keyword instead.",
             "Usage",
             DiagnosticSeverity.Warning, true);
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -78,17 +78,66 @@ namespace Azure.ClientSdk.Analyzers
             "Internal visible to product libraries effectively become public API and have to be versioned appropriately", "Usage", DiagnosticSeverity.Warning, true);
             
 
-        public static DiagnosticDescriptor AZC0012 = new DiagnosticDescriptor(
-            nameof(AZC0012),
+        public static DiagnosticDescriptor AZC0100 = new DiagnosticDescriptor(
+            nameof(AZC0100),
             "ConfigureAwait(false) must be used.",
             "ConfigureAwait(false) must be used.",
             "Usage",
             DiagnosticSeverity.Warning, true);
 
-        public static DiagnosticDescriptor AZC0013 = new DiagnosticDescriptor(
-            nameof(AZC0013),
+        public static DiagnosticDescriptor AZC0101 = new DiagnosticDescriptor(
+            nameof(AZC0101),
             "Use ConfigureAwait(false) instead of ConfigureAwait(true).",
             "Use ConfigureAwait(false) instead of ConfigureAwait(true).",
+            "Usage",
+            DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0102 = new DiagnosticDescriptor(
+            nameof(AZC0102),
+            "Do not use GetAwaiter().GetResult().",
+            "Do not use GetAwaiter().GetResult(). Use TaskExtensions.EnsureCompleted() extension method instead.",
+            "Usage",
+            DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0103 = new DiagnosticDescriptor(
+            nameof(AZC0103),
+            "Do not use EnsureCompleted in asynchronous scope.",
+            "Do not use EnsureCompleted in asynchronous scope. Use await keyword instead.",
+            "Usage",
+            DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0104 = new DiagnosticDescriptor(
+            nameof(AZC0104),
+            "Use EnsureCompleted() directly on asynchronous method return value.",
+            "Don't use EnsureCompleted on the {0}. Call EnsureCompleted() extension method directly on the return value of the asynchronous method that has 'bool async' parameter.",
+            "Usage",
+            DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0105 = new DiagnosticDescriptor(
+            nameof(AZC0105),
+            "DO NOT add 'async' parameter to public methods.",
+            "DO provide both asynchronous and synchronous variants for all service methods instead of one variant with 'async' parameter.",
+            "Usage",
+            DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0106 = new DiagnosticDescriptor(
+            nameof(AZC0106),
+            "Non-public asynchronous method needs 'async' parameter.",
+            "Non-public asynchronous method that is called in synchronous scope should have a boolean 'async' parameter.",
+            "Usage",
+            DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0107 = new DiagnosticDescriptor(
+            nameof(AZC0107),
+            "Incorrect 'async' parameter value.",
+            "In {0} scope 'async' parameter for the '{1}' method call should be '{2}'.",
+            "Usage",
+            DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0108 = new DiagnosticDescriptor(
+            nameof(AZC0108),
+            "Misuse of 'async' parameter.",
+            "'async' parameter in asynchronous method can't be changed and can only be used as an exclusive condition in '?:' operator or conditional statement.",
             "Usage",
             DiagnosticSeverity.Warning, true);
     }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/MethodBodyAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/MethodBodyAnalyzer.cs
@@ -1,0 +1,316 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Azure.ClientSdk.Analyzers 
+{
+    internal readonly struct MethodBodyAnalyzer 
+    {
+        private readonly AsyncAnalyzerUtilities _asyncUtilities;
+        private readonly INamedTypeSymbol _boolType;
+        private readonly INamedTypeSymbol _azureTaskExtensionsType;
+        private readonly Stack<(IEnumerator<IOperation>, MethodAnalysisContext)> _symbolIteratorsStack;
+        private readonly Action<Diagnostic> _reportDiagnostic;
+
+        public MethodBodyAnalyzer(Action<Diagnostic> reportDiagnostic, Compilation compilation, AsyncAnalyzerUtilities utilities) 
+        {
+            _reportDiagnostic = reportDiagnostic;
+            _asyncUtilities = utilities;
+            
+            _boolType = compilation.GetSpecialType(SpecialType.System_Boolean);
+            _azureTaskExtensionsType = compilation.GetTypeByMetadataName("Azure.Core.Pipeline.TaskExtensions");
+            _symbolIteratorsStack = new Stack<(IEnumerator<IOperation>, MethodAnalysisContext)>();
+        }
+
+        public void Run(IMethodSymbol method, IBlockOperation methodBody) 
+        {
+            var asyncParameter = GetAsyncParameter(method);
+            if (IsPublicMethod(method) && asyncParameter != null) 
+            {
+                ReportPublicMethodWithIsAsyncDiagnostic(method);
+            }
+
+            _symbolIteratorsStack.Push((methodBody.Children.GetEnumerator(), new MethodAnalysisContext(method, asyncParameter, method.IsAsync)));
+
+            while (_symbolIteratorsStack.Any())
+            {
+                var (enumerator, context) = _symbolIteratorsStack.Peek();
+                if (!enumerator.MoveNext())
+                {
+                    _symbolIteratorsStack.Pop();
+                    continue;
+                }
+
+                var current = enumerator.Current;
+                if (current == null) 
+                {
+                    continue;
+                }
+
+                switch (current)
+                {
+                    case IParameterReferenceOperation reference when reference.Parameter == context.AsyncParameter:
+                        AnalyzeAsyncParameterReference(context, reference);
+                        continue;
+                    case IAnonymousFunctionOperation function when function.Symbol != null:
+                        context = context.WithNewMethod(function.Symbol, context.AsyncParameter ?? GetAsyncParameter(function.Symbol));
+                        break;
+                    case ILocalFunctionOperation function when function.Symbol != null:
+                        context = context.WithNewMethod(function.Symbol, context.AsyncParameter ?? GetAsyncParameter(function.Symbol));
+                        break;
+                    case IInvocationOperation invocation:
+                        AnalyzeInvocation(context, invocation);
+                        break;
+                }
+
+                _symbolIteratorsStack.Push((current.Children.GetEnumerator(), context));
+            }
+        }
+        
+        private void AnalyzeAsyncParameterReference(in MethodAnalysisContext context, IOperation reference) 
+        {
+            switch (reference.Parent) 
+            {
+                case IConditionalOperation conditional:
+                    _symbolIteratorsStack.Pop(); // Remove condition from stack
+                    TryPushOperationToStack(context, conditional.WhenFalse, false);
+                    TryPushOperationToStack(context, conditional.WhenTrue, true);
+                    return;
+                case IUnaryOperation unary when unary.OperatorKind == UnaryOperatorKind.Not && unary.Parent is IConditionalOperation conditional:
+                    _symbolIteratorsStack.Pop();
+                    _symbolIteratorsStack.Pop();
+                    TryPushOperationToStack(context, conditional.WhenFalse, true);
+                    TryPushOperationToStack(context, conditional.WhenTrue, false);
+                    return;
+                default:
+                    ReportDiagnosticOnOperation(reference.Parent, Descriptors.AZC0108);
+                    return;
+            }
+        }
+        
+        private void AnalyzeInvocation(in MethodAnalysisContext context, IInvocationOperation invocation) 
+        {
+            var targetMethod = invocation.TargetMethod;
+
+            if (_asyncUtilities.IsConfigureAwait(targetMethod)) 
+            {
+                AnalyzeConfigureAwait(context, invocation);
+            }
+            else if (_asyncUtilities.IsGetAwaiter(targetMethod)) 
+            {
+                AnalyzeGetAwaiter(context, invocation);
+            } 
+            else if (IsEnsureCompleted(targetMethod)) 
+            {
+                AnalyzeEnsureCompleted(context, invocation);
+            }
+        }
+
+        private void AnalyzeConfigureAwait(in MethodAnalysisContext context, IInvocationOperation operation)
+        {
+            // There is no reason to call ConfigureAwait in sync method
+            if (!context.Method.IsAsync) 
+            {
+                return;
+            }
+            
+            // ConfigureAwait is either an instance method with one parameter or a static extension method with two.
+            // We need to check if the last argument is a bool and if it is 'true'
+            var constantValue = operation.Arguments.Last().Value?.ConstantValue;
+            if (constantValue != null && constantValue.Value.Value is bool value && value)
+            {
+                ReportDiagnosticOnMember(operation, Descriptors.AZC0101);
+            }
+
+            if (operation.Instance is IInvocationOperation invocation) 
+            {
+                // In async scope, pass 'async: true' to the async method
+                AnalyzeAsyncParameterValue(invocation, true);
+            }
+        }
+        
+        private void AnalyzeGetAwaiter(in MethodAnalysisContext context, IOperation operation) 
+        {
+            // There is no reason to call GetAwaiter in async method
+            if (context.Method.IsAsync) 
+            {
+                return;
+            }
+
+            // Only checking for the most common GetAwaiter().GetResult() combination
+            if (operation.Parent is IInvocationOperation invocation && _asyncUtilities.IsAwaiterGetResultMethod(invocation.TargetMethod)) 
+            {
+                ReportDiagnosticOnMember(operation, Descriptors.AZC0102);
+            }
+        }
+        
+        private void AnalyzeEnsureCompleted(in MethodAnalysisContext context, IInvocationOperation ensureCompletedInvocation) 
+        {
+            // TaskExtensions.EnsureCompleted is an extension method, so use its first argument to find out how it is used.
+            var argumentValue = ensureCompletedInvocation.Arguments[0].Value;
+
+            switch (argumentValue) 
+            {
+                case IFieldReferenceOperation fieldReference:
+                    ReportDiagnosticOnOperation(fieldReference, Descriptors.AZC0104, "field");
+                    return;
+                case ILocalReferenceOperation localReference:
+                    ReportDiagnosticOnOperation(localReference, Descriptors.AZC0104, "variable");
+                    return;
+                case IParameterReferenceOperation parameterReference:
+                    ReportDiagnosticOnOperation(parameterReference, Descriptors.AZC0104, "parameter");
+                    return;
+                case IPropertyReferenceOperation propertyReference:
+                    ReportDiagnosticOnOperation(propertyReference, Descriptors.AZC0104, "property");
+                    return;
+                case IInvocationOperation invocation:
+                    if (context.AsyncScope) 
+                    {
+                        // In async scope, use await keyword instead of EnsureCompleted
+                        ReportDiagnosticOnMember(ensureCompletedInvocation, Descriptors.AZC0103);
+                    } 
+                    else 
+                    {
+                        // In sync scope, pass 'async: false' to the async method
+                        AnalyzeAsyncParameterValue(invocation, false);
+                    }
+                    return;
+            }
+        }
+
+        private void AnalyzeAsyncParameterValue(IInvocationOperation invocation, bool asyncValue) 
+        {
+            var asyncParameterIndex = GetAsyncParameterIndex(invocation.TargetMethod);
+            if (asyncParameterIndex == -1) 
+            {
+                if (!asyncValue) 
+                {
+                    ReportDiagnosticOnMember(invocation, Descriptors.AZC0106);
+                }
+            }
+            else if (invocation.Arguments[asyncParameterIndex].Value.ConstantValue.Value is bool value && value != asyncValue) 
+            {
+                var messageArgs = asyncValue
+                    ? new object[] { "asynchronous", invocation.TargetMethod.Name, "true" }
+                    : new object[] { "synchronous", invocation.TargetMethod.Name, "false" };
+                ReportDiagnosticOnOperation(invocation.Arguments[asyncParameterIndex], Descriptors.AZC0107, messageArgs);
+            }
+        }
+        
+        private IParameterSymbol GetAsyncParameter(IMethodSymbol method) 
+        {
+            var index = GetAsyncParameterIndex(method);
+            return index == -1 ? null : method.Parameters[index];
+        }
+
+        private int GetAsyncParameterIndex(IMethodSymbol method) 
+        {
+            for (var i = 0; i < method.Parameters.Length; i++) 
+            {
+                var parameter = method.Parameters[i];
+                if (parameter.Name == "async" && parameter.Type.Equals(_boolType)) 
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+                
+        private bool IsEnsureCompleted(IMethodSymbol method) 
+            => _azureTaskExtensionsType != null && method.Name == "EnsureCompleted" && method.IsExtensionMethod && method.Parameters.Length == 1 && Equals(method.ReceiverType, _azureTaskExtensionsType);
+        
+        private void TryPushOperationToStack(in MethodAnalysisContext context, IOperation operation, bool isAsync) 
+        {
+            if (operation == null) 
+            {
+                return;
+            }
+
+            IEnumerable<IOperation> enumerable = new[] {operation};
+            _symbolIteratorsStack.Push((enumerable.GetEnumerator(), context.WithScope(isAsync)));
+        }
+
+        private void ReportPublicMethodWithIsAsyncDiagnostic(ISymbol symbol) 
+        {
+            var diagnostics = symbol.Locations
+                .Where(location => location.IsInSource)
+                .Select(location => Diagnostic.Create(Descriptors.AZC0105, location));
+
+            foreach (var diagnostic in diagnostics)
+            {
+                _reportDiagnostic(diagnostic);
+            }
+        }
+
+        private void ReportDiagnosticOnOperation(IOperation operation, DiagnosticDescriptor diagnosticDescriptor, params object[] messageArgs) 
+        {
+            var location = operation.Syntax.GetLocation();
+            var diagnostic = Diagnostic.Create(diagnosticDescriptor, location, messageArgs);
+            _reportDiagnostic(diagnostic);
+        }
+
+        private void ReportDiagnosticOnMember(IOperation operation, DiagnosticDescriptor diagnosticDescriptor) 
+        {
+            var invocation = (InvocationExpressionSyntax)operation.Syntax;
+            var name = invocation.Expression is MemberAccessExpressionSyntax memberAccess ? memberAccess.Name : invocation.Expression;
+            var start = name.Span.Start;
+            var end = invocation.Span.End;
+            var diagnostic = Diagnostic.Create(diagnosticDescriptor, Location.Create(invocation.SyntaxTree, new TextSpan(start, end - start)));
+            _reportDiagnostic(diagnostic);
+        }
+        
+        private static bool IsPublicMethod(IMethodSymbol method) 
+        {
+            if (method.DeclaredAccessibility != Accessibility.Public) 
+            {
+                return false;
+            }
+
+            if (method.AssociatedSymbol != null && method.AssociatedSymbol.DeclaredAccessibility != Accessibility.Public) 
+            {
+                return false;
+            }
+
+            var type = method.ContainingType;
+            while (type != null) 
+            {
+                if (type.DeclaredAccessibility != Accessibility.Public) 
+                {
+                    return false;
+                }
+
+                type = type.ContainingType;
+            }
+
+            return true;
+        }
+
+        private readonly struct MethodAnalysisContext 
+        {
+            public IMethodSymbol Method { get; }
+            public IParameterSymbol AsyncParameter { get; }
+            public bool AsyncScope { get; }
+
+            public MethodAnalysisContext(IMethodSymbol method, IParameterSymbol asyncParameter, bool asyncScope) 
+            {
+                Method = method;
+                AsyncParameter = asyncParameter;
+                AsyncScope = asyncScope;
+            }
+
+            public MethodAnalysisContext WithNewMethod(IMethodSymbol method, IParameterSymbol asyncParameter) 
+                => new MethodAnalysisContext(method, AsyncParameter ?? asyncParameter, method.IsAsync);
+
+            public MethodAnalysisContext WithScope(bool async) 
+                => new MethodAnalysisContext(Method, AsyncParameter, async);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/MethodBodyAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/MethodBodyAnalyzer.cs
@@ -90,7 +90,7 @@ namespace Azure.ClientSdk.Analyzers
                     TryPushOperationToStack(context, conditional.WhenTrue, false);
                     return;
                 default:
-                    ReportDiagnosticOnOperation(reference.Parent, Descriptors.AZC0108);
+                    ReportDiagnosticOnOperation(reference.Parent, Descriptors.AZC0109);
                     return;
             }
         }
@@ -192,9 +192,11 @@ namespace Azure.ClientSdk.Analyzers
             var asyncParameterIndex = GetAsyncParameterIndex(invocation.TargetMethod);
             if (asyncParameterIndex == -1) 
             {
-                if (!asyncValue) 
-                {
-                    ReportDiagnosticOnMember(invocation, Descriptors.AZC0106);
+                if (!asyncValue) {
+                    var descriptor = IsPublicMethod(invocation.TargetMethod)
+                        ? Descriptors.AZC0107
+                        : Descriptors.AZC0106;
+                    ReportDiagnosticOnMember(invocation, descriptor);
                 }
             }
             else if (invocation.Arguments[asyncParameterIndex].Value.ConstantValue.Value is bool value && value != asyncValue) 
@@ -202,7 +204,7 @@ namespace Azure.ClientSdk.Analyzers
                 var messageArgs = asyncValue
                     ? new object[] { "asynchronous", invocation.TargetMethod.Name, "true" }
                     : new object[] { "synchronous", invocation.TargetMethod.Name, "false" };
-                ReportDiagnosticOnOperation(invocation.Arguments[asyncParameterIndex], Descriptors.AZC0107, messageArgs);
+                ReportDiagnosticOnOperation(invocation.Arguments[asyncParameterIndex], Descriptors.AZC0108, messageArgs);
             }
         }
         


### PR DESCRIPTION
Use Roslyn test utilities instead of `DiagnosticAnalyzerRunner`