### PR TITLE
Update VersionParsing to Resolve Release Errors for Python

### DIFF
--- a/eng/common/scripts/modules/Package-Properties.psm1
+++ b/eng/common/scripts/modules/Package-Properties.psm1
@@ -17,7 +17,13 @@ class PackageProps
     )
     {
         $this.pkgName = $pkgName
-        $this.pkgVersion = [AzureEngSemanticVersion]::ParseVersionString($pkgVersion)
+
+        $versionObj = [AzureEngSemanticVersion]::ParseVersionString($pkgVersion)
+        $this.pkgVersion = $versionObj.RawVersion
+
+        Write-Host $versionObj.RawVersion
+        Write-Host $this.pkgVersion
+
         if ($this.pkgVersion -eq $null)
         {
             Write-Error "Invalid version in $pkgDirectoryPath"
@@ -109,6 +115,7 @@ function Extract-PythonPkgProps ($pkgPath, $serviceName, $pkgName)
         pushd $RepoRoot
         $setupProps = (python -c "import sys; import os; sys.path.append(os.path.join('scripts', 'devops_tasks')); from common_tasks import parse_setup; obj=parse_setup('$setupLocation'); print('{0},{1}'.format(obj[0], obj[1]));") -split ","
         popd
+
         if (($setupProps -ne $null) -and ($setupProps[0] -eq $pkgName))
         {
             return [PackageProps]::new($setupProps[0], $setupProps[1], $pkgPath, $serviceName)


### PR DESCRIPTION
Currently we're seeing [failing releases](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=450458&view=logs&j=7a9a3a09-f74e-5f55-65bc-59f7e8172950&t=2a4df810-d532-54f5-a55d-2385d43df013) because we're looking for changelog versions that don't exist.

This is my attempt at fixing it. Something _really_ weird is happening though. 

In the following code
![image](https://user-images.githubusercontent.com/45376673/86874010-5e6b3b00-c094-11ea-9a5e-6b0b3cc4cae1.png)

I'd expect the values to be identical.

And _yet_:
![image](https://user-images.githubusercontent.com/45376673/86874045-75aa2880-c094-11ea-9884-2d4b0db2facc.png)

Oh man PS is frustrating.

#772  might actually relate directly to this.

@Azure/azure-sdk-eng 
