### PR TITLE
Update PR Tagging For Release Failures

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -69,6 +69,7 @@ steps:
 - task: PowerShell@2
   displayName: Tag a Reviewer on PR
   condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
+  continueOnError: true
   inputs:
     pwsh: true
     workingDirectory: ${{ parameters.WorkingDirectory }}

--- a/eng/common/pipelines/templates/steps/get-pr-owners.yml
+++ b/eng/common/pipelines/templates/steps/get-pr-owners.yml
@@ -20,12 +20,12 @@ steps:
         --identity "$(Build.QueuedBy)"
 
       $resolvedIdentity = ""
-      try { $resolvedIdentity = $result[-1] | ConvertFrom-Json } catch { $null}
+      try { $resolvedIdentity = $result[-1] | ConvertFrom-Json } catch {}
 
       if($resolvedIdentity) {
         Write-Host $resolvedIdentity
 
-        Write-Output "##vso[task.setvariable variable=${{ parameters.TargetVariable }}]$($resolvedIdentity.GithubUserName)"
+        Write-Host "##vso[task.setvariable variable=${{ parameters.TargetVariable }}]$($resolvedIdentity.GithubUserName)"
       }
       else {
         Write-Host "Unable to locate a github user for identity $(Build.QueuedBy)"
@@ -49,6 +49,6 @@ steps:
       $originalValue = "$(${{ parameters.TargetVariable }})"
       $result = $(Build.SourcesDirectory)/eng/common/scripts/get-codeowners.ps1 -TargetDirectory /sdk/${{ parameters.ServiceDirectory }}/ -RootDirectory $(Build.SourcesDirectory)
       if ($result) {
-        Write-Output "##vso[task.setvariable variable=${{ parameters.TargetVariable }}]$originalValue,$result"
+        Write-Host "##vso[task.setvariable variable=${{ parameters.TargetVariable }}]$originalValue,$result"
       }
     displayName: Add CodeOwners if Present

--- a/eng/common/pipelines/templates/steps/get-pr-owners.yml
+++ b/eng/common/pipelines/templates/steps/get-pr-owners.yml
@@ -18,11 +18,18 @@ steps:
         --kusto-database-var KUSTO_DB `
         --kusto-table-var KUSTO_TABLE `
         --identity "$(Build.QueuedBy)"
-      $resolvedIdentity = $result[-1] | ConvertFrom-Json
 
-      Write-Host $resolvedIdentity
+      $resolvedIdentity = ""
+      try { $resolvedIdentity = $result[-1] | ConvertFrom-Json } catch { $null}
 
-      Write-Output "##vso[task.setvariable variable=${{ parameters.TargetVariable }}]$($resolvedIdentity.GithubUserName)"
+      if($resolvedIdentity) {
+        Write-Host $resolvedIdentity
+
+        Write-Output "##vso[task.setvariable variable=${{ parameters.TargetVariable }}]$($resolvedIdentity.GithubUserName)"
+      }
+      else {
+        Write-Host "Unable to locate a github user for identity $(Build.QueuedBy)"
+      }
     displayName: 'Resolving Queuing User'
     workingDirectory: $(Build.SourcesDirectory)/tools_repo/tools/notification-configuration/identity-resolver
     env:

--- a/eng/common/pipelines/templates/steps/get-pr-owners.yml
+++ b/eng/common/pipelines/templates/steps/get-pr-owners.yml
@@ -31,6 +31,7 @@ steps:
         Write-Host "Unable to locate a github user for identity $(Build.QueuedBy)"
       }
     displayName: 'Resolving Queuing User'
+    continueOnError: true
     workingDirectory: $(Build.SourcesDirectory)/tools_repo/tools/notification-configuration/identity-resolver
     env:
       APP_ID: $(notification-aad-app-id)

--- a/eng/common/scripts/add-pullrequest-reviewers.ps1
+++ b/eng/common/scripts/add-pullrequest-reviewers.ps1
@@ -18,6 +18,28 @@ param(
     $AuthToken
 )
 
+function AddMembers($memberName, $additionSet) {
+  $headers = @{
+    Authorization = "bearer $AuthToken"
+  }
+  $uri = "https://api.github.com/repos/$RepoOwner/$RepoName/pulls/$PRNumber/requested_reviewers"
+
+  foreach ($id in $additionSet) {
+    try {
+      $postResp = @{}
+      $postResp[$memberName] = @($id)
+      $postResp = $postResp | ConvertTo-Json
+
+      Write-Host $postResp
+      $resp = Invoke-RestMethod -Method Post -Headers $headers -Body $postResp -Uri $uri -MaximumRetryCount 3
+      $resp | Write-Verbose
+    }
+    catch {
+      Write-Error "Error attempting to add $user `n$_"
+    }
+  }
+}
+
 # at least one of these needs to be populated
 if (-not $GitHubUsers -and -not $GitHubTeams) {
   Write-Host "No user provided for addition, exiting."
@@ -27,54 +49,5 @@ if (-not $GitHubUsers -and -not $GitHubTeams) {
 $userAdditions = @($GitHubUsers.Split(",") | % { $_.Trim() } | ? { return $_ })
 $teamAdditions = @($GitHubTeams.Split(",") | % { $_.Trim() } | ? { return $_ })
 
-$headers = @{
-  Authorization = "bearer $AuthToken"
-}
-$uri = "https://api.github.com/repos/$RepoOwner/$RepoName/pulls/$PRNumber/requested_reviewers"
-
-try {
-  $resp = Invoke-RestMethod -Headers $headers $uri -MaximumRetryCount 3
-}
-catch {
-  Write-Error "Invoke-RestMethod [$uri] failed with exception:`n$_"
-  exit 1
-}
-
-# the response object takes this form: https://developer.github.com/v3/pulls/review_requests/#response-1
-# before we can push a new reviewer, we need to pull the simple Ids out of the complex objects that came back in the response
-$userReviewers = @($resp.users | % { return $_.login })
-$teamReviewers = @($resp.teams | % { return $_.slug })
-
-if (!$userReviewers) { $modifiedUserReviewers = @() } else { $modifiedUserReviewers = $userReviewers.Clone() }
-$modifiedUserReviewers += ($userAdditions | ? { !$modifiedUserReviewers.Contains($_) })
-
-if ($teamReviewers) { $modifiedTeamReviewers = @() } else { $modifiedTeamReviewers = $teamReviewers.Clone() }
-$modifiedTeamReviewers += ($teamAdditions | ? { !$modifiedTeamReviewers.Contains($_) })
-
-$detectedUserDiffs = Compare-Object -ReferenceObject $userReviewers -DifferenceObject $modifiedUserReviewers
-$detectedTeamDiffs = Compare-Object -ReferenceObject $teamReviewers -DifferenceObject $modifiedTeamReviewers
-
-# Compare-Object returns values when there is a difference between the comparied objects.
-# we only want to run the update if there IS a difference.
-if ($detectedUserDiffs -or $detectedTeamDiffs) {
-  $postResp = @{}
-
-  if ($modifiedUserReviewers) { $postResp["reviewers"] = $modifiedUserReviewers }
-  if ($modifiedTeamReviewers) { $postResp["team_reviewers"] = $modifiedTeamReviewers }
-
-  $postResp = $postResp | ConvertTo-Json
-
-  try {
-    Write-Host $postResp
-    $resp = Invoke-RestMethod -Method Post -Headers $headers -Body $postResp -Uri $uri -MaximumRetryCount 3
-    $resp | Write-Verbose
-  }
-  catch {
-    Write-Error "Unable to update PR reviewers. `n$_"
-  }
-}
-else {
-  $results = $GitHubUsers + $GitHubTeams
-  Write-Host "Reviewers $results already added. Exiting."
-  exit(0)
-}
+AddMembers -memberName "reviewers" -additionSet $userAdditions
+AddMembers -memberName "team_reviewers" -additionSet $teamAdditions

--- a/eng/common/scripts/add-pullrequest-reviewers.ps1
+++ b/eng/common/scripts/add-pullrequest-reviewers.ps1
@@ -18,13 +18,12 @@ param(
     $AuthToken
 )
 
-$errorOccurred = $false
-
 function AddMembers($memberName, $additionSet) {
   $headers = @{
     Authorization = "bearer $AuthToken"
   }
   $uri = "https://api.github.com/repos/$RepoOwner/$RepoName/pulls/$PRNumber/requested_reviewers"
+  $errorOccurred = $false
 
   foreach ($id in $additionSet) {
     try {
@@ -41,6 +40,8 @@ function AddMembers($memberName, $additionSet) {
       $errorOccurred = $true
     }
   }
+
+  return $errorOccurred
 }
 
 # at least one of these needs to be populated
@@ -52,9 +53,9 @@ if (-not $GitHubUsers -and -not $GitHubTeams) {
 $userAdditions = @($GitHubUsers.Split(",") | % { $_.Trim() } | ? { return $_ })
 $teamAdditions = @($GitHubTeams.Split(",") | % { $_.Trim() } | ? { return $_ })
 
-AddMembers -memberName "reviewers" -additionSet $userAdditions
-AddMembers -memberName "team_reviewers" -additionSet $teamAdditions
+$errorsOccurredAddingUsers = AddMembers -memberName "reviewers" -additionSet $userAdditions
+$errorsOccurredAddingTeams = AddMembers -memberName "team_reviewers" -additionSet $teamAdditions
 
-if ($errorOccurred) {
+if ($errorsOccurredAddingUsers -or $errorsOccurredAddingTeams) {
   exit 1
 }

--- a/eng/common/scripts/add-pullrequest-reviewers.ps1
+++ b/eng/common/scripts/add-pullrequest-reviewers.ps1
@@ -18,6 +18,8 @@ param(
     $AuthToken
 )
 
+$errorOccurred = $false
+
 function AddMembers($memberName, $additionSet) {
   $headers = @{
     Authorization = "bearer $AuthToken"
@@ -35,7 +37,8 @@ function AddMembers($memberName, $additionSet) {
       $resp | Write-Verbose
     }
     catch {
-      Write-Error "Error attempting to add $user `n$_"
+      Write-Host "Error attempting to add $user `n$_"
+      $errorOccurred = $true
     }
   }
 }
@@ -51,3 +54,7 @@ $teamAdditions = @($GitHubTeams.Split(",") | % { $_.Trim() } | ? { return $_ })
 
 AddMembers -memberName "reviewers" -additionSet $userAdditions
 AddMembers -memberName "team_reviewers" -additionSet $teamAdditions
+
+if ($errorOccurred) {
+  exit 1
+}


### PR DESCRIPTION
- [x] Additional Error Handling on Resolving an Identity
- [x] Rework how users are added to a PR 
- [x] Allow Failed Tagging of a User on PR

My understanding after reading the github API docs was that the assignees setting was replaced by a push. It's actually additive, forgiving of duplicates. Adjust to push 1 at a time, turning the step _yellow_ when any fail to add.