### PR TITLE
Make Remove-TestResource invoke custom script prior to deletion of the resource group

### DIFF
--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -38,6 +38,9 @@ param (
     [Parameter(ParameterSetName = 'Default+Provisioner', Mandatory = $true)]
     [Parameter(ParameterSetName = 'ResourceGroup+Provisioner', Mandatory = $true)]
     [string] $ProvisionerApplicationSecret,
+    
+    [Parameter(Mandatory = $false)]
+    [string] $ServiceDirectory,
 
     [Parameter()]
     [ValidateSet('AzureCloud', 'AzureUSGovernment', 'AzureChinaCloud')]
@@ -116,6 +119,13 @@ if (!$ResourceGroupName) {
     $ResourceGroupName = "rg-$BaseName"
 }
 
+$root = [System.IO.Path]::Combine("$PSScriptRoot/../../../sdk", $ServiceDirectory) | Resolve-Path
+$preRemovalScript = Join-Path -Path $root -ChildPath 'remove-test-resources-pre.ps1'
+if (Test-Path $preRemovalScript) {
+    Log "Invoking pre resource removal script '$preRemovalScript'"
+    &$preRemovalScript -ResourceGroupName $ResourceGroupName @PSBoundParameters
+}
+
 Log "Deleting resource group '$ResourceGroupName'"
 if (Retry { Remove-AzResourceGroup -Name "$ResourceGroupName" -Force:$Force }) {
     Write-Verbose "Successfully deleted resource group '$ResourceGroupName'"
@@ -156,6 +166,10 @@ A service principal ID to provision test resources when a provisioner is specifi
 
 .PARAMETER ProvisionerApplicationSecret
 A service principal secret (password) to provision test resources when a provisioner is specified.
+
+.PARAMETER ServiceDirectory
+A directory under 'sdk' in the repository root - optionally with subdirectories
+specified - in which to discover pre removal script named 'remove-test-resources-pre.json'.
 
 .PARAMETER Environment
 Name of the cloud environment. The default is the Azure Public Cloud

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -119,11 +119,13 @@ if (!$ResourceGroupName) {
     $ResourceGroupName = "rg-$BaseName"
 }
 
-$root = [System.IO.Path]::Combine("$PSScriptRoot/../../../sdk", $ServiceDirectory) | Resolve-Path
-$preRemovalScript = Join-Path -Path $root -ChildPath 'remove-test-resources-pre.ps1'
-if (Test-Path $preRemovalScript) {
-    Log "Invoking pre resource removal script '$preRemovalScript'"
-    &$preRemovalScript -ResourceGroupName $ResourceGroupName @PSBoundParameters
+if (![string]::IsNullOrWhiteSpace($ServiceDirectory)) {
+    $root = [System.IO.Path]::Combine("$PSScriptRoot/../../../sdk", $ServiceDirectory) | Resolve-Path
+    $preRemovalScript = Join-Path -Path $root -ChildPath 'remove-test-resources-pre.ps1'
+    if (Test-Path $preRemovalScript) {
+        Log "Invoking pre resource removal script '$preRemovalScript'"
+        &$preRemovalScript -ResourceGroupName $ResourceGroupName @PSBoundParameters
+    }
 }
 
 Log "Deleting resource group '$ResourceGroupName'"

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -39,7 +39,7 @@ param (
     [Parameter(ParameterSetName = 'ResourceGroup+Provisioner', Mandatory = $true)]
     [string] $ProvisionerApplicationSecret,
     
-    [Parameter(Mandatory = $false)]
+    [Parameter()]
     [string] $ServiceDirectory,
 
     [Parameter()]

--- a/eng/common/TestResources/Remove-TestResources.ps1.md
+++ b/eng/common/TestResources/Remove-TestResources.ps1.md
@@ -169,6 +169,22 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ServiceDirectory
+A directory under 'sdk' in the repository root - optionally with subdirectories
+specified - specified - in which to discover pre removal script named 'remove-test-resources-pre.json'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -Environment
 Name of the cloud environment.
 The default is the Azure Public Cloud

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -9,7 +9,7 @@
 
 parameters:
   ServiceDirectory: ''
-  
+
 steps:
   - pwsh: >
       eng/common/TestResources/Remove-TestResources.ps1
@@ -18,7 +18,7 @@ steps:
       -SubscriptionId '$(azure-subscription-id)'
       -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id)'
       -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret)'
-      -ServiceDirectory ${{ parameters.ServiceDirectory }}
+      -ServiceDirectory '${{ parameters.ServiceDirectory }}'
       -Environment 'AzureCloud'
       -Force
       -Verbose
@@ -33,7 +33,7 @@ steps:
       -SubscriptionId '$(azure-subscription-id-gov)'
       -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id-gov)'
       -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret-gov)'
-      -ServiceDirectory ${{ parameters.ServiceDirectory }}
+      -ServiceDirectory '${{ parameters.ServiceDirectory }}'
       -Environment 'AzureUSGovernment'
       -Force
       -Verbose
@@ -48,7 +48,7 @@ steps:
       -SubscriptionId '$(azure-subscription-id-cn)'
       -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id-cn)'
       -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret-cn)'
-      -ServiceDirectory ${{ parameters.ServiceDirectory }}
+      -ServiceDirectory '${{ parameters.ServiceDirectory }}'
       -Environment 'AzureChinaCloud'
       -Force
       -Verbose

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -7,6 +7,9 @@
 # Assumes steps in deploy-test-resources.yml was run previously. Requires
 # environment variable: AZURE_RESOURCEGROUP_NAME and Az PowerShell module
 
+parameters:
+  ServiceDirectory: ''
+  
 steps:
   - pwsh: >
       eng/common/TestResources/Remove-TestResources.ps1
@@ -15,6 +18,7 @@ steps:
       -SubscriptionId '$(azure-subscription-id)'
       -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id)'
       -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret)'
+      -ServiceDirectory ${{ parameters.ServiceDirectory }}
       -Environment 'AzureCloud'
       -Force
       -Verbose
@@ -29,6 +33,7 @@ steps:
       -SubscriptionId '$(azure-subscription-id-gov)'
       -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id-gov)'
       -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret-gov)'
+      -ServiceDirectory ${{ parameters.ServiceDirectory }}
       -Environment 'AzureUSGovernment'
       -Force
       -Verbose
@@ -43,6 +48,7 @@ steps:
       -SubscriptionId '$(azure-subscription-id-cn)'
       -ProvisionerApplicationId '$(aad-azure-sdk-test-client-id-cn)'
       -ProvisionerApplicationSecret '$(aad-azure-sdk-test-client-secret-cn)'
+      -ServiceDirectory ${{ parameters.ServiceDirectory }}
       -Environment 'AzureChinaCloud'
       -Force
       -Verbose


### PR DESCRIPTION
Since there are certain actions that might need to be taken prior to deletion of test resources, we will invoke custom scripts in the service directory named : remove-test-resources-pre.ps1

