### PR TITLE
Exclude bypass-local-dns step when a container variable is specified

### DIFF
--- a/eng/common/pipelines/templates/steps/bypass-local-dns.yml
+++ b/eng/common/pipelines/templates/steps/bypass-local-dns.yml
@@ -3,4 +3,9 @@ steps:
     # https://github.com/actions/virtual-environments/issues/798
     - script: sudo ln -sf /run/systemd/resolve/resolv.conf /etc/resolv.conf
       displayName: Bypass local DNS server to workaround issue resolving cognitiveservices names
-      condition: and(succeededOrFailed(), eq(variables['OSVmImage'], 'ubuntu-18.04'))
+      condition: |
+        and(
+          succeededOrFailed(),
+          eq(variables['OSVmImage'], 'ubuntu-18.04'),
+          eq(variables['Container'], '')
+        )

--- a/eng/common/pipelines/templates/steps/verify-agent-os.yml
+++ b/eng/common/pipelines/templates/steps/verify-agent-os.yml
@@ -1,4 +1,4 @@
-parameters: 
+parameters:
   OSVmImage: $(OSVmImage)
 
 steps:


### PR DESCRIPTION
The bypass-local-dns check fails when running in a container (and is unnecessary since we aren't using the pipelines agent image), so this adds another step to the condition to exclude it. This requires the container being set specifically with a `Container` variable.