### PR TITLE
Add condition to always run resource cleanup step

### DIFF
--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -32,4 +32,5 @@ steps:
         -Force `
         -Verbose
     displayName: Remove test resources
+    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), succeededOrFailed())
     continueOnError: true


### PR DESCRIPTION
Using `succeededOrFailed()` because returning agents to the pool during a mass cancelation is more important than removing resources (the daily cleanup process will handle any resources left behind). 

Strong arguments could also be made for situations where a mass-cancellation may leave behind resources that have tighter quotas. To that point we have to weigh the collective agent time spent on removing resources automatically during a mass cancelation against having to manually clean up resources that fit this criteria in the wake of a mass cancelation. 