### PR TITLE
Remove iOS from pipeline generation.

### DIFF
--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -24,12 +24,6 @@ jobs:
         Prefix: android
         PublicOptions: ''
         InternalOptions: '--variablegroup 1 --variablegroup 58 --variablegroup 76'
-      iOS:
-        RepositoryName: azure-sdk-for-ios
-        Branch: master
-        Prefix: ios
-        PublicOptions: ''
-        InternalOptions: '--variablegroup 1 --variablegroup 58 --variablegroup 76'
       JavaScript:
         RepositoryName: azure-sdk-for-js
         Branch: master


### PR DESCRIPTION
This PR removes iOS from the automatic pipeline generation process. Because the iOS repository just has the one pipeline, it is managed manually.