### PR TITLE
Filter PRs from search for invalid customer issues.

### DIFF
--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/CustomerReportedInvalidState/FindCustomerRelatedIssuesInvalidState.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/CustomerReportedInvalidState/FindCustomerRelatedIssuesInvalidState.cs
@@ -50,7 +50,11 @@ namespace Azure.Sdk.Tools.GitHubIssues.Reports
             tc.DefineTableColumn("Issues Found", i => i.Note);
 
             List<ReportIssue> issuesWithNotes = new List<ReportIssue>();
-            foreach (Issue issue in context.GitHubClient.SearchForGitHubIssues(CreateQuery(repositoryConfig)))
+
+            SearchIssuesRequest searchRequest = CreateQuery(repositoryConfig);
+            searchRequest.Type = IssueTypeQualifier.Issue;
+
+            foreach (Issue issue in context.GitHubClient.SearchForGitHubIssues(searchRequest))
             {
                 if (!ValidateIssue(issue, out string issuesFound))
                 {


### PR DESCRIPTION
Fixes #1255 

This PR adds a filter to only show issues (and not PRs) in the customer issues in an invalid state query. The key change here is setting the ```Type``` property on the search request which narrows down the scope.