### PR TITLE
Added automation for Doc.MS release step

### DIFF
--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -10,6 +10,7 @@ parameters:
   TargetDocRepoOwner: ''
   PRBranchName: 'smoke-test-rdme'
   SourceBranchName: 'smoke-test'
+  PRLabels: 'automation'
   ArtifactName: ''
   Language: ''
   DocRepoDestinationPath: '' #usually docs-ref-services/
@@ -81,6 +82,7 @@ steps:
     ScriptDirectory: ${{ parameters.WorkingDirectory }}/${{ parameters.ScriptDirectory }}
     GHReviewersVariable: ${{ parameters.GHReviewersVariable }}
     GHTeamReviewersVariable: ${{ parameters.GHTeamReviewersVariable }} 
+    PRLabels: ${{ parameters.PRLabels }}
 
 - ${{if ne( parameters['OnboardingBranch'], '')}}:
   - pwsh: |

--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -10,7 +10,7 @@ parameters:
   TargetDocRepoOwner: ''
   PRBranchName: 'smoke-test-rdme'
   SourceBranchName: 'smoke-test'
-  PRLabels: 'automation'
+  PRLabels: 'auto-merge'
   ArtifactName: ''
   Language: ''
   DocRepoDestinationPath: '' #usually docs-ref-services/


### PR DESCRIPTION
This is an ask from Doc.MS release step. We want to create pull request with automation label.

Issue: https://github.com/Azure/azure-sdk/issues/1635

Added the `auto-merge` label for testing.
PR: https://github.com/MicrosoftDocs/azure-docs-sdk-node/pull/843