### PR TITLE
Run python parser using python configured at PYTHONPROCESSORPATH

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
@@ -7,6 +7,7 @@
 
 import glob
 import sys
+from sys import exit
 import os
 import argparse
 
@@ -226,9 +227,11 @@ class StubGenerator:
     def _install_package(self, pkg_name):
         # Uninstall the package and reinstall it to parse so inspect can get members in package
         # We don't want to force reinstall to avoid reinstalling other dependent packages
-        commands = [sys.executable, "-m", "pip", "uninstall", pkg_name, "--yes", "-q"]
+        # executable is stubgen. so we need to find path to python using APIVIEW_PYTHON env variable
+        python_executable = os.path.join(os.getenv("APIVIEW_PYTHON", ""), "python")
+        commands = [python_executable, "-m", "pip", "uninstall", pkg_name, "--yes", "-q"]
         check_call(commands)
-        commands = [sys.executable, "-m", "pip", "install", self.pkg_path , "-q"]
+        commands = [python_executable, "-m", "pip", "install", self.pkg_path , "-q"]
         check_call(commands)
 
 

--- a/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
@@ -7,7 +7,6 @@
 
 import glob
 import sys
-from sys import exit
 import os
 import argparse
 

--- a/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
@@ -226,11 +226,9 @@ class StubGenerator:
     def _install_package(self, pkg_name):
         # Uninstall the package and reinstall it to parse so inspect can get members in package
         # We don't want to force reinstall to avoid reinstalling other dependent packages
-        # executable is stubgen. so we need to find path to python using APIVIEW_PYTHON env variable
-        python_executable = os.path.join(os.getenv("APIVIEW_PYTHON", ""), "python")
-        commands = [python_executable, "-m", "pip", "uninstall", pkg_name, "--yes", "-q"]
+        commands = [sys.executable, "-m", "pip", "uninstall", pkg_name, "--yes", "-q"]
         check_call(commands)
-        commands = [python_executable, "-m", "pip", "install", self.pkg_path , "-q"]
+        commands = [sys.executable, "-m", "pip", "install", self.pkg_path , "-q"]
         check_call(commands)
 
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -3,17 +3,27 @@
 
 using System;
 using System.IO;
+using Microsoft.Extensions.Configuration;
 
 namespace APIViewWeb
 {
     public class PythonLanguageService : LanguageProcessor
     {
-        private static readonly string PythonHome = Environment.GetEnvironmentVariable("APIVIEW_PYTHONHOME") ?? string.Empty;
-
+        private readonly string ApiViewPythonProcessor;
         public override string Name { get; } = "Python";
         public override string Extension { get; } = ".whl";
-        public override string ProcessName { get; } = Path.Combine(PythonHome, "Scripts", "apistubgen");
+        public override string ProcessName
+        {
+            get{ return ApiViewPythonProcessor; }
+        }
         public override string VersionString { get; } = "0.1.1";
+
+        public PythonLanguageService(IConfiguration configuration)
+        {
+            // apistubgen is located in python's scripts path e.g. <Pythonhome>/Scripts
+            var PythonHome = configuration["APIVIEW_PYTHONHOME"] ?? string.Empty;
+            ApiViewPythonProcessor = Path.Combine(PythonHome, "Scripts", "apistubgen");
+        }
 
         public override string GetProccessorArguments(string originalName, string tempDirectory, string jsonPath)
         {

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -9,20 +9,18 @@ namespace APIViewWeb
 {
     public class PythonLanguageService : LanguageProcessor
     {
-        private readonly string ApiViewPythonProcessor;
+        private readonly string _apiViewPythonProcessor;
         public override string Name { get; } = "Python";
         public override string Extension { get; } = ".whl";
-        public override string ProcessName
-        {
-            get{ return ApiViewPythonProcessor; }
-        }
+        public override string ProcessName => _apiViewPythonProcessor;
         public override string VersionString { get; } = "0.1.1";
 
         public PythonLanguageService(IConfiguration configuration)
         {
             // apistubgen is located in python's scripts path e.g. <Pythonhome>/Scripts
-            var PythonHome = configuration["APIVIEW_PYTHONHOME"] ?? string.Empty;
-            ApiViewPythonProcessor = Path.Combine(PythonHome, "Scripts", "apistubgen");
+            // Env variable PYTHONPROCESSORPATH is set to <pythonhome>/Scripts where parser is located
+            var processorPath = configuration["PYTHONPROCESSORPATH"] ?? string.Empty;
+            _apiViewPythonProcessor = Path.Combine(processorPath, "apistubgen");
         }
 
         public override string GetProccessorArguments(string originalName, string tempDirectory, string jsonPath)

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -8,21 +8,16 @@ namespace APIViewWeb
 {
     public class PythonLanguageService : LanguageProcessor
     {
-        private static readonly string PythonHome = Environment.GetEnvironmentVariable("PYTHONHOME") ?? string.Empty;
+        private static readonly string PythonHome = Environment.GetEnvironmentVariable("APIVIEW_PYTHONHOME") ?? string.Empty;
 
         public override string Name { get; } = "Python";
         public override string Extension { get; } = ".whl";
-        public override string ProcessName { get; } = Path.Combine(PythonHome, "python");
+        public override string ProcessName { get; } = Path.Combine(PythonHome, "Scripts", "apistubgen");
         public override string VersionString { get; } = "0.1.1";
 
         public override string GetProccessorArguments(string originalName, string tempDirectory, string jsonPath)
         {
-            var pythonScriptPath = Path.Combine(
-                    Path.GetDirectoryName(typeof(PythonLanguageService).Assembly.Location),
-                    "api-stub-generator",
-                    "apistubgen.py"
-                    );
-            return $"{pythonScriptPath} --pkg-path {originalName} --temp-path {tempDirectory}" +
+            return $"--pkg-path {originalName} --temp-path {tempDirectory}" +
                 $" --out-path {jsonPath} --hide-report";
         }
     }

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -17,10 +17,9 @@ namespace APIViewWeb
 
         public PythonLanguageService(IConfiguration configuration)
         {
-            // apistubgen is located in python's scripts path e.g. <Pythonhome>/Scripts
-            // Env variable PYTHONPROCESSORPATH is set to <pythonhome>/Scripts where parser is located
-            var processorPath = configuration["PYTHONPROCESSORPATH"] ?? string.Empty;
-            _apiViewPythonProcessor = Path.Combine(processorPath, "apistubgen");
+            // apistubgen is located in python's scripts path e.g. <Pythonhome>/Scripts/apistubgen
+            // Env variable PYTHONPROCESSORPATH is set to <pythonhome>/Scripts/apistubgen where parser is located
+            _apiViewPythonProcessor = configuration["PYTHONPROCESSORPATH"] ?? string.Empty;
         }
 
         public override string GetProccessorArguments(string originalName, string tempDirectory, string jsonPath)


### PR DESCRIPTION
Run apistubgen from installed script location. sys.executable wont be python when executing "apistubgen" so we need to find python path that is configured in APIVIEW_PYTHONHOME and install package to parse using it.