### PR TITLE
Check Enforcer timeout handling (WIP)

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.2" />
+    <PackageReference Include="Azure.Data.Tables" Version="3.0.0-beta.2" />
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.1.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -11,15 +11,15 @@
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.1.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.9" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="RateLimiter" Version="2.1.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/PullRequestTimeoutFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/PullRequestTimeoutFunction.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Functions
+{
+    public class PullRequestTimeoutFunction
+    {
+        [FunctionName("PullRequestTimeoutFunction")]
+        public async Task Run([TimerTrigger("0 */1 * * * *")]TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
+        }
+    }
+}

--- a/tools/check-enforcer/CheckEnforcer.sln
+++ b/tools/check-enforcer/CheckEnforcer.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CheckEnforcer", "Azure.Sdk.Tools.CheckEnforcer\Azure.Sdk.Tools.CheckEnforcer.csproj", "{97850C3F-0A6C-446B-B00B-B1E571426661}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Sdk.Tools.CheckEnforcer.Tests", "Azure.Sdk.Tools.CheckEnforcer.Tests\Azure.Sdk.Tools.CheckEnforcer.Tests.csproj", "{4C33C118-A3C1-4742-B407-57D032497769}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CheckEnforcer.Tests", "Azure.Sdk.Tools.CheckEnforcer.Tests\Azure.Sdk.Tools.CheckEnforcer.Tests.csproj", "{4C33C118-A3C1-4742-B407-57D032497769}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This PR adds support for timeout behaviors in Check Enforcer. The way it works is that Check Enforcer will fire a function at a regular interval and read a list of pull requests that it has seen recently from Azure Storage (tables). It will then query that pull request to determine whether it has any check-runs, and if it doesn't, and add a comment with the contents of a markdown file from the source repository.

This will require a modification to the existing ```CHECKENFORCER``` configuration file to specify the timeout period. The markdown file will be discovered by convention ... ```CHECKENFORCER-TIMEOUT.md```.

Protections will need to be in place to make sure that Check Enforcer doesn't spam PRs with comments so the rule will be that if Check Enforcer has ever added a comment to a PR, then it won't ever again.