### PR TITLE
Fix OSName setvariable failures

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-agent-os.yml
+++ b/eng/common/pipelines/templates/steps/verify-agent-os.yml
@@ -33,6 +33,5 @@ steps:
 
         if (agent_os.lower() == os_parameter.lower()):
             print('Job ran on OS: %s' % (agent_os))
-            print('##vso[task.setvariable variable=OSName]%s' % (agent_os))
         else:
             raise Exception('Job ran on the wrong OS: %s' % (agent_os))


### PR DESCRIPTION
Noticing a bunch of failures in our release pipelines because the OSName variable is flagged as read only and we are attempting to change it in the verify OS template. This removes that line altogether. Although I am not sure what side effects this will cause since I don't know why this setvariable was in there in the first place.