### PR TITLE
Output script name and args for debugging purposes

### DIFF
--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -41,7 +41,7 @@ param(
   $PRBody = $PRTitle
 )
 
-Write-Host $MyInvocation.Line
+Write-Host "> $PSCommandPath $args"
 
 $query = "state=open&head=${PROwner}:${PRBranch}&base=${BaseBranch}"
 

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -10,7 +10,7 @@ param (
   $UploadLatest=1
 )
 
-Write-Host $MyInvocation.Line
+Write-Host "> $PSCommandPath $args"
 
 $Language = $Language.ToLower()
 

--- a/eng/common/scripts/copy-readmes-to-docs.ps1
+++ b/eng/common/scripts/copy-readmes-to-docs.ps1
@@ -9,7 +9,9 @@ param (
   [String]$TargetServices
 )
 
-$PACKAGE_README_REGEX = ".*[\/\\]sdk[\\\/][^\/\\]+[\\\/][^\/\\]+[\/\\]README\.md" 
+Write-Host "> $PSCommandPath $args"
+
+$PACKAGE_README_REGEX = ".*[\/\\]sdk[\\\/][^\/\\]+[\\\/][^\/\\]+[\/\\]README\.md"
 
 Write-Host "repo is $CodeRepo"
 
@@ -52,10 +54,10 @@ else {
 
 foreach($service in $selectedServices){
   $readmePath = Join-Path -Path $CodeRepo  -ChildPath "sdk/$service"
-  Write-Host "Examining: $readmePath" 
+  Write-Host "Examining: $readmePath"
 
   $libraries = $metadataResponse | Where-Object { $_.RepoPath -eq $service }
-  
+
   foreach($library in $libraries){
 
     $package = $library.Package

--- a/eng/common/scripts/create-tags-and-git-release.ps1
+++ b/eng/common/scripts/create-tags-and-git-release.ps1
@@ -18,7 +18,7 @@ param (
   [switch]$forceCreate = $false
 )
 
-Write-Host  $MyInvocation.Line
+Write-Host "> $PSCommandPath $args"
 
 $VERSION_REGEX = "(?<major>\d+)(\.(?<minor>\d+))?(\.(?<patch>\d+))?((?<pre>[^0-9][^\s]+))?"
 $SDIST_PACKAGE_REGEX = "^(?<package>.*)\-(?<versionstring>$VERSION_REGEX$)"

--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -28,7 +28,7 @@ param(
     [string] $PushArgs = ""
 )
 
-Write-Host $MyInvocation.Line
+Write-Host "> $PSCommandPath $args"
 
 # This is necessay because of the janky git command output writing to stderr.
 # Without explicitly setting the ErrorActionPreference to continue the script


### PR DESCRIPTION
Try #2 as the first attempt https://github.com/Azure/azure-sdk-tools/pull/481 didn't work in all cases. In particular it doesn't work when you invoke the powershell script across multiple lines as `$myInvocation.Line` only gives you the first line of context. Why? I have no idea but this new approach seems to work from my limited testing. I guess time will tell if there are any other weird issues.

cc @Azure/azure-sdk-eng 