### PR TITLE
Correct typo and broader applicability.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DownloadSecretsFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DownloadSecretsFailureClassifier.cs
@@ -15,14 +15,14 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
             var failedTasks = from r in context.Timeline.Records
                               where r.RecordType == "Task"
                               where r.Result == TaskResult.Failed
-                              where r.Name.StartsWith("Download secrets")
+                              where r.Name.Contains("Download secrets")
                               select r;
 
             if (failedTasks.Count() > 0)
             {
                 foreach (var failedTask in failedTasks)
                 {
-                    context.AddFailure(failedTask, "Secerts Failure");
+                    context.AddFailure(failedTask, "Secrets Failure");
                 }
             }
         }


### PR DESCRIPTION
This PR changes the download secrets failure classifier to look for that sequence anywhere in the task name. It also corrects an error in the classification name.