### PR TITLE
[APIView] Java improvements to APIView

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -351,13 +351,13 @@ public class ASTAnalyser implements Analyser {
                         addToken(new Token(KEYWORD, "transitive"), SPACE);
                     }
 
-                    addToken(new Token(TYPE_NAME, d.getNameAsString(), makeId(MODULE_INFO_KEY + "-" + d.getNameAsString())));
+                    addToken(new Token(TYPE_NAME, d.getNameAsString(), makeId(MODULE_INFO_KEY + "-requires-" + d.getNameAsString())));
                     addToken(new Token(PUNCTUATION, ";"), NEWLINE);
                 });
 
                 moduleDirective.ifModuleExportsStmt(d -> {
                     addToken(new Token(KEYWORD, "exports"), SPACE);
-                    addToken(new Token(TYPE_NAME, d.getNameAsString(), makeId(MODULE_INFO_KEY + "-" + d.getNameAsString())));
+                    addToken(new Token(TYPE_NAME, d.getNameAsString(), makeId(MODULE_INFO_KEY + "-exports-" + d.getNameAsString())));
 
                     NodeList<Name> names = d.getModuleNames();
 
@@ -379,7 +379,7 @@ public class ASTAnalyser implements Analyser {
 
                 moduleDirective.ifModuleOpensStmt(d -> {
                     addToken(new Token(KEYWORD, "opens"), SPACE);
-                    addToken(new Token(TYPE_NAME, d.getNameAsString(), makeId(MODULE_INFO_KEY + "-" + d.getNameAsString())));
+                    addToken(new Token(TYPE_NAME, d.getNameAsString(), makeId(MODULE_INFO_KEY + "-opens-" + d.getNameAsString())));
 
                     NodeList<Name> names = d.getModuleNames();
                     if (names.size() > 0) {
@@ -400,13 +400,13 @@ public class ASTAnalyser implements Analyser {
 
                 moduleDirective.ifModuleUsesStmt(d -> {
                     addToken(new Token(KEYWORD, "uses"), SPACE);
-                    addToken(new Token(TYPE_NAME, d.getNameAsString(), makeId(MODULE_INFO_KEY + "-" + d.getNameAsString())));
+                    addToken(new Token(TYPE_NAME, d.getNameAsString(), makeId(MODULE_INFO_KEY + "-uses-" + d.getNameAsString())));
                     addToken(new Token(PUNCTUATION, ";"), NEWLINE);
                 });
 
                 moduleDirective.ifModuleProvidesStmt(d -> {
                     addToken(new Token(KEYWORD, "provides"), SPACE);
-                    addToken(new Token(TYPE_NAME, d.getNameAsString(), makeId(MODULE_INFO_KEY + "-" + d.getNameAsString())), SPACE);
+                    addToken(new Token(TYPE_NAME, d.getNameAsString(), makeId(MODULE_INFO_KEY + "-provides-" + d.getNameAsString())), SPACE);
                     addToken(new Token(KEYWORD, "with"), SPACE);
 
                     NodeList<Name> names = d.getWith();

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/DiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/DiagnosticRule.java
@@ -4,5 +4,9 @@ import com.azure.tools.apiview.processor.model.APIListing;
 import com.github.javaparser.ast.CompilationUnit;
 
 public interface DiagnosticRule {
-    void scan(CompilationUnit cu, APIListing listing);
+    void scanIndividual(CompilationUnit cu, APIListing listing);
+
+    default void scanFinal(APIListing listing) {
+        // no-op (not all diagnostics care about doing a final scan)
+    }
 }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
@@ -25,8 +25,9 @@ import static com.azure.tools.apiview.processor.diagnostics.rules.RequiredBuilde
 import static com.azure.tools.apiview.processor.diagnostics.rules.IllegalMethodNamesDiagnosticRule.Rule;
 
 public class Diagnostics {
-    private static final List<DiagnosticRule> diagnostics = new ArrayList<>();
-    static {
+    private final List<DiagnosticRule> diagnostics = new ArrayList<>();
+
+    public Diagnostics() {
         diagnostics.add(new PackageNameDiagnosticRule());
         diagnostics.add(new ImportsDiagnosticRule("com.sun"));
         diagnostics.add(new IllegalPackageAPIExportsDiagnosticRule("implementation", "netty"));
@@ -63,13 +64,21 @@ public class Diagnostics {
             .add("retryPolicy", new ExactTypeNameCheckFunction("RetryPolicy")));
     }
 
-    public static void scan(CompilationUnit cu, APIListing listing) {
+    /**
+     * Runs any diagnostics that can be run against the single compilation unit that has been provided.
+     */
+    public void scanIndividual(CompilationUnit cu, APIListing listing) {
         // We do not scan compilation units that are missing any primary type (i.e. they are completely commented out).
         if (! cu.getPrimaryType().isPresent()) {
             return;
         }
-        for (DiagnosticRule rule : diagnostics) {
-            rule.scan(cu, listing);
-        }
+        diagnostics.forEach(rule -> rule.scanIndividual(cu, listing));
+    }
+
+    /**
+     * Called once to allow for any full analysis to be performed after all individual scans have been completed.
+     */
+    public void scanFinal(APIListing listing) {
+        diagnostics.forEach(rule -> rule.scanFinal(listing));
     }
 }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ConsiderFinalClassDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ConsiderFinalClassDiagnosticRule.java
@@ -5,29 +5,55 @@ import com.azure.tools.apiview.processor.model.APIListing;
 import com.azure.tools.apiview.processor.model.Diagnostic;
 import com.github.javaparser.ast.CompilationUnit;
 import com.github.javaparser.ast.Modifier;
+import com.github.javaparser.ast.body.TypeDeclaration;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
 
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
 
 import static com.azure.tools.apiview.processor.model.DiagnosticKind.*;
 
 public class ConsiderFinalClassDiagnosticRule implements DiagnosticRule {
+    private final List<TypeDeclaration<?>> nonFinalTypes = new ArrayList<>();
+    private final Set<String> knownParentClasses = new TreeSet<>(String::compareTo);
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
-        // TODO we would ideally delay this diagnostic until we have completed analysing, so that we can look up
-        // to see if any other types extend from this particular compilation unit. At present we somewhat embarrasingly
-        // tell people to consider final for types that are extended in the same library.
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         cu.getTypes().forEach(type -> {
             if (type.isEnumDeclaration()) return;
             if (type.hasModifier(Modifier.Keyword.ABSTRACT)) return;
             if (type.isClassOrInterfaceDeclaration() && type.asClassOrInterfaceDeclaration().isInterface()) return;
             if (type.isAnnotationDeclaration()) return;
+
+            // if we are here we are looking at a type we are interested in tracking.
+            // for the type we are looking at, we check to see if it is a final type...
             if (!type.hasModifier(Modifier.Keyword.FINAL)) {
-                listing.addDiagnostic(new Diagnostic(
-                    INFO,
-                    makeId(type),
-                    "Consider making all classes final by default - only make non-final if subclassing is supported."));
+                nonFinalTypes.add(type);
             }
+
+            // and we also care whether this type extends any other type, because for each of those types we extend,
+            // they obvious cannot be final and therefore we shouldn't include an error message about that type.
+            type.asClassOrInterfaceDeclaration().getExtendedTypes().forEach(parentType -> {
+                knownParentClasses.add(parentType.getNameAsString());
+            });
         });
+    }
+
+    @Override
+    public void scanFinal(final APIListing listing) {
+        for (final TypeDeclaration<?> type : nonFinalTypes) {
+            final String name = type.getNameAsString();
+            if (!knownParentClasses.contains(name)) {
+                listing.addDiagnostic(new Diagnostic(
+                        INFO,
+                        makeId(type),
+                        "Consider making all classes final by default - only make non-final if subclassing is supported."));
+            }
+        }
     }
 }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/FluentSetterReturnTypeDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/FluentSetterReturnTypeDiagnosticRule.java
@@ -17,7 +17,7 @@ public class FluentSetterReturnTypeDiagnosticRule implements DiagnosticRule {
     }
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         cu.getTypes().forEach(type -> {
             type.getAnnotationByName("Fluent").ifPresent(a -> processFluentType(type, listing));
         });

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/IllegalMethodNamesDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/IllegalMethodNamesDiagnosticRule.java
@@ -26,7 +26,7 @@ public class IllegalMethodNamesDiagnosticRule implements DiagnosticRule {
     }
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         getClassName(cu).ifPresent(className ->
             getPublicOrProtectedMethods(cu).forEach(method -> {
                 final String methodName = method.getNameAsString();

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/IllegalPackageAPIExportsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/IllegalPackageAPIExportsDiagnosticRule.java
@@ -30,7 +30,7 @@ public class IllegalPackageAPIExportsDiagnosticRule implements DiagnosticRule {
     }
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         getPublicOrProtectedConstructors(cu)
                 .forEach(methodDecl -> {
                     final String methodId = makeId(methodDecl);

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ImportsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ImportsDiagnosticRule.java
@@ -25,7 +25,7 @@ public class ImportsDiagnosticRule implements DiagnosticRule {
     }
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         // we need to map the issue to the class id, because import text isn't printed in the APIView output
         getClassName(cu).map(listing.getKnownTypes()::get).ifPresent(typeId -> {
             ASTUtils.getImports(cu).forEach(importStr -> {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingAnnotationsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingAnnotationsDiagnosticRule.java
@@ -16,7 +16,7 @@ import static com.azure.tools.apiview.processor.model.DiagnosticKind.*;
 public class MissingAnnotationsDiagnosticRule implements DiagnosticRule {
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         getClasses(cu).forEach(typeDeclaration -> {
             String className = typeDeclaration.getNameAsString();
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavaDocDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavaDocDiagnosticRule.java
@@ -17,7 +17,7 @@ public class MissingJavaDocDiagnosticRule implements DiagnosticRule {
     private static boolean IGNORE_OVERRIDES = true;
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         getClasses(cu).forEach(typeDeclaration -> {
             if (!typeDeclaration.hasJavaDocComment()) {
                 // the type is missing JavaDoc

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/NoPublicFieldsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/NoPublicFieldsDiagnosticRule.java
@@ -11,7 +11,7 @@ import static com.azure.tools.apiview.processor.model.DiagnosticKind.*;
 public class NoPublicFieldsDiagnosticRule implements DiagnosticRule {
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         getPublicOrProtectedFields(cu)
                 .filter(fieldDecl -> !fieldDecl.isStatic())
                 .forEach(fieldDecl -> {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/PackageNameDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/PackageNameDiagnosticRule.java
@@ -14,7 +14,7 @@ public class PackageNameDiagnosticRule implements DiagnosticRule {
     final static Pattern regex = Pattern.compile("^com.azure(\\.[a-z0-9]+)+$");
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         getPackageName(cu).ifPresent(packageName -> {
             // we need to map the issue to the class id, because package text isn't printed in the APIView output
             getClassName(cu).map(listing.getKnownTypes()::get).ifPresent(typeId -> {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/RequiredBuilderMethodsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/RequiredBuilderMethodsDiagnosticRule.java
@@ -48,7 +48,7 @@ public class RequiredBuilderMethodsDiagnosticRule implements DiagnosticRule {
     }
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         // check if the class has the @ServiceClientBuilder annotation, if not, do nothing
         getClasses(cu).forEach(typeDeclaration -> {
             if (typeDeclaration.isAnnotationPresent(BUILDER_ANNOTATION)) {
@@ -87,7 +87,7 @@ public class RequiredBuilderMethodsDiagnosticRule implements DiagnosticRule {
                     listing.addDiagnostic(new Diagnostic(
                             WARNING,
                             makeId(typeDeclaration),
-                            "Not all expected builder methods are present. The following methods were expected but not found: " + missingMethods,
+                            "This builder is missing common APIs. These are not required, but please consider if the following methods should exist: " + missingMethods,
                             "https://azure.github.io/azure-sdk/java_design.html#java-service-client-builder-consistency"));
                 }
             }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/UpperCaseNamingDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/UpperCaseNamingDiagnosticRule.java
@@ -24,7 +24,7 @@ public class UpperCaseNamingDiagnosticRule implements DiagnosticRule {
     }
 
     @Override
-    public void scan(final CompilationUnit cu, final APIListing listing) {
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         // check class name
         getClassName(cu).ifPresent(name -> check(name, makeId(cu), listing));
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/APIListing.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/APIListing.java
@@ -24,7 +24,7 @@ public class APIListing {
     @JsonProperty("PackageName")
     private String packageName;
 
-    @JsonProperty("PackageVersion")
+    @JsonIgnore//("PackageVersion")
     private String packageVersion;
 
     // This string is taken from here:

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/APIListing.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/APIListing.java
@@ -18,9 +18,14 @@ public class APIListing {
     @JsonProperty("Name")
     private String name;
 
-//    @JsonProperty("Language")
-    @JsonIgnore
+    @JsonProperty("Language")
     private String language;
+
+    @JsonProperty("PackageName")
+    private String packageName;
+
+    @JsonProperty("PackageVersion")
+    private String packageVersion;
 
     // This string is taken from here:
     // https://github.com/Azure/azure-sdk-tools/blob/master/src/dotnet/APIView/APIView/Languages/CodeFileBuilder.cs#L50
@@ -73,6 +78,22 @@ public class APIListing {
 
     public void setLanguage(final String language) {
         this.language = language;
+    }
+
+    public String getPackageName() {
+        return packageName;
+    }
+
+    public void setPackageName(final String packageName) {
+        this.packageName = packageName;
+    }
+
+    public String getPackageVersion() {
+        return packageVersion;
+    }
+
+    public void setPackageVersion(final String packageVersion) {
+        this.packageVersion = packageVersion;
     }
 
     public List<Token> getTokens() {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/APIListing.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/APIListing.java
@@ -30,7 +30,7 @@ public class APIListing {
     // This string is taken from here:
     // https://github.com/Azure/azure-sdk-tools/blob/master/src/dotnet/APIView/APIView/Languages/CodeFileBuilder.cs#L50
     @JsonProperty("VersionString")
-    private final String versionString = "18";
+    private final String versionString = "19";
 
     @JsonProperty("Tokens")
     private List<Token> tokens;


### PR DESCRIPTION
This PR contains improvements to the APIView tooling, including:

 * Fixing an issue where module-info was duplicating definition IDs
 * Adding extra review metadata to support upcoming improvements to APIView (language, package name, and package version).
 * Add support for a final end-run of diagnostics, after all files have been processed. This allows for other types of diagnostics where we need to know information about all of the types in the library. This has already been used in the subtype checking, so that we don't warn about missing 'final' keywords in places where there is a known subclass in the same library. 

This **should not** be merged until APIView is ready to work with the new metadata.