### PR TITLE
Add PowerShell module install failure classifier.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePowerShellModuleInstallationFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePowerShellModuleInstallationFailureClassifier.cs
@@ -1,0 +1,33 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class AzurePowerShellModuleInstallationFailureClassifier : IFailureClassifier
+    {
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            if (context.Build.Definition.Name.EndsWith("- tests"))
+            {
+                var failedTasks = from r in context.Timeline.Records
+                                  where r.Result == TaskResult.Failed
+                                  where r.RecordType == "Task"
+                                  where r.Name == "Install Azure PowerShell module"
+                                  select r;
+
+                if (failedTasks.Count() > 0)
+                {
+                    foreach (var failedTask in failedTasks)
+                    {
+                        context.AddFailure(failedTask, "Azure PS Module");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -85,6 +85,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, JsDevFeedPublishingFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, DownloadSecretsFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, GitCheckoutFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, AzurePowerShellModuleInstallationFailureClassifier>();
         }
     }
 }


### PR DESCRIPTION
This closes #825. We see periodic failures around the installation of the Azure PowerShell module. This will help us quantify it.