### PR TITLE
Add retries at repo level

### DIFF
--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/ReportExecutionContext.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/ReportExecutionContext.cs
@@ -10,9 +10,8 @@ namespace Azure.Sdk.Tools.GitHubIssues.Reports
 {
     public class ReportExecutionContext
     {
-        public ReportExecutionContext(ILogger log, string fromAddress, string sendGridToken, string gitHubPersonalAccessToken, IEnumerable<RepositoryConfiguration> repositoryConfigurations, GitHubClient gitHubClient)
+        public ReportExecutionContext(string fromAddress, string sendGridToken, string gitHubPersonalAccessToken, IEnumerable<RepositoryConfiguration> repositoryConfigurations, GitHubClient gitHubClient)
         {
-            this.Log = log;
             this.FromAddress = fromAddress;
             this.SendGridToken = sendGridToken;
             this.GitHubPersonalAccessToken = gitHubPersonalAccessToken;
@@ -20,7 +19,6 @@ namespace Azure.Sdk.Tools.GitHubIssues.Reports
             this.GitHubClient = gitHubClient;
         }
 
-        public ILogger Log { get; private set; }
         public string FromAddress { get; private set; }
         public string SendGridToken { get; private set; }
         public string GitHubPersonalAccessToken { get; private set; }


### PR DESCRIPTION
This PR moves the retry logic down to the repo level so that we can retry individual repos without retrying (and spamming) everyone if we get stuck. It introduces a ```ExecuteWithRetryAsync(int, Func<Task>)``` method which is then wrapped around each iteration over the repository configuration entries.

I also moved to the the constructor injected logger infrastructure for the reports.