### PR TITLE
[Doc-Warden] Remove Code Fence Blocks During Parsing

### DIFF
--- a/packages/python-packages/doc-warden/changelog.md
+++ b/packages/python-packages/doc-warden/changelog.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 0.6.1
+- `Pygments` style code-fence blocks are parsed badly by `markdown2`. This results in phantom headers that break document hierarchy. Remove these blocks right after reading the readme and before passing to html parsing.
+
 ## 0.6.0 
 - Support for `sub-heading` verification. Consumption of `sub-heading` yml will crash on less than version `0.6.0`.
 

--- a/packages/python-packages/doc-warden/warden/enforce_readme_content.py
+++ b/packages/python-packages/doc-warden/warden/enforce_readme_content.py
@@ -65,7 +65,7 @@ def verify_md_readme(readme, config, section_sorting_dict):
     # we need to sanitize to remove the fenced code blocks. The reasoning here is that markdown2 is having issues
     # parsing the pygments style that we use with github.
     sanitized_html_content = re.sub(CODE_FENCE_REGEX, "", readme_content)
-    html_readme_content = markdown2.markdown(readme_content)
+    html_readme_content = markdown2.markdown(sanitized_html_content)
     html_soup = bs4.BeautifulSoup(html_readme_content, "html.parser")
 
     missed_patterns = find_missed_sections(html_soup, config.required_readme_sections)

--- a/packages/python-packages/doc-warden/warden/enforce_readme_content.py
+++ b/packages/python-packages/doc-warden/warden/enforce_readme_content.py
@@ -13,6 +13,7 @@ from docutils.writers.html4css1 import Writer,HTMLTranslator
 import logging
 
 README_PATTERNS = ['*/readme.md', '*/readme.rst', '*/README.md', '*/README.rst']
+CODE_FENCE_REGEX = r"```[\s\S]*?```"
 
 # entry point
 def verify_readme_content(config):
@@ -60,6 +61,10 @@ def verify_md_readme(readme, config, section_sorting_dict):
 
     with open(readme, 'r', encoding="utf-8") as f:
         readme_content = f.read()
+        
+    # we need to sanitize to remove the fenced code blocks. The reasoning here is that markdown2 is having issues
+    # parsing the pygments style that we use with github.
+    sanitized_html_content = re.sub(CODE_FENCE_REGEX, "", readme_content)
     html_readme_content = markdown2.markdown(readme_content)
     html_soup = bs4.BeautifulSoup(html_readme_content, "html.parser")
 

--- a/packages/python-packages/doc-warden/warden/version.py
+++ b/packages/python-packages/doc-warden/warden/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.6.0'
+VERSION = '0.6.1'


### PR DESCRIPTION
If we ever hit a case where we need to use the content of the code of those fences, we'll parse it separately.

If we DON'T remove code-fence blocks, the implicit hierarchy of the markdown document is broken by phantom h1 headers. Discovered this while enabling sub-header verification in .NET.

@Azure/azure-sdk-eng 