### PR TITLE
ContinueOnError Revisions for Docs Metadata

### DIFF
--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -42,6 +42,7 @@ steps:
       -DocRepoLocation "${{parameters.WorkingDirectory}}/repo" 
       -Language "${{parameters.Language}}" 
       -DocRepoContentLocation ${{ parameters.DocRepoDestinationPath }}
+      -continueOnError
     pwsh: true
   env:
     GH_TOKEN: $(azuresdk-github-pat)
@@ -56,6 +57,4 @@ steps:
     BaseBranchName: smoke-test
     WorkingDirectory: ${{parameters.WorkingDirectory}}/repo
     ScriptDirectory: ${{parameters.WorkingDirectory}}/${{parameters.ScriptDirectory}}
-
-
 

--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -42,7 +42,6 @@ steps:
       -DocRepoLocation "${{parameters.WorkingDirectory}}/repo" 
       -Language "${{parameters.Language}}" 
       -DocRepoContentLocation ${{ parameters.DocRepoDestinationPath }}
-      -continueOnError
     pwsh: true
   env:
     GH_TOKEN: $(azuresdk-github-pat)

--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -56,4 +56,3 @@ steps:
     BaseBranchName: smoke-test
     WorkingDirectory: ${{parameters.WorkingDirectory}}/repo
     ScriptDirectory: ${{parameters.WorkingDirectory}}/${{parameters.ScriptDirectory}}
-

--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -358,7 +358,7 @@ function GetExistingTags($apiUrl) {
 }
 
 # Walk across all build artifacts, check them against the appropriate repository, return a list of tags/releases
-function VerifyPackages($pkgRepository, $artifactLocation, $workingDirectory, $apiUrl, $releaseSha, $exitOnError = $True) {
+function VerifyPackages($pkgRepository, $artifactLocation, $workingDirectory, $apiUrl, $releaseSha,  $continueOnError = $false) {
   $pkgList = [array]@()
   $ParsePkgInfoFn = ""
   $packagePattern = ""
@@ -404,7 +404,7 @@ function VerifyPackages($pkgRepository, $artifactLocation, $workingDirectory, $a
         continue
       }
 
-      if ($parsedPackage.Deployable -ne $True -and $exitOnError) {
+      if ($parsedPackage.Deployable -ne $True -and !$continueOnError) {
         Write-Host "Package $($parsedPackage.PackageId) is marked with version $($parsedPackage.PackageVersion), the version $($parsedPackage.PackageVersion) has already been deployed to the target repository."
         Write-Host "Maybe a pkg version wasn't updated properly?"
         exit(1)
@@ -430,8 +430,8 @@ function VerifyPackages($pkgRepository, $artifactLocation, $workingDirectory, $a
   
   $intersect = $results | % { $_.Tag } | ? { $existingTags -contains $_ }
 
-  if ($intersect.Length -gt 0 -and $exitOnError) {
-    CheckArtifactShaAgainstTagsList -priorExistingTagList $intersect -releaseSha $releaseSha -apiUrl $apiUrl -exitOnError $exitOnError
+  if ($intersect.Length -gt 0 -and !$continueOnError) {
+    CheckArtifactShaAgainstTagsList -priorExistingTagList $intersect -releaseSha $releaseSha -apiUrl $apiUrl -continueOnError $continueOnError
 
     # all the tags are clean. remove them from the list of releases we will publish.
     $results = $results | ? { -not ($intersect -contains $_.Tag ) }
@@ -443,7 +443,7 @@ function VerifyPackages($pkgRepository, $artifactLocation, $workingDirectory, $a
 # given a set of tags that we want to release, we need to ensure that if they already DO exist.
 # if they DO exist, quietly exit if the commit sha of the artifact matches that of the tag
 # if the commit sha does not match, exit with error and report both problem shas
-function CheckArtifactShaAgainstTagsList($priorExistingTagList, $releaseSha, $apiUrl, $exitOnError) {
+function CheckArtifactShaAgainstTagsList($priorExistingTagList, $releaseSha, $apiUrl, $continueOnError) {
   $headers = @{
     "Content-Type"  = "application/json"
     "Authorization" = "token $($env:GH_TOKEN)"
@@ -465,7 +465,7 @@ function CheckArtifactShaAgainstTagsList($priorExistingTagList, $releaseSha, $ap
     }
   }
 
-  if ($unmatchedTags.Length -gt 0 -and $exitOnError) {
+  if ($unmatchedTags.Length -gt 0 -and !$continueOnError) {
     Write-Host "Tags already existing with different SHA versions. Exiting."
     exit(1)
   }

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -218,18 +218,18 @@ function Upload-Blobs
 
 if ($Language -eq "javascript")
 {
-    $PublishedDocs = Get-ChildItem "$($DocLocation)" | Where-Object -FilterScript {$_.Name.EndsWith(".zip")}
+    $PublishedDocs = Get-ChildItem "$($DocLocation)/documentation" | Where-Object -FilterScript {$_.Name.EndsWith(".zip")}
 
     foreach ($Item in $PublishedDocs) {
         $PkgName = "azure-$($Item.BaseName)"
         Write-Host $PkgName
-        Expand-Archive -Force -Path "$($DocLocation)/$($Item.Name)" -DestinationPath "$($DocLocation)/$($Item.BaseName)"
-        $dirList = Get-ChildItem "$($DocLocation)/$($Item.BaseName)/$($Item.BaseName)" -Attributes Directory
+        Expand-Archive -Force -Path "$($DocLocation)/documentation/$($Item.Name)" -DestinationPath "$($DocLocation)/documentation/$($Item.BaseName)"
+        $dirList = Get-ChildItem "$($DocLocation)/documentation/$($Item.BaseName)/$($Item.BaseName)" -Attributes Directory
 
         if($dirList.Length -eq 1){
             $DocVersion = $dirList[0].Name
             Write-Host "Uploading Doc for $($PkgName) Version:- $($DocVersion)..."
-            Upload-Blobs -DocDir "$($DocLocation)/$($Item.BaseName)/$($Item.BaseName)/$($DocVersion)" -PkgName $PkgName -DocVersion $DocVersion
+            Upload-Blobs -DocDir "$($DocLocation)/documentation/$($Item.BaseName)/$($Item.BaseName)/$($DocVersion)" -PkgName $PkgName -DocVersion $DocVersion
         }
         else{
             Write-Host "found more than 1 folder under the documentation for package - $($Item.Name)"

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -218,18 +218,18 @@ function Upload-Blobs
 
 if ($Language -eq "javascript")
 {
-    $PublishedDocs = Get-ChildItem "$($DocLocation)/documentation" | Where-Object -FilterScript {$_.Name.EndsWith(".zip")}
+    $PublishedDocs = Get-ChildItem "$($DocLocation)" | Where-Object -FilterScript {$_.Name.EndsWith(".zip")}
 
     foreach ($Item in $PublishedDocs) {
         $PkgName = "azure-$($Item.BaseName)"
         Write-Host $PkgName
-        Expand-Archive -Force -Path "$($DocLocation)/documentation/$($Item.Name)" -DestinationPath "$($DocLocation)/documentation/$($Item.BaseName)"
-        $dirList = Get-ChildItem "$($DocLocation)/documentation/$($Item.BaseName)/$($Item.BaseName)" -Attributes Directory
+        Expand-Archive -Force -Path "$($DocLocation)/$($Item.Name)" -DestinationPath "$($DocLocation)/$($Item.BaseName)"
+        $dirList = Get-ChildItem "$($DocLocation)/$($Item.BaseName)/$($Item.BaseName)" -Attributes Directory
 
         if($dirList.Length -eq 1){
             $DocVersion = $dirList[0].Name
             Write-Host "Uploading Doc for $($PkgName) Version:- $($DocVersion)..."
-            Upload-Blobs -DocDir "$($DocLocation)/documentation/$($Item.BaseName)/$($Item.BaseName)/$($DocVersion)" -PkgName $PkgName -DocVersion $DocVersion
+            Upload-Blobs -DocDir "$($DocLocation)/$($Item.BaseName)/$($Item.BaseName)/$($DocVersion)" -PkgName $PkgName -DocVersion $DocVersion
         }
         else{
             Write-Host "found more than 1 folder under the documentation for package - $($Item.Name)"

--- a/eng/common/scripts/create-tags-and-git-release.ps1
+++ b/eng/common/scripts/create-tags-and-git-release.ps1
@@ -15,7 +15,7 @@ param (
   $repoOwner = "", # the owning organization of the repository. EG "Azure"
   $repoName = "", # the name of the repository. EG "azure-sdk-for-java"
   $repoId = "$repoOwner/$repoName", # full repo id. EG azure/azure-sdk-for-net  DevOps: $(Build.Repository.Id),
-  [switch]$forceCreate = $false
+  [switch]$continueOnError = $false
 )
 
 Write-Host "> $PSCommandPath $args"
@@ -26,7 +26,7 @@ $apiUrl = "https://api.github.com/repos/$repoId"
 Write-Host "Using API URL $apiUrl"
 
 # VERIFY PACKAGES
-$pkgList = VerifyPackages -pkgRepository $packageRepository -artifactLocation $artifactLocation -workingDirectory $workingDirectory -apiUrl $apiUrl -releaseSha $releaseSha
+$pkgList = VerifyPackages -pkgRepository $packageRepository -artifactLocation $artifactLocation -workingDirectory $workingDirectory -apiUrl $apiUrl -releaseSha $releaseSha -continueOnError $continueOnError
 
 if ($pkgList) {
   Write-Host "Given the visible artifacts, github releases will be created for the following:"

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -86,7 +86,7 @@ $pkgs = VerifyPackages -pkgRepository $Repository `
   -workingDirectory $WorkDirectory `
   -apiUrl $apiUrl `
   -releaseSha $ReleaseSHA `
-  -exitOnError $False
+  -continueOnError $True
 
 if ($pkgs) {
   Write-Host "Given the visible artifacts, readmes will be copied for the following packages"


### PR DESCRIPTION
`docs` metadata does not care about the status of the tag/release. Given this, we don't want our call of `VerifyPackages` (which also gets the package metadata) to fail with that error.

