### PR TITLE
Switch the content from array to string.

### DIFF
--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -205,7 +205,7 @@ function Upload-Blobs
     if ($ReleaseTag) {
         foreach ($htmlFile in (Get-ChildItem $DocDir -include *.html -r)) 
         {
-            $fileContent = Get-Content -Path $htmlFile
+            $fileContent = Get-Content -Path $htmlFile -Raw
             $updatedFileContent = $fileContent -replace $RepoReplaceRegex, "`${1}$ReleaseTag"
             if ($updatedFileContent -ne $fileContent) {
                 Set-Content -Path $htmlFile -Value $updatedFileContent


### PR DESCRIPTION
Fixed the issue: https://github.com/Azure/azure-sdk-for-js/issues/11827

JS pipeline running super slow on array object of `Get-Content`.
Tested using -Raw, replacement works correctly and the entire process speeds up.