### PR TITLE
Java test failure classifier.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JavaPipelineTestFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JavaPipelineTestFailureClassifier.cs
@@ -1,0 +1,33 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class JavaPipelineTestFailureClassifier : IFailureClassifier
+    {
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            if (context.Build.Definition.Name.StartsWith("java - "))
+            {
+                var failedTasks = from r in context.Timeline.Records
+                                  where r.Result == TaskResult.Failed
+                                  where r.RecordType == "Task"
+                                  where r.Name.StartsWith("Run tests")
+                                  select r;
+
+                if (failedTasks.Count() > 0)
+                {
+                    foreach (var failedTask in failedTasks)
+                    {
+                        context.AddFailure(failedTask, "Test Failure");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -29,6 +29,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, JavaScriptLiveTestFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, TestResourcesDeploymentFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, DotnetPipelineTestFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, JavaPipelineTestFailureClassifier>();
 
             // POSSIBLE WORKAROUND: The Azure Functions host environment has a health check
             //                      which pulls down the host if it exceeds 300 active outbound


### PR DESCRIPTION
This PR adds a classifier for the Java test failures. This PR depends on changes in [this PR](https://github.com/Azure/azure-sdk-for-java/pull/12224), but it can go in safely now and not cause any problems.