### PR TITLE
Add sovereign clouds to live test resource cleanup

### DIFF
--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -1,6 +1,6 @@
 schedules:
-# At minute 15 past every hour
-- cron: "15 */1 * * *"
+# At 12:00 every day
+- cron: "0 12 * * *"
   displayName: Hourly
   branches:
     include:

--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -20,5 +20,26 @@ stages:
           -ProvisionerApplicationSecret "$(provisioner-aad-secret)"
           -ProvisionerApplicationTenantId "$(provisioner-aad-tenant)"
           -SubscriptionId "$(provisioner-subscription)"
+          -Environment 'AzureCloud'
           -Verbose
-        displayName: Clean up subscription resources
+        displayName: Clean up subscription resources (AzureCloud)
+
+      - pwsh: >
+          ./tools/live-test-cleanup/cleanup.ps1
+          -ProvisionerApplicationId "$(provisioner-aad-id-gov)"
+          -ProvisionerApplicationSecret "$(provisioner-aad-secret-gov)"
+          -ProvisionerApplicationTenantId "$(provisioner-aad-tenant-gov)"
+          -SubscriptionId "$(provisioner-subscription-gov)"
+          -Environment 'AzureUSGovernment'
+          -Verbose
+        displayName: Clean up subscription resources (AzureUSGovernment)
+
+      - pwsh: >
+          ./tools/live-test-cleanup/cleanup.ps1
+          -ProvisionerApplicationId "$(provisioner-aad-id-cn)"
+          -ProvisionerApplicationSecret "$(provisioner-aad-secret-cn)"
+          -ProvisionerApplicationTenantId "$(provisioner-aad-tenant-cn)"
+          -SubscriptionId "$(provisioner-subscription-cn)"
+          -Environment 'AzureChinaCloud'
+          -Verbose
+        displayName: Clean up subscription resources (AzureChinaCloud)

--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -1,6 +1,14 @@
+schedules:
+# At minute 15 past every hour
+- cron: "15 */1 * * *"
+  displayName: Hourly
+  branches:
+    include:
+    - master
+  always: true
 
-trigger: none
 pr: none
+trigger: none
 
 stages:
 - stage: Run

--- a/tools/live-test-cleanup/cleanup.ps1
+++ b/tools/live-test-cleanup/cleanup.ps1
@@ -25,10 +25,15 @@ param (
     [string] $SubscriptionId,
 
     [Parameter()]
+    [ValidateNotNullOrEmpty()]
+    $Environment = "AzureCloud",
+
+    [Parameter()]
     [switch] $Force
 )
 
 Write-Verbose "Logging in"
+az cloud set --name $Environment
 az login --service-principal --username=$ProvisionerApplicationId --password=$ProvisionerApplicationSecret --tenant=$ProvisionerApplicationTenantId
 Write-Verbose "Setting account"
 az account set --subscription=$SubscriptionId


### PR DESCRIPTION
Sovereign clouds now have smoke tests run against them periodically, this script makes us good stewards of those resources. 