### PR TITLE
Check Enforcer rate limit logging improvement

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
@@ -57,19 +57,20 @@ namespace Azure.Sdk.Tools.CheckEnforcer
                     switch (ex)
                     {
                         case AbuseException abuseException:
+                            retryDelay = TimeSpan.FromSeconds((double)abuseException.RetryAfterSeconds);
                             logger.LogWarning("Abuse exception detected. Retry after seconds is: {retrySeconds}",
                                 abuseException.RetryAfterSeconds
                                 );
-                            retryDelay = TimeSpan.FromSeconds((double)abuseException.RetryAfterSeconds);
                             break;
 
                         case RateLimitExceededException rateLimitExceededException:
-                            logger.LogWarning(
-                                "Rate limit exception detected. Limit is: {limit}, reset is: {reset}",
-                                rateLimitExceededException.Limit,
-                                rateLimitExceededException.Reset
-                                );
                             retryDelay = rateLimitExceededException.GetRetryAfterTimeSpan();
+                            logger.LogWarning(
+                                "Rate limit exception detected. Limit is: {limit}, reset is: {reset}, retry seconds is: {retrySeconds}",
+                                rateLimitExceededException.Limit,
+                                rateLimitExceededException.Reset,
+                                retryDelay.TotalSeconds
+                                );
                             break;
                     }
 

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/GitHubWebhookProcessor.cs
@@ -57,12 +57,18 @@ namespace Azure.Sdk.Tools.CheckEnforcer
                     switch (ex)
                     {
                         case AbuseException abuseException:
-                            logger.LogWarning("Abuse exception detected, attempting retry.");
+                            logger.LogWarning("Abuse exception detected. Retry after seconds is: {retrySeconds}",
+                                abuseException.RetryAfterSeconds
+                                );
                             retryDelay = TimeSpan.FromSeconds((double)abuseException.RetryAfterSeconds);
                             break;
 
                         case RateLimitExceededException rateLimitExceededException:
-                            logger.LogWarning("Rate limit exception detected, attempting retry.");
+                            logger.LogWarning(
+                                "Rate limit exception detected. Limit is: {limit}, reset is: {reset}",
+                                rateLimitExceededException.Limit,
+                                rateLimitExceededException.Reset
+                                );
                             retryDelay = rateLimitExceededException.GetRetryAfterTimeSpan();
                             break;
                     }


### PR DESCRIPTION
Log limit data when we receive a RateLimitExceededException.