### PR TITLE
Add debug flag to arm deployment command

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -385,7 +385,15 @@ foreach ($templateFile in $templateFiles) {
 
     Log "Deploying template '$templateFile' to resource group '$($resourceGroup.ResourceGroupName)'"
     $deployment = Retry {
-        New-AzResourceGroupDeployment -Name $BaseName -ResourceGroupName $resourceGroup.ResourceGroupName -TemplateFile $templateFile -TemplateParameterObject $templateFileParameters
+        $lastDebugPreference = $DebugPreference
+        try {
+            $DebugPreference = "Continue"
+            New-AzResourceGroupDeployment -Name $BaseName -ResourceGroupName $resourceGroup.ResourceGroupName -TemplateFile $templateFile -TemplateParameterObject $templateFileParameters
+        } catch {
+            throw $_
+        } finally {
+            $DebugPreference = $lastDebugPreference
+        }
     }
 
     if ($deployment.ProvisioningState -eq 'Succeeded') {

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -308,7 +308,7 @@ if ($CI) {
     if ($EnvironmentVariables.ContainsKey('AZURE_RESOURCEGROUP_NAME') -and `
         $EnvironmentVariables['AZURE_RESOURCEGROUP_NAME'] -ne $ResourceGroupName)
     {
-        Write-Warning ("Overwriting 'EnvironmentVariables.AZURE_RESOURCEGROUP_NAME' with value " + 
+        Write-Warning ("Overwriting 'EnvironmentVariables.AZURE_RESOURCEGROUP_NAME' with value " +
             "'$($EnvironmentVariables['AZURE_RESOURCEGROUP_NAME'])' " + "to new value '$($ResourceGroupName)'")
     }
     $EnvironmentVariables['AZURE_RESOURCEGROUP_NAME'] = $ResourceGroupName
@@ -387,10 +387,10 @@ foreach ($templateFile in $templateFiles) {
     $deployment = Retry {
         $lastDebugPreference = $DebugPreference
         try {
-            $DebugPreference = "Continue"
+            if ($CI) {
+                $DebugPreference = "Continue"
+            }
             New-AzResourceGroupDeployment -Name $BaseName -ResourceGroupName $resourceGroup.ResourceGroupName -TemplateFile $templateFile -TemplateParameterObject $templateFileParameters
-        } catch {
-            throw $_
         } finally {
             $DebugPreference = $lastDebugPreference
         }


### PR DESCRIPTION
There are some ARM deployment errors that do not surface adequate messages for debugging in the default error output. For example issues related to template validation (that can be a result of account quotas, invalid names, etc.):

```
WARNING: Attempt 1 failed: Exception calling "Invoke" with "0" argument(s): "The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop:
07:13:02 - Error: Code=InvalidTemplateDeployment; Message=The template deployment 'benbp-foobar' is not valid according to the validation procedure. The tracking id is '182f1217-fa54-4fa8-bff3-ef74605e2fe9'. See inner errors for details.
``` 

By updating the `$DebugPreference` for the `New-AzResourceGroupDeployment` command, we print the inner error messages without having to plug correlation IDs into the ARM internal kusto to get the actual error.

```
DEBUG: ============================ HTTP RESPONSE ============================

Status Code:
BadRequest

Headers:
Cache-Control                 : no-cache
Pragma                        : no-cache
x-ms-failure-cause            : gateway
x-ms-ratelimit-remaining-subscription-writes: 1199
x-ms-request-id               : 11a8a92c-21ba-43dc-b504-84b92524c71b
x-ms-correlation-request-id   : 11a8a92c-21ba-43dc-b504-84b92524c71b
x-ms-routing-request-id       : EASTUS:20201110T225406Z:11a8a92c-21ba-43dc-b504-84b92524c71b
Strict-Transport-Security     : max-age=31536000; includeSubDomains
X-Content-Type-Options        : nosniff
Date                          : Tue, 10 Nov 2020 22:54:06 GMT

Body:
{
  "error": {
    "code": "InvalidTemplateDeployment",
    "message": "The template deployment 'benbp-foobar' is not valid according to the validation procedure. The tracking id is '11a8a92c-21ba-43dc-b504-84b92524c71b'. See inner errors for details.",
    "details": [
      {
        "code": "PreflightValidationCheckFailed",
        "message": "Preflight validation failed. Please refer to the details for the specific errors.",
        "details": [
          {
            "code": "AccountNameInvalid",
            "target": "benbp-basenameprim",
            "message": "benbp-basenameprim is not a valid storage account name. Storage account name must be between 3 and 24 characters in length and use numbers and lower-case letters only."
          },

```

An example full log with failures can be found here: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=614171&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=5431112d-2b61-5a5f-7042-ef698f761043