### PR TITLE
Always clean up resources (runs during cancel)

### DIFF
--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -32,5 +32,5 @@ steps:
         -Force `
         -Verbose
     displayName: Remove test resources
-    condition: and(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), succeededOrFailed())
+    condition: ne(variables['AZURE_RESOURCEGROUP_NAME'], '')
     continueOnError: true


### PR DESCRIPTION
Partial https://github.com/Azure/azure-sdk-tools/issues/754 ... The `succeededOrFailed()` returns false in the case of a canceled build. This removes that criteria so we remove the resources on a canceled build. 

Since we don't have asynchronous resource deletion yet this synchronous step trades a few minutes of extra agent time for a more clean Test Resources subscription. 