### PR TITLE
Ignore neutral conclusion events.

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/CheckRunHandler.cs
@@ -65,19 +65,26 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
                         (DateTimeOffset.UtcNow - payload.CheckRun.StartedAt).Days
                         );
                 }
+                else if (payload.CheckRun.Conclusion == new StringEnum<CheckConclusion>(CheckConclusion.Neutral))
+                {
+                    Logger.LogInformation("" +
+                        "Skipping processing event for: {runIdentifier} check-run conclusion is neutral.",
+                        runIdentifier
+                        );
+                    return;
+                }
+                else if (payload.CheckRun.Status != new StringEnum<CheckStatus>(CheckStatus.Completed))
+                {
+                    Logger.LogInformation(
+                        "Skipping processing event for: {runIdentifier} check-run status not completed.",
+                        runIdentifier
+                        );
+                    return;
+                }
                 else
                 {
                     try
                     {
-                        if (payload.CheckRun.Status != new StringEnum<CheckStatus>(CheckStatus.Completed))
-                        {
-                            Logger.LogInformation(
-                                "Skipping processing event for: {runIdentifier} check-run status not completed.",
-                                runIdentifier
-                                );
-                            return;
-                        }
-
                         var configuration = await this.RepositoryConfigurationProvider.GetRepositoryConfigurationAsync(installationId, repositoryId, sha, cancellationToken);
                         if (configuration.IsEnabled)
                         {


### PR DESCRIPTION
This PR adds a new bail-out condition for ```CheckRunHandler``` which drops the message if the conclusion is neutral. We are seeing neutral conclusion events on merge commits where Azure Pipelines puts a neutral condition for lots of pipelines in the repo. These neutral conclusion events slide straight through and trigger evaluation which consumes valuable GitHub requests when in reality no one ever sees them and we can ignore them.