### PR TITLE
Add methods to skip lint check and fix typehint regex

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
@@ -31,7 +31,7 @@ from ._apiview import ApiView, APIViewEncoder, Navigation, Kind, NavigationTag
 
 INIT_PY_FILE = "__init__.py"
 
-logging.getLogger().setLevel(logging.INFO)
+logging.getLogger().setLevel(logging.ERROR)
 
 
 class StubGenerator:
@@ -87,7 +87,7 @@ class StubGenerator:
             pkg_root_path = self.pkg_path
             pkg_name, version, namespace = parse_setup_py(pkg_root_path)
 
-        logging.debug("package name: {0}, version:{1}".format(pkg_name, version))
+        logging.debug("package name: {0}, version:{1}, namespace:{2}".format(pkg_name, version, namespace))
 
         logging.debug("Installing package from {}".format(self.pkg_path))
         self._install_package(pkg_name)
@@ -156,8 +156,18 @@ class StubGenerator:
         apiview = ApiView(nodeindex, package_name, 0, version, namespace)
         modules = self._find_modules(pkg_root_path)
         logging.debug("Modules to generate tokens: {}".format(modules))
+
+        # find root module name
+        root_module = ""
+        if namespace:
+            root_module = namespace.split(".")[0]
+
         # load all modules and parse them recursively
         for m in modules:
+            if not m.startswith(root_module):
+                logging.debug("Skipping module {0}. Module should start with {1}".format(m, root_module))
+                continue
+
             logging.debug("Importing module {}".format(m))
             try:
                 module_obj = importlib.import_module(m)

--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.1.1"
+VERSION = "0.1.2"

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -17,7 +17,7 @@ find_multi_type_regex = "(?<!:):({0})\s?{1}:([\s]*([\S]+)(\s+or\s+[\S]+)+)(?!:)"
 find_docstring_return_type = "(?<!:):rtype\s?:\s+([^:\n]+)(?!:)"
 
 # Regex to parse type hints
-find_type_hint_ret_type = "(?<!#)#\stype:[\s\S]*->\s?([^\n]*)"
+find_type_hint_ret_type = "(?<!#)#\s+type:[^\n]*->\s+([^\n]*)"
 
 docstring_types = ["param", "type", "paramtype", "keyword", "rtype"]
 


### PR DESCRIPTION
Changes:
1. Skip any modules that doesn't start with root module name (for e.g. azure) from importing 
2. Excluded known implementation methods from lint check
3. Fix issues in typehint parsing