### PR TITLE
Fix an issue where paths without a label would lead to a crash.

### DIFF
--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Program.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Program.cs
@@ -31,19 +31,6 @@ namespace CreateRuleFabricBot
                 return;
             }
 
-            if (s_options.Prompt)
-            {
-                Colorizer.Write("Proceed with [Cyan!{0}] for repo [Yellow!{1}\\{2}] (y/n)? ", s_options.Action, s_options.Owner, s_options.Repo);
-                var key = Console.ReadKey();
-
-                if (key.Key != ConsoleKey.Y)
-                {
-                    Colorizer.WriteLine("No action taken.");
-                    return;
-                }
-                Colorizer.WriteLine("");
-            }
-
             FabricBotClient rs = new FabricBotClient(s_options.Owner, s_options.Repo, s_options.CookieToken);
 
             string payload = string.Empty;
@@ -56,6 +43,19 @@ namespace CreateRuleFabricBot
                 BaseCapability capability = CreateCapabilityObject(s_options);
                 payload = capability.GetPayload();
                 taskId = capability.GetTaskId();
+            }
+
+            if (s_options.Prompt)
+            {
+                Colorizer.Write("Proceed with [Cyan!{0}] for repo [Yellow!{1}\\{2}] (y/n)? ", s_options.Action, s_options.Owner, s_options.Repo);
+                var key = Console.ReadKey();
+
+                if (key.Key != ConsoleKey.Y)
+                {
+                    Colorizer.WriteLine("No action taken.");
+                    return;
+                }
+                Colorizer.WriteLine("");
             }
 
             try

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/CodeOwnerEntry.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/CodeOwnerEntry.cs
@@ -1,12 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace CreateRuleFabricBot.Rules.PullRequestLabel
 {
     internal class CodeOwnerEntry
     {
         public string PathExpression { get; set; }
-        
+
         public bool ContainsWildcard { get; set; }
 
         public List<string> Owners { get; set; } = new List<string>();
@@ -18,15 +19,19 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
             // The format for the Codeowners File will be:
             // <path> @<owner> ... @<owner> %<label> ... %<label>
 
-            if (string.IsNullOrEmpty(line) || line.TrimStart().StartsWith('#'))
+            // get rid of tabs
+            line = line.Replace('\t', ' ');
+            // trim the line to get rid of whitespace before and after.
+            line = line.Trim();
+
+            if (string.IsNullOrEmpty(line) || line.StartsWith('#'))
             {
                 return null;
             }
 
-            line = line.Replace('\t', ' ');
-            string[] entries = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            List<string> entries = SplitLine(line).ToList();
 
-            if (entries.Length == 0)
+            if (!entries.Any())
             {
                 return null;
             }
@@ -34,7 +39,7 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
             CodeOwnerEntry coe = new CodeOwnerEntry
             {
                 // the first entry is the path/regex
-                PathExpression = entries[0].Trim(),
+                PathExpression = entries[0],
                 ContainsWildcard = entries[0].Contains('*')
             };
 
@@ -44,7 +49,7 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
                 coe.PathExpression = coe.PathExpression.Substring(1);
             }
 
-            for (int i = 1; i < entries.Length; i++)
+            for (int i = 1; i < entries.Count; i++)
             {
                 string entry = entries[i].Trim();
 
@@ -60,6 +65,24 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
             }
 
             return coe;
+        }
+
+        private static IEnumerable<string> SplitLine(string line)
+        {
+            // Split the line into segments that are delimited by '@', '%' and the end of the string.
+
+            int previousSplit = 0;
+            for (int i = 0; i < line.Length; i++)
+            {
+                if (line[i] == '@' || line[i] == '%')
+                {
+                    yield return line.Substring(previousSplit, i - previousSplit ).Trim();
+                    previousSplit = i;
+                }
+            }
+
+            // add the last entry
+            yield return line.Substring(previousSplit, line.Length - previousSplit).Trim();
         }
 
         public override string ToString()

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/CodeOwnerEntry.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/CodeOwnerEntry.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 
 namespace CreateRuleFabricBot.Rules.PullRequestLabel
@@ -76,7 +75,7 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
             {
                 if (line[i] == '@' || line[i] == '%')
                 {
-                    yield return line.Substring(previousSplit, i - previousSplit ).Trim();
+                    yield return line.Substring(previousSplit, i - previousSplit).Trim();
                     previousSplit = i;
                 }
             }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -61,7 +61,7 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
 
                     if (entries[i].Labels.Any())
                     {
-                        Colorizer.WriteLine("[Yellow!Warning]: The expression '{0}' contains a wildcard and a label '{1}' which is not supported!", entries[i].PathExpression, string.Join(',', entries[i].Labels));
+                        Colorizer.WriteLine("[Yellow!Warning]: The path '[Cyan!{0}]' contains a wildcard and a label '[Magenta!{1}]' which is not supported!", entries[i].PathExpression, string.Join(',', entries[i].Labels));
                     }
 
                     continue; //TODO: regex expressions are not yet supported
@@ -70,7 +70,13 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
                 // Entries with more than one label are not yet supported.
                 if (entries[i].Labels.Count > 1)
                 {
-                    Colorizer.WriteLine("[Yellow!Warning]: Multiple labels for the same path are not yet supported");
+                    Colorizer.WriteLine("[Yellow!Warning]: Multiple labels for the same path '[Cyan!{0}]' are not yet supported", entries[i].PathExpression);
+                    continue;
+                }
+
+                if (entries[i].Labels.Count==0)
+                {
+                    Colorizer.WriteLine("[Yellow!Warning]: The path '[Cyan!{0}]' does not contain a label.", entries[i].PathExpression, string.Join(',', entries[i].Labels));
                     continue;
                 }
 

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -53,6 +53,9 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
 
             StringBuilder configPayload = new StringBuilder();
 
+            List<CodeOwnerEntry> entriesToCreate = new List<CodeOwnerEntry>();
+
+            // Filter our the list of entries that we want to create.
             for (int i = 0; i < entries.Count; i++)
             {
                 // Entries with wildcards are not yet supported
@@ -81,17 +84,29 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
                     continue;
                 }
 
+                entriesToCreate.Add(entries[i]);
+            }
+
+            Colorizer.WriteLine("Found the following rules:");
+
+            // Create the payload.
+            foreach (var entry in entriesToCreate)
+            {
                 // get the payload
-                string entryPayload = ToConfigString(entries[i]);
+                string entryPayload = ToConfigString(entry);
 
-                Colorizer.WriteLine("Found path '[Cyan!{0}]' with label '[Magenta!{1}]'", entries[i].PathExpression, entries[i].Labels.FirstOrDefault());
+                Colorizer.WriteLine("[Cyan!{0}] => [Magenta!{1}]", entry.PathExpression, entry.Labels.FirstOrDefault());
 
-                configPayload.Append(ToConfigString(entries[i]));
+                configPayload.Append(ToConfigString(entry));
                 configPayload.Append(',');
             }
 
+
             // remove the trailing ','
             configPayload.Remove(configPayload.Length - 1, 1);
+
+            // Log the set of paths we are creating.
+
 
             // create the payload from the template
             return s_template

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Encodings.Web;
 
 namespace CreateRuleFabricBot.Rules.IssueRouting
 {
@@ -86,6 +87,7 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
                 Colorizer.WriteLine("Found path '[Cyan!{0}]' with label '[Magenta!{1}]'", entries[i].PathExpression, entries[i].Labels.FirstOrDefault());
 
                 configPayload.Append(ToConfigString(entries[i]));
+                configPayload.Append(',');
             }
 
             // remove the trailing ','


### PR DESCRIPTION
Move the prompt a bit later in the process to allow for the task to output messages before creating the task.

Add better logs before creating the task.