### PR TITLE
Update subscription configuration schema to include new parameters

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -59,7 +59,10 @@ param (
     [string] $Environment = 'AzureCloud',
 
     [Parameter()]
-    [hashtable] $AdditionalParameters,
+    [hashtable] $ArmTemplateParameters,
+
+    [Parameter()]
+    [hashtable] $EnvironmentVariables,
 
     [Parameter()]
     [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
@@ -322,11 +325,11 @@ if ($TenantId) {
 if ($TestApplicationSecret) {
     $templateParameters.Add('testApplicationSecret', $TestApplicationSecret)
 }
-if ($AdditionalParameters) {
-    $templateParameters += $AdditionalParameters
+if ($ArmTemplateParameters) {
+    $templateParameters += $ArmTemplateParameters
 }
 
-# Include environment-specific parameters only if not already provided as part of the "AdditionalParameters"
+# Include environment-specific parameters only if not already provided as part of the "ArmTemplateParameters"
 if (($context.Environment.StorageEndpointSuffix) -and (-not ($templateParameters.ContainsKey('storageEndpointSuffix')))) {
     $templateParameters.Add('storageEndpointSuffix', $context.Environment.StorageEndpointSuffix)
 }
@@ -570,8 +573,11 @@ is based on the cloud to which the template is being deployed:
 Name of the cloud environment. The default is the Azure Public Cloud
 ('AzureCloud')
 
-.PARAMETER AdditionalParameters
+.PARAMETER ArmTemplateParameters
 Optional key-value pairs of parameters to pass to the ARM template(s).
+
+.PARAMETER EnvironmentVariables
+Optional key-value pairs of parameters to set as environment variables to the shell.
 
 .PARAMETER CI
 Indicates the script is run as part of a Continuous Integration / Continuous

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -65,7 +65,7 @@ param (
     [hashtable] $AdditionalParameters,
 
     [Parameter()]
-    [ValidateNotNullOrEmpty()]
+    [ValidateNotNull()]
     [hashtable] $EnvironmentVariables = @{},
 
     [Parameter()]

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -331,8 +331,8 @@ if ($TestApplicationSecret) {
 if ($ArmTemplateParameters) {
     $templateParameters += $ArmTemplateParameters
 }
-if ($AdditionalParameters) {
-    $templateParameters += $AdditionalParameters
+foreach ($key in $AdditionalParameters.Keys) {
+  $templateParameters[$key] = $AdditionalParameters[$key]
 }
 
 # Include environment-specific parameters only if not already provided as part of the "ArmTemplateParameters"
@@ -397,8 +397,8 @@ foreach ($templateFile in $templateFiles) {
         "$($serviceDirectoryPrefix)STORAGE_ENDPOINT_SUFFIX" = $context.Environment.StorageEndpointSuffix;
     }
 
-    foreach ($ev in $EnvironmentVariables) {
-        $deploymentOutputs[$ev.Name] = $ev.Value
+    foreach ($key in $EnvironmentVariables.Keys) {
+        $deploymentOutputs.Add($key, $EnvironmentVariables[$key])
     }
 
     foreach ($key in $deployment.Outputs.Keys) {

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -65,7 +65,8 @@ param (
     [hashtable] $AdditionalParameters,
 
     [Parameter()]
-    [hashtable] $EnvironmentVariables,
+    [ValidateNotNullOrEmpty()]
+    [hashtable] $EnvironmentVariables = @{},
 
     [Parameter()]
     [switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID),
@@ -124,7 +125,6 @@ $repositoryRoot = "$PSScriptRoot/../../.." | Resolve-Path
 $root = [System.IO.Path]::Combine($repositoryRoot, "sdk", $ServiceDirectory) | Resolve-Path
 $templateFileName = 'test-resources.json'
 $templateFiles = @()
-$outputEnvironmentVariables = @{}
 # Azure SDK Developer Playground
 $defaultSubscription = "faa080af-c1d8-40ad-9cce-e1a450ca5b57"
 
@@ -295,7 +295,7 @@ if ($CI) {
     # Set the resource group name variable.
     Write-Host "Setting variable 'AZURE_RESOURCEGROUP_NAME': $ResourceGroupName"
     Write-Host "##vso[task.setvariable variable=AZURE_RESOURCEGROUP_NAME;]$ResourceGroupName"
-    $outputEnvironmentVariables['AZURE_RESOURCEGROUP_NAME'] = $ResourceGroupName
+    $EnvironmentVariables['AZURE_RESOURCEGROUP_NAME'] = $ResourceGroupName
 }
 
 Log "Creating resource group '$ResourceGroupName' in location '$Location'"
@@ -435,7 +435,7 @@ foreach ($templateFile in $templateFiles) {
 
         foreach ($key in $deploymentOutputs.Keys) {
             $value = $deploymentOutputs[$key]
-            $outputEnvironmentVariables[$key] = $value
+            $EnvironmentVariables[$key] = $value
 
             if ($CI) {
                 # Treat all ARM template output variables as secrets since "SecureString" variables do not set values.
@@ -466,7 +466,7 @@ $exitActions.Invoke()
 
 # Suppress output locally
 if ($CI) {
-    return $outputEnvironmentVariables
+    return $EnvironmentVariables
 }
 
 <#

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -647,6 +647,4 @@ Run this in an Azure DevOps CI (with approrpiate variables configured) before
 executing live tests. The script will output variables as secrets (to enable
 log redaction).
 
-.LINK
-Remove-TestResources.ps1
 #>

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -108,7 +108,7 @@ function Retry([scriptblock] $Action, [int] $Attempts = 5) {
     }
 }
 
-function MergeHashes([System.Collections.HashTable] $source, [psvariable] $dest) {
+function MergeHashes([hashtable] $source, [psvariable] $dest) {
     foreach ($key in $source.Keys) {
         if ($dest.Value[$key]) {
             Write-Warning ("Overwriting '$($dest.Name).$($key)' with value '$($dest.Value[$key])' " +
@@ -338,8 +338,9 @@ if ($TenantId) {
 if ($TestApplicationSecret) {
     $templateParameters.Add('testApplicationSecret', $TestApplicationSecret)
 }
-MergeHashes($ArmTemplateParameters, $(Get-Variable $templateParameters))
-MergeHashes($AdditionalParameters, $(Get-Variable $templateParameters))
+
+MergeHashes $ArmTemplateParameters $(Get-Variable templateParameters)
+MergeHashes $AdditionalParameters $(Get-Variable templateParameters)
 
 # Include environment-specific parameters only if not already provided as part of the "ArmTemplateParameters"
 if (($context.Environment.StorageEndpointSuffix) -and (-not ($templateParameters.ContainsKey('storageEndpointSuffix')))) {
@@ -403,7 +404,7 @@ foreach ($templateFile in $templateFiles) {
         "$($serviceDirectoryPrefix)STORAGE_ENDPOINT_SUFFIX" = $context.Environment.StorageEndpointSuffix;
     }
 
-    MergeHashes($EnvironmentVariables, $(Get-Variable $deploymentOutputs))
+    MergeHashes $EnvironmentVariables $(Get-Variable deploymentOutputs)
 
     foreach ($key in $deployment.Outputs.Keys) {
         $variable = $deployment.Outputs[$key]

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -10,7 +10,7 @@
 
 [CmdletBinding(DefaultParameterSetName = 'Default', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
 param (
-    # Limit $BaseName to enough characters to be under limit plus prefixes, and https://docs.microsoft.com/azure/architecture/best-practices/resource-naming.
+    # Limit $BaseName to enough characters to be under limit plus prefixes, and https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
     [Parameter()]
     [ValidatePattern('^[-a-zA-Z0-9\.\(\)_]{0,80}(?<=[a-zA-Z0-9\(\)])$')]
     [string] $BaseName,
@@ -110,7 +110,7 @@ function Retry([scriptblock] $Action, [int] $Attempts = 5) {
 
 function MergeHashes([hashtable] $source, [psvariable] $dest) {
     foreach ($key in $source.Keys) {
-        if ($dest.Value[$key]) {
+        if ($dest.Value.ContainsKey($key) -and $dest.Value[$key] -ne $source[$key]) {
             Write-Warning ("Overwriting '$($dest.Name).$($key)' with value '$($dest.Value[$key])' " +
                           "to new value '$($source[$key])'")
         }
@@ -305,6 +305,12 @@ if ($CI) {
     # Set the resource group name variable.
     Write-Host "Setting variable 'AZURE_RESOURCEGROUP_NAME': $ResourceGroupName"
     Write-Host "##vso[task.setvariable variable=AZURE_RESOURCEGROUP_NAME;]$ResourceGroupName"
+    if ($EnvironmentVariables.ContainsKey('AZURE_RESOURCEGROUP_NAME') -and `
+        $EnvironmentVariables['AZURE_RESOURCEGROUP_NAME'] -ne $ResourceGroupName)
+    {
+        Write-Warning ("Overwriting 'EnvironmentVariables.AZURE_RESOURCEGROUP_NAME' with value " + 
+            "'$($EnvironmentVariables['AZURE_RESOURCEGROUP_NAME'])' " + "to new value '$($ResourceGroupName)'")
+    }
     $EnvironmentVariables['AZURE_RESOURCEGROUP_NAME'] = $ResourceGroupName
 }
 

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -16,8 +16,9 @@ Deploys live test resources defined for a service directory to Azure.
 ```
 New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-ServiceDirectory] <String>
  [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
- [-DeleteAfterHours <Int32>] [-Location <String>] [-Environment <String>] [-AdditionalParameters <Hashtable>]
- [-CI] [-Force] [-OutFile] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-DeleteAfterHours <Int32>] [-Location <String>] [-Environment <String>] [-ArmTemplateParameters <Hashtable>]
+ [-AdditionalParameters <Hashtable>] [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile] [-WhatIf]
+ [-Confirm] [<CommonParameters>]
 ```
 
 ### Provisioner
@@ -26,8 +27,8 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
  [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
  -TenantId <String> [-SubscriptionId <String>] -ProvisionerApplicationId <String>
  -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>] [-Location <String>]
- [-Environment <String>] [-AdditionalParameters <Hashtable>] [-CI] [-Force] [-OutFile] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-Environment <String>] [-ArmTemplateParameters <Hashtable>] [-AdditionalParameters <Hashtable>]
+ [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -339,7 +340,7 @@ Accept wildcard characters: False
 ### -Environment
 Name of the cloud environment.
 The default is the Azure Public Cloud
-('PublicCloud')
+('AzureCloud')
 
 ```yaml
 Type: String
@@ -353,8 +354,38 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -AdditionalParameters
+### -ArmTemplateParameters
 Optional key-value pairs of parameters to pass to the ARM template(s).
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -AdditionalParameters
+Optional key-value pairs of parameters to pass to the ARM template(s) and pre-post scripts.
+
+```yaml
+Type: Hashtable
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -EnvironmentVariables
+Optional key-value pairs of parameters to set as environment variables to the shell.
 
 ```yaml
 Type: Hashtable
@@ -449,7 +480,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -458,3 +489,6 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
+
+[Remove-TestResources.ps1]()
+

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -394,7 +394,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: None
+Default value: @{}
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -480,7 +480,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 
@@ -489,6 +489,3 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## NOTES
 
 ## RELATED LINKS
-
-[Remove-TestResources.ps1]()
-

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -214,6 +214,4 @@ Remove-TestResources.ps1 `
 When run in the context of an Azure DevOps pipeline, this script removes the
 resource group whose name is stored in the environment variable
 AZURE_RESOURCEGROUP_NAME.
-.LINK
-New-TestResources.ps1
 #>

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -1,9 +1,11 @@
 parameters:
   ServiceDirectory: not-set
-  ArmTemplateParameters: '@{}'
+  ArmTemplateParameters: '$subscriptionConfiguration.ArmTemplateParameters'
+  PlatformArmTemplateParameters: ''
   DeleteAfterHours: 24
   Location: ''
   SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+  Platform: ''
 
 # SubscriptionConfiguration will be splat into the parameters of the test
 # resources script. It should be JSON in the form:
@@ -38,35 +40,40 @@ steps:
   - pwsh: |
       eng/common/TestResources/Import-AzModules.ps1
 
-      $subscriptionConfiguration = @"
+      $subscriptionConfiguration = @'
         ${{ parameters.SubscriptionConfiguration }}
-      "@ | ConvertFrom-Json -AsHashtable;
+      '@ | ConvertFrom-Json -AsHashtable;
 
-      if ($subscriptionConfiguration.ArmTemplateParameters) {
-        # Handle subscription configuration containing arm template parameters
-        $armTemplateParameters = $subscriptionConfiguration.ArmTemplateParameters
-      } else {
-        # Handle legacy subscription configuration, with arm template params passed in by templates
-        $armTemplateParameters = ${{ parameters.ArmTemplateParameters }}
-      }
+      # Support legacy ArmTemplateParameters passed in directly as a hashmap, otherwise default to subscriptionConfiguration JSON.
+      #   Example legacy input: @{ 'param1' = 'foo' ; 'param2' = 'bar' }
+      $subscriptionConfiguration.ArmTemplateParameters = ${{ parameters.ArmTemplateParameters }} ? ${{ parameters.ArmTemplateParameters }} : @{}
 
-      $accessParameters = @{
-        "SubscriptionId" = $subscriptionConfiguration.SubscriptionId;
-        "TenantId" = $subscriptionConfiguration.TenantId;
-        "TestApplicationId" = $subscriptionConfiguration.TestApplicationId;
-        "TestApplicationSecret" = $subscriptionConfiguration.TestApplicationSecret;
-        "ProvisionerApplicationId" = $subscriptionConfiguration.ProvisionerApplicationId;
-        "ProvisionerApplicationSecret" = $subscriptionConfiguration.ProvisionerApplicationSecret;
-        "Environment" = $subscriptionConfiguration.Environment
+      # Support additional sdk pipeline and/or platform specific arm template parameters:
+      #   EnableHsm:
+      #     Value: true
+      #     Platforms:
+      #       - Linux_NetCore_Keyring
+      #   TestGlobalParam:
+      #     Value: global foo
+      # For duplicate keys, prefer the template/script parameter.
+      $platformArmTemplateParameters = @'
+        ${{ parameters.PlatformArmTemplateParameters }}
+      '@ | ConvertFrom-Json -AsHashtable;
+
+      if ($platformArmTemplateParameters) {
+        foreach ($p in $platformArmTemplateParameters.GetEnumerator()) {
+          if (!$p.Value.Platforms -or '${{ parameters.Platform }}' -in $p.Value.Platforms) {
+            $subscriptionConfiguration.ArmTemplateParameters[$p.Name] = $p.Value.Value
+          }
+        }
       }
 
       eng/common/TestResources/New-TestResources.ps1 `
         -BaseName 'Generated' `
-        -ServiceDirectory ${{ parameters.ServiceDirectory }} `
+        -ServiceDirectory '${{ parameters.ServiceDirectory }}' `
         -Location '${{ parameters.Location }}' `
-        -DeleteAfterHours ${{ parameters.DeleteAfterHours }} `
-        -AdditionalParameters $armTemplateParameters `
-        @accessParameters `
+        -DeleteAfterHours '${{ parameters.DeleteAfterHours }}' `
+        @subscriptionConfiguration `
         -CI `
         -Force `
         -Verbose | Out-Null

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -15,7 +15,22 @@ parameters:
 #   "ProvisionerApplicationId": "<provisioner app id>",
 #   "ProvisionerApplicationSecret": "<provisioner app secret>",
 #   "Environment": "AzureCloud | AzureGov | AzureChina | <other environment>"
+#   "EnvironmentVariables": {
+#       "SERVICE_MANAGEMENT_URL": "<service management url>",
+#       "STORAGE_ENDPOINT_SUFFIX": "<storage endpoint suffix>",
+#       "RESOURCE_MANAGER_URL": "<resource manager url>",
+#       "SEARCH_ENDPOINT_SUFFIX": "<search endpoint suffix>",
+#       "COSMOS_TABLES_ENDPOINT_SUFFIX": "<cosmos tables endpoint suffix>"
+#   },
+#   "ArmTemplateParameters": {
+#       "keyVaultDomainSuffix": "<keyVaultDomainSuffix>",
+#       "storageEndpointSuffix": "<storageEndpointSuffix>",
+#       "endpointSuffix": "<endpointSuffix>",
+#       "azureAuthorityHost": "<azureAuthorityHost>",
+#       "keyVaultEndpointSuffix": "<keyVaultEndpointSuffix>"
+#   }
 # }
+
 
 steps:
   - template: /eng/common/TestResources/setup-az-modules.yml
@@ -27,13 +42,31 @@ steps:
         ${{ parameters.SubscriptionConfiguration }}
       "@ | ConvertFrom-Json -AsHashtable;
 
+      if ($subscriptionConfiguration.ArmTemplateParameters) {
+        # Handle subscription configuration containing arm template parameters
+        $armTemplateParameters = $subscriptionConfiguration.ArmTemplateParameters
+      } else {
+        # Handle legacy subscription configuration, with arm template params passed in by templates
+        $armTemplateParameters = ${{ parameters.ArmTemplateParameters }}
+      }
+
+      $accessParameters = @{
+        "SubscriptionId" = $subscriptionConfiguration.SubscriptionId;
+        "TenantId" = $subscriptionConfiguration.TenantId;
+        "TestApplicationId" = $subscriptionConfiguration.TestApplicationId;
+        "TestApplicationSecret" = $subscriptionConfiguration.TestApplicationSecret;
+        "ProvisionerApplicationId" = $subscriptionConfiguration.ProvisionerApplicationId;
+        "ProvisionerApplicationSecret" = $subscriptionConfiguration.ProvisionerApplicationSecret;
+        "Environment" = $subscriptionConfiguration.Environment
+      }
+
       eng/common/TestResources/New-TestResources.ps1 `
         -BaseName 'Generated' `
         -ServiceDirectory ${{ parameters.ServiceDirectory }} `
         -Location '${{ parameters.Location }}' `
         -DeleteAfterHours ${{ parameters.DeleteAfterHours }} `
-        -AdditionalParameters ${{ parameters.ArmTemplateParameters }} `
-        @subscriptionConfiguration `
+        -AdditionalParameters $armTemplateParameters `
+        @accessParameters `
         -CI `
         -Force `
         -Verbose | Out-Null

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -49,12 +49,13 @@ steps:
       $subscriptionConfiguration.ArmTemplateParameters = ${{ parameters.ArmTemplateParameters }} ? ${{ parameters.ArmTemplateParameters }} : @{}
 
       # Support additional sdk pipeline and/or platform specific arm template parameters:
-      #   EnableHsm:
-      #     Value: true
-      #     Platforms:
-      #       - Linux_NetCore_Keyring
-      #   TestGlobalParam:
-      #     Value: global foo
+      #   ArmTemplateParameters:
+      #     EnableHsm:
+      #       Value: true
+      #       Platforms:
+      #         - Linux_NetCore_Keyring
+      #     TestGlobalParam:
+      #       Value: global foo
       # For duplicate keys, prefer the template/script parameter.
       $platformArmTemplateParameters = @'
         ${{ parameters.PlatformArmTemplateParameters }}

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -1,13 +1,11 @@
 parameters:
   ServiceDirectory: not-set
-  ArmTemplateParameters: '$subscriptionConfiguration.ArmTemplateParameters'
-  PlatformArmTemplateParameters: ''
+  ArmTemplateParameters: '@{}'
   DeleteAfterHours: 24
   Location: ''
   SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
-  Platform: ''
 
-# SubscriptionConfiguration will be splat into the parameters of the test
+# SubscriptionConfiguration will be splatted into the parameters of the test
 # resources script. It should be JSON in the form:
 # {
 #   "SubscriptionId": "<subscription id>",
@@ -44,29 +42,13 @@ steps:
         ${{ parameters.SubscriptionConfiguration }}
       '@ | ConvertFrom-Json -AsHashtable;
 
-      # Support legacy ArmTemplateParameters passed in directly as a hashmap, otherwise default to subscriptionConfiguration JSON.
-      #   Example legacy input: @{ 'param1' = 'foo' ; 'param2' = 'bar' }
-      $subscriptionConfiguration.ArmTemplateParameters = ${{ parameters.ArmTemplateParameters }} ? ${{ parameters.ArmTemplateParameters }} : @{}
+      if (!$subscriptionConfiguration.ArmTemplateParameters) {
+        $subscriptionConfiguration.ArmTemplateParameters = @{}
+      }
 
-      # Support additional sdk pipeline and/or platform specific arm template parameters:
-      #   ArmTemplateParameters:
-      #     EnableHsm:
-      #       Value: true
-      #       Platforms:
-      #         - Linux_NetCore_Keyring
-      #     TestGlobalParam:
-      #       Value: global foo
-      # For duplicate keys, prefer the template/script parameter.
-      $platformArmTemplateParameters = @'
-        ${{ parameters.PlatformArmTemplateParameters }}
-      '@ | ConvertFrom-Json -AsHashtable;
-
-      if ($platformArmTemplateParameters) {
-        foreach ($p in $platformArmTemplateParameters.GetEnumerator()) {
-          if (!$p.Value.Platforms -or '${{ parameters.Platform }}' -in $p.Value.Platforms) {
-            $subscriptionConfiguration.ArmTemplateParameters[$p.Name] = $p.Value.Value
-          }
-        }
+      $armTemplateParameters = ${{ parameters.ArmTemplateParameters }}
+      foreach ($p in $armTemplateParameters.GetEnumerator()) {
+        $subscriptionConfiguration.ArmTemplateParameters[$p.Name] = $p.Value
       }
 
       eng/common/TestResources/New-TestResources.ps1 `

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -42,21 +42,16 @@ steps:
         ${{ parameters.SubscriptionConfiguration }}
       '@ | ConvertFrom-Json -AsHashtable;
 
-      if (!$subscriptionConfiguration.ArmTemplateParameters) {
-        $subscriptionConfiguration.ArmTemplateParameters = @{}
-      }
-
-      $armTemplateParameters = ${{ parameters.ArmTemplateParameters }}
-      foreach ($key in $armTemplateParameters.Keys) {
-        $subscriptionConfiguration.ArmTemplateParameters[$key] = $armTemplateParameters[$key]
-      }
-
+      # The subscriptionConfiguration may have ArmTemplateParameters defined, so
+      # pass those in via the ArmTemplateParameters flag, and handle any
+      # additional parameters from the pipelines via AdditionalParameters
       eng/common/TestResources/New-TestResources.ps1 `
         -BaseName 'Generated' `
         -ServiceDirectory '${{ parameters.ServiceDirectory }}' `
         -Location '${{ parameters.Location }}' `
         -DeleteAfterHours '${{ parameters.DeleteAfterHours }}' `
         @subscriptionConfiguration `
+        -AdditionalParameters ${{ parameters.ArmTemplateParameters }} `
         -CI `
         -Force `
         -Verbose | Out-Null

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -47,8 +47,8 @@ steps:
       }
 
       $armTemplateParameters = ${{ parameters.ArmTemplateParameters }}
-      foreach ($p in $armTemplateParameters.GetEnumerator()) {
-        $subscriptionConfiguration.ArmTemplateParameters[$p.Name] = $p.Value
+      foreach ($key in $armTemplateParameters.Keys) {
+        $subscriptionConfiguration.ArmTemplateParameters[$key] = $armTemplateParameters[$key]
       }
 
       eng/common/TestResources/New-TestResources.ps1 `


### PR DESCRIPTION
This change simplifies cloud configurations in our live test pipelines. Currently these parameters get defined per cloud in the live test template, which ends up creating a large, verbose configuration. To simplify these definitions, I'd like to move them into the subscription configuration. The resulting template usage becomes more like:

```
- name: CloudConfig
  type: object
  default:
    Public:
      SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
    Preview:
      SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
    Canary:
      SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources-preview)
      Location: 'eastus2euap'                                                                                                                                                                                                                                                                UsGov:
      SubscriptionConfiguration: $(sub-config-gov-test-resources)
    China:
      SubscriptionConfiguration: $(sub-config-cn-test-resources)
```

This change will require an update to the above 4 subscription configurations. The script change handles both the old and new data structure.

Passing live test referencing the new configuration: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=600922&view=logs&j=bbd7d436-e05d-51a8-99a8-0701dc9dffeb&t=20f065cd-bf8b-5b9d-5626-dd2113fcfcf1

Passing live test referencing the old configuration: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=600932&view=results
