### PR TITLE
Fixed the bug of reading package name in cpp.

### DIFF
--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -336,7 +336,7 @@ function ParseCppArtifact($pkg, $workingDirectory) {
   return New-Object PSObject -Property @{
     PackageId      = $pkgName
     PackageVersion = $pkgVersion
-    ReleaseTag     = "$($pkgId)_$($pkgVersion)"
+    ReleaseTag     = "$($pkgName)_$($pkgVersion)"
     # Artifact info is always considered deployable for now becasue it is not
     # deployed anywhere. Dealing with duplicate tags happens downstream in
     # CheckArtifactShaAgainstTagsList

--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -336,7 +336,7 @@ function ParseCppArtifact($pkg, $workingDirectory) {
   return New-Object PSObject -Property @{
     PackageId      = $pkgName
     PackageVersion = $pkgVersion
-    ReleaseTag     = "$($pkgName)_$($pkgVersion)"
+    ReleaseTag     = "${pkgName}_${pkgVersion}"
     # Artifact info is always considered deployable for now becasue it is not
     # deployed anywhere. Dealing with duplicate tags happens downstream in
     # CheckArtifactShaAgainstTagsList


### PR DESCRIPTION
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=531488&view=logs&j=a129effc-2dd1-54d1-fb5a-ad7bdc0e851d

Newly created tag: https://github.com/Azure/azure-sdk-for-cpp/tree/azure-template_1.0.0-beta.2