### PR TITLE
Add rate limiter to GitHub calls.

### DIFF
--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
@@ -6,16 +6,17 @@
     <NoWarn>$(NoWarn);8002</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.1" />
-    <PackageReference Include="Azure.Identity" Version="1.2.0" />
+    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.2" />
+    <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.5.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
-    <PackageReference Include="Sendgrid" Version="9.20.0" />
+    <PackageReference Include="RateLimiter" Version="2.1.0" />
+    <PackageReference Include="Sendgrid" Version="9.21.0" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
This PR adds rate limiting (1 request per second) for all outbound calls from the GitHub issues function to GitHub. The GitHub Issues function is getting hit by rate limiting because it does a bunch of queries in a very short space over time across multiple repositories. This will slow it down quite a bit bit make it less likely to fail.