### PR TITLE
Update Azure SDK dependencies in use new AppConfig API

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -6,15 +6,15 @@
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.2.0" />
+    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.2" />
+    <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.1.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.5.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="Polly" Version="7.2.1" />

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Startup.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Startup.cs
@@ -36,19 +36,15 @@ namespace Azure.Sdk.Tools.CheckEnforcer
 
                 var keyVaultUri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.vault.azure.net");
                 builder.AddSecretClient(keyVaultUri);
+                
+                var configurationUri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.azconfig.io/");
+                builder.AddConfigurationClient(configurationUri);
 
                 // To inject the cryptography client with the extension helpers
                 // here we need to first find the Key ID.
                 var keyClient = new KeyClient(keyVaultUri, credential);
                 KeyVaultKey key = keyClient.GetKey("github-app-private-key");
                 builder.AddCryptographyClient(key.Id);
-            });
-
-            builder.Services.AddSingleton((builder) =>
-            {
-                var configurationUri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.azconfig.io/");
-                var configurationClient = new ConfigurationClient(configurationUri, credential);
-                return configurationClient;
             });
 
             builder.Services.AddSingleton<IGlobalConfigurationProvider, GlobalConfigurationProvider>();


### PR DESCRIPTION
This PR updates Check Enforcer to the latest Azure SDK dependencies. It also changes the way AppConfig is used to take advantage of the new API added in the latest release of the AppConfig API (allows you to ```AddConfigurationClient``` and take advantage of the pre-configured ```DefaultAzureCredentials``` rather than having to pass it in.