### PR TITLE
Fix to code-signing classifier.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CodeSigningFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CodeSigningFailureClassifier.cs
@@ -15,7 +15,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
                               where r.Result == TaskResult.Failed
                               where r.RecordType == "Task"
                               where r.Task != null
-                              where r.Task.Name == "ESRP Code Signing"
+                              where r.Task.Name == "EsrpCodeSigning"
                               where r.Log != null
                               select r;
 


### PR DESCRIPTION
I was using the display name for the code signing task not the task name itself, so it wasn't classifying correctly.