### PR TITLE
Switch to auto adding the `Central-EngSys` label

### DIFF
--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -35,7 +35,7 @@ steps:
         CommitMsg: ${{ parameters.CommitMessage }}
         PRTitle: ${{ parameters.PRTitle }}
         PRBody: ${{ parameters.PRBody }}
-        PRLabels: "EngSys"
+        PRLabels: "Central-EngSys"
         PushArgs: -f
         WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
         ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -35,7 +35,7 @@ steps:
         CommitMsg: ${{ parameters.CommitMessage }}
         PRTitle: ${{ parameters.PRTitle }}
         PRBody: ${{ parameters.PRBody }}
-        PRLabels: "Central-EngSys"
+        PRLabels: "Central-EngSys, EngSys"
         PushArgs: -f
         WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
         ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts


### PR DESCRIPTION
This replaces the `EngSys` label.
Fixes #1045