### PR TITLE
Variant support for Pipeline Generator

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
@@ -16,10 +16,10 @@ namespace PipelineGenerator.Conventions
 
         protected override string GetDefinitionName(SdkComponent component)
         {
-            return $"{Context.Prefix} - {component.Name} - ci";
+            return component.Variant == null ? $"{Context.Prefix} - {component.Name} - ci" : $"{Context.Prefix} - {component.Name} - ci.{component.Variant}";
         }
 
-        public override string SearchPattern => "ci.yml";
+        public override string SearchPattern => "ci*.yml";
 
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)
         {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -16,10 +16,10 @@ namespace PipelineGenerator.Conventions
 
         protected override string GetDefinitionName(SdkComponent component)
         {
-            return $"{Context.Prefix} - {component.Name}";
+            return component.Variant == null ? $"{Context.Prefix} - {component.Name}" : $"{Context.Prefix} - {component.Name} - {component.Variant}";
         }
 
-        public override string SearchPattern => "ci.yml";
+        public override string SearchPattern => "ci*.yml";
 
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)
         {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/SdkComponent.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/SdkComponent.cs
@@ -10,5 +10,6 @@ namespace PipelineGenerator
         public string Name { get; set; }
         public DirectoryInfo Path { get; set; }
         public string RelativeYamlPath { get; set; }
+        public string Variant { get; set; }
     }
 }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/SdkComponentScanner.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/SdkComponentScanner.cs
@@ -4,12 +4,15 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace PipelineGenerator
 {
     public class SdkComponentScanner
     {
+        private static Regex variantExtractionExpression = new Regex("^ci\\.(?<variant>([a-z]+))\\.yml$");
+
         public SdkComponentScanner(ILogger<SdkComponentScanner> logger)
         {
             Logger = logger;
@@ -49,6 +52,14 @@ namespace PipelineGenerator
                     Path = pipelineYamlFile.Directory,
                     RelativeYamlPath = relativePath
                 };
+
+                // Append variant information.
+                if (variantExtractionExpression.IsMatch(pipelineYamlFile.Name))
+                {
+                    var match = variantExtractionExpression.Match(pipelineYamlFile.Name);
+                    var variant = match.Groups["variant"].Value;
+                    component.Variant = variant;
+                }
 
                 yield return component;
             }


### PR DESCRIPTION
This PR adds support for variants to generated pipelines. In the Java repository we have adopted a convention of having ```ci.mgmt.yml``` and ```ci.data.yml``` files in addition to the regular ```ci.yml``` files. The additional ```.[something]``` signifies a variation to the pipeline for a particular scenario, for example building track 1 libraries or building management plane libraries where they can't co-exist within the same build (or we don't want them to for performance reasons).

What this change does is for PR and CI pipelines, it changes the search criteria to ```ci*.yml``` which picks up these variants. I am then using a regular expression to extract the variant detail and append it to the pipeline name so it is unique. This is inline with the convention that we adopted for the current hand-crafted pipelines.