### PR TITLE
Read issue routing from codeowners

### DIFF
--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnerEntry.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnerEntry.cs
@@ -19,18 +19,6 @@ namespace CreateRuleFabricBot
         internal const string PRLabelMoniker = "PRLabel";
         internal const string ServiceLabelMoniker = "ServiceLabel";
 
-        public CodeOwnerEntry(string entryLine, string PRLabelsLine, string ServiceLabelLine)
-        {
-            PRLabels = new List<string>(ParseLabels(PRLabelsLine, PRLabelMoniker));
-            ServiceLabels = new List<string>(ParseLabels(ServiceLabelLine, ServiceLabelMoniker));
-            ParseOwnersAndPath(entryLine);
-        }
-
-        public CodeOwnerEntry()
-        {
-
-        }
-
         public string PathExpression { get; set; }
 
         public bool ContainsWildcard { get; set; }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnerEntry.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnerEntry.cs
@@ -18,6 +18,7 @@ namespace CreateRuleFabricBot
         const char OwnerSeparator = '@';
         internal const string PRLabelMoniker = "PRLabel";
         internal const string ServiceLabelMoniker = "ServiceLabel";
+        internal const string MissingFolder = "#/<NotInRepo>/";
 
         public string PathExpression { get; set; }
 
@@ -89,7 +90,7 @@ namespace CreateRuleFabricBot
 
         public void ParseOwnersAndPath(string line)
         {
-            if (string.IsNullOrEmpty(line) || line.StartsWith('#'))
+            if (string.IsNullOrEmpty(line) || (line.StartsWith('#') && !(line.IndexOf(CodeOwnerEntry.MissingFolder, StringComparison.OrdinalIgnoreCase) >= 0)))
             {
                 return;
             }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnerEntry.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnerEntry.cs
@@ -90,12 +90,22 @@ namespace CreateRuleFabricBot
 
         public void ParseOwnersAndPath(string line)
         {
-            if (string.IsNullOrEmpty(line) || (line.StartsWith('#') && !(line.IndexOf(CodeOwnerEntry.MissingFolder, StringComparison.OrdinalIgnoreCase) >= 0)))
+            if (string.IsNullOrEmpty(line) ||
+               (line.StartsWith('#') && !(line.IndexOf(CodeOwnerEntry.MissingFolder, StringComparison.OrdinalIgnoreCase) >= 0)))
             {
                 return;
             }
 
             line = ParsePath(line);
+
+            //remove any comments from the line, if any.
+            // this is the case when we have something like @user #comment
+            int commentIndex = line.IndexOf("#");
+
+            if (commentIndex >= 0)
+            {
+                line = line.Substring(0, commentIndex).Trim();
+            }
 
             foreach (string author in SplitLine(line, OwnerSeparator).ToList())
             {

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnerEntry.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnerEntry.cs
@@ -29,7 +29,6 @@ namespace CreateRuleFabricBot
 
         public List<string> ServiceLabels { get; set; } = new List<string>();
 
-
         public bool IsValid
         {
             get

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwners.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwners.cs
@@ -56,6 +56,12 @@ namespace CreateRuleFabricBot
                         line = NormalizeLine(line);
                     }
 
+                    // Empty line, move on
+                    if (string.IsNullOrEmpty(line))
+                    {
+                        continue;
+                    }
+
                     // If this is not a comment line.
                     if (line.IndexOf('#') == -1)
                     {

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwners.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwners.cs
@@ -1,0 +1,103 @@
+﻿using OutputColorizer;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+
+namespace CreateRuleFabricBot
+{
+    public static class CodeOwners
+    {
+        public static List<CodeOwnerEntry> ReadOwnersFromFile(string filePathOrUrl)
+        {
+            string content;
+            Colorizer.Write("Retrieving file content from [Yellow!{0}]... ", filePathOrUrl);
+            content = GetFileContents(filePathOrUrl);
+            Colorizer.WriteLine("[Green!Done]");
+
+            return ParseOwnersFromContent(content);
+        }
+
+        public static List<CodeOwnerEntry> ParseOwnersFromContent(string fileContent)
+        {
+            Colorizer.Write("Parsing CODEOWNERS table... ");
+            List<CodeOwnerEntry> entries = new List<CodeOwnerEntry>();
+            string line;
+            using (StringReader sr = new StringReader(fileContent))
+            {
+                while ((line = sr.ReadLine()) != null)
+                {
+                    // Does the line start with '# PRLabel: "label1", "label2"
+
+                    // Remove tabs and trim extra whitespace
+                    line = NormalizeLine(line);
+
+                    // Empty line, move on
+                    if (string.IsNullOrEmpty(line))
+                    {
+                        continue;
+                    }
+
+                    CodeOwnerEntry entry = new CodeOwnerEntry();
+
+                    // if we have the moniker in the line, parse the labels
+                    while (line.StartsWith('#') && entry.ProcessLabelsOnLine(line))
+                    {
+                        // We need to read the next line as we parsed this line
+                        line = sr.ReadLine();
+
+                        if (line == null)
+                        {
+                            break;
+                        }
+
+                        // Remove tabs and trim extra whitespace
+                        line = NormalizeLine(line);
+                    }
+
+                    // If this is not a comment line.
+                    if (line.IndexOf('#') == -1)
+                    {
+                        entry.ParseOwnersAndPath(line);
+                    }
+
+                    if (entry.IsValid)
+                    {
+                        entries.Add(entry);
+                    }
+                }
+            }
+            Colorizer.WriteLine("[Green!Done]");
+            return entries;
+        }
+
+        private static string NormalizeLine(string line)
+        {
+            // Remove tabs and trim extra whitespace
+            return line.Replace('\t', ' ').Trim();
+        }
+
+        private static string GetFileContents(string fileOrUri)
+        {
+            if (File.Exists(fileOrUri))
+            {
+                return File.ReadAllText(fileOrUri);
+            }
+
+            // try to parse it as an Uri
+            Uri uri = new Uri(fileOrUri, UriKind.Absolute);
+            if (uri.Scheme.ToLowerInvariant() != "https")
+            {
+                throw new ArgumentException("Cannot download off non-https uris");
+            }
+
+            // try to download it.
+            using (HttpClient client = new HttpClient())
+            {
+                HttpResponseMessage response = client.GetAsync(fileOrUri).ConfigureAwait(false).GetAwaiter().GetResult();
+                return response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+        }
+    }
+}

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
@@ -1,9 +1,7 @@
-﻿using OutputColorizer;
-using System;
+﻿using CreateRuleFabricBot.Helpers;
+using OutputColorizer;
 using System.Collections.Generic;
 using System.IO;
-using System.Net.Http;
-using System.Text;
 
 namespace CreateRuleFabricBot
 {
@@ -13,7 +11,7 @@ namespace CreateRuleFabricBot
         {
             string content;
             Colorizer.Write("Retrieving file content from [Yellow!{0}]... ", filePathOrUrl);
-            content = GetFileContents(filePathOrUrl);
+            content = FileHelpers.GetFileContents(filePathOrUrl);
             Colorizer.WriteLine("[Green!Done]");
 
             return ParseContent(content);
@@ -82,28 +80,6 @@ namespace CreateRuleFabricBot
         {
             // Remove tabs and trim extra whitespace
             return line.Replace('\t', ' ').Trim();
-        }
-
-        private static string GetFileContents(string fileOrUri)
-        {
-            if (File.Exists(fileOrUri))
-            {
-                return File.ReadAllText(fileOrUri);
-            }
-
-            // try to parse it as an Uri
-            Uri uri = new Uri(fileOrUri, UriKind.Absolute);
-            if (uri.Scheme.ToLowerInvariant() != "https")
-            {
-                throw new ArgumentException("Cannot download off non-https uris");
-            }
-
-            // try to download it.
-            using (HttpClient client = new HttpClient())
-            {
-                HttpResponseMessage response = client.GetAsync(fileOrUri).ConfigureAwait(false).GetAwaiter().GetResult();
-                return response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-            }
         }
     }
 }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
@@ -22,53 +22,42 @@ namespace CreateRuleFabricBot
             Colorizer.Write("Parsing CODEOWNERS table... ");
             List<CodeOwnerEntry> entries = new List<CodeOwnerEntry>();
             string line;
+
+
+            // An entry ends when we get to a path (a real path or a commented dummy path)
+
             using (StringReader sr = new StringReader(fileContent))
             {
+                CodeOwnerEntry entry = new CodeOwnerEntry();
+
+                // we are going to read line by line until we find a line that is not a comment OR that is using the placeholder entry inside the comment.
+                // while we are trying to find the folder entry, we parse all comment lines to extract the labels from it.
+                // when we find the path or placeholder, we add the completed entry and create a new one.
                 while ((line = sr.ReadLine()) != null)
                 {
-                    // Remove tabs and trim extra whitespace
                     line = NormalizeLine(line);
 
-                    // Empty line, move on
-                    if (string.IsNullOrEmpty(line))
+                    if (string.IsNullOrWhiteSpace(line))
                     {
                         continue;
                     }
 
-                    CodeOwnerEntry entry = new CodeOwnerEntry();
-
-                    // if we have a comment on the line AND if the line contains special delimiters
-                    while (line.StartsWith('#') && entry.ProcessLabelsOnLine(line))
+                    if (!line.StartsWith('#') || line.IndexOf(CodeOwnerEntry.MissingFolder, System.StringComparison.OrdinalIgnoreCase) >= 0)
                     {
-                        // We need to read the next line as we parsed this line
-                        line = sr.ReadLine();
+                        // If this is not a comment line OR this is a placeholder entry
 
-                        if (line == null)
-                        {
-                            break;
-                        }
-
-                        // Remove tabs and trim extra whitespace
-                        line = NormalizeLine(line);
-                    }
-
-                    // Empty line, move on
-                    if (string.IsNullOrEmpty(line))
-                    {
-                        continue;
-                    }
-
-                    // If this is not a comment line.
-                    if (line.IndexOf('#') == -1 ||
-                        line.IndexOf(CodeOwnerEntry.MissingFolder, System.StringComparison.OrdinalIgnoreCase) >= 0)
-                    {
                         entry.ParseOwnersAndPath(line);
+                        entries.Add(entry);
+
+                        // create a new entry.
+                        entry = new CodeOwnerEntry();
+                    }
+                    else if (line.StartsWith('#'))
+                    {
+                        // try to process the line in case there are markers that need to be extracted
+                        entry.ProcessLabelsOnLine(line);
                     }
 
-                    if (entry.IsValid)
-                    {
-                        entries.Add(entry);
-                    }
                 }
             }
             Colorizer.WriteLine("[Green!Done]");
@@ -77,6 +66,11 @@ namespace CreateRuleFabricBot
 
         private static string NormalizeLine(string line)
         {
+            if (string.IsNullOrEmpty(line))
+            {
+                return line;
+            }
+
             // Remove tabs and trim extra whitespace
             return line.Replace('\t', ' ').Trim();
         }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
@@ -26,8 +26,6 @@ namespace CreateRuleFabricBot
             {
                 while ((line = sr.ReadLine()) != null)
                 {
-                    // Does the line start with '# PRLabel: "label1", "label2"
-
                     // Remove tabs and trim extra whitespace
                     line = NormalizeLine(line);
 
@@ -39,7 +37,7 @@ namespace CreateRuleFabricBot
 
                     CodeOwnerEntry entry = new CodeOwnerEntry();
 
-                    // if we have the moniker in the line, parse the labels
+                    // if we have a comment on the line AND if the line contains special delimiters
                     while (line.StartsWith('#') && entry.ProcessLabelsOnLine(line))
                     {
                         // We need to read the next line as we parsed this line

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
@@ -47,7 +47,12 @@ namespace CreateRuleFabricBot
                         // If this is not a comment line OR this is a placeholder entry
 
                         entry.ParseOwnersAndPath(line);
-                        entries.Add(entry);
+
+                        // only add it if it is a valid entry
+                        if (entry.IsValid)
+                        {
+                            entries.Add(entry);
+                        }
 
                         // create a new entry.
                         entry = new CodeOwnerEntry();

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
@@ -7,19 +7,19 @@ using System.Text;
 
 namespace CreateRuleFabricBot
 {
-    public static class CodeOwners
+    public static class CodeOwnersFile
     {
-        public static List<CodeOwnerEntry> ReadOwnersFromFile(string filePathOrUrl)
+        public static List<CodeOwnerEntry> ParseFile(string filePathOrUrl)
         {
             string content;
             Colorizer.Write("Retrieving file content from [Yellow!{0}]... ", filePathOrUrl);
             content = GetFileContents(filePathOrUrl);
             Colorizer.WriteLine("[Green!Done]");
 
-            return ParseOwnersFromContent(content);
+            return ParseContent(content);
         }
 
-        public static List<CodeOwnerEntry> ParseOwnersFromContent(string fileContent)
+        public static List<CodeOwnerEntry> ParseContent(string fileContent)
         {
             Colorizer.Write("Parsing CODEOWNERS table... ");
             List<CodeOwnerEntry> entries = new List<CodeOwnerEntry>();

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnersFile.cs
@@ -61,7 +61,8 @@ namespace CreateRuleFabricBot
                     }
 
                     // If this is not a comment line.
-                    if (line.IndexOf('#') == -1)
+                    if (line.IndexOf('#') == -1 ||
+                        line.IndexOf(CodeOwnerEntry.MissingFolder, System.StringComparison.OrdinalIgnoreCase) >= 0)
                     {
                         entry.ParseOwnersAndPath(line);
                     }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/FileHelpers.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/FileHelpers.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net.Http;
+using System.Text;
+
+namespace CreateRuleFabricBot.Helpers
+{
+    public static class FileHelpers
+    {
+        public static string GetFileContents(string fileOrUri)
+        {
+            if (File.Exists(fileOrUri))
+            {
+                return File.ReadAllText(fileOrUri);
+            }
+
+            // try to parse it as an Uri
+            Uri uri = new Uri(fileOrUri, UriKind.Absolute);
+            if (uri.Scheme.ToLowerInvariant() != "https")
+            {
+                throw new ArgumentException("Cannot download off non-https uris");
+            }
+
+            // try to download it.
+            using (HttpClient client = new HttpClient())
+            {
+                HttpResponseMessage response = client.GetAsync(fileOrUri).ConfigureAwait(false).GetAwaiter().GetResult();
+                return response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            }
+        }
+    }
+}

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Markdown/MarkdownTable.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Markdown/MarkdownTable.cs
@@ -15,7 +15,7 @@ namespace CreateRuleFabricBot.Markdown
             MarkdownTable mt = new MarkdownTable();
             string line;
 
-            using (StreamReader sr = new StreamReader(FileHelpers.GetFileContents(filePath)))
+            using (StringReader sr = new StringReader(FileHelpers.GetFileContents(filePath)))
             {
                 while ((line = sr.ReadLine()) != null)
                 {

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Markdown/MarkdownTable.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Markdown/MarkdownTable.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using CreateRuleFabricBot.Helpers;
+using System;
 using System.Collections.Generic;
 using System.IO;
 
@@ -14,7 +15,7 @@ namespace CreateRuleFabricBot.Markdown
             MarkdownTable mt = new MarkdownTable();
             string line;
 
-            using (StreamReader sr = new StreamReader(filePath))
+            using (StreamReader sr = new StreamReader(FileHelpers.GetFileContents(filePath)))
             {
                 while ((line = sr.ReadLine()) != null)
                 {

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Program.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Program.cs
@@ -3,6 +3,7 @@ using CreateRuleFabricBot.CommandLine;
 using CreateRuleFabricBot.Markdown;
 using CreateRuleFabricBot.Rules;
 using CreateRuleFabricBot.Rules.IssueRouting;
+using CreateRuleFabricBot.Rules.PullRequestLabel;
 using CreateRuleFabricBot.Service;
 using OutputColorizer;
 using System;

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/IssueRouting/IssueRoutingCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/IssueRouting/IssueRoutingCapability.cs
@@ -58,18 +58,11 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
                 // If we have labels for the specific codeowners entry, add that to the triage list
                 if (entry.ServiceLabels.Any())
                 {
-
-                    // Use 'Service Attention' as well as the service label
-                    List<string> labelsToApply = new List<string>(entry.PRLabels)
-                                                {
-                                                    "Service Attention"
-                                                };
-
                     // Remove the '@' from the owners handle
                     IEnumerable<string> mentionees = entry.Owners.Select(x => x.Replace("@", "").Trim());
 
                     //add the service
-                    AddService(labelsToApply, mentionees);
+                    AddService(entry.ServiceLabels, mentionees);
                 }
             }
 

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/IssueRouting/IssueRoutingCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/IssueRouting/IssueRoutingCapability.cs
@@ -51,7 +51,7 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
 
         public override string GetPayload()
         {
-            List<CodeOwnerEntry> entries = CodeOwners.ReadOwnersFromFile(_codeownersFile);
+            List<CodeOwnerEntry> entries = CodeOwnersFile.ParseFile(_codeownersFile);
 
             foreach (CodeOwnerEntry entry in entries)
             {

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/IssueRouting/IssueRoutingCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/IssueRouting/IssueRoutingCapability.cs
@@ -4,6 +4,7 @@ using OutputColorizer;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection.Emit;
 
 namespace CreateRuleFabricBot.Rules.IssueRouting
 {
@@ -27,18 +28,19 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
 
         private readonly string _repo;
         private readonly string _owner;
-        private readonly string _servicesFile;
+        private readonly string _codeownersFile;
 
         private List<TriageConfig> _triageConfig = new List<TriageConfig>();
 
         private int RouteCount { get { return _triageConfig.Count; } }
 
-        public IssueRoutingCapability(string org, string repo, string servicesFile)
+        public IssueRoutingCapability(string org, string repo, string codeownersFile)
         {
             _repo = repo;
             _owner = org;
-            _servicesFile = servicesFile;
+            _codeownersFile = codeownersFile;
         }
+
         private void AddService(IEnumerable<string> labels, IEnumerable<string> mentionees)
         {
             var tc = new TriageConfig();
@@ -49,26 +51,33 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
 
         public override string GetPayload()
         {
-            Colorizer.Write("Parsing service table... ");
-            MarkdownTable table = MarkdownTable.Parse(_servicesFile);
-            Colorizer.WriteLine("[Green!done].");
+            List<CodeOwnerEntry> entries = CodeOwners.ReadOwnersFromFile(_codeownersFile);
 
-            foreach (var row in table.Rows)
+            foreach (CodeOwnerEntry entry in entries)
             {
-                if (!string.IsNullOrEmpty(row[2].Trim()))
+                // If we have labels for the specific codeowners entry, add that to the triage list
+                if (entry.ServiceLabels.Any())
                 {
-                    // the row at position 0 is the label to use on top of 'Service Attention'
-                    string[] labels = new string[] { "Service Attention", row[0] };
 
-                    // The row at position 2 is the set of mentionees to ping on the issue.
-                    IEnumerable<string> mentionees = row[2].Split(',').Select(x => x.Replace("@", "").Trim());
+                    // Use 'Service Attention' as well as the service label
+                    List<string> labelsToApply = new List<string>(entry.PRLabels)
+                                                {
+                                                    "Service Attention"
+                                                };
+
+                    // Remove the '@' from the owners handle
+                    IEnumerable<string> mentionees = entry.Owners.Select(x => x.Replace("@", "").Trim());
 
                     //add the service
-                    AddService(labels, mentionees);
+                    AddService(labelsToApply, mentionees);
                 }
             }
 
             Colorizer.WriteLine("Found [Yellow!{0}] service routes.", RouteCount);
+            foreach (TriageConfig triage in _triageConfig)
+            {
+                Colorizer.WriteLine("Labels:[Yellow!{0}], Owners:[Yellow!{1}]", string.Join(',', triage.Labels), string.Join(',', triage.Mentionee));
+            }
 
             return s_template
                 .Replace("###repo###", GetTaskId())

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -72,6 +72,13 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
                     continue; //TODO: regex expressions are not yet supported
                 }
 
+                if (entries[i].PathExpression.IndexOf(CodeOwnerEntry.MissingFolder, StringComparison.OrdinalIgnoreCase) !=-1)
+                {
+                    Colorizer.WriteLine("[Yellow!Warning]: The path '[Cyan!{0}]' is marked with the non-existing path marker.", entries[i].PathExpression);
+
+                    continue; 
+                }
+
                 // Entries with more than one label are not yet supported.
                 if (entries[i].PRLabels.Count > 1)
                 {

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -1,5 +1,4 @@
-﻿using CreateRuleFabricBot.Rules.PullRequestLabel;
-using OutputColorizer;
+﻿using OutputColorizer;
 using System;
 using System.Collections.Generic;
 using System.Data;
@@ -9,7 +8,7 @@ using System.Net.Http;
 using System.Text;
 using System.Text.Encodings.Web;
 
-namespace CreateRuleFabricBot.Rules.IssueRouting
+namespace CreateRuleFabricBot.Rules.PullRequestLabel
 {
     public class PullRequestLabelFolderCapability : BaseCapability
     {
@@ -51,9 +50,7 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
 
         public override string GetPayload()
         {
-            Colorizer.Write("Parsing CODEOWNERS table... ");
-            List<CodeOwnerEntry> entries = ReadOwnersFromFile();
-            Colorizer.WriteLine("[Green!Done]");
+            List<CodeOwnerEntry> entries = CodeOwners.ReadOwnersFromFile(_codeownersFile);
 
             StringBuilder configPayload = new StringBuilder();
 
@@ -67,24 +64,24 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
                 {
                     // log a warning there
 
-                    if (entries[i].Labels.Any())
+                    if (entries[i].PRLabels.Any())
                     {
-                        Colorizer.WriteLine("[Yellow!Warning]: The path '[Cyan!{0}]' contains a wildcard and a label '[Magenta!{1}]' which is not supported!", entries[i].PathExpression, string.Join(',', entries[i].Labels));
+                        Colorizer.WriteLine("[Yellow!Warning]: The path '[Cyan!{0}]' contains a wildcard and a label '[Magenta!{1}]' which is not supported!", entries[i].PathExpression, string.Join(',', entries[i].PRLabels));
                     }
 
                     continue; //TODO: regex expressions are not yet supported
                 }
 
                 // Entries with more than one label are not yet supported.
-                if (entries[i].Labels.Count > 1)
+                if (entries[i].PRLabels.Count > 1)
                 {
                     Colorizer.WriteLine("[Yellow!Warning]: Multiple labels for the same path '[Cyan!{0}]' are not yet supported", entries[i].PathExpression);
                     continue;
                 }
 
-                if (entries[i].Labels.Count == 0)
+                if (entries[i].PRLabels.Count == 0)
                 {
-                    Colorizer.WriteLine("[Yellow!Warning]: The path '[Cyan!{0}]' does not contain a label.", entries[i].PathExpression, string.Join(',', entries[i].Labels));
+                    Colorizer.WriteLine("[Yellow!Warning]: The path '[Cyan!{0}]' does not contain a label.", entries[i].PathExpression, string.Join(',', entries[i].PRLabels));
                     continue;
                 }
 
@@ -99,7 +96,7 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
                 // get the payload
                 string entryPayload = ToConfigString(entry);
 
-                Colorizer.WriteLine("[Cyan!{0}] => [Magenta!{1}]", entry.PathExpression, entry.Labels.FirstOrDefault());
+                Colorizer.WriteLine("[Cyan!{0}] => [Magenta!{1}]", entry.PathExpression, entry.PRLabels.FirstOrDefault());
 
                 configPayload.Append(ToConfigString(entry));
                 configPayload.Append(',');
@@ -122,7 +119,7 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
         {
             string result = s_configTemplate;
 
-            result = result.Replace("###label###", entry.Labels.First());
+            result = result.Replace("###label###", entry.PRLabels.First());
 
             // at this point we should remove the leading '/' if any
             if (entry.PathExpression.StartsWith("/"))
@@ -132,88 +129,6 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
             result = result.Replace("###srcFolders###", $"\"{entry.PathExpression}\"");
 
             return result;
-        }
-
-        private string GetFileContents(string fileOrUri)
-        {
-            if (File.Exists(fileOrUri))
-            {
-                return File.ReadAllText(fileOrUri);
-            }
-
-            // try to parse it as an Uri
-            Uri uri = new Uri(fileOrUri, UriKind.Absolute);
-            if (uri.Scheme.ToLowerInvariant() != "https")
-            {
-                throw new ArgumentException("Cannot download off non-https uris");
-            }
-
-            // try to download it.
-            using (HttpClient client = new HttpClient())
-            {
-                HttpResponseMessage response = client.GetAsync(fileOrUri).ConfigureAwait(false).GetAwaiter().GetResult();
-                return response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
-            }
-        }
-
-        private List<CodeOwnerEntry> ReadOwnersFromFile()
-        {
-            List<CodeOwnerEntry> entries = new List<CodeOwnerEntry>();
-            string line;
-            using (StringReader sr = new StringReader(GetFileContents(_codeownersFile)))
-            {
-                while ((line = sr.ReadLine()) != null)
-                {
-                    // Does the line start with '# PRLabel: "label1", "label2"
-
-                    // Remove tabs and trim extra whitespace
-                    line = NormalizeLine(line);
-
-                    // Empty line, move on
-                    if (string.IsNullOrEmpty(line))
-                    {
-                        continue;
-                    }
-
-                    CodeOwnerEntry entry = new CodeOwnerEntry();
-
-                    // if we have the moniker in the line, parse the labels
-                    if (line.StartsWith('#') &&                        
-                        line.IndexOf(CodeOwnerEntry.LabelMoniker, System.StringComparison.OrdinalIgnoreCase) >= 0)
-                    {
-                        entry.ParseLabels(line);
-
-                        // We need to read the next line
-                        line = sr.ReadLine();
-
-                        if (line == null)
-                        {
-                            break;
-                        }
-
-                        // Remove tabs and trim extra whitespace
-                        line = NormalizeLine(line);
-                    }
-
-                    // If this is not a comment line.
-                    if (line.IndexOf('#') == -1)
-                    {
-                        entry.ParseOwnersAndPath(line);
-                    }
-
-                    if (entry.IsValid)
-                    {
-                        entries.Add(entry);
-                    }
-                }
-            }
-            return entries;
-        }
-
-        private static string NormalizeLine(string line)
-        {
-            // Remove tabs and trim extra whitespace
-            return line.Replace('\t', ' ').Trim();
         }
 
         public override string GetTaskId()

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -50,7 +50,7 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
 
         public override string GetPayload()
         {
-            List<CodeOwnerEntry> entries = CodeOwners.ReadOwnersFromFile(_codeownersFile);
+            List<CodeOwnerEntry> entries = CodeOwnersFile.ParseFile(_codeownersFile);
 
             StringBuilder configPayload = new StringBuilder();
 

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/CodeOwnerTests.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/CodeOwnerTests.cs
@@ -3,6 +3,8 @@ using CreateRuleFabricBot.Rules.PullRequestLabel;
 using CreateRuleFabricBotTests;
 using NUnit.Framework;
 using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 
 namespace Tests
 {
@@ -16,8 +18,6 @@ namespace Tests
                 new TestAndExpected("/test @author", "# PRLabel: %label1 %label2", "/test", new []{ "author"}, new[]{"label1", "label2" }),
                 // no labels
                 new TestAndExpected("/test @author", "", "/test", new []{ "author"}, new string[]{ }),
-                // no path and owners
-                new TestAndExpected("", "# PRLabel: %label1 %label2", null, new string[]{ }, new string[]{ "label1", "label2" }), 
 
                 // Different casing for PRLabel marker
                 new TestAndExpected("/test @author1 @author2", "# prlabeL  : %label", "/test", new []{ "author1", "author2"}, new[]{"label" }),
@@ -37,13 +37,28 @@ namespace Tests
         [Theory]
         public void ValidateOwnersLines(TestAndExpected entry)
         {
-            CodeOwnerEntry coe = new CodeOwnerEntry(entry.PathAndOwners, entry.LabelsLine, string.Empty);
+            // create the content
+            string content = $"{entry.LabelsLine}\r\n{entry.PathAndOwners}";
 
+            CodeOwnerEntry coe = CodeOwners.ParseOwnersFromContent(content).First();
             Assert.AreEqual(entry.ExpectedLabels, coe.PRLabels);
             Assert.AreEqual(entry.ExpectedOwners, coe.Owners);
             Assert.AreEqual(entry.ExpectedPath, coe.PathExpression);
         }
 
+        [Test]
+        public void ParseInvalidEntry()
+        {
+            // no path and owners
+            var entry = new TestAndExpected("", "# PRLabel: %label1 %label2", string.Empty, new string[] { }, new string[] { "label1", "label2" });
+
+            // create the content
+            string content = $"{entry.LabelsLine}\r\n{entry.PathAndOwners}";
+
+            CodeOwnerEntry coe = CodeOwners.ParseOwnersFromContent(content).FirstOrDefault();
+
+            Assert.IsNull(coe);
+        }
 
         [Test]
         public void ValidateCodeOwnersContent()

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/CodeOwnerTests.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/CodeOwnerTests.cs
@@ -82,11 +82,18 @@ namespace Tests
 
 /folder5/                                   @user5
 
+# ServiceLabel: %MyService
+#/<NotInRepo>/           @user6
+
+
+# ServiceLabel: %MyService
+# CommentedLine           @user7
 ";
 
             List<CodeOwnerEntry> entries = CodeOwnersFile.ParseContent(content);
+            Assert.AreEqual(6, entries.Count);
 
-            Assert.AreEqual(5, entries.Count);
+
             Assert.AreEqual("F1", entries[0].PRLabels[0]);
             Assert.AreEqual("F1", entries[0].ServiceLabels[0]);
             Assert.AreEqual("Service Attention", entries[0].ServiceLabels[1]);
@@ -107,6 +114,11 @@ namespace Tests
             Assert.AreEqual(0, entries[4].ServiceLabels.Count);
             Assert.AreEqual(0, entries[4].PRLabels.Count);
             Assert.AreEqual("/folder5/", entries[4].PathExpression);
+
+
+            Assert.AreEqual(1, entries[5].ServiceLabels.Count);
+            Assert.AreEqual(0, entries[5].PRLabels.Count);
+            Assert.AreEqual("#/<NotInRepo>/", entries[5].PathExpression);
         }
     }
 }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/CodeOwnerTests.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/CodeOwnerTests.cs
@@ -88,10 +88,17 @@ namespace Tests
 
 # ServiceLabel: %MyService
 # CommentedLine           @user7
+
+
+/folder6            @user7
+
+
+# ServiceLabel: %MyService
+/folder8           @user6  #This has comment at the end
 ";
 
             List<CodeOwnerEntry> entries = CodeOwnersFile.ParseContent(content);
-            Assert.AreEqual(6, entries.Count);
+            Assert.AreEqual(8, entries.Count);
 
 
             Assert.AreEqual("F1", entries[0].PRLabels[0]);
@@ -115,10 +122,18 @@ namespace Tests
             Assert.AreEqual(0, entries[4].PRLabels.Count);
             Assert.AreEqual("/folder5/", entries[4].PathExpression);
 
-
             Assert.AreEqual(1, entries[5].ServiceLabels.Count);
             Assert.AreEqual(0, entries[5].PRLabels.Count);
             Assert.AreEqual("#/<NotInRepo>/", entries[5].PathExpression);
+
+            Assert.AreEqual(1, entries[6].ServiceLabels.Count);
+            Assert.AreEqual(0, entries[6].PRLabels.Count);
+            Assert.AreEqual("/folder6", entries[6].PathExpression);
+
+            Assert.AreEqual(1, entries[7].ServiceLabels.Count);
+            Assert.AreEqual(0, entries[7].PRLabels.Count);
+            Assert.AreEqual("/folder8", entries[7].PathExpression);
+            Assert.AreEqual("user6", entries[7].Owners[0]);
         }
     }
 }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/CodeOwnerTests.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/CodeOwnerTests.cs
@@ -40,7 +40,7 @@ namespace Tests
             // create the content
             string content = $"{entry.LabelsLine}\r\n{entry.PathAndOwners}";
 
-            CodeOwnerEntry coe = CodeOwners.ParseOwnersFromContent(content).First();
+            CodeOwnerEntry coe = CodeOwnersFile.ParseContent(content).First();
             Assert.AreEqual(entry.ExpectedLabels, coe.PRLabels);
             Assert.AreEqual(entry.ExpectedOwners, coe.Owners);
             Assert.AreEqual(entry.ExpectedPath, coe.PathExpression);
@@ -55,7 +55,7 @@ namespace Tests
             // create the content
             string content = $"{entry.LabelsLine}\r\n{entry.PathAndOwners}";
 
-            CodeOwnerEntry coe = CodeOwners.ParseOwnersFromContent(content).FirstOrDefault();
+            CodeOwnerEntry coe = CodeOwnersFile.ParseContent(content).FirstOrDefault();
 
             Assert.IsNull(coe);
         }
@@ -84,7 +84,7 @@ namespace Tests
 
 ";
 
-            List<CodeOwnerEntry> entries = CodeOwners.ParseOwnersFromContent(content);
+            List<CodeOwnerEntry> entries = CodeOwnersFile.ParseContent(content);
 
             Assert.AreEqual(5, entries.Count);
             Assert.AreEqual("F1", entries[0].PRLabels[0]);


### PR DESCRIPTION
This is the first step towards the unification of the data sources for issue routing and PR labels for the Azure SDK repos.

We are going to add a comment in the CODEOWNERS file above the path representing the service with the set of labels that, when present, will ensure that the owners get tagged in the issue with those labels. 