### PR TITLE
Classifier for Azurite install failures.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzuriteInstallFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzuriteInstallFailureClassifier.cs
@@ -1,0 +1,30 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class AzuriteInstallFailureClassifier : IFailureClassifier
+    {
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            var failedTasks = from r in context.Timeline.Records
+                                where r.Result == TaskResult.Failed
+                                where r.RecordType == "Task"
+                                where r.Name == "Install Azurite"
+                                select r;
+
+            if (failedTasks.Count() > 0)
+            {
+                foreach (var failedTask in failedTasks)
+                {
+                    context.AddFailure(failedTask, "Azurite Install");
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -73,6 +73,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddMemoryCache();
             builder.Services.AddSingleton<RunProcessor>();
             builder.Services.AddSingleton<IFailureAnalyzer, FailureAnalyzer>();
+            builder.Services.AddSingleton<IFailureClassifier, AzuriteInstallFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, CancelledTaskClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, CosmosDbEmulatorStartFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, AzurePipelinesPoolOutageClassifier>();
@@ -85,7 +86,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, JsDevFeedPublishingFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, DownloadSecretsFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, GitCheckoutFailureClassifier>();
-            builder.Services.AddSingleton<IFailureClassifier, AzurePowerShellModuleInstallationFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, AzuriteInstallFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, MavenBrokenPipeFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, CodeSigningFailureClassifier>();
         }


### PR DESCRIPTION
This PR looks for failures in the Install Azurite install task. At this point its just looking based on the task display name. Once we get enough of these occurring we might be able to write one that picks up the underlying NPM error for a broader set of tasks. The trick is to do it in an efficient way so we don't have to always pull all of the log entries for a run.

Fixes #1237 