### PR TITLE
Handle new files presence in Create-Pull-Request.ps1

### DIFF
--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -123,6 +123,11 @@ do
 
             Write-Host "git add -A"
             git add -A 
+            if ($LASTEXITCODE -ne 0)
+            {
+                Write-Error "Unable to git add LASTEXITCODE=$($LASTEXITCODE), see command output above."
+                continue
+            }
 
             Write-Host "git -c user.name=`"azure-sdk`" -c user.email=`"azuresdk@microsoft.com`" commit -m `"$($CommitMsg)`""
             git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" commit -m "$($CommitMsg)"

--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -121,8 +121,11 @@ do
                 continue
             }
 
-            Write-Host "git -c user.name=`"azure-sdk`" -c user.email=`"azuresdk@microsoft.com`" commit -am `"$($CommitMsg)`""
-            git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" commit -am "$($CommitMsg)"
+            Write-Host "git add -A"
+            git add -A 
+
+            Write-Host "git -c user.name=`"azure-sdk`" -c user.email=`"azuresdk@microsoft.com`" commit -m `"$($CommitMsg)`""
+            git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" commit -m "$($CommitMsg)"
             if ($LASTEXITCODE -ne 0)
             {
                 Write-Error "Unable to commit LASTEXITCODE=$($LASTEXITCODE), see command output above."


### PR DESCRIPTION
Extend the template to also include NEW files during rebase and patch apply.

If the patch that is applied after rebase contains new files, the following:

` commit -am "$($CommitMsg)"`

Will not pick them up.  This PR swaps it to an explicit add all to handle this situation.

@Azure/azure-sdk-eng 