### PR TITLE
Update Tools repo Sync to make use of patch files

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -42,6 +42,7 @@ steps:
     echo "RepoName = $repName"
 
   displayName: Check for changes
+  condition: and(succeeded(), eq(variables['HasChanges'], ''))
   workingDirectory: ${{ parameters.WorkingDirectory }}
   ignoreLASTEXITCODE: true
 

--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -17,6 +17,7 @@ parameters:
   GHTeamReviewersVariable: ''
   # Multiple labels seperated by comma, e.g. "bug, APIView"
   PRLabels: ''
+  SkipCheckingForChanges: false
 
 steps:
 
@@ -35,16 +36,19 @@ steps:
       echo "##vso[task.setvariable variable=HasChanges]$false"
       echo "No changes so skipping code push"
     }
+  displayName: Check for changes
+  condition: and(succeeded(), eq(${{ parameters.SkipCheckingForChanges }}, false))
+  workingDirectory: ${{ parameters.WorkingDirectory }}
+  ignoreLASTEXITCODE: true
 
+- pwsh: |
     # Remove the repo owner from the front of the repo name if it exists there
     $repoName = "${{ parameters.RepoName }}" -replace "^${{ parameters.RepoOwner }}/", ""
     echo "##vso[task.setvariable variable=RepoNameWithoutOwner]$repoName"
-    echo "RepoName = $repName"
-
-  displayName: Check for changes
-  condition: and(succeeded(), eq(variables['HasChanges'], ''))
+    echo "RepoName = $repoName"
+  displayName: Remove Repo Owner from Repo Name
+  condition: succeeded()
   workingDirectory: ${{ parameters.WorkingDirectory }}
-  ignoreLASTEXITCODE: true
 
 - task: PowerShell@2
   displayName: Push changes
@@ -58,6 +62,7 @@ steps:
       -CommitMsg "${{ parameters.CommitMsg }}"
       -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.PROwner }}/$(RepoNameWithoutOwner).git"
       -PushArgs "${{ parameters.PushArgs }}"
+      -SkipCommit "${{parameters.SkipCheckingForChanges}}"
 
 - task: PowerShell@2
   displayName: Create pull request

--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -69,6 +69,9 @@ if (!$SkipCommit) {
         exit $LASTEXITCODE
     }
 }
+else {
+    Write-Host "Skipped applying commit"
+}
 
 # The number of retries can be increased if necessary. In theory, the number of retries
 # should be the max number of libraries in the largest pipeline -1 as everything except

--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -25,7 +25,10 @@ param(
     [string] $GitUrl,
 
     [Parameter(Mandatory = $false)]
-    [string] $PushArgs = ""
+    [string] $PushArgs = "",
+
+    [Parameter(Mandatory = $false)]
+    [string] $SkipCommit = $false
 )
 
 # This is necessay because of the janky git command output writing to stderr.
@@ -57,12 +60,14 @@ if ($LASTEXITCODE -ne 0)
     exit $LASTEXITCODE
 }
 
-Write-Host "git -c user.name=`"azure-sdk`" -c user.email=`"azuresdk@microsoft.com`" commit -am `"$($CommitMsg)`""
-git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" commit -am "$($CommitMsg)"
-if ($LASTEXITCODE -ne 0)
-{
-    Write-Error "Unable to add files and create commit LASTEXITCODE=$($LASTEXITCODE), see command output above."
-    exit $LASTEXITCODE
+if (!$SkipCommit) {
+    Write-Host "git -c user.name=`"azure-sdk`" -c user.email=`"azuresdk@microsoft.com`" commit -am `"$($CommitMsg)`""
+    git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" commit -am "$($CommitMsg)"
+    if ($LASTEXITCODE -ne 0)
+    {
+        Write-Error "Unable to add files and create commit LASTEXITCODE=$($LASTEXITCODE), see command output above."
+        exit $LASTEXITCODE
+    }
 }
 
 # The number of retries can be increased if necessary. In theory, the number of retries

--- a/eng/common/scripts/modules/ChangeLog-Operations.psm1
+++ b/eng/common/scripts/modules/ChangeLog-Operations.psm1
@@ -1,5 +1,5 @@
 # Common Changelog Operations
-
+# This Files has been retired
 $RELEASE_TITLE_REGEX = "(?<releaseNoteTitle>^\#+.*(?<version>\b\d+\.\d+\.\d+([^0-9\s][^\s:]+)?)(\s(?<releaseStatus>\(Unreleased\)|\(\d{4}-\d{2}-\d{2}\)))?)"
 
 # Returns a Collection of changeLogEntry object containing changelog info for all version present in the gived CHANGELOG

--- a/eng/common/scripts/modules/Package-Properties.psm1
+++ b/eng/common/scripts/modules/Package-Properties.psm1
@@ -1,3 +1,4 @@
+# This Files has been retired
 # Helper functions for retireving useful information from azure-sdk-for-* repo
 # Example Use : Import-Module .\eng\common\scripts\modules
 class PackageProps

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -36,6 +36,7 @@ stages:
               CommitMessage: "Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools repository for Tools PR $(System.PullRequest.PullRequestNumber)"
               DirectoryToSync: ${{ parameters.DirectoryToSync }}
               PRBranchName: "sync-${{ parameters.DirectoryToSync }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
+              BaseBranchName: $(system.pullRequest.targetBranch) 
               PRTitle: "Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools for PR $(System.PullRequest.PullRequestNumber)"
               PRBody: >
                 Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools for PR https://github.com/Azure/azure-sdk-tools/pull/$(System.PullRequest.PullRequestNumber)<br>

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -30,6 +30,41 @@ stages:
         displayName: Sync ${{ parameters.DirectoryToSync }} Directory
 
         steps:
+        - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+          - task: PowerShell@2
+            displayName: 'Get alias of the Tools PR Creator'
+            inputs:
+              targetType: filePath
+              filePath: $(Build.SourcesDirectory)/eng/common/scripts/get-pr-creator.ps1
+              arguments: >
+                -RepoOwner "Azure"
+                -RepoName "azure-sdk-tools"
+                -PullRequestNumber "$(System.PullRequest.PullRequestNumber)"
+                -VsoPRCreatorVariable "System.PullRequest.Creator"
+                -AuthToken "$(azuresdk-github-pat)"
+              pwsh: true
+
+          - pwsh: |
+              Set-PsDebug -Trace 1
+              $patchDir = "$(Build.ArtifactStagingDirectory)/patchfiles"
+              $patchfiles = git format-patch --output-directory $patchDir HEAD...origin/$(system.pullRequest.targetBranch) -- "${{ parameters.DirectoryToSync }}"
+              if ($patchfiles -and ($LASTEXITCODE -eq 0)) {
+                echo "##vso[task.setvariable variable=PatchFilesLocation]$patchDir"
+                echo "Setting PatchFilesLocation"
+              }
+              else {
+                Write-Host "Failed to Create PatchFiles from Pull Request [https://github.com/Azure/azure-sdk-tools/pull/$(System.PullRequest.PullRequestNumber)]"
+                exit 1
+              }
+            displayName: Create Patch Files from Changes in PR
+            workingDirectory: $(System.DefaultWorkingDirectory)
+
+          - task: PublishPipelineArtifact@1
+            condition: and(succeeded(), ne(variables['PatchFilesLocation'],''))
+            inputs:
+              artifactName: patchfiles
+              path: "$(PatchFilesLocation)"
+
         - template: ./templates/steps/sync-directory.yml
           parameters:
             ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
@@ -41,6 +76,7 @@ stages:
               PRBody: >
                 Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools for PR https://github.com/Azure/azure-sdk-tools/pull/$(System.PullRequest.PullRequestNumber)<br>
                 See [eng/common workflow](https://github.com/Azure/azure-sdk-tools/blob/master/eng/common/README.md#workflow)
+              SkipCheckingForChanges: true
             ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
               CommitMessage: Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools repository
               DirectoryToSync: ${{ parameters.DirectoryToSync }}

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -31,19 +31,6 @@ stages:
 
         steps:
         - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-          - task: PowerShell@2
-            displayName: 'Get alias of the Tools PR Creator'
-            inputs:
-              targetType: filePath
-              filePath: $(Build.SourcesDirectory)/eng/common/scripts/get-pr-creator.ps1
-              arguments: >
-                -RepoOwner "Azure"
-                -RepoName "azure-sdk-tools"
-                -PullRequestNumber "$(System.PullRequest.PullRequestNumber)"
-                -VsoPRCreatorVariable "System.PullRequest.Creator"
-                -AuthToken "$(azuresdk-github-pat)"
-              pwsh: true
-
           - pwsh: |
               Set-PsDebug -Trace 1
               $patchDir = "$(Build.ArtifactStagingDirectory)/patchfiles"
@@ -51,6 +38,7 @@ stages:
               if ($patchfiles -and ($LASTEXITCODE -eq 0)) {
                 echo "##vso[task.setvariable variable=PatchFilesLocation]$patchDir"
                 echo "Setting PatchFilesLocation"
+                ls $patchDir
               }
               else {
                 Write-Host "Failed to Create PatchFiles from Pull Request [https://github.com/Azure/azure-sdk-tools/pull/$(System.PullRequest.PullRequestNumber)]"

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -38,7 +38,6 @@ stages:
               if ($patchfiles -and ($LASTEXITCODE -eq 0)) {
                 echo "##vso[task.setvariable variable=PatchFilesLocation]$patchDir"
                 echo "Setting PatchFilesLocation"
-                ls $patchDir
               }
               else {
                 Write-Host "Failed to Create PatchFiles from Pull Request [https://github.com/Azure/azure-sdk-tools/pull/$(System.PullRequest.PullRequestNumber)]"

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -7,6 +7,7 @@ parameters:
   PRTitle: pr-title-not-set
   PRBody: pr-body-not-set
   PRDataArtifactPath: pr-data-artifact-path-not-set
+  SkipCheckingForChanges: false
 
 steps:
   - pwsh: |
@@ -15,16 +16,26 @@ steps:
 
   - ${{ each repo in parameters.Repos }}:
     - pwsh: |
+        Set-PsDebug -Trace 1
         git clone --branch ${{ parameters.BaseBranchName }} https://github.com/azure/${{ repo }}
         $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
-        if ($PatchFilesLocation)
+        if ('$(PatchFilesLocation)')
         {
           pushd ${{ repo }}
-          $results = Get-ChildItem $PatchFilesLocation | % { $git am $_.FullName }
-          if ($results.Count -ne (Get-ChildItem $PatchFilesLocation).Count)
+          $results = @()
+          echo "##vso[task.setvariable variable=HasChanges]$false"
+          foreach ($file in (Get-ChildItem $(PatchFilesLocation)))
           {
-            Write-Output "Failed to apply patch files"
-            exit 1
+            $results += git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" am $file.FullName
+          }
+          if (($results.Count -eq (Get-ChildItem $(PatchFilesLocation))) -and ($LASTEXITCODE -eq 0))
+          {
+            echo "##vso[task.setvariable variable=HasChanges]$true"
+          }
+          else
+          {
+            Write-Output "Failed to properly apply patch files to [https://github.com/azure/${{ repo }}]"
+            echo "##vso[task.setvariable variable=HasChanges]$false"
           }
         }
         else
@@ -50,6 +61,9 @@ steps:
         PushArgs: -f
         WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
         ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts
+        GHReviewersVariable: "System.PullRequest.Creator"
+        GHAssignessVariable: "System.PullRequest.Creator"
+        SkipCheckingForChanges: ${{ parameters.SkipCheckingForChanges }}
 
     - pwsh: |
         $PRData = "Azure;${{ repo }};$(Submitted.PullRequest.Number)"

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -8,6 +8,9 @@ parameters:
   PRBody: pr-body-not-set
   PRDataArtifactPath: pr-data-artifact-path-not-set
   SkipCheckingForChanges: false
+  ScriptDirectory: eng/common/scripts
+  PROwner: Azure
+  PushArgs:
 
 steps:
   - pwsh: |
@@ -25,7 +28,6 @@ steps:
           $results = @()
           echo "##vso[task.setvariable variable=HasChanges]$false"
           $shaBeforePatches = git rev-parse --short HEAD
-          Write-Host $shaBeforePatches
           foreach ($file in (Get-ChildItem $(PatchFilesLocation)))
           {
              Write-Host $file.FullName
@@ -37,7 +39,6 @@ steps:
              }
           }
           $shaAfterPatches = git rev-parse --short HEAD
-          Write-Host $shaAfterPatches
           $hasChanges = $shaBeforePatches -ne $shaAfterPatches
           echo "##vso[task.setvariable variable=HasChanges]$hasChanges"
         }
@@ -48,25 +49,22 @@ steps:
           Copy-Item -v -r $(Build.SourcesDirectory)/${{ parameters.DirectoryToSync }} $repoPath
           Get-ChildItem -r $repoPath
         }
-      displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}
+      displayName: Copy or Apply Patch for ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}
       workingDirectory: $(System.DefaultWorkingDirectory)
 
-    - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
-      parameters:
-        RepoName: ${{ repo }}
-        RepoOwner: Azure
-        PRBranchName: ${{ parameters.PRBranchName }}
-        BaseBranchName: ${{ parameters.BaseBranchName }}
-        CommitMsg: ${{ parameters.CommitMessage }}
-        PRTitle: ${{ parameters.PRTitle }}
-        PRBody: ${{ parameters.PRBody }}
-        PRLabels: "EngSys"
-        PushArgs: -f
-        WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
-        ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts
-        GHReviewersVariable: "System.PullRequest.Creator"
-        GHAssignessVariable: "System.PullRequest.Creator"
-        SkipCheckingForChanges: ${{ parameters.SkipCheckingForChanges }}
+    - task: PowerShell@2
+      displayName: Push changes
+      condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
+      inputs:
+        pwsh: true
+        workingDirectory: ${{ parameters.WorkingDirectory }}
+        filePath: ${{ parameters.ScriptDirectory }}/git-branch-push.ps1
+        arguments: >
+          -PRBranchName "${{ parameters.PRBranchName }}"
+          -CommitMsg "${{ parameters.CommitMessage }}"
+          -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.PROwner }}/${{ repo }}.git"
+          -PushArgs "${{ parameters.PushArgs }}"
+          -SkipCommit "${{parameters.SkipCheckingForChanges}}"
 
     - pwsh: |
         $PRData = "Azure;${{ repo }};$(Submitted.PullRequest.Number)"

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -24,19 +24,22 @@ steps:
           pushd ${{ repo }}
           $results = @()
           echo "##vso[task.setvariable variable=HasChanges]$false"
+          $shaBeforePatches = git rev-parse --short HEAD
+          Write-Host $shaBeforePatches
           foreach ($file in (Get-ChildItem $(PatchFilesLocation)))
           {
-            $results += git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" am $file.FullName
+             Write-Host $file.FullName
+             git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" am -3 $file.FullName
+             if ($lastExitCode -ne 0) { 
+               git am --show-current-patch=diff
+               Write-Error "##vso[task.LogIssue type=warning;]Failed to properly apply patch files to [https://github.com/azure/${{ repo }}]"
+               exit 1
+             }
           }
-          if (($results.Count -eq (Get-ChildItem $(PatchFilesLocation))) -and ($LASTEXITCODE -eq 0))
-          {
-            echo "##vso[task.setvariable variable=HasChanges]$true"
-          }
-          else
-          {
-            Write-Output "Failed to properly apply patch files to [https://github.com/azure/${{ repo }}]"
-            echo "##vso[task.setvariable variable=HasChanges]$false"
-          }
+          $shaAfterPatches = git rev-parse --short HEAD
+          Write-Host $shaAfterPatches
+          $hasChanges = $shaBeforePatches -ne $shaAfterPatches
+          echo "##vso[task.setvariable variable=HasChanges]$hasChanges"
         }
         else
         {

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -14,32 +14,28 @@ steps:
     displayName: Create PRData Artifact
 
   - ${{ each repo in parameters.Repos }}:
-    - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
-      - pwsh: |
-          git clone --branch ${{ parameters.BaseBranchName }} https://github.com/azure/${{ repo }}
-          $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
-
+    - pwsh: |
+        git clone --branch ${{ parameters.BaseBranchName }} https://github.com/azure/${{ repo }}
+        $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
+        if ($PatchFilesLocation)
+        {
+          pushd ${{ repo }}
+          $results = Get-ChildItem $PatchFilesLocation | % { $git am $_.FullName }
+          if ($results.Count -ne (Get-ChildItem $PatchFilesLocation).Count)
+          {
+            Write-Output "Failed to apply patch files"
+            exit 1
+          }
+        }
+        else
+        {
           if (!(Test-Path $repoPath)) { mkdir $repoPath }
           Remove-Item -v -r $repoPath
           Copy-Item -v -r $(Build.SourcesDirectory)/${{ parameters.DirectoryToSync }} $repoPath
           Get-ChildItem -r $repoPath
-        displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}
-        workingDirectory: $(System.DefaultWorkingDirectory)
-
-    - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
-      - pwsh: |
-          git clone --branch ${{ parameters.BaseBranchName }} https://github.com/azure/${{ repo }}
-          $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
-          $patchDir = "${{ repo }}/patchfiles"
-
-          pushd $(Build.SourcesDirectory)
-          git format-patch ${{ parameters.BaseBranchName }}...upstream/master ${{ parameters.DirectoryToSync }} -o $patchDir
-          popd
-          pushd ${{ repo }}
-          Get-ChildItem $patchDir | % { git am $_.FullName }
-          git clean -xfd
-        displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}
-        workingDirectory: $(System.DefaultWorkingDirectory)
+        }
+      displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}
+      workingDirectory: $(System.DefaultWorkingDirectory)
 
     - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
       parameters:

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -14,17 +14,32 @@ steps:
     displayName: Create PRData Artifact
 
   - ${{ each repo in parameters.Repos }}:
-    - pwsh: |
-        git clone --branch ${{ parameters.BaseBranchName }} https://github.com/azure/${{ repo }}
-        $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
+    - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+      - pwsh: |
+          git clone --branch ${{ parameters.BaseBranchName }} https://github.com/azure/${{ repo }}
+          $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
 
-        if (!(Test-Path $repoPath)) { mkdir $repoPath }
-        Remove-Item -v -r $repoPath
-        Copy-Item -v -r $(Build.SourcesDirectory)/${{ parameters.DirectoryToSync }} $repoPath
-        Get-ChildItem -r $repoPath
+          if (!(Test-Path $repoPath)) { mkdir $repoPath }
+          Remove-Item -v -r $repoPath
+          Copy-Item -v -r $(Build.SourcesDirectory)/${{ parameters.DirectoryToSync }} $repoPath
+          Get-ChildItem -r $repoPath
+        displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}
+        workingDirectory: $(System.DefaultWorkingDirectory)
 
-      displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}
-      workingDirectory: $(System.DefaultWorkingDirectory)
+    - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+      - pwsh: |
+          git clone --branch ${{ parameters.BaseBranchName }} https://github.com/azure/${{ repo }}
+          $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
+          $patchDir = "${{ repo }}/patchfiles"
+
+          pushd $(Build.SourcesDirectory)
+          git format-patch ${{ parameters.BaseBranchName }}...upstream/master ${{ parameters.DirectoryToSync }} -o $patchDir
+          popd
+          pushd ${{ repo }}
+          Get-ChildItem $patchDir | % { git am $_.FullName }
+          git clean -xfd
+        displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}
+        workingDirectory: $(System.DefaultWorkingDirectory)
 
     - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
       parameters:


### PR DESCRIPTION
For pull request triggered runs of the sync pipeline. Rather that copying over all the files in the Sync directory make use of a patch file to apply only the changes associated with the latest commits.