### PR TITLE
Docs.MS Release Script - Stability Improvements

### DIFF
--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -45,9 +45,9 @@ function GetMetaData($lang){
     }
   }
 
-  Write-Host "MetaData URL: "
-  Write-Host $metadataUri
   $metadataResponse = Invoke-WebRequest-WithHandling -url $metadataUri -method "GET" | ConvertFrom-Csv
+
+  return $metadataResponse
 }
 
 function GetAdjustedReadmeContent($pkgInfo, $lang){
@@ -59,6 +59,7 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
 
     try {
       $metadata = GetMetaData -lang $lang 
+
       $service = $metadata | ? { $_.Package -eq $pkgId }
 
       if ($service) {
@@ -70,18 +71,18 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
       Write-Host "Unable to retrieve service metadata for packageId $($pkgInfo.PackageId)"
     }
 
-    $header = "---`r`ntitle: $headerContentMatch`r`nkeywords: Azure, $lang, SDK, API, $service $($pkgInfo.PackageId)`r`nauthor: maggiepint`r`nms.author: magpint`r`nms.date: $date`r`nms.topic: article`r`nms.prod: azure`r`nms.technology: azure`r`nms.devlang: $lang`r`nms.service: $service`r`n---`r`n"
+    $header = "---`ntitle: $headerContentMatch`nkeywords: Azure, $lang, SDK, API, $service $($pkgInfo.PackageId)`nauthor: maggiepint`nms.author: magpint`nms.date: $date`nms.topic: article`nms.prod: azure`nms.technology: azure`nms.devlang: $lang`nms.service: $service`n---`n"
     $fileContent = $pkgInfo.ReadmeContent
 
     # only replace the version if the formatted header can be found
     $headerContentMatches = (Select-String -InputObject $pkgInfo.ReadmeContent -Pattern 'Azure .+? (client|plugin|shared) library for (JavaScript|Java|Python|\.NET|C)')
     if ($headerContentMatches) {
       $headerContentMatch = $headerContentMatches.Matches[0]
-      $fileContent = $pkgInfo.ReadmeContent -replace $headerContentMatch, "$headerContentMatch - Version $($pkgInfo.PackageVersion) `r`n"
+      $fileContent = $pkgInfo.ReadmeContent -replace $headerContentMatch, "$headerContentMatch - Version $($pkgInfo.PackageVersion) `n"
     }
 
     if ($fileContent) {
-      return "$header`r`n$fileContent"
+      return "$header`n$fileContent"
     }
     else {
       return ""

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -63,7 +63,7 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
       $service = $metadata | ? { $_.Package -eq $pkgId }
 
       if ($service) {
-        $service = "$service,"
+        $service = "$($service.Service)"
       }
     }
     catch {
@@ -71,13 +71,13 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
       Write-Host "Unable to retrieve service metadata for packageId $($pkgInfo.PackageId)"
     }
 
-    $header = "---`ntitle: $headerContentMatch`nkeywords: Azure, $lang, SDK, API, $service $($pkgInfo.PackageId)`nauthor: maggiepint`nms.author: magpint`nms.date: $date`nms.topic: article`nms.prod: azure`nms.technology: azure`nms.devlang: $lang`nms.service: $service`n---`n"
     $fileContent = $pkgInfo.ReadmeContent
 
     # only replace the version if the formatted header can be found
     $headerContentMatches = (Select-String -InputObject $pkgInfo.ReadmeContent -Pattern 'Azure .+? (client|plugin|shared) library for (JavaScript|Java|Python|\.NET|C)')
     if ($headerContentMatches) {
       $headerContentMatch = $headerContentMatches.Matches[0]
+      $header = "---`ntitle: $headerContentMatch`nkeywords: Azure, $lang, SDK, API, $($pkgInfo.PackageId), $service`nauthor: maggiepint`nms.author: magpint`nms.date: $date`nms.topic: article`nms.prod: azure`nms.technology: azure`nms.devlang: $lang`nms.service: $service`n---`n"
       $fileContent = $pkgInfo.ReadmeContent -replace $headerContentMatch, "$headerContentMatch - Version $($pkgInfo.PackageVersion) `n"
     }
 


### PR DESCRIPTION
Resolves the following issues:

- [x] `Service` not populating appropriately 
- [x] Extra Space breaking `h1` title line of the readme
- [x] Unparsable readme (aka been added to .docsettings ignore to ignore a readme) still generates a PR w/ the untouched readme.

@Azure/azure-sdk-eng 
