### PR TITLE
Remove param validation from create-tags-and-git-release.ps1 that breaks C release

### DIFF
--- a/eng/common/scripts/create-tags-and-git-release.ps1
+++ b/eng/common/scripts/create-tags-and-git-release.ps1
@@ -6,7 +6,6 @@ param (
   # used by VerifyPackages
   $artifactLocation, # the root of the artifact folder. DevOps $(System.ArtifactsDirectory)
   $workingDirectory, # directory that package artifacts will be extracted into for examination (if necessary)
-  [ValidateSet("Nuget","NPM","PyPI","Maven")]
   $packageRepository, # used to indicate destination against which we will check the existing version.
   # valid options: PyPI, Nuget, NPM, Maven, C
   # used by CreateTags


### PR DESCRIPTION
@chidozieononiwu - Please have a look