### PR TITLE
Classify recent download secrets errors.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DownloadSecretsFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DownloadSecretsFailureClassifier.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class DownloadSecretsFailureClassifier : IFailureClassifier
+    {
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            var failedTasks = from r in context.Timeline.Records
+                              where r.RecordType == "Task"
+                              where r.Result == TaskResult.Failed
+                              where r.Name.StartsWith("Download secrets")
+                              select r;
+
+            if (failedTasks.Count() > 0)
+            {
+                foreach (var failedTask in failedTasks)
+                {
+                    context.AddFailure(failedTask, "Secerts Failure");
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -32,6 +32,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, JavaPipelineTestFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, JsSamplesExecutionFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, JsDevFeedPublishingFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, DownloadSecretsFailureClassifier>();
 
             // POSSIBLE WORKAROUND: The Azure Functions host environment has a health check
             //                      which pulls down the host if it exceeds 300 active outbound


### PR DESCRIPTION
We were getting a bunch of failures in our internal pipelines where Azure Pipelines was failing on the _Download secrets ..._ task. This PR adds a classifier for those errors so we can keep an eye on what is going on.