### PR TITLE
use the new location for extracting release notes

### DIFF
--- a/scripts/powershell/create-tags-and-git-release.ps1
+++ b/scripts/powershell/create-tags-and-git-release.ps1
@@ -287,7 +287,7 @@ function ParseCArtifact($pkg, $workingDirectory) {
   $packageInfo = Get-Content -Raw -Path $pkg | ConvertFrom-JSON
   $packageArtifactLocation = (Get-ItemProperty $pkg).Directory.FullName
 
-  $releaseNotes = ExtractReleaseNotes -changeLogLocation @(Get-ChildItem -Path $packageArtifactLocation -Recurse -Include "CHANGELOG.md")[0]
+  $releaseNotes = &"${PSScriptRoot}/../../eng/common/Extract-ReleaseNotes.ps1" -ChangeLogLocation @(Get-ChildItem -Path $packageArtifactLocation -Recurse -Include "CHANGELOG.md")[0]
 
   return New-Object PSObject -Property @{
     PackageId      = $packageInfo.name


### PR DESCRIPTION
@chidozieononiwu pointed out that this file has moved on a bit from our other version. The release notes extraction has been extracted for reuse. 