### PR TITLE
Add a classifier for detecting code signing failures.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CodeSigningFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CodeSigningFailureClassifier.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.TeamFoundation.Build.WebApi;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class CodeSigningFailureClassifier : IFailureClassifier
+    {
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            var failedTasks = from r in context.Timeline.Records
+                              where r.Result == TaskResult.Failed
+                              where r.RecordType == "Task"
+                              where r.Task != null
+                              where r.Task.Name == "ESRP Code Signing"
+                              where r.Log != null
+                              select r;
+
+            if (failedTasks.Count() > 0)
+            {
+                foreach (var failedTask in failedTasks)
+                {
+                    context.AddFailure(failedTask, "Code Signing");
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -87,6 +87,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, GitCheckoutFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, AzurePowerShellModuleInstallationFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, MavenBrokenPipeFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, CodeSigningFailureClassifier>();
         }
     }
 }


### PR DESCRIPTION
This PR adds a failure classifier for Pipeline Witness. We experienced a burst of code signing failures overnight and I want to pull those errors out separately in our reports so we can quantify the impact over time. This classifier looks for any instance of the _ESRP Code Signing_ task that failed and reports it.