### PR TITLE
Create more buckets for pipeline generator

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.VisualStudio.Services.Common;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +11,8 @@ namespace PipelineGenerator.Conventions
     public class IntegrationTestingPipelineConvention : PipelineConvention
     {
         public override string SearchPattern => "tests.yml";
+        public override bool IsScheduled => true;
+
 
         public IntegrationTestingPipelineConvention(ILogger logger, PipelineGenerationContext context) : base(logger, context)
         {
@@ -23,29 +26,6 @@ namespace PipelineGenerator.Conventions
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)
         {
             var hasChanges = await base.ApplyConventionAsync(definition, component);
-
-            // Ensure Schedule Trigger
-            var scheduleTriggers = definition.Triggers.OfType<ScheduleTrigger>();
-
-            if (scheduleTriggers == default || !scheduleTriggers.Any())
-            {
-                var schedule = new Schedule
-                {
-                    DaysToBuild = ScheduleDays.All,
-                    ScheduleOnlyWithChanges = false,
-                    StartHours = StartHourOffset + HashBucket(definition.Name),
-                    StartMinutes = 0,
-                    TimeZoneId = "Pacific Standard Time",
-                };
-                schedule.BranchFilters.Add("+master");
-
-                definition.Triggers.Add(new ScheduleTrigger
-                {
-                    Schedules = new List<Schedule> { schedule }
-                });
-
-                hasChanges = true;
-            }
 
             // Ensure PR trigger
             var prTriggers = definition.Triggers.OfType<PullRequestTrigger>();

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -244,24 +244,24 @@ namespace PipelineGenerator.Conventions
 
         protected const int FirstSchedulingHour = 0;
         protected const int LastSchedulingHour = 12;
+        protected const int TotalHours = LastSchedulingHour - FirstSchedulingHour;
+        protected const int TotalMinutes = TotalHours * 60;
         protected const int BucketSizeInMinutes = 15;
+        protected const int TotalBuckets = TotalMinutes / BucketSizeInMinutes;
+        protected const int BucketsPerHour = 60 / BucketSizeInMinutes;
 
         protected Schedule CreateScheduleFromDefinition(BuildDefinition definition)
         {
-            var totalHours = LastSchedulingHour - FirstSchedulingHour;
-            var totalMinutes = totalHours * 60;
-            var totalBuckets = totalMinutes / BucketSizeInMinutes;
-
-            var bucket = definition.Id % totalBuckets;
-            var startHours = bucket / 4;
-            var startMinutes = bucket % 4;
+            var bucket = definition.Id % TotalBuckets;
+            var startHours = bucket / BucketsPerHour;
+            var startMinutes = bucket % BucketsPerHour;
 
             var schedule = new Schedule
             {
                 DaysToBuild = ScheduleDays.All,
                 ScheduleOnlyWithChanges = false,
                 StartHours = FirstSchedulingHour + startHours,
-                StartMinutes = startMinutes * 15,
+                StartMinutes = startMinutes * BucketSizeInMinutes,
                 TimeZoneId = "UTC",
             };
             schedule.BranchFilters.Add("+master");

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -249,7 +249,7 @@ namespace PipelineGenerator.Conventions
         /// <summary>
         /// Number of buckets for hour hashing
         /// </summary>
-        protected const int HourBuckets = 3;
+        protected const int HourBuckets = 12;
 
         protected int HashBucket(string pipelineName)
         {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
@@ -20,6 +20,7 @@ namespace PipelineGenerator.Conventions
         }
 
         public override string SearchPattern => "ci*.yml";
+        public override bool IsScheduled => false;
 
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)
         {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -20,6 +20,7 @@ namespace PipelineGenerator.Conventions
         }
 
         public override string SearchPattern => "ci*.yml";
+        public override bool IsScheduled => true;
 
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)
         {
@@ -27,29 +28,6 @@ namespace PipelineGenerator.Conventions
             // API that can do equality comparisons (without having to do all the checks myself).
 
             var hasChanges = await base.ApplyConventionAsync(definition, component);
-
-            // Ensure Schedule Trigger
-            var scheduleTriggers = definition.Triggers.OfType<ScheduleTrigger>();
-
-            if (scheduleTriggers == default || !scheduleTriggers.Any())
-            {
-                var schedule = new Schedule
-                {
-                    DaysToBuild = ScheduleDays.All,
-                    ScheduleOnlyWithChanges = false,
-                    StartHours = StartHourOffset + HashBucket(definition.Name),
-                    StartMinutes = 0,
-                    TimeZoneId = "Pacific Standard Time",
-                };
-                schedule.BranchFilters.Add("+master");
-
-                definition.Triggers.Add(new ScheduleTrigger
-                {
-                    Schedules = new List<Schedule> { schedule }
-                });
-
-                hasChanges = true;
-            }
 
             var ciTrigger = definition.Triggers.OfType<ContinuousIntegrationTrigger>().SingleOrDefault();
 


### PR DESCRIPTION
In an effort to space scheduled builds/live test runs out a bit more, increasing the number of buckets that we distribute across.

/cc @danieljurek for input on whether this is the right approach.