### PR TITLE
Support moniker specific folders for readmes (and incoming service overviews)

### DIFF
--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -48,7 +48,7 @@ steps:
       -WorkDirectory "${{ parameters.WorkingDirectory }}"
       -DocRepoLocation "${{ parameters.WorkingDirectory }}/repo"
       -Language "${{parameters.Language}}"
-      -DocRepoContentLocation ${{ parameters.DocRepoDestinationPath }}
+      -Configs "${{ parameters.CIConfigs }}"
     pwsh: true
   env:
     GH_TOKEN: $(azuresdk-github-pat)

--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -65,7 +65,7 @@ steps:
       -RepoId ${{ parameters.RepoId }}
       -Repository ${{ parameters.PackageRepository }}
       -ReleaseSHA ${{ parameters.ReleaseSha }}
-      -CIRepository "${{ parameters.WorkingDirectory }}/repo"
+      -DocRepoLocation "${{ parameters.WorkingDirectory }}/repo"
       -Configs "${{ parameters.CIConfigs }}"
     pwsh: true
   env:
@@ -107,7 +107,7 @@ steps:
         -RepoId ${{ parameters.RepoId }}
         -Repository ${{ parameters.PackageRepository }}
         -ReleaseSHA ${{ parameters.ReleaseSha }}
-        -CIRepository "${{ parameters.WorkingDirectory }}/repo"
+        -DocRepoLocation "${{ parameters.WorkingDirectory }}/repo"
         -Configs "${{ parameters.CIConfigs }}"
       pwsh: true
     env:

--- a/eng/common/scripts/update-docs-ci.ps1
+++ b/eng/common/scripts/update-docs-ci.ps1
@@ -50,7 +50,7 @@ foreach ($config in $targets) {
   if ($config.mode -eq "Preview") { $includePreview = $true } else { $includePreview = $false }
   $pkgsFiltered = $pkgs | ? { $_.IsPrerelease -eq $includePreview}
 
-  if ($pkgs) {
+  if ($pkgsFiltered) {
     Write-Host "Given the visible artifacts, CI updates against $($config.path_to_config) will be processed for the following packages."
     Write-Host ($pkgsFiltered | % { $_.PackageId + " " + $_.PackageVersion })
 

--- a/eng/common/scripts/update-docs-ci.ps1
+++ b/eng/common/scripts/update-docs-ci.ps1
@@ -24,10 +24,10 @@ param (
   $Repository, # EG: "Maven", "PyPI", "NPM"
 
   [Parameter(Mandatory = $true)]
-  $CIRepository,
+  $DocRepoLocation, # the location of the cloned doc repo
 
   [Parameter(Mandatory = $true)]
-  $Configs
+  $Configs # The configuration elements informing important locations within the cloned doc repo
 )
 
 . (Join-Path $PSScriptRoot common.ps1)
@@ -37,7 +37,8 @@ $targets = ($Configs | ConvertFrom-Json).targets
 #{
 # path_to_config:
 # mode:
-# monikerid
+# monikerid:
+# content_folder:
 #}
 
 $apiUrl = "https://api.github.com/repos/$repoId"
@@ -56,7 +57,7 @@ foreach ($config in $targets) {
 
     if ($UpdateDocCIFn -and (Test-Path "Function:$UpdateDocCIFn"))
     {
-      &$UpdateDocCIFn -pkgs $pkgsFiltered -ciRepo $CIRepository -locationInDocRepo $config.path_to_config -monikerId $config.monikerid
+      &$UpdateDocCIFn -pkgs $pkgsFiltered -ciRepo $DocRepoLocation -locationInDocRepo $config.path_to_config -monikerId $config.monikerid
     }
     else
     {

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -2,16 +2,24 @@
 # powershell core is a requirement for successful execution.
 param (
   # arguments leveraged to parse and identify artifacts
+  [Parameter(Mandatory = $true)]
   $ArtifactLocation, # the root of the artifact folder. DevOps $(System.ArtifactsDirectory)
+  [Parameter(Mandatory = $true)]
   $WorkDirectory, # a clean folder that we can work in
+  [Parameter(Mandatory = $true)]
   $ReleaseSHA, # the SHA for the artifacts. DevOps: $(Release.Artifacts.<artifactAlias>.SourceVersion) or $(Build.SourceVersion)
+  [Parameter(Mandatory = $true)]
   $RepoId, # full repo id. EG azure/azure-sdk-for-net  DevOps: $(Build.Repository.Id). Used as a part of VerifyPackages
+  [Parameter(Mandatory = $true)]
   $Repository, # EG: "Maven", "PyPI", "NPM"
 
   # arguments necessary to power the docs release
+  [Parameter(Mandatory = $true)]
   $DocRepoLocation, # the location on disk where we have cloned the documentation repository
+  [Parameter(Mandatory = $true)]
   $Language # EG: js, java, dotnet. Used in language for the embedded readme.
-  $Configs
+  [Parameter(Mandatory = $true)]
+  $Configs # The configuration elements informing important locations within the cloned doc repo
 )
 
 . (Join-Path $PSScriptRoot common.ps1)
@@ -99,10 +107,10 @@ foreach ($config in $targets) {
       }
   
       $readmeName = "$($packageInfo.PackageId.Replace('azure-','').Replace('Azure.', '').Replace('@azure/', '').ToLower())-readme$rdSuffix.md"
-      $readmeLocation = Join-Path $CIRepository $config.metadata_folder
+      $readmeLocation = Join-Path $CIRepository $config.content_folder
   
       # what happens if this is the first time we've written to this folder? It won't exist. Resolve that.
-      if(!(test-path $readmeLocation))
+      if(!(Test-Path $readmeLocation))
       {
         New-Item -ItemType Directory -Force -Path $readmeLocation
       }

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -101,6 +101,12 @@ foreach ($config in $targets) {
       $readmeName = "$($packageInfo.PackageId.Replace('azure-','').Replace('Azure.', '').Replace('@azure/', '').ToLower())-readme$rdSuffix.md"
       $readmeLocation = Join-Path $CIRepository $config.metadata_folder
   
+      # what happens if this is the first time we've written to this folder? It won't exist. Resolve that.
+      if(!(test-path $readmeLocation))
+      {
+        New-Item -ItemType Directory -Force -Path $readmeLocation
+      }
+
       if ($packageInfo.ReadmeContent) {
         $adjustedContent = GetAdjustedReadmeContent -pkgInfo $packageInfo
       }

--- a/eng/common/scripts/update-docs-metadata.ps1
+++ b/eng/common/scripts/update-docs-metadata.ps1
@@ -17,7 +17,7 @@ param (
   [Parameter(Mandatory = $true)]
   $DocRepoLocation, # the location on disk where we have cloned the documentation repository
   [Parameter(Mandatory = $true)]
-  $Language # EG: js, java, dotnet. Used in language for the embedded readme.
+  $Language, # EG: js, java, dotnet. Used in language for the embedded readme.
   [Parameter(Mandatory = $true)]
   $Configs # The configuration elements informing important locations within the cloned doc repo
 )


### PR DESCRIPTION
Current.

```
<doc repo root>/
   docs-ref-services/
      storage-blob-readme.md
      storage-blob-readme-pre.md
```

New

```
<doc repo root>/
   docs-ref-services/
      latest/
         storage-blob-readme.md
      preview/
         storage-blob-readme.md
```

This is enabled by [docfx updates](https://github.com/MicrosoftDocs/azure-docs-sdk-node/commit/a01c7619aababf83881804f4c08130075621a0f4) that change our publishing to pull from the **different folders** but write to the _same URL PATH_. 

The outcome of this + the SyncToC update + other updates to release configs is that we will be able to swap between monikers as expected!