### PR TITLE
[APIView] Java diagnostic updates

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>APIViewWeb</AssemblyName>
     <UserSecretsId>79cceff6-d533-4370-a0ee-f3321a343907</UserSecretsId>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <JavaProcessor>..\..\..\java\apiview-java-processor\target\apiview-java-processor-1.17.0.jar</JavaProcessor>
+    <JavaProcessor>..\..\..\java\apiview-java-processor\target\apiview-java-processor-1.18.0.jar</JavaProcessor>
     <PythonProcessor>..\..\..\..\packages\python-packages\api-stub-generator\dist\api_stub_generator-0.1.0-py3-none-any.whl</PythonProcessor>
     <JavaScriptProcessor>..\..\..\ts\ts-genapi\</JavaScriptProcessor>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>

--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
@@ -10,7 +10,7 @@ namespace APIViewWeb
         public override string Name { get; } = "Java";
         public override string Extension { get; } = ".jar";
         public override string ProcessName { get; } = "java";
-        public override string VersionString { get; } = "apiview-java-processor-1.17.0.jar";
+        public override string VersionString { get; } = "apiview-java-processor-1.18.0.jar";
 
         public override string GetProcessorArguments(string originalName, string tempDirectory, string jsonPath)
         {

--- a/src/java/apiview-java-processor/pom.xml
+++ b/src/java/apiview-java-processor/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.azure</groupId>
     <artifactId>apiview-java-processor</artifactId>
-    <version>1.17.0</version>
+    <version>1.18.0</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -674,6 +674,11 @@ public class ASTAnalyser implements Analyser {
                         .allMatch(callableDeclaration -> isPrivateOrPackagePrivate(callableDeclaration.getAccessSpecifier()));
 
                 if (isAllPrivateOrPackagePrivate) {
+                    if (typeDeclaration.isEnumDeclaration()) {
+                        unindent();
+                        return;
+                    }
+
                     addToken(INDENT,
                             new Token(COMMENT, "// This class does not have any public constructors, and is not able to be instantiated using 'new'."),
                             NEWLINE);

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
@@ -41,15 +41,16 @@ public class ASTUtils {
     }
 
     public static Stream<ConstructorDeclaration> getPublicOrProtectedConstructors(CompilationUnit cu) {
-        return cu.getTypes().stream()
-                       .flatMap(typeDeclaration -> typeDeclaration.getConstructors().stream())
+        return cu.getTypes().stream().flatMap(ASTUtils::getPublicOrProtectedConstructors);
+    }
+
+    public static Stream<ConstructorDeclaration> getPublicOrProtectedConstructors(TypeDeclaration<?> typeDeclaration) {
+        return typeDeclaration.getConstructors().stream()
                        .filter(type -> isPublicOrProtected(type.getAccessSpecifier()));
     }
 
     public static Stream<MethodDeclaration> getPublicOrProtectedMethods(CompilationUnit cu) {
-        return cu.getTypes().stream()
-                       .flatMap(typeDeclaration -> typeDeclaration.getMethods().stream())
-                       .filter(type -> isPublicOrProtected(type.getAccessSpecifier()));
+        return cu.getTypes().stream().flatMap(ASTUtils::getPublicOrProtectedMethods);
     }
 
     public static Stream<MethodDeclaration> getPublicOrProtectedMethods(TypeDeclaration<?> typeDeclaration) {
@@ -58,8 +59,11 @@ public class ASTUtils {
     }
 
     public static Stream<FieldDeclaration> getPublicOrProtectedFields(CompilationUnit cu) {
-        return cu.getTypes().stream()
-                       .flatMap(typeDeclaration -> typeDeclaration.getFields().stream())
+        return cu.getTypes().stream().flatMap(ASTUtils::getPublicOrProtectedFields);
+    }
+
+    public static Stream<FieldDeclaration> getPublicOrProtectedFields(TypeDeclaration<?> typeDeclaration) {
+        return typeDeclaration.getFields().stream()
                        .filter(type -> isPublicOrProtected(type.getAccessSpecifier()));
     }
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
@@ -6,6 +6,7 @@ import com.azure.tools.apiview.processor.diagnostics.rules.IllegalMethodNamesDia
 import com.azure.tools.apiview.processor.diagnostics.rules.IllegalPackageAPIExportsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.ImportsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.MissingAnnotationsDiagnosticRule;
+import com.azure.tools.apiview.processor.diagnostics.rules.MissingJavaDocDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.NoPublicFieldsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.PackageNameDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.RequiredBuilderMethodsDiagnosticRule;
@@ -31,17 +32,6 @@ public class Diagnostics {
         diagnostics.add(new IllegalPackageAPIExportsDiagnosticRule("implementation", "netty"));
         diagnostics.add(new NoPublicFieldsDiagnosticRule());
         diagnostics.add(new UpperCaseNamingDiagnosticRule("URL", "HTTP", "XML", "JSON", "SAS", "CPK", "API"));
-        diagnostics.add(new RequiredBuilderMethodsDiagnosticRule()
-            .add("addPolicy", new ExactTypeNameCheckFunction("HttpPipelinePolicy"))
-            .add("configuration", new ExactTypeNameCheckFunction("Configuration"))
-            .add("credential", new ExactTypeNameCheckFunction(new ParameterAllowedTypes("TokenCredential", "AzureKeyCredential")))
-            .add("connectionString", new ExactTypeNameCheckFunction("String"))
-            .add("endpoint", new ExactTypeNameCheckFunction("String"))
-            .add("httpClient", new ExactTypeNameCheckFunction("HttpClient"))
-            .add("httpLogOptions", new ExactTypeNameCheckFunction("HttpLogOptions"))
-            .add("pipeline", new ExactTypeNameCheckFunction("HttpPipeline"))
-            .add("retryPolicy", new ExactTypeNameCheckFunction("RetryPolicy"))
-            .add("serviceVersion", new DirectSubclassCheckFunction("ServiceVersion")));
         diagnostics.add(new MissingAnnotationsDiagnosticRule());
         diagnostics.add(new FluentSetterReturnTypeDiagnosticRule());
         diagnostics.add(new ConsiderFinalClassDiagnosticRule());
@@ -51,6 +41,26 @@ public class Diagnostics {
             new Rule("^isHas"),
             new Rule("^setHas")
         ));
+        diagnostics.add(new MissingJavaDocDiagnosticRule());
+
+        // common APIs for all builders (below we will do rules for http or amqp builders)
+        diagnostics.add(new RequiredBuilderMethodsDiagnosticRule(null)
+            .add("configuration", new ExactTypeNameCheckFunction("Configuration"))
+            .add("clientOptions", new ExactTypeNameCheckFunction("ClientOptions"))
+            .add("connectionString", new ExactTypeNameCheckFunction("String"))
+            .add("credential", new ExactTypeNameCheckFunction(new ParameterAllowedTypes("TokenCredential", "AzureKeyCredential")))
+            .add("endpoint", new ExactTypeNameCheckFunction("String"))
+            .add("serviceVersion", new DirectSubclassCheckFunction("ServiceVersion")));
+        diagnostics.add(new RequiredBuilderMethodsDiagnosticRule("amqp")
+            .add("proxyOptions", new ExactTypeNameCheckFunction("ProxyOptions"))
+            .add("retry", new ExactTypeNameCheckFunction("AmqpRetryOptions"))
+            .add("transportType", new DirectSubclassCheckFunction("AmqpTransportType")));
+        diagnostics.add(new RequiredBuilderMethodsDiagnosticRule("http")
+            .add("addPolicy", new ExactTypeNameCheckFunction("HttpPipelinePolicy"))
+            .add("httpClient", new ExactTypeNameCheckFunction("HttpClient"))
+            .add("httpLogOptions", new ExactTypeNameCheckFunction("HttpLogOptions"))
+            .add("pipeline", new ExactTypeNameCheckFunction("HttpPipeline"))
+            .add("retryPolicy", new ExactTypeNameCheckFunction("RetryPolicy")));
     }
 
     public static void scan(CompilationUnit cu, APIListing listing) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ConsiderFinalClassDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ConsiderFinalClassDiagnosticRule.java
@@ -17,6 +17,7 @@ public class ConsiderFinalClassDiagnosticRule implements DiagnosticRule {
         cu.getTypes().forEach(type -> {
             if (type.isEnumDeclaration()) return;
             if (type.hasModifier(Modifier.Keyword.ABSTRACT)) return;
+            if (type.isClassOrInterfaceDeclaration() && type.asClassOrInterfaceDeclaration().isInterface()) return;
             if (!type.hasModifier(Modifier.Keyword.FINAL)) {
                 listing.addDiagnostic(new Diagnostic(
                     INFO,

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavaDocDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavaDocDiagnosticRule.java
@@ -1,0 +1,37 @@
+package com.azure.tools.apiview.processor.diagnostics.rules;
+
+import com.azure.tools.apiview.processor.diagnostics.DiagnosticRule;
+import com.azure.tools.apiview.processor.model.APIListing;
+import com.azure.tools.apiview.processor.model.Diagnostic;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
+
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getClasses;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPublicOrProtectedConstructors;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPublicOrProtectedFields;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPublicOrProtectedMethods;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
+import static com.azure.tools.apiview.processor.model.DiagnosticKind.WARNING;
+
+public class MissingJavaDocDiagnosticRule implements DiagnosticRule {
+
+    @Override
+    public void scan(final CompilationUnit cu, final APIListing listing) {
+        getClasses(cu).forEach(typeDeclaration -> {
+            if (!typeDeclaration.hasJavaDocComment()) {
+                // the type is missing JavaDoc
+                listing.addDiagnostic(new Diagnostic(WARNING, makeId(typeDeclaration), "This API is missing JavaDoc."));
+            }
+
+            getPublicOrProtectedConstructors(typeDeclaration).forEach(n -> checkJavaDoc(n, makeId(n), listing));
+            getPublicOrProtectedMethods(typeDeclaration).forEach(n -> checkJavaDoc(n, makeId(n), listing));
+            getPublicOrProtectedFields(typeDeclaration).forEach(n -> checkJavaDoc(n, makeId(n), listing));
+        });
+    }
+
+    private void checkJavaDoc(NodeWithJavadoc n, String id, APIListing listing) {
+        if (!n.hasJavaDocComment()) {
+            listing.addDiagnostic(new Diagnostic(WARNING, id, "This API is missing JavaDoc."));
+        }
+    }
+}

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/RequiredBuilderMethodsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/RequiredBuilderMethodsDiagnosticRule.java
@@ -4,6 +4,7 @@ import com.azure.tools.apiview.processor.diagnostics.DiagnosticRule;
 import com.azure.tools.apiview.processor.model.APIListing;
 import com.azure.tools.apiview.processor.model.Diagnostic;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.Node;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.expr.MemberValuePair;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
@@ -53,6 +54,8 @@ public class RequiredBuilderMethodsDiagnosticRule implements DiagnosticRule {
             if (typeDeclaration.isAnnotationPresent(BUILDER_ANNOTATION)) {
                 // if it does, we try to read from it the 'protocol' so that we can determine if this
                 // builder is an HTTP or AMQP builder, and then we can apply the appropriate rules.
+                // If the protocol specified in the builder is not present, we will use the previous logic
+                // of this diagnostic rule and just assume we are looking at an http protocol.
                 // This is unless the builderProtocol is null, in which case the set of rules we have
                 // will all be applied.
                 final String protocolName = typeDeclaration.getAnnotationByName(BUILDER_ANNOTATION).get()
@@ -62,9 +65,9 @@ public class RequiredBuilderMethodsDiagnosticRule implements DiagnosticRule {
                       .map(n -> (MemberValuePair) n)
                       .filter(p -> "protocol".equals(p.getNameAsString()))
                       .map(MemberValuePair::getValue)
-                      .map(e -> e.toString())
+                      .map(Node::toString)
                       .findFirst()
-                      .orElse("");
+                      .orElse("http");  // TODO for now we assume that no specified protocol in the builder means we will be http
 
                 if (builderProtocol != null) {
                     if (!builderProtocol.equals(protocolName) || protocolName.isEmpty()) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/RequiredBuilderMethodsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/RequiredBuilderMethodsDiagnosticRule.java
@@ -5,14 +5,16 @@ import com.azure.tools.apiview.processor.model.APIListing;
 import com.azure.tools.apiview.processor.model.Diagnostic;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.body.MethodDeclaration;
+import com.github.javaparser.ast.expr.MemberValuePair;
 import com.github.javaparser.ast.type.ClassOrInterfaceType;
 import com.github.javaparser.ast.type.Type;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.*;
@@ -23,17 +25,24 @@ import static com.azure.tools.apiview.processor.model.DiagnosticKind.*;
  * Not all builders require all methods, but we should warn regardless so it can be considered.
  */
 public class RequiredBuilderMethodsDiagnosticRule implements DiagnosticRule {
+    private static final String BUILDER_ANNOTATION = "ServiceClientBuilder";
 
     // maps from the expected method name to the type of the arguments passed into that method.
     // Normally this would be a single argument, but we allow here for multiple arguments, just in case.
     private final Map<String, Function<MethodDeclaration, Optional<Diagnostic>>> builderMethods;
 
-    public RequiredBuilderMethodsDiagnosticRule() {
+    private final String builderProtocol;
+
+    private final List<String> missingMethods = new ArrayList<>();
+
+    public RequiredBuilderMethodsDiagnosticRule(String builderProtocol) {
         this.builderMethods = new HashMap<>();
+        this.builderProtocol = builderProtocol;
     }
 
     public RequiredBuilderMethodsDiagnosticRule add(String methodName, Function<MethodDeclaration, Optional<Diagnostic>> func) {
         builderMethods.put(methodName, func);
+        missingMethods.add(methodName);
         return this;
     }
 
@@ -41,22 +50,43 @@ public class RequiredBuilderMethodsDiagnosticRule implements DiagnosticRule {
     public void scan(final CompilationUnit cu, final APIListing listing) {
         // check if the class has the @ServiceClientBuilder annotation, if not, do nothing
         getClasses(cu).forEach(typeDeclaration -> {
-            if (typeDeclaration.isAnnotationPresent("ServiceClientBuilder")) {
-                AtomicInteger count = new AtomicInteger();
+            if (typeDeclaration.isAnnotationPresent(BUILDER_ANNOTATION)) {
+                // if it does, we try to read from it the 'protocol' so that we can determine if this
+                // builder is an HTTP or AMQP builder, and then we can apply the appropriate rules.
+                // This is unless the builderProtocol is null, in which case the set of rules we have
+                // will all be applied.
+                final String protocolName = typeDeclaration.getAnnotationByName(BUILDER_ANNOTATION).get()
+                      .getChildNodes()
+                      .stream()
+                      .filter(n -> n instanceof MemberValuePair)
+                      .map(n -> (MemberValuePair) n)
+                      .filter(p -> "protocol".equals(p.getNameAsString()))
+                      .map(MemberValuePair::getValue)
+                      .map(e -> e.toString())
+                      .findFirst()
+                      .orElse("");
+
+                if (builderProtocol != null) {
+                    if (!builderProtocol.equals(protocolName) || protocolName.isEmpty()) {
+                        return;
+                    }
+                }
+
                 getPublicOrProtectedMethods(typeDeclaration).forEach(methodDeclaration -> {
-                    String methodName = methodDeclaration.getNameAsString();
+                    final String methodName = methodDeclaration.getNameAsString();
                     if (builderMethods.containsKey(methodName)) {
-                        count.incrementAndGet();
                         builderMethods.get(methodName).apply(methodDeclaration).ifPresent(listing::addDiagnostic);
                     }
+                    missingMethods.remove(methodName);
                 });
 
-                // TODO replace with suggestions about methods that are not existing that the user might want to consider
-//                if (count.get() < builderMethods.size()) {
-//                    listing.addDiagnostic(new Diagnostic(makeId(cu),
-//                            "Not all expected builder methods are present.",
-//                            "https://azure.github.io/azure-sdk/java_design.html#java-service-client-builder-consistency"));
-//                }
+                if (!missingMethods.isEmpty()) {
+                    listing.addDiagnostic(new Diagnostic(
+                            WARNING,
+                            makeId(typeDeclaration),
+                            "Not all expected builder methods are present. The following methods were expected but not found: " + missingMethods,
+                            "https://azure.github.io/azure-sdk/java_design.html#java-service-client-builder-consistency"));
+                }
             }
         });
     }


### PR DESCRIPTION
Add diagnostic for warning about missing JavaDoc, and improve the builder methods diagnostic to support different expected APIs for HTTP and AMQP builders, and warn when expected methods are missing.