### PR TITLE
Rename SemVer due to type conflict

### DIFF
--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -104,5 +104,4 @@ class AzureEngSemanticVersion {
             $this.PrereleaseNumber++
         }
     }
-
 }


### PR DESCRIPTION
- A builtin Powershell version of SemVer exists in 'System.Management.Automation'. At this time, it does not parsing of PrereleaseNumber. It's name is also type accelerated to 'SemVer'.
- Add some additional common parsing logic