### PR TITLE
Use DI for AppConfig & KeyVault in Webhook Router.

### DIFF
--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Azure.Sdk.Tools.WebhookRouter.csproj
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Azure.Sdk.Tools.WebhookRouter.csproj
@@ -1,15 +1,16 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.2.0" />
-    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.1.0" />
+    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.2" />
+    <PackageReference Include="Azure.Identity" Version="1.2.3" />
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.2.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.7" />
+    <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Startup.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Startup.cs
@@ -1,6 +1,7 @@
 ﻿using Azure.Sdk.Tools.WebhookRouter;
 using Azure.Sdk.Tools.WebhookRouter.Routing;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
+using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
@@ -12,8 +13,35 @@ namespace Azure.Sdk.Tools.WebhookRouter
 {
     public class Startup : FunctionsStartup
     {
+
+        private string GetWebsiteResourceGroupEnvironmentVariable()
+        {
+            var websiteResourceGroupEnvironmentVariable = Environment.GetEnvironmentVariable("WEBSITE_RESOURCE_GROUP");
+            return websiteResourceGroupEnvironmentVariable;
+        }
+
+        private Uri GetKeyVaultUri()
+        {
+            var websiteResourceGroupEnvironmentVariable = GetWebsiteResourceGroupEnvironmentVariable();
+            var uri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.vault.azure.net/");
+            return uri;
+        }
+
+        private Uri GetConfigurationUri()
+        {
+            var websiteResourceGroupEnvironmentVariable = GetWebsiteResourceGroupEnvironmentVariable();
+            var uri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.azconfig.io/");
+            return uri;
+        }
+
         public override void Configure(IFunctionsHostBuilder builder)
         {
+            builder.Services.AddAzureClients((builder) =>
+            {
+                builder.AddConfigurationClient(GetConfigurationUri());
+                builder.AddSecretClient(GetKeyVaultUri());
+            });
+
             builder.Services.AddSingleton<IRouter, Router>();
             builder.Services.AddMemoryCache();
         }


### PR DESCRIPTION
This PR moves the instantiation of ```ConfigurationClient``` and ```SecretClient``` into ```Startup.cs```. This is best practices for using Azure clients in ASP.NET Core/Functions. I still have the event hubs producer clients instansiated in ```Router.cs``` because I need to have a mapping from route ID to event hub client rather than just having one shared client across the entire app.

Also updated to all the latest Azure client bits.