### PR TITLE
Remove resource group asynchronously and do not wait for completion

### DIFF
--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -138,8 +138,8 @@ if (![string]::IsNullOrWhiteSpace($ServiceDirectory)) {
 }
 
 Log "Deleting resource group '$ResourceGroupName'"
-if (Retry { Remove-AzResourceGroup -Name "$ResourceGroupName" -Force:$Force }) {
-    Write-Verbose "Successfully deleted resource group '$ResourceGroupName'"
+if (Remove-AzResourceGroup -Name "$ResourceGroupName" -Force:$Force -AsJob) {
+    Write-Verbose "Requested async deletion of resource group '$ResourceGroupName'"
 }
 
 $exitActions.Invoke()

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -141,11 +141,11 @@ $verifyDeleteScript = {
     try {
         $group = Get-AzResourceGroup -name $ResourceGroupName
     } catch {
-        if ($Error[0].ToString().Contains("Provided resource group does not exist")) {
+        if ($_.ToString().Contains("Provided resource group does not exist")) {
             Write-Verbose "Resource group '$ResourceGroupName' not found. Continuing..."
             return
         }
-        throw $Error[0]
+        throw $_
     }
 
     if ($group.ProvisioningState -ne "Deleting")


### PR DESCRIPTION
Since we have background jobs that poll for zombie resource groups already, we don't need to block on resource group deletion. This should save us a couple minutes in our live test pipelines.

Example improvement on a test pipeline (the step takes 4 seconds now):
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=593112&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043

I also verified in the activity log that we had a successful deletion event.

Resolves #754 