### PR TITLE
Change iOS pipeline generation configuration.

### DIFF
--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -26,7 +26,7 @@ jobs:
         InternalOptions: '--variablegroup 1 --variablegroup 58 --variablegroup 76'
       iOS:
         RepositoryName: azure-sdk-for-ios
-        Branch: dev
+        Branch: master
         Prefix: ios
         PublicOptions: ''
         InternalOptions: '--variablegroup 1 --variablegroup 58 --variablegroup 76'


### PR DESCRIPTION
The following PR changes the configuration for pipeline generator to stop generating from the ```dev``` branch for the ios repository.