### PR TITLE
Update New-TestResources.ps1 parameter documentation to match defaults

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -562,7 +562,7 @@ is based on the cloud to which the template is being deployed:
 
 .PARAMETER Environment
 Name of the cloud environment. The default is the Azure Public Cloud
-('PublicCloud')
+('AzureCloud')
 
 .PARAMETER AdditionalParameters
 Optional key-value pairs of parameters to pass to the ARM template(s).


### PR DESCRIPTION
The default parameter value is 'AzureCloud' but the parameter docs use 'PublicCloud', so this change changes the latter to the former.

Related to https://github.com/Azure/azure-sdk-for-net/pull/15258