### PR TITLE
Ignore job notifications.

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
@@ -38,6 +38,18 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
                     await EvaluatePullRequestAsync(context.Client, installationId, repositoryId, sha, cancellationToken);
                 }
+                else if (payload.CheckRun.Name.Contains("("))
+                {
+                    // HACK: This change short circuits processing of events that come from jobs rather than runs. We
+                    //       are leveraging the fact that Azure Pipelines jobs have check names with an opening bracket.
+                    //       This is a short term fox to stop the bleeding whilst we figure out a better way to ignore
+                    //       notifications from the job level.
+
+                    Logger.LogInformation(
+                        "Skipping processing event for: {runIdentifier} because based on the name it is a job, not a run.",
+                        runIdentifier
+                        );
+                }
                 else if (payload.CheckRun.Name == this.GlobalConfigurationProvider.GetApplicationName())
                 {
                     Logger.LogInformation(


### PR DESCRIPTION
This PR filters out job notifications from processing to try and reduce the volume of messages that we are processing. It is a bit of a hack to make sure that we aren't getting multi-hour delays in processing. It should dramatically reduce the vollume of requests we make to GitHub.

The reason for not doing this is that there is always a chance of a dropped message from GitHub so I was using these messages as a way of making sure that we take every chance possible to inspect the GitHub state. But it just isn't scaling so this step is necessary.