### PR TITLE
Accept zipped ast files

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
@@ -4,6 +4,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
@@ -68,7 +69,7 @@ namespace APIViewWeb
 
         public string Name { get; } = "C";
 
-        public bool IsSupportedExtension(string extension) => string.Equals(extension, ".ast", comparisonType: StringComparison.OrdinalIgnoreCase);
+        public bool IsSupportedExtension(string extension) => string.Equals(extension, ".zip", comparisonType: StringComparison.OrdinalIgnoreCase);
 
         public bool CanUpdate(string versionString) => true;
 
@@ -76,16 +77,34 @@ namespace APIViewWeb
         {
             MemoryStream astStream = new MemoryStream();
             await stream.CopyToAsync(astStream);
+            astStream.Position = 0;
 
-            return BuildNodes(originalName, astStream);
-        }
+            var archive = new ZipArchive(astStream);
 
-        private static CodeFile BuildNodes(string originalName, MemoryStream astStream)
-        {
-            Span<byte> ast = astStream.ToArray();
 
             CodeFileTokensBuilder builder = new CodeFileTokensBuilder();
             Dictionary<string, NavigationItem> navigation = new Dictionary<string, NavigationItem>();
+
+            foreach (var entry in archive.Entries)
+            {
+                var entryStream = new MemoryStream();
+                await entry.Open().CopyToAsync(entryStream);
+                BuildNodes(builder, navigation, entryStream);
+            }
+
+            return new CodeFile()
+            {
+                Name = originalName,
+                Language = "C",
+                Tokens = builder.Tokens.ToArray(),
+                Navigation = navigation.Values.ToArray(),
+                VersionString = CurrentVersion,
+            };
+        }
+
+        private static void BuildNodes(CodeFileTokensBuilder builder, Dictionary<string, NavigationItem> navigation, MemoryStream astStream)
+        {
+            Span<byte> ast = astStream.ToArray();
 
             while (ast.Length > 2)
             {
@@ -340,15 +359,6 @@ namespace APIViewWeb
                     builder.NewLine();
                 }
             }
-
-            return new CodeFile()
-            {
-                Name = originalName,
-                Language = "C",
-                Tokens = builder.Tokens.ToArray(),
-                Navigation = navigation.Values.ToArray(),
-                VersionString = CurrentVersion,
-            };
         }
 
         private static void BuildType(CodeFileTokensBuilder builder, string type, HashSet<string> types)

--- a/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
@@ -71,7 +71,7 @@ namespace APIViewWeb
 
         public bool IsSupportedExtension(string extension) => string.Equals(extension, ".zip", comparisonType: StringComparison.OrdinalIgnoreCase);
 
-        public bool CanUpdate(string versionString) => true;
+        public bool CanUpdate(string versionString) => versionString != CurrentVersion;
 
         public async Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis)
         {

--- a/src/dotnet/APIView/APIViewWeb/Program.cs
+++ b/src/dotnet/APIView/APIViewWeb/Program.cs
@@ -18,10 +18,6 @@ namespace APIViewWeb
                     config.AddEnvironmentVariables(prefix: "APIVIEW_");
                     config.AddUserSecrets(typeof(Program).Assembly);
                 })
-                .ConfigureKestrel(options =>
-                {
-                    options.Limits.MaxRequestBodySize = 100 * 1024 * 1024;
-                })
                 .UseStartup<Startup>();
     }
 }


### PR DESCRIPTION
Upload artifact is clang JSON AST file(s) in a zip archive. **Requires clang 10**

To produce it run the following command:

```powershell
clang <inputs like az_*.h> -Xclang -ast-dump=json -I ..\..\..\core\core\inc -I "c:\Program Files (x86)\Microsoft Visual Studio\2019\Preview\VC\Tools\MSVC\14.26.28801\include\" > az_core.ast

#powershell
Compress-Archive az_core.ast -DestinationPath az_core.zip
```

Upload the resulting `.zip` file.

