### PR TITLE
Update pwsh calls to follow new PS tips

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -35,27 +35,31 @@ steps:
   workingDirectory: ${{ parameters.WorkingDirectory }}
   ignoreLASTEXITCODE: true
 
-- pwsh: |
-    ${{ parameters.ScriptDirectory }}/git-branch-push.ps1 `
-      -PRBranchName "${{ parameters.PRBranchName }}" `
-      -CommitMsg "${{ parameters.CommitMsg }}" `
-      -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.PROwner }}/${{ parameters.RepoName }}.git" `
-      -PushArgs "${{ parameters.PushArgs }}"
-
+- task: PowerShell@2
   displayName: Push changes
   workingDirectory: ${{ parameters.WorkingDirectory }}
   condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
+  inputs:
+    pwsh: true
+    filePath: ${{ parameters.ScriptDirectory }}/git-branch-push.ps1
+    arguments: >
+      -PRBranchName "${{ parameters.PRBranchName }}"
+      -CommitMsg "${{ parameters.CommitMsg }}"
+      -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.PROwner }}/${{ parameters.RepoName }}.git"
+      -PushArgs "${{ parameters.PushArgs }}"
 
-- pwsh: |
-    ${{ parameters.ScriptDirectory }}/Submit-PullRequest.ps1 `
-      -RepoOwner "${{ parameters.RepoOwner }}" `
-      -RepoName "${{ parameters.RepoName }}" `
-      -BaseBranch "${{ parameters.BaseBranchName }}" `
-      -PROwner "${{ parameters.PROwner }}" `
-      -PRBranch "${{ parameters.PRBranchName }}" `
-      -AuthToken "$(azuresdk-github-pat)" `
-      -PRTitle "${{ parameters.PRTitle }}"
-
+- task: PowerShell@2
   displayName: Create pull request
   workingDirectory: ${{ parameters.WorkingDirectory }}
   condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
+  inputs:
+    pwsh: true
+    filePath: ${{ parameters.ScriptDirectory }}/Submit-PullRequest.ps1
+    arguments: >
+      -RepoOwner "${{ parameters.RepoOwner }}"
+      -RepoName "${{ parameters.RepoName }}"
+      -BaseBranch "${{ parameters.BaseBranchName }}"
+      -PROwner "${{ parameters.PROwner }}"
+      -PRBranch "${{ parameters.PRBranchName }}"
+      -AuthToken "$(azuresdk-github-pat)"
+      -PRTitle "${{ parameters.PRTitle }}"

--- a/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+++ b/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
@@ -10,9 +10,13 @@ steps:
 - task: PowerShell@2
   displayName: 'Verify Package Tags and Create Git Releases'
   inputs:
-    targetType: filePath
     filePath: ${{ parameters.ScriptDirectory }}/create-tags-and-git-release.ps1
-    arguments: -artifactLocation ${{parameters.ArtifactLocation}} -packageRepository ${{parameters.PackageRepository}} -releaseSha ${{parameters.ReleaseSha}} -repoId ${{parameters.RepoId}} -workingDirectory '${{parameters.WorkingDirectory}}'
+    arguments: >
+      -artifactLocation ${{ parameters.ArtifactLocation }}
+      -packageRepository ${{ parameters.PackageRepository }}
+      -releaseSha ${{ parameters.ReleaseSha }}
+      -repoId ${{ parameters.RepoId }}
+      -workingDirectory '${{ parameters.WorkingDirectory }}'
     pwsh: true
   timeoutInMinutes: 5
   env:

--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -16,10 +16,10 @@ parameters:
 steps:
 - pwsh: |
     git clone https://github.com/${{ parameters.TargetDocRepoOwner }}/${{ parameters.TargetDocRepoName }} ${{ parameters.WorkingDirectory }}/repo
-    
+
     try {
       Push-Location ${{ parameters.WorkingDirectory }}/repo
-    
+
       Write-Host "git checkout smoke-test"
       git checkout smoke-test
     } finally {
@@ -33,14 +33,14 @@ steps:
   inputs:
     targetType: filePath
     filePath: ${{ parameters.ScriptDirectory }}/update-docs-metadata.ps1
-    arguments: > 
-      -ArtifactLocation ${{parameters.ArtifactLocation}} 
-      -Repository ${{parameters.PackageRepository}} 
-      -ReleaseSHA ${{parameters.ReleaseSha}} 
-      -RepoId ${{parameters.RepoId}} 
-      -WorkDirectory '${{parameters.WorkingDirectory}}' 
-      -DocRepoLocation "${{parameters.WorkingDirectory}}/repo" 
-      -Language "${{parameters.Language}}" 
+    arguments: >
+      -ArtifactLocation ${{ parameters.ArtifactLocation }}
+      -Repository ${{ parameters.PackageRepository }}
+      -ReleaseSHA ${{ parameters.ReleaseSha }}
+      -RepoId ${{ parameters.RepoId }}
+      -WorkDirectory "${{ parameters.WorkingDirectory }}"
+      -DocRepoLocation "${{ parameters.WorkingDirectory }}/repo"
+      -Language "${{parameters.Language}}"
       -DocRepoContentLocation ${{ parameters.DocRepoDestinationPath }}
     pwsh: true
   env:
@@ -54,5 +54,5 @@ steps:
     CommitMsg: "Update readme content for ${{ parameters.ArtifactName }}"
     PRTitle: "Docs.MS Readme Update."
     BaseBranchName: smoke-test
-    WorkingDirectory: ${{parameters.WorkingDirectory}}/repo
-    ScriptDirectory: ${{parameters.WorkingDirectory}}/${{parameters.ScriptDirectory}}
+    WorkingDirectory: ${{ parameters.WorkingDirectory }}/repo
+    ScriptDirectory: ${{ parameters.WorkingDirectory }}/${{ parameters.ScriptDirectory }}

--- a/eng/common/pipelines/templates/steps/publish-blobs.yml
+++ b/eng/common/pipelines/templates/steps/publish-blobs.yml
@@ -7,16 +7,20 @@ parameters:
 
 steps:
 - pwsh: |
-    Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://aka.ms/downloadazcopy-v10-windows" `
-    -OutFile "azcopy.zip" | Wait-Process; Expand-Archive -Path "azcopy.zip" -DestinationPath "$(Build.BinariesDirectory)/azcopy/"
+    Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://aka.ms/downloadazcopy-v10-windows" -OutFile "azcopy.zip" | Wait-Process;
+    Expand-Archive -Path "azcopy.zip" -DestinationPath "$(Build.BinariesDirectory)/azcopy/"
   workingDirectory: $(Build.BinariesDirectory)
   displayName: Download and Extract azcopy Zip
 
 - task: Powershell@2
   inputs:
-    targetType: 'filePath'
     filePath: ${{ parameters.ScriptPath }}
-    arguments: -AzCopy $(Resolve-Path "$(Build.BinariesDirectory)/azcopy/azcopy_windows_amd64_*/azcopy.exe")[0] -DocLocation "${{ parameters.FolderForUpload }}" -SASKey "${{ parameters.BlobSASKey }}" -Language "${{ parameters.TargetLanguage }}" -BlobName "${{ parameters.BlobName }}"
+    arguments: >
+      -AzCopy $(Resolve-Path "$(Build.BinariesDirectory)/azcopy/azcopy_windows_amd64_*/azcopy.exe")[0]
+      -DocLocation "${{ parameters.FolderForUpload }}"
+      -SASKey "${{ parameters.BlobSASKey }}"
+      -Language "${{ parameters.TargetLanguage }}"
+      -BlobName "${{ parameters.BlobName }}"
     pwsh: true
     workingDirectory: $(Pipeline.Workspace)
   displayName: Copy Docs to Blob

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -41,8 +41,6 @@ param(
   $PRBody = $PRTitle
 )
 
-Write-Host "> $PSCommandPath $args"
-
 $query = "state=open&head=${PROwner}:${PRBranch}&base=${BaseBranch}"
 
 $resp = Invoke-RestMethod "https://api.github.com/repos/$RepoOwner/$RepoName/pulls?$query"

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -10,8 +10,6 @@ param (
   $UploadLatest=1
 )
 
-Write-Host "> $PSCommandPath $args"
-
 $Language = $Language.ToLower()
 
 # Regex inspired but simplified from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string

--- a/eng/common/scripts/create-tags-and-git-release.ps1
+++ b/eng/common/scripts/create-tags-and-git-release.ps1
@@ -18,8 +18,6 @@ param (
   [switch]$continueOnError = $false
 )
 
-Write-Host "> $PSCommandPath $args"
-
 . (Join-Path $PSScriptRoot artifact-metadata-parsing.ps1)
 
 $apiUrl = "https://api.github.com/repos/$repoId"

--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -28,8 +28,6 @@ param(
     [string] $PushArgs = ""
 )
 
-Write-Host "> $PSCommandPath $args"
-
 # This is necessay because of the janky git command output writing to stderr.
 # Without explicitly setting the ErrorActionPreference to continue the script
 # would fail the first time git wrote command output.
@@ -122,7 +120,7 @@ do
             }
 
             Write-Host "git add -A"
-            git add -A 
+            git add -A
             if ($LASTEXITCODE -ne 0)
             {
                 Write-Error "Unable to git add LASTEXITCODE=$($LASTEXITCODE), see command output above."

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -14,8 +14,6 @@ param (
   $DocRepoContentLocation = "docs-ref-services/" # within the doc repo, where does our readme go?
 )
 
-Write-Host "> $PSCommandPath $args"
-
 
 # import artifact parsing and semver handling
 . (Join-Path $PSScriptRoot artifact-metadata-parsing.ps1)
@@ -58,7 +56,7 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
     $pkgId = $pkgInfo.PackageId.Replace("@azure/", "")
 
     try {
-      $metadata = GetMetaData -lang $lang 
+      $metadata = GetMetaData -lang $lang
 
       $service = $metadata | ? { $_.Package -eq $pkgId }
 
@@ -99,7 +97,7 @@ $pkgs = VerifyPackages -pkgRepository $Repository `
 
 if ($pkgs) {
   Write-Host "Given the visible artifacts, readmes will be copied for the following packages"
-  Write-Host ($pkgs | % { $_.PackageId }) 
+  Write-Host ($pkgs | % { $_.PackageId })
 
   foreach ($packageInfo in $pkgs) {
     # sync the doc repo

--- a/scripts/powershell/update-docrepo-from-source.ps1
+++ b/scripts/powershell/update-docrepo-from-source.ps1
@@ -9,8 +9,6 @@ param (
   [String]$TargetServices
 )
 
-Write-Host "> $PSCommandPath $args"
-
 $PACKAGE_README_REGEX = ".*[\/\\]sdk[\\\/][^\/\\]+[\\\/][^\/\\]+[\/\\]README\.md"
 
 Write-Host "repo is $CodeRepo"


### PR DESCRIPTION
In particular for cases where we are only calling a script
we want to use the Powershell filepath version instead of inline
so that we get extra logging that shows the exact command that is
being called. This helps with reproducing issues if you need to
debug.

There have been a number of attempts to add lines at the top of our
powershell script that will echo out the command line used to call it
however unfortunately all our attempts have failed for one reason or
another.

- $PSCommandPath $args -> Only shows unbound arguments
- $MyInvocation.Line -> Only shows first line so calls spread over multiple
lines fail to show the full command. See https://github.com/PowerShell/PowerShell/issues/12609

The current attempt is to simply use the DevOps task with filepath which
shows the full command line it puts in the wrapper script.

PTAL @Azure/azure-sdk-eng 