### PR TITLE
Remove validation for $AdditionalParameters

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -56,7 +56,6 @@ param (
     [string] $Environment = 'AzureCloud',
 
     [Parameter()]
-    [ValidateNotNullOrEmpty()]
     [hashtable] $AdditionalParameters,
 
     [Parameter()]


### PR DESCRIPTION
Remove validation for $AdditionalParameters because it throws an error when an empty set is provided. having this validation in place makes it difficult to provide the option for additional parameters and instead either requires that the template exclude the -AdditionalParameters parameter or that it fill it with something that is effectively meaningless.