### PR TITLE
Change live test resource DeleteAfterHours tag to 8 hours

### DIFF
--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -1,7 +1,7 @@
 parameters:
   ServiceDirectory: not-set
   ArmTemplateParameters: '@{}'
-  DeleteAfterHours: 24
+  DeleteAfterHours: 8
   Location: ''
   SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
 


### PR DESCRIPTION
This reduces the default from 24 hours to 8 hours. The cleanup pipeline takes only a few minutes so this shouldn't add any load: https://dev.azure.com/azure-sdk/internal/_build?definitionId=1357&_a=summary

The original 24 value was arbitrary. I'm picking 8 because it's the lowest value that's safely longer than any of our existing live tests (currently storage takes 6 hours).

Related to https://github.com/Azure/azure-sdk-tools/issues/754