### PR TITLE
Update package requirement

### DIFF
--- a/packages/python-packages/doc-warden/changelog.md
+++ b/packages/python-packages/doc-warden/changelog.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 0.5.2
+- Update package requirement to pathlib2
+
 ## 0.5.1
 - Allow omission of individual folders, while still allowing issues BELOW that folder to be detected.
 

--- a/packages/python-packages/doc-warden/setup.py
+++ b/packages/python-packages/doc-warden/setup.py
@@ -55,7 +55,7 @@ setup(
         'beautifulsoup4', # parsing of generated html
         'jinja2', # used for generation from template for index_packages
         'requests', # utilized to validate published repository URLs. 
-        'pathlib'
+        'pathlib2'
     ],
     entry_points = {
         'console_scripts': [

--- a/packages/python-packages/doc-warden/warden/version.py
+++ b/packages/python-packages/doc-warden/warden/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.5.1'
+VERSION = '0.5.2'


### PR DESCRIPTION
Packages pathlib and pathlib2 are conflicting when doc-warden and virtualenv is installed together. Fix is to update package requirement to pathlib2