### PR TITLE
Set TLS to 1.2 for Az module download.

### DIFF
--- a/eng/common/TestResources/setup-az-modules.yml
+++ b/eng/common/TestResources/setup-az-modules.yml
@@ -26,7 +26,9 @@ steps:
   # this helped resolve the issue. I've adding it as a conditioned step because
   # I'm not confident that this is the solution ... so I'd like to test it on a few
   # pipelines prior to making it the default.
-  
+  # Article: https://techcommunity.microsoft.com/t5/windows-powershell/failed-downloading-az-and-other-modules-for-powershell/m-p/1292985
+
+
   # New-TestResources command requires Az module with TLS 1.2
   - pwsh: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12

--- a/eng/common/TestResources/setup-az-modules.yml
+++ b/eng/common/TestResources/setup-az-modules.yml
@@ -21,7 +21,9 @@ steps:
     condition: contains(variables['OSVmImage'], 'mac')
 
   # New-TestResources command requires Az module
-  - pwsh: Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose
+  - pwsh: |
+      [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+      Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose
     displayName: Install Azure PowerShell module
 
   - task: Powershell@2

--- a/eng/common/TestResources/setup-az-modules.yml
+++ b/eng/common/TestResources/setup-az-modules.yml
@@ -20,10 +20,24 @@ steps:
     displayName: (MacOS) Grant access to ~/.Azure
     condition: contains(variables['OSVmImage'], 'mac')
 
-  # New-TestResources command requires Az module
+  # This alternative invocation is being setup so that PowerShell will use
+  # TLS 1.2 when downloading from the PowerShell Gallery. We are seeing instances
+  # of failed downloads similar to reported in this article and it seemed this
+  # this helped resolve the issue. I've adding it as a conditioned step because
+  # I'm not confident that this is the solution ... so I'd like to test it on a few
+  # pipelines prior to making it the default.
+  
+  # New-TestResources command requires Az module with TLS 1.2
   - pwsh: |
       [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
       Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose
+    condition: and(succeeded(), eq(variables.UseTls12, true))
+    displayName: Install Azure PowerShell module (TLS 1.2)
+
+  # New-TestResources command requires Az module with system default TLS version
+  - pwsh: |
+      Install-Module -Name Az -Scope CurrentUser -AllowClobber -Force -Verbose
+    condition: and(succeeded(), ne(variables.UseTls12, true))
     displayName: Install Azure PowerShell module
 
   - task: Powershell@2

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePowerShellModuleInstallationFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePowerShellModuleInstallationFailureClassifier.cs
@@ -17,7 +17,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
                 var failedTasks = from r in context.Timeline.Records
                                   where r.Result == TaskResult.Failed
                                   where r.RecordType == "Task"
-                                  where r.Name == "Install Azure PowerShell module"
+                                  where r.Name.StartsWith("Install Azure PowerShell module")
                                   select r;
 
                 if (failedTasks.Count() > 0)


### PR DESCRIPTION
This PR conditionalizes the installation of the Azure PowerShell modules. When the UseTls12 variable is set on a pipeline it will set the .NET Service Endpoint Manager to use TLS 1.2, otherwise use the default.