### PR TITLE
change for sourceless modules

### DIFF
--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -304,6 +304,17 @@ if ($Language -eq "java")
             jar -xf "$($Item.FullName)"
             Set-Location $CurrentLocation
 
+            # If javadocs are produced for a library with source, there will always be an
+            # index.html. If this file doesn't exist in the UnjarredDocumentationPath then
+            # this is a sourceless library which means there are no javadocs and nothing
+            # should be uploaded to blob storage.
+            $IndexHtml = Join-Path -Path $UnjarredDocumentationPath -ChildPath "index.html"
+            if (!(Test-Path -path $IndexHtml))
+            {
+                Write-Host "$($PkgName) does not have an index.html file, skippping."
+                continue
+            }
+
             # Get the POM file for the artifact we're processing
             $PomFile = $Item.FullName.Substring(0,$Item.FullName.LastIndexOf(("-javadoc.jar"))) + ".pom"
             Write-Host "PomFile $($PomFile)"


### PR DESCRIPTION
The spring starter modules won't have sources which means that their javadoc will effectively be empty. This means that there won't be an index.html (which is what the github.io docs links to for each version) and if there isn't one there, output a message saying it's not being copied and continue to the next iteration of the loop.