### PR TITLE
Add rate limit recovery to GitHub Issues.

### DIFF
--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />


### PR DESCRIPTION
This PR adds the same rate limiting recovery logic that we use in Check Enforcer (knowing how to use the backoff details in rate limiting/abuse exceptions). This is to stop the bleeding whilst the auth logic is swapped over to GitHub apps to get an increased/dedicated rate limit.