### PR TITLE
Webhook Router: Payload output on routing errors

### DIFF
--- a/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/RouteConfigurationException.cs
+++ b/tools/webhook-router/Azure.Sdk.Tools.WebhookRouter/Routing/RouteConfigurationException.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Azure.Sdk.Tools.WebhookRouter.Routing
+{
+    [Serializable]
+    public class RouterConfigurationException : RouterException
+    {
+        public RouterConfigurationException() { }
+        public RouterConfigurationException(string message) : base(message) { }
+        public RouterConfigurationException(string message, Exception inner) : base(message, inner) { }
+        protected RouterConfigurationException(
+          System.Runtime.Serialization.SerializationInfo info,
+          System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    }
+}


### PR DESCRIPTION
This PR changes Webhook Router so that when a payload is received that doesn't match a known route that the payload is logged so that it can be used to track down where the event is coming from. At the moment we don't have any mechanism to find sources of routed events when we are dropping them short of looking through all of our repositories to try and find them. This should make diagnosis much easier.

The reason I am doing this is that over the past week or so we've seen some routing failures and I haven't been able to find the source. I'm concerned that there is a routing rule missing that I haven't previously considered.