### PR TITLE
Port serviceName New-TestResources fix

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -172,18 +172,19 @@ if ($TestApplicationId -and !$TestApplicationOid) {
     }
 }
 
+
+# If the ServiceDirectory is an absolute path use the last directory name
+# (e.g. D:\foo\bar\ -> bar)
+$serviceName = if (Split-Path -IsAbsolute  $ServiceDirectory) {
+    Split-Path -Leaf $ServiceDirectory
+} else {
+    $ServiceDirectory
+}
+
 # Format the resource group name based on resource group naming recommendations and limitations.
 $resourceGroupName = if ($CI) {
     $BaseName = 't' + (New-Guid).ToString('n').Substring(0, 16)
     Write-Verbose "Generated base name '$BaseName' for CI build"
-
-    # If the ServiceDirectory is an absolute path use the last directory name
-    # (e.g. D:\foo\bar\ -> bar)
-    $serviceName = if (Split-Path -IsAbsolute  $ServiceDirectory) {
-        Split-Path -Leaf $ServiceDirectory
-    } else {
-        $ServiceDirectory
-    }
 
     "rg-{0}-$BaseName" -f ($serviceName -replace '[\\\/:]', '-').Substring(0, [Math]::Min($serviceName.Length, 90 - $BaseName.Length - 4)).Trim('-')
 } else {


### PR DESCRIPTION
We use $serviceName for non-CI scenarios but it was set only on CI.