### PR TITLE
Make up the css using for .net sdk github io pages

### DIFF
--- a/eng/common/docgeneration/Generate-DocIndex.ps1
+++ b/eng/common/docgeneration/Generate-DocIndex.ps1
@@ -165,7 +165,6 @@ function UpdateDocIndexFiles {
     Param (
         [Parameter(Mandatory=$false)] [String]$appTitleLang = $Language,
         [Parameter(Mandatory=$false)] [String]$lang = $Language,
-        [Parameter(Mandatory=$false)] [String]$indexhtmlloc = "index.html",
         [Parameter(Mandatory=$false)] [String]$packageRegex = "`"`"",
         [Parameter(Mandatory=$false)] [String]$regexReplacement = ""
     )
@@ -177,8 +176,6 @@ function UpdateDocIndexFiles {
     # Update main.js var lang
     $mainJsContent = Get-Content -Path $MainJsPath -Raw
     $mainJsContent = $mainJsContent -replace "var SELECTED_LANGUAGE = ''", "var SELECTED_LANGUAGE = '$lang'"
-    # Update main.js var index html
-    $mainJsContent = $mainJsContent -replace "var INDEX_HTML = ''", "var INDEX_HTML = '$indexhtmlloc'"
     # Update main.js package regex and replacement
     $mainJsContent = $mainJsContent -replace "var PACKAGE_REGEX = ''", "var PACKAGE_REGEX = $packageRegex"
     $mainJsContent = $mainJsContent -replace "var PACKAGE_REPLACEMENT = ''", "var PACKAGE_REPLACEMENT = `"$regexReplacement`""

--- a/eng/common/docgeneration/templates/matthews/styles/main.css
+++ b/eng/common/docgeneration/templates/matthews/styles/main.css
@@ -300,3 +300,12 @@ article h4 {
     background-color: #0071c5;
   }
 }
+
+.navbar-version-select {	
+  padding: 2px;	
+  border: none;	
+  border-radius: 2px;	
+  box-shadow: none;	
+  -webkit-appearance: media-time-remaining-display;	
+  margin-top: 14px;	
+}

--- a/eng/common/docgeneration/templates/matthews/styles/main.js
+++ b/eng/common/docgeneration/templates/matthews/styles/main.js
@@ -5,7 +5,6 @@ containers.addClass("container-fluid");
 
 WINDOW_CONTENTS = window.location.href.split('/')
 var SELECTED_LANGUAGE = ''
-var INDEX_HTML = ''
 var PACKAGE_REGEX = ''
 var PACKAGE_REPLACEMENT = ''
 
@@ -198,7 +197,7 @@ function populateIndexList(selector, packageName) {
 }
 
 function getPackageUrl(language, package, version) {
-    return "https://azuresdkdocs.blob.core.windows.net/$web/" + language + "/" + package + "/" + version + "/" + INDEX_HTML
+    return "https://azuresdkdocs.blob.core.windows.net/$web/" + language + "/" + package + "/" + version + "/index.html"
 }
 
 // Populate Versions


### PR DESCRIPTION
.NET individual sdk link missed the css for version dropdown effect. Added back to make sure .NET is working as expected. The changes do not affect other langs.

The PR is pending for: https://github.com/Azure/azure-sdk-for-net/pull/17400