### PR TITLE
Fixed the bug of missing title

### DIFF
--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -76,7 +76,6 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
     $fileTitle = ""
     if ($pkgInfo.ReadmeContent -match $titleRegex) {
       $fileContent = $fileContent -replace $titleRegex, "`${0} - Version $($pkgInfo.PackageVersion) `n"
-      # The if block gurantee there is at least one match which starts with the format of "# Azure..."
       $fileTitle = $matches["filetitle"]
     }
     # Replace github master link with release tag.

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -73,10 +73,10 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
 
     # only replace the version if the formatted header can be found
     $titleRegex = "(\#\s+(?<filetitle>Azure .+? (?:client|plugin|shared) library for (?:JavaScript|Java|Python|\.NET|C)))"
-    $fileTitle = ""
+    $foundTitle = ""
     if ($pkgInfo.ReadmeContent -match $titleRegex) {
       $fileContent = $fileContent -replace $titleRegex, "`${0} - Version $($pkgInfo.PackageVersion) `n"
-      $fileTitle = $matches["filetitle"]
+      $foundTitle = $matches["filetitle"]
     }
     # Replace github master link with release tag.
     $ReplacementPattern = "`${1}$($pkgInfo.Tag)"

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -77,6 +77,7 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
     $fileTitle = ""
     if ($pkgInfo.ReadmeContent -match $titleRegex) {
       $fileContent = $pkgInfo.ReadmeContent -replace $titleRegex, "`${1} - Version $($pkgInfo.PackageVersion) `n"
+      # The if block gurantee there is at least one match which starts with the format of "# Azure..."
       $fileTitle = $Matches[0].Substring(2)
     }
     # Replace github master link with release tag.

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -72,12 +72,12 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
     $fileContent = $pkgInfo.ReadmeContent
 
     # only replace the version if the formatted header can be found
-    $titleRegex = "(\# Azure .+? (?:client|plugin|shared) library for (?:JavaScript|Java|Python|\.NET|C))"
+    $titleRegex = "(\#.*(?<filetitle>Azure .+? (?:client|plugin|shared) library for (?:JavaScript|Java|Python|\.NET|C)))"
     $fileTitle = ""
     if ($pkgInfo.ReadmeContent -match $titleRegex) {
-      $fileContent = $pkgInfo.ReadmeContent -replace $titleRegex, "`${1} - Version $($pkgInfo.PackageVersion) `n"
+      $fileContent = $fileContent -replace $titleRegex, "`${0} - Version $($pkgInfo.PackageVersion) `n"
       # The if block gurantee there is at least one match which starts with the format of "# Azure..."
-      $fileTitle = $Matches[0].Substring(2)
+      $fileTitle = $matches["filetitle"]
     }
     # Replace github master link with release tag.
     $ReplacementPattern = "`${1}$($pkgInfo.Tag)"

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -74,7 +74,7 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
     # only replace the version if the formatted header can be found
     $titleRegex = "(\#\s+(?<filetitle>Azure .+? (?:client|plugin|shared) library for (?:JavaScript|Java|Python|\.NET|C)))"
     $foundTitle = ""
-    if ($pkgInfo.ReadmeContent -match $titleRegex) {
+    if ($fileContent -match $titleRegex) {
       $fileContent = $fileContent -replace $titleRegex, "`${0} - Version $($pkgInfo.PackageVersion) `n"
       $foundTitle = $matches["filetitle"]
     }

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -73,7 +73,6 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
 
     # only replace the version if the formatted header can be found
     $titleRegex = "(\# Azure .+? (?:client|plugin|shared) library for (?:JavaScript|Java|Python|\.NET|C))"
-    $titleRegex = "(\# Azure .+? (?:client|plugin|shared) library for (?:JavaScript|Java|Python|\.NET|C))"
     $fileTitle = ""
     if ($pkgInfo.ReadmeContent -match $titleRegex) {
       $fileContent = $pkgInfo.ReadmeContent -replace $titleRegex, "`${1} - Version $($pkgInfo.PackageVersion) `n"

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -70,12 +70,15 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
     }
 
     $fileContent = $pkgInfo.ReadmeContent
-    $foundTitle = ""
 
     # only replace the version if the formatted header can be found
     $titleRegex = "(\# Azure .+? (?:client|plugin|shared) library for (?:JavaScript|Java|Python|\.NET|C))"
-    $fileContent = $pkgInfo.ReadmeContent -replace $titleRegex, "`${1} - Version $($pkgInfo.PackageVersion) `n"
-    
+    $titleRegex = "(\# Azure .+? (?:client|plugin|shared) library for (?:JavaScript|Java|Python|\.NET|C))"
+    $fileTitle = ""
+    if ($pkgInfo.ReadmeContent -match $titleRegex) {
+      $fileContent = $pkgInfo.ReadmeContent -replace $titleRegex, "`${1} - Version $($pkgInfo.PackageVersion) `n"
+      $fileTitle = $Matches[0].Substring(2)
+    }
     # Replace github master link with release tag.
     $ReplacementPattern = "`${1}$($pkgInfo.Tag)"
     $fileContent = $fileContent -replace $releaseReplaceRegex, $ReplacementPattern


### PR DESCRIPTION
Introduce a bug of missing title.
Examples: https://github.com/Azure/azure-docs-sdk-java/pull/1230/files

Expect to see title there

The PR generated from testing template pipeline:
https://github.com/Azure/azure-docs-sdk-java/pull/1255/files