### PR TITLE
Stop Overwriting OSName value

### DIFF
--- a/eng/pipelines/templates/scripts/verify-agent-os.yml
+++ b/eng/pipelines/templates/scripts/verify-agent-os.yml
@@ -30,6 +30,5 @@ steps:
 
         if (agent_os.lower() == os_parameter.lower()):
             print('Job ran on OS: %s' % (agent_os))
-            print('##vso[task.setvariable variable=OSName]%s' % (agent_os))
         else:
             raise Exception('Job ran on the wrong OS: %s' % (agent_os))


### PR DESCRIPTION
There is no need to set this again here as the variable is already set in the pipeline that calls the script.