### PR TITLE
Handle leading and trailing whitespace for comments.

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
@@ -24,7 +24,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
             var payload = context.Payload;
             var installationId = payload.Installation.Id;
             var repositoryId = payload.Repository.Id;
-            var comment = payload.Comment.Body.ToLower();
+            var comment = payload.Comment.Body.ToLower().Trim();
             var issueId = payload.Issue.Number;
 
             // Bail early if we aren't even a check enforcer comment. Reduces exception noise.


### PR DESCRIPTION
This PR closes #616. Just trimming whitespace from issue comments before seeing if it is a ```/check-enforcer [action]``` command. Makes it more resilient to folks copying the command from somewhere with a leading or trailing space.