### PR TITLE
Fix for rate limiting in GitHub Issues function

### DIFF
--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
@@ -8,15 +8,19 @@
   <ItemGroup>
     <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.2" />
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
+    <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.1.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.7.1" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="RateLimiter" Version="2.1.0" />
     <PackageReference Include="Sendgrid" Version="9.21.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Constants.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Constants.cs
@@ -16,6 +16,9 @@
             public static string ServiceAttention = "Service Attention";
             public static string EngSys = "EngSys";
             public static string MgmtEngSys = "Mgmt-EngSys";
+
         }
+
+        public const int ApplicationTokenLifetimeInMinutes = 10;
     }
 }

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/Configuration/ConfigurationService.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/Configuration/ConfigurationService.cs
@@ -63,6 +63,22 @@ namespace Azure.Sdk.Tools.GitHubIssues.Services.Configuration
             return secret.Value;
         }
 
+        public async Task<string> GetApplicationIDAsync()
+        {
+            logger.LogInformation("Reading github-app-id from Azure KeyVault");
+            KeyVaultSecret secret = await secretClient.GetSecretAsync("github-app-id");
+            logger.LogInformation("Read github-app-id from Azure KeyVault");
+            return secret.Value;
+        }
+
+        public async Task<string> GetApplicationNameAsync()
+        {
+            logger.LogInformation("Reading github-app-name from Azure KeyVault");
+            KeyVaultSecret secret = await secretClient.GetSecretAsync("github-app-name");
+            logger.LogInformation("Read github-app-name from Azure KeyVault");
+            return secret.Value;
+        }
+
         public async Task<string> GetGitHubPersonalAccessTokenAsync()
         {
             logger.LogInformation("Reading github-token from Azure KeyVault");
@@ -70,5 +86,24 @@ namespace Azure.Sdk.Tools.GitHubIssues.Services.Configuration
             logger.LogInformation("Read github-token from Azure KeyVault");
             return secret.Value;
         }
+
+        public async Task<int> GetMaxRequestsPerPeriodAsync()
+        {
+            logger.LogInformation("Reading max-requests-per-period from Azure KeyVault");
+            KeyVaultSecret secret = await secretClient.GetSecretAsync("github-token");
+            logger.LogInformation("Read max-requests-per-period from Azure KeyVault");
+            return int.Parse(secret.Value);
+        }
+
+        public async Task<int> GetPeriodDurationInSecondsAsync()
+        {
+            logger.LogInformation("Reading period-duration-in-seconds from Azure KeyVault");
+            KeyVaultSecret secret = await secretClient.GetSecretAsync("period-duration-in-seconds");
+            logger.LogInformation("Read period-duration-in-seconds from Azure KeyVault");
+            return int.Parse(secret.Value);
+        }
+
+
+
     }
 }

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/Configuration/IConfigurationService.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/Configuration/IConfigurationService.cs
@@ -12,5 +12,9 @@ namespace Azure.Sdk.Tools.GitHubIssues.Services.Configuration
         Task<string> GetGitHubPersonalAccessTokenAsync();
         Task<string> GetFromAddressAsync();
         Task<string> GetSendGridTokenAsync();
+        Task<string> GetApplicationIDAsync();
+        Task<string> GetApplicationNameAsync();
+        Task<int> GetMaxRequestsPerPeriodAsync();
+        Task<int> GetPeriodDurationInSecondsAsync();
     }
 }

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/GitHub/GitHubClientProvider.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/GitHub/GitHubClientProvider.cs
@@ -1,0 +1,138 @@
+﻿using Azure.Core;
+using Azure.Identity;
+using Azure.Sdk.Tools.GitHubIssues.Services.Configuration;
+using Azure.Sdk.Tools.GitHubIssues.Integrations.GitHub;
+using Azure.Security.KeyVault.Keys;
+using Azure.Security.KeyVault.Keys.Cryptography;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.IdentityModel.Tokens;
+using Octokit;
+using System;
+using System.Collections.Concurrent;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.GitHubIssues
+{
+    public class GitHubClientProvider : IGitHubClientProvider
+    {
+        public GitHubClientProvider(IConfigurationService configurationService, IMemoryCache cache, CryptographyClient cryptographyClient, GitHubRateLimiter limiter)
+        {
+            this.configurationService = configurationService;
+            this.cache = cache;
+            this.cryptographyClient = cryptographyClient;
+            this.limiter = limiter;
+        }
+
+        private IConfigurationService configurationService;
+        private IMemoryCache cache;
+
+        private async Task<string> GetTokenAsync(CancellationToken cancellationToken)
+        {
+            var cachedApplicationToken = await cache.GetOrCreateAsync<string>("applicationTokenCacheKey", async (entry) =>
+            {
+                entry.AbsoluteExpirationRelativeToNow = TimeSpan.FromMinutes(Constants.ApplicationTokenLifetimeInMinutes - 1);
+
+                var headerAndPayloadString = GenerateJwtTokenHeaderAndPayload();
+                var digest = ComputeHeaderAndPayloadDigest(headerAndPayloadString);
+                var encodedSignature = await SignHeaderAndPayloadDigestWithGitHubApplicationKey(digest, cancellationToken);
+                var applicationToken = AppendSignatureToHeaderAndPayload(headerAndPayloadString, encodedSignature);
+                return applicationToken;
+            });
+
+            return cachedApplicationToken;
+        }
+
+        private string AppendSignatureToHeaderAndPayload(string headerAndPayloadString, string encodedSignature)
+        {
+            return $"{headerAndPayloadString}.{encodedSignature}";
+        }
+
+        private async Task<string> SignHeaderAndPayloadDigestWithGitHubApplicationKey(byte[] digest, CancellationToken cancellationToken)
+        {
+            var signResult = await cryptographyClient.SignAsync(
+                SignatureAlgorithm.RS256,
+                digest,
+                cancellationToken
+                );
+
+            var encodedSignature = Base64UrlEncoder.Encode(signResult.Signature);
+            return encodedSignature;
+        }
+
+        private byte[] ComputeHeaderAndPayloadDigest(string headerAndPayloadString)
+        {
+            var headerAndPayloadBytes = Encoding.UTF8.GetBytes(headerAndPayloadString);
+
+            var sha256 = new SHA256CryptoServiceProvider();
+            var digest = sha256.ComputeHash(headerAndPayloadBytes);
+            return digest;
+        }
+
+        private string GenerateJwtTokenHeaderAndPayload()
+        {
+            var jwtHeader = new JwtHeader();
+            jwtHeader["alg"] = "RS256";
+
+            var jwtPayload = new JwtPayload(
+                issuer: globalConfigurationProvider.GetApplicationID(),
+                audience: null,
+                claims: null,
+                notBefore: DateTime.UtcNow,
+                expires: DateTime.UtcNow.AddMinutes(Constants.ApplicationTokenLifetimeInMinutes),
+                issuedAt: DateTime.UtcNow
+                );
+
+            var jwtToken = new JwtSecurityToken(jwtHeader, jwtPayload);
+            var headerAndPayloadString = $"{jwtToken.EncodedHeader}.{jwtToken.EncodedPayload}";
+            return headerAndPayloadString;
+        }
+
+        private CryptographyClient cryptographyClient;
+        private GitHubRateLimiter limiter;
+
+        public async Task<GitHubClient> GetApplicationClientAsync(CancellationToken cancellationToken)
+        {
+            var token = await GetTokenAsync(cancellationToken);
+
+            var appClient = new GitHubClient(new ProductHeaderValue(globalConfigurationProvider.GetApplicationName()))
+            {
+                Credentials = new Credentials(token, AuthenticationType.Bearer)
+            };
+
+            return appClient;
+        }
+
+        private ConcurrentDictionary<long, Octokit.AccessToken> cachedInstallationTokens = new ConcurrentDictionary<long, Octokit.AccessToken>();
+
+        private async Task<string> GetInstallationTokenAsync(long installationId, CancellationToken cancellationToken)
+        {
+            var installationTokenCacheKey = $"{installationId}_installationTokenCacheKey";
+
+            var cachedInstallationToken = await cache.GetOrCreateAsync<Octokit.AccessToken>(installationTokenCacheKey, async (entry) =>
+            {
+                var appClient = await GetApplicationClientAsync(cancellationToken);
+                await limiter.WaitForGitHubCapacityAsync();
+                var installationToken = await appClient.GitHubApps.CreateInstallationToken(installationId);
+                return installationToken;
+            });
+
+            return cachedInstallationToken.Token;
+        }
+
+        public async Task<GitHubClient> GetInstallationClientAsync(long installationId, CancellationToken cancellationToken)
+        {
+            var installationToken = await GetInstallationTokenAsync(installationId, cancellationToken);
+            var installationClient = new GitHubClient(new ProductHeaderValue($"{globalConfigurationProvider.GetApplicationName()}-{installationId}"))
+            {
+                Credentials = new Credentials(installationToken)
+            };
+
+            return installationClient;
+        }
+    }
+}

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/GitHub/GitHubRateLimiter.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/GitHub/GitHubRateLimiter.cs
@@ -1,0 +1,28 @@
+﻿using Azure.Sdk.Tools.GitHubIssues.Configuration;
+using ComposableAsync;
+using RateLimiter;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.GitHubIssues.Integrations.GitHub
+{
+    public class GitHubRateLimiter
+    {
+        public GitHubRateLimiter(IConfigurationService configurationService)
+        {
+            limiter = TimeLimiter.GetFromMaxCountByInterval(
+                configurationService.GetMaxRequestsPerPeriod(),
+                TimeSpan.FromSeconds(configurationService.GetPeriodDurationInSeconds())
+                );
+        }
+
+        private TimeLimiter limiter;
+
+        public async Task WaitForGitHubCapacityAsync()
+        {
+            await limiter;
+        }
+    }
+}

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/GitHub/GitHubWebhookSignatureValidator.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/GitHub/GitHubWebhookSignatureValidator.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.GitHubIssues.Integrations.GitHub
+{
+    public static class GitHubWebhookSignatureValidator
+    {
+        public const string GitHubWebhookSignatureHeader = "X-Hub-Signature";
+        
+        public static bool IsValid(byte[] body, string signature, string secret)
+        {
+            var key = Encoding.UTF8.GetBytes(secret);
+            var sha1 = new HMACSHA1(key);
+
+            var digest = sha1.ComputeHash(body);
+            var hex = BitConverter.ToString(digest).Replace("-", "").ToLower();
+            var generatedSignature = $"sha1={hex}";
+
+            return signature == generatedSignature;
+        }
+    }
+}

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/GitHub/IGitHubClientProvider.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Services/GitHub/IGitHubClientProvider.cs
@@ -1,0 +1,15 @@
+﻿using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.GitHubIssues.Integrations.GitHub
+{
+    public interface IGitHubClientProvider
+    {
+        Task<GitHubClient> GetApplicationClientAsync(CancellationToken cancellationToken);
+        Task<GitHubClient> GetInstallationClientAsync(long installationId, CancellationToken cancellationToken);
+    }
+}

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Startup.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Startup.cs
@@ -29,17 +29,13 @@ namespace Azure.Sdk.Tools.GitHubIssues
             builder.Services.AddAzureClients(builder =>
             {
                 builder.UseCredential(credential);
+
                 var keyVaultUri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.vault.azure.net/");
                 builder.AddSecretClient(keyVaultUri);
-            });
 
-            builder.Services.AddSingleton<ConfigurationClient>((provider) =>
-            {
-                var appConfigurationUri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.azconfig.io/");
-                var configurationClient = new ConfigurationClient(appConfigurationUri, credential);
-                return configurationClient;
+                var configurationUri = new Uri($"https://{websiteResourceGroupEnvironmentVariable}.azconfig.io/");
+                builder.AddConfigurationClient(configurationUri);
             });
-
 
             builder.Services.AddLogging();
             builder.Services.AddSingleton<IConfigurationService, ConfigurationService>();


### PR DESCRIPTION
We are still getting rate limited in the GitHub Issues function app despite introducing rate limiting within the app itself. This is possibly due to the fact that the ```azure-sdk``` bot identity that we use is over subscribed in terms of automation. To mitigate this, in this PR I'm going to flip over to using a GitHub App registration which has a completely independent request limit.

The complexity is that rather than a simple _personal access token_ for authentication, a GitHub application uses a certificate which is used to sign tokens for particular app installations. We've got this logic already implemented in Check Enforcer so I'll be transplanting some of the git integration from that project to here.