### PR TITLE
Combine Check Enforcer reset and evaluate

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/IssueCommentHandler.cs
@@ -41,9 +41,11 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
                 case "/check-enforcer reset":
                     await CreateCheckAsync(context.Client, installationId, repositoryId, sha, true, cancellationToken);
+                    await EvaluatePullRequestAsync(context.Client, installationId, repositoryId, sha, cancellationToken);
                     break;
 
                 case "/check-enforcer evaluate":
+                    await CreateCheckAsync(context.Client, installationId, repositoryId, sha, true, cancellationToken);
                     await EvaluatePullRequestAsync(context.Client, installationId, repositoryId, sha, cancellationToken);
                     break;
 


### PR DESCRIPTION
This PR is related to #629. Basically people who are using the Check Enforcer ```/check-enforcer reset``` command don't know to do an ```evaluate``` afterwards. This change makes both commands do the same thing.

I'll be removing references in our documentation around ```reset``` since ```evaluate``` is probably the way we want people to think about it moving forward.