### PR TITLE
Add lint errors in API review

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/__init__.py
+++ b/packages/python-packages/api-stub-generator/apistub/__init__.py
@@ -4,6 +4,7 @@ from ._stub_generator import StubGenerator
 from ._token import Token
 from ._token_kind import TokenKind
 from ._apiview import ApiView, Navigation, NavigationTag, Kind
+from ._diagnostic import Diagnostic
 
 __version__ = VERSION
 
@@ -15,6 +16,7 @@ __all__ = [
     "Navigation",
     "NavigationTag",
     "Kind",
+    "Diagnostic",
 ]
 
 

--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -7,11 +7,17 @@ import importlib
 from ._token import Token
 from ._token_kind import TokenKind
 from ._version import VERSION
+from ._diagnostic import Diagnostic
 
-JSON_FIELDS = ["Name", "Version", "VersionString", "Navigation", "Tokens"]
+JSON_FIELDS = ["Name", "Version", "VersionString", "Navigation", "Tokens", "Diagnostics"]
 
 HEADER_TEXT = "# Package is parsed using api-stub-generator(version:{})".format(VERSION)
 COMPLEX_DATA_TYPE_PATTERN = re.compile("([a-zA-Z]+)(\[|\()[^\]\)]+(\]|\))")
+
+# Lint warnings
+SOURCE_LINK_NOT_AVAILABLE = "Source definition link is not available for [{0}]. Please check and ensure type is fully qualified name in docstring"
+RETURN_TYPE_MISMATCH = "Return type in type hint is not matching return type in docstring"
+
 
 class ApiView:
     """Entity class that holds API view for all namespaces within a package
@@ -28,6 +34,7 @@ class ApiView:
         self.Language = "Python"
         self.Tokens = []
         self.Navigation = []
+        self.Diagnostics = []
         self.indent = 0
         self.nodeindex = nodeindex
         self.add_literal(HEADER_TEXT)
@@ -85,7 +92,7 @@ class ApiView:
         if postfix_space:
             self.add_space()
 
-    def _generate_type_tokens(self, type_name, prefix_type):
+    def _generate_type_tokens(self, type_name, prefix_type, line_id = None):
         # Generate tokens for multiple data types
         # for e.g. Union[type1, type2,] or dict(type1, type2)
         # For some args, type is given as just "dict"
@@ -104,14 +111,14 @@ class ApiView:
             types = type_names.split(",")
             type_count = len(types)
             for index in range(type_count):
-                self.add_type(types[index].strip())
+                self.add_type(types[index].strip(), line_id)
                 # Add seperator between types
                 if index < type_count - 1:
                     self.add_punctuation(",", False, True)
             self.add_punctuation(type_name[-1])
 
 
-    def add_type(self, type_name, id=None):
+    def add_type(self, type_name, line_id=None):
         # This method replace full qualified internal types to short name and generate tokens
         if not type_name:
             return
@@ -120,25 +127,34 @@ class ApiView:
         # Those types needs to be recursively processed
         multi_types = re.search(COMPLEX_DATA_TYPE_PATTERN,type_name)
         if multi_types:
-            self._generate_type_tokens(type_name, multi_types.groups()[0])
+            self._generate_type_tokens(type_name, multi_types.groups()[0], line_id)
         else:
             # Encode mutliple types with or seperator into Union
             types = [t for t in type_name.split() if t != 'or']
             if len(types) > 1:
                 # Make a Union of types if multiple types are present
-                self._generate_type_tokens("Union[{}]".format(", ".join(types)), "Union")
+                self._generate_type_tokens("Union[{}]".format(", ".join(types)), "Union", line_id)
             else:
-                self._add_type_token(types[0])
+                self._add_type_token(types[0], line_id)
 
 
-    def _add_type_token(self, type_name):
+    def _add_type_token(self, type_name, line_id = None):
         token = Token(type_name, TokenKind.TypeName)
         type_full_name = type_name[1:] if type_name.startswith("~") else type_name
         token.set_value(type_full_name.split(".")[-1])
         navigate_to_id = self.nodeindex.get_id(type_full_name)
         if navigate_to_id:
             token.NavigateToId = navigate_to_id
+        elif type_name.startswith("~") and line_id:
+            # if navigation ID is missing for internal type, add diagnostic error
+            self.add_diagnostic(SOURCE_LINK_NOT_AVAILABLE.format(token.Value), line_id)            
         self.add_token(token)
+
+
+    def add_diagnostic(self, text, line_id):
+        self.Diagnostics.append(Diagnostic(line_id, text))
+        # log diagnostic as error
+        logging.error(text)
 
 
     def add_member(self, name, id):
@@ -170,6 +186,7 @@ class APIViewEncoder(JSONEncoder):
             or isinstance(obj, Token)
             or isinstance(obj, Navigation)
             or isinstance(obj, NavigationTag)
+            or isinstance(obj, Diagnostic)
         ):            
             # Remove fields in APIview that are not required in json
             if isinstance(obj, ApiView):
@@ -183,6 +200,10 @@ class APIViewEncoder(JSONEncoder):
                     del obj_dict["DefinitionId"]
                 if not obj.NavigateToId:
                     del obj_dict["NavigateToId"]
+            elif isinstance(obj, Diagnostic):
+                obj_dict = obj.__dict__
+                if not obj.HelpLinkUri:
+                    del obj_dict["HelpLinkUri"]
             else:
                 obj_dict = obj.__dict__
 

--- a/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
@@ -93,7 +93,10 @@ class StubGenerator:
         self._install_package(pkg_name)
         logging.debug("Generating tokens")
         apiview = self._generate_tokens(pkg_root_path, pkg_name, version)
-        logging.info("Completed parsing package and generating tokens")
+        if apiview.Diagnostics:
+            logging.info("*************** Completed parsing package with errors ***************")
+        else:
+            logging.info("*************** Completed parsing package and generating tokens ***************")
         return apiview
 
 

--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.0.1"
+VERSION = "0.0.2"

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
@@ -195,6 +195,7 @@ class ClassNode(NodeEntityBase):
         """Generates token for the node and it's children recursively and add it to apiview
         :param ApiView: apiview
         """
+        logging.info("Processing class {}".format(self.parent_node.namespace_id))
         # Generate class name line
         apiview.add_whitespace()
         apiview.add_line_marker(self.namespace_id)
@@ -204,14 +205,14 @@ class ClassNode(NodeEntityBase):
         # Add inherited base classes
         if self.base_class_names:
             apiview.add_punctuation("(")
-            _generate_token_for_collection(self.base_class_names, apiview)
+            self._generate_token_for_collection(self.base_class_names, apiview)
             apiview.add_punctuation(")")
         apiview.add_punctuation(":")
 
         # Add any ABC implementation list
         if self.implements:
             apiview.add_keyword("implements", True, True)
-            _generate_token_for_collection(self.implements, apiview)
+            self._generate_token_for_collection(self.implements, apiview)
 
         # Generate token for child nodes
         if self.child_nodes:
@@ -237,11 +238,11 @@ class ClassNode(NodeEntityBase):
         apiview.end_group()
 
 
-def _generate_token_for_collection(values, apiview):
-    # Helper method to concatenate list of values and generate tokens
-    list_len = len(values)
-    for index in range(list_len):
-        apiview.add_type(values[index])
-        # Add punctuation betwen types
-        if index < list_len - 1:
-            apiview.add_punctuation(",", False, True)
+    def _generate_token_for_collection(self, values, apiview):
+        # Helper method to concatenate list of values and generate tokens
+        list_len = len(values)
+        for index in range(list_len):
+            apiview.add_type(values[index], self.namespace_id)
+            # Add punctuation betwen types
+            if index < list_len - 1:
+                apiview.add_punctuation(",", False, True)


### PR DESCRIPTION
Find missing information when parsing package and add these as diagnostic errors in API review.
1. Type missing for arguements
2. Incorrect docstring for internal types
3. missing return type
4. Return type not matching between typehint and docstring