### PR TITLE
Update resource deployment scripts to support deployments to sovereign clouds

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -45,8 +45,7 @@ param (
     [int] $DeleteAfterHours,
 
     [Parameter()]
-    [ValidateNotNullOrEmpty()]
-    [string] $Location = 'westus2',
+    [string] $Location = '',
 
     [Parameter()]
     [ValidateNotNullOrEmpty()]
@@ -121,6 +120,23 @@ Get-ChildItem -Path $root -Filter $templateFileName -Recurse | ForEach-Object {
 if (!$templateFiles) {
     Write-Warning -Message "No template files found under '$root'"
     exit
+}
+
+# If no location is specified use safe default locations for the given
+# environment. If no matching environment is found $Location remains an empty
+# string.
+if (!$Location) {
+    $defaultLocations = @{
+        'AzureCloud' = 'westus2';
+        'AzureUSGovernment' = 'usgovvirginia';
+        'AzureChinaCloud' = 'chinaeast2';
+    }
+
+    if ($defaultLocations.ContainsKey($Environment)) {
+        $Location = $defaultLocations[$Environment]
+    }
+
+    Write-Verbose "Location was not set using location: '$Location'"
 }
 
 # Log in if requested; otherwise, the user is expected to already be authenticated via Connect-AzAccount.

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -136,7 +136,7 @@ if (!$Location) {
         $Location = $defaultLocations[$Environment]
     }
 
-    Write-Verbose "Location was not set using location: '$Location'"
+    Write-Verbose "Location was not set. Using default location for environment: '$Location'"
 }
 
 # Log in if requested; otherwise, the user is expected to already be authenticated via Connect-AzAccount.

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -1,12 +1,14 @@
 # Deploys resources to a cloud type specified by the variable (not parameter)
 # 'CloudType'. Use this as part of a matrix to deploy resources to a particular
-# cloud instance.
+# cloud instance. Normally we would use template parameters instead of variables
+# but matrix variables are not available during template expansion so any
+# benefits of parameters are lost.
 
 parameters:
   ServiceDirectory: not-set
-  AdditionalParameters: ''
+  ArmTemplateParameters: '@{}'
   DeleteAfterHours: 24
-  Location: 'westus2'
+  Location: ''
 
 steps:
   # New-TestResources command requires Az module
@@ -22,15 +24,15 @@ steps:
       -TestApplicationSecret '$(aad-azure-sdk-test-client-secret)'
       -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id)'
       -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret)'
-      -AdditionalParameters ${{ parameters.AdditionalParameters }}
+      -AdditionalParameters ${{ parameters.ArmTemplateParameters }}
       -DeleteAfterHours ${{ parameters.DeleteAfterHours }}
       -Location '${{ parameters.Location }}'
       -Environment 'AzureCloud'
       -CI
       -Force
       -Verbose
-    displayName: Deploy test resources (public)
-    condition: and(succeeded(), eq(variables['CloudType'], 'public'))
+    displayName: Deploy test resources (AzureCloud)
+    condition: and(succeeded(), eq(variables['CloudType'], 'AzureCloud'))
 
   - pwsh: >
       eng/common/TestResources/New-TestResources.ps1
@@ -41,15 +43,15 @@ steps:
       -TestApplicationSecret '$(aad-azure-sdk-test-client-secret-gov)'
       -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id-gov)'
       -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret-gov)'
-      -AdditionalParameters ${{ parameters.AdditionalParameters }}
+      -AdditionalParameters ${{ parameters.ArmTemplateParameters }}
       -DeleteAfterHours ${{ parameters.DeleteAfterHours }}
       -Location '${{ parameters.Location }}'
       -Environment 'AzureUSGovernment'
       -CI
       -Force
       -Verbose
-    displayName: Deploy test resources (gov)
-    condition: and(succeeded(), eq(variables['CloudType'], 'gov'))
+    displayName: Deploy test resources (AzureUSGovernment)
+    condition: and(succeeded(), eq(variables['CloudType'], 'AzureUSGovernment'))
 
   - pwsh: >
       eng/common/TestResources/New-TestResources.ps1
@@ -60,12 +62,12 @@ steps:
       -TestApplicationSecret '$(aad-azure-sdk-test-client-secret-cn)'
       -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id-cn)'
       -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret-cn)'
-      -AdditionalParameters ${{ parameters.AdditionalParameters }}
+      -AdditionalParameters ${{ parameters.ArmTemplateParameters }}
       -DeleteAfterHours ${{ parameters.DeleteAfterHours }}
       -Location '${{ parameters.Location }}'
       -Environment 'AzureChinaCloud'
       -CI
       -Force
       -Verbose
-    displayName: Deploy test resources (cn)
-    condition: and(succeeded(), eq(variables['CloudType'], 'cn'))
+    displayName: Deploy test resources (AzureChinaCloud)
+    condition: and(succeeded(), eq(variables['CloudType'], 'AzureChinaCloud'))

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -1,41 +1,71 @@
+# Deploys resources to a cloud type specified by the variable (not parameter)
+# 'CloudType'. Use this as part of a matrix to deploy resources to a particular
+# cloud instance.
+
 parameters:
-    ServiceDirectory: not-specified
-    TenantId: not-specified
-    TestApplicationId: not-specified
-    TestApplicationSecret: not-specified
-    TestApplicationObjectId: not-specified
-    ProvisionerApplicationId: not-specified
-    ProvisionerApplicationSecret: not-specified
-    AdditionalParameters: ''
-    Location: 'westus2'
-    Environment: 'AzureCloud'
-    DeleteAfterHours: 24
-    Condition: succeeded()
+  ServiceDirectory: not-set
+  AdditionalParameters: ''
+  DeleteAfterHours: 24
+  Location: 'westus2'
 
 steps:
-    # New-TestResources command requires Az module
-    - pwsh: Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose
-      displayName: Install Azure PowerShell module
-      condition: ${{ parameters.Condition }}
+  # New-TestResources command requires Az module
+  - pwsh: Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose
+    displayName: Install Azure PowerShell module
 
-    # Command sets an environment variable in the pipeline's context:
-    # AZURE_RESOURCEGROUP_NAME
-    - pwsh: >
-        eng/common/TestResources/New-TestResources.ps1
-        -BaseName 'Generated'
-        -ServiceDirectory '${{ parameters.ServiceDirectory }}'
-        -TenantId '${{ parameters.TenantId }}'
-        -TestApplicationId '${{ parameters.TestApplicationId }}'
-        -TestApplicationSecret '${{ parameters.TestApplicationSecret }}'
-        -TestApplicationOid '${{ parameters.TestApplicationObjectId }}'
-        -ProvisionerApplicationId '${{ parameters.ProvisionerApplicationId }}'
-        -ProvisionerApplicationSecret '${{ parameters.ProvisionerApplicationSecret }}'
-        -AdditionalParameters ${{ parameters.AdditionalParameters }}
-        -DeleteAfterHours ${{ parameters.DeleteAfterHours }}
-        -Location '${{ parameters.Location }}'
-        -Environment '${{ parameters.Environment }}'
-        -CI
-        -Force
-        -Verbose
-      displayName: Deploy test resources
-      condition: ${{ parameters.Condition }}
+  - pwsh: >
+      eng/common/TestResources/New-TestResources.ps1
+      -BaseName 'Generated'
+      -ServiceDirectory '${{ parameters.ServiceDirectory }}'
+      -TenantId '$(aad-azure-sdk-test-tenant-id)'
+      -TestApplicationId '$(aad-azure-sdk-test-client-id)'
+      -TestApplicationSecret '$(aad-azure-sdk-test-client-secret)'
+      -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id)'
+      -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret)'
+      -AdditionalParameters ${{ parameters.AdditionalParameters }}
+      -DeleteAfterHours ${{ parameters.DeleteAfterHours }}
+      -Location '${{ parameters.Location }}'
+      -Environment 'AzureCloud'
+      -CI
+      -Force
+      -Verbose
+    displayName: Deploy test resources (public)
+    condition: and(succeeded(), eq(variables['CloudType'], 'public'))
+
+  - pwsh: >
+      eng/common/TestResources/New-TestResources.ps1
+      -BaseName 'Generated'
+      -ServiceDirectory '${{ parameters.ServiceDirectory }}'
+      -TenantId '$(aad-azure-sdk-test-tenant-id-gov)'
+      -TestApplicationId '$(aad-azure-sdk-test-client-id-gov)'
+      -TestApplicationSecret '$(aad-azure-sdk-test-client-secret-gov)'
+      -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id-gov)'
+      -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret-gov)'
+      -AdditionalParameters ${{ parameters.AdditionalParameters }}
+      -DeleteAfterHours ${{ parameters.DeleteAfterHours }}
+      -Location '${{ parameters.Location }}'
+      -Environment 'AzureUSGovernment'
+      -CI
+      -Force
+      -Verbose
+    displayName: Deploy test resources (gov)
+    condition: and(succeeded(), eq(variables['CloudType'], 'gov'))
+
+  - pwsh: >
+      eng/common/TestResources/New-TestResources.ps1
+      -BaseName 'Generated'
+      -ServiceDirectory '${{ parameters.ServiceDirectory }}'
+      -TenantId '$(aad-azure-sdk-test-tenant-id-cn)'
+      -TestApplicationId '$(aad-azure-sdk-test-client-id-cn)'
+      -TestApplicationSecret '$(aad-azure-sdk-test-client-secret-cn)'
+      -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id-cn)'
+      -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret-cn)'
+      -AdditionalParameters ${{ parameters.AdditionalParameters }}
+      -DeleteAfterHours ${{ parameters.DeleteAfterHours }}
+      -Location '${{ parameters.Location }}'
+      -Environment 'AzureChinaCloud'
+      -CI
+      -Force
+      -Verbose
+    displayName: Deploy test resources (cn)
+    condition: and(succeeded(), eq(variables['CloudType'], 'cn'))

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -1,22 +1,45 @@
+# Removes resources from a cloud type specified by the variable (not parameter)
+# 'CloudType'. Use this as part of a matrix to remove resources from a
+# particular cloud instance.
 # Assumes steps in deploy-test-resources.yml was run previously. Requires
 # environment variable: AZURE_RESOURCEGROUP_NAME and Az PowerShell module
-parameters:
-  TenantId: not-specified
-  ProvisionerApplicationId: not-specified
-  ProvisionerApplicationSecret: not-specified
-  Environment: 'AzureCloud'
-  Condition: true
 
 steps:
   - pwsh: >
       eng/common/TestResources/Remove-TestResources.ps1
       -ResourceGroupName "${env:AZURE_RESOURCEGROUP_NAME}"
-      -TenantId '${{ parameters.TenantId }}'
-      -ProvisionerApplicationId '${{ parameters.ProvisionerApplicationId }}'
-      -ProvisionerApplicationSecret '${{ parameters.ProvisionerApplicationSecret }}'
-      -Environment '${{ parameters.Environment }}'
+      -TenantId '$(aad-azure-sdk-test-tenant-id)'
+      -ProvisionerApplicationId '$(provisioner-aad-id)'
+      -ProvisionerApplicationSecret '$(provisioner-aad-secret)'
+      -Environment 'AzureCloud'
       -Force
       -Verbose
     displayName: Remove test resources
-    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), ${{ parameters.Condition }})
+    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'public'))
+    continueOnError: true
+
+  - pwsh: >
+      eng/common/TestResources/Remove-TestResources.ps1
+      -ResourceGroupName "${env:AZURE_RESOURCEGROUP_NAME}"
+      -TenantId '$(aad-azure-sdk-test-tenant-id-gov)'
+      -ProvisionerApplicationId '$(provisioner-aad-id-gov)'
+      -ProvisionerApplicationSecret '$(provisioner-aad-secret-gov)'
+      -Environment 'AzureUSGovernment'
+      -Force
+      -Verbose
+    displayName: Remove test resources
+    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'gov'))
+    continueOnError: true
+
+  - pwsh: >
+      eng/common/TestResources/Remove-TestResources.ps1
+      -ResourceGroupName "${env:AZURE_RESOURCEGROUP_NAME}"
+      -TenantId '$(aad-azure-sdk-test-tenant-id-cn)'
+      -ProvisionerApplicationId '$(provisioner-aad-id-cn)'
+      -ProvisionerApplicationSecret '$(provisioner-aad-secret-cn)'
+      -Environment 'AzureChinaCloud'
+      -Force
+      -Verbose
+    displayName: Remove test resources
+    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'cn'))
     continueOnError: true

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -9,12 +9,12 @@ steps:
       eng/common/TestResources/Remove-TestResources.ps1
       -ResourceGroupName "${env:AZURE_RESOURCEGROUP_NAME}"
       -TenantId '$(aad-azure-sdk-test-tenant-id)'
-      -ProvisionerApplicationId '$(provisioner-aad-id)'
-      -ProvisionerApplicationSecret '$(provisioner-aad-secret)'
+      -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id)'
+      -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret)'
       -Environment 'AzureCloud'
       -Force
       -Verbose
-    displayName: Remove test resources
+    displayName: Remove test resources (public)
     condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'public'))
     continueOnError: true
 
@@ -22,12 +22,12 @@ steps:
       eng/common/TestResources/Remove-TestResources.ps1
       -ResourceGroupName "${env:AZURE_RESOURCEGROUP_NAME}"
       -TenantId '$(aad-azure-sdk-test-tenant-id-gov)'
-      -ProvisionerApplicationId '$(provisioner-aad-id-gov)'
-      -ProvisionerApplicationSecret '$(provisioner-aad-secret-gov)'
+      -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id-gov)'
+      -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret-gov)'
       -Environment 'AzureUSGovernment'
       -Force
       -Verbose
-    displayName: Remove test resources
+    displayName: Remove test resources (gov)
     condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'gov'))
     continueOnError: true
 
@@ -35,11 +35,11 @@ steps:
       eng/common/TestResources/Remove-TestResources.ps1
       -ResourceGroupName "${env:AZURE_RESOURCEGROUP_NAME}"
       -TenantId '$(aad-azure-sdk-test-tenant-id-cn)'
-      -ProvisionerApplicationId '$(provisioner-aad-id-cn)'
-      -ProvisionerApplicationSecret '$(provisioner-aad-secret-cn)'
+      -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id-cn)'
+      -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret-cn)'
       -Environment 'AzureChinaCloud'
       -Force
       -Verbose
-    displayName: Remove test resources
+    displayName: Remove test resources (cn)
     condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'cn'))
     continueOnError: true

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -1,6 +1,9 @@
 # Removes resources from a cloud type specified by the variable (not parameter)
 # 'CloudType'. Use this as part of a matrix to remove resources from a
-# particular cloud instance.
+# particular cloud instance. Normally we would use template variables instead of
+# parameters but matrix variables are not available during template expansion
+# so any benefits of parameters are lost.
+
 # Assumes steps in deploy-test-resources.yml was run previously. Requires
 # environment variable: AZURE_RESOURCEGROUP_NAME and Az PowerShell module
 
@@ -14,8 +17,8 @@ steps:
       -Environment 'AzureCloud'
       -Force
       -Verbose
-    displayName: Remove test resources (public)
-    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'public'))
+    displayName: Remove test resources (AzureCloud)
+    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'AzureCloud'))
     continueOnError: true
 
   - pwsh: >
@@ -27,8 +30,8 @@ steps:
       -Environment 'AzureUSGovernment'
       -Force
       -Verbose
-    displayName: Remove test resources (gov)
-    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'gov'))
+    displayName: Remove test resources (AzureUSGovernment)
+    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'AzureUSGovernment'))
     continueOnError: true
 
   - pwsh: >
@@ -40,6 +43,6 @@ steps:
       -Environment 'AzureChinaCloud'
       -Force
       -Verbose
-    displayName: Remove test resources (cn)
-    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'cn'))
+    displayName: Remove test resources (AzureChinaCloud)
+    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(variables['CloudType'], 'AzureChinaCloud'))
     continueOnError: true


### PR DESCRIPTION
* remove the need to specify secrets/variables from the calling template
* consolidate provisioner and test application so we have to manage fewer secrets
* add support for deploying to sovereign clouds based on a variable (e.g. can be specified in matrix)