### PR TITLE
Allow nested directories in sync-directory template

### DIFF
--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -11,11 +11,12 @@ steps:
       $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
 
       if (!(Test-Path $repoPath)) { mkdir $repoPath }
-      rm -v -r $repoPath/*.*
-      cp -v -r $(Build.SourcesDirectory)/${{ parameters.DirectoryToSync }}/*.* $repoPath
-      ls -r $repoPath
+      Remove-Item -v -r $repoPath
+      Copy-Item -v -r $(Build.SourcesDirectory)/${{ parameters.DirectoryToSync }} $repoPath
+      Get-ChildItem -r $repoPath
 
     displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}
+    workingDirectory: $(System.DefaultWorkingDirectory)
 
   - template: pipelines/steps/create-pull-request.yml@azure-sdk-build-tools
     parameters:


### PR DESCRIPTION
If you pass `*.*` with the remove or copy cmdlets it doesn't copy
the nested subdirectories even if you pass the -r option. To fix
we need to just remove those wildcards as they aren't necessary.

PTAL @danieljurek @chidozieononiwu 

cc @Azure/azure-sdk-eng 