### PR TITLE
Fix display issue in complex types and remove invalid lint errors for…

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -13,7 +13,7 @@ from ._diagnostic import Diagnostic
 JSON_FIELDS = ["Name", "Version", "VersionString", "Navigation", "Tokens", "Diagnostics"]
 
 HEADER_TEXT = "# Package is parsed using api-stub-generator(version:{})".format(VERSION)
-COMPLEX_DATA_TYPE_PATTERN = re.compile("([a-zA-Z]+)(\[|\()[^\]\)]+(\]|\))")
+COMPLEX_DATA_TYPE_PATTERN = re.compile("([\w.]+)(\[|\()[^\]\)]+(\]|\))")
 
 # Lint warnings
 SOURCE_LINK_NOT_AVAILABLE = "Source definition link is not available for [{0}]. Please check and ensure type is fully qualified name in docstring"
@@ -104,6 +104,7 @@ class ApiView:
             self.add_keyword(prefix_type)
             return
 
+        logging.debug("Processing type {0} and prefix {1}".format(type_name, prefix_type))
         prefix_len = len(prefix_type)
         type_names = type_name[prefix_len + 1 : -1]
         if type_names:
@@ -125,6 +126,7 @@ class ApiView:
         if not type_name:
             return
 
+        logging.debug("Processing type {}".format(type_name))
         # Check if type is multi value types like Union, Dict, list etc
         # Those types needs to be recursively processed
         multi_types = re.search(COMPLEX_DATA_TYPE_PATTERN,type_name)

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -11,7 +11,7 @@ find_arg_and_type_regex = (
 )
 find_single_type_regex = "(?<!:):{0}\s?{1}:[\s]*([\S]+)(?!:)"
 find_union_type_regex = (
-    "(?<!:):{0}\s?{1}:[\s]*([\w]*((\[[^\[\]]+\])|(\([^\(\)]+\))))(?!:)"
+    "(?<!:):{0}\s?{1}:[\s]*([\w.]*((\[[^\n]+\])|(\([^\n]+\))))(?!:)"
 )
 find_multi_type_regex = "(?<!:):({0})\s?{1}:([\s]*([\S]+)(\s+or\s+[\S]+)+)(?!:)"
 find_docstring_return_type = "(?<!:):rtype\s?:\s+([^:\n]+)(?!:)"

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -98,6 +98,9 @@ class FunctionNode(NodeEntityBase):
         # Find signature to find positional args and return type
         sig = inspect.signature(self.obj)
         params = sig.parameters
+        # Add all keyword only args here temporarily until docstring is parsed
+        # This is to habdle the scenario is keyword arg typehint (py2 style is present in signature itself)
+        self.kw_args = []
         for argname in params:
             arg = ArgType(argname, get_qualified_name(params[argname].annotation), "", self)
             # set default value if available
@@ -106,7 +109,11 @@ class FunctionNode(NodeEntityBase):
             # Store handle to kwarg object to replace it later
             if params[argname].kind == Parameter.VAR_KEYWORD:
                 arg.argname = KW_ARG_NAME
-            self.args.append(arg)
+
+            if params[argname].kind == Parameter.KEYWORD_ONLY:
+                self.kw_args.append(arg)
+            else:
+                self.args.append(arg)
 
         if sig.return_annotation:
             self.return_type = get_qualified_name(sig.return_annotation)
@@ -115,10 +122,36 @@ class FunctionNode(NodeEntityBase):
         self._parse_docstring()
         # parse type hints
         self._parse_typehint()
+        self._copy_kw_args()
+
         if not self.return_type and is_typehint_mandatory(self.name):
             self.errors.append("Return type is missing in both typehint and docstring")
         # Validate return type
         self._validate_pageable_api()
+
+
+    def _copy_kw_args(self):
+        # Copy kw only args from signature and docstring
+        kwargs = [x for x in self.args if x.argname == KW_ARG_NAME]
+        # add keyword args
+        if self.kw_args:
+            # Add separator to differentiate pos_arg and keyword args
+            self.args.append(ArgType("*"))
+            self.kw_args.sort(key=operator.attrgetter("argname"))
+            # Add parsed keyword args to function signature after updating current function node as parent in arg
+            for arg in self.kw_args:
+                arg.set_function_node(self)
+                self.args.append(arg)
+
+            # remove arg with name "**kwarg and add at the end"
+            if kwargs:
+                kw_arg = kwargs[0]
+                self.args.remove(kw_arg)
+                self.args.append(kw_arg)
+
+        # API must have **kwargs for non async methods. Flag it as an error if it is missing for public API
+        if not kwargs and is_kwarg_mandatory(self.name):
+            self.errors.append("Keyword arg (**kwargs) is missing in method {}".format(self.name))
 
 
     def _parse_docstring(self):
@@ -155,26 +188,7 @@ class FunctionNode(NodeEntityBase):
                     pos_arg.argname, pos_arg.argtype
                 )
 
-            kwargs = [x for x in self.args if x.argname == KW_ARG_NAME]
-            # add keyword args
-            if parsed_docstring.kw_args:
-                # Add separator to differentiate pos_arg and keyword args
-                self.args.append(ArgType("*"))
-                parsed_docstring.kw_args.sort(key=operator.attrgetter("argname"))
-                # Add parsed keyword args to function signature after updating current function node as parent in arg
-                for arg in parsed_docstring.kw_args:
-                    arg.set_function_node(self)
-                    self.args.append(arg)
-
-                # remove arg with name "**kwarg and add at the end"
-                if kwargs:
-                    kw_arg = kwargs[0]
-                    self.args.remove(kw_arg)
-                    self.args.append(kw_arg)
-
-            # API must have **kwargs. Flag it as an error if it is missing for public API
-            if not kwargs and is_kwarg_mandatory(self.name):
-                self.errors.append("Keyword arg (**kwargs) is missing in method {}".format(self.name))
+            self.kw_args.extend(parsed_docstring.kw_args)            
 
 
     def _parse_typehint(self):

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -99,7 +99,7 @@ class FunctionNode(NodeEntityBase):
         sig = inspect.signature(self.obj)
         params = sig.parameters
         # Add all keyword only args here temporarily until docstring is parsed
-        # This is to habdle the scenario is keyword arg typehint (py2 style is present in signature itself)
+        # This is to handle the scenario is keyword arg typehint (py3 style is present in signature itself)
         self.kw_args = []
         for argname in params:
             arg = ArgType(argname, get_qualified_name(params[argname].annotation), "", self)

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -56,6 +56,17 @@ docstring_param_type1 = """
 ~azure.dummy.datastream
 """
 
+docstring_param_typing_optional = """
+:param group: Optional group to check if user exists in.
+:type group: typing.Optional[str]
+"""
+
+docstring_param_nested_union = """
+:param dummyarg: Optional group to check if user exists in.
+:type dummyarg: typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]
+"""
+
+
 class TestDocStringParser:
 
     def _test_return_type(self, docstring, expected):
@@ -105,3 +116,9 @@ class TestDocStringParser:
     def test_param_or_type(self):
         self._test_variable_type(docstring_param_type1, "data", "str or ~azure.dummy.datastream")
         self._test_variable_type(docstring_param_type1, "pipeline", None)
+
+    def test_type_typing_optional(self):
+        self._test_variable_type(docstring_param_typing_optional, "group", "typing.Optional[str]")
+
+    def test_nested_union_type(self):
+        self._test_variable_type(docstring_param_nested_union, "dummyarg", "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]")


### PR DESCRIPTION
1. Fix  parse and display issues for Union and other complex types
2. Disable typehint lint check for asyn methods
3. Version update to 0.1.1
4. Show separator between pos arg and kw arg when kw only arg is added in signature itself.