### PR TITLE
Add single-word type name analyzer

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Testing;
 using Xunit;
 using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientAssemblyNamespaceAnalyzer>;
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
@@ -20,7 +20,7 @@ namespace RandomNamespace
 
             var diagnostic = Verifier.Diagnostic("AZC0001")
                 .WithMessage("Namespace 'RandomNamespace' shouldn't contain public types. Use one of the following pre-approved namespace groups (https://azure.github.io/azure-sdk/registered_namespaces.html):" +
-                             " Azure.AI, Azure.Analytics, Azure.Data, Azure.Iot, Azure.Media, Azure.Messaging, Azure.Search, Azure.Security, Azure.Storage, Azure.Template, Azure.Identity, Microsoft.Extensions.Azure")
+                             " Azure.AI, Azure.Analytics, Azure.Data, Azure.Iot, Azure.Media, Azure.Management, Azure.Messaging, Azure.Search, Azure.Security, Azure.Storage, Azure.Template, Azure.Identity, Microsoft.Extensions.Azure")
                 .WithSpan(2, 11, 2, 26);
 
             await Verifier.VerifyAnalyzerAsync(code, diagnostic);

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0012Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0012Tests.cs
@@ -10,7 +10,7 @@ namespace Azure.ClientSdk.Analyzers.Tests
     public class AZC0012Tests
     {
         [Fact]
-        public async Task AZC0001ProducedForSingleWordTypeNames()
+        public async Task AZC0012ProducedForSingleWordTypeNames()
         {
             const string code = @"
 namespace Azure.Data
@@ -22,7 +22,7 @@ namespace Azure.Data
         }
 
         [Fact]
-        public async Task AZC0001NotProducedForNonPublicTypes()
+        public async Task AZC0012NotProducedForNonPublicTypes()
         {
             const string code = @"
 namespace Azure.Data
@@ -33,7 +33,7 @@ namespace Azure.Data
         }
 
         [Fact]
-        public async Task AZC0001NotProducedForMultiWordTypes()
+        public async Task AZC0012NotProducedForMultiWordTypes()
         {
             const string code = @"
 namespace Azure.Data

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0012Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0012Tests.cs
@@ -22,6 +22,18 @@ namespace Azure.Data
         }
 
         [Fact]
+        public async Task AZC0012ProducedForSingleWordInterfaceNames()
+        {
+            const string code = @"
+namespace Azure.Data
+{
+    public interface [|IProgram|] { }
+}";
+
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
         public async Task AZC0012NotProducedForNonPublicTypes()
         {
             const string code = @"

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0012Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0012Tests.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.TypeNameAnalyzer>;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC0012Tests
+    {
+        [Fact]
+        public async Task AZC0001ProducedForSingleWordTypeNames()
+        {
+            const string code = @"
+namespace Azure.Data
+{
+    public class [|Program|] { }
+}";
+
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0001NotProducedForNonPublicTypes()
+        {
+            const string code = @"
+namespace Azure.Data
+{
+    internal class Program { }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0001NotProducedForMultiWordTypes()
+        {
+            const string code = @"
+namespace Azure.Data
+{
+    public class NiceProgram { }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net48</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <LangVersion>8</LangVersion>
   </PropertyGroup>

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.0;net48</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <LangVersion>8</LangVersion>
   </PropertyGroup>

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAnalyzerBase.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAnalyzerBase.cs
@@ -6,7 +6,6 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Azure.ClientSdk.Analyzers
 {

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
@@ -17,6 +17,7 @@ namespace Azure.ClientSdk.Analyzers
             "Azure.Data",
             "Azure.Iot",
             "Azure.Media",
+            "Azure.Management",
             "Azure.Messaging",
             "Azure.Search",
             "Azure.Security",

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -77,6 +77,9 @@ namespace Azure.ClientSdk.Analyzers
             nameof(AZC0011), "Avoid InternalsVisibleTo to non-test assemblies",
             "Internal visible to product libraries effectively become public API and have to be versioned appropriately", "Usage", DiagnosticSeverity.Warning, true);
 
+        public static DiagnosticDescriptor AZC0012 = new DiagnosticDescriptor(
+            nameof(AZC0012), "Avoid single word type names",
+            "Single word class names are too generic and have high chance of collision with BCL types or types from other libraries", "Usage", DiagnosticSeverity.Warning, true);
 
         public static DiagnosticDescriptor AZC0100 = new DiagnosticDescriptor(
             nameof(AZC0100),

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/TypeNameAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/TypeNameAnalyzer.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.ClientSdk.Analyzers
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class TypeNameAnalyzer : SymbolAnalyzerBase
+    {
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptors.AZC0012);
+        public override SymbolKind[] SymbolKinds { get; } = { SymbolKind.NamedType };
+
+        public override void Analyze(ISymbolAnalysisContext context)
+        {
+            var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
+
+            if (namedTypeSymbol.DeclaredAccessibility == Accessibility.Public &&
+                IsSingleWord(namedTypeSymbol.Name))
+            {
+                foreach (var location in namedTypeSymbol.Locations)
+                {
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0012, location, context.Symbol), context.Symbol);
+                }
+            }
+        }
+
+        private bool IsSingleWord(string name)
+        {
+            int i = 0;
+            foreach (var c in name)
+            {
+                if (char.IsUpper(c))
+                {
+                    i++;
+                }
+
+                if (i > 1)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/TypeNameAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/TypeNameAnalyzer.cs
@@ -17,8 +17,10 @@ namespace Azure.ClientSdk.Analyzers
         {
             var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
 
+            // Account for an `I` prefix in the interfaces.
+            var minimumWordCount = namedTypeSymbol.TypeKind == TypeKind.Interface ? 2 : 1;
             if (namedTypeSymbol.DeclaredAccessibility == Accessibility.Public &&
-                IsSingleWord(namedTypeSymbol.Name))
+                CountWords(namedTypeSymbol.Name) <= minimumWordCount)
             {
                 foreach (var location in namedTypeSymbol.Locations)
                 {
@@ -27,7 +29,7 @@ namespace Azure.ClientSdk.Analyzers
             }
         }
 
-        private bool IsSingleWord(string name)
+        private int CountWords(string name)
         {
             int i = 0;
             foreach (var c in name)
@@ -36,14 +38,9 @@ namespace Azure.ClientSdk.Analyzers
                 {
                     i++;
                 }
-
-                if (i > 1)
-                {
-                    return false;
-                }
             }
 
-            return true;
+            return i;
         }
     }
 }


### PR DESCRIPTION
And Management to an allowed namespace list

Fixes: https://github.com/Azure/azure-sdk-tools/issues/459