### PR TITLE
Retarget master as the base branch for docs metadata release

### DIFF
--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -8,8 +8,8 @@ parameters:
   ScriptDirectory: eng/common/scripts
   TargetDocRepoName: ''
   TargetDocRepoOwner: ''
-  PRBranchName: 'smoke-test-rdme'
-  SourceBranchName: 'smoke-test'
+  PRBranchName: 'master-rdme'
+  SourceBranchName: 'master'
   PRLabels: 'auto-merge'
   ArtifactName: ''
   Language: ''


### PR DESCRIPTION
Have a PR submitted to the docs team that allows for non-conflicting commits. We can definitely get rid of smoke-test now.

Docs CI will also need to be updated, but that happens separately from this PR.