### PR TITLE
Fix bad dot include of logging script

### DIFF
--- a/eng/scripts/Verify-And-Merge-PRs.ps1
+++ b/eng/scripts/Verify-And-Merge-PRs.ps1
@@ -4,7 +4,7 @@ param(
   $ShouldMerge
 )
 
-. "${PSScriptRoot}..\common\scripts\logging.ps1"
+. "${PSScriptRoot}\..\common\scripts\logging.ps1"
 
 $ReadyForMerge = $true
 $mergablePRs = @()


### PR DESCRIPTION
See break at https://dev.azure.com/azure-sdk/internal/_build/results?buildId=556899&view=logs&j=f6a7114c-32c6-5cc4-d467-98fb1350225d&t=a2695e80-e975-5318-3c29-d781630e749d