### PR TITLE
Hide details label if diagnostic error doesn't have any details link

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -36,7 +36,7 @@
                         @lineDiagnostic.Text
                     }
 
-                    @if (!String.IsNullOrEmpty(lineDiagnostic.HelpLinkUri))
+                    @if (!string.IsNullOrEmpty(lineDiagnostic.HelpLinkUri))
                     {
                         <a href="@lineDiagnostic.HelpLinkUri">Details</a>
                     }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -35,7 +35,11 @@
                     {
                         @lineDiagnostic.Text
                     }
-                    <a href="@lineDiagnostic.HelpLinkUri">Details</a>
+
+                    @if (!String.IsNullOrEmpty(lineDiagnostic.HelpLinkUri))
+                    {
+                        <a href="@lineDiagnostic.HelpLinkUri">Details</a>
+                    }
                 </p>
             }
         </td>


### PR DESCRIPTION
Hide "Details" label when underlying link is not present.