### PR TITLE
Handle synchronize events in Check Enforcer

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
@@ -36,7 +36,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
                 runIdentifier
                 );
 
-            if (action == "opened" || action == "reopened")
+            if (action == "opened" || action == "reopened" || action == "synchronize")
             {
                 var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
 


### PR DESCRIPTION
This PR (merging immediately) fixes a logic bug with the last set of changes I made to Check Enforcer where it doesn't handle updates to PRs (which are signaled via the synchronize action via a PR event).

Thanks to @kurtzeborn for asking the question that made me take a closer look at this.