### PR TITLE
Fix parser error when type has private name

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -13,7 +13,7 @@ from ._diagnostic import Diagnostic
 JSON_FIELDS = ["Name", "Version", "VersionString", "Navigation", "Tokens", "Diagnostics"]
 
 HEADER_TEXT = "# Package is parsed using api-stub-generator(version:{})".format(VERSION)
-TYPE_NAME_REGEX = re.compile("(~?[a-zA-Z\d.]+)")
+TYPE_NAME_REGEX = re.compile("(~?[a-zA-Z\d._]+)")
 TYPE_OR_SEPERATOR = " or "
 
 # Lint warnings

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -98,6 +98,13 @@ docstring_multi_complex_type = """
                 :caption: Detecting language in a batch of documents.
 """
 
+docstring_param_type_private = """
+:param str name: Dummy name param
+:param client: Value type
+:type client: ~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase
+"""
+
+
 class TestDocStringParser:
 
     def _test_return_type(self, docstring, expected):
@@ -136,6 +143,9 @@ class TestDocStringParser:
 
     def test_param_type(self):
         self._test_variable_type(docstring_param_type, "val", "str")
+
+    def test_param_type_private(self):
+        self._test_variable_type(docstring_param_type_private, "client", "~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase")
 
     def test_params(self):
         args = [ArgType("name", "str"), ArgType("val", "str")]


### PR DESCRIPTION
Type parsing REGEX fails when type has "_" and if type is from private module names then module name will have _