### PR TITLE
Add non-volatile state tracking to Check Enforcer

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Handlers/PullRequestHandler.cs
@@ -46,13 +46,7 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Handlers
 
                 if (configuration.IsEnabled)
                 {
-                    var pullRequestTrackingTicket = new PullRequestTrackingTicket()
-                    {
-                        InstallationId = installationId,
-                        RepositoryId = repositoryId,
-                        PullRequestNumber = pullRequestNumber
-                    };
-
+                    var pullRequestTrackingTicket = new PullRequestTrackingTicket(installationId, repositoryId, pullRequestNumber);
                     await pullRequestTracker.StartTrackingPullRequestAsync(pullRequestTrackingTicket);
 
                     await CreateCheckAsync(context.Client, installationId, repositoryId, sha, false, cancellationToken);

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/PullRequestTracker.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/PullRequestTracker.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Azure.Data.Tables;
+using Azure.Security.KeyVault.Secrets;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Text;
@@ -8,31 +10,61 @@ namespace Azure.Sdk.Tools.CheckEnforcer.Services.PullRequestTracking
 {
     public class PullRequestTracker : IPullRequestTracker
     {
-        private List<PullRequestTrackingTicket> pullRequestTrackingTickets = new List<PullRequestTrackingTicket>();
+        private SecretClient secretClient;
 
-        public PullRequestTracker()
+        public PullRequestTracker(SecretClient secretClient)
         {
+            this.secretClient = secretClient;
+        }
+
+        private const string ConnectionStringSecretName = "table-storage-connection-string";
+        private const string PullRequestStateTableName = "pullrequests";
+        private object tableClientLock = new object();
+        private TableClient tableClient;
+
+        private TableClient GetTableClient()
+        {
+            if (tableClient == null)
+            {
+                lock (tableClientLock)
+                {
+                    if (tableClient == null)
+                    {
+                        KeyVaultSecret secret = secretClient.GetSecret(ConnectionStringSecretName);
+                        var connectionString = secret.Value;
+
+                        tableClient = new TableClient(connectionString, PullRequestStateTableName);
+                    }
+                }
+            }
+
+            return tableClient;
         }
 
         public async Task StartTrackingPullRequestAsync(PullRequestTrackingTicket pullRequestTrackingTicket)
         {
-            pullRequestTrackingTickets.Add(pullRequestTrackingTicket);
+            var tableClient = GetTableClient();
+            await tableClient.UpsertEntityAsync<PullRequestTrackingTicket>(pullRequestTrackingTicket, TableUpdateMode.Replace);
         }
 
         public async Task StopTrackingPullRequestAsync(PullRequestTrackingTicket pullRequestTrackingTicket)
         {
-            pullRequestTrackingTickets.RemoveAll((ticket) =>
-            {
-                return
-                    ticket.InstallationId == pullRequestTrackingTicket.InstallationId &&
-                    ticket.RepositoryId == pullRequestTrackingTicket.RepositoryId &&
-                    ticket.PullRequestNumber == pullRequestTrackingTicket.PullRequestNumber;
-            });
+            var tableClient = GetTableClient();
+            await tableClient.DeleteEntityAsync(pullRequestTrackingTicket.PartitionKey, pullRequestTrackingTicket.RowKey);
         }
 
         public async Task<IEnumerable<PullRequestTrackingTicket>> GetTrackedPullRequestsAsync()
         {
-            return pullRequestTrackingTickets.ToImmutableList();
+            var tableClient = GetTableClient();
+            var pagable = tableClient.QueryAsync<PullRequestTrackingTicket>();
+            var tickets = new List<PullRequestTrackingTicket>();
+
+            await foreach (var ticket in pagable)
+            {
+                tickets.Add(ticket);
+            }
+
+            return tickets;
         }
     }
 }

--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/PullRequestTrackingTicket.cs
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Services/PullRequestTracking/PullRequestTrackingTicket.cs
@@ -1,13 +1,31 @@
-﻿using System;
+﻿using Azure.Data.Tables;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
 namespace Azure.Sdk.Tools.CheckEnforcer.Services.PullRequestTracking
 {
-    public class PullRequestTrackingTicket
+    public class PullRequestTrackingTicket : ITableEntity
     {
+        public PullRequestTrackingTicket()
+        {
+        }
+
+        public PullRequestTrackingTicket(long installationId, long repositoryId, int pullRequestNumber)
+        {
+            this.InstallationId = installationId;
+            this.RepositoryId = repositoryId;
+            this.PullRequestNumber = pullRequestNumber;
+            this.PartitionKey = $"{installationId}.{repositoryId}";
+            this.RowKey = $"{this.PartitionKey}.{pullRequestNumber}";
+        }
+
         public long InstallationId { get; set; }
         public long RepositoryId { get; set; }
         public int PullRequestNumber { get; set;  }
+        public string PartitionKey { get; set; }
+        public string RowKey { get; set; }
+        public DateTimeOffset? Timestamp { get; set; }
+        public ETag ETag { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds non-volatile state tracking to Check Enforcer. This replaces the existing in-memory implementation. The overall design of this is that we should be able to drain the list of pull requests that are being tracked in this storage pretty quickly.