### PR TITLE
Fix for pull request issue resetting pull requests.

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
@@ -43,6 +43,11 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
                 if (configuration.IsEnabled)
                 {
                     await CreateCheckAsync(context.Client, installationId, repositoryId, sha, false, cancellationToken);
+
+                    if (action == "reopened")
+                    {
+                        await EvaluatePullRequestAsync(context.Client, installationId, repositoryId, sha, cancellationToken);
+                    }
                 }
             }
             else

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
@@ -36,12 +36,23 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
                 runIdentifier
                 );
 
-            var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
-
-            if (configuration.IsEnabled)
+            if (action == "opened" || action == "reopened")
             {
-                await CreateCheckAsync(context.Client, installationId, repositoryId, sha, false, cancellationToken);
+                var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
+
+                if (configuration.IsEnabled)
+                {
+                    await CreateCheckAsync(context.Client, installationId, repositoryId, sha, false, cancellationToken);
+                }
             }
+            else
+            {
+                Logger.LogInformation(
+                    "Ignoring pull request event because action was not 'opened' or 'reopened'. It was {action}.",
+                    action
+                    );
+            }
+
         }
     }
 }


### PR DESCRIPTION
This PR makes processing of pull request events conditional on whether the action was ```opened``` or ```reopened```. We narrow down to these subset of event actions because they are the ones that should logically reset the PR.

In the case of reopened, we also want to re-evaluate the request as well. This PR closes #654 