### PR TITLE
Webhook router payload validation

### DIFF
--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Azure.Sdk.Tools.WebhookRouter.csproj
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Azure.Sdk.Tools.WebhookRouter.csproj
@@ -7,6 +7,7 @@
     <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.1.1" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.0.1" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
   </ItemGroup>

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Functions/RouteWebhookFunction.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Functions/RouteWebhookFunction.cs
@@ -28,10 +28,7 @@ namespace Azure.Sdk.Tools.WebhookRouter.Functions
             ILogger log,
             Guid route)
         {
-            var rule = await router.GetRuleAsync(route);
-            var payload = await rule.ParseRequestAsync(req);
-            await router.RouteAsync(rule, payload);
-            
+            await router.RouteAsync(req);            
             return new OkResult();
         }
     }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Functions/RouteWebhookFunction.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Functions/RouteWebhookFunction.cs
@@ -28,7 +28,7 @@ namespace Azure.Sdk.Tools.WebhookRouter.Functions
             ILogger log,
             Guid route)
         {
-            await router.RouteAsync(req);            
+            await router.RouteAsync(route, req);            
             return new OkResult();
         }
     }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Integrations/GitHub/GitHubWebhookSignatureValidator.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Integrations/GitHub/GitHubWebhookSignatureValidator.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+
+namespace Azure.Sdk.Tools.WebhookRouter.Integrations.GitHub
+{
+    public static class GitHubWebhookSignatureValidator
+    {
+        public static bool IsValid(byte[] body, string signature, string secret)
+        {
+            var key = Encoding.UTF8.GetBytes(secret);
+            var sha1 = new HMACSHA1(key);
+
+            var digest = sha1.ComputeHash(body);
+            var hex = BitConverter.ToString(digest).Replace("-", "").ToLower();
+            var generatedSignature = $"sha1={hex}";
+
+            return signature == generatedSignature;
+        }
+    }
+}

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Integrations/GitHub/GitHubWebhookSignatureValidator.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Integrations/GitHub/GitHubWebhookSignatureValidator.cs
@@ -9,6 +9,8 @@ namespace Azure.Sdk.Tools.WebhookRouter.Integrations.GitHub
 {
     public static class GitHubWebhookSignatureValidator
     {
+        public const string GitHubWebhookSignatureHeader = "X-Hub-Signature";
+
         public static bool IsValid(byte[] body, string signature, string secret)
         {
             var key = Encoding.UTF8.GetBytes(secret);

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Integrations/GitHub/GitHubWebhookSignatureValidator.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Integrations/GitHub/GitHubWebhookSignatureValidator.cs
@@ -4,7 +4,6 @@ using System.IO;
 using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
-using Azure.Sdk.Tools.CheckEnforcer.Configuration;
 
 namespace Azure.Sdk.Tools.WebhookRouter.Integrations.GitHub
 {

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/AzureDevOpsRule.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/AzureDevOpsRule.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.WebhookRouter.Routing
+{
+    public class AzureDevOpsRule : Rule
+    {
+        public AzureDevOpsRule(Guid route, string eventHubsNamespace, string eventHubName) : base(route, eventHubsNamespace, eventHubName)
+        {
+        }
+    }
+}

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/GenericRule.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/GenericRule.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.WebhookRouter.Routing
+{
+    public class GenericRule : Rule
+    {
+        public GenericRule(Guid route, string eventHubsNamespace, string eventHubName) : base(route, eventHubsNamespace, eventHubName)
+        {
+        }
+    }
+}

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/GitHubRule.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/GitHubRule.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.WebhookRouter.Routing
+{
+    public class GitHubRule : Rule
+    {
+        public GitHubRule(Guid route, string eventHubsNamespace, string eventHubName, string webhookSecret) : base(route, eventHubsNamespace, eventHubName)
+        {
+            this.WebhookSecret = webhookSecret;
+        }
+
+        public string WebhookSecret { get; private set; }
+    }
+}

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/IRouter.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/IRouter.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Http;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading.Tasks;
@@ -7,7 +8,6 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
 {
     public interface IRouter
     {
-        Task RouteAsync(Rule rule, Payload payload);
-        Task<Rule> GetRuleAsync(Guid routeId);
+        Task RouteAsync(Guid route, HttpRequest request);
     }
 }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Payload.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Payload.cs
@@ -10,10 +10,10 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
 {
     public class Payload
     {
-        public Payload(IDictionary<string, StringValues> headers, JsonElement content)
+        public Payload(IDictionary<string, StringValues> headers, byte[] content)
         {
             Headers = headers;
-            Content = content;
+            Content = Convert.ToBase64String(content);
         }
 
         [JsonPropertyName("format")]
@@ -23,6 +23,6 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
         public IDictionary<string, StringValues> Headers { get; private set; }
 
         [JsonPropertyName("content")]
-        public JsonElement Content { get; private set; }
+        public string Content { get; private set; }
     }
 }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/PayloadType.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/PayloadType.cs
@@ -6,6 +6,8 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
 {
     public enum PayloadType
     {
-        Raw
+        GitHub,
+        AzureDevOps,
+        Generic
     }
 }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Router.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Router.cs
@@ -100,9 +100,5 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
             batch.TryAdd(@event);
             await producer.SendAsync(batch);
         }
-
-        public async Task RouteAsync(Rule rule, Payload payload)
-        {
-        }
     }
 }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Router.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Router.cs
@@ -2,10 +2,13 @@
 using Azure.Identity;
 using Azure.Messaging.EventHubs;
 using Azure.Messaging.EventHubs.Producer;
+using Azure.Sdk.Tools.WebhookRouter.Integrations.GitHub;
+using Azure.Security.KeyVault.Secrets;
 using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -14,12 +17,34 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
 {
     public class Router : IRouter
     {
+        private Uri GetSecretClientUri()
+        {
+            var websiteResourceGroupEnvironmentVariable = Environment.GetEnvironmentVariable("WEBSITE_RESOURCE_GROUP");
+            var uri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.vault.azure.net/");
+            return uri;
+        }
 
         private Uri GetConfigurationUri()
         {
             var websiteResourceGroupEnvironmentVariable = Environment.GetEnvironmentVariable("WEBSITE_RESOURCE_GROUP");
-            var uri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.azconfig.io");
+            var uri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.azconfig.io/");
             return uri;
+        }
+
+        private SecretClient GetSecretClient()
+        {
+            var uri = GetSecretClientUri();
+            var credential = new DefaultAzureCredential();
+            var client = new SecretClient(uri, credential);
+            return client;
+        }
+
+        private async Task<string> GetSecretAsync(string secretName)
+        {
+            var client = GetSecretClient();
+            var response = await client.GetSecretAsync(secretName);
+            var secret = response.Value.Value; // Urgh!
+            return secret;
         }
 
         private ConfigurationClient GetConfigurationClient()
@@ -67,17 +92,54 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
         private async Task<Rule> GetRuleAsync(Guid route)
         {
             var settings = await GetSettingsAsync(route);
-            var rule = new Rule(route, settings);
+
+            var payloadType = (PayloadType)Enum.Parse(typeof(PayloadType), settings["payload-type"], true);
+            var eventHubsNamespace = settings["eventhubs-namespace"];
+            var eventHubName = settings["eventhub-name"];
+
+            Rule rule = payloadType switch
+            {
+                PayloadType.GitHub => new GitHubRule(route, eventHubsNamespace, eventHubName, settings["github-webhook-secret"]),
+                PayloadType.AzureDevOps => new AzureDevOpsRule(route, eventHubsNamespace, eventHubName),
+                _ => new GenericRule(route, eventHubsNamespace, eventHubName)
+            };
+
             return rule;
         }
 
-        private async Task<Payload> CreateAndValidatePayloadAsync(Rule rule, HttpRequest request)
+        private async Task<byte[]> ReadAndValidateContentFromGitHubAsync(GitHubRule rule, HttpRequest request)
+        {
+            var payloadContent = await ReadAndValidateContentFromGenericAsync(rule, request);
+
+            var secret = await GetSecretAsync(rule.WebhookSecret);
+            var signature = request.Headers[GitHubWebhookSignatureValidator.GitHubWebhookSignatureHeader];
+            bool isValid = GitHubWebhookSignatureValidator.IsValid(payloadContent, signature, secret);
+
+            return payloadContent;
+        }
+
+        private async Task<byte[]> ReadAndValidateContentFromAzureDevOpsAsync(AzureDevOpsRule rule, HttpRequest request)
+        {
+            var payloadContent = await ReadAndValidateContentFromGenericAsync(rule, request);
+            return payloadContent;
+        }
+
+        private async Task<byte[]> ReadAndValidateContentFromGenericAsync(Rule rule, HttpRequest request)
         {
             using var stream = new MemoryStream();
             await request.Body.CopyToAsync(stream);
             var payloadContent = stream.ToArray();
+            return payloadContent;
+        }
 
-            // TODO: Payload validation goes here.
+        private async Task<Payload> CreateAndValidatePayloadAsync(Rule rule, HttpRequest request)
+        {
+            var payloadContent = rule switch
+            {
+                GitHubRule gitHubRule => await ReadAndValidateContentFromGitHubAsync(gitHubRule, request),
+                AzureDevOpsRule azureDevopsRule => await ReadAndValidateContentFromAzureDevOpsAsync(azureDevopsRule, request),
+                _ => await ReadAndValidateContentFromGenericAsync(rule, request)
+            };
 
             var payload = new Payload(request.Headers, payloadContent);
             return payload;

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Rule.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Rule.cs
@@ -8,20 +8,17 @@ using System.Threading.Tasks;
 
 namespace Azure.Sdk.Tools.WebhookRouter.Routing
 {
-    public class Rule
+    public abstract class Rule
     {
-        public Rule(Guid route, Dictionary<string, string> settings)
+        public Rule(Guid route, string eventHubsNamespace, string eventHubName)
         {
-            this.route = route;
-            this.settings = settings;
+            this.Route = route;
+            this.EventHubsNamespace = eventHubsNamespace;
+            this.EventHubName = eventHubName;
         }
 
-        private Guid route;
-        private Dictionary<string, string> settings;
-
-        public Guid Route => route;
-        public string EventHubsNamespace => settings["eventhubs-namespace"];
-        public string EventHubName => settings["eventhub-name"];
-        public PayloadType PayloadType => (PayloadType)Enum.Parse(typeof(PayloadType), settings["payload-type"]);
+        public Guid Route { get; private set; }
+        public string EventHubsNamespace { get; private set; }
+        public string EventHubName { get; private set; }
     }
 }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Rule.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Rule.cs
@@ -23,12 +23,5 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
         public string EventHubsNamespace => settings["eventhubs-namespace"];
         public string EventHubName => settings["eventhub-name"];
         public PayloadType PayloadType => (PayloadType)Enum.Parse(typeof(PayloadType), settings["payload-type"]);
-
-        public async Task<Payload> ParseRequestAsync(HttpRequest request)
-        {
-            var body = await JsonDocument.ParseAsync(request.Body);
-            var payload = new Payload(request.Headers, body.RootElement);
-            return payload;
-        }
     }
 }


### PR DESCRIPTION
This PR adds payload validation (for GitHub webhooks) in the Webhook Router. It adds a configuration value to the app config store which specifies the secret in KeyVault. The secret is then fetched and used to validate the signature header that GitHub adds to the webhook payload.

There is a stub for AzureDevOps validation as well but at the moment it just passes through.