### PR TITLE
Feature/review load perf

### DIFF
--- a/src/dotnet/APIView/APIView/CodeFileHtmlRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileHtmlRenderer.cs
@@ -18,7 +18,7 @@ namespace ApiView
         public static CodeFileHtmlRenderer Normal { get; } = new CodeFileHtmlRenderer(false);
         public static CodeFileHtmlRenderer ReadOnly { get; } = new CodeFileHtmlRenderer(true);
 
-        protected override void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedToken, bool isDocumentation)
+        protected override void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedToken)
         {
             if (token.Value == null)
             {
@@ -50,11 +50,6 @@ namespace ApiView
             if (isDeprecatedToken)
             {
                 elementClass += " deprecated";
-            }
-
-            if (isDocumentation)
-            {
-                elementClass += " documentation";
             }
 
             string href = null;

--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -10,7 +10,8 @@ namespace ApiView
     public class CodeFileRenderer
     {
         public static CodeFileRenderer Instance = new CodeFileRenderer();
-
+        const string DOCUMENTATION_SPAN_START = "<span class=\"documentation\">";
+        const string DOCUMENTATION_SPAN_END = "</span>";
         public CodeLine[] Render(CodeFile file)
         {
             var list = new List<CodeLine>();
@@ -33,18 +34,31 @@ namespace ApiView
                 switch(token.Kind)
                 {
                     case CodeFileTokenKind.Newline:
+                        //Close documentation span if within doc range
+                        if(isDocumentation)
+                        {
+                            stringBuilder.Append(DOCUMENTATION_SPAN_END);
+                        }
                         list.Add(new CodeLine(stringBuilder.ToString(), currentId, isLineAllDocumentation));
                         currentId = null;
                         stringBuilder.Clear();
+                        //Start documentation span if tokens still in documentation range
+                        if(isDocumentation)
+                        {
+                            stringBuilder.Append(DOCUMENTATION_SPAN_START);
+                        }
+                        //Reset flag for line documentation. This will be set to false if atleast one token is not a doc
                         isLineAllDocumentation = true;
                         break;
 
                     case CodeFileTokenKind.DocumentRangeStart:
                         isDocumentation = true;
+                        stringBuilder.Append(DOCUMENTATION_SPAN_START);
                         break;
 
                     case CodeFileTokenKind.DocumentRangeEnd:
                         isDocumentation = false;
+                        stringBuilder.Append(DOCUMENTATION_SPAN_END);
                         break;
 
                     case CodeFileTokenKind.DeprecatedRangeStart:
@@ -60,7 +74,7 @@ namespace ApiView
                         {
                             currentId = token.DefinitionId;
                         }
-                        RenderToken(token, stringBuilder, isDeprecatedToken, isDocumentation);
+                        RenderToken(token, stringBuilder, isDeprecatedToken);
                         if(!isDocumentation)
                         {
                             isLineAllDocumentation = false;
@@ -70,7 +84,7 @@ namespace ApiView
             }
         }
 
-        protected virtual void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedToken, bool isDocumentation)
+        protected virtual void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedToken)
         {
             if (token.Value != null)
             {

--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -24,15 +24,19 @@ namespace ApiView
             string currentId = null;
             bool isDocumentation = false;
             bool isDeprecatedToken = false;
+            //This will be set to true by default when a new line starts and 
+            // set to false when any non documentation token is found within the line
+            bool isLineAllDocumentation = false;
 
             foreach (var token in node)
             {
                 switch(token.Kind)
                 {
                     case CodeFileTokenKind.Newline:
-                        list.Add(new CodeLine(stringBuilder.ToString(), currentId));
+                        list.Add(new CodeLine(stringBuilder.ToString(), currentId, isLineAllDocumentation));
                         currentId = null;
                         stringBuilder.Clear();
+                        isLineAllDocumentation = true;
                         break;
 
                     case CodeFileTokenKind.DocumentRangeStart:
@@ -57,6 +61,10 @@ namespace ApiView
                             currentId = token.DefinitionId;
                         }
                         RenderToken(token, stringBuilder, isDeprecatedToken, isDocumentation);
+                        if(!isDocumentation)
+                        {
+                            isLineAllDocumentation = false;
+                        }
                         break;
                 }                
             }

--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -27,7 +27,7 @@ namespace ApiView
             bool isDeprecatedToken = false;
             //This will be set to true by default when a new line starts and 
             // set to false when any non documentation token is found within the line
-            bool isLineAllDocumentation = false;
+            bool isLineAllDocumentation = true;
 
             foreach (var token in node)
             {

--- a/src/dotnet/APIView/APIView/CodeLine.cs
+++ b/src/dotnet/APIView/APIView/CodeLine.cs
@@ -6,10 +6,13 @@ namespace ApiView
     {
         public string DisplayString { get; }
         public string ElementId { get; }
-        public CodeLine(string html, string id)
+
+        public bool isLineAllDocumentation { get; }
+        public CodeLine(string html, string id, bool isLineAllDocumentation)
         {
             this.DisplayString = html;
             this.ElementId = id;
+            this.isLineAllDocumentation = isLineAllDocumentation;
         }
 
         public override string ToString()

--- a/src/dotnet/APIView/APIViewWeb/Client/src/documentation.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/documentation.ts
@@ -2,35 +2,16 @@
   const SEL_DOC_CLASS = ".documentation";
   const SHOW_DOC_CHECKBOX = "#show-documentation-checkbox";
   const SHOW_DOC_CHECK_COMPONENT = "#show-documentation-component";
-  const SEL_CODE_INNER_CLASS = ".code-inner";
-  const SEL_CODE_LINE = ".code-line";
 
   hideCheckboxIfNoDocs();
-  toggleEmptyLineVisibility(false);
-
+ 
   $(document).on("click", SHOW_DOC_CHECKBOX, e => {
-      toggleAllDocumentationVisibility(e.target.checked);
+      $(SEL_DOC_CLASS).toggle(e.target.checked);
   });
 
   function hideCheckboxIfNoDocs() {
       if ($(SEL_DOC_CLASS).length == 0) {
           $(SHOW_DOC_CHECK_COMPONENT).hide();
       }
-  }
-
-  function toggleEmptyLineVisibility(showDocuments: boolean) {
-      //If code line only has documentation then toggle that line
-      $(SEL_CODE_LINE).each(function () {
-          var tokenElements = $(this).find(SEL_CODE_INNER_CLASS).children();
-          //Checking atleast one doc node is present to avoid hiding explicit empty lines
-          if (tokenElements.filter(SEL_DOC_CLASS).length > 0 && tokenElements.not(SEL_DOC_CLASS).length == 0) {
-                $(this).toggle(showDocuments);
-            }
-      });
-  }
-
-  function toggleAllDocumentationVisibility(showDocuments: boolean) {
-      $(SEL_DOC_CLASS).toggle(showDocuments);
-      toggleEmptyLineVisibility(showDocuments);
   }
 });

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -9,9 +9,11 @@
         DiffLineKind.Added => "code-added",
         _ => ""
     };
+    string documentationClass = Model.CodeLine.isLineAllDocumentation? "documentation": "";
+
 }
 
-<tr class="code-line" data-line-id="@(isRemoved ? string.Empty : Model.CodeLine.ElementId)">
+<tr class="code-line @documentationClass" data-line-id="@(isRemoved ? string.Empty : Model.CodeLine.ElementId)">
     <td class="line-comment-button-cell">
         @if (!isRemoved && Model.CodeLine.ElementId != null)
         {


### PR DESCRIPTION
Tag entire line as documentation if all tokens are within doc range. Instead of tagging each token as documentation start a span of documentation around tokens. 

Instead of hiding documentation after loading, set them as hidden by default. 