### PR TITLE
Check Enforcer EventHubs cut-over

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.4.1" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
     <PackageReference Include="Octokit" Version="0.47.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -8,6 +8,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.0.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.4.1" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
     <PackageReference Include="Octokit" Version="0.47.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookFunction.cs
@@ -27,23 +27,25 @@ using System.Runtime.CompilerServices;
 using Azure.Sdk.Tools.CheckEnforcer.Configuration;
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
 
-namespace Azure.Sdk.Tools.CheckEnforcer
+namespace Azure.Sdk.Tools.CheckEnforcer.Functions
 {
-    public static class GitHubWebhookFunction
+    public class GitHubWebhookFunction
     {
-        private static IGlobalConfigurationProvider globalConfigurationProvider = new GlobalConfigurationProvider();
-        private static IGitHubClientProvider gitHubClientProvider = new GitHubClientProvider(globalConfigurationProvider);
-        private static IRepositoryConfigurationProvider repositoryConfigurationProvider = new RepositoryConfigurationProvider(gitHubClientProvider);
-        private static GitHubWebhookProcessor gitHubWebhookProcessor = new GitHubWebhookProcessor(globalConfigurationProvider, gitHubClientProvider, repositoryConfigurationProvider);
+        public GitHubWebhookFunction(GitHubWebhookProcessor processor)
+        {
+            this.processor = processor;
+        }
+
+        private GitHubWebhookProcessor processor;
 
         [FunctionName("webhook")]
-        public static async Task<IActionResult> Run(
+        public async Task<IActionResult> Run(
             [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = null)] HttpRequest req,
             ILogger log, CancellationToken cancellationToken)
         {
             try
             {
-                await gitHubWebhookProcessor.ProcessWebhookAsync(req, log, cancellationToken);
+                await processor.ProcessWebhookAsync(req, log, cancellationToken);
                 return new OkResult();
             }
             catch (CheckEnforcerSecurityException ex)

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using Microsoft.Azure.EventHubs;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Functions
+{
+    public class GitHubWebhookOverEventHubsFunction
+    {
+        public GitHubWebhookOverEventHubsFunction(GitHubWebhookProcessor processor)
+        {
+            this.processor = processor;
+        }
+
+        private GitHubWebhookProcessor processor;
+
+        [FunctionName("webhook-eventhubs")]
+        public async Task Run([EventHubTrigger("github-webhooks", Connection = "CheckEnforcerEventHubConnectionString")] EventData eventData, ILogger log)
+        {
+            string messageBody = Encoding.UTF8.GetString(eventData.Body.Array, eventData.Body.Offset, eventData.Body.Count);
+            var message = JsonDocument.Parse(messageBody);
+            var encodedContent = message.RootElement.GetProperty("content").ToString();
+            var contentBytes = Convert.FromBase64String(encodedContent);
+            var json = Encoding.UTF8.GetString(contentBytes);
+
+            log.LogInformation("EventHubs Payload: {json}", json);
+        }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs;
@@ -21,15 +22,34 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Functions
         private GitHubWebhookProcessor processor;
 
         [FunctionName("webhook-eventhubs")]
-        public async Task Run([EventHubTrigger("github-webhooks", Connection = "CheckEnforcerEventHubConnectionString")] EventData eventData, ILogger log)
+        public async Task Run([EventHubTrigger("github-webhooks", Connection = "CheckEnforcerEventHubConnectionString")] EventData eventData, ILogger log, CancellationToken cancellationToken)
         {
-            string messageBody = Encoding.UTF8.GetString(eventData.Body.Array, eventData.Body.Offset, eventData.Body.Count);
-            var message = JsonDocument.Parse(messageBody);
+            var message = GetMessage(eventData);
+            var eventName = GetEventName(message);
+
             var encodedContent = message.RootElement.GetProperty("content").ToString();
             var contentBytes = Convert.FromBase64String(encodedContent);
             var json = Encoding.UTF8.GetString(contentBytes);
 
-            log.LogInformation("EventHubs Payload: {json}", json);
+            await processor.ProcessWebhookAsync(eventName, json, log, cancellationToken);
+        }
+
+        private string GetEventName(JsonDocument message)
+        {
+            return message
+                .RootElement
+                .GetProperty("headers")
+                .GetProperty("X-GitHub-Event")
+                .EnumerateArray()
+                .Single()
+                .ToString();
+        }
+
+        private JsonDocument GetMessage(EventData eventData)
+        {
+            string messageBody = Encoding.UTF8.GetString(eventData.Body.Array, eventData.Body.Offset, eventData.Body.Count);
+            var message = JsonDocument.Parse(messageBody);
+            return message;
         }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverHttpFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverHttpFunction.cs
@@ -29,9 +29,9 @@ using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
 
 namespace Azure.Sdk.Tools.CheckEnforcer.Functions
 {
-    public class GitHubWebhookFunction
+    public class GitHubWebhookOverHttpFunction
     {
-        public GitHubWebhookFunction(GitHubWebhookProcessor processor)
+        public GitHubWebhookOverHttpFunction(GitHubWebhookProcessor processor)
         {
             this.processor = processor;
         }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubWebhookSignatureValidator.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubWebhookSignatureValidator.cs
@@ -10,6 +10,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub
 {
     public static class GitHubWebhookSignatureValidator
     {
+        public const string GitHubWebhookSignatureHeader = "X-Hub-Signature";
+        
         public static bool IsValid(byte[] body, string signature, string secret)
         {
             var key = Encoding.UTF8.GetBytes(secret);

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Startup.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Startup.cs
@@ -1,0 +1,24 @@
+﻿using Azure.Sdk.Tools.CheckEnforcer;
+using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+[assembly: FunctionsStartup(typeof(Startup))]
+
+namespace Azure.Sdk.Tools.CheckEnforcer
+{
+    public class Startup : FunctionsStartup
+    {
+        public override void Configure(IFunctionsHostBuilder builder)
+        {
+            builder.Services.AddSingleton<IGlobalConfigurationProvider, GlobalConfigurationProvider>();
+            builder.Services.AddSingleton<IGitHubClientProvider, GitHubClientProvider>();
+            builder.Services.AddSingleton<IRepositoryConfigurationProvider, RepositoryConfigurationProvider>();
+            builder.Services.AddSingleton<GitHubWebhookProcessor>();
+        }
+    }
+}


### PR DESCRIPTION
This PR cuts Check Enforcer over to using Event Hubs to receive webhook notifications (indirectly via our Webhook Router).

Cutover for staging will take place on off this feature branch for validation purposes and will be done by changing the webhook URL for the Check Enforcer (staging) app to route within Webhook Router. Messages will temporarily flowing to Check Enforcer at which point we'll deploy the update (takes a few minutes) and then Check Enforcer will start processing the events via Event Hubs instead.

A subsequent update will remove the HTTP trigger from the function (once we are sure it isn't needed anymore). We'll probably run in staging for a while just to identify any teething problems and make sure we've got all we need in terms of telemetry.