### PR TITLE
Switch pipeline generator install to PowerShell.

### DIFF
--- a/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
+++ b/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
@@ -2,10 +2,8 @@ parameters:
   ToolPath: $(Pipeline.Workspace)/pipeline-generator
 
 steps:
-  - script: >
-      mkdir $(Pipeline.Workspace)/pipeline-generator
-    displayName: Setup working directory for pipeline generator.
-  - script: >
+  - pwsh: >
+      New-Item -Type Directory -Name ${{parameters.ToolPath}}
       dotnet tool install
       Azure.Sdk.Tools.PipelineGenerator
       --version 1.0.2-dev.20201020.1


### PR DESCRIPTION
This PR swaps the pipeline generator install template over to using PowerShell just to avoid any annoying x-plat pathing issues.