### PR TITLE
Treat any import error during stubgen as hard error

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
@@ -176,11 +176,8 @@ class StubGenerator:
                 continue
 
             logging.debug("Importing module {}".format(m))
-            try:
-                module_obj = importlib.import_module(m)
-                self.module_dict[m] = ModuleNode(m, module_obj, nodeindex)
-            except:
-                logging.error("Failed to import {}".format(m))
+            module_obj = importlib.import_module(m)
+            self.module_dict[m] = ModuleNode(m, module_obj, nodeindex)
 
         # Create navigation info to navigate within APIreview tool
         navigation = Navigation(package_name, None)


### PR DESCRIPTION
APIStubgen is not reporting any import failure properly. Any import module exception must be a hard failure. This was soft error earlier due to import of all folders( including non modules) in code repo with init.py and was causing storm of errors. This was already changed to import modules starting with root module name only but failure was not changed from soft error to hard error.