### PR TITLE
Fix bug in DevOps logging command

### DIFF
--- a/eng/common/scripts/logging.ps1
+++ b/eng/common/scripts/logging.ps1
@@ -31,7 +31,7 @@ function LogDebug
 {
     if ($isDevOpsRun) 
     {
-        Write-Host "##vso[task.LogIssue type=debug;]$args"
+        Write-Host "[debug]$args"
     }
     else 
     {


### PR DESCRIPTION
Use the correct syntax for debug logging in DevOps.