### PR TITLE
Check Enforcer improvements for DI and AppConfig

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -6,12 +6,14 @@
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.2.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.1.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/GlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/GlobalConfigurationProvider.cs
@@ -9,44 +9,27 @@ namespace Azure.Sdk.Tools.CheckEnforcer
     {
         public string GetApplicationID()
         {
-            var id = Environment.GetEnvironmentVariable("GITHUBAPP_ID");
-            return id;
+            return "61253";
         }
 
         public string GetApplicationName()
         {
-            var applicationName = Environment.GetEnvironmentVariable("CHECK_NAME");
-            return applicationName;
+            return "check-enforcer";
         }
 
         public string GetKeyVaultUri()
         {
-            var keyVaultUri = Environment.GetEnvironmentVariable("KEYVAULT_URI");
-            return keyVaultUri;
+            return "https://checkenforcerstaging.vault.azure.net/";
         }
 
         public string GetGitHubAppPrivateKeyName()
         {
-            var gitHubAppPrivateKeyName = Environment.GetEnvironmentVariable("KEYVAULT_GITHUBAPP_KEY_NAME");
-            return gitHubAppPrivateKeyName;
+            return "github-app-private-key";
         }
 
         public string GetGitHubAppWebhookSecretName()
         {
-            var gitHubAppWebhookSecretName = Environment.GetEnvironmentVariable("GITHUBAPP_WEBHOOK_SECRET");
-            return gitHubAppWebhookSecretName;
-        }
-
-        public string GetDistributedLockStorageUri()
-        {
-            var distributedLockStorageUri = Environment.GetEnvironmentVariable("DISTRIBUTED_LOCK_STORAGE_URI");
-            return distributedLockStorageUri;
-        }
-
-        public string GetDistributedLockContainerName()
-        {
-            var distributedLockContainerName = Environment.GetEnvironmentVariable("DISTRIBUTED_LOCK_CONTAINER_NAME");
-            return distributedLockContainerName;
+            return "github-app-webhook-secret";
         }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/GlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/GlobalConfigurationProvider.cs
@@ -1,4 +1,6 @@
-﻿using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+﻿using Azure.Data.AppConfiguration;
+using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Microsoft.Extensions.Azure;
 using System;
 using System.Collections.Generic;
 using System.Text;
@@ -7,29 +9,55 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public class GlobalConfigurationProvider : IGlobalConfigurationProvider
     {
+        private ConfigurationClient configurationClient;
+
+        public GlobalConfigurationProvider(ConfigurationClient configurationClient)
+        {
+            this.configurationClient = configurationClient;
+        }
+
+        private object applicationIDLock = new object();
+        private string applicationID;
+
         public string GetApplicationID()
         {
-            return "61253";
+            if (applicationID == null)
+            {
+                lock(applicationIDLock)
+                {
+                    if (applicationID == null)
+                    {
+                        ConfigurationSetting applicationIDSetting = configurationClient.GetConfigurationSetting(
+                            "checkenforcer/github-app-id"
+                            );
+                        applicationID = applicationIDSetting.Value;
+                    }
+                }
+            }
+
+            return applicationID;
         }
+
+        private object applicationNameLock = new object();
+        private string applicationName;
 
         public string GetApplicationName()
         {
-            return "check-enforcer";
-        }
+            if (applicationName == null)
+            {
+                lock (applicationNameLock)
+                {
+                    if (applicationName == null)
+                    {
+                        ConfigurationSetting applicationNameSetting = configurationClient.GetConfigurationSetting(
+                            "checkenforcer/check-name"
+                            );
+                        applicationName = applicationNameSetting.Value;
+                    }
+                }
+            }
 
-        public string GetKeyVaultUri()
-        {
-            return "https://checkenforcerstaging.vault.azure.net/";
-        }
-
-        public string GetGitHubAppPrivateKeyName()
-        {
-            return "github-app-private-key";
-        }
-
-        public string GetGitHubAppWebhookSecretName()
-        {
-            return "github-app-webhook-secret";
+            return applicationName;
         }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
@@ -8,8 +8,5 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
     {
         string GetApplicationID();
         string GetApplicationName();
-        string GetGitHubAppPrivateKeyName();
-        string GetGitHubAppWebhookSecretName();
-        string GetKeyVaultUri();
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
@@ -11,8 +11,5 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
         string GetGitHubAppPrivateKeyName();
         string GetGitHubAppWebhookSecretName();
         string GetKeyVaultUri();
-        string GetDistributedLockStorageUri();
-        string GetDistributedLockContainerName();
-
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
@@ -22,7 +22,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Functions
         private GitHubWebhookProcessor processor;
 
         [FunctionName("webhook-eventhubs")]
-        public async Task Run([EventHubTrigger("github-webhooks", Connection = "CheckEnforcerEventHubConnectionString")] EventData eventData, ILogger log, CancellationToken cancellationToken)
+        public async Task Run([EventHubTrigger("github-webhooks", Connection = "CheckEnforcerEventHubConnectionString", ConsumerGroup = "localdebugging")] EventData eventData, ILogger log, CancellationToken cancellationToken)
         {
             var message = GetMessage(eventData);
             var eventName = GetEventName(message);

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
@@ -1,37 +1,81 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Azure.Security.KeyVault.Secrets;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Logging;
+using Octokit;
 
 namespace Azure.Sdk.Tools.CheckEnforcer.Functions
 {
     public class GitHubWebhookOverEventHubsFunction
     {
-        public GitHubWebhookOverEventHubsFunction(GitHubWebhookProcessor processor)
+        public GitHubWebhookOverEventHubsFunction(GitHubWebhookProcessor processor, SecretClient secretClient)
         {
             this.processor = processor;
+            this.secretClient = secretClient;
         }
 
         private GitHubWebhookProcessor processor;
+        private SecretClient secretClient;
 
         [FunctionName("webhook-eventhubs")]
-        public async Task Run([EventHubTrigger("github-webhooks", Connection = "CheckEnforcerEventHubConnectionString", ConsumerGroup = "localdebugging")] EventData eventData, ILogger log, CancellationToken cancellationToken)
+        public async Task Run([EventHubTrigger("github-webhooks", Connection = "CheckEnforcerEventHubConnectionString")] EventData eventData, ILogger log, CancellationToken cancellationToken)
         {
             var message = GetMessage(eventData);
             var eventName = GetEventName(message);
+            var eventSignature = GetEventSignature(message);
 
             var encodedContent = message.RootElement.GetProperty("content").ToString();
             var contentBytes = Convert.FromBase64String(encodedContent);
-            var json = Encoding.UTF8.GetString(contentBytes);
+            var json = ReadAndVerifyContent(contentBytes, eventSignature);
 
             await processor.ProcessWebhookAsync(eventName, json, log, cancellationToken);
+        }
+
+        private static string gitHubAppWebhookSecret;
+        private static object gitHubAppWebhookSecretLock = new object();
+
+        private const string GitHubWebhookSecretName = "github-app-webhook-secret";
+
+        private string GetGitHubAppWebhookSecret()
+        {
+            if (gitHubAppWebhookSecret == null)
+            {
+                lock (gitHubAppWebhookSecretLock)
+                {
+                    if (gitHubAppWebhookSecret == null)
+                    {
+                        KeyVaultSecret secret = secretClient.GetSecret(GitHubWebhookSecretName);
+                        gitHubAppWebhookSecret = secret.Value;
+                    }
+                }
+            }
+
+            return gitHubAppWebhookSecret;
+        }
+
+        private string ReadAndVerifyContent(byte[] contentBytes, string signature)
+        {
+            var secret = GetGitHubAppWebhookSecret();
+            var isValid = GitHubWebhookSignatureValidator.IsValid(contentBytes, signature, secret);
+                 
+            if (!isValid)
+            {
+                throw new CheckEnforcerSecurityException("Webhook signature validation failed.");
+            }
+
+            var content = Encoding.UTF8.GetString(contentBytes);
+            return content;
         }
 
         private string GetEventName(JsonDocument message)
@@ -40,6 +84,17 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Functions
                 .RootElement
                 .GetProperty("headers")
                 .GetProperty("X-GitHub-Event")
+                .EnumerateArray()
+                .Single()
+                .ToString();
+        }
+
+        private string GetEventSignature(JsonDocument message)
+        {
+            return message
+                .RootElement
+                .GetProperty("headers")
+                .GetProperty(GitHubWebhookSignatureValidator.GitHubWebhookSignatureHeader)
                 .EnumerateArray()
                 .Single()
                 .ToString();

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubClientProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Integrations/GitHub/GitHubClientProvider.cs
@@ -4,6 +4,7 @@ using Azure.Sdk.Tools.CheckEnforcer.Configuration;
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
+using Azure.Security.KeyVault.Secrets;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.IdentityModel.Tokens;
 using Octokit;
@@ -19,14 +20,16 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public class GitHubClientProvider : IGitHubClientProvider
     {
-        public GitHubClientProvider(IGlobalConfigurationProvider globalConfigurationProvider, IMemoryCache cache)
+        public GitHubClientProvider(IGlobalConfigurationProvider globalConfigurationProvider, IMemoryCache cache, KeyClient keyClient)
         {
             this.globalConfigurationProvider = globalConfigurationProvider;
             this.cache = cache;
+            this.keyClient = keyClient;
         }
 
         private IGlobalConfigurationProvider globalConfigurationProvider;
         private IMemoryCache cache;
+        private KeyClient keyClient;
 
         private async Task<string> GetTokenAsync(CancellationToken cancellationToken)
         {
@@ -51,7 +54,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 
         private async Task<string> SignHeaderAndPayloadDigestWithGitHubApplicationKey(byte[] digest, CancellationToken cancellationToken)
         {
-            var cryptographyClient = await GetCryptographyClient(cancellationToken);
+            var cryptographyClient = GetCryptographyClient();
             var signResult = await cryptographyClient.SignAsync(
                 SignatureAlgorithm.RS256,
                 digest,
@@ -90,48 +93,33 @@ namespace Azure.Sdk.Tools.CheckEnforcer
             return headerAndPayloadString;
         }
 
-        private async Task<CryptographyClient> GetCryptographyClient(CancellationToken cancellationToken)
+        private object cryptographyClientLock = new object();
+        private CryptographyClient cryptographyClient;
+
+        private CryptographyClient GetCryptographyClient()
         {
-            // Using DefaultAzureCredential to support local development. If developing
-            // locally you'll need to register an AAD application and set the following
-            // variables:
-            //
-            //      AZURE_TENANT_ID (the ID of the AAD tenant)
-            //      AZURE_CLIENT_ID (the iD of the AAD application you registered)
-            //      AZURE_CLIENT_SECRET (the secret for the AAD application you registered)
-            //
-            // You can get these values when you configure the application. Set them in
-            // the Debug section of the project properties. Once this is done you will need
-            // to create a KeyVault instance and then register a GitHub application and upload
-            // the private key into the vault. The AAD application that you just created needs
-            // to have Get and Sign rights - so set an access policy up which grants the app
-            // those rights.
-            //
-            var credential = new DefaultAzureCredential();
+            if (cryptographyClient == null)
+            {
+                lock (cryptographyClientLock)
+                {
+                    if (cryptographyClient == null)
+                    {
+                        var key = GetKey(this.keyClient);
 
-            var keyClient = GetKeyClient(credential);
-            var key = await GetKey(keyClient, cancellationToken);
+                        var credential = new DefaultAzureCredential();
+                        cryptographyClient = new CryptographyClient(key.Id, credential);
+                    }
+                }
+            }
 
-            var cryptographyClient = new CryptographyClient(key.Id, credential);
             return cryptographyClient;
         }
 
-        private async Task<KeyVaultKey> GetKey(KeyClient keyClient, CancellationToken cancellationToken)
+        private KeyVaultKey GetKey(KeyClient keyClient)
         {
-            var keyResponse = await keyClient.GetKeyAsync(
-                globalConfigurationProvider.GetGitHubAppPrivateKeyName(),
-                cancellationToken: cancellationToken
-                );
-
+            var keyResponse = keyClient.GetKey(globalConfigurationProvider.GetGitHubAppPrivateKeyName());
             var key = keyResponse.Value;
             return key;
-        }
-
-        private KeyClient GetKeyClient(TokenCredential credential)
-        {
-            var keyVaultUri = new Uri(globalConfigurationProvider.GetKeyVaultUri());
-            var keyClient = new KeyClient(keyVaultUri, credential);
-            return keyClient;
         }
 
         public async Task<GitHubClient> GetApplicationClientAsync(CancellationToken cancellationToken)

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Startup.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Startup.cs
@@ -1,7 +1,10 @@
-﻿using Azure.Sdk.Tools.CheckEnforcer;
+﻿using Azure.Data.AppConfiguration;
+using Azure.Identity;
+using Azure.Sdk.Tools.CheckEnforcer;
 using Azure.Sdk.Tools.CheckEnforcer.Configuration;
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -13,8 +16,34 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public class Startup : FunctionsStartup
     {
+        private string GetWebsiteResourceGroupEnvironmentVariable()
+        {
+            var websiteResourceGroupEnvironmentVariable = Environment.GetEnvironmentVariable("WEBSITE_RESOURCE_GROUP");
+            return websiteResourceGroupEnvironmentVariable;
+        }
+
         public override void Configure(IFunctionsHostBuilder builder)
         {
+            var websiteResourceGroupEnvironmentVariable = GetWebsiteResourceGroupEnvironmentVariable();
+
+            var credential = new DefaultAzureCredential();
+
+            builder.Services.AddAzureClients((builder) =>
+            {
+                builder.UseCredential(credential);
+
+                var keyVaultUri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.vault.azure.net");
+                builder.AddKeyClient(keyVaultUri);
+                builder.AddSecretClient(keyVaultUri);
+            });
+
+            builder.Services.AddSingleton((builder) =>
+            {
+                var configurationUri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.azconfig.io/");
+                var configurationClient = new ConfigurationClient(configurationUri, credential);
+                return configurationClient;
+            });
+
             builder.Services.AddSingleton<IGlobalConfigurationProvider, GlobalConfigurationProvider>();
             builder.Services.AddSingleton<IGitHubClientProvider, GitHubClientProvider>();
             builder.Services.AddSingleton<IRepositoryConfigurationProvider, RepositoryConfigurationProvider>();


### PR DESCRIPTION
This PR shifts construction of ```CryptographyClient``` and ```SecretClient``` into ```Startup.cs``` and shifts configuration that was previously in environment variables over into Azure AppConfiguration. I've also removed some of the caching logic since the cache does not provide stampede connection, and some of the secrets we don't need to worry about rotating between function node restarts.

I've also added some locks in there to avoid rushing KeyVault and other dependencies when the function starts on a large backlog of messages from Event Hubs. This is to avoid asking for the same keys/secrets multiple times when a node first comes up after a restart (if we have been down for a longer period of time the start-up could result in unnecessary failures from either KeyVault or GitHub).