### PR TITLE
Skip stale check-run events in Check Enforcer

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
@@ -36,6 +36,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
         private static readonly EventId SkippedProcessingCheckEnforcerCheckRunEventEventId = new EventId(EventIdBase + 18, "Skipped Processing Check Enforcer Check Run Event");
         private static readonly EventId SkippedProcessingIncompleteCheckRunEventEventId = new EventId(EventIdBase + 19, "Skipped Processing Incomplete Check Run Event");
         private static readonly EventId FailedToAcquiredDistributedLockEventId = new EventId(EventIdBase + 20, "Failed to acquired distributed lock, giving up.");
+        private static readonly EventId SkippedProcessStaleCheckRunEventEventId = new EventId(EventIdBase + 21, "Skipped Porcessing Stale Check Run Event");
+
 
         public CheckRunHandler(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubCLientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, ILogger logger) : base(globalConfigurationProvider, gitHubCLientProvider, repositoryConfigurationProvider, logger)
         {
@@ -58,6 +60,15 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
                         SkippedProcessingCheckEnforcerCheckRunEventEventId,
                         "Skipping processing event for: {runIdentifier} because appplication name match.",
                         runIdentifier
+                        );
+                }
+                else if (payload.CheckRun.StartedAt < DateTimeOffset.UtcNow.Subtract(TimeSpan.FromDays(1)))
+                {
+                    Logger.LogWarning(
+                        SkippedProcessStaleCheckRunEventEventId,
+                        "Skipping stake check-run event for: {runIdentifier} because it started {days} ago.",
+                        runIdentifier,
+                        (DateTimeOffset.UtcNow - payload.CheckRun.StartedAt).Days
                         );
                 }
                 else


### PR DESCRIPTION
Azure Pipelines is spamming check-run completion events for old runs and its causing us to hammer GitHub and get rate limited. We don't need to process these events so we can just ignore them. I arbitrarily set it so that we only process messages for Check Runs that started a day ago or less.