### PR TITLE
Detect Maven dependency download issues (broken pipes)

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePowerShellModuleInstallationFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePowerShellModuleInstallationFailureClassifier.cs
@@ -1,0 +1,33 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class AzurePowerShellModuleInstallationFailureClassifier : IFailureClassifier
+    {
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            if (context.Build.Definition.Name.EndsWith("- tests"))
+            {
+                var failedTasks = from r in context.Timeline.Records
+                                  where r.Result == TaskResult.Failed
+                                  where r.RecordType == "Task"
+                                  where r.Name == "Install Azure PowerShell module"
+                                  select r;
+
+                if (failedTasks.Count() > 0)
+                {
+                    foreach (var failedTask in failedTasks)
+                    {
+                        context.AddFailure(failedTask, "Azure PS Module");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/MavenBrokenPipeFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/MavenBrokenPipeFailureClassifier.cs
@@ -1,0 +1,46 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class MavenBrokenPipeFailureClassifier : IFailureClassifier
+    {
+        public MavenBrokenPipeFailureClassifier(VssConnection vssConnection)
+        {
+            this.vssConnection = vssConnection;
+            buildClient = vssConnection.GetClient<BuildHttpClient>();
+        }
+
+        private VssConnection vssConnection;
+        private BuildHttpClient buildClient;
+
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            var failedTasks = from r in context.Timeline.Records
+                              where r.Result == TaskResult.Failed
+                              where r.RecordType == "Task"
+                              where r.Task.Name == "Maven"
+                              select r;
+
+            foreach (var failedTask in failedTasks)
+            {
+                var lines = await buildClient.GetBuildLogLinesAsync(
+                    context.Build.Project.Id,
+                    context.Build.Id,
+                    failedTask.Log.Id
+                    );
+
+                if (lines.Any(line => line.Contains("Connection reset")))
+                {
+                    context.AddFailure(failedTask, "Maven Broken Pipe");
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -86,6 +86,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, DownloadSecretsFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, GitCheckoutFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, AzurePowerShellModuleInstallationFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, MavenBrokenPipeFailureClassifier>();
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -85,6 +85,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, JsDevFeedPublishingFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, DownloadSecretsFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, GitCheckoutFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, AzurePowerShellModuleInstallationFailureClassifier>();
         }
     }
 }


### PR DESCRIPTION
This PR adds a new classifier which pulls the logs for failed Maven tasks to determine whether they are actually a broken pipe issue (identified by a "Connection reset" message in the log output. This is the first classifier that leverages the fact that classifiers themselves are create by the DI container and can therefore access the various services to make outbound calls (such as ```BuildHttpClient``` via ```VssConnection```).

This PR is build on top of the branch for #835 which adds a PowerShell classifier, but they are otherwise unrelated (just avoiding some merge hassle).