### PR TITLE
Make broken pipe classifier cover more scenarios.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/MavenBrokenPipeFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/MavenBrokenPipeFailureClassifier.cs
@@ -38,7 +38,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
                     failedTask.Log.Id
                     );
 
-                if (lines.Any(line => line.Contains("Connection reset")))
+                if (lines.Any(line => line.Contains("Connection reset") || line.Contains("Connection timed out") || line.Contains("504 Gateway Timeout")))
                 {
                     context.AddFailure(failedTask, "Maven Broken Pipe");
                 }


### PR DESCRIPTION
This PR adds some other strings to search for in logs which are related to dependency download issues in Maven.