### PR TITLE
Removed hardcoded root name space check for azure namespace

### DIFF
--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Release History
 
 ## Version 0.0.1 (Unreleased)
+Added support for packages with non-azure root namespace
+
+## Version 0.0.1 (Unreleased)
 Initial version of API stub generator for Azure SDK API view tool

--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.1.3"
+VERSION = "0.2.0"

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
@@ -42,7 +42,7 @@ class NodeEntityBase:
             apiview.end_group()
 
 
-def get_qualified_name(obj):
+def get_qualified_name(obj, namespace):
     """Generate and return fully qualified name of object with module name for internal types.
        If module name is not available for the object then it will return name
     :param: obj
@@ -60,7 +60,7 @@ def get_qualified_name(obj):
     module_name = ""
     if hasattr(obj, "__module__"):
         module_name = getattr(obj, "__module__")
-    if module_name and module_name.startswith("azure"):
+    if module_name and module_name.startswith(namespace):
         return "{0}.{1}".format(module_name, name)
 
     return name

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
@@ -101,7 +101,7 @@ class ClassNode(NodeEntityBase):
             return False
         if hasattr(func_obj, "__module__"):
             function_module = getattr(func_obj, "__module__")
-            return function_module and function_module.startswith("azure.")
+            return function_module and function_module.startswith(self.namespace)
 
         return False
 

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -113,7 +113,7 @@ class FunctionNode(NodeEntityBase):
         # This is to handle the scenario is keyword arg typehint (py3 style is present in signature itself)
         self.kw_args = []
         for argname in params:
-            arg = ArgType(argname, get_qualified_name(params[argname].annotation), "", self)
+            arg = ArgType(argname, get_qualified_name(params[argname].annotation, self.namespace), "", self)
             # set default value if available
             if params[argname].default != Parameter.empty:
                 arg.default = str(params[argname].default)
@@ -127,7 +127,7 @@ class FunctionNode(NodeEntityBase):
                 self.args.append(arg)
 
         if sig.return_annotation:
-            self.return_type = get_qualified_name(sig.return_annotation)
+            self.return_type = get_qualified_name(sig.return_annotation, self.namespace)
 
         # parse docstring
         self._parse_docstring()

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
@@ -68,7 +68,7 @@ class ModuleNode(NodeEntityBase):
 
         # Skip any member in module level that is defined in external or built in package
         if hasattr(member_obj, "__module__"):
-            return not getattr(member_obj, "__module__").startswith("azure.")
+            return not getattr(member_obj, "__module__").startswith(self.namespace)
         # Don't skip member if module name is not available. This is just to be on safer side
         return False
 


### PR DESCRIPTION
APIStubGen is skipping classes in microsoft root namespace. PR is to check for namespace based on parsed namespace.