### PR TITLE
Path filter improvements

### DIFF
--- a/.azure-pipelines/apiview.yml
+++ b/.azure-pipelines/apiview.yml
@@ -7,8 +7,8 @@ trigger:
       - hotfix/*
   paths:
     include:
-      - src/dotnet
-      - src/java
+      - src/dotnet/APIView
+      - src/java/apiview-java-processor
 
 pr:
   branches:
@@ -19,8 +19,8 @@ pr:
       - hotfix/*
   paths:
     include:
-      - src/dotnet
-      - src/java
+      - src/dotnet/APIView
+      - src/java/apiview-java-processor
 
 variables:
   DotNetCoreVersion: '3.0.100'

--- a/.azure-pipelines/dotnet.yml
+++ b/.azure-pipelines/dotnet.yml
@@ -3,7 +3,26 @@
 # VersioningProps - A collection of extra msbuild versioning properties like OfficialBuildId, PreReleaseVersionLabel, and DotNetFinalVersionKind
 
 trigger:
-  - master
+  branches:
+    include:
+      - master
+      - feature/*
+      - release/*
+      - hotfix/*
+  paths:
+    include:
+      - src/Azure.ClientSdk.Analyzers
+
+pr:
+  branches:
+    include:
+      - master
+      - feature/*
+      - release/*
+      - hotfix/*
+  paths:
+    include:
+      - src/Azure.ClientSdk.Analyzers
 
 resources:
   repositories:

--- a/.azure-pipelines/warden.yml
+++ b/.azure-pipelines/warden.yml
@@ -1,5 +1,24 @@
 trigger:
-- master
+  branches:
+    include:
+      - master
+      - feature/*
+      - release/*
+      - hotfix/*
+  paths:
+    include:
+      - eng/packages/python-packages/doc-warden
+
+pr:
+  branches:
+    include:
+      - master
+      - feature/*
+      - release/*
+      - hotfix/*
+  paths:
+    include:
+      - eng/packages/python-packages/doc-warden
 
 jobs:
 - job: 'Build'


### PR DESCRIPTION
Noticed some pipelines running that don't need to based on path filter. This is an initial step in starting to clean some of this up. Ultimately we should adopt a similar practice to what we do in the other mono repos where each discrete "thing" has its own pipeline, with its own ci.yml file. That would mean we can use the pipeline generator on the SDK tools repo as well.