### PR TITLE
Add retry logic for rate limiting exceptions.

### DIFF
--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="CommandLine.Net" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.3" />
     <PackageReference Include="Octokit" Version="0.36.0" />
+    <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="Sendgrid" Version="9.12.0" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/CustomerReportedInvalidState/FindCustomerRelatedIssuesInvalidState.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/CustomerReportedInvalidState/FindCustomerRelatedIssuesInvalidState.cs
@@ -17,7 +17,7 @@ namespace GitHubIssues.Reports
 
         }
 
-        public override void Execute()
+        protected override void ExecuteCore()
         {
             foreach (RepositoryConfig repositoryConfig in _cmdLine.RepositoriesList)
             {

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindIssuesInBacklogMilestones.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindIssuesInBacklogMilestones.cs
@@ -16,7 +16,7 @@ namespace GitHubIssues.Reports
 
         }
 
-        public override void Execute()
+        protected override void ExecuteCore()
         {
             foreach (RepositoryConfig repositoryConfig in _cmdLine.RepositoriesList)
             {

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindIssuesInPastDueMilestones.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindIssuesInPastDueMilestones.cs
@@ -16,7 +16,7 @@ namespace GitHubIssues.Reports
 
         }
 
-        public override void Execute()
+        protected override void ExecuteCore()
         {
             foreach (RepositoryConfig repositoryConfig in _cmdLine.RepositoriesList)
             {

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindNewGitHubIssuesAndPRs.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindNewGitHubIssuesAndPRs.cs
@@ -24,7 +24,7 @@ namespace GitHubIssues.Reports
         private static string ContainerName = "lastaccessed";
 #endif
 
-        public override void Execute()
+        protected override void ExecuteCore()
         {
             _log.LogInformation($"Started function execution: {DateTime.Now}");
 

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindStalePRs.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindStalePRs.cs
@@ -16,7 +16,7 @@ namespace GitHubIssues.Reports
 
         }
 
-        public override void Execute()
+        protected override void ExecuteCore()
         {
             foreach (RepositoryConfig repositoryConfig in _cmdLine.RepositoriesList)
             {


### PR DESCRIPTION
This PR wraps all the GitHub Issues reports in a Polly policy that retries report generation at least 3 times with a spacing of 30 seconds. This is a crude attempt to get over some rate limiting issues. It may not work in production but it'll give us some insights into the next steps.