### PR TITLE
Fix type parsing issue for complex types

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -13,7 +13,8 @@ from ._diagnostic import Diagnostic
 JSON_FIELDS = ["Name", "Version", "VersionString", "Navigation", "Tokens", "Diagnostics"]
 
 HEADER_TEXT = "# Package is parsed using api-stub-generator(version:{})".format(VERSION)
-COMPLEX_DATA_TYPE_PATTERN = re.compile("([\w.]+)(\[|\()[^\]\)]+(\]|\))")
+TYPE_NAME_REGEX = re.compile("(~?[a-zA-Z\d.]+)")
+TYPE_OR_SEPERATOR = " or "
 
 # Lint warnings
 SOURCE_LINK_NOT_AVAILABLE = "Source definition link is not available for [{0}]. Please check and ensure type is fully qualified name in docstring"
@@ -94,55 +95,26 @@ class ApiView:
         if postfix_space:
             self.add_space()
 
-    def _generate_type_tokens(self, type_name, prefix_type, line_id = None):
-        # Generate tokens for multiple data types
-        # for e.g. Union[type1, type2,] or dict(type1, type2)
-        # For some args, type is given as just "dict"
-        # We should not process further if type name is same as prefix(In above e.g. dict)
-        logging.debug("Generating tokens for type: {}".format(type_name))
-        if prefix_type == type_name:
-            self.add_keyword(prefix_type)
-            return
-
-        logging.debug("Processing type {0} and prefix {1}".format(type_name, prefix_type))
-        prefix_len = len(prefix_type)
-        type_names = type_name[prefix_len + 1 : -1]
-        if type_names:
-            self.add_keyword(prefix_type)
-            self.add_punctuation(type_name[prefix_len])
-            # Split types and add individual types
-            types = type_names.split(",")
-            type_count = len(types)
-            for index in range(type_count):
-                self.add_type(types[index].strip(), line_id)
-                # Add separator between types
-                if index < type_count - 1:
-                    self.add_punctuation(",", False, True)
-            self.add_punctuation(type_name[-1])
-
 
     def add_type(self, type_name, line_id=None):
         # This method replace full qualified internal types to short name and generate tokens
         if not type_name:
             return
 
+        type_name = type_name.replace(":class:", "")
         logging.debug("Processing type {}".format(type_name))
-        # Check if type is multi value types like Union, Dict, list etc
-        # Those types needs to be recursively processed
-        multi_types = re.search(COMPLEX_DATA_TYPE_PATTERN,type_name)
-        if multi_types:
-            self._generate_type_tokens(type_name, multi_types.groups()[0], line_id)
-        else:
-            # Encode mutliple types with or separator into Union
-            types = [t for t in type_name.split() if t != 'or']
-            if len(types) > 1:
-                # Make a Union of types if multiple types are present
-                self._generate_type_tokens("Union[{}]".format(", ".join(types)), "Union", line_id)
-            else:
-                self._add_type_token(types[0], line_id)
+        # Check if multiple types are listed with 'or' seperator
+        # Encode mutliple types with or separator into Union
+        if TYPE_OR_SEPERATOR in type_name:
+            types = [t.strip() for t in type_name.split(TYPE_OR_SEPERATOR) if t != TYPE_OR_SEPERATOR]
+            # Make a Union of types if multiple types are present
+            type_name = "Union[{}]".format(", ".join(types))
+
+        self._add_type_token(type_name, line_id)
 
 
-    def _add_type_token(self, type_name, line_id = None):
+    def _add_token_for_type_name(self, type_name, line_id = None):
+        logging.debug("Generating tokens for type name {}".format(type_name))
         token = Token(type_name, TokenKind.TypeName)
         type_full_name = type_name[1:] if type_name.startswith("~") else type_name
         token.set_value(type_full_name.split(".")[-1])
@@ -157,6 +129,29 @@ class ApiView:
                 # Navigation ID is missing for internal type, add diagnostic error
                 self.add_diagnostic(SOURCE_LINK_NOT_AVAILABLE.format(token.Value), line_id)            
         self.add_token(token)
+
+
+    def _add_type_token(self, type_name, line_id = None):
+        # parse to get individual type name
+        logging.debug("Generating tokens for type {}".format(type_name))
+        types = re.search(TYPE_NAME_REGEX, type_name)
+        if types:
+            # Generate token for the prefix before internal type
+            # process internal type
+            # process post fix of internal type recursively to find replace more internal types
+            parsed_type = types.groups()[0]
+            index = type_name.find(parsed_type)
+            prefix = type_name[:index]
+            if prefix:
+                self.add_punctuation(prefix)
+            # process parsed type name. internal or built in
+            self._add_token_for_type_name(parsed_type)
+            postfix = type_name[index + len(parsed_type):]
+            # process remaining string in type recursively
+            self._add_type_token(postfix, line_id)
+        else:
+            # This is required group ending punctuations
+            self.add_punctuation(type_name)        
 
 
     def add_diagnostic(self, text, line_id):

--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -104,7 +104,7 @@ class ApiView:
         type_name = type_name.replace(":class:", "")
         logging.debug("Processing type {}".format(type_name))
         # Check if multiple types are listed with 'or' seperator
-        # Encode mutliple types with or separator into Union
+        # Encode multiple types with or separator into Union
         if TYPE_OR_SEPERATOR in type_name:
             types = [t.strip() for t in type_name.split(TYPE_OR_SEPERATOR) if t != TYPE_OR_SEPERATOR]
             # Make a Union of types if multiple types are present

--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.1.2"
+VERSION = "0.1.3"

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -13,7 +13,7 @@ find_single_type_regex = "(?<!:):{0}\s?{1}:[\s]*([\S]+)(?!:)"
 find_union_type_regex = (
     "(?<!:):{0}\s?{1}:[\s]*([\w.]*((\[[^\n]+\])|(\([^\n]+\))))(?!:)"
 )
-find_multi_type_regex = "(?<!:):({0})\s?{1}:([\s]*([\S]+)(\s+or\s+[\S]+)+)(?!:)"
+find_multi_type_regex = "(?<!:):({0})\s?{1}:([^:]+)(?!:)"
 find_docstring_return_type = "(?<!:):rtype\s?:\s+([^:\n]+)(?!:)"
 
 # Regex to parse type hints

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -66,6 +66,37 @@ docstring_param_nested_union = """
 :type dummyarg: typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]
 """
 
+docstring_multi_complex_type = """
+        :param documents: The set of documents to process as part of this batch.
+            If you wish to specify the ID and country_hint on a per-item basis you must
+            use as input a list[:class:`~azure.ai.textanalytics.DetectLanguageInput`] or a list of
+            dict representations of :class:`~azure.ai.textanalytics.DetectLanguageInput`, like
+            `{"id": "1", "country_hint": "us", "text": "hello world"}`.
+        :type documents:
+            list[str] or list[~azure.ai.textanalytics.DetectLanguageInput] or list[dict[str, str]]
+        :keyword str country_hint: A country hint for the entire batch. Accepts two
+            letter country codes specified by ISO 3166-1 alpha-2. Per-document
+            country hints will take precedence over whole batch hints. Defaults to
+            "US". If you don't want to use a country hint, pass the string "none".
+        :keyword str model_version: This value indicates which model will
+            be used for scoring, e.g. "latest", "2019-10-01". If a model-version
+            is not specified, the API will default to the latest, non-preview version.
+        :keyword bool show_stats: If set to true, response will contain document
+            level statistics.
+        :return: The combined list of :class:`~azure.ai.textanalytics.DetectLanguageResult` and
+            :class:`~azure.ai.textanalytics.DocumentError` in the order the original documents were
+            passed in.
+        :rtype: list[~azure.ai.textanalytics.DetectLanguageResult,
+            ~azure.ai.textanalytics.DocumentError]
+        :raises ~azure.core.exceptions.HttpResponseError or TypeError or ValueError:
+        .. admonition:: Example:
+            .. literalinclude:: ../samples/sample_detect_language.py
+                :start-after: [START batch_detect_language]
+                :end-before: [END batch_detect_language]
+                :language: python
+                :dedent: 8
+                :caption: Detecting language in a batch of documents.
+"""
 
 class TestDocStringParser:
 
@@ -122,3 +153,6 @@ class TestDocStringParser:
 
     def test_nested_union_type(self):
         self._test_variable_type(docstring_param_nested_union, "dummyarg", "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]")
+
+    def test_multi_text_analytics_type(self):
+        self._test_variable_type(docstring_multi_complex_type, "documents", "list[str] or list[~azure.ai.textanalytics.DetectLanguageInput] or list[dict[str, str]]")


### PR DESCRIPTION
APIStubGen is failing to parse any types that has space in it due to current regex being used. Fix includes a change in regex to find the type as well as to tokenize those types properly. Previously types were tokenized with asuumption that there is no space within type itself and this is not true if a Union type has Dict[<type1>, <type2>] is present.