### PR TITLE
Create PR to target against master

### DIFF
--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -8,8 +8,8 @@ parameters:
   ScriptDirectory: eng/common/scripts
   TargetDocRepoName: ''
   TargetDocRepoOwner: ''
-  PRBranchName: 'smoke-test-rdme'
-  SourceBranchName: 'smoke-test'
+  PRBranchName: 'master-rdme'
+  SourceBranchName: 'master'
   PRLabels: 'auto-merge'
   ArtifactName: ''
   Language: ''


### PR DESCRIPTION
We did not observe OPS build issue recently. The migration actually solves the build time and build error problems at the same time. We can move forward with smoke-test deprecation work.