### PR TITLE
Add packaging to pre-req install in verify-changelog.yml

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-changelog.yml
+++ b/eng/common/pipelines/templates/steps/verify-changelog.yml
@@ -13,6 +13,10 @@ parameters:
   default: false
 
 steps:
+  - pwsh: | 
+      pip install packaging==20.4
+    displayName: Install Requirements
+
   - task: Powershell@2
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/common/scripts/Verify-ChangeLog.ps1


### PR DESCRIPTION
Open for discussion. @chidozieononiwu given that this is common tooling, I totally get why `packaging` wasn't already present as part of the template.

Unfortunately, IMO we should always install it. We cannot make assumptions about the downstream installed packages. I'm thinking that I actually remove the specific version dependency and just update it to `packaging` alone.  

Reason this worked in build, but not release, is that the release phases don't have all the python packages already installed (due to other reasons) like the Build phase does.