### PR TITLE
Check Enforcer timeout

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -7,19 +7,20 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Data.AppConfiguration" Version="1.0.2" />
+    <PackageReference Include="Azure.Data.Tables" Version="3.0.0-beta.2" />
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.1.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
-    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.9" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="RateLimiter" Version="2.1.0" />
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.7.1" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.8.0" />
     <PackageReference Include="YamlDotNet" Version="8.1.2" />
   </ItemGroup>
   <ItemGroup>

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IRepositoryConfiguration.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IRepositoryConfiguration.cs
@@ -8,8 +8,8 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
     {
         string Format { get; }
         bool IsEnabled { get; }
-
         uint MinimumCheckRuns { get; }
         uint TimeoutInMinutes { get; }
+        string Message { get; }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IRepositoryConfiguration.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/IRepositoryConfiguration.cs
@@ -10,5 +10,6 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
         bool IsEnabled { get; }
 
         uint MinimumCheckRuns { get; }
+        uint TimeoutInMinutes { get; }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfiguration.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfiguration.cs
@@ -10,14 +10,12 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
     {
         public RepositoryConfiguration()
         {
+            // These value represent defaults.
             MinimumCheckRuns = 1;
             IsEnabled = true;
             TimeoutInMinutes = 1;
-            Message = @"This repository is protected by Check Enforcer. The _check-enforcer_
-check-run will not pass until there is at least one more check-run successfully passing. Check Enforcer supports
-the following comment commands:
+            Message = @"This repository is protected by Check Enforcer. The _check-enforcer_ check-run will not pass until there is at least one more check-run successfully passing. Check Enforcer supports the following comment commands:
 
-- ```/check-enforcer reset```; resets Check Enforcer to its initial state.
 - ```/check-enforcer evaluate```; tells Check Enforcer to evaluate this pull request.
 - ```/check-enforcer override```; by-pass Check Enforcer (approvals still required).";
         }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfiguration.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfiguration.cs
@@ -12,7 +12,14 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
         {
             MinimumCheckRuns = 1;
             IsEnabled = true;
-            TimeoutInMinutes = 5;
+            TimeoutInMinutes = 1;
+            Message = @"This repository is protected by Check Enforcer. The _check-enforcer_
+check-run will not pass until there is at least one more check-run successfully passing. Check Enforcer supports
+the following comment commands:
+
+- ```/check-enforcer reset```; resets Check Enforcer to its initial state.
+- ```/check-enforcer evaluate```; tells Check Enforcer to evaluate this pull request.
+- ```/check-enforcer override```; by-pass Check Enforcer (approvals still required).";
         }
 
         [YamlMember(Alias = "minimumCheckRuns")]
@@ -26,6 +33,9 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
 
         [YamlMember(Alias = "timeout")]
         public uint TimeoutInMinutes { get; internal set; }
+
+        [YamlMember(Alias = "message")]
+        public string Message { get; internal set; }
 
         public override string ToString()
         {

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfiguration.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Configuration/RepositoryConfiguration.cs
@@ -12,6 +12,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
         {
             MinimumCheckRuns = 1;
             IsEnabled = true;
+            TimeoutInMinutes = 5;
         }
 
         [YamlMember(Alias = "minimumCheckRuns")]
@@ -22,6 +23,9 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Configuration
 
         [YamlMember(Alias = "format")]
         public string Format { get; internal set; }
+
+        [YamlMember(Alias = "timeout")]
+        public uint TimeoutInMinutes { get; internal set; }
 
         public override string ToString()
         {

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/PullRequestTimeoutFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/PullRequestTimeoutFunction.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Functions
+{
+    public class PullRequestTimeoutFunction
+    {
+        [FunctionName("PullRequestTimeoutFunction")]
+        public async Task Run([TimerTrigger("0 */1 * * * *")]TimerInfo myTimer, ILogger log)
+        {
+            log.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
+        }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/PullRequestTimeoutFunction.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Functions/PullRequestTimeoutFunction.cs
@@ -1,17 +1,136 @@
 using System;
+using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
+using Azure.Sdk.Tools.CheckEnforcer.Configuration;
+using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Azure.Sdk.Tools.CheckEnforcer.Services.PullRequestTracking;
 using Microsoft.Azure.WebJobs;
 using Microsoft.Azure.WebJobs.Host;
 using Microsoft.Extensions.Logging;
+using Octokit;
 
 namespace Azure.Sdk.Tools.CheckEnforcer.Functions
 {
     public class PullRequestTimeoutFunction
     {
-        [FunctionName("PullRequestTimeoutFunction")]
-        public async Task Run([TimerTrigger("0 */1 * * * *")]TimerInfo myTimer, ILogger log)
+        public PullRequestTimeoutFunction(IPullRequestTracker pullRequestTracker, IGitHubClientProvider gitHubClientProvider, GitHubRateLimiter limiter, IRepositoryConfigurationProvider repositoryConfigurationProvider, IGlobalConfigurationProvider globalConfigurationProvider)
         {
-            log.LogInformation($"C# Timer trigger function executed at: {DateTime.Now}");
+            this.pullRequestTracker = pullRequestTracker;
+            this.gitHubClientProvider = gitHubClientProvider;
+            this.limiter = limiter;
+            this.repositoryConfigurationProvider = repositoryConfigurationProvider;
+            this.globalConfigurationProvider = globalConfigurationProvider;
+        }
+
+        private IPullRequestTracker pullRequestTracker;
+        private IGitHubClientProvider gitHubClientProvider;
+        private GitHubRateLimiter limiter;
+        private IRepositoryConfigurationProvider repositoryConfigurationProvider;
+        private IGlobalConfigurationProvider globalConfigurationProvider;
+
+        [FunctionName("PullRequestTimeoutFunction")]
+        public async Task Run([TimerTrigger("*/30 * * * * *")]TimerInfo myTimer, ILogger log, CancellationToken cancellationToken)
+        {
+            log.LogInformation("Fetching tracked pull request tickets.");
+            var pullRequestTrackingTickets = await pullRequestTracker.GetTrackedPullRequestsAsync();
+            log.LogInformation("Found {ticketCount} pull request tickets.", pullRequestTrackingTickets.Count());
+
+            foreach (var pullRequestTrackingTicket in pullRequestTrackingTickets)
+            {
+                log.LogInformation(
+                    "Processing pull request tracking ticket for installation {installationId} in repository {repositoryId} for pull request number {pullRequestNumber}.",
+                    pullRequestTrackingTicket.InstallationId,
+                    pullRequestTrackingTicket.RepositoryId,
+                    pullRequestTrackingTicket.PullRequestNumber
+                    );
+
+                var gitHubClient = await gitHubClientProvider.GetInstallationClientAsync(
+                    pullRequestTrackingTicket.InstallationId,
+                    cancellationToken
+                    );
+
+                await limiter.WaitForGitHubCapacityAsync();
+                var pullRequest = await gitHubClient.PullRequest.Get(
+                    pullRequestTrackingTicket.RepositoryId,
+                    pullRequestTrackingTicket.PullRequestNumber
+                    );
+
+                var sha = pullRequest.Head.Sha;
+                log.LogInformation(
+                    "HEAD SHA for pull request {pullRequestNumber} is {sha}",
+                    pullRequestTrackingTicket.PullRequestNumber,
+                    sha
+                    );
+
+                var configuration = await repositoryConfigurationProvider.GetRepositoryConfigurationAsync(
+                    pullRequestTrackingTicket.InstallationId,
+                    pullRequestTrackingTicket.RepositoryId,
+                    sha,
+                    cancellationToken
+                    );
+
+                if (configuration.IsEnabled != true)
+                {
+                    log.LogInformation(
+                        "Stopping tracking for pull request {pullRequestNumber} in repository {repositoryId} for installation {installationId} because Check Enforcer is not enabled.",
+                        pullRequestTrackingTicket.PullRequestNumber,
+                        pullRequestTrackingTicket.RepositoryId,
+                        pullRequestTrackingTicket.InstallationId
+                        );
+                    await pullRequestTracker.StopTrackingPullRequestAsync(pullRequestTrackingTicket);
+                    continue;
+                }
+                else if (pullRequest.State != new StringEnum<ItemState>(ItemState.Open))
+                {
+                    log.LogInformation(
+                        "Stopping tracking for pull request {pullRequestNumber} in repository {repositoryId} for installation {installationId} because it is no longer open.",
+                        pullRequestTrackingTicket.PullRequestNumber,
+                        pullRequestTrackingTicket.RepositoryId,
+                        pullRequestTrackingTicket.InstallationId
+                        );
+                    await pullRequestTracker.StopTrackingPullRequestAsync(pullRequestTrackingTicket);
+                    continue;    
+                }
+                else if (DateTimeOffset.UtcNow < pullRequest.UpdatedAt.AddMinutes(configuration.TimeoutInMinutes))
+                {
+                    log.LogInformation(
+                        "Skipping pull request {pullRequestNumber} in repository {repositoryId} for installation {installationId} because it is still too new.",
+                        pullRequestTrackingTicket.PullRequestNumber,
+                        pullRequestTrackingTicket.RepositoryId,
+                        pullRequestTrackingTicket.InstallationId
+                        );
+                    continue;
+                }
+                else
+                {
+                    await limiter.WaitForGitHubCapacityAsync();
+                    var checkRunRepsonse = await gitHubClient.Check.Run.GetAllForReference(pullRequestTrackingTicket.RepositoryId, sha);
+
+                    
+                    if (checkRunRepsonse.TotalCount > 0 && checkRunRepsonse.CheckRuns.All((checkRun) => checkRun.Name == globalConfigurationProvider.GetApplicationName()))
+                    {
+                        log.LogInformation(
+                            "Adding timeout comment to pull request {pullRequestNumber} in repository {repositoryId} for installation {installationId} because it has checks.",
+                            pullRequestTrackingTicket.PullRequestNumber,
+                            pullRequestTrackingTicket.RepositoryId,
+                            pullRequestTrackingTicket.InstallationId
+                            );
+
+                        // TODO: Add logic to add comment 
+                    }
+                    else
+                    {
+                        log.LogInformation(
+                            "Stopping tracking pull request {pullRequestNumber} in repository {repositoryId} for installation{installationId} because it has checks.",
+                            pullRequestTrackingTicket.PullRequestNumber,
+                            pullRequestTrackingTicket.RepositoryId,
+                            pullRequestTrackingTicket.InstallationId
+                            );
+                        await pullRequestTracker.StopTrackingPullRequestAsync(pullRequestTrackingTicket);
+                    }
+                }
+            }
         }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/IPullRequestTracker.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/IPullRequestTracker.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Services.PullRequestTracking
+{
+    public interface IPullRequestTracker
+    {
+        Task StartTrackingPullRequestAsync(PullRequestTrackingTicket pullRequest);
+        Task StopTrackingPullRequestAsync(PullRequestTrackingTicket pullRequest);
+        Task<IEnumerable<PullRequestTrackingTicket>> GetTrackedPullRequestsAsync();
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/PullRequestTracker.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/PullRequestTracker.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
 using System.Threading.Tasks;
 
@@ -31,7 +32,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Services.PullRequestTracking
 
         public async Task<IEnumerable<PullRequestTrackingTicket>> GetTrackedPullRequestsAsync()
         {
-            return pullRequestTrackingTickets;
+            return pullRequestTrackingTickets.ToImmutableList();
         }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/PullRequestTracker.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/PullRequestTracker.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Services.PullRequestTracking
+{
+    public class PullRequestTracker : IPullRequestTracker
+    {
+        private List<PullRequestTrackingTicket> pullRequestTrackingTickets = new List<PullRequestTrackingTicket>();
+
+        public PullRequestTracker()
+        {
+        }
+
+        public async Task StartTrackingPullRequestAsync(PullRequestTrackingTicket pullRequestTrackingTicket)
+        {
+            pullRequestTrackingTickets.Add(pullRequestTrackingTicket);
+        }
+
+        public async Task StopTrackingPullRequestAsync(PullRequestTrackingTicket pullRequestTrackingTicket)
+        {
+            pullRequestTrackingTickets.RemoveAll((ticket) =>
+            {
+                return
+                    ticket.InstallationId == pullRequestTrackingTicket.InstallationId &&
+                    ticket.RepositoryId == pullRequestTrackingTicket.RepositoryId &&
+                    ticket.PullRequestNumber == pullRequestTrackingTicket.PullRequestNumber;
+            });
+        }
+
+        public async Task<IEnumerable<PullRequestTrackingTicket>> GetTrackedPullRequestsAsync()
+        {
+            return pullRequestTrackingTickets;
+        }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/PullRequestTrackingTicket.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/PullRequestTrackingTicket.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.CheckEnforcer.Services.PullRequestTracking
+{
+    public class PullRequestTrackingTicket
+    {
+        public long InstallationId { get; set; }
+        public long RepositoryId { get; set; }
+        public int PullRequestNumber { get; set;  }
+    }
+}

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Startup.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Startup.cs
@@ -1,8 +1,10 @@
 ﻿using Azure.Data.AppConfiguration;
+using Azure.Data.Tables;
 using Azure.Identity;
 using Azure.Sdk.Tools.CheckEnforcer;
 using Azure.Sdk.Tools.CheckEnforcer.Configuration;
 using Azure.Sdk.Tools.CheckEnforcer.Integrations.GitHub;
+using Azure.Sdk.Tools.CheckEnforcer.Services.PullRequestTracking;
 using Azure.Security.KeyVault.Keys;
 using Azure.Security.KeyVault.Keys.Cryptography;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
@@ -47,6 +49,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer
                 builder.AddCryptographyClient(key.Id);
             });
 
+            builder.Services.AddSingleton<IPullRequestTracker, PullRequestTracker>();
             builder.Services.AddSingleton<GitHubRateLimiter>();
             builder.Services.AddSingleton<IGlobalConfigurationProvider, GlobalConfigurationProvider>();
             builder.Services.AddSingleton<IGitHubClientProvider, GitHubClientProvider>();

--- a/tools/check-enforcer/CheckEnforcer.sln
+++ b/tools/check-enforcer/CheckEnforcer.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.29215.179
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CheckEnforcer", "Azure.Sdk.Tools.CheckEnforcer\Azure.Sdk.Tools.CheckEnforcer.csproj", "{97850C3F-0A6C-446B-B00B-B1E571426661}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Sdk.Tools.CheckEnforcer.Tests", "Azure.Sdk.Tools.CheckEnforcer.Tests\Azure.Sdk.Tools.CheckEnforcer.Tests.csproj", "{4C33C118-A3C1-4742-B407-57D032497769}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CheckEnforcer.Tests", "Azure.Sdk.Tools.CheckEnforcer.Tests\Azure.Sdk.Tools.CheckEnforcer.Tests.csproj", "{4C33C118-A3C1-4742-B407-57D032497769}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
This PR adds a pull request tracker for the purpose of adding comments to PRs where a check run has not executed. This implementation does not use any durable state. I'm planning on rolling this out as is just to validate the overall flow in our production environment. Once that is validated I'll submit another PR that adds the durable state, so until that is done it may occasionally skip adding a comment.

I've validated the current approach here and ensure we don't get duplicate comments added:

https://github.com/Azure/azure-sdk-tools/pull/1141

The solution is composed of a few elements:

1. Pull Request Tracker; a component which keeps track of pull requests that we want to look at.
2. A timer function that fetches the list of pull requests we are looking at and processes them (with rules to stop tracking etc).
3. Adjustment to PullRequestHandler which starts tracking pull requests.

This approach should handle situations where pull requests are updated (closed, then opened) and subsequent commits are added because the pull request is updated.

When this rolls out we'll need to grant the Check Enforcer app the ability to write comments (this has already been done in the staging instance connected to _azure-sdk-tools_).