### PR TITLE
Check Enforcer: remove debug commands, update docs

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
@@ -35,18 +35,6 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
             switch (comment)
             {
-                case "/check-enforcer queued":
-                    await SetQueuedAsync(context.Client, repositoryId, sha, cancellationToken);
-                    break;
-
-                case "/check-enforcer inprogress":
-                    await SetInProgressAsync(context.Client, repositoryId, sha, cancellationToken);
-                    break;
-
-                case "/check-enforcer success":
-                    await SetSuccessAsync(context.Client, repositoryId, sha, cancellationToken);
-                    break;
-
                 case "/check-enforcer reset":
                     await CreateCheckAsync(context.Client, installationId, repositoryId, sha, true, cancellationToken);
                     break;

--- a/tools/check-enforcer/README.md
+++ b/tools/check-enforcer/README.md
@@ -34,6 +34,22 @@ enabled: false
 minimumCheckRuns: 2
 ```
 
+## PR Comment Commands
+
+Check Enforcer supports a limited number of commands which can by issued via PR comments. For example if Check Enforcer appears to be stuck you can add a comment as follows to reset the state of Check Enforcer on the PR:
+
+```
+/check-enforcer reset
+```
+
+Check Enforcer will revert to an "in-progress" state. You can then trigger Check Enforcer to re-evaluate the pull request using the following PR comment:
+
+```
+/check-enforcer evaluate
+```
+
+These are the only commands that Check Enforcer supports at this time.
+
 ## Need Help?
 
 Check Enforcer is built primarily for use by the Azure SDK Engineering Systems teams for use within their mono-repositories. But we are happy for others to pick it up and start using it. If you have any issues feel free to log an issue on this GitHub repository and we'll do our best to help you out.


### PR DESCRIPTION
Now that Check Enforcer is live and appears to be behaving itself we can remove the debug commands. I also added a section to the README that outlines the updated commands.