### PR TITLE
Handle BoM in Doc-Warden

### DIFF
--- a/packages/python-packages/api-stub-generator/setup.py
+++ b/packages/python-packages/api-stub-generator/setup.py
@@ -35,8 +35,6 @@ setup(
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/packages/python-packages/doc-warden/README.md
+++ b/packages/python-packages/doc-warden/README.md
@@ -12,7 +12,7 @@ Features:
     - Changelogs contain entry and content for the latest package version
 * Generates report for included observed packages
 
-This package is tested on Python 2.7 -> 3.8.
+This package is tested on Python 3.4 -> 3.8. This package went python3-only starting with `0.7.0`.
 
 ## Prerequisites
 This package is intended to be run as part of a pipeline within Azure DevOps. As such, [Python](https://www.python.org/downloads/) must be installed prior to attempting to install or use `Doc-Warden.` While `pip` comes pre-installed on most modern Python installs, if `pip` is an unrecognized command when attempting to install `warden`, run the following command **after** your Python installation is complete.

--- a/packages/python-packages/doc-warden/changelog.md
+++ b/packages/python-packages/doc-warden/changelog.md
@@ -1,5 +1,8 @@
 # Release History
 
+## 0.6.2
+- Fixed an issue where `doc-warden` ignored the very first h1 element. This is due to a BOM not being handled properly.
+
 ## 0.6.1
 - `Pygments` style code-fence blocks are parsed badly by `markdown2`. This results in phantom headers that break document hierarchy. Remove these blocks right after reading the readme and before passing to html parsing.
 

--- a/packages/python-packages/doc-warden/changelog.md
+++ b/packages/python-packages/doc-warden/changelog.md
@@ -1,7 +1,7 @@
 # Release History
 
-## 0.6.2
-- Fixed an issue where `doc-warden` ignored the very first h1 element. This is due to a BOM not being handled properly.
+## 0.7.0
+- Fixed an issue where `doc-warden` ignored the very first h1 element. This is due to a BOM not being handled properly. Dropped support for py2.7.
 
 ## 0.6.1
 - `Pygments` style code-fence blocks are parsed badly by `markdown2`. This results in phantom headers that break document hierarchy. Remove these blocks right after reading the readme and before passing to html parsing.

--- a/packages/python-packages/doc-warden/warden/enforce_readme_content.py
+++ b/packages/python-packages/doc-warden/warden/enforce_readme_content.py
@@ -59,7 +59,7 @@ def verify_md_readme(readme, config, section_sorting_dict):
     if config.verbose_output:
         print('Examining content in {}'.format(readme))
 
-    with open(readme, 'r', encoding="utf-8") as f:
+    with open(readme, 'r', encoding="utf-8-sig") as f:
         readme_content = f.read()
         
     # we need to sanitize to remove the fenced code blocks. The reasoning here is that markdown2 is having issues

--- a/packages/python-packages/doc-warden/warden/version.py
+++ b/packages/python-packages/doc-warden/warden/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.6.1'
+VERSION = '0.6.2'

--- a/packages/python-packages/doc-warden/warden/version.py
+++ b/packages/python-packages/doc-warden/warden/version.py
@@ -1,1 +1,1 @@
-VERSION = '0.6.2'
+VERSION = '0.7.0'


### PR DESCRIPTION
Need to do some additional smoke-test on `python 2.7`. OR I drop `python 2.7` support. I'm leaning that way right now.


@Azure/azure-sdk-eng  