### PR TITLE
Add pipeline generation template for building one pipeline

### DIFF
--- a/eng/pipelines/pipeline-generation-single.yml
+++ b/eng/pipelines/pipeline-generation-single.yml
@@ -1,0 +1,48 @@
+# Variables defined in pipeline definition
+# DevOpsProject - public, internal
+# Branch - master
+# Prefix - net, python, js, java, <lang>-pr
+# RepositoryName - azure-sdk-for-<lang>
+# DevOpsPath - $(Prefix)\pr
+# ServiceDirectory - "", keyvault, storage, etc.
+# PipelineConvention - ci, up, tests
+# AdditionalOptions - potentially add variablegroups via "--variablegroup x"
+
+pr: none
+
+trigger: none
+
+variables:
+  skipComponentGovernanceDetection: true
+  DevOpsOrg: https://dev.azure.com/azure-sdk
+  PathFilter: $(Pipeline.Workspace)/$(RepositoryName)/sdk/$(ServiceDirectory)
+
+jobs:
+- job: GeneratePipeline
+  pool:
+    vmImage: 'windows-2019'
+  steps:
+  - checkout: none
+  - template: templates/steps/install-pipeline-generation.yml
+  - script: |
+      git clone --filter=blob:none --branch $(Branch) https://$(azuresdk-github-pat)@github.com/azure/$(RepositoryName) $(Pipeline.Workspace)/$(RepositoryName)
+    displayName: 'Clone repository: $(RepositoryName)'
+  - script: >
+      pipeline-generator
+      --organization $(DevOpsOrg)
+      --project $(DevOpsProject)
+      --prefix $(Prefix)
+      --devopspath "$(DevOpsPath)"
+      --path $(PathFilter)
+      --endpoint Azure
+      --repository Azure/$(RepositoryName)
+      --convention $(PipelineConvention)
+      --agentpool Hosted
+      --branch refs/heads/$(Branch)
+      --patvar PATVAR
+      --debug
+      $(AdditionalOptions)
+    displayName: 'Generate pipeline'
+    env:
+      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -4,8 +4,6 @@ trigger: none
 
 variables:
   skipComponentGovernanceDetection: true
-  PipelineGeneratorToolVersion: 1.0.2-dev.20200502.1
-  AzureSdkPublicFeed: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk/nuget/v3/index.json
 
 jobs:
 - job: GeneratePipelines
@@ -65,9 +63,7 @@ jobs:
         PublicOptions: ''
         InternalOptions: '--variablegroup 58 --variablegroup 76'
   steps:
-  - script: |
-      dotnet tool install Azure.Sdk.Tools.PipelineGenerator --version $(PipelineGeneratorToolVersion) --add-source $(AzureSdkPublicFeed) --global
-    displayName: 'Install pipeline generator tool'
+  - template: templates/steps/install-pipeline-generation.yml
   - script: |
       git clone https://github.com/azure/$(RepositoryName) $(Pipeline.Workspace)/$(RepositoryName)
       cd $(Pipeline.Workspace)/$(RepositoryName)

--- a/eng/pipelines/templates/steps/install-pipeline-generation.yml
+++ b/eng/pipelines/templates/steps/install-pipeline-generation.yml
@@ -1,0 +1,8 @@
+steps:
+  - script: >
+      dotnet tool install
+      Azure.Sdk.Tools.PipelineGenerator
+      --version 1.0.2-dev.20200502.1
+      --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk/nuget/v3/index.json
+      --global
+    displayName: 'Install pipeline generator tool'


### PR DESCRIPTION
PTAL @mitchdenny @danieljurek 

I've setup the pipeline that wraps this at https://dev.azure.com/azure-sdk/internal/_build?definitionId=1702&_a=summary. I used to to setup the tests pipeline for the iot team earlier and we can use this to setup other one-off pipelines and perhaps even add in the logic to create the initial yml files for new pipelines also. 