### PR TITLE
Feature/apiview improvements

### DIFF
--- a/src/dotnet/APIView/APIView/CodeFileHtmlRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileHtmlRenderer.cs
@@ -18,7 +18,7 @@ namespace ApiView
         public static CodeFileHtmlRenderer Normal { get; } = new CodeFileHtmlRenderer(false);
         public static CodeFileHtmlRenderer ReadOnly { get; } = new CodeFileHtmlRenderer(true);
 
-        protected override void RenderToken(CodeFileToken token, StringBuilder stringBuilder)
+        protected override void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedLine)
         {
             if (token.Value == null)
             {
@@ -45,6 +45,11 @@ namespace ApiView
                 case CodeFileTokenKind.Comment:
                     elementClass = "code-comment";
                     break;
+            }
+
+            if (isDeprecatedLine)
+            {
+                elementClass += " deprecated";
             }
 
             string href = null;

--- a/src/dotnet/APIView/APIView/CodeFileHtmlRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileHtmlRenderer.cs
@@ -18,7 +18,7 @@ namespace ApiView
         public static CodeFileHtmlRenderer Normal { get; } = new CodeFileHtmlRenderer(false);
         public static CodeFileHtmlRenderer ReadOnly { get; } = new CodeFileHtmlRenderer(true);
 
-        protected override void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedLine)
+        protected override void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedToken, bool isDocumentation)
         {
             if (token.Value == null)
             {
@@ -47,9 +47,14 @@ namespace ApiView
                     break;
             }
 
-            if (isDeprecatedLine)
+            if (isDeprecatedToken)
             {
                 elementClass += " deprecated";
+            }
+
+            if (isDocumentation)
+            {
+                elementClass += " documentation";
             }
 
             string href = null;

--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -23,33 +23,32 @@ namespace ApiView
             var stringBuilder = new StringBuilder();
             string currentId = null;
             bool isDocumentation = false;
-            bool isDeprecatedLine = false;
+            bool isDeprecatedToken = false;
 
             foreach (var token in node)
             {
                 switch(token.Kind)
                 {
-                    // One assumption here is that documention line will not have actual code in same line
-                    // Assumption is based on that requirement to hide documention on demand
                     case CodeFileTokenKind.Newline:
-                    case CodeFileTokenKind.DocumentRangeEnd:
-                        list.Add(new CodeLine(stringBuilder.ToString(), currentId, isDocumentation));
+                        list.Add(new CodeLine(stringBuilder.ToString(), currentId));
                         currentId = null;
                         stringBuilder.Clear();
-                        if (token.Kind == CodeFileTokenKind.DocumentRangeEnd)
-                            isDocumentation = false;
                         break;
 
                     case CodeFileTokenKind.DocumentRangeStart:
                         isDocumentation = true;
                         break;
 
+                    case CodeFileTokenKind.DocumentRangeEnd:
+                        isDocumentation = false;
+                        break;
+
                     case CodeFileTokenKind.DeprecatedRangeStart:
-                        isDeprecatedLine = true;
+                        isDeprecatedToken = true;
                         break;
 
                     case CodeFileTokenKind.DeprecatedRangeEnd:
-                        isDeprecatedLine = false;
+                        isDeprecatedToken = false;
                         break;
 
                     default:
@@ -57,13 +56,13 @@ namespace ApiView
                         {
                             currentId = token.DefinitionId;
                         }
-                        RenderToken(token, stringBuilder, isDeprecatedLine);
+                        RenderToken(token, stringBuilder, isDeprecatedToken, isDocumentation);
                         break;
                 }                
             }
         }
 
-        protected virtual void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedLine)
+        protected virtual void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedToken, bool isDocumentation)
         {
             if (token.Value != null)
             {

--- a/src/dotnet/APIView/APIView/CodeLine.cs
+++ b/src/dotnet/APIView/APIView/CodeLine.cs
@@ -6,13 +6,10 @@ namespace ApiView
     {
         public string DisplayString { get; }
         public string ElementId { get; }
-        public bool isDocumentation { get; }
-
-        public CodeLine(string html, string id, bool isDocumentationLine)
+        public CodeLine(string html, string id)
         {
             this.DisplayString = html;
             this.ElementId = id;
-            this.isDocumentation = isDocumentationLine;
         }
 
         public override string ToString()

--- a/src/dotnet/APIView/APIView/CodeLine.cs
+++ b/src/dotnet/APIView/APIView/CodeLine.cs
@@ -6,11 +6,13 @@ namespace ApiView
     {
         public string DisplayString { get; }
         public string ElementId { get; }
+        public bool isDocumentation { get; }
 
-        public CodeLine(string html, string id)
+        public CodeLine(string html, string id, bool isDocumentationLine)
         {
             this.DisplayString = html;
             this.ElementId = id;
+            this.isDocumentation = isDocumentationLine;
         }
 
         public override string ToString()

--- a/src/dotnet/APIView/APIView/Model/CodeFileTokenKind.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFileTokenKind.cs
@@ -14,6 +14,10 @@ namespace APIView
         MemberName = 7,
         StringLiteral = 8,
         Literal = 9,
-        Comment = 10
+        Comment = 10,
+        DocumentRangeStart = 11,
+        DocumentRangeEnd = 12,
+        DeprecatedRangeStart = 13,
+        DeprecatedRangeEnd = 14
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -35,7 +35,15 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Remove="Client\src\documentation.ts" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\APIView\APIView.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <TypeScriptCompile Include="Client\src\documentation.ts" />
   </ItemGroup>
 
 

--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -35,16 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Remove="Client\src\documentation.ts" />
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\APIView\APIView.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <TypeScriptCompile Include="Client\src\documentation.ts" />
-  </ItemGroup>
-
 
 </Project>

--- a/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
@@ -516,3 +516,14 @@ code-inner {
 .code-removed {
     background-color: #ffeef0;
 }
+
+.deprecated {
+    text-decoration: line-through;
+}
+
+.documentation {
+    white-space: pre-wrap;
+    font-family: Consolas, monospace;
+    line-height: 20px;
+    display: none;
+}

--- a/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
@@ -522,8 +522,5 @@ code-inner {
 }
 
 .documentation {
-    white-space: pre-wrap;
-    font-family: Consolas, monospace;
-    line-height: 20px;
     display: none;
 }

--- a/src/dotnet/APIView/APIViewWeb/Client/src/documentation.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/documentation.ts
@@ -5,11 +5,8 @@
   const SEL_CODE_INNER_CLASS = ".code-inner";
   const SEL_CODE_LINE = ".code-line";
 
-  $(document).ready(function () {
-      hideCheckboxIfNoDocs();
-      toggleEmptyLineVisibility(false);
-  });
-
+  hideCheckboxIfNoDocs();
+  toggleEmptyLineVisibility(false);
 
   $(document).on("click", SHOW_DOC_CHECKBOX, e => {
       toggleAllDocumentationVisibility(e.target.checked);
@@ -32,10 +29,8 @@
       });
   }
 
-
   function toggleAllDocumentationVisibility(showDocuments: boolean) {
       $(SEL_DOC_CLASS).toggle(showDocuments);
       toggleEmptyLineVisibility(showDocuments);
   }
-
 });

--- a/src/dotnet/APIView/APIViewWeb/Client/src/documentation.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/documentation.ts
@@ -1,0 +1,12 @@
+﻿$(() => {
+  const SEL_DOC_CLASS = ".documentation";
+
+  $(document).on("click", "#show-documentation-checkbox", e => {
+    toggleAllDocumentationVisibility(e.target.checked);
+  });
+
+  function toggleAllDocumentationVisibility(showDocumentation: boolean) {
+    $(SEL_DOC_CLASS).toggle(showDocumentation);
+  }
+
+});

--- a/src/dotnet/APIView/APIViewWeb/Client/src/documentation.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/documentation.ts
@@ -1,12 +1,41 @@
-﻿$(() => {
+﻿$(() => {  
   const SEL_DOC_CLASS = ".documentation";
+  const SHOW_DOC_CHECKBOX = "#show-documentation-checkbox";
+  const SHOW_DOC_CHECK_COMPONENT = "#show-documentation-component";
+  const SEL_CODE_INNER_CLASS = ".code-inner";
+  const SEL_CODE_LINE = ".code-line";
 
-  $(document).on("click", "#show-documentation-checkbox", e => {
-    toggleAllDocumentationVisibility(e.target.checked);
+  $(document).ready(function () {
+      hideCheckboxIfNoDocs();
+      toggleEmptyLineVisibility(false);
   });
 
-  function toggleAllDocumentationVisibility(showDocumentation: boolean) {
-    $(SEL_DOC_CLASS).toggle(showDocumentation);
+
+  $(document).on("click", SHOW_DOC_CHECKBOX, e => {
+      toggleAllDocumentationVisibility(e.target.checked);
+  });
+
+  function hideCheckboxIfNoDocs() {
+      if ($(SEL_DOC_CLASS).length == 0) {
+          $(SHOW_DOC_CHECK_COMPONENT).hide();
+      }
+  }
+
+  function toggleEmptyLineVisibility(showDocuments: boolean) {
+      //If code line only has documentation then toggle that line
+      $(SEL_CODE_LINE).each(function () {
+          var tokenElements = $(this).find(SEL_CODE_INNER_CLASS).children();
+          //Checking atleast one doc node is present to avoid hiding explicit empty lines
+          if (tokenElements.filter(SEL_DOC_CLASS).length > 0 && tokenElements.not(SEL_DOC_CLASS).length == 0) {
+                $(this).toggle(showDocuments);
+            }
+      });
+  }
+
+
+  function toggleAllDocumentationVisibility(showDocuments: boolean) {
+      $(SEL_DOC_CLASS).toggle(showDocuments);
+      toggleEmptyLineVisibility(showDocuments);
   }
 
 });

--- a/src/dotnet/APIView/APIViewWeb/Client/src/main.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/main.ts
@@ -2,3 +2,4 @@ import "./comments.ts";
 import "./revisions.ts";
 import "./file-input.ts";
 import "./navbar.ts";
+import "./documentation.ts";

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -88,6 +88,12 @@
                         Show comments
                     </label>
                 </span>
+                <span class="dropdown-item checkbox">
+                    <label>
+                        <input type="checkbox" id="show-documentation-checkbox">
+                        Show documentation
+                    </label>
+                </span>
             </div>
         </div>
     </div>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -88,7 +88,7 @@
                         Show comments
                     </label>
                 </span>
-                <span class="dropdown-item checkbox">
+                <span class="dropdown-item checkbox" id="show-documentation-component">
                     <label>
                         <input type="checkbox" id="show-documentation-checkbox">
                         Show documentation

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -9,9 +9,10 @@
         DiffLineKind.Added => "code-added",
         _ => ""
     };
+    bool isDocumentation = Model.CodeLine.isDocumentation;
 }
 
-<tr class="code-line" data-line-id="@(isRemoved ? string.Empty : Model.CodeLine.ElementId)">
+<tr class="@(!Model.CodeLine.isDocumentation? "code-line" :"documentation")" data-line-id="@(isRemoved ? string.Empty : Model.CodeLine.ElementId)">
     <td class="line-comment-button-cell">
         @if (!isRemoved && Model.CodeLine.ElementId != null)
         {

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -12,7 +12,7 @@
 
 }
 
-<tr class="@(!Model.CodeLine.isDocumentation? "code-line" :"documentation")" data-line-id="@(isRemoved ? string.Empty : Model.CodeLine.ElementId)">
+<tr class="code-line" data-line-id="@(isRemoved ? string.Empty : Model.CodeLine.ElementId)">
     <td class="line-comment-button-cell">
         @if (!isRemoved && Model.CodeLine.ElementId != null)
         {

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -9,7 +9,7 @@
         DiffLineKind.Added => "code-added",
         _ => ""
     };
-    bool isDocumentation = Model.CodeLine.isDocumentation;
+
 }
 
 <tr class="@(!Model.CodeLine.isDocumentation? "code-line" :"documentation")" data-line-id="@(isRemoved ? string.Empty : Model.CodeLine.ElementId)">

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -9,7 +9,6 @@
         DiffLineKind.Added => "code-added",
         _ => ""
     };
-
 }
 
 <tr class="code-line" data-line-id="@(isRemoved ? string.Empty : Model.CodeLine.ElementId)">


### PR DESCRIPTION
Enhancements:
- Show deprecated methods or types as strikethrough
- Show Documentation only if "Show documentation" checkbox is selected. By default documentation is hidden.
- Show Documentation checkbox is currently shown for all languages even though documentation is shown only for Java at this point. Something to enhance later to show this checkbox only for supported language or add the support include documentation in language side.

