### PR TITLE
Add test resource deployment failure classifier.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/TestResourcesDeploymentFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/TestResourcesDeploymentFailureClassifier.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+   public class TestResourcesDeploymentFailureClassifier : IFailureClassifier
+    {
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            var failedTasks = from r in context.Timeline.Records
+                              where r.Name.StartsWith("Deploy test resources")
+                              where r.Result == TaskResult.Failed
+                              select r;
+
+            if (failedTasks.Count() > 0)
+            {
+                foreach (var failedTask in failedTasks)
+                {
+                    context.AddFailure(failedTask, "Test Resource Failure");
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -27,6 +27,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, AzurePipelinesPoolOutageClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, PythonPipelineTestFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, JavaScriptLiveTestFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, TestResourcesDeploymentFailureClassifier>();
 
             // POSSIBLE WORKAROUND: The Azure Functions host environment has a health check
             //                      which pulls down the host if it exceeds 300 active outbound


### PR DESCRIPTION
We had some test resource deployment failures in the net-pr pipelines overnight. This classifier will pick them up across multiple pipelines so we can see if it is a common problem. In this case I think it was just that our sub doesn't have the resource provider enabled.

/cc @danieljurek 