### PR TITLE
GitHub rate limiting fix (via retries)

### DIFF
--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindCustomerReportedIssuesInInvalidStateFunction.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindCustomerReportedIssuesInInvalidStateFunction.cs
@@ -17,12 +17,11 @@ namespace Azure.Sdk.Tools.GitHubIssues.Functions
         }
 
         private FindCustomerRelatedIssuesInvalidState report;
-        private ILogger<FindCustomerReportedIssuesInInvalidStateFunction> logger;
 
         [FunctionName("FindCustomerReportedIssuesInInvalidStateFunction")]
-        public async Task Run([TimerTrigger("0 0 16 * * MON")]TimerInfo timer, ILogger log, CancellationToken cancellationToken)
+        public async Task Run([TimerTrigger("0 0 16 * * MON")]TimerInfo timer)
         {
-            await report.ExecuteAsync(log);
+            await report.ExecuteAsync();
         }
     }
 }

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindIssuesInBacklogMilestonesFunction.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindIssuesInBacklogMilestonesFunction.cs
@@ -19,9 +19,9 @@ namespace Azure.Sdk.Tools.GitHubIssues.Functions
         private FindIssuesInBacklogMilestones report;
 
         [FunctionName("FindIssuesInBacklogMilestonesFunction")]
-        public async Task Run([TimerTrigger("0 30 15 1 * *")]TimerInfo timer, ILogger log, CancellationToken cancellationToken)
+        public async Task Run([TimerTrigger("0 30 15 1 * *")]TimerInfo timer)
         {
-            await report.ExecuteAsync(log);
+            await report.ExecuteAsync();
         }
     }
 }

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindIssuesInPastDueMilestonesFunction.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindIssuesInPastDueMilestonesFunction.cs
@@ -19,9 +19,9 @@ namespace Azure.Sdk.Tools.GitHubIssues.Functions
         private FindIssuesInPastDueMilestones report;
 
         [FunctionName("FindIssuesInPastDueMilestones")]
-        public async Task Run([TimerTrigger("0 0 15 * * WED")]TimerInfo timer, ILogger log, CancellationToken cancellationToken)
+        public async Task Run([TimerTrigger("0 0 15 * * WED")]TimerInfo timer)
         {
-            await report.ExecuteAsync(log);
+            await report.ExecuteAsync();
         }
     }
 }

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindNewGitHubIssuesAndPrsAt2pmFunction.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindNewGitHubIssuesAndPrsAt2pmFunction.cs
@@ -19,9 +19,9 @@ namespace Azure.Sdk.Tools.GitHubIssues.Functions
         private FindNewGitHubIssuesAndPRs report;
 
         [FunctionName("FindNewGitHubIssuesAndPRs_2pm")]
-        public async Task Run([TimerTrigger("0 30 21 * * *")]TimerInfo timer, ILogger log, CancellationToken cancellationToken)
+        public async Task Run([TimerTrigger("0 30 21 * * *")]TimerInfo timer)
         {
-            await report.ExecuteAsync(log);
+            await report.ExecuteAsync();
         }
     }
 }

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindNewGitHubIssuesAndPrsAt7amFunction.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindNewGitHubIssuesAndPrsAt7amFunction.cs
@@ -20,9 +20,9 @@ namespace Azure.Sdk.Tools.GitHubIssues.Functions
         private FindNewGitHubIssuesAndPRs report;
 
         [FunctionName("FindNewGitHubIssuesAndPRs_7am")]
-        public async Task Run([TimerTrigger("0 30 14 * * *")]TimerInfo timer, ILogger log, CancellationToken cancellationToken)
+        public async Task Run([TimerTrigger("0 30 14 * * *")]TimerInfo timer)
         {
-            await report.ExecuteAsync(log);
+            await report.ExecuteAsync();
         }
     }
 }

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindPRsOlderThan3MonthsFunction.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindPRsOlderThan3MonthsFunction.cs
@@ -19,9 +19,9 @@ namespace Azure.Sdk.Tools.GitHubIssues.Functions
         private FindStalePRs report;
 
         [FunctionName("FindPRsOlderThan3MonthsFunction")]
-        public async Task Run([TimerTrigger("0 30 15 * * MON")]TimerInfo timer, ILogger log, CancellationToken cancellationToken)
+        public async Task Run([TimerTrigger("0 30 15 * * MON")]TimerInfo timer)
         {
-            await report.ExecuteAsync(log);
+            await report.ExecuteAsync();
         }
     }
 }

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/BaseReport.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/BaseReport.cs
@@ -2,6 +2,7 @@
 using Azure.Security.KeyVault.Secrets;
 using GitHubIssues.Helpers;
 using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Client;
 using Octokit;
 using Polly;
 using System;
@@ -15,33 +16,35 @@ namespace Azure.Sdk.Tools.GitHubIssues.Reports
     public abstract class BaseReport
     {
         protected IConfigurationService ConfigurationService { get; private set; }
+        protected ILogger<BaseReport> Logger { get; private set; }
 
-        public BaseReport(IConfigurationService configurationService)
+        public BaseReport(IConfigurationService configurationService, ILogger<BaseReport> logger)
         {
             ConfigurationService = configurationService;
+            Logger = logger;
         }
 
-        public async Task ExecuteAsync(ILogger log)
+        protected async Task ExecuteWithRetryAsync(int retryCount, Func<Task> action)
         {
             await Policy
                 .Handle<AbuseException>()
                 .Or<RateLimitExceededException>()
                 .RetryAsync(3, async (ex, retryCount) =>
                 {
-                TimeSpan retryDelay = TimeSpan.FromSeconds(10); // Default.
+                    TimeSpan retryDelay = TimeSpan.FromSeconds(10); // Default.
 
                     switch (ex)
                     {
                         case AbuseException abuseException:
                             retryDelay = TimeSpan.FromSeconds((double)abuseException.RetryAfterSeconds);
-                            log.LogWarning("Abuse exception detected. Retry after seconds is: {retrySeconds}",
+                            Logger.LogWarning("Abuse exception detected. Retry after seconds is: {retrySeconds}",
                                 abuseException.RetryAfterSeconds
                                 );
                             break;
 
                         case RateLimitExceededException rateLimitExceededException:
                             retryDelay = rateLimitExceededException.GetRetryAfterTimeSpan();
-                            log.LogWarning(
+                            Logger.LogWarning(
                                 "Rate limit exception detected. Limit is: {limit}, reset is: {reset}, retry seconds is: {retrySeconds}",
                                 rateLimitExceededException.Limit,
                                 rateLimitExceededException.Reset,
@@ -50,30 +53,31 @@ namespace Azure.Sdk.Tools.GitHubIssues.Reports
                             break;
                     }
                 })
-                .ExecuteAsync(async () =>
-                {
-                    Task<string> pendingGitHubPersonalAccessToken = ConfigurationService.GetGitHubPersonalAccessTokenAsync();
+                .ExecuteAsync(action);
+        }
 
-                    var gitHubClient = new GitHubClient(new ProductHeaderValue("github-issues"))
-                    {
-                        Credentials = new Credentials(await pendingGitHubPersonalAccessToken)
-                    };
+        public async Task ExecuteAsync()
+        {
+            Task<string> pendingGitHubPersonalAccessToken = ConfigurationService.GetGitHubPersonalAccessTokenAsync();
 
-                    log.LogInformation("Preparing report execution context for: {reportType}", this.GetType());
+            var gitHubClient = new GitHubClient(new ProductHeaderValue("github-issues"))
+            {
+                Credentials = new Credentials(await pendingGitHubPersonalAccessToken)
+            };
 
-                    var context = new ReportExecutionContext(
-                        log,
-                        await ConfigurationService.GetFromAddressAsync(),
-                        await ConfigurationService.GetSendGridTokenAsync(),
-                        await pendingGitHubPersonalAccessToken,
-                        await ConfigurationService.GetRepositoryConfigurationsAsync(),
-                        gitHubClient
-                        );
+            Logger.LogInformation("Preparing report execution context for: {reportType}", this.GetType());
 
-                    log.LogInformation("Executing report: {reportType}", this.GetType());
-                    await ExecuteCoreAsync(context);
-                    log.LogInformation("Executed report: {reportType}", this.GetType());
-                });
+            var context = new ReportExecutionContext(
+                await ConfigurationService.GetFromAddressAsync(),
+                await ConfigurationService.GetSendGridTokenAsync(),
+                await pendingGitHubPersonalAccessToken,
+                await ConfigurationService.GetRepositoryConfigurationsAsync(),
+                gitHubClient
+                );
+
+            Logger.LogInformation("Executing report: {reportType}", this.GetType());
+            await ExecuteCoreAsync(context);
+            Logger.LogInformation("Executed report: {reportType}", this.GetType());
         }
 
         protected abstract Task ExecuteCoreAsync(ReportExecutionContext context);

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/BaseReport.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/BaseReport.cs
@@ -51,6 +51,12 @@ namespace Azure.Sdk.Tools.GitHubIssues.Reports
                                 retryDelay.TotalSeconds
                                 );
                             break;
+
+                        default:
+                            Logger.LogError(
+                                "Fall through case invoked, this should never happen!"
+                                );
+                            break;
                     }
 
                     await Task.Delay(retryDelay);

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/ReportExecutionContext.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/ReportExecutionContext.cs
@@ -10,9 +10,8 @@ namespace Azure.Sdk.Tools.GitHubIssues.Reports
 {
     public class ReportExecutionContext
     {
-        public ReportExecutionContext(ILogger log, string fromAddress, string sendGridToken, string gitHubPersonalAccessToken, IEnumerable<RepositoryConfiguration> repositoryConfigurations, GitHubClient gitHubClient)
+        public ReportExecutionContext(string fromAddress, string sendGridToken, string gitHubPersonalAccessToken, IEnumerable<RepositoryConfiguration> repositoryConfigurations, GitHubClient gitHubClient)
         {
-            this.Log = log;
             this.FromAddress = fromAddress;
             this.SendGridToken = sendGridToken;
             this.GitHubPersonalAccessToken = gitHubPersonalAccessToken;
@@ -20,7 +19,6 @@ namespace Azure.Sdk.Tools.GitHubIssues.Reports
             this.GitHubClient = gitHubClient;
         }
 
-        public ILogger Log { get; private set; }
         public string FromAddress { get; private set; }
         public string SendGridToken { get; private set; }
         public string GitHubPersonalAccessToken { get; private set; }

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/host.json
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/host.json
@@ -1,3 +1,9 @@
 {
-    "version": "2.0"
+  "version": "2.0",
+  "logging": {
+    "fileLoggingMode": "debugOnly",
+    "logLevel": {
+      "default": "Trace"
+    }
+  }
 }


### PR DESCRIPTION
This PR is an alternative to [this](https://github.com/Azure/azure-sdk-tools/pull/1040) (incomplete) PR. As I was implementing the GitHub apps auth model it dawned on me that if I retried on a per repo basis, with the back-off logic it would eventually go through rather than tripping up every time. 

I've been running this code in production of a few days and it is definitely behaving more reliably. Alas there is another issue impacting mail delivery (SengGrid IP pool is blocked as a spammer) - but that is a separate issue which may require changes to the way that we actually send e-mails.

Telemetry for this change though is looking good, we aren't getting rate limiting errors stopping report transmission (it recovers cleanly).