### PR TITLE
Fix the logic for removal script

### DIFF
--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -125,7 +125,7 @@ if (![string]::IsNullOrWhiteSpace($ServiceDirectory)) {
     if (Test-Path $preRemovalScript) {
         Log "Invoking pre resource removal script '$preRemovalScript'"
 
-        if ($PSCmdlet.ParameterSetName.StartsWith('ResourceGroup')) {
+        if (!$PSCmdlet.ParameterSetName.StartsWith('ResourceGroup')) {
             $PSBoundParameters.Add('ResourceGroupName', $ResourceGroupName);
         }
 


### PR DESCRIPTION
This fixes a bug where if you have provided a resource group name in your inputs, it will try to add it again whereas it should do the opposite. 
This only affects services that are using a pre-removal script (as of today only Azure IoT)