### PR TITLE
Add banned assemblies and method return type analyzers

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
@@ -29,7 +29,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code, "AZC0002");
+            await Verifier.CreateAnalyzer(code, "AZC0002")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -53,7 +55,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code, "AZC0002");
+            await Verifier.CreateAnalyzer(code, "AZC0002")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -77,7 +81,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code, "AZC0002");
+            await Verifier.CreateAnalyzer(code, "AZC0002")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -110,7 +116,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code);
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
 
@@ -144,7 +152,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code, "AZC0002");
+            await Verifier.CreateAnalyzer(code, "AZC0002")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -168,7 +178,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code, "AZC0002");
+            await Verifier.CreateAnalyzer(code, "AZC0002")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0003Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0003Tests.cs
@@ -30,7 +30,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code, "AZC0003");
+            await Verifier.CreateAnalyzer(code, "AZC0003")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -54,7 +56,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code);
+            await Verifier.CreateAnalyzer(code, "AZC0003")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -86,7 +90,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code);
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0004Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0004Tests.cs
@@ -26,7 +26,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code, "AZC0004");
+            await Verifier.CreateAnalyzer(code, "AZC0004")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -50,7 +52,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code);
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -79,7 +83,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code, "AZC0004");
+            await Verifier.CreateAnalyzer(code, "AZC0004")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -113,7 +119,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code);
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -142,7 +150,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code, "AZC0004");
+            await Verifier.CreateAnalyzer(code, "AZC0004")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -176,7 +186,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code);
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
 
         [Fact]
@@ -200,7 +212,9 @@ namespace RandomNamespace
         }
     }
 }";
-            await Verifier.VerifyAnalyzerAsync(code, "AZC0004");
+            await Verifier.CreateAnalyzer(code, "AZC0004")
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0014Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0014Tests.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.BannedAssembliesAnalyzer>;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC0014Tests
+    {
+        [Theory]
+        [InlineData("public class [|Class|]: System.IProgress<JsonElement> { public void Report (JsonElement [|value|]) {} }")]
+        [InlineData("public void Report(JsonElement [|value|]) {}")]
+        [InlineData("public JsonElement [|Report|]() { return default; }")]
+        [InlineData("public IEnumerable<JsonElement> [|Report|]() { return default; }")]
+        [InlineData("public JsonElement [|Report|] { get; }")]
+        [InlineData("public JsonElement [|Report|];")]
+        [InlineData("public event EventHandler<JToken> [|Report|];")]
+        [InlineData("protected JToken [|Report|];")]
+        public async Task AZC0014ProducedForJsonTypeUsageInPublicApi(string usage)
+        {
+            string code = $@"
+using System;
+using System.Threading.Tasks;
+using System.Text.Json;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace RandomNamespace
+{{
+    public class SomeClient
+    {{
+        {usage}       
+    }}
+}}";
+            await Verifier.VerifyAnalyzerAsync(code, "AZC0014");
+        }
+
+
+        [Theory]
+        [InlineData("internal class Class: System.IProgress<JsonElement> { public void Report (JsonElement value) {} }")]
+        [InlineData("public void Report(string value) {}")]
+        public async Task AZC0014NotProducedForNonPublicApisOrAllowedTypes(string usage)
+        {
+            string code = $@"
+using System;
+using System.Threading.Tasks;
+using System.Text.Json;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
+
+namespace RandomNamespace
+{{
+    public class SomeClient
+    {{
+        {usage}       
+    }}
+}}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0015Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0015Tests.cs
@@ -29,9 +29,9 @@ namespace RandomNamespace
         {usage}       
     }}
 }}";
-            var analyzer = Verifier.CreateAnalyzer(code, "AZC0015");
-            analyzer.DisabledDiagnostics.AddRange(new [] { "AZC0002", "AZC0003", "AZC0004" });
-            await analyzer.RunAsync();
+            await Verifier.CreateAnalyzer(code, "AZC0015")
+                .WithDisabledDiagnostics("AZC0002", "AZC0003", "AZC0004")
+                .RunAsync();
         }
 
         [Theory]
@@ -56,10 +56,9 @@ namespace RandomNamespace
         {usage}       
     }}
 }}";
-            var analyzer = Verifier.CreateAnalyzer(code);
-            analyzer.DisabledDiagnostics.AddRange(new [] { "AZC0002", "AZC0003", "AZC0004" });
-            await analyzer.RunAsync();
+            await Verifier.CreateAnalyzer(code, "AZC0015")
+                .WithDisabledDiagnostics("AZC0002", "AZC0003", "AZC0004")
+                .RunAsync();
         }
-
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0015Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0015Tests.cs
@@ -1,0 +1,64 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Threading.Tasks;
+using Xunit;
+using Verifier = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<Azure.ClientSdk.Analyzers.ClientMethodsAnalyzer>;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class AZC0015Tests
+    {
+        [Theory]
+        [InlineData("public Task<Operation<int>> [|ClientMethodAsync|]() { return default; }")]
+        [InlineData("public Task<Pageable<int>> [|ClientMethodAsync|]() { return default; }")]
+        [InlineData("public int [|ClientMethodAsync|]() { return default; }")]
+        [InlineData("public ValueTask<Response<int>> [|ClientMethodAsync|]() { return default; }")]
+        [InlineData("public string [|ClientMethodAsync|]() { return default; }")]
+        public async Task AZC0015ProducedForInvalidClientMethodReturnTypes(string usage)
+        {
+            string code = $@"
+using System;
+using System.Threading.Tasks;
+using Azure;
+
+namespace RandomNamespace
+{{
+    public class SomeClient
+    {{
+        {usage}       
+    }}
+}}";
+            var analyzer = Verifier.CreateAnalyzer(code, "AZC0015");
+            analyzer.DisabledDiagnostics.AddRange(new [] { "AZC0002", "AZC0003", "AZC0004" });
+            await analyzer.RunAsync();
+        }
+
+        [Theory]
+        [InlineData("public Operation<int> ClientMethodAsync() { return default; }")]
+        [InlineData("public Pageable<int> ClientMethodAsync() { return default; }")]
+        [InlineData("public AsyncPageable<int> ClientMethodAsync() { return default; }")]
+        [InlineData("public Response<int> ClientMethodAsync() { return default; }")]
+        [InlineData("public Response ClientMethodAsync() { return default; }")]
+        [InlineData("public SomeClient ClientMethod() { return default; }")]
+        public async Task AZC0015NotProducedForValidReturnTypes(string usage)
+        {
+            string code = $@"
+using System;
+using System.Threading.Tasks;
+using Azure;
+
+namespace RandomNamespace
+{{
+    public class SomeClient
+    {{
+        {usage}       
+    }}
+}}";
+            var analyzer = Verifier.CreateAnalyzer(code);
+            analyzer.DisabledDiagnostics.AddRange(new [] { "AZC0002", "AZC0003", "AZC0004" });
+            await analyzer.RunAsync();
+        }
+
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0015Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0015Tests.cs
@@ -10,7 +10,7 @@ namespace Azure.ClientSdk.Analyzers.Tests
     public class AZC0015Tests
     {
         [Theory]
-        [InlineData("public Task<Operation<int>> [|ClientMethodAsync|]() { return default; }")]
+        [InlineData("public Task<AsyncPageable<int>> [|ClientMethodAsync|]() { return default; }")]
         [InlineData("public Task<Pageable<int>> [|ClientMethodAsync|]() { return default; }")]
         [InlineData("public int [|ClientMethodAsync|]() { return default; }")]
         [InlineData("public ValueTask<Response<int>> [|ClientMethodAsync|]() { return default; }")]
@@ -35,6 +35,7 @@ namespace RandomNamespace
         }
 
         [Theory]
+        [InlineData("public Task<Operation<int>> ClientMethodAsync() { return default; }")]
         [InlineData("public Operation<int> ClientMethodAsync() { return default; }")]
         [InlineData("public Pageable<int> ClientMethodAsync() { return default; }")]
         [InlineData("public AsyncPageable<int> ClientMethodAsync() { return default; }")]

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
@@ -25,6 +25,9 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
+
+    <PackageReference Include="System.Text.Json" Version="4.6.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net'))">
     <PackageReference Include="System.Interactive.Async" Version="4.0.0" />

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
@@ -25,9 +25,6 @@
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.4.0" />
-
-    <PackageReference Include="System.Text.Json" Version="4.6.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('net'))">
     <PackageReference Include="System.Interactive.Async" Version="4.0.0" />

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
@@ -10,16 +10,19 @@ using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 
-namespace Azure.ClientSdk.Analyzers.Tests 
+namespace Azure.ClientSdk.Analyzers.Tests
 {
-    public class AzureAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier> where TAnalyzer : DiagnosticAnalyzer, new() 
+    public class AzureAnalyzerTest<TAnalyzer> : CSharpAnalyzerTest<TAnalyzer, XUnitVerifier> where TAnalyzer : DiagnosticAnalyzer, new()
     {
         private static readonly ReferenceAssemblies DefaultReferenceAssemblies =
             ReferenceAssemblies.Default.AddPackages(ImmutableArray.Create(
+                new PackageIdentity("Azure.Core", "1.0.0"),
                 new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "1.1.0"),
+                new PackageIdentity("System.Text.Json", "4.6.0"),
+                new PackageIdentity("Newtonsoft.Json", "12.0.3"),
                 new PackageIdentity("System.Threading.Tasks.Extensions", "4.5.3")));
 
-        public AzureAnalyzerTest(LanguageVersion languageVersion = LanguageVersion.Latest) 
+        public AzureAnalyzerTest(LanguageVersion languageVersion = LanguageVersion.Latest)
         {
             SolutionTransforms.Add((solution, projectId) =>
             {
@@ -33,8 +36,8 @@ namespace Azure.ClientSdk.Analyzers.Tests
 
         public string DescriptorName { get; set; }
 
-        protected override DiagnosticDescriptor GetDefaultDiagnostic(DiagnosticAnalyzer[] analyzers) 
-            => string.IsNullOrWhiteSpace(DescriptorName) 
+        protected override DiagnosticDescriptor GetDefaultDiagnostic(DiagnosticAnalyzer[] analyzers)
+            => string.IsNullOrWhiteSpace(DescriptorName)
                 ? base.GetDefaultDiagnostic(analyzers)
                 : analyzers.SelectMany(a => a.SupportedDiagnostics).FirstOrDefault(d => d.Id == DescriptorName) ?? base.GetDefaultDiagnostic(analyzers);
     }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
@@ -1,0 +1,88 @@
+﻿using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+
+namespace Azure.ClientSdk.Analyzers
+{
+    public sealed class BannedAssembliesAnalyzer : SymbolAnalyzerBase
+    {
+        private static HashSet<string> BannedAssemblies = new HashSet<string>()
+        {
+            "System.Text.Json",
+            "Newtonsoft.Json",
+            "System.Collections.Immutable"
+        };
+
+        private static readonly string BannedAssembliesMessageArgs = string.Join(", ", BannedAssemblies);
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptors.AZC0014);
+
+        public override SymbolKind[] SymbolKinds { get; } = new[]
+        {
+            SymbolKind.Method,
+            SymbolKind.Field,
+            SymbolKind.Property,
+            SymbolKind.Parameter,
+            SymbolKind.Event,
+            SymbolKind.NamedType
+        };
+
+        public override void Analyze(ISymbolAnalysisContext context)
+        {
+            void CheckType(ITypeSymbol type, ISymbol symbol)
+            {
+                if (type is INamedTypeSymbol namedTypeSymbol)
+                {
+                    if (BannedAssemblies.Contains(type.ContainingAssembly.Name))
+                    {
+                        context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0014, symbol.Locations.First(), BannedAssembliesMessageArgs), symbol);
+                    }
+
+                    if (namedTypeSymbol.IsGenericType)
+                    {
+                        foreach (var typeArgument in namedTypeSymbol.TypeArguments)
+                        {
+                            CheckType(typeArgument, symbol);
+                        }
+                    }
+                }
+            }
+
+            if (!IsPublicApi(context.Symbol))
+            {
+                return;
+            }
+
+            switch (context.Symbol)
+            {
+                case IParameterSymbol parameterSymbol:
+                    CheckType(parameterSymbol.Type, parameterSymbol);
+                    break;
+                case IMethodSymbol methodSymbol:
+                    if (methodSymbol.MethodKind == MethodKind.PropertyGet || methodSymbol.MethodKind == MethodKind.PropertySet)
+                    {
+                        return;
+                    }
+                    CheckType(methodSymbol.ReturnType, methodSymbol);
+                    break;
+                case IEventSymbol eventSymbol:
+                    CheckType(eventSymbol.Type, eventSymbol);
+                    break;
+                case IPropertySymbol propertySymbol:
+                    CheckType(propertySymbol.Type, propertySymbol);
+                    break;
+                case IFieldSymbol fieldSymbol:
+                    CheckType(fieldSymbol.Type, fieldSymbol);
+                    break;
+                case INamedTypeSymbol namedTypeSymbol:
+                    CheckType(namedTypeSymbol.BaseType, namedTypeSymbol);
+                    foreach (var iface in namedTypeSymbol.Interfaces)
+                    {
+                        CheckType(iface, namedTypeSymbol);
+                    }
+                    break;
+            }
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
@@ -2,9 +2,11 @@
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Azure.ClientSdk.Analyzers
 {
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public sealed class BannedAssembliesAnalyzer : SymbolAnalyzerBase
     {
         private static HashSet<string> BannedAssemblies = new HashSet<string>()

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
@@ -32,7 +32,7 @@ namespace Azure.ClientSdk.Analyzers
 
         public override void Analyze(ISymbolAnalysisContext context)
         {
-            void CheckType(ITypeSymbol type, ISymbol symbol)
+            static void CheckType(ISymbolAnalysisContext context, ITypeSymbol type, ISymbol symbol)
             {
                 if (type is INamedTypeSymbol namedTypeSymbol)
                 {
@@ -45,7 +45,7 @@ namespace Azure.ClientSdk.Analyzers
                     {
                         foreach (var typeArgument in namedTypeSymbol.TypeArguments)
                         {
-                            CheckType(typeArgument, symbol);
+                            CheckType(context, typeArgument, symbol);
                         }
                     }
                 }
@@ -59,29 +59,29 @@ namespace Azure.ClientSdk.Analyzers
             switch (context.Symbol)
             {
                 case IParameterSymbol parameterSymbol:
-                    CheckType(parameterSymbol.Type, parameterSymbol);
+                    CheckType(context, parameterSymbol.Type, parameterSymbol);
                     break;
                 case IMethodSymbol methodSymbol:
                     if (methodSymbol.MethodKind == MethodKind.PropertyGet || methodSymbol.MethodKind == MethodKind.PropertySet)
                     {
                         return;
                     }
-                    CheckType(methodSymbol.ReturnType, methodSymbol);
+                    CheckType(context, methodSymbol.ReturnType, methodSymbol);
                     break;
                 case IEventSymbol eventSymbol:
-                    CheckType(eventSymbol.Type, eventSymbol);
+                    CheckType(context, eventSymbol.Type, eventSymbol);
                     break;
                 case IPropertySymbol propertySymbol:
-                    CheckType(propertySymbol.Type, propertySymbol);
+                    CheckType(context, propertySymbol.Type, propertySymbol);
                     break;
                 case IFieldSymbol fieldSymbol:
-                    CheckType(fieldSymbol.Type, fieldSymbol);
+                    CheckType(context, fieldSymbol.Type, fieldSymbol);
                     break;
                 case INamedTypeSymbol namedTypeSymbol:
-                    CheckType(namedTypeSymbol.BaseType, namedTypeSymbol);
+                    CheckType(context, namedTypeSymbol.BaseType, namedTypeSymbol);
                     foreach (var iface in namedTypeSymbol.Interfaces)
                     {
-                        CheckType(iface, namedTypeSymbol);
+                        CheckType(context, iface, namedTypeSymbol);
                     }
                     break;
             }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -90,6 +90,20 @@ namespace Azure.ClientSdk.Analyzers
             "Usage",
             DiagnosticSeverity.Warning, true);
 
+        public static DiagnosticDescriptor AZC0014 = new DiagnosticDescriptor(
+            nameof(AZC0014),
+            "Avoid using banned types in public API",
+            "Types from {0} assemblies should not be exposed as part of public API surface.",
+            "Usage",
+            DiagnosticSeverity.Warning, true);
+
+        public static DiagnosticDescriptor AZC0015 = new DiagnosticDescriptor(
+            nameof(AZC0015),
+            "Unexpected client method return type.",
+            "Client methods should return Pageable<T>/AsyncPageable<T>/Operation<T>/Response/Response<T>/Task<Response>/Task<Response<T>> or other client class found {0} instead.",
+            "Usage",
+            DiagnosticSeverity.Warning, true);
+
         public static DiagnosticDescriptor AZC0100 = new DiagnosticDescriptor(
             nameof(AZC0100),
             "ConfigureAwait(false) must be used.",

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -100,7 +100,7 @@ namespace Azure.ClientSdk.Analyzers
         public static DiagnosticDescriptor AZC0015 = new DiagnosticDescriptor(
             nameof(AZC0015),
             "Unexpected client method return type.",
-            "Client methods should return Pageable<T>/AsyncPageable<T>/Operation<T>/Response/Response<T>/Task<Response>/Task<Response<T>> or other client class found {0} instead.",
+            "Client methods should return Pageable<T>/AsyncPageable<T>/Operation<T>/Task<Operation<T>>/Response/Response<T>/Task<Response>/Task<Response<T>> or other client class found {0} instead.",
             "Usage",
             DiagnosticSeverity.Warning, true);
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/SymbolAnalyzerBase.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/SymbolAnalyzerBase.cs
@@ -18,6 +18,18 @@ namespace Azure.ClientSdk.Analyzers
             context.RegisterSymbolAction(c => Analyze(new RoslynSymbolAnalysisContext(c)), SymbolKinds);
         }
 
+        protected bool IsPublicApi(ISymbol symbol)
+        {
+            if (symbol.ContainingSymbol != null && !IsPublicApi(symbol.ContainingSymbol))
+            {
+                return false;
+            }
+
+            return symbol.DeclaredAccessibility == Accessibility.NotApplicable ||
+                   symbol.DeclaredAccessibility == Accessibility.Public ||
+                   symbol.DeclaredAccessibility == Accessibility.Protected;
+        }
+
         class RoslynSymbolAnalysisContext : ISymbolAnalysisContext
         {
             private readonly SymbolAnalysisContext _context;
@@ -28,6 +40,7 @@ namespace Azure.ClientSdk.Analyzers
             }
 
             public ISymbol Symbol => _context.Symbol;
+
             public void ReportDiagnostic(Diagnostic diagnostic, ISymbol symbol)
             {
                 _context.ReportDiagnostic(diagnostic);


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-tools/issues/641
Fixes: https://github.com/Azure/azure-sdk-tools/issues/573