### PR TITLE
Remove invalid characters in basename sourced from username

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -152,6 +152,8 @@ if (!$templateFiles) {
 }
 
 $UserName =  if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
+# Remove spaces, etc. that may be in $UserName
+$UserName = $UserName -replace '\W'
 
 # If no base name is specified use current user name
 if (!$BaseName) {


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-tools/issues/1189

This fixes a bug where a username may contain spaces or other invalid characters, e.g.
```
(py39_new) PS C:\github.com\azure-sdk-for-python> .\eng\common\TestResources\New-TestResources.ps1 'schemaregistry'
New-TestResources.ps1: The variable cannot be validated because the value Sean Kaneschemaregistry is not a valid value for the BaseName variable.
```