### PR TITLE
Fix issue with .NET pipeline preparation.

### DIFF
--- a/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
+++ b/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
@@ -3,9 +3,13 @@ parameters:
 
 steps:
   - script: >
+      mkdir $(Pipeline.Workspace)/pipeline-generator
+    displayName: Setup working directory for pipeline generator.
+  - script: >
       dotnet tool install
       Azure.Sdk.Tools.PipelineGenerator
       --version 1.0.2-dev.20201020.1
       --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk/nuget/v3/index.json
       --tool-path ${{parameters.ToolPath}}
+    workingDirectory: $(Pipeline.Workspace)/pipeline-generator
     displayName: 'Install pipeline generator tool'

--- a/eng/common/pipelines/templates/steps/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/steps/prepare-pipelines.yml
@@ -34,6 +34,7 @@ steps:
         --patvar PATVAR
         --debug
         ${{parameters.CIConventionOptions}}
+      displayName: Create CI pipelines for public repository
       env:
         PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
     - script: >
@@ -51,6 +52,7 @@ steps:
         --patvar PATVAR
         --debug
         ${{parameters.UPConventionOptions}}
+      displayName: Create UP pipelines for public repository
       env:
         PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
     - script: >
@@ -68,6 +70,7 @@ steps:
         --patvar PATVAR
         --debug
         ${{parameters.TestsConventionOptions}}
+      displayName: Create Live Test pipelines for public repository
       env:
         PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 
@@ -89,6 +92,7 @@ steps:
         --debug
         --no-schedule
         ${{parameters.CIConventionOptions}}
+      displayName: Create CI pipelines for private repository
       env:
         PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
     - script: >
@@ -107,6 +111,7 @@ steps:
         --debug
         --no-schedule
         ${{parameters.UPConventionOptions}}
+      displayName: Create UP pipelines for private repository
       env:
         PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
     - script: >
@@ -125,5 +130,6 @@ steps:
         --debug
         --no-schedule
         ${{parameters.TestsConventionOptions}}
+      displayName: Create Live Test pipelines for private repository
       env:
         PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)


### PR DESCRIPTION
This PR fixes up a bug in pipeline preparation where we are running the tool installer in the .NET repos root directory and the dotnet tooling complaining about the invocation being ambiguous. This works around it by creating a pipeline generator path and invoking the command in that working directory rather than the source root, or the pipeline workspace.