### PR TITLE
Revert "OSName variable set at run time"

### DIFF
--- a/eng/pipelines/templates/scripts/verify-agent-os.yml
+++ b/eng/pipelines/templates/scripts/verify-agent-os.yml
@@ -30,6 +30,5 @@ steps:
 
         if (agent_os.lower() == os_parameter.lower()):
             print('Job ran on OS: %s' % (agent_os))
-            print('##vso[task.setvariable variable=OSName]%s' % (agent_os))
         else:
             raise Exception('Job ran on the wrong OS: %s' % (agent_os))


### PR DESCRIPTION
Reverts Azure/azure-sdk-tools#603

This is breaking pipelines so we are going to revert and do it differently. 