### PR TITLE
Check Enforcer improvements for DI and AppConfig (#940)

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -6,12 +6,14 @@
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.1" />
     <PackageReference Include="Azure.Identity" Version="1.2.0" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.1.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.5.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.7" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IGlobalConfigurationProvider.cs
@@ -8,11 +8,5 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
     {
         string GetApplicationID();
         string GetApplicationName();
-        string GetGitHubAppPrivateKeyName();
-        string GetGitHubAppWebhookSecretName();
-        string GetKeyVaultUri();
-        string GetDistributedLockStorageUri();
-        string GetDistributedLockContainerName();
-
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
@@ -1,37 +1,81 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading;
 using System.Threading.Tasks;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Azure.Security.KeyVault.Secrets;
 using Microsoft.Azure.EventHubs;
 using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Logging;
+using Octokit;
 
 namespace Azure.Sdk.Tools.CheckEnforcer.Functions
 {
     public class GitHubWebhookOverEventHubsFunction
     {
-        public GitHubWebhookOverEventHubsFunction(GitHubWebhookProcessor processor)
+        public GitHubWebhookOverEventHubsFunction(GitHubWebhookProcessor processor, SecretClient secretClient)
         {
             this.processor = processor;
+            this.secretClient = secretClient;
         }
 
         private GitHubWebhookProcessor processor;
+        private SecretClient secretClient;
 
         [FunctionName("webhook-eventhubs")]
         public async Task Run([EventHubTrigger("github-webhooks", Connection = "CheckEnforcerEventHubConnectionString")] EventData eventData, ILogger log, CancellationToken cancellationToken)
         {
             var message = GetMessage(eventData);
             var eventName = GetEventName(message);
+            var eventSignature = GetEventSignature(message);
 
             var encodedContent = message.RootElement.GetProperty("content").ToString();
             var contentBytes = Convert.FromBase64String(encodedContent);
-            var json = Encoding.UTF8.GetString(contentBytes);
+            var json = ReadAndVerifyContent(contentBytes, eventSignature);
 
             await processor.ProcessWebhookAsync(eventName, json, log, cancellationToken);
+        }
+
+        private static string gitHubAppWebhookSecret;
+        private static object gitHubAppWebhookSecretLock = new object();
+
+        private const string GitHubWebhookSecretName = "github-app-webhook-secret";
+
+        private string GetGitHubAppWebhookSecret()
+        {
+            if (gitHubAppWebhookSecret == null)
+            {
+                lock (gitHubAppWebhookSecretLock)
+                {
+                    if (gitHubAppWebhookSecret == null)
+                    {
+                        KeyVaultSecret secret = secretClient.GetSecret(GitHubWebhookSecretName);
+                        gitHubAppWebhookSecret = secret.Value;
+                    }
+                }
+            }
+
+            return gitHubAppWebhookSecret;
+        }
+
+        private string ReadAndVerifyContent(byte[] contentBytes, string signature)
+        {
+            var secret = GetGitHubAppWebhookSecret();
+            var isValid = GitHubWebhookSignatureValidator.IsValid(contentBytes, signature, secret);
+                 
+            if (!isValid)
+            {
+                throw new CheckEnforcerSecurityException("Webhook signature validation failed.");
+            }
+
+            var content = Encoding.UTF8.GetString(contentBytes);
+            return content;
         }
 
         private string GetEventName(JsonDocument message)
@@ -40,6 +84,17 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Functions
                 .RootElement
                 .GetProperty("headers")
                 .GetProperty("X-GitHub-Event")
+                .EnumerateArray()
+                .Single()
+                .ToString();
+        }
+
+        private string GetEventSignature(JsonDocument message)
+        {
+            return message
+                .RootElement
+                .GetProperty("headers")
+                .GetProperty(GitHubWebhookSignatureValidator.GitHubWebhookSignatureHeader)
                 .EnumerateArray()
                 .Single()
                 .ToString();

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
@@ -31,80 +31,20 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public class GitHubWebhookProcessor
     {
-        public GitHubWebhookProcessor(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider)
+        public GitHubWebhookProcessor(IGlobalConfigurationProvider globalConfigurationProvider, IGitHubClientProvider gitHubClientProvider, IRepositoryConfigurationProvider repositoryConfigurationProvider, SecretClient secretClient)
         {
             this.globalConfigurationProvider = globalConfigurationProvider;
             this.gitHubClientProvider = gitHubClientProvider;
             this.repositoryConfigurationProvider = repositoryConfigurationProvider;
+            this.secretClient = secretClient;
         }
         
         public IGlobalConfigurationProvider globalConfigurationProvider;
         public IGitHubClientProvider gitHubClientProvider;
         private IRepositoryConfigurationProvider repositoryConfigurationProvider;
-        private const string GitHubEventHeader = "X-GitHub-Event";
-
-        private DateTimeOffset gitHubAppWebhookSecretExpiry = DateTimeOffset.MinValue;
-        private string gitHubAppWebhookSecret;
         private SecretClient secretClient;
 
-        private async Task<string> GetGitHubAppWebhookSecretAsync(CancellationToken cancellationToken)
-        {
-            if (gitHubAppWebhookSecretExpiry < DateTimeOffset.UtcNow)
-            {
-                var gitHubAppWebhookSecretName = globalConfigurationProvider.GetGitHubAppWebhookSecretName();
-
-                var client = GetSecretClient();
-                var response = await client.GetSecretAsync(gitHubAppWebhookSecretName, cancellationToken: cancellationToken);
-                var secret = response.Value;
-
-                gitHubAppWebhookSecretExpiry = DateTimeOffset.UtcNow.AddSeconds(30);
-                gitHubAppWebhookSecret = secret.Value;
-            }
-
-            return gitHubAppWebhookSecret;
-        }
-
-        private SecretClient GetSecretClient()
-        {
-            var keyVaultUri = globalConfigurationProvider.GetKeyVaultUri();
-            var credential = new DefaultAzureCredential();
-
-            if (secretClient == null)
-            {
-                secretClient = new SecretClient(new Uri(keyVaultUri), credential);
-            }
-
-            return secretClient;
-        }
-
-        private async Task<string> ReadAndVerifyBodyAsync(HttpRequest request, CancellationToken cancellationToken)
-        {
-            using (var reader = new StreamReader(request.Body))
-            {
-                var json = await reader.ReadToEndAsync();
-                var jsonBytes = Encoding.UTF8.GetBytes(json);
-
-                if (request.Headers.TryGetValue(GitHubWebhookSignatureValidator.GitHubWebhookSignatureHeader, out StringValues signature))
-                {
-                    var secret = await GetGitHubAppWebhookSecretAsync(cancellationToken);
-
-                    var isValid = GitHubWebhookSignatureValidator.IsValid(jsonBytes, signature, secret);
-                    if (isValid)
-                    {
-                        return json;
-                    }
-                    else
-                    {
-                        throw new CheckEnforcerSecurityException("Webhook signature validation failed.");
-                    }
-                }
-                else
-                {
-                    throw new CheckEnforcerSecurityException("Webhook missing event signature.");
-                }
-            }
-        }
-
+        private const string GitHubEventHeader = "X-GitHub-Event";
         public async Task ProcessWebhookAsync(string eventName, string json, ILogger logger, CancellationToken cancellationToken)
         {
             await Policy
@@ -135,20 +75,6 @@ namespace Azure.Sdk.Tools.CheckEnforcer
                         await handler.HandleAsync(json, cancellationToken);
                     }
                 });
-        }
-
-        public async Task ProcessWebhookAsync(HttpRequest request, ILogger logger, CancellationToken cancellationToken)
-        {
-
-            if (request.Headers.TryGetValue(GitHubEventHeader, out StringValues eventName))
-            {
-                var json = await ReadAndVerifyBodyAsync(request, cancellationToken);
-                await ProcessWebhookAsync(eventName, json, logger, cancellationToken);
-            }
-            else
-            {
-                throw new CheckEnforcerException($"Could not find header '{GitHubEventHeader}'.");
-            }
         }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Startup.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Startup.cs
@@ -1,7 +1,12 @@
-﻿using Azure.Sdk.Tools.CheckEnforcer;
+﻿using Azure.Data.AppConfiguration;
+using Azure.Identity;
+using Azure.Sdk.Tools.CheckEnforcer;
 using Azure.Sdk.Tools.CheckEnforcer.Configuration;
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -13,8 +18,39 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 {
     public class Startup : FunctionsStartup
     {
+        private string GetWebsiteResourceGroupEnvironmentVariable()
+        {
+            var websiteResourceGroupEnvironmentVariable = Environment.GetEnvironmentVariable("WEBSITE_RESOURCE_GROUP");
+            return websiteResourceGroupEnvironmentVariable;
+        }
+
         public override void Configure(IFunctionsHostBuilder builder)
         {
+            var websiteResourceGroupEnvironmentVariable = GetWebsiteResourceGroupEnvironmentVariable();
+
+            var credential = new DefaultAzureCredential();
+
+            builder.Services.AddAzureClients((builder) =>
+            {
+                builder.UseCredential(credential);
+
+                var keyVaultUri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.vault.azure.net");
+                builder.AddSecretClient(keyVaultUri);
+
+                // To inject the cryptography client with the extension helpers
+                // here we need to first find the Key ID.
+                var keyClient = new KeyClient(keyVaultUri, credential);
+                KeyVaultKey key = keyClient.GetKey("github-app-private-key");
+                builder.AddCryptographyClient(key.Id);
+            });
+
+            builder.Services.AddSingleton((builder) =>
+            {
+                var configurationUri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.azconfig.io/");
+                var configurationClient = new ConfigurationClient(configurationUri, credential);
+                return configurationClient;
+            });
+
             builder.Services.AddSingleton<IGlobalConfigurationProvider, GlobalConfigurationProvider>();
             builder.Services.AddSingleton<IGitHubClientProvider, GitHubClientProvider>();
             builder.Services.AddSingleton<IRepositoryConfigurationProvider, RepositoryConfigurationProvider>();


### PR DESCRIPTION
This PR shifts construction of CryptographyClient and SecretClient into Startup.cs and shifts configuration that was previously in environment variables over into Azure AppConfiguration. I've also removed some of the caching logic since the cache does not provide stampede protection, and some of the secrets we don't need to worry about rotating between function node restarts.

I've also added some locks in there to avoid rushing KeyVault and other dependencies when the function starts on a large backlog of messages from Event Hubs. This is to avoid asking for the same keys/secrets multiple times when a node first comes up after a restart (if we have been down for a longer period of time the start-up could result in unnecessary failures from either KeyVault or GitHub).