### PR TITLE
Add --no-schedule option to Pipeline Generator.

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
@@ -11,7 +11,7 @@ namespace PipelineGenerator.Conventions
     public class IntegrationTestingPipelineConvention : PipelineConvention
     {
         public override string SearchPattern => "tests.yml";
-        public override bool IsScheduled => true;
+        public override bool IsScheduled => !Context.NoSchedule;
         public override bool RemoveCITriggers => true;
 
         public IntegrationTestingPipelineConvention(ILogger logger, PipelineGenerationContext context) : base(logger, context)

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -20,7 +20,7 @@ namespace PipelineGenerator.Conventions
         }
 
         public override string SearchPattern => "ci*.yml";
-        public override bool IsScheduled => true;
+        public override bool IsScheduled => !Context.NoSchedule;
         public override bool RemoveCITriggers => true;
 
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
@@ -36,7 +36,8 @@ namespace PipelineGenerator
             string[] variableGroups,
             string devOpsPath,
             string prefix, 
-            bool whatIf)
+            bool whatIf,
+            bool noSchedule)
         {
             this.organization = organization;
             this.project = project;
@@ -49,11 +50,13 @@ namespace PipelineGenerator
             this.devOpsPath = devOpsPath;
             this.Prefix = prefix;
             this.WhatIf = whatIf;
+            this.NoSchedule = noSchedule;
         }
 
         public string Branch { get; }
         public string Prefix { get; }
         public bool WhatIf { get; }
+        public bool NoSchedule { get; }
         public int[] VariableGroups => this.variableGroups;
         public string DevOpsPath => string.IsNullOrEmpty(this.devOpsPath) ? Prefix : this.devOpsPath;
 

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
@@ -60,6 +60,7 @@ namespace PipelineGenerator
             var openOption = app.Option("--open", "Open a browser window to the definitions that are created.", CommandOptionType.NoValue);
             var destroyOption = app.Option("--destroy", "Use this switch to delete the pipelines instead (DANGER!)", CommandOptionType.NoValue);
             var debugOption = app.Option("--debug", "Turn on debug level logging.", CommandOptionType.NoValue);
+            var noScheduleOption = app.Option("--no-schedule", "Don't create any scheduled triggers.", CommandOptionType.NoValue);
 
             app.OnExecute(() =>
             {
@@ -81,6 +82,7 @@ namespace PipelineGenerator
                     whatifOption.HasValue(),
                     openOption.HasValue(),
                     destroyOption.HasValue(),
+                    noScheduleOption.HasValue(),
                     cancellationTokenSource.Token
                     ).Result;
 
@@ -139,6 +141,7 @@ namespace PipelineGenerator
             bool whatIf,
             bool open,
             bool destroy,
+            bool noSchedule,
             CancellationToken cancellationToken)
         {
             try
@@ -159,7 +162,8 @@ namespace PipelineGenerator
                     variableGroups,
                     devOpsPathValue,
                     prefix,
-                    whatIf
+                    whatIf,
+                    noSchedule
                     );
 
                 var pipelineConvention = GetPipelineConvention(convention, context);


### PR DESCRIPTION
This PR adds a ```--no-schedule``` option to Pipeline Generator. This switch will impact the ```up``` and ```tests``` conventions which are the only two that have schedules. We want this feature so that we can streamline pipeline creation from within a PR, but support it in our private repos where we definitely don't want scheduled pipelines created.