### PR TITLE
Space between bounded type parameter and no default constructor in enum

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>APIViewWeb</AssemblyName>
     <UserSecretsId>79cceff6-d533-4370-a0ee-f3321a343907</UserSecretsId>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <JavaProcessor>..\..\..\java\apiview-java-processor\target\apiview-java-processor-1.3.0.jar</JavaProcessor>
+    <JavaProcessor>..\..\..\java\apiview-java-processor\target\apiview-java-processor-1.4.0.jar</JavaProcessor>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>
     <TypeScriptCompileBlocked>true</TypeScriptCompileBlocked>
   </PropertyGroup>

--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
@@ -13,7 +13,7 @@ namespace APIViewWeb
     {
         public string Name { get; } = "Java";
 
-        public string JarName = "apiview-java-processor-1.3.0.jar";
+        public string JarName = "apiview-java-processor-1.4.0.jar";
 
         public bool IsSupportedExtension(string extension)
         {

--- a/src/java/apiview-java-processor/pom.xml
+++ b/src/java/apiview-java-processor/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.azure</groupId>
     <artifactId>apiview-java-processor</artifactId>
-    <version>1.3.0</version>
+    <version>1.4.0</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -210,8 +210,8 @@ public class ASTAnalyser implements Analyser {
             // get Constructors
             final List<ConstructorDeclaration> constructors = typeDeclaration.getConstructors();
             if (constructors.isEmpty()) {
-                // add default constructor if there is no constructor at all
-                if (!isInterfaceDeclaration) {
+                // add default constructor if there is no constructor at all, except interface and enum
+                if (!isInterfaceDeclaration && !typeDeclaration.isEnumDeclaration()) {
                     addDefaultConstructor(typeDeclaration);
                 } else {
                     // skip and do nothing if there is no constructor in the interface.

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -501,6 +501,11 @@ public class ASTAnalyser implements Analyser {
                 // type parameters of methods
                 getTypeParameters(callableDeclaration.getTypeParameters());
 
+                // if type parameters of method is not empty, we need to add an space before adding type name
+                if (!callableDeclaration.getTypeParameters().isEmpty()) {
+                    addToken(new Token(WHITESPACE, " "));
+                }
+
                 // type name
                 if (callableDeclaration instanceof MethodDeclaration) {
                     getType(callableDeclaration);


### PR DESCRIPTION

fixes: #451 No default constructor in Enum 
Result: Green highlight is the bug shown. This PR resolved it.
<img width="578" alt="bugs1" src="https://user-images.githubusercontent.com/45607042/77500330-fa3ca800-6e11-11ea-8cda-fcf16c803cf1.PNG">

fixes: #441 Bounded type parameter is missing space in between
Result: 
<img width="448" alt="不告诉" src="https://user-images.githubusercontent.com/45607042/77500473-63bcb680-6e12-11ea-9475-d8d300905ace.PNG">

