### PR TITLE
[APIView] Misc Java-specific improvements

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
@@ -7,6 +7,7 @@ import com.azure.tools.apiview.processor.diagnostics.rules.IllegalPackageAPIExpo
 import com.azure.tools.apiview.processor.diagnostics.rules.ImportsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.MissingAnnotationsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.MissingJavaDocDiagnosticRule;
+import com.azure.tools.apiview.processor.diagnostics.rules.NoLocalesInJavadocUrlDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.NoPublicFieldsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.PackageNameDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.RequiredBuilderMethodsDiagnosticRule;
@@ -43,6 +44,7 @@ public class Diagnostics {
             new Rule("^setHas")
         ));
         diagnostics.add(new MissingJavaDocDiagnosticRule());
+        diagnostics.add(new NoLocalesInJavadocUrlDiagnosticRule());
 
         // common APIs for all builders (below we will do rules for http or amqp builders)
         diagnostics.add(new RequiredBuilderMethodsDiagnosticRule(null)

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/NoLocalesInJavadocUrlDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/NoLocalesInJavadocUrlDiagnosticRule.java
@@ -1,0 +1,57 @@
+package com.azure.tools.apiview.processor.diagnostics.rules;
+
+import com.azure.tools.apiview.processor.diagnostics.DiagnosticRule;
+import com.azure.tools.apiview.processor.model.APIListing;
+import com.azure.tools.apiview.processor.model.Diagnostic;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
+
+import java.util.Arrays;
+import java.util.Locale;
+
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getClasses;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPublicOrProtectedConstructors;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPublicOrProtectedFields;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPublicOrProtectedMethods;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
+import static com.azure.tools.apiview.processor.model.DiagnosticKind.WARNING;
+
+public class NoLocalesInJavadocUrlDiagnosticRule implements DiagnosticRule {
+
+    private final String[] languageTags;
+
+    public NoLocalesInJavadocUrlDiagnosticRule() {
+        languageTags = Arrays.stream(Locale.getAvailableLocales())
+           .map(Locale::toLanguageTag)
+           .map(String::toLowerCase)
+           .toArray(String[]::new);
+    }
+
+    @Override
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
+        getClasses(cu).forEach(typeDeclaration -> {
+            // Javadoc on the type itself
+            checkJavaDoc(typeDeclaration, makeId(typeDeclaration), listing);
+
+            // then get constructors, fields, and methods and check the javadoc on them
+            getPublicOrProtectedConstructors(typeDeclaration).forEach(n -> checkJavaDoc(n, makeId(n), listing));
+            getPublicOrProtectedFields(typeDeclaration).forEach(n -> checkJavaDoc(n, makeId(n), listing));
+            getPublicOrProtectedMethods(typeDeclaration).forEach(n -> checkJavaDoc(n, makeId(n), listing));
+        });
+    }
+
+    private void checkJavaDoc(NodeWithJavadoc<?> n, String id, APIListing listing) {
+        n.getJavadocComment().ifPresent(javadoc -> {
+            final String javadocString = javadoc.toString().toLowerCase();
+
+            Arrays.stream(languageTags).forEach(langTag -> {
+                if (javadocString.contains("/" + langTag + "/")) {
+                    listing.addDiagnostic(new Diagnostic(WARNING, id,
+                        "The JavaDoc string for this API contains what appears to be a locale ('/" + langTag + "/'). " +
+                            "Commonly, this indicates a URL in the JavaDoc is linking to a specific locale. If so, this " +
+                            "should be removed, so we do not assume about the users locale when accessing a URL."));
+                }
+            });
+        });
+    }
+}


### PR DESCRIPTION
1. Add new diagnostic rule that checks if URLs have locale language tags in them (e.g. 'en-us').