### PR TITLE
Fix Crashing GetExistingTags

### DIFF
--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -406,7 +406,7 @@ function IsPythonPackageVersionPublished($pkgId, $pkgVersion) {
 # Retrieves the list of all tags that exist on the target repository
 function GetExistingTags($apiUrl) {
   try {
-    return (Invoke-WebRequest -Method "GET" -Uri "$apiUrl/git/refs/tags"  -MaximumRetryCount 3 -RetryIntervalSec 10) | % { $_.ref.Replace("refs/tags/", "") }
+    return (Invoke-RestMethod -Method "GET" -Uri "$apiUrl/git/refs/tags"  -MaximumRetryCount 3 -RetryIntervalSec 10) | % { $_.ref.Replace("refs/tags/", "") }
   }
   catch {
     Write-Host $_


### PR DESCRIPTION
Before this update, **any** execution of the `GetExistingTags` method will hard error the script. I ran into this while testing releases for the new docs ci updates.

![image](https://user-images.githubusercontent.com/45376673/88586504-548c8600-d009-11ea-8994-c087838394e4.png)

The code as-is legitimately won't work. To test, here's a version that has apiUrl substituted.

`(Invoke-WebRequest -Method "GET" -Uri "https://api.github.com/repos/Azure/azure-sdk-for-python/git/refs/tags"  -MaximumRetryCount 3 -RetryIntervalSec 10) | % { $_.ref.Replace("refs/tags/", "") }`

Execute that, notice that it errors. We can't directly use `Content` either. It's much easier to just use `Invoke-RestMethod` and get the content back ready for action.

`(Invoke-RestMethod -Method "GET" -Uri "https://api.github.com/repos/Azure/azure-sdk-for-python/git/refs/tags"  -MaximumRetryCount 3 -RetryIntervalSec 10) | % { $_.ref.Replace("refs/tags/", "") }`

Notice the only shift is from `Invoke-RestMethod` to `Invoke-WebRequest`

@Azure/azure-sdk-eng 