### PR TITLE
Updated Webhook Router dependencies.

### DIFF
--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Azure.Sdk.Tools.WebhookRouter.csproj
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Azure.Sdk.Tools.WebhookRouter.csproj
@@ -4,13 +4,13 @@
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.0" />
-    <PackageReference Include="Azure.Identity" Version="1.1.1" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.0.1" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.0.3" />
+    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.1" />
+    <PackageReference Include="Azure.Identity" Version="1.2.0" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.1.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.3" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
This PR updates all the packages that Webhook Router users. I'm doing this because our telemetry shows a lot of failed dependency calls through ```Azure.Identity.DefaultAzureCredential```. This was a known issue where identity logged errors for normal execution.

I also decided to update all the other dependencies at the same time. Experience tells me that we need to run this code in the staging slot which is why I'm doing this on a feature branch of the upstream. Sometimes functions can break due to dependency updates so I want to run this feature branch with real load for a few days to just double check that it won't cause problems.