### PR TITLE
Add debugging link on resource deployment failures to log output

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -393,6 +393,17 @@ foreach ($templateFile in $templateFiles) {
                 $DebugPreference = "Continue"
             }
             New-AzResourceGroupDeployment -Name $BaseName -ResourceGroupName $resourceGroup.ResourceGroupName -TemplateFile $templateFile -TemplateParameterObject $templateFileParameters
+        } catch {
+            $msg = @(
+                "",
+                "==================================================",
+                "For help debugging live test provisioning issues,",
+                "see http://aka.ms/azure-sdk-live-test-help",
+                "=================================================="
+            ) -join ([Environment]::NewLine)
+            Write-Output $msg
+
+            throw $_
         } finally {
             $DebugPreference = $lastDebugPreference
         }

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -394,16 +394,13 @@ foreach ($templateFile in $templateFiles) {
             }
             New-AzResourceGroupDeployment -Name $BaseName -ResourceGroupName $resourceGroup.ResourceGroupName -TemplateFile $templateFile -TemplateParameterObject $templateFileParameters
         } catch {
-            $msg = @(
-                "",
-                "==================================================",
-                "For help debugging live test provisioning issues,",
-                "see http://aka.ms/azure-sdk-live-test-help",
-                "=================================================="
-            ) -join ([Environment]::NewLine)
-            Write-Output $msg
-
-            throw $_
+            Write-Output @"
+==================================================
+For help debugging live test provisioning issues,
+see http://aka.ms/azsdk/engsys/live-test-help,
+==================================================
+"@
+            throw
         } finally {
             $DebugPreference = $lastDebugPreference
         }


### PR DESCRIPTION
Available information currently gets logged on failures with ARM template provisioning, but we should provide a link to help people who want to debug further or understand what is going wrong.