### PR TITLE
Allow version increase PRs to be created on branches

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -2,7 +2,7 @@
 # Expects the buildtools to be cloned
 
 parameters:
-  BaseBranchName: master
+  BaseBranchName: $(Build.SourceBranch)
   PRBranchName: not-specified
   PROwner: azure-sdk
   CommitMsg: not-specified


### PR DESCRIPTION
This change will allow version increase PRs to be created for branches instead of only master. Since we're still in the middle of transitioning files out of the azure-sdk-build-tools repo, the same change is going to be made to the same file in that repo as well.