### PR TITLE
Enable pre-commit eng/common sync

### DIFF
--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -1,14 +1,14 @@
 # Mirror the eng/common folder to all subscribed langauge repos.
 
-trigger:
+trigger: none
+
+pr:
   branches:
     include:
       - master
   paths:
     include:
       - eng/common
-
-pr: none
 
 pool:
   vmImage: windows-2019
@@ -20,8 +20,9 @@ jobs:
     steps:
     - template: ./templates/steps/sync-directory.yml
       parameters:
-        CommitMessage: Sync eng/common directory with azure-sdk-tools repository
-        DirectoryToSync: eng/common
+        CommitMessage: "Sync eng/common directory with azure-sdk-tools repository for Tools PR #$(System.PullRequest.PullRequestNumber)"
+        DirectoryToSync: "eng/common"
+        PRBranchName: "sync-eng-common-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
         Repos:
           - azure-sdk-for-android
           - azure-sdk-for-c

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -2,6 +2,7 @@ parameters:
   Repos: []
   DirectoryToSync: eng/common
   CommitMessage: commit-message-not-set
+  PRBranchName: branch-name-not-set
 
 steps:
 
@@ -21,7 +22,7 @@ steps:
   - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
     parameters:
       RepoName: ${{ repo }}
-      PRBranchName: sync-${{ parameters.DirectoryToSync }}
+      PRBranchName: ${{ parameters.PRBranchName }}
       CommitMsg: ${{ parameters.CommitMessage }}
       PRTitle: ${{ parameters.CommitMessage }}
       PushArgs: -f


### PR DESCRIPTION
Enabling pre-commit sync of the `eng/common` directory to all for end-to-end testing of changes.