### PR TITLE
Fix Transient Error prior to Module Install

### DIFF
--- a/eng/common/scripts/modules/Package-Properties.psm1
+++ b/eng/common/scripts/modules/Package-Properties.psm1
@@ -65,6 +65,9 @@ class PackageProps
 }
 
 $ProgressPreference = "SilentlyContinue"
+
+
+Register-PSRepository -Default -ErrorAction:SilentlyContinue
 Install-Module -Name powershell-yaml -RequiredVersion 0.4.1 -Force -Scope CurrentUser
 
 function Extract-PkgProps ($pkgPath, $serviceName, $pkgName, $lang)


### PR DESCRIPTION
Fix transient failure due to installing unregistered PSGallery repository.
https://dev.azure.com/azure-sdk/public/_build/results?buildId=453244&view=logs&jobId=b70e5e73-bbb6-5567-0939-8415943fadb9&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=ac8f4042-9b76-5db4-27b1-2a4abaa9bb3c