### PR TITLE
Fixed the aggressive title replacements

### DIFF
--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -73,16 +73,13 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
     $foundTitle = ""
 
     # only replace the version if the formatted header can be found
-    $headerContentMatches = (Select-String -InputObject $pkgInfo.ReadmeContent -Pattern 'Azure .+? (client|plugin|shared) library for (JavaScript|Java|Python|\.NET|C)')
-    if ($headerContentMatches) {
-      $foundTitle = $headerContentMatches.Matches[0]
-      $fileContent = $pkgInfo.ReadmeContent -replace $foundTitle, "$foundTitle - Version $($pkgInfo.PackageVersion) `n"
-
-      # Replace github master link with release tag.
-      $ReplacementPattern = "`${1}$($pkgInfo.Tag)"
-      $fileContent = $fileContent -replace $releaseReplaceRegex, $ReplacementPattern
-    }
-
+    $titleRegex = "(\# Azure .+? (?:client|plugin|shared) library for (?:JavaScript|Java|Python|\.NET|C))"
+    $fileContent = $pkgInfo.ReadmeContent -replace $titleRegex, "`${1} - Version $($pkgInfo.PackageVersion) `n"
+    
+    # Replace github master link with release tag.
+    $ReplacementPattern = "`${1}$($pkgInfo.Tag)"
+    $fileContent = $fileContent -replace $releaseReplaceRegex, $ReplacementPattern
+  
     $header = "---`ntitle: $foundTitle`nkeywords: Azure, $lang, SDK, API, $($pkgInfo.PackageId), $service`nauthor: maggiepint`nms.author: magpint`nms.date: $date`nms.topic: article`nms.prod: azure`nms.technology: azure`nms.devlang: $lang`nms.service: $service`n---`n"
 
     if ($fileContent) {


### PR DESCRIPTION
Fixed the bug of `update-doc-metadata.ps1` script which replace the title too aggressively. 
Issue: https://github.com/Azure/azure-sdk/issues/1674

Tested in local with python storage pkg. 
![image](https://user-images.githubusercontent.com/48036328/92537264-8e4bd180-f1f0-11ea-8ed1-4e852565ee37.png)
![image](https://user-images.githubusercontent.com/48036328/92537274-96a40c80-f1f0-11ea-9255-75361732e514.png)
