### PR TITLE
Remove PackageId from C release

### DIFF
--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -298,7 +298,7 @@ function ParseCArtifact($pkg, $workingDirectory) {
   }
 
   return New-Object PSObject -Property @{
-    PackageId      = 'azure-sdk-for-c'
+    PackageId      = ''
     PackageVersion = $pkgVersion
     # Artifact info is always considered deployable for C becasue it is not
     # deployed anywhere. Dealing with duplicate tags happens downstream in


### PR DESCRIPTION
Hold this until after release. The appropriate changes are already in place for the C repo. 