### PR TITLE
Log processing delays in Check Enforcer.

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/GitHubWebhookOverEventHubsFunction.cs
@@ -31,6 +31,9 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Functions
         [FunctionName("webhook-eventhubs")]
         public async Task Run([EventHubTrigger("github-webhooks", Connection = "CheckEnforcerEventHubConnectionString")] EventData eventData, ILogger log, CancellationToken cancellationToken)
         {
+            var processingDelay = DateTimeOffset.UtcNow - eventData.SystemProperties.EnqueuedTimeUtc;
+            log.LogInformation("Webhook event processing delay is: {seconds} (seconds)", processingDelay.TotalSeconds);
+
             var message = GetMessage(eventData);
             var eventName = GetEventName(message);
             var eventSignature = GetEventSignature(message);


### PR DESCRIPTION
This PR logs the processing delays between enqueue time (over on Webhook Router) and being received by Check Enforcer. I want to get a sense of the time that things are spending in the queue.