### PR TITLE
Fix formatting issue for diagnostic messages

### DIFF
--- a/src/dotnet/APIView/APIView/Model/CodeDiagnosticLevel.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeDiagnosticLevel.cs
@@ -4,6 +4,7 @@ namespace APIView
 {
     public enum CodeDiagnosticLevel
     {
+        Default = 0,
         Info = 1,
         Warning = 2,
         Error = 3

--- a/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
@@ -465,10 +465,6 @@ code-inner {
     margin: 0;
 }
 
-.code-diagnostics a {
-    font-weight: bold;
-}
-
 /* ICONS */
 .icon {
     height: 16px;

--- a/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
@@ -447,15 +447,18 @@ code-inner {
 
 /* DIAGNOSTICS */
 .code-diagnostics-error {
-    background-color: lightcoral;
+    background-color: lightpink;
+    border: 1px solid red;
 }
 
 .code-diagnostics-warn {
-    background-color: #ffe066;
+    background-color: lightyellow;
+    border: 1px solid #ffe066;
 }
 
 .code-diagnostics-info {
     background-color: lightskyblue;
+    border: 1px solid blue;
 }
 
 .code-diagnostics p {

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -23,7 +23,7 @@
 </tr>
 @if (Model.Diagnostics.Any())
 {
-    var errorDiags = Model.Diagnostics.Where(d => d.Level == 0 || d.Level == APIView.CodeDiagnosticLevel.Error);
+    var errorDiags = Model.Diagnostics.Where(d => d.Level == APIView.CodeDiagnosticLevel.Default || d.Level == APIView.CodeDiagnosticLevel.Error);
     var warningDiags = Model.Diagnostics.Where(d => d.Level == APIView.CodeDiagnosticLevel.Warning);
     var infoDiags = Model.Diagnostics.Where(d => d.Level == APIView.CodeDiagnosticLevel.Info);
     <tr class="code-diagnostics" data-line-id="@Model.CodeLine.ElementId">

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -9,7 +9,7 @@
         DiffLineKind.Added => "code-added",
         _ => ""
     };
-    string documentationClass = Model.CodeLine.IsDocumentationLine? "documentation": "";
+    string documentationClass = Model.CodeLine.IsDocumentationLine ? "documentation" : "";
 }
 
 <tr class="code-line @documentationClass" data-line-id="@(isRemoved ? string.Empty : Model.CodeLine.ElementId)">
@@ -23,33 +23,17 @@
 </tr>
 @if (Model.Diagnostics.Any())
 {
+    var errorDiags = Model.Diagnostics.Where(d => d.Level == 0 || d.Level == APIView.CodeDiagnosticLevel.Error);
+    var warningDiags = Model.Diagnostics.Where(d => d.Level == APIView.CodeDiagnosticLevel.Warning);
+    var infoDiags = Model.Diagnostics.Where(d => d.Level == APIView.CodeDiagnosticLevel.Info);
     <tr class="code-diagnostics" data-line-id="@Model.CodeLine.ElementId">
-        <td colspan="2">
-            @foreach (var lineDiagnostic in Model.Diagnostics)
-            {
-                string diagClass = lineDiagnostic.Level switch
-                {
-                    APIView.CodeDiagnosticLevel.Warning => "code-diagnostics-warn",
-                    APIView.CodeDiagnosticLevel.Info => "code-diagnostics-info",
-                    _ => "code-diagnostics-error"
-                };
-                <p class="@diagClass">
-                    @if (lineDiagnostic.Text.StartsWith("DO"))
-                    {
-                        @:✅ <b>DO</b> @lineDiagnostic.Text.Substring(2)
-                    }
-                    else
-                    {
-                        @lineDiagnostic.Text
-                    }
-
-                    @if (!string.IsNullOrEmpty(lineDiagnostic.HelpLinkUri))
-                    {
-                        <a href="@lineDiagnostic.HelpLinkUri">Details</a>
-                    }
-                </p>
-            }
-        </td>
+        <partial name="_DiagnosticsPartial" model="@errorDiags" />
+    </tr>
+    <tr class="code-diagnostics" data-line-id="@Model.CodeLine.ElementId">
+        <partial name="_DiagnosticsPartial" model="@warningDiags" />
+    </tr>
+    <tr class="code-diagnostics" data-line-id="@Model.CodeLine.ElementId">
+        <partial name="_DiagnosticsPartial" model="@infoDiags" />
     </tr>
 }
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_DiagnosticsPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_DiagnosticsPartial.cshtml
@@ -1,0 +1,30 @@
+﻿@model IEnumerable<APIView.CodeDiagnostic>
+@if (Model.Any())
+{
+    string diagnosticClass = Model.First().Level switch
+    {
+        APIView.CodeDiagnosticLevel.Info => "code-diagnostics-info",
+        APIView.CodeDiagnosticLevel.Warning => "code-diagnostics-warn",
+        _ => "code-diagnostics-error"
+    };
+    <td colspan="2" class="@diagnosticClass">
+        @foreach (var lineDiagnostic in Model)
+        {
+            <p>
+                @if (lineDiagnostic.Text.StartsWith("DO"))
+                {
+                    @:✅ <b>DO</b> @lineDiagnostic.Text.Substring(2)
+                }
+                else
+                {
+                    @lineDiagnostic.Text
+                }
+
+                @if (!string.IsNullOrEmpty(lineDiagnostic.HelpLinkUri))
+                {
+                    <a href="@lineDiagnostic.HelpLinkUri">Details</a>
+                }
+            </p>
+        }
+    </td>
+}


### PR DESCRIPTION
Changes to show border for diag messages and to fix padding issue. Previous change was setting background color at each <p> node that has messed the layout. I have updated this to group all diagnostic messages of same type and show it as row.

Reverted background color for error and updated warning color to lightyellow.

