### PR TITLE
Support alpha and azure pipeline build version formats for SemVer parsing and sorting

### DIFF
--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -7,6 +7,9 @@ See https://azure.github.io/azure-sdk/policies_releases.html#package-versioning
 Example: 1.2.3-beta.4
 Components: Major.Minor.Patch-PrereleaseLabel.PrereleaseNumber
 
+Example: 1.2.3-alpha.20200828.4
+Components: Major.Minor.Patch-PrereleaseLabel.PrereleaseNumber.BuildNumber
+
 Note: A builtin Powershell version of SemVer exists in 'System.Management.Automation'. At this time, it does not parsing of PrereleaseNumber. It's name is also type accelerated to 'SemVer'.
 #>
 
@@ -17,14 +20,20 @@ class AzureEngSemanticVersion {
   [string] $PrereleaseLabelSeparator
   [string] $PrereleaseLabel
   [string] $PrereleaseNumberSeparator
+  [string] $BuildNumberSeparator
+  [int] $BuildNumber
   [int] $PrereleaseNumber
   [bool] $IsPrerelease
+  [bool] $HasBuildNumber
   [string] $RawVersion
   [bool] $IsSemVerFormat
   [string] $DefaultPrereleaseLabel
+  [string] $DefaultAlphaReleaseLabel
+  [string] $SortingDummyValue = 9999999
 
   # Regex inspired but simplified from https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
-  static [string] $SEMVER_REGEX = "(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:(?<presep>-?)(?<prelabel>[a-zA-Z-]*)(?<prenumsep>\.?)(?<prenumber>0|[1-9]\d*))?"
+  # Validation: https://regex101.com/r/vkijKf/426
+  static [string] $SEMVER_REGEX = "(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:(?<presep>-?)(?<prelabel>[a-zA-Z]+)(?:(?<prenumsep>\.?)(?<prenumber>[0-9]{1,8})(?:(?<buildnumsep>\.?)(?<buildnumber>\d{1,3}))?)?)?"
   static [string] $ParseLanguage = $Language
 
   static [AzureEngSemanticVersion] ParseVersionString([string] $versionString)
@@ -70,7 +79,7 @@ class AzureEngSemanticVersion {
       {
         # artifically provide these values for non-prereleases to enable easy sorting of them later than prereleases.
         $this.PrereleaseLabel = "zzz"
-        $this.PrereleaseNumber = 999
+        $this.PrereleaseNumber = $this.SortingDummyValue
         $this.IsPrerelease = $false
       }
       else
@@ -80,6 +89,15 @@ class AzureEngSemanticVersion {
         $this.PrereleaseNumber = [int]$matches["prenumber"]
         $this.PrereleaseNumberSeparator = $matches["prenumsep"]
         $this.IsPrerelease = $true
+      }
+      if ($null -eq $matches["buildnumber"]) {
+        $this.HasBuildNumber = $false
+      } else {
+        $this.BuildNumberSeparator = $matches["buildnumsep"]
+        if ($matches.ContainsKey("buildnumber")) {
+          $this.BuildNumber = [int]$matches["buildnumber"]
+        }
+        $this.HasBuildNumber = $true
       }
     }
     else
@@ -94,8 +112,9 @@ class AzureEngSemanticVersion {
   [bool] HasValidPrereleaseLabel()
   {
     if ($this.IsPrerelease -eq $true) {
-      if ($this.PrereleaseLabel -ne $this.DefaultPrereleaseLabel) {
-        Write-Host "Unexpected pre-release identifier '$($this.PrereleaseLabel)', should be '$($this.DefaultPrereleaseLabel)'"
+      if ($this.PrereleaseLabel -ne $this.DefaultPrereleaseLabel -or $this.PrereleaseLabel -ne $this.DefaultAlphaReleaseLabel) {
+        Write-Host "Unexpected pre-release identifier '$($this.PrereleaseLabel)', "`
+                   "should be '$($this.DefaultPrereleaseLabel) or $($this.DefaultAlphaReleaseLabel)'"
         return $false;
       }
       if ($this.PrereleaseNumber -lt 1)
@@ -104,6 +123,7 @@ class AzureEngSemanticVersion {
         return $false;
       }
     }
+
     return $true;
   }
 
@@ -114,6 +134,13 @@ class AzureEngSemanticVersion {
     if ($this.IsPrerelease)
     {
       $versionString += $this.PrereleaseLabelSeparator + $this.PrereleaseLabel + $this.PrereleaseNumberSeparator + $this.PrereleaseNumber
+      if ($this.HasBuildNumber) {
+        if ([AzureEngSemanticVersion]::ParseLanguage -eq "python") {
+          $versionString += $this.BuildNumberSeparator + ("{0:d3}" -f $this.BuildNumber)
+        } else {
+          $versionString += $this.BuildNumberSeparator + $this.BuildNumber
+        }
+      }
     }
     return $versionString;
   }
@@ -129,6 +156,9 @@ class AzureEngSemanticVersion {
     }
     else
     {
+      if ($this.HasBuildNumber) {
+        throw "Cannot increment releases tagged with azure pipelines build numbers"
+      }
       $this.PrereleaseNumber++
     }
   }
@@ -138,6 +168,7 @@ class AzureEngSemanticVersion {
     # Python uses no separators and "b" for beta so this sets up the the object to work with those conventions
     $this.PrereleaseLabelSeparator = $this.PrereleaseNumberSeparator = ""
     $this.DefaultPrereleaseLabel = "b"
+    $this.DefaultAlphaReleaseLabel = "a"
   }
 
   [void] SetupDefaultConventions() 
@@ -146,6 +177,7 @@ class AzureEngSemanticVersion {
     $this.PrereleaseLabelSeparator = "-"
     $this.PrereleaseNumberSeparator = "."
     $this.DefaultPrereleaseLabel = "beta"
+    $this.DefaultAlphaReleaseLabel = "alpha"
   }
 
   static [string[]] SortVersionStrings([string[]] $versionStrings)
@@ -157,7 +189,7 @@ class AzureEngSemanticVersion {
 
   static [AzureEngSemanticVersion[]] SortVersions([AzureEngSemanticVersion[]] $versions)
   {
-    return ($versions | Sort-Object -Property Major, Minor, Patch, PrereleaseLabel, PrereleaseNumber -Descending)
+    return ($versions | Sort-Object -Property Major, Minor, Patch, PrereleaseLabel, PrereleaseNumber, BuildNumber -Descending)
   }
 
   static [void] QuickTests()
@@ -165,9 +197,12 @@ class AzureEngSemanticVersion {
     $versions = @(
       "1.0.1", 
       "2.0.0", 
-      "2.0.0-alpha.20200920", 
+      "2.0.0-alpha.20200920",
+      "2.0.0-alpha.20200920.1",
       "2.0.0-beta.2", 
       "1.0.10", 
+      "2.0.0-alpha.20201221.5",
+      "2.0.0-alpha.20201221.2",
       "2.0.0-beta.1", 
       "2.0.0-beta.10", 
       "1.0.0", 
@@ -179,6 +214,9 @@ class AzureEngSemanticVersion {
       "2.0.0-beta.10",
       "2.0.0-beta.2",
       "2.0.0-beta.1",
+      "2.0.0-alpha.20201221.5",
+      "2.0.0-alpha.20201221.2",
+      "2.0.0-alpha.20200920.1",
       "2.0.0-alpha.20200920",
       "1.0.10",
       "1.0.2",
@@ -191,7 +229,7 @@ class AzureEngSemanticVersion {
     for ($i = 0; $i -lt $expectedSort.Count; $i++)
     {
       if ($sort[$i] -ne $expectedSort[$i]) { 
-        Write-Host "Error: Incorrect sort:"
+        Write-Host "Error: Incorrect version sort:"
         Write-Host "Expected: "
         Write-Host $expectedSort
         Write-Host "Actual:"
@@ -200,15 +238,51 @@ class AzureEngSemanticVersion {
       }
     }
 
-    $devVerString = "1.2.3-alpha.20200828.1"
-    $devVerNew = [AzureEngSemanticVersion]::new($devVerString)
-    if (!$devVerNew -or $devVerNew.IsSemVerFormat -ne $false) {
-      Write-Host "Error: Didn't expect daily dev version to match our semver regex because of the extra .r"
+    $alphaVerString = "1.2.3-alpha.20200828.9"
+    $alphaVer = [AzureEngSemanticVersion]::new($alphaVerString)
+    if (!$alphaVer.IsPrerelease) {
+      Write-Host "Expected alpha version to be marked as prerelease"
     }
-    $devVerparse = [AzureEngSemanticVersion]::ParseVersionString($devVerString)
-    if ($devVerparse) {
-      Write-Host "Error: Didn't expect daily dev version to parse because of the extra .r"
+    if ($alphaVer.Major -ne 1 -or $alphaVer.Minor -ne 2 -or $alphaVer.Patch -ne 3 -or `
+        $alphaVer.PrereleaseLabel -ne "alpha" -or $alphaVer.PrereleaseNumber -ne 20200828 -or $alphaVer.BuildNumber -ne 9) {
+      Write-Host "Error: Didn't correctly parse alpha version string $alphaVerString"
     }
+    if ($alphaVerString -ne $alphaVer.ToString()) {
+      Write-Host "Error: alpha string did not correctly round trip with ToString. Expected: $($alphaVerString), Actual: $($alphaVer)"
+    }
+
+    [AzureEngSemanticVersion]::ParseLanguage = "python"
+    $pythonAlphaVerString = "1.2.3a20200828009"
+    $pythonAlphaVer = [AzureEngSemanticVersion]::new($pythonAlphaVerString)
+    if (!$pythonAlphaVer.IsPrerelease) {
+      Write-Host "Expected python alpha version to be marked as prerelease"
+    }
+    # Note: For python we lump build number into prerelease number, since it simplifies the code and regex, and is behaviorally the same
+    if ($pythonAlphaVer.Major -ne 1 -or $pythonAlphaVer.Minor -ne 2 -or $pythonAlphaVer.Patch -ne 3 `
+        -or $pythonAlphaVer.PrereleaseLabel -ne "a" -or $pythonAlphaVer.PrereleaseNumber -ne 20200828 `
+        -or $pythonAlphaVer.BuildNumber -ne 9) {
+      Write-Host "Error: Didn't correctly parse python alpha version string $pythonAlphaVerString"
+    }
+    if ($pythonAlphaVerString -ne $pythonAlphaVer.ToString()) {
+      Write-Host "Error: python alpha string did not correctly round trip with ToString. Expected: $($pythonAlphaVerString), Actual: $($pythonAlphaVer)"
+    }
+
+    $versions = @("1.0.1", "2.0.0", "2.0.0a20201208001", "2.0.0a20201208002", "2.0.0b2", "1.0.10", "2.0.0b1", "2.0.0b10", "1.0.0", "1.0.0b2", "1.0.2")
+    $expectedSort = @("2.0.0", "2.0.0b10", "2.0.0b2", "2.0.0b1", "2.0.0a20201208002", "2.0.0a20201208001", "1.0.10", "1.0.2", "1.0.1", "1.0.0", "1.0.0b2")
+    $sort = [AzureEngSemanticVersion]::SortVersionStrings($versions)
+    for ($i = 0; $i -lt $expectedSort.Count; $i++)
+    {
+      if ($sort[$i] -ne $expectedSort[$i]) { 
+        Write-Host "Error: Incorrect python version sort:"
+        Write-Host "Expected: "
+        Write-Host $expectedSort
+        Write-Host "Actual:"
+        Write-Host $sort
+        break
+      }
+    }
+
+    [AzureEngSemanticVersion]::ParseLanguage = ""
 
     $gaVerString = "1.2.3"
     $gaVer = [AzureEngSemanticVersion]::ParseVersionString($gaVerString)
@@ -216,7 +290,7 @@ class AzureEngSemanticVersion {
       Write-Host "Error: Didn't correctly parse ga version string $gaVerString"
     }
     if ($gaVerString -ne $gaVer.ToString()) {
-      Write-Host "Error: Ga string did not correctly round trip with ToString"
+      Write-Host "Error: Ga string did not correctly round trip with ToString. Expected: $($gaVerString), Actual: $($gaVer)"
     }
     $gaVer.IncrementAndSetToPrerelease()
     if ("1.3.0-beta.1" -ne $gaVer.ToString()) {
@@ -229,7 +303,7 @@ class AzureEngSemanticVersion {
       Write-Host "Error: Didn't correctly parse beta version string $betaVerString"
     }
     if ($betaVerString -ne $betaVer.ToString()) {
-      Write-Host "Error: beta string did not correctly round trip with ToString"
+      Write-Host "Error: beta string did not correctly round trip with ToString. Expected: $($betaVerString), Actual: $($betaVer)"
     }
     $betaVer.IncrementAndSetToPrerelease()
     if ("1.2.3-beta.5" -ne $betaVer.ToString()) {

--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -127,8 +127,10 @@ class AzureEngSemanticVersion {
     if ($this.IsPrerelease)
     {
       $versionString += $this.PrereleaseLabelSeparator + $this.PrereleaseLabel + `
-                        $this.PrereleaseNumberSeparator + $this.PrereleaseNumber + `
-                        $this.BuildNumberSeparator + $this.BuildNumber
+                        $this.PrereleaseNumberSeparator + $this.PrereleaseNumber
+      if ($this.BuildNumber) {
+          $versionString += $this.BuildNumberSeparator + $this.BuildNumber
+      }
     }
     return $versionString;
   }
@@ -164,6 +166,7 @@ class AzureEngSemanticVersion {
     # Use the default common conventions
     $this.PrereleaseLabelSeparator = "-"
     $this.PrereleaseNumberSeparator = "."
+    $this.BuildNumberSeparator = "."
     $this.DefaultPrereleaseLabel = "beta"
     $this.DefaultAlphaReleaseLabel = "alpha"
   }

--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -94,9 +94,7 @@ class AzureEngSemanticVersion {
         $this.HasBuildNumber = $false
       } else {
         $this.BuildNumberSeparator = $matches["buildnumsep"]
-        if ($matches.ContainsKey("buildnumber")) {
-          $this.BuildNumber = [int]$matches["buildnumber"]
-        }
+        $this.BuildNumber = [int]$matches["buildnumber"]
         $this.HasBuildNumber = $true
       }
     }
@@ -166,7 +164,7 @@ class AzureEngSemanticVersion {
   [void] SetupPythonConventions() 
   {
     # Python uses no separators and "b" for beta so this sets up the the object to work with those conventions
-    $this.PrereleaseLabelSeparator = $this.PrereleaseNumberSeparator = ""
+    $this.PrereleaseLabelSeparator = $this.PrereleaseNumberSeparator = $this.BuildNumberSeparator = ""
     $this.DefaultPrereleaseLabel = "b"
     $this.DefaultAlphaReleaseLabel = "a"
   }
@@ -201,8 +199,11 @@ class AzureEngSemanticVersion {
       "2.0.0-alpha.20200920.1",
       "2.0.0-beta.2", 
       "1.0.10", 
+      "2.0.0-alpha.20201221.1",
+      "2.0.0-alpha.20201221.01",
       "2.0.0-alpha.20201221.5",
       "2.0.0-alpha.20201221.2",
+      "2.0.0-alpha.20201221.10",
       "2.0.0-beta.1", 
       "2.0.0-beta.10", 
       "1.0.0", 
@@ -214,8 +215,11 @@ class AzureEngSemanticVersion {
       "2.0.0-beta.10",
       "2.0.0-beta.2",
       "2.0.0-beta.1",
+      "2.0.0-alpha.20201221.10",
       "2.0.0-alpha.20201221.5",
       "2.0.0-alpha.20201221.2",
+      "2.0.0-alpha.20201221.1",
+      "2.0.0-alpha.20201221.1",
       "2.0.0-alpha.20200920.1",
       "2.0.0-alpha.20200920",
       "1.0.10",

--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -105,9 +105,9 @@ class AzureEngSemanticVersion {
   [bool] HasValidPrereleaseLabel()
   {
     if ($this.IsPrerelease -eq $true) {
-      if ($this.PrereleaseLabel -ne $this.DefaultPrereleaseLabel -or $this.PrereleaseLabel -ne $this.DefaultAlphaReleaseLabel) {
+      if ($this.PrereleaseLabel -ne $this.DefaultPrereleaseLabel -and $this.PrereleaseLabel -ne $this.DefaultAlphaReleaseLabel) {
         Write-Host "Unexpected pre-release identifier '$($this.PrereleaseLabel)', "`
-                   "should be '$($this.DefaultPrereleaseLabel) or $($this.DefaultAlphaReleaseLabel)'"
+                   "should be '$($this.DefaultPrereleaseLabel)' or '$($this.DefaultAlphaReleaseLabel)'"
         return $false;
       }
       if ($this.PrereleaseNumber -lt 1)


### PR DESCRIPTION
This PR updates the semver tooling to support our dev feed formats like:

```
5.3.0-alpha.20200928.3
# Python
2.0.0a20201208001
```

Supporting this format will enable us to sort release feeds that contain alpha releases, primarily so we can target smoke tests against the latest nightly and/or preview release, where applicable. Currently the smoke tests (at least for .net) have a bug where they are testing against very old dev releases, since they just pick the last item in the API response.