### PR TITLE
Webhook Router optmization pass

### DIFF
--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Azure.Sdk.Tools.WebhookRouter.csproj
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Azure.Sdk.Tools.WebhookRouter.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.0.1" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.3" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Startup.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Startup.cs
@@ -15,6 +15,7 @@ namespace Azure.Sdk.Tools.WebhookRouter
         public override void Configure(IFunctionsHostBuilder builder)
         {
             builder.Services.AddSingleton<IRouter, Router>();
+            builder.Services.AddMemoryCache();
         }
     }
 }


### PR DESCRIPTION
This PR adds a simple 60 second cache to route settings and secrets (the two most expensive calls in terms of execution time per request). This should help performance during busy times but won't do much if the system has cooled off (we would need to actively fetch this data in advance to optimize for that scenario).

This took the request duration down from 7 seconds on my local machine (factoring in route trip time for multiple calls to West US 2 down to under 100ms (except when the cache expired). This should shift the percentile lines quite a bit and then we can figure out if we want to go further from there.