### PR TITLE
Fix for #384 - missing nested interfaces

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
@@ -88,4 +88,30 @@ public class ASTUtils {
             return "";
         }
     }
+
+    /**
+     * Returns true if the type is public or protected, or it the type is an interface that is defined within another
+     * public interface.
+     */
+    public static boolean isTypeAPublicAPI(TypeDeclaration type) {
+        final boolean isInterfaceType = type.isClassOrInterfaceDeclaration();
+        final boolean isNestedType = type.isNestedType();
+
+        // Skip if the class is private or package-private, unless it is a nested type defined inside a public interface
+        if (isPrivateOrPackagePrivate(type.getAccessSpecifier())) {
+            if (isNestedType && isInterfaceType) {
+                boolean isInPublicParent = type.getParentNode()
+                       .filter(parentNode -> parentNode instanceof ClassOrInterfaceDeclaration)
+                       .map(parentNode -> isPublicOrProtected(((ClassOrInterfaceDeclaration)parentNode).getAccessSpecifier()))
+                       .orElse(false);
+
+                if (! isInPublicParent) {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+        }
+        return true;
+    }
 }


### PR DESCRIPTION
Fix for #384 where nested interfaces were not being shown in the API view when they should be, because they were defined within another interface where they are implicitly public.

Fixes #384 