### PR TITLE
Remove extra newline at the end of the file

### DIFF
--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -208,7 +208,7 @@ function Upload-Blobs
             $fileContent = Get-Content -Path $htmlFile -Raw
             $updatedFileContent = $fileContent -replace $RepoReplaceRegex, "`${1}$ReleaseTag"
             if ($updatedFileContent -ne $fileContent) {
-                Set-Content -Path $htmlFile -Value $updatedFileContent
+                Set-Content -Path $htmlFile -Value $updatedFileContent -NoNewLine
             }
         }
     } 


### PR DESCRIPTION
This is a follow up PR (https://github.com/Azure/azure-sdk-tools/pull/1103) which introduced extra new line at the end of the file. 
Local testing indicates we added new line at end.
Checked the github io, and it does not bring too many differences.
E.g.
After PR,
https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-template/1.0.9-beta.22/index.html
Before PR,
https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-template/1.0.9-beta.20/index.html

