### PR TITLE
Pipeline Witness Failure Analysis

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Azure.Sdk.Tools.PipelineWitness.csproj
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Azure.Sdk.Tools.PipelineWitness.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Failure.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Failure.cs
@@ -14,6 +14,8 @@ namespace Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines
 
         public Failure(string scope, string classification)
         {
+            this.Scope = scope;
+            this.Classification = classification;
         }
 
         public string Scope { get; set; }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Failure.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Failure.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+#nullable disable
+
+namespace Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines
+{
+    public class Failure
+    {
+        public Failure(string scope, string classification)
+        {
+        }
+
+        public string Scope { get; set; }
+        public string Classification { get; set; }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Failure.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Failure.cs
@@ -8,6 +8,10 @@ namespace Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines
 {
     public class Failure
     {
+        public Failure()
+        {
+        }
+
         public Failure(string scope, string classification)
         {
         }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Run.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Run.cs
@@ -69,5 +69,8 @@ namespace Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines
 
         [JsonPropertyName("queueDurationInSeconds")]
         public double QueueDurationInSeconds { get; set; }
+
+        [JsonPropertyName("failures")]
+        public Failure[] Failures { get; set; }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/RunProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/RunProcessor.cs
@@ -164,8 +164,8 @@ namespace Azure.Sdk.Tools.PipelineWitness
                     Failures = await GetFailureClassificationsAsync(build, timeline)
                 };
 
-//                var container = await GetItemContainerAsync("azure-pipelines-runs");
-//                await container.UpsertItemAsync(run);
+                var container = await GetItemContainerAsync("azure-pipelines-runs");
+                await container.UpsertItemAsync(run);
             }
             catch (ContentNotFoundException ex)
             {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/RunProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/RunProcessor.cs
@@ -1,6 +1,7 @@
 ﻿using Azure.Cosmos;
 using Azure.Identity;
 using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis;
 using Azure.Security.KeyVault.Secrets;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Caching.Memory;
@@ -25,13 +26,15 @@ namespace Azure.Sdk.Tools.PipelineWitness
 {
     public class RunProcessor
     {
-        public RunProcessor(ILogger<RunProcessor> logger, IMemoryCache cache, HttpClient httpClient)
+        public RunProcessor(IFailureAnalyzer failureAnalyzer, ILogger<RunProcessor> logger, IMemoryCache cache, HttpClient httpClient)
         {
+            this.failureAnalyzer = failureAnalyzer;
             this.logger = logger;
             this.cache = cache;
             this.httpClient = httpClient;
         }
 
+        private IFailureAnalyzer failureAnalyzer;
         private ILogger<RunProcessor> logger;
         private IMemoryCache cache;
         private HttpClient httpClient;
@@ -157,17 +160,27 @@ namespace Azure.Sdk.Tools.PipelineWitness
                     StartTime = build.StartTime.Value,
                     FinishTime = build.FinishTime.Value,
                     AgentDurationInSeconds = agentDurationInSeconds,
-                    QueueDurationInSeconds = queueDurationInSeconds
+                    QueueDurationInSeconds = queueDurationInSeconds,
+                    Failures = await GetFailureClassificationsAsync(build, timeline)
                 };
 
-                var container = await GetItemContainerAsync("azure-pipelines-runs");
-                await container.UpsertItemAsync(run);
+//                var container = await GetItemContainerAsync("azure-pipelines-runs");
+//                await container.UpsertItemAsync(run);
             }
             catch (ContentNotFoundException ex)
             {
                 logger.LogWarning(ex, "Run information was not found, possibly a PR run that was cancelled and removed?");
                 return;
             }
+        }
+
+        public async Task<Failure[]> GetFailureClassificationsAsync(Build build, Timeline timeline)
+        {
+            // If there is no timeline, we can't analyze anything!
+            if (timeline == null) return new Failure[0];
+
+            var failures = await failureAnalyzer.AnalyzeFailureAsync(build, timeline);
+            return failures.ToArray();
         }
 
         private async Task<CosmosClient> GetCosmosClientAsync()

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzer.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzer.cs
@@ -1,0 +1,38 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class FailureAnalyzer : IFailureAnalyzer
+    {
+        public FailureAnalyzer(IFailureClassifier[] classifiers)
+        {
+            this.classifiers = classifiers;
+        }
+
+        private IFailureClassifier[] classifiers;
+
+        public async Task<IEnumerable<Failure>> AnalyzeFailureAsync(Build build, Timeline timeline)
+        {
+            var failures = new List<Failure>();
+
+            var context = new FailureAnalyzerContext(build, timeline, failures);
+            foreach (var classifier in classifiers)
+            {
+                await classifier.ClassifyAsync(context);
+            }
+
+            if (failures.Count == 0)
+            {
+                failures.Add(new Failure("Global", "Unknown"));
+            }
+
+            return failures;
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzerContext.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzerContext.cs
@@ -1,0 +1,58 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class FailureAnalyzerContext
+    {
+        public FailureAnalyzerContext(Build build, Timeline timeline, IList<Failure> failures)
+        {
+            Build = build;
+            Timeline = timeline;
+            this.failures = failures;
+        }
+
+        public Build Build { get; private set; }
+        public Timeline Timeline { get; private set; }
+
+        private IList<Failure> failures;
+
+        private string GetScope(TimelineRecord record)
+        {
+            var timelineStack = new Stack<TimelineRecord>();
+
+            var current = record;
+            while (true)
+            {
+                timelineStack.Push(current);
+
+                var parent = Timeline.Records.Where(r => r.Id == current.ParentId).SingleOrDefault();
+                if (parent == null)
+                {
+                    break;
+                } else
+                {
+                    current = parent;
+                }
+            }
+
+            var scopeBuilder = new StringBuilder();
+            timelineStack.ForEach(r => scopeBuilder.Append($"/{r.RecordType}:{r.Name}"));
+
+            var scope = scopeBuilder.ToString();
+            return scope;
+        }
+
+        public void AddFailure(TimelineRecord record, string classification)
+        {
+            var scope = GetScope(record);
+            var failure = new Failure(scope, classification);
+            failures.Add(failure);
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureAnalyzer.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureAnalyzer.cs
@@ -1,0 +1,14 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public interface IFailureAnalyzer
+    {
+        Task<IEnumerable<Failure>> AnalyzeFailureAsync(Build build, Timeline timeline);
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureClassifier.cs
@@ -1,0 +1,14 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public interface IFailureClassifier
+    {
+        Task ClassifyAsync(FailureAnalyzerContext context);
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/TimeoutClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/TimeoutClassifier.cs
@@ -1,0 +1,30 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.Design;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class CancelledTaskClassifier : IFailureClassifier
+    {
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            var timedOutTestTasks = from r in context.Timeline.Records
+                                    where r.RecordType == "Task"
+                                    where r.Result == TaskResult.Canceled
+                                    select r;
+
+            if (timedOutTestTasks.Count() > 0)
+            {
+                foreach (var timedOutTestTask in timedOutTestTasks)
+                {
+                    context.AddFailure(timedOutTestTask, "Cancelled Task");
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Cosmos;
 using Azure.Sdk.Tools.PipelineWitness;
+using Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,6 +21,8 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddLogging();
             builder.Services.AddMemoryCache();
             builder.Services.AddSingleton<RunProcessor>();
+            builder.Services.AddSingleton<IFailureAnalyzer, FailureAnalyzer>();
+            builder.Services.AddSingleton<IFailureClassifier, CancelledTaskClassifier>();
 
             // POSSIBLE WORKAROUND: The Azure Functions host environment has a health check
             //                      which pulls down the host if it exceeds 300 active outbound


### PR DESCRIPTION
This PR provides the basic plumbing for automated failure analysis in Pipeline Witness. The way this works is that for every failed pipeline run we execute analysis of the build and timeline to see if we can automatically bucket the failure into predefined failure states (the implication here is that when we detect a new kind of failure state that we want to look into we would need to update the service).

The way it works is that I have a FailureAnalyzer which routes the build/timeline though a series of classifiers which determine whether they can register a failure against the run. If a new kind of "unknown failure" starts appearing in our reporting we can look into the symptoms and create a classifier for it and then over time get some kind of sense of how big of a problem it is (to prioritize EngSys effort).

Classifiers are registered with the Dependency Injection system because I wanted them to be able to depend on external data sources/systems in order to help classify the failure. Ideally we won't need many that do that, but by registering with the DI container we get that option whilst still retaining some composability.

This first pass sets out the plumbing and provides a simple timeout classifier to prove out the system.

This data goes from Cosmos DB and into Power BI. In Power BI I'll filter the pipeline runs to just the failed runs (in a referenced table) and then expand out the rows for each failure. From there we can have reports that do things like count the failure instances over time and also cluster the failures by scope (for example we might only see failures on a specific platform and that information would be embedded into the scope string).