### PR TITLE
Switch Android repo to pipeline generation on master

### DIFF
--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -20,7 +20,7 @@ jobs:
         TestOptions: '--variablegroup 64'
       Android:
         RepositoryName: azure-sdk-for-android
-        Branch: dev
+        Branch: master
         Prefix: android
         PublicOptions: ''
         InternalOptions: '--variablegroup 1 --variablegroup 58 --variablegroup 76'


### PR DESCRIPTION
This PR switches pipeline generation to generate pipelines off master instead of dev.