### PR TITLE
Fix null ref exception in Pipeline Witness.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/MavenBrokenPipeFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/MavenBrokenPipeFailureClassifier.cs
@@ -23,11 +23,12 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
         public async Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var failedTasks = from r in context.Timeline.Records
-                              where r.Result == TaskResult.Failed
-                              where r.RecordType == "Task"
-                              where r.Task.Name == "Maven"
-                              where r.Log != null
-                              select r;
+                                where r.Result == TaskResult.Failed
+                                where r.RecordType == "Task"
+                                where r.Task != null
+                                where r.Task.Name == "Maven"
+                                where r.Log != null
+                                select r;
 
             foreach (var failedTask in failedTasks)
             {


### PR DESCRIPTION
This PR fixes a bug in Maven broken pipe classifier. I managed to snag the exception by replaying the debug consumer group and found the error in my logic. This classifier is the first instance where I'm actually interrogating the task name (as opposed to the display name) because I'm looking for failures in Maven regardless of the actual step.

Anyway .. long story short, some steps/tasks can be in a failure state without the task value being populated, and that was causing me errors. In my case I just add a clause to filter those errors out.