### PR TITLE
Add support for creating task to label PRs in the office bot

### DIFF
--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/CommandLine/ActionType.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/CommandLine/ActionType.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CreateRuleFabricBot.CommandLine
+{
+    public enum TaskType
+    {
+        IssueRouting,
+        PullRequestLabel
+    }
+}

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/CommandLine/ActionType.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/CommandLine/ActionType.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace CreateRuleFabricBot.CommandLine
+﻿namespace CreateRuleFabricBot.CommandLine
 {
     public enum TaskType
     {

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/CommandLine/Options.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/CommandLine/Options.cs
@@ -23,7 +23,7 @@ namespace CreateRuleFabricBot.CommandLine
 
         [ArgumentGroup(nameof(ActionToTake.create))]
         [ArgumentGroup(nameof(ActionToTake.update))]
-        [OptionalArgument(null, "inputDataFile", "File with additional data. For IssueRouting: Structure for the table Labels: Column1, Handles: Column3. For PullRequestLabel: CODEOWNERS file")]
+        [OptionalArgument(null, "additionalData", "File with additional data. For IssueRouting: Structure for the table Labels: Column1, Handles: Column3. For PullRequestLabel: CODEOWNERS file")]
         public string InputDataFile { get; set; }
 
         [ArgumentGroup(nameof(ActionToTake.delete))]

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/CommandLine/Options.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/CommandLine/Options.cs
@@ -18,8 +18,13 @@ namespace CreateRuleFabricBot.CommandLine
 
         [ArgumentGroup(nameof(ActionToTake.create))]
         [ArgumentGroup(nameof(ActionToTake.update))]
-        [RequiredArgument(2, "servicesFile", "The file containing the service table. Structure for the table Labels: Column1, Handles: Column3")]
-        public string ServicesFile { get; set; }
+        [RequiredArgument(2, "taskType", "The type of the task that you want to create/update.")]
+        public TaskType TaskType{ get; set; }
+
+        [ArgumentGroup(nameof(ActionToTake.create))]
+        [ArgumentGroup(nameof(ActionToTake.update))]
+        [OptionalArgument(null, "inputDataFile", "File with additional data. For IssueRouting: Structure for the table Labels: Column1, Handles: Column3. For PullRequestLabel: CODEOWNERS file")]
+        public string InputDataFile { get; set; }
 
         [ArgumentGroup(nameof(ActionToTake.delete))]
         [RequiredArgument(2, "task", "The task id to delete.")]

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/CreateRuleFabricBot.csproj
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/CreateRuleFabricBot.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLine.Net" Version="2.1.1" />
-    <PackageReference Include="System.Text.Json" Version="4.7.1" />
+    <PackageReference Include="CommandLine.Net" Version="2.2.1" />
+    <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>
 
 </Project>

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Program.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Program.cs
@@ -1,12 +1,14 @@
 ﻿using CommandLine;
 using CreateRuleFabricBot.CommandLine;
 using CreateRuleFabricBot.Markdown;
+using CreateRuleFabricBot.Rules;
 using CreateRuleFabricBot.Rules.IssueRouting;
 using CreateRuleFabricBot.Service;
 using OutputColorizer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace CreateRuleFabricBot
 {
@@ -28,36 +30,6 @@ namespace CreateRuleFabricBot
                 return;
             }
 
-            FabricBotClient rs = new FabricBotClient(s_options.Owner, s_options.Repo, s_options.CookieToken);
-            IssueRoutingCapability irc = new IssueRoutingCapability(s_options.Owner, s_options.Repo);
-
-            string payload = string.Empty;
-
-            if (s_options.Action == ActionToTake.create || s_options.Action == ActionToTake.update)
-            {
-                Colorizer.Write("Parsing service table... ");
-                MarkdownTable table = MarkdownTable.Parse(s_options.ServicesFile);
-                Colorizer.WriteLine("[Green!done].");
-
-                foreach (var row in table.Rows)
-                {
-                    if (!string.IsNullOrEmpty(row[2].Trim()))
-                    {
-                        // the row at position 0 is the label to use on top of 'Service Attention'
-                        string[] labels = new string[] { "Service Attention", row[0] };
-
-                        // The row at position 2 is the set of mentionees to ping on the issue.
-                        IEnumerable<string> mentionees = row[2].Split(',').Select(x => x.Replace("@", "").Trim());
-
-                        //add the service
-                        irc.AddService(labels, mentionees);
-                    }
-                }
-
-                payload = irc.ToJson();
-                Colorizer.WriteLine("Found [Yellow!{0}] service routes.", irc.RouteCount);
-            }
-
             if (s_options.Prompt)
             {
                 Colorizer.WriteLine("Proceed with [Cyan!{0}] for repo [Yellow!{1}\\{2}] (y/n)? ", s_options.Action, s_options.Owner, s_options.Repo);
@@ -70,6 +42,20 @@ namespace CreateRuleFabricBot
                 }
             }
 
+            FabricBotClient rs = new FabricBotClient(s_options.Owner, s_options.Repo, s_options.CookieToken);
+
+            string payload = string.Empty;
+            string taskId = string.Empty;
+
+            // for Create and update, construct the payload and taskId 
+            if (s_options.Action == ActionToTake.create || s_options.Action == ActionToTake.update)
+            {
+                // Instantiate the object based on the TaskType 
+                BaseCapability capability = CreateCapabilityObject(s_options);
+                payload = capability.GetPayload();
+                taskId = capability.GetTaskId();
+            }
+
             try
             {
                 switch (s_options.Action)
@@ -78,7 +64,7 @@ namespace CreateRuleFabricBot
                         rs.CreateTask(payload);
                         break;
                     case ActionToTake.update:
-                        rs.UpdateTask(IssueRoutingCapability.GetTaskId(s_options.Owner, s_options.Repo), payload);
+                        rs.UpdateTask(taskId, payload);
                         break;
                     case ActionToTake.delete:
                         rs.DeleteTask(s_options.TaskId);
@@ -103,6 +89,19 @@ namespace CreateRuleFabricBot
             {
                 Colorizer.WriteLine("[Red!Error]: {0}", e.Message);
             }
+        }
+
+        private static BaseCapability CreateCapabilityObject(CommandLineArgs s_options)
+        {
+            switch (s_options.TaskType)
+            {
+                case TaskType.IssueRouting:
+                    return new IssueRoutingCapability(s_options.Owner, s_options.Repo, s_options.InputDataFile);
+                case TaskType.PullRequestLabel:
+                    return new PullRequestLabelFolderCapability(s_options.Owner, s_options.Repo, s_options.InputDataFile);
+            }
+
+            throw new InvalidOperationException("Unknown task type " + s_options.TaskType);
         }
     }
 }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Program.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Program.cs
@@ -8,6 +8,7 @@ using OutputColorizer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace CreateRuleFabricBot
@@ -32,7 +33,7 @@ namespace CreateRuleFabricBot
 
             if (s_options.Prompt)
             {
-                Colorizer.WriteLine("Proceed with [Cyan!{0}] for repo [Yellow!{1}\\{2}] (y/n)? ", s_options.Action, s_options.Owner, s_options.Repo);
+                Colorizer.Write("Proceed with [Cyan!{0}] for repo [Yellow!{1}\\{2}] (y/n)? ", s_options.Action, s_options.Owner, s_options.Repo);
                 var key = Console.ReadKey();
 
                 if (key.Key != ConsoleKey.Y)
@@ -40,6 +41,7 @@ namespace CreateRuleFabricBot
                     Colorizer.WriteLine("No action taken.");
                     return;
                 }
+                Colorizer.WriteLine("");
             }
 
             FabricBotClient rs = new FabricBotClient(s_options.Owner, s_options.Repo, s_options.CookieToken);

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/BaseCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/BaseCapability.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-
-namespace CreateRuleFabricBot.Rules
+﻿namespace CreateRuleFabricBot.Rules
 {
     public abstract class BaseCapability
     {

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/BaseCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/BaseCapability.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace CreateRuleFabricBot.Rules
+{
+    public abstract class BaseCapability
+    {
+        public abstract string GetPayload();
+        public abstract string GetTaskId();
+    }
+}

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/CodeOwnerEntry.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/CodeOwnerEntry.cs
@@ -7,7 +7,7 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
     {
         public string PathExpression { get; set; }
         
-        public bool IsRegex { get; set; }
+        public bool ContainsWildcard { get; set; }
 
         public List<string> Owners { get; set; } = new List<string>();
 
@@ -35,7 +35,7 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
             {
                 // the first entry is the path/regex
                 PathExpression = entries[0].Trim(),
-                IsRegex = entries[0].Contains('*')
+                ContainsWildcard = entries[0].Contains('*')
             };
 
             // remove the '/' from the path
@@ -64,7 +64,7 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
 
         public override string ToString()
         {
-            return $"RegEx:{IsRegex} Expression:{PathExpression} Owners:{string.Join(',', Owners)}  Labels:{string.Join(',', Labels)}";
+            return $"RegEx:{ContainsWildcard} Expression:{PathExpression} Owners:{string.Join(',', Owners)}  Labels:{string.Join(',', Labels)}";
         }
     }
 }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/CodeOwnerEntry.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/CodeOwnerEntry.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace CreateRuleFabricBot.Rules.PullRequestLabel
+{
+    internal class CodeOwnerEntry
+    {
+        public string PathExpression { get; set; }
+        
+        public bool IsRegex { get; set; }
+
+        public List<string> Owners { get; set; } = new List<string>();
+
+        public List<string> Labels { get; set; } = new List<string>();
+
+        public static CodeOwnerEntry Parse(string line)
+        {
+            // The format for the Codeowners File will be:
+            // <path> @<owner> ... @<owner> %<label> ... %<label>
+
+            if (string.IsNullOrEmpty(line) || line.TrimStart().StartsWith('#'))
+            {
+                return null;
+            }
+
+            line = line.Replace('\t', ' ');
+            string[] entries = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            if (entries.Length == 0)
+            {
+                return null;
+            }
+
+            CodeOwnerEntry coe = new CodeOwnerEntry
+            {
+                // the first entry is the path/regex
+                PathExpression = entries[0].Trim(),
+                IsRegex = entries[0].Contains('*')
+            };
+
+            // remove the '/' from the path
+            if (coe.PathExpression.StartsWith("/"))
+            {
+                coe.PathExpression = coe.PathExpression.Substring(1);
+            }
+
+            for (int i = 1; i < entries.Length; i++)
+            {
+                string entry = entries[i].Trim();
+
+                if (entry[0] == '@')
+                {
+                    coe.Owners.Add(entry.Substring(1));
+                }
+
+                if (entry[0] == '%')
+                {
+                    coe.Labels.Add(entry.Substring(1));
+                }
+            }
+
+            return coe;
+        }
+
+        public override string ToString()
+        {
+            return $"RegEx:{IsRegex} Expression:{PathExpression} Owners:{string.Join(',', Owners)}  Labels:{string.Join(',', Labels)}";
+        }
+    }
+}

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -55,7 +55,7 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
             for (int i = 0; i < entries.Count; i++)
             {
                 // Entries with wildcards are not yet supported
-                if (entries[i].IsRegex)
+                if (entries[i].ContainsWildcard)
                 {
                     // log a warning there
 

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -1,0 +1,57 @@
+﻿using CreateRuleFabricBot.CommandLine;
+using CreateRuleFabricBot.Markdown;
+using OutputColorizer;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CreateRuleFabricBot.Rules.IssueRouting
+{
+    public class PullRequestLabelFolderCapability : BaseCapability
+    {
+        private static readonly string s_template = @"
+{
+      ""taskType"": ""trigger"",
+      ""capabilityId"": ""PrAutoLabel"",
+      ""subCapability"": ""Path"",
+      ""version"": ""1.0"",
+      ""id"": ""###taskId###"",
+      ""config"": {
+        ""configs"": [
+          {
+            ""label"": ""###label###"",
+            ""pathFilter"": [ ###srcFolders### ],
+            ""exclude"": [ ]
+    }
+        ]
+      }
+    }
+";
+
+        private readonly string _repo;
+        private readonly string _owner;
+        private readonly string _codeownersFile;
+
+        public PullRequestLabelFolderCapability(string org, string name, string codeownersFile)
+        {
+            _repo = org;
+            _owner = name;
+            _codeownersFile = codeownersFile;
+        }
+
+        public override string GetPayload()
+        {
+            Colorizer.Write("Parsing CODEOWNERS table... ");
+
+            return s_template
+                .Replace("###taskId###", GetTaskId())
+                .Replace("###label###", "Client")
+                .Replace(" ###srcFolders###", string.Join(",", new string[] { "src1", "src2" }));
+        }
+
+        public override string GetTaskId()
+        {
+            return $"AzureSDKPullRequestLabelFolder_{_owner}_{_repo}";
+        }
+    }
+}

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -1,9 +1,9 @@
-﻿using CreateRuleFabricBot.CommandLine;
-using CreateRuleFabricBot.Markdown;
+﻿using CreateRuleFabricBot.Rules.PullRequestLabel;
 using OutputColorizer;
-using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Text;
 
 namespace CreateRuleFabricBot.Rules.IssueRouting
 {
@@ -18,14 +18,19 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
       ""id"": ""###taskId###"",
       ""config"": {
         ""configs"": [
+            ###labelConfig###
+        ],
+      ""taskName"" :""Auto PR based on folder paths ""
+      }
+    }
+";
+
+        private static readonly string s_configTemplate = @"
           {
             ""label"": ""###label###"",
             ""pathFilter"": [ ###srcFolders### ],
             ""exclude"": [ ]
-    }
-        ]
-      }
-    }
+          }
 ";
 
         private readonly string _repo;
@@ -42,11 +47,76 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
         public override string GetPayload()
         {
             Colorizer.Write("Parsing CODEOWNERS table... ");
+            List<CodeOwnerEntry> entries = ReadOwnersFromFile();
+            Colorizer.WriteLine("[Green!Done]");
 
+            StringBuilder configPayload = new StringBuilder();
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                // Entries with wildcards are not yet supported
+                if (entries[i].IsRegex)
+                {
+                    // log a warning there
+
+                    if (entries[i].Labels.Any())
+                    {
+                        Colorizer.WriteLine("[Yellow!Warning]: The expression '{0}' contains a wildcard and a label '{1}' which is not supported!", entries[i].PathExpression, string.Join(',', entries[i].Labels));
+                    }
+
+                    continue; //TODO: regex expressions are not yet supported
+                }
+
+                // Entries with more than one label are not yet supported.
+                if (entries[i].Labels.Count > 1)
+                {
+                    Colorizer.WriteLine("[Yellow!Warning]: Multiple labels for the same path are not yet supported");
+                    continue;
+                }
+
+                // get the payload
+                string entryPayload = ToConfigString(entries[i]);
+
+                Colorizer.WriteLine("Found path '[Cyan!{0}]' with label '[Magenta!{1}]'", entries[i].PathExpression, entries[i].Labels.FirstOrDefault());
+
+                configPayload.Append(ToConfigString(entries[i]));
+            }
+
+            // remove the trailing ','
+            configPayload.Remove(configPayload.Length - 1, 1);
+
+            // create the payload from the template
             return s_template
                 .Replace("###taskId###", GetTaskId())
-                .Replace("###label###", "Client")
-                .Replace(" ###srcFolders###", string.Join(",", new string[] { "src1", "src2" }));
+                .Replace("###labelConfig###", configPayload.ToString());
+        }
+
+        private string ToConfigString(CodeOwnerEntry entry)
+        {
+            string result = s_configTemplate;
+
+            result = result.Replace("###label###", entry.Labels.First());
+            result = result.Replace("###srcFolders###", $"\"{entry.PathExpression}\"");
+
+            return result;
+        }
+
+        private List<CodeOwnerEntry> ReadOwnersFromFile()
+        {
+            List<CodeOwnerEntry> entries = new List<CodeOwnerEntry>();
+            string line;
+            using (StreamReader sr = new StreamReader(_codeownersFile))
+            {
+                while ((line = sr.ReadLine()) != null)
+                {
+                    CodeOwnerEntry entry = CodeOwnerEntry.Parse(line);
+                    if (entry != null)
+                    {
+                        entries.Add(entry);
+                    }
+                }
+            }
+            return entries;
         }
 
         public override string GetTaskId()

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/LiveTests.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/LiveTests.cs
@@ -27,32 +27,32 @@ namespace Tests
         [Test]
         public void CreateUpdateDeleteRule()
         {
-            IssueRoutingCapability irc = new IssueRoutingCapability(_org, _repo);
+            IssueRoutingCapability irc = new IssueRoutingCapability(_org, _repo, "");
 
-            _requestSender.CreateTask(irc.ToJson());
+            _requestSender.CreateTask(irc.GetPayload());
             // delay for the service to react
             Thread.Sleep(3000);
 
             var ids = _requestSender.GetTaskIds();
-            Assert.Contains(IssueRoutingCapability.GetTaskId(_org, _repo), ids);
+            Assert.Contains(irc.GetTaskId(), ids);
             // delay for the service to react
             Thread.Sleep(3000);
 
-            _requestSender.UpdateTask(IssueRoutingCapability.GetTaskId(_org, _repo), irc.ToJson());
-            // delay for the service to react
-            Thread.Sleep(3000);
-
-            ids = _requestSender.GetTaskIds();
-            Assert.Contains(IssueRoutingCapability.GetTaskId(_org, _repo), ids);
-            // delay for the service to react
-            Thread.Sleep(3000);
-
-            _requestSender.DeleteTask(IssueRoutingCapability.GetTaskId(_org, _repo));
+            _requestSender.UpdateTask(irc.GetTaskId(), irc.GetPayload());
             // delay for the service to react
             Thread.Sleep(3000);
 
             ids = _requestSender.GetTaskIds();
-            Assert.False(ids.Any(x => x == IssueRoutingCapability.GetTaskId(_org, _repo)));
+            Assert.Contains(irc.GetTaskId(), ids);
+            // delay for the service to react
+            Thread.Sleep(3000);
+
+            _requestSender.DeleteTask(irc.GetTaskId());
+            // delay for the service to react
+            Thread.Sleep(3000);
+
+            ids = _requestSender.GetTaskIds();
+            Assert.False(ids.Any(x => x == irc.GetTaskId()));
         }
     }
 }


### PR DESCRIPTION
This adds support in the tool that creates tasks for the Office bot for the task that adds labels to PRs based on the folders they are in.

The tool should be pointed at a CODEOWNERS file (urls not supported) and will create a task based on those.

The following are the limitations:
- Wildcards are not supported
- A single label per folder is allowed

To specify a label, add a `%LabelName` on the same line as the folder it applies to in the CODEOWNERS file.

Next steps after this is merged:
- Update the codeowners files in the repos where we want to enable this
- Update the documentation describing what is allowed in the CODEOWNERS file and the limitations noted above
- Creating the rules in the office bot for all the repos

/cc @weshaggard @mitchdenny @alzimmermsft 
Note: The syntax for using the tool has changes slightly (/cc @lilyjma)
