### PR TITLE
Scope module Installation to only the function where it is used

### DIFF
--- a/eng/common/scripts/modules/Package-Properties.psm1
+++ b/eng/common/scripts/modules/Package-Properties.psm1
@@ -64,12 +64,6 @@ class PackageProps
     }
 }
 
-$ProgressPreference = "SilentlyContinue"
-
-
-Register-PSRepository -Default -ErrorAction:SilentlyContinue
-Install-Module -Name powershell-yaml -RequiredVersion 0.4.1 -Force -Scope CurrentUser
-
 function Extract-PkgProps ($pkgPath, $serviceName, $pkgName, $lang)
 {
     if ($lang -eq "net")
@@ -261,6 +255,9 @@ function Operate-OnPackages ($activePkgList, $serviceName, $language, $repoRoot,
 
 function Get-PkgListFromYml ($ciYmlPath)
 {
+    $ProgressPreference = "SilentlyContinue"
+    Register-PSRepository -Default -ErrorAction:SilentlyContinue
+    Install-Module -Name powershell-yaml -RequiredVersion 0.4.1 -Force -Scope CurrentUser
     $ciYmlContent = Get-Content $ciYmlPath -Raw
     $ciYmlObj = ConvertFrom-Yaml $ciYmlContent -Ordered
     if ($ciYmlObj.Contains("stages"))


### PR DESCRIPTION
Powershell-yaml is only needed for the 'Get-AllPkgProperties' function which right now is only used for local dev scenarios.
So scoping module installation to the function where it is used.