### PR TITLE
Add auth header checks to DevOps rule.

### DIFF
--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter.Administration/New-AzureDevOpsRuleCredentials.ps1
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter.Administration/New-AzureDevOpsRuleCredentials.ps1
@@ -1,0 +1,18 @@
+$username = New-Guid
+$password = New-Guid
+$salt = New-Guid
+
+$basicAuthorizationHeaderValue = "$($username):$($password)"
+$basicAuthorizationHeaderValueBytes = [System.Text.Encoding]::UTF8.GetBytes($basicAuthorizationHeaderValue)
+$encodedBasicAuthorizationHeaderValue = [System.Convert]::ToBase64String($basicAuthorizationHeaderValueBytes)
+$saltedEncodedBasicAuthorizationHeaderValue = "$encodedBasicAuthorizationHeaderValue$salt"
+$saltedEncodedBasicAuthorizationHeaderValueBytes = [System.Text.Encoding]::UTF8.GetBytes($saltedEncodedBasicAuthorizationHeaderValue)
+
+$sha256 = [System.Security.Cryptography.SHA256CryptoServiceProvider]::new()
+$hashBytes = $sha256.ComputeHash($saltedEncodedBasicAuthorizationHeaderValueBytes)
+$encodedHash = [System.Convert]::ToBase64String($hashBytes)
+
+Write-Host "Username: $username"
+Write-Host "Password: $password"
+Write-Host "Salt: $salt"
+Write-Host "Hash: $encodedHash"

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Functions/RouteWebhookFunction.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Functions/RouteWebhookFunction.cs
@@ -35,6 +35,7 @@ namespace Azure.Sdk.Tools.WebhookRouter.Functions
             }
             catch (RouterAuthorizationException ex)
             {
+                log.LogError(ex, "Request did not pass validation.");
                 return new UnauthorizedResult();
             }
         }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Functions/RouteWebhookFunction.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Functions/RouteWebhookFunction.cs
@@ -28,8 +28,15 @@ namespace Azure.Sdk.Tools.WebhookRouter.Functions
             ILogger log,
             Guid route)
         {
-            await router.RouteAsync(route, req);            
-            return new OkResult();
+            try
+            {
+                await router.RouteAsync(route, req);            
+                return new OkResult();
+            }
+            catch (RouterAuthorizationException ex)
+            {
+                return new UnauthorizedResult();
+            }
         }
     }
 }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/AzureDevOpsRule.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/AzureDevOpsRule.cs
@@ -9,10 +9,10 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
         public AzureDevOpsRule(Guid route, string eventHubsNamespace, string eventHubName, string credentialHash, string credentialSalt) : base(route, eventHubsNamespace, eventHubName)
         {
             CredentialHash = credentialHash;
-            CrdentialSalt = credentialSalt;
+            CredentialSalt = credentialSalt;
         }
 
         public string CredentialHash { get; private set; }
-        public string CrdentialSalt { get; private set; }
+        public string CredentialSalt { get; private set; }
     }
 }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/AzureDevOpsRule.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/AzureDevOpsRule.cs
@@ -6,8 +6,13 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
 {
     public class AzureDevOpsRule : Rule
     {
-        public AzureDevOpsRule(Guid route, string eventHubsNamespace, string eventHubName) : base(route, eventHubsNamespace, eventHubName)
+        public AzureDevOpsRule(Guid route, string eventHubsNamespace, string eventHubName, string credentialHash, string credentialSalt) : base(route, eventHubsNamespace, eventHubName)
         {
+            CredentialHash = credentialHash;
+            CrdentialSalt = credentialSalt;
         }
+
+        public string CredentialHash { get; private set; }
+        public string CrdentialSalt { get; private set; }
     }
 }

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Router.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Router.cs
@@ -11,6 +11,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Runtime.CompilerServices;
+using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
@@ -107,7 +108,7 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
 
             var settings = await GetSettingsAsync(route);
 
-            logger.LogInformation("Route {route} had {dictionaryCount} in settings dictionary.", route, settings.Count);
+            logger.LogInformation("Route {route}     had {dictionaryCount} in settings dictionary.", route, settings.Count);
 
             var payloadType = (PayloadType)Enum.Parse(typeof(PayloadType), settings["payload-type"], true);
             var eventHubsNamespace = settings["eventhubs-namespace"];
@@ -123,9 +124,21 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
 
             Rule rule = payloadType switch
             {
-                PayloadType.GitHub => new GitHubRule(route, eventHubsNamespace, eventHubName, settings["github-webhook-secret"]),
-                PayloadType.AzureDevOps => new AzureDevOpsRule(route, eventHubsNamespace, eventHubName),
-                _ => new GenericRule(route, eventHubsNamespace, eventHubName)
+                PayloadType.GitHub => new GitHubRule(
+                    route,
+                    eventHubsNamespace,
+                    eventHubName,
+                    settings["github-webhook-secret"]),
+                PayloadType.AzureDevOps => new AzureDevOpsRule(
+                    route,
+                    eventHubsNamespace,
+                    eventHubName,
+                    settings["azure-devops-webhook-credential-hash"],
+                    settings["azure-devops-webhook-credential-salt"]),
+                _ => new GenericRule(
+                    route,
+                    eventHubsNamespace,
+                    eventHubName)
             };
 
             return rule;
@@ -139,12 +152,38 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
             var signature = request.Headers[GitHubWebhookSignatureValidator.GitHubWebhookSignatureHeader];
             bool isValid = GitHubWebhookSignatureValidator.IsValid(payloadContent, signature, secret);
 
+            if (!isValid)
+            {
+                // TODO: Replace with an exception so we get a 401.
+                throw new Exception("Signature validation failed.");
+            }
+
             return payloadContent;
         }
+
+        private SHA256CryptoServiceProvider sha256 = new SHA256CryptoServiceProvider();
 
         private async Task<byte[]> ReadAndValidateContentFromAzureDevOpsAsync(AzureDevOpsRule rule, HttpRequest request)
         {
             var payloadContent = await ReadAndValidateContentFromGenericAsync(rule, request);
+
+            var credentialHash = await GetSecretAsync(rule.CredentialHash);
+            var credentialSalt = await GetSecretAsync(rule.CrdentialSalt);
+
+            var authorizationHeader = request.Headers["Authorization"].ToString();
+            var base64EncodedCredentials = authorizationHeader.Replace("Basic ", "");
+
+            var base64EncodedCredentialsWithSalt = $"{base64EncodedCredentials}{credentialSalt}";
+            var base64EncodedCredentialsWithSaltBytes = Encoding.UTF8.GetBytes(base64EncodedCredentialsWithSalt);
+            var generatedCredentialHashBytes = sha256.ComputeHash(base64EncodedCredentialsWithSaltBytes);
+            var generatedCredentialHash = Convert.ToBase64String(generatedCredentialHashBytes);
+
+            if (credentialHash != generatedCredentialHash)
+            {
+                // TODO: Replace with an exception so we get a 401.
+                throw new Exception("Credential validation failed.");
+            }
+
             return payloadContent;
         }
 

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Router.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Router.cs
@@ -108,7 +108,7 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
 
             var settings = await GetSettingsAsync(route);
 
-            logger.LogInformation("Route {route}     had {dictionaryCount} in settings dictionary.", route, settings.Count);
+            logger.LogInformation("Route {route} had {dictionaryCount} in settings dictionary.", route, settings.Count);
 
             var payloadType = (PayloadType)Enum.Parse(typeof(PayloadType), settings["payload-type"], true);
             var eventHubsNamespace = settings["eventhubs-namespace"];
@@ -154,8 +154,7 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
 
             if (!isValid)
             {
-                // TODO: Replace with an exception so we get a 401.
-                throw new Exception("Signature validation failed.");
+                throw new RouterAuthorizationException("Signature validation failed.");
             }
 
             return payloadContent;
@@ -180,8 +179,7 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
 
             if (credentialHash != generatedCredentialHash)
             {
-                // TODO: Replace with an exception so we get a 401.
-                throw new Exception("Credential validation failed.");
+                throw new RouterAuthorizationException("Credential validation failed.");
             }
 
             return payloadContent;

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Router.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/Router.cs
@@ -167,7 +167,7 @@ namespace Azure.Sdk.Tools.WebhookRouter.Routing
             var payloadContent = await ReadAndValidateContentFromGenericAsync(rule, request);
 
             var credentialHash = await GetSecretAsync(rule.CredentialHash);
-            var credentialSalt = await GetSecretAsync(rule.CrdentialSalt);
+            var credentialSalt = await GetSecretAsync(rule.CredentialSalt);
 
             var authorizationHeader = request.Headers["Authorization"].ToString();
             var base64EncodedCredentials = authorizationHeader.Replace("Basic ", "");

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/RouterAuthorizationException.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/RouterAuthorizationException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.WebhookRouter.Routing
+{
+    [Serializable]
+    public class RouterAuthorizationException : RouterException
+    {
+        public RouterAuthorizationException() { }
+        public RouterAuthorizationException(string message) : base(message) { }
+        public RouterAuthorizationException(string message, Exception inner) : base(message, inner) { }
+        protected RouterAuthorizationException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}

--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Startup.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Startup.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Sdk.Tools.WebhookRouter;
+﻿using Azure.Identity;
+using Azure.Sdk.Tools.WebhookRouter;
 using Azure.Sdk.Tools.WebhookRouter.Routing;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Extensions.Azure;


### PR DESCRIPTION
This PR adds ```Authorization``` header checks to the Azure DevOps routing rules. We store a hash and salt in KeyVault for each routing rule. The hash is a combination of the ```base64(username:password)``` part of the header combined with the salt which is then SHA256 hashed and base 64 encoded.

This also fixes a bug where we were validation GitHub signatures but not throwing if signature validation failed (note this is mitigated by the fact that we were also validating in Check Enforcer correctly).

Things left to do:

- [x] Create a script to simplify the credential creation process.
- [x] Add decent exceptions when validation fails (we want to return a 401).