### PR TITLE
Fix remove-test-resources script to provide sufficient parameters to the pre-removal script depending on the input parameters.

### DIFF
--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -124,7 +124,13 @@ if (![string]::IsNullOrWhiteSpace($ServiceDirectory)) {
     $preRemovalScript = Join-Path -Path $root -ChildPath 'remove-test-resources-pre.ps1'
     if (Test-Path $preRemovalScript) {
         Log "Invoking pre resource removal script '$preRemovalScript'"
-        &$preRemovalScript -ResourceGroupName $ResourceGroupName @PSBoundParameters
+        if ($BaseName){
+            &$preRemovalScript -ResourceGroupName $ResourceGroupName @PSBoundParameters
+        }
+        else {
+            &$preRemovalScript @PSBoundParameters
+        }
+        
     }
 }
 

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -117,7 +117,6 @@ if ($ProvisionerApplicationId) {
 if (!$ResourceGroupName) {
     # Format the resource group name like in New-TestResources.ps1.
     $ResourceGroupName = "rg-$BaseName"
-    $PSBoundParameters.Add("ResourceGroupName", $ResourceGroupName);
 }
 
 
@@ -126,6 +125,11 @@ if (![string]::IsNullOrWhiteSpace($ServiceDirectory)) {
     $preRemovalScript = Join-Path -Path $root -ChildPath 'remove-test-resources-pre.ps1'
     if (Test-Path $preRemovalScript) {
         Log "Invoking pre resource removal script '$preRemovalScript'"
+
+        if ($PSCmdlet.ParameterSetName.StartsWith('ResourceGroup')) {
+            $PSBoundParameters.Add('ResourceGroupName', $ResourceGroupName);
+        }
+
         &$preRemovalScript @PSBoundParameters
     }
 }

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -117,20 +117,16 @@ if ($ProvisionerApplicationId) {
 if (!$ResourceGroupName) {
     # Format the resource group name like in New-TestResources.ps1.
     $ResourceGroupName = "rg-$BaseName"
+    $PSBoundParameters.Add("ResourceGroupName", $ResourceGroupName);
 }
+
 
 if (![string]::IsNullOrWhiteSpace($ServiceDirectory)) {
     $root = [System.IO.Path]::Combine("$PSScriptRoot/../../../sdk", $ServiceDirectory) | Resolve-Path
     $preRemovalScript = Join-Path -Path $root -ChildPath 'remove-test-resources-pre.ps1'
     if (Test-Path $preRemovalScript) {
         Log "Invoking pre resource removal script '$preRemovalScript'"
-        if ($BaseName){
-            &$preRemovalScript -ResourceGroupName $ResourceGroupName @PSBoundParameters
-        }
-        else {
-            &$preRemovalScript @PSBoundParameters
-        }
-        
+        &$preRemovalScript @PSBoundParameters        
     }
 }
 

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -119,7 +119,6 @@ if (!$ResourceGroupName) {
     $ResourceGroupName = "rg-$BaseName"
 }
 
-
 if (![string]::IsNullOrWhiteSpace($ServiceDirectory)) {
     $root = [System.IO.Path]::Combine("$PSScriptRoot/../../../sdk", $ServiceDirectory) | Resolve-Path
     $preRemovalScript = Join-Path -Path $root -ChildPath 'remove-test-resources-pre.ps1'

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -126,7 +126,7 @@ if (![string]::IsNullOrWhiteSpace($ServiceDirectory)) {
     $preRemovalScript = Join-Path -Path $root -ChildPath 'remove-test-resources-pre.ps1'
     if (Test-Path $preRemovalScript) {
         Log "Invoking pre resource removal script '$preRemovalScript'"
-        &$preRemovalScript @PSBoundParameters        
+        &$preRemovalScript @PSBoundParameters
     }
 }
 


### PR DESCRIPTION
If the -ResourceGroupName parameter is provided, we can't specify it when we pass all parameters to the sub-scripts so we will only do that if the resource group name is a calculated parameter and not when it has been specified in the input