### PR TITLE
Add comment when updating pipelines

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -88,6 +88,7 @@ namespace PipelineGenerator.Conventions
                 {
                     Logger.LogInformation("Convention had changes, updating '{0}' definition.", definitionName);
                     var buildClient = await Context.GetBuildHttpClientAsync(cancellationToken);
+                    definition.Comment = "Updated by pipeline generation tool";
                     definition = await buildClient.UpdateDefinitionAsync(
                         definition: definition,
                         cancellationToken: cancellationToken


### PR DESCRIPTION
Without adding an explicit comment it basically keeps
the last comment which is a little misleading when looking
at the history.