### PR TITLE
Change log should not be updated if version is already present 

### DIFF
--- a/eng/common/Update-Change-Log.ps1
+++ b/eng/common/Update-Change-Log.ps1
@@ -63,11 +63,27 @@ function Get-NewChangeLog( [System.Collections.ArrayList]$ChangelogLines, $Versi
    # find index of current version
    $Index = 0
    $CurrentTitle = ""
+   $CurrentIndex = 0
+   # Version increment tool passes replaceversion as False and Unreleased as True
+   $is_version_increment = $ReplaceVersion -eq $False -and $Unreleased -eq $True
+
    for(; $Index -lt $ChangelogLines.Count; $Index++){
       if (Version-Matches($ChangelogLines[$Index])){
-         $CurrentTitle = $ChangelogLines[$Index]
-         Write-Host "Current Version title: $CurrentTitle"
-         break
+         # Find current title in change log
+         if( -not $CurrentTitle){
+            $CurrentTitle = $ChangelogLines[$Index]
+            $CurrentIndex = $Index
+            Write-Host "Current Version title: $CurrentTitle"
+         }
+
+         # Ensure change log doesn't have new version when incrementing version
+         # update change log script is triggered for all packages with current version for Java ( or any language where version is maintained in common file)
+         # and this can cause an issue if someone changes changelog manually to prepare for release without updating actual version in central version file
+         # Do not add new line or replace existing title when version is already present and script is triggered to add new line
+         if ($is_version_increment -and $ChangelogLines[$Index].Contains($Version)){
+            Write-Host "Version is already present in change log."
+            exit(0)
+         }
       }
    }
 
@@ -79,12 +95,7 @@ function Get-NewChangeLog( [System.Collections.ArrayList]$ChangelogLines, $Versi
       exit(0)
    }
 
-   # update change log script is triggered for all packages with current version for Java ( or any language where version is maintained in common file)
-   # Do not add new line or replace existing title when version is already present and script is triggered to add new line
-   if (($ReplaceVersion -eq $False) -and ($Unreleased -eq $True) -and $CurrentTitle.Contains($Version)){
-      Write-Host "Version is already present in change log."
-      exit(0)
-   }
+   
 
    if (($ReplaceVersion -eq $True) -and ($Unreleased -eq $False) -and (-not $CurrentTitle.Contains($UNRELEASED_TAG))){
       Write-Host "Version is already present in change log with a release date."
@@ -100,14 +111,14 @@ function Get-NewChangeLog( [System.Collections.ArrayList]$ChangelogLines, $Versi
    # if version is already found and not replacing then nothing to do
    if ($ReplaceVersion -eq $False){
       Write-Host "Adding version title $newVersionTitle"
-      $ChangelogLines.insert($Index, "")
-      $ChangelogLines.insert($Index, "")
-      $ChangelogLines.insert($Index, $newVersionTitle)
+      $ChangelogLines.insert($CurrentIndex, "")
+      $ChangelogLines.insert($CurrentIndex, "")
+      $ChangelogLines.insert($CurrentIndex, $newVersionTitle)
    }
    else{
       # Script is executed to replace an existing version title
       Write-Host "Replacing current version title to $newVersionTitle"
-      $ChangelogLines[$index] = $newVersionTitle
+      $ChangelogLines[$CurrentIndex] = $newVersionTitle
    }
 
    return $ChangelogLines      


### PR DESCRIPTION
Version increment tool is called for all packages in case of Java due to centralized version file and update change log should new entry only if version is not present in log. so far check was against latest version title in change log and it works in most of the scenarios except below when multiple packages are getting released within short duration.
Let's say someone manually updates change log to set release date or to add new version title to prepare for release but that version is not yet updated for package in centralized version file. Meanwhile if another package is released and it triggers version increment tool. This will also call for the package that is being prepared for release and update change log script doesn't find the package version in latest version title in log and as a result it adds another version log for previous version again. 

Change in this PR is to ensure version is not already present in change log before adding a new line for the version.
@JimSuplizio Please let me know if above description is missing any additional info.
