### PR TITLE
Python Docs.MS CI needs updated name of exclude_path instead of excludePath

### DIFF
--- a/eng/common/scripts/update-docs-ci.ps1
+++ b/eng/common/scripts/update-docs-ci.ps1
@@ -81,7 +81,7 @@ function UpdateParamsJsonPython($pkgs, $ciRepo, $locationInDocRepo){
             install_type = "pypi"
             name=$releasingPkg.PackageId
           }
-          excludePath = @("test*","example*","sample*","doc*")
+          exclude_path = @("test*","example*","sample*","doc*")
         }
       $allJson.packages += $newItem
     }


### PR DESCRIPTION
Updates what we write to the ci-config json from `excludePath` to `exclude_path` within the individual package specification.