### PR TITLE
Classifiers for two new kinds of JS failures.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsDevFeedPublishingFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsDevFeedPublishingFailureClassifier.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class JsDevFeedPublishingFailureClassifier : IFailureClassifier
+    {
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            if (context.Build.Definition.Name.StartsWith("js -"))
+            {
+                var failedJobs = from r in context.Timeline.Records
+                                 where r.Name == "Publish packages to daily feed"
+                                 where r.RecordType == "Job"
+                                 where r.Result == TaskResult.Failed
+                                 select r;
+
+                if (failedJobs.Count() > 0)
+                {
+                    foreach (var failedJob in failedJobs)
+                    {
+                        context.AddFailure(failedJob, "Publish Failure");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsSamplesExecutionFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsSamplesExecutionFailureClassifier.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class JsSamplesExecutionFailureClassifier : IFailureClassifier
+    {
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            if (context.Build.Definition.Name.StartsWith("js -"))
+            {
+                var failedTasks = from r in context.Timeline.Records
+                                  where r.Name == "Execute Samples"
+                                  where r.Result == TaskResult.Failed
+                                  select r;
+
+                if (failedTasks.Count() > 0)
+                {
+                    foreach (var failedTask in failedTasks)
+                    {
+                        context.AddFailure(failedTask, "Sample Execution");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -30,6 +30,8 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, TestResourcesDeploymentFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, DotnetPipelineTestFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, JavaPipelineTestFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, JsSamplesExecutionFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, JsDevFeedPublishingFailureClassifier>();
 
             // POSSIBLE WORKAROUND: The Azure Functions host environment has a health check
             //                      which pulls down the host if it exceeds 300 active outbound


### PR DESCRIPTION
This PR adds classifiers for two kinds of failures we are seeing in the pipelines. One is for dev feed publishing (seeing a few of these). And the other is for a relatively uncommon (from what I can tell) failure to execute samples.