### PR TITLE
Check Enforcer ... listen to PR events

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
@@ -126,6 +126,11 @@ namespace Azure.Sdk.Tools.CheckEnforcer
                     var handler = new IssueCommentHandler(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger);
                     await handler.HandleAsync(json, cancellationToken);
                 }
+                else if (eventName == "pull_request")
+                {
+                    var handler = new PullRequestHandler(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger);
+                    await handler.HandleAsync(json, cancellationToken);
+                }
                 else
                 {
                     throw new CheckEnforcerUnsupportedEventException(eventName);

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
@@ -1,0 +1,40 @@
+﻿using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Primitives;
+using Microsoft.Identity.Client;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
+{
+    public class PullRequestHandler : Handler<PullRequestEventPayload>
+    {
+        public PullRequestHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, ILogger logger) : base(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider, logger)
+        {
+        }
+
+        protected override async Task HandleCoreAsync(HandlerContext<PullRequestEventPayload> context, CancellationToken cancellationToken)
+        {
+            var payload = context.Payload;
+            var installationId = payload.Installation.Id;
+            var repositoryId = payload.Repository.Id;
+            var sha = payload.PullRequest.Head.Sha;
+            var runIdentifier = $"{installationId}/{repositoryId}/{sha}";
+            var action = payload.Action;
+            var pullRequestNumber = payload.PullRequest.Number;
+
+            Logger.LogInformation(
+                "Received {action} action on PR# {pullRequestNumber} against {runIdentifier}",
+                action,
+                pullRequestNumber,
+                runIdentifier
+                );
+        }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
@@ -35,6 +35,13 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
                 pullRequestNumber,
                 runIdentifier
                 );
+
+            var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
+
+            if (configuration.IsEnabled)
+            {
+                await CreateCheckAsync(context.Client, installationId, repositoryId, sha, false, cancellationToken);
+            }
         }
     }
 }


### PR DESCRIPTION
Up until now Check Enforcer has been listening for Check Suite and Check Run events. However I noticed that with forked PRs that the check suite event never seemed to get sent, and previous attempts to make Check Enforcer resilient to this can lead to race conditions.

This change adds an event handler for the ```pull_request``` event so that when a PR is updated that there is an opportunity for Check Enforcer to create the Check Run instance which later ```check_run``` completion events update the state on.

I'm running this in staging now and production shortly (deploying off a feature branch) and it appears to be stable.