### PR TITLE
Generate lint error report and list them on console

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -153,8 +153,6 @@ class ApiView:
 
     def add_diagnostic(self, text, line_id):
         self.Diagnostics.append(Diagnostic(line_id, text))
-        # log diagnostic as error
-        logging.error(text)
 
 
     def add_member(self, name, id):

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
@@ -246,3 +246,19 @@ class ClassNode(NodeEntityBase):
             # Add punctuation between types
             if index < list_len - 1:
                 apiview.add_punctuation(",", False, True)
+
+
+    def print_errors(self):
+        has_error = False
+        # Check if atleast one error is present in child nodes
+        for c in self.child_nodes:
+            if hasattr(c, "errors") and c.errors:
+                has_error = True
+                break
+        if has_error:
+            print("-"*150)
+            print("class {}".format(self.full_name))
+            for c in self.child_nodes:
+                c.print_errors()
+
+

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -114,7 +114,11 @@ class TypeHintParser:
 
     def __init__(self, obj):
         self.obj = obj
-        self.code = inspect.getsource(obj)
+        try:
+            self.code = inspect.getsource(obj)
+        except:
+            self.code = None
+            logging.error("Failed to get source of object {}".format(obj))
 
     def find_return_type(self):
         """Returns return type is type hint is available

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_enum_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_enum_node.py
@@ -28,3 +28,9 @@ class EnumNode(NodeEntityBase):
             apiview.add_stringliteral(self.value)
         else:
             apiview.add_literal(str(self.value))
+
+    def print_errors(self):
+        if self.errors:
+            print("enum: {}".format(self.name))
+            for e in self.errors:
+                print("    {}".format(e))

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
@@ -106,3 +106,8 @@ class ModuleNode(NodeEntityBase):
                 )
                 navigation.add_child(child_nav)
             return navigation
+
+
+    def print_errors(self):
+        for c in self.child_nodes:
+            c.print_errors()

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_property_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_property_node.py
@@ -60,3 +60,10 @@ class PropertyNode(NodeEntityBase):
         if self.read_only:
             apiview.add_whitespace()
             apiview.add_literal("# Read-only")
+
+
+    def print_errors(self):
+        if self.errors:
+            print("property: {}".format(self.name))
+            for e in self.errors:
+                print("    {}".format(e))

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_variable_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_variable_node.py
@@ -35,3 +35,10 @@ class VariableNode(NodeEntityBase):
                 else apiview.add_literal
             )
             add_value(self.value)
+
+
+    def print_errors(self):
+        if self.errors:
+            print("{0}: {1}".format("ivar" if self.is_ivar else "cvar", self.name))
+            for e in self.errors:
+                print("    {}".format(e))


### PR DESCRIPTION
Changes:
1. Generate list error report to show in console
2. Ignore return type validation for dunder methods
3. Remove invalid type error for split argument "*"