### PR TITLE
Default the repo parameters to the repo being built

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -7,7 +7,7 @@ parameters:
   PROwner: azure-sdk
   CommitMsg: not-specified
   RepoOwner: Azure
-  RepoName: not-specified
+  RepoName: $(Build.Repository.Name)
   PushArgs:
   WorkingDirectory: $(System.DefaultWorkingDirectory)
   PRTitle: not-specified
@@ -36,6 +36,11 @@ steps:
       echo "No changes so skipping code push"
     }
 
+    # Remove the repo owner from the front of the repo name if it exists there
+    $repoName = "${{ parameters.RepoName }}" -replace "^${{ parameters.RepoOwner }}/", ""
+    echo "##vso[task.setvariable variable=RepoNameWithoutOwner]$repoName"
+    echo "RepoName = $repName"
+
   displayName: Check for changes
   workingDirectory: ${{ parameters.WorkingDirectory }}
   ignoreLASTEXITCODE: true
@@ -50,7 +55,7 @@ steps:
     arguments: >
       -PRBranchName "${{ parameters.PRBranchName }}"
       -CommitMsg "${{ parameters.CommitMsg }}"
-      -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.PROwner }}/${{ parameters.RepoName }}.git"
+      -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.PROwner }}/$(RepoNameWithoutOwner).git"
       -PushArgs "${{ parameters.PushArgs }}"
 
 - task: PowerShell@2
@@ -62,7 +67,7 @@ steps:
     filePath: ${{ parameters.ScriptDirectory }}/Submit-PullRequest.ps1
     arguments: >
       -RepoOwner "${{ parameters.RepoOwner }}"
-      -RepoName "${{ parameters.RepoName }}"
+      -RepoName "$(RepoNameWithoutOwner)"
       -BaseBranch "${{ parameters.BaseBranchName }}"
       -PROwner "${{ parameters.PROwner }}"
       -PRBranch "${{ parameters.PRBranchName }}"
@@ -81,7 +86,7 @@ steps:
     filePath: ${{ parameters.ScriptDirectory }}/add-pullrequest-reviewers.ps1
     arguments: >
       -RepoOwner "${{ parameters.RepoOwner }}"
-      -RepoName "${{ parameters.RepoName }}"
+      -RepoName "$(RepoNameWithoutOwner)"
       -AuthToken "$(azuresdk-github-pat)"
       -GitHubUsers "$(${{ parameters.GHReviewersVariable }})"
       -GitHubTeams "$(${{ parameters.GHTeamReviewersVariable }})"

--- a/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+++ b/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
@@ -2,7 +2,7 @@ parameters:
   ArtifactLocation: 'not-specified'
   PackageRepository: 'not-specified'
   ReleaseSha: 'not-specified'
-  RepoId: 'not-specified'
+  RepoId: $(Build.Repository.Name)
   WorkingDirectory: ''
   ScriptDirectory: eng/common/scripts
 

--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -3,7 +3,7 @@ parameters:
   ArtifactLocation: 'not-specified'
   PackageRepository: 'not-specified'
   ReleaseSha: 'not-specified'
-  RepoId: 'not-specified'
+  RepoId: $(Build.Repository.Name)
   WorkingDirectory: ''
   ScriptDirectory: eng/common/scripts
   TargetDocRepoName: ''

--- a/eng/common/pipelines/templates/steps/replace-relative-links.yml
+++ b/eng/common/pipelines/templates/steps/replace-relative-links.yml
@@ -2,7 +2,7 @@ parameters:
   TargetFolder: ''
   RootFolder: ''
   BuildSHA: ''
-  RepoId: ''
+  RepoId: $(Build.Repository.Name)
 
 steps:
   - task: PythonScript@0


### PR DESCRIPTION
As part of an effort to make our templates work in other repos, like our private repos, we have a number of places were we need to remove the hard-coded repo names as part of that I've updated our common templates to default to the repo being built.

Once this goes in we will also need to make other changes in the language repo's to stop passing in hard-coded paths for the repo, see https://github.com/Azure/azure-sdk-for-java-pr/commit/d69194e6990f45ef2994fa6d4ade1dabc02031fc for my template tests in the java repo. 