### PR TITLE
Update release title regex to match versions with 4 digits

### DIFF
--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -2,7 +2,7 @@
 . "${PSScriptRoot}\logging.ps1"
 . "${PSScriptRoot}\SemVer.ps1"
 
-$RELEASE_TITLE_REGEX = "(?<releaseNoteTitle>^\#+.*(?<version>\b\d+\.\d+\.\d+([^0-9\s][^\s:]+)?)(\s+(?<releaseStatus>\(Unreleased\)|\(\d{4}-\d{2}-\d{2}\)))?)"
+$RELEASE_TITLE_REGEX = "(?<releaseNoteTitle>^\#+\s*(?<version>\b\d+\.\d+\.\d+(\.\d+)?([^0-9\s][^\s:]+)?)(\s+(?<releaseStatus>\(Unreleased\)|\(\d{4}-\d{2}-\d{2}\)))?)"
 $CHANGELOG_UNRELEASED_STATUS = "(Unreleased)"
 $CHANGELOG_DATE_FORMAT = "yyyy-MM-dd"
 


### PR DESCRIPTION
This [regex101](https://regex101.com/r/IUzFYX/3) highlights the problem and this PR's prospective resolution.

The error turned up [here.](https://dev.azure.com/azure-sdk/public/_build/results?buildId=638794&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=a880e989-7d1a-5c96-a41f-d540b383cc43)

I have also disabled changelog verify for the one that was erroring. This PR isn't blocking any releases.

@chidozieononiwu I'm leery as to even submitting this. Really thinking we just say "nah we're not verifying changelogs if you don't match the versioning scheme"
 

