### PR TITLE
[Java-Bugs] Type parameters extra space and private inner class should not shown

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>APIViewWeb</AssemblyName>
     <UserSecretsId>79cceff6-d533-4370-a0ee-f3321a343907</UserSecretsId>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <JavaProcessor>..\..\..\java\apiview-java-processor\target\apiview-java-processor-1.2.0.jar</JavaProcessor>
+    <JavaProcessor>..\..\..\java\apiview-java-processor\target\apiview-java-processor-1.3.0.jar</JavaProcessor>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
   </PropertyGroup>

--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
@@ -13,7 +13,7 @@ namespace APIViewWeb
     {
         public string Name { get; } = "Java";
 
-        public string JarName = "apiview-java-processor-1.2.0.jar";
+        public string JarName = "apiview-java-processor-1.3.0.jar";
 
         public bool IsSupportedExtension(string extension)
         {

--- a/src/java/apiview-java-processor/pom.xml
+++ b/src/java/apiview-java-processor/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.azure</groupId>
     <artifactId>apiview-java-processor</artifactId>
-    <version>1.2.0</version>
+    <version>1.3.0</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -581,7 +581,6 @@ public class ASTAnalyser implements Analyser {
                 }
             }
             addToken(new Token(PUNCTUATION, ">"));
-            addToken(new Token(WHITESPACE, " "));
         }
 
         private void getGenericTypeParameter(TypeParameter typeParameter) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -51,6 +51,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPackageName;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.isInterfaceType;
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.isPrivateOrPackagePrivate;
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.isTypeAPublicAPI;
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
@@ -195,11 +196,7 @@ public class ASTAnalyser implements Analyser {
             }
 
             // Get if the declaration is interface or not
-            boolean isInterfaceDeclaration = false;
-            if (typeDeclaration.isClassOrInterfaceDeclaration()) {
-                // could be interface or custom annotation @interface
-                isInterfaceDeclaration = typeDeclaration.asClassOrInterfaceDeclaration().isInterface();
-            }
+            boolean isInterfaceDeclaration = isInterfaceType(typeDeclaration);
 
             // public custom annotation @interface's members
             if (typeDeclaration.isAnnotationDeclaration() && !isPrivateOrPackagePrivate(typeDeclaration.getAccessSpecifier())) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
@@ -11,10 +11,6 @@ import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
 import com.github.javaparser.ast.body.VariableDeclarator;
-import com.github.javaparser.ast.type.ClassOrInterfaceType;
-import com.github.javaparser.ast.type.Type;
-import com.github.javaparser.resolution.types.ResolvedReferenceType;
-import com.github.javaparser.symbolsolver.javaparsermodel.JavaParserFacade;
 
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -111,7 +107,7 @@ public class ASTUtils {
      * public interface.
      */
     public static boolean isTypeAPublicAPI(TypeDeclaration type) {
-        final boolean isInterfaceType = type.isClassOrInterfaceDeclaration();
+        final boolean isInterfaceType = isInterfaceType(type);
         final boolean isNestedType = type.isNestedType();
 
         // Skip if the class is private or package-private, unless it is a nested type defined inside a public interface
@@ -130,5 +126,15 @@ public class ASTUtils {
             }
         }
         return true;
+    }
+
+    /**
+     * Returns true if the type is a public interface.
+     */
+    public static boolean isInterfaceType(TypeDeclaration type) {
+        if (type.isClassOrInterfaceDeclaration()) {
+            return type.asClassOrInterfaceDeclaration().isInterface();
+        }
+        return false;
     }
 }


### PR DESCRIPTION
- Bounded type parameters has extra space after.
- Private inner class should not be shown. 

Fixes: #429