### PR TITLE
Set Package name for C++, C and JS and filter review to namespace for C++

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
@@ -16,7 +16,7 @@ namespace APIViewWeb
 {
     public class CLanguageService : LanguageService
     {
-        private const string CurrentVersion = "3";
+        private const string CurrentVersion = "4";
         private static Regex _typeTokenizer = new Regex("\\w+|[^\\w]+", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static HashSet<string> _keywords = new HashSet<string>()
         {
@@ -67,6 +67,8 @@ namespace APIViewWeb
             "_Thread_local"
         };
 
+        private static Regex _packageNameParser = new Regex("([A-Za-z_]*)", RegexOptions.Compiled);
+
         public override string Name { get; } = "C";
 
         public override string Extension { get; } = ".zip";
@@ -82,7 +84,12 @@ namespace APIViewWeb
             var archive = new ZipArchive(astStream);
 
             //Generate pacakge name from original file name
-            var packageNamespace = originalName.Substring(0, originalName.LastIndexOf(".")).Replace("_", ".");
+            string packageNamespace = "";
+            var packageNameMatch = _packageNameParser.Match(originalName);
+            if (packageNameMatch.Success)
+            {
+                packageNamespace = packageNameMatch.Groups[1].Value.Replace("_", "::");
+            }
 
             CodeFileTokensBuilder builder = new CodeFileTokensBuilder();
             List<NavigationItem> navigation = new List<NavigationItem>();

--- a/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
@@ -81,6 +81,8 @@ namespace APIViewWeb
 
             var archive = new ZipArchive(astStream);
 
+            //Generate pacakge name from original file name
+            var packageNamespace = originalName.Substring(0, originalName.LastIndexOf(".")).Replace("_", ".");
 
             CodeFileTokensBuilder builder = new CodeFileTokensBuilder();
             List<NavigationItem> navigation = new List<NavigationItem>();
@@ -99,6 +101,7 @@ namespace APIViewWeb
                 Tokens = builder.Tokens.ToArray(),
                 Navigation = navigation.ToArray(),
                 VersionString = CurrentVersion,
+                PackageName = packageNamespace
             };
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/CppLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CppLanguageService.cs
@@ -121,7 +121,7 @@ namespace APIViewWeb
             astStream.Position = 0;
 
             //Generate pacakge name from original file name
-            var packageNamespace = originalName.Substring(0,originalName.LastIndexOf(".")).Replace("_", "::");
+            var packageNamespace = originalName.Substring(0,originalName.LastIndexOf(".")).Replace("_", "::").ToLower();
 
             CodeFileTokensBuilder builder = new CodeFileTokensBuilder();
             List<NavigationItem> navigation = new List<NavigationItem>();
@@ -175,7 +175,7 @@ namespace APIViewWeb
 
                 var nameSpace = namespacebldr.ToString();
                 // Skip <partialnamespace>::Details namespace
-                if (nameSpace.EndsWith(DetailsNamespacePostfix) || !nameSpace.StartsWith(packageNamespace))
+                if (nameSpace.EndsWith(DetailsNamespacePostfix) || !nameSpace.ToLower().StartsWith(packageNamespace))
                     continue;
 
                 if (!namespaceLeafMap.ContainsKey(nameSpace))

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml
@@ -141,13 +141,13 @@
                                     </li>
                                     <li>
                                         Run
-                                        <code>clang++ [input like .\sdk\storage\azure-storage-files-datalake\inc\azure\storage\files\datalake\datalake.hpp] -I .\sdk\storage\azure-storage-files-datalake\inc -I .\sdk\core\azure-core\inc -Xclang  -ast-dump -I .\sdk\storage\azure-storage-common\inc  -I .\sdk\storage\azure-storage-blobs\inc > az_datalake.ast</code>
+                                        <code>clang++ [input like .\sdk\storage\azure-storage-files-datalake\inc\azure\storage\files\datalake\datalake.hpp] -I .\sdk\storage\azure-storage-files-datalake\inc -I .\sdk\core\azure-core\inc -Xclang  -ast-dump -I .\sdk\storage\azure-storage-common\inc  -I .\sdk\storage\azure-storage-blobs\inc > azure_storage_files_datalake.ast</code>
                                     </li>
                                     <li>
-                                        Archive the file <code>Compress-Archive az_datalake.ast -DestinationPath az_datalake.zip</code>
+                                        Archive the file <code>Compress-Archive azure_storage_files_datalake.ast -DestinationPath azure_storage_files_datalake.zip</code>
                                     </li>
                                     <li>
-                                        Rename the file <code>Rename-Item az_datalake.zip -NewName  az_datalake.cppast</code>
+                                        Rename the file <code>Rename-Item azure_storage_files_datalake.zip -NewName  azure_storage_files_datalake.cppast</code>
                                     </li>
                                     <li>
                                         Upload the resulting archive.

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml
@@ -141,13 +141,13 @@
                                     </li>
                                     <li>
                                         Run
-                                        <code>clang++ [input like .\sdk\storage\azure-storage-files-datalake\inc\azure\storage\files\datalake\datalake.hpp] -I .\sdk\storage\azure-storage-files-datalake\inc -I .\sdk\core\azure-core\inc -Xclang  -ast-dump -I .\sdk\storage\azure-storage-common\inc  -I .\sdk\storage\azure-storage-blobs\inc > azure_storage_files_datalake.ast</code>
+                                        <code>clang++ [input like .\sdk\storage\azure-storage-files-datalake\inc\azure\storage\files\datalake\datalake.hpp] -I .\sdk\storage\azure-storage-files-datalake\inc -I .\sdk\core\azure-core\inc -Xclang  -ast-dump -I .\sdk\storage\azure-storage-common\inc  -I .\sdk\storage\azure-storage-blobs\inc > Azure_Storage_Files_Datalake.ast</code>
                                     </li>
                                     <li>
-                                        Archive the file <code>Compress-Archive azure_storage_files_datalake.ast -DestinationPath azure_storage_files_datalake.zip</code>
+                                        Archive the file <code>Compress-Archive Azure_Storage_Files_Datalake.ast -DestinationPath Azure_Storage_Files_Datalake.zip</code>
                                     </li>
                                     <li>
-                                        Rename the file <code>Rename-Item azure_storage_files_datalake.zip -NewName  azure_storage_files_datalake.cppast</code>
+                                        Rename the file <code>Rename-Item Azure_Storage_Files_Datalake.zip -NewName  Azure_Storage_Files_Datalake.cppast</code>
                                     </li>
                                     <li>
                                         Upload the resulting archive.

--- a/src/ts/ts-genapi/export.ts
+++ b/src/ts/ts-genapi/export.ts
@@ -107,7 +107,8 @@ for (const modelPackage of apiModel.packages) {
 var apiViewFile: IApiViewFile = {
     Name: apiModel.packages[0].name,
     Navigation: navigation,
-    Tokens: builder.tokens
+    Tokens: builder.tokens,
+    PackageName: apiModel.packages[0].name
 }
 
 writeFile(process.argv[3], JSON.stringify(apiViewFile), err => {

--- a/src/ts/ts-genapi/models.ts
+++ b/src/ts/ts-genapi/models.ts
@@ -15,6 +15,7 @@ export declare interface IApiViewFile {
     Name: string;
     Tokens: IApiViewToken[];
     Navigation: IApiViewNavItem[];
+    PackageName: string;
 }
 
 export declare interface IApiViewToken {

--- a/src/ts/ts-genapi/package.json
+++ b/src/ts/ts-genapi/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-genapi",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Package name is required to find master review for each package and this needs to be set by each language. Also made a change to filter C++ review based on the namespace.