### PR TITLE
Check Enforcer back-off

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
     <PackageReference Include="Octokit" Version="0.47.0" />
+    <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.5.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR makes use of the PR library to introduce some back-off logic (retry 3 times after the timeout suggested by GitHub). I'm making use of the Polly library for this. We can do this now because we aren't on the critical path for a HTTP response.

I don't know if GitHub adds jitter to their back-off suggestions.