### PR TITLE
Refactor eng/common/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,38 +28,4 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 [![Azure DevOps builds](https://img.shields.io/azure-devops/build/azure-sdk/internal/1372?label=eng%2Fcommon%20sync)](https://dev.azure.com/azure-sdk/internal/_build/latest?definitionId=1372&branchName=master)
 
-## Common Engineering System
-
-The `eng/common` directory contains engineering files that are common across the various azure-sdk language repos.
-It should remain relatively small and only contain textual based files like scripts, configs, or templates. It
-should not contain binary files as they don't play well with git.
-
-### Code Structure
-
-To help keep the content of the `eng/common` directory as small as possible we should split the language specific parts of a common script out if possible.
-- Keep the language specific logic as a function in the `eng/scripts/Language-Settings.ps1` files found in each language repo.
-- Assign the function name to a variable in the `eng/common/scripts/common.ps1` file.
-- Call the function using the variable name like so `&$VariableName`.
-
-### Updating
-
-Any updates to files in the `eng/common` directory should be made in the [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) repo.
-All changes made will cause a PR to created in all subscribed azure-sdk language repos which will blindly replace all contents of
-the `eng/common` directory in that repo. For that reason do **NOT** make changes to files in this directory in the individual azure-sdk
-languages repos as they will be overwritten the next time an update is taken from the common azure-sdk-tools repo.
-
-### Workflow
-
-The 'Sync eng/common directory' PRs will be created in the language repositories when a pull request that touches the eng/common directory is submitted against the master branch. This will make it easier for changes to be tested in each individual language repo before merging the changes in the azure-sdk-tools repo. The workflow is explained below:
-
-1. Create a PR (**Tools PR**) in the `azure-sdk-tools` repo with changes to eng/common directory.
-2. `azure-sdk-tools - sync - eng-common` pipeline is triggered for the **Tools PR**
-3. The  `azure-sdk-tools - sync - eng-common` pipeline queues test runs for template pipelines in various languages. These help you test your changes in the **Tools PR**.
-4. If there are changes in the **Tools PR** that will affect the release stage you should approve the release test pipelines by clicking the approval gate. The test (template) pipeline will automatically release the next eligible version without needing manual intervention for the versioning. Please approve your test releases as quickly as possible. A race condition may occur due to someone else queueing the pipeline and going all the way to release using your version while yours is still waiting. If this occurs manually rerun the pipeline that failed.
-5.  If you make additional changes to your **Tools PR** repeat steps 1 - 4 until you have completed the necessary testing of your changes. This includes full releases of the template package, if necessary.
-6. Sign off on CreateSyncPRs stage of the sync pipeline using the approval gate. This stage will create the **Sync PRs** in the various language repos. A link to each of the **Sync PRs** will show up in the **Tools PR** for you to click and review.
-7. Go review and approve each of your **Sync PRs**.
-8. Sign Off on the VerifyAndMerge stage. This will merge any remaining open **Sync PR** and also append `auto-merge` to the **Tools PR**.
-   * If a **Sync PR** has any failing checks, it will need to be manually merged, even if `/check-enforcer override` has been run ([azure-sdk-tools#1147](https://github.com/Azure/azure-sdk-tools/issues/1147)).
-
 C:/repo/sdk-tools/packages/java-packages/snippet-replacer-maven-plugin

--- a/README.md
+++ b/README.md
@@ -28,4 +28,38 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 [![Azure DevOps builds](https://img.shields.io/azure-devops/build/azure-sdk/internal/1372?label=eng%2Fcommon%20sync)](https://dev.azure.com/azure-sdk/internal/_build/latest?definitionId=1372&branchName=master)
 
+## Common Engineering System
+
+The `eng/common` directory contains engineering files that are common across the various azure-sdk language repos.
+It should remain relatively small and only contain textual based files like scripts, configs, or templates. It
+should not contain binary files as they don't play well with git.
+
+### Code Structure
+
+To help keep the content of the `eng/common` directory as small as possible we should split the language specific parts of a common script out if possible.
+- Keep the language specific logic as a function in the `eng/scripts/Language-Settings.ps1` files found in each language repo.
+- Assign the function name to a variable in the `eng/common/scripts/common.ps1` file.
+- Call the function using the variable name like so `&$VariableName`.
+
+### Updating
+
+Any updates to files in the `eng/common` directory should be made in the [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) repo.
+All changes made will cause a PR to created in all subscribed azure-sdk language repos which will blindly replace all contents of
+the `eng/common` directory in that repo. For that reason do **NOT** make changes to files in this directory in the individual azure-sdk
+languages repos as they will be overwritten the next time an update is taken from the common azure-sdk-tools repo.
+
+### Workflow
+
+The 'Sync eng/common directory' PRs will be created in the language repositories when a pull request that touches the eng/common directory is submitted against the master branch. This will make it easier for changes to be tested in each individual language repo before merging the changes in the azure-sdk-tools repo. The workflow is explained below:
+
+1. Create a PR (**Tools PR**) in the `azure-sdk-tools` repo with changes to eng/common directory.
+2. `azure-sdk-tools - sync - eng-common` pipeline is triggered for the **Tools PR**
+3. The  `azure-sdk-tools - sync - eng-common` pipeline queues test runs for template pipelines in various languages. These help you test your changes in the **Tools PR**.
+4. If there are changes in the **Tools PR** that will affect the release stage you should approve the release test pipelines by clicking the approval gate. The test (template) pipeline will automatically release the next eligible version without needing manual intervention for the versioning. Please approve your test releases as quickly as possible. A race condition may occur due to someone else queueing the pipeline and going all the way to release using your version while yours is still waiting. If this occurs manually rerun the pipeline that failed.
+5.  If you make additional changes to your **Tools PR** repeat steps 1 - 4 until you have completed the necessary testing of your changes. This includes full releases of the template package, if necessary.
+6. Sign off on CreateSyncPRs stage of the sync pipeline using the approval gate. This stage will create the **Sync PRs** in the various language repos. A link to each of the **Sync PRs** will show up in the **Tools PR** for you to click and review.
+7. Go review and approve each of your **Sync PRs**.
+8. Sign Off on the VerifyAndMerge stage. This will merge any remaining open **Sync PR** and also append `auto-merge` to the **Tools PR**.
+   * If a **Sync PR** has any failing checks, it will need to be manually merged, even if `/check-enforcer override` has been run ([azure-sdk-tools#1147](https://github.com/Azure/azure-sdk-tools/issues/1147)).
+
 C:/repo/sdk-tools/packages/java-packages/snippet-replacer-maven-plugin

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,5 @@
+This folder contains some documentations for this repository.
+
+The folder structure is the following.
+
+- [common:](https://github.com/Azure/azure-sdk-tools/doc/common) contains documentation for engineering system common tools.

--- a/doc/common/common_engsys.md
+++ b/doc/common/common_engsys.md
@@ -1,0 +1,33 @@
+# Common Engineering System
+
+The `eng/common` directory contains engineering files that are common across the various azure-sdk language repos.
+It should remain relatively small and only contain textual based files like scripts, configs, or templates. It
+should not contain binary files as they don't play well with git.
+
+## Code Structure
+
+To help keep the content of the `eng/common` directory as small as possible we should split the language specific parts of a common script out if possible.
+- Keep the language specific logic as a function in the `eng/scripts/Language-Settings.ps1` files found in each language repo.
+- Assign the function name to a variable in the `eng/common/scripts/common.ps1` file.
+- Call the function using the variable name like so `&$VariableName`.
+
+## Updating
+
+Any updates to files in the `eng/common` directory should be made in the [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) repo.
+All changes made will cause a PR to created in all subscribed azure-sdk language repos which will blindly replace all contents of
+the `eng/common` directory in that repo. For that reason do **NOT** make changes to files in this directory in the individual azure-sdk
+languages repos as they will be overwritten the next time an update is taken from the common azure-sdk-tools repo.
+
+## Workflow
+
+The 'Sync eng/common directory' PRs will be created in the language repositories when a pull request that touches the eng/common directory is submitted against the master branch. This will make it easier for changes to be tested in each individual language repo before merging the changes in the azure-sdk-tools repo. The workflow is explained below:
+
+1. Create a PR (**Tools PR**) in the `azure-sdk-tools` repo with changes to eng/common directory.
+2. `azure-sdk-tools - sync - eng-common` pipeline is triggered for the **Tools PR**
+3. The  `azure-sdk-tools - sync - eng-common` pipeline queues test runs for template pipelines in various languages. These help you test your changes in the **Tools PR**.
+4. If there are changes in the **Tools PR** that will affect the release stage you should approve the release test pipelines by clicking the approval gate. The test (template) pipeline will automatically release the next eligible version without needing manual intervention for the versioning. Please approve your test releases as quickly as possible. A race condition may occur due to someone else queueing the pipeline and going all the way to release using your version while yours is still waiting. If this occurs manually rerun the pipeline that failed.
+5.  If you make additional changes to your **Tools PR** repeat steps 1 - 4 until you have completed the necessary testing of your changes. This includes full releases of the template package, if necessary.
+6. Sign off on CreateSyncPRs stage of the sync pipeline using the approval gate. This stage will create the **Sync PRs** in the various language repos. A link to each of the **Sync PRs** will show up in the **Tools PR** for you to click and review.
+7. Go review and approve each of your **Sync PRs**.
+8. Sign Off on the VerifyAndMerge stage. This will merge any remaining open **Sync PR** and also append `auto-merge` to the **Tools PR**.
+   * If a **Sync PR** has any failing checks, it will need to be manually merged, even if `/check-enforcer override` has been run ([azure-sdk-tools#1147](https://github.com/Azure/azure-sdk-tools/issues/1147)).

--- a/eng/common/README.md
+++ b/eng/common/README.md
@@ -1,26 +1,2 @@
-# Common Engineering System
-
-The `eng/common` directory contains engineering files that are common across the various azure-sdk language repos.
-It should remain relatively small and only contain textual based files like scripts, configs, or templates. It
-should not contain binary files as they don't play well with git.
-
-## Updating
-
-Any updates to files in the `eng/common` directory should be made in the [azure-sdk-tools](https://github.com/azure/azure-sdk-tools) repo.
-All changes made will cause a PR to created in all subscribed azure-sdk language repos which will blindly replace all contents of
-the `eng/common` directory in that repo. For that reason do **NOT** make changes to files in this directory in the individual azure-sdk
-languages repos as they will be overwritten the next time an update is taken from the common azure-sdk-tools repo.
-
-### Workflow
-
-The 'Sync eng/common directory' PRs will be created in the language repositories when a pull request that touches the eng/common directory is submitted against the master branch. This will make it easier for changes to be tested in each individual language repo before merging the changes in the azure-sdk-tools repo. The workflow is explained below:
-
-1. Create a PR (**Tools PR**) in the `azure-sdk-tools` repo with changes to eng/common directory.
-2. `azure-sdk-tools - sync - eng-common` pipeline is triggered for the **Tools PR**
-3. The  `azure-sdk-tools - sync - eng-common` pipeline queues test runs for template pipelines in various languages. These help you test your changes in the **Tools PR**.
-4. If there are changes in the **Tools PR** that will affect the release stage you should approve the release test pipelines by clicking the approval gate. The test (template) pipeline will automatically release the next eligible version without needing manual intervention for the versioning. Please approve your test releases as quickly as possible. A race condition may occur due to someone else queueing the pipeline and going all the way to release using your version while yours is still waiting. If this occurs manually rerun the pipeline that failed.
-5.  If you make additional changes to your **Tools PR** repeat steps 1 - 4 until you have completed the necessary testing of your changes. This includes full releases of the template package, if necessary.
-6. Sign off on CreateSyncPRs stage of the sync pipeline using the approval gate. This stage will create the **Sync PRs** in the various language repos. A link to each of the **Sync PRs** will show up in the **Tools PR** for you to click and review.
-7. Go review and approve each of your **Sync PRs**.
-8. Sign Off on the VerifyAndMerge stage. This will merge any remaining open **Sync PR** and also append `auto-merge` to the **Tools PR**.
-   * If a **Sync PR** has any failing checks, it will need to be manually merged, even if `/check-enforcer override` has been run ([azure-sdk-tools#1147](https://github.com/Azure/azure-sdk-tools/issues/1147)).
+## Common Engineering System
+See [common engineering system docs](https://github.com/Azure/azure-sdk-tools/blob/master/README.md#common-engineering-system)

--- a/eng/common/README.md
+++ b/eng/common/README.md
@@ -1,2 +1,3 @@
-## Common Engineering System
-See [common engineering system docs](https://github.com/Azure/azure-sdk-tools/blob/master/README.md#common-engineering-system)
+# Common Engineering System
+
+Updates under this directory should only be made in the `azure-sdk-tools` repo as any changes under this directory outside of that repo will end up getting overwritten with future updates. For information about making updates see [common engineering system docs](https://github.com/Azure/azure-sdk-tools/doc/common/common_engsys.md#common-engineering-system)


### PR DESCRIPTION
Move Common Engineering System Doc to main README.md Doc.
Add information for how to structure unique language logic.