### PR TITLE
Simplify New-TestResources usage

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -151,7 +151,7 @@ if (!$CI -and !$PSBoundParameters.ContainsKey('OutFile') -and $IsWindows)
     if (Test-Path "$repositoryRoot/eng/service.proj")
     {
         $OutFile = $true
-        Log "Detected .NET repository, defaulting OutFile to true. Test environment settings would be stored into the file, you don't need to set environment variables manually."
+        Log "Detected .NET repository. Defaulting OutFile to true. Test environment settings would be stored into the file so you don't need to set environment variables manually."
     }
 }
 

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -145,7 +145,7 @@ if (!$BaseName) {
 }
 
 # Try detecting repos that support OutFile and defaulting to it
-if (!$CI -and !$PSBoundParameters.ContainsKey('OutFile'))
+if (!$CI -and !$PSBoundParameters.ContainsKey('OutFile') -and $IsWindows)
 {
     # TODO: find a better way to detect the language
     if (Test-Path "$repositoryRoot/eng/service.proj")

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -511,7 +511,7 @@ test resources (e.g. Role Assignments on resources). It is passed as to the ARM
 template as 'testApplicationOid'
 
 For more information on the relationship between AAD Applications and Service
-Principals see: https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
+Principals see: https://docs.microsoft.com/azure/active-directory/develop/app-objects-and-service-principals
 
 .PARAMETER TenantId
 The tenant ID of a service principal when a provisioner is specified. The same

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -11,14 +11,14 @@
 [CmdletBinding(DefaultParameterSetName = 'Default', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
 param (
     # Limit $BaseName to enough characters to be under limit plus prefixes, and https://docs.microsoft.com/azure/architecture/best-practices/resource-naming.
-    [Parameter(Position = 0)]
+    [Parameter()]
     [ValidatePattern('^[-a-zA-Z0-9\.\(\)_]{0,80}(?<=[a-zA-Z0-9\(\)])$')]
     [string] $BaseName,
 
     [ValidatePattern('^[-\w\._\(\)]+$')]
     [string] $ResourceGroupName,
 
-    [Parameter(Mandatory = $true)]
+    [Parameter(Mandatory = $true, Position = 0)]
     [string] $ServiceDirectory,
 
     [Parameter()]

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -11,7 +11,7 @@
 [CmdletBinding(DefaultParameterSetName = 'Default', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
 param (
     # Limit $BaseName to enough characters to be under limit plus prefixes, and https://docs.microsoft.com/azure/architecture/best-practices/resource-naming.
-    [Parameter(Mandatory = $true, Position = 0)]
+    [Parameter(Position = 0)]
     [ValidatePattern('^[-a-zA-Z0-9\.\(\)_]{0,80}(?<=[a-zA-Z0-9\(\)])$')]
     [string] $BaseName,
 
@@ -21,7 +21,7 @@ param (
     [Parameter(Mandatory = $true)]
     [string] $ServiceDirectory,
 
-    [Parameter(Mandatory = $true)]
+    [Parameter()]
     [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
     [string] $TestApplicationId,
 
@@ -119,6 +119,8 @@ $root = [System.IO.Path]::Combine($repositoryRoot, "sdk", $ServiceDirectory) | R
 $templateFileName = 'test-resources.json'
 $templateFiles = @()
 $environmentVariables = @{}
+# Azure SDK Developer Playground
+$defaultSubscription = "faa080af-c1d8-40ad-9cce-e1a450ca5b57"
 
 Write-Verbose "Checking for '$templateFileName' files under '$root'"
 Get-ChildItem -Path $root -Filter $templateFileName -Recurse | ForEach-Object {
@@ -131,6 +133,26 @@ Get-ChildItem -Path $root -Filter $templateFileName -Recurse | ForEach-Object {
 if (!$templateFiles) {
     Write-Warning -Message "No template files found under '$root'"
     exit
+}
+
+$UserName =  if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
+
+# If no base name is specified use current user name
+if (!$BaseName) {
+    $BaseName = "$UserName$ServiceDirectory"
+
+    Log "BaseName was not set. Using default base name: '$BaseName'"
+}
+
+# Try detecting repos that support OutFile and defaulting to it
+if (!$CI -and !$PSBoundParameters.ContainsKey('OutFile'))
+{
+    # TODO: find a better way to detect the language
+    if (Test-Path "$repositoryRoot/eng/service.proj")
+    {
+        $OutFile = $true
+        Log "Detected .NET repository, defaulting OutFile to true. Test environment settings would be stored into the file, you don't need to set environment variables manually."
+    }
 }
 
 # If no location is specified use safe default locations for the given
@@ -147,7 +169,7 @@ if (!$Location) {
     Write-Verbose "Location was not set. Using default location for environment: '$Location'"
 }
 
-# Log in if requested; otherwise, the user is expected to already be authenticated via Connect-AzAccount.
+# Log in if requested; otherwise, try to login into playground subscription.
 if ($ProvisionerApplicationId) {
     $null = Disable-AzContextAutosave -Scope Process
 
@@ -174,6 +196,25 @@ if ($ProvisionerApplicationId) {
         if ($PSCmdlet.ShouldProcess($ProvisionerApplicationId)) {
             $null = Disconnect-AzAccount -AzureContext $provisionerAccount.Context
         }
+    }
+}
+elseif (!$CI)
+{
+    # check if user is logged in and login into
+    $context = Get-AzContext;
+    if (!$context)
+    {
+        Log "You are not logged in, connecting to 'Azure SDK Developer Playground'"
+        Connect-AzAccount -Subscription $defaultSubscription
+    }
+    
+    # If no test application id is specified create a new service principal
+    if (!$TestApplicationId) {        
+        Log "TestApplicationId was not specified, creating a new service principal."
+        $servicePrincipal = New-AzADServicePrincipal -Role Owner
+
+        $TestApplicationId = $servicePrincipal.ApplicationId
+        $TestApplicationSecret = (ConvertFrom-SecureString $servicePrincipal.Secret -AsPlainText);
     }
 }
 
@@ -215,7 +256,7 @@ $ResourceGroupName = if ($ResourceGroupName) {
 
 # Tag the resource group to be deleted after a certain number of hours if specified.
 $tags = @{
-    Creator = if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
+    Creator = $UserName
     ServiceDirectory = $ServiceDirectory
 }
 
@@ -403,7 +444,11 @@ foreach ($templateFile in $templateFiles) {
 
 $exitActions.Invoke()
 
-return $environmentVariables
+# Suppress output locally
+if ($CI)
+{
+    return $environmentVariables
+}
 
 <#
 .SYNOPSIS

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -14,16 +14,16 @@ Deploys live test resources defined for a service directory to Azure.
 
 ### Default (Default)
 ```
-New-TestResources.ps1 [-BaseName] <String> [-ResourceGroupName <String>] -ServiceDirectory <String>
- -TestApplicationId <String> [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
+New-TestResources.ps1 [[-BaseName] <String>] [-ResourceGroupName <String>] -ServiceDirectory <String>
+ [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
  [-DeleteAfterHours <Int32>] [-Location <String>] [-Environment <String>] [-AdditionalParameters <Hashtable>]
  [-CI] [-Force] [-OutFile] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Provisioner
 ```
-New-TestResources.ps1 [-BaseName] <String> [-ResourceGroupName <String>] -ServiceDirectory <String>
- -TestApplicationId <String> [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
+New-TestResources.ps1 [[-BaseName] <String>] [-ResourceGroupName <String>] -ServiceDirectory <String>
+ [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
  -TenantId <String> [-SubscriptionId <String>] -ProvisionerApplicationId <String>
  -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>] [-Location <String>]
  [-Environment <String>] [-AdditionalParameters <Hashtable>] [-CI] [-Force] [-OutFile] [-WhatIf] [-Confirm]
@@ -106,7 +106,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: 1
 Default value: None
 Accept pipeline input: False
@@ -159,7 +159,7 @@ Type: String
 Parameter Sets: (All)
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -197,7 +197,7 @@ It is passed as to the ARM
 template as 'testApplicationOid'
 
 For more information on the relationship between AAD Applications and Service
-Principals see: https://docs.microsoft.com/azure/active-directory/develop/app-objects-and-service-principals
+Principals see: https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
 
 ```yaml
 Type: String
@@ -458,3 +458,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[Remove-TestResources.ps1]()
+

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -14,7 +14,7 @@ Deploys live test resources defined for a service directory to Azure.
 
 ### Default (Default)
 ```
-New-TestResources.ps1 [[-BaseName] <String>] [-ResourceGroupName <String>] -ServiceDirectory <String>
+New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-ServiceDirectory] <String>
  [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
  [-DeleteAfterHours <Int32>] [-Location <String>] [-Environment <String>] [-AdditionalParameters <Hashtable>]
  [-CI] [-Force] [-OutFile] [-WhatIf] [-Confirm] [<CommonParameters>]
@@ -22,7 +22,7 @@ New-TestResources.ps1 [[-BaseName] <String>] [-ResourceGroupName <String>] -Serv
 
 ### Provisioner
 ```
-New-TestResources.ps1 [[-BaseName] <String>] [-ResourceGroupName <String>] -ServiceDirectory <String>
+New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-ServiceDirectory] <String>
  [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
  -TenantId <String> [-SubscriptionId <String>] -ProvisionerApplicationId <String>
  -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>] [-Location <String>]
@@ -107,7 +107,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: False
-Position: 1
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -140,7 +140,7 @@ Parameter Sets: (All)
 Aliases:
 
 Required: True
-Position: Named
+Position: 1
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -197,7 +197,7 @@ It is passed as to the ARM
 template as 'testApplicationOid'
 
 For more information on the relationship between AAD Applications and Service
-Principals see: https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
+Principals see: https://docs.microsoft.com/azure/active-directory/develop/app-objects-and-service-principals
 
 ```yaml
 Type: String
@@ -458,6 +458,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-
-[Remove-TestResources.ps1]()
-

--- a/eng/common/TestResources/README.md
+++ b/eng/common/TestResources/README.md
@@ -26,6 +26,7 @@ Note that `-Subscription` is an optional parameter but recommended if your accou
 is a member of multiple subscriptions.
 
 ```powershell
+Connect-AzAccount -Subscription 'YOUR SUBSCRIPTION ID'
 eng\common\TestResources\New-TestResources.ps1 -ServiceDirectory 'search'
 ```
 

--- a/eng/common/TestResources/README.md
+++ b/eng/common/TestResources/README.md
@@ -26,17 +26,10 @@ Note that `-Subscription` is an optional parameter but recommended if your accou
 is a member of multiple subscriptions.
 
 ```powershell
-Connect-AzAccount -Subscription 'YOUR SUBSCRIPTION ID'
-$sp = New-AzADServicePrincipal -Role Owner
-eng\common\TestResources\New-TestResources.ps1 `
-  -BaseName 'myusername' `
-  -ServiceDirectory 'search' `
-  -TestApplicationId $sp.ApplicationId `
-  -TestApplicationSecret (ConvertFrom-SecureString $sp.Secret -AsPlainText)
+eng\common\TestResources\New-TestResources.ps1 -ServiceDirectory 'search'
 ```
 
-If you are running this for a .NET project on Windows, the recommended method is to
-add the `-OutFile` switch to the above command. This will save test environment settings
+The `OutFile` switch would be set if you are running this for a .NET project on Windows. This will save test environment settings
 into a test-resources.json.env file next to test-resources.json. The file is protected via DPAPI.
 The environment file would be scoped to the current repository directory and avoids the need to
 set environment variables or restart your IDE to recognize them.


### PR DESCRIPTION
Make the script easy to use locally:

Default to Out-File in .NET repo.
Default to username + servicedirectory as a basepath
Automatically login into `Azure SDK Developer Playground` if not logged in
Suppress extra output caused by returning variable locally
Auto-create service principal

Typical usage becomes `eng\common\TestResources\New-TestResources.ps1 search`


Fixes https://github.com/Azure/azure-sdk-tools/issues/541
Fixes https://github.com/Azure/azure-sdk-tools/issues/485