### PR TITLE
Handle JS packages with prefix @microsoft

### DIFF
--- a/eng/common/scripts/modules/Package-Properties.psm1
+++ b/eng/common/scripts/modules/Package-Properties.psm1
@@ -107,7 +107,16 @@ function Extract-JsPkgProps ($pkgPath, $serviceName, $pkgName)
     if (Test-Path $projectPath)
     {
         $projectJson = Get-Content $projectPath | ConvertFrom-Json
-        $jsStylePkgName = $pkgName.replace("azure-", "@azure/")
+        $jsStylePkgName = ""
+        if ($pkgName.StartsWith("azure-"))
+        {
+            $jsStylePkgName = $pkgName.replace("azure-", "@azure/")
+        }
+        else if ($pkgName.StartsWith("microsoft-"))
+        {
+            $jsStylePkgName = $pkgName.replace("microsoft-", "@microsoft/")
+        }
+
         if ($projectJson.name -eq "$jsStylePkgName")
         {
             return [PackageProps]::new($projectJson.name, $projectJson.version, $pkgPath, $serviceName)

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -53,7 +53,7 @@ function GetAdjustedReadmeContent($pkgInfo, $lang){
     $service = ""
 
     # the namespace is not expected to be present for js.
-    $pkgId = $pkgInfo.PackageId.Replace("@azure/", "")
+    $pkgId = $pkgInfo.PackageId.Replace("@azure/", "").Replace("@microsoft/", "")
 
     try {
       $metadata = GetMetaData -lang $lang
@@ -112,7 +112,13 @@ if ($pkgs) {
       $rdSuffix = "-pre"
     }
 
-    $readmeName = "$($packageInfo.PackageId.Replace('azure-','').Replace('Azure.', '').Replace('@azure/', '').ToLower())-readme$rdSuffix.md"
+    $packageId = $packageInfo.PackageId
+    # JS opentelemetry has "azure-" word inside package name and this should not be replaced
+    if ( $packageId.StartsWith("azure-")) 
+    {
+      $packageId = $packageId.Replace("azure-", "")
+    }
+    $readmeName = "$($packageId.Replace('Azure.', '').Replace('@azure/', '').Replace('@microsoft/', '').ToLower())-readme$rdSuffix.md"
     $readmeLocation = Join-Path $DocRepoLocation $DocRepoContentLocation $readmeName
 
     if ($packageInfo.ReadmeContent) {


### PR DESCRIPTION
JS has renamed open telemetry package from `@azure/monitor-opentelemetry-exporter` to `@microsoft/opentelemetry-exporter-azure-monitor` in PR #12417 and this will require change in verify change log check and docs release. 