### PR TITLE
Added a step of skipping package json update for spring boot packages

### DIFF
--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -53,23 +53,24 @@ steps:
   env:
     GH_TOKEN: $(azuresdk-github-pat)
 
-- task: PowerShell@2
-  displayName: 'Update Docs.MS CI Targeted Packages'
-  condition: and(succeededOrFailed(), eq('${{ parameters.OnboardingBranch }}',''))
-  inputs:
-    targetType: filePath
-    filePath: ${{ parameters.ScriptDirectory }}/update-docs-ci.ps1
-    arguments: >
-      -ArtifactLocation ${{ parameters.ArtifactLocation }}
-      -WorkDirectory "${{ parameters.WorkingDirectory }}"
-      -RepoId ${{ parameters.RepoId }}
-      -Repository ${{ parameters.PackageRepository }}
-      -ReleaseSHA ${{ parameters.ReleaseSha }}
-      -DocRepoLocation "${{ parameters.WorkingDirectory }}/repo"
-      -Configs "${{ parameters.CIConfigs }}"
-    pwsh: true
-  env:
-    GH_TOKEN: $(azuresdk-github-pat)
+  - ${{if ne(artifact.skipUpdatePackageJson, 'true')}}:
+    - task: PowerShell@2
+      displayName: 'Update Docs.MS CI Targeted Packages'
+      condition: and(succeededOrFailed(), eq('${{ parameters.OnboardingBranch }}',''))
+      inputs:
+        targetType: filePath
+        filePath: ${{ parameters.ScriptDirectory }}/update-docs-ci.ps1
+        arguments: >
+          -ArtifactLocation ${{ parameters.ArtifactLocation }}
+          -WorkDirectory "${{ parameters.WorkingDirectory }}"
+          -RepoId ${{ parameters.RepoId }}
+          -Repository ${{ parameters.PackageRepository }}
+          -ReleaseSHA ${{ parameters.ReleaseSha }}
+          -DocRepoLocation "${{ parameters.WorkingDirectory }}/repo"
+          -Configs "${{ parameters.CIConfigs }}"
+        pwsh: true
+      env:
+        GH_TOKEN: $(azuresdk-github-pat)
 
 - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
   parameters:

--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -54,24 +54,23 @@ steps:
   env:
     GH_TOKEN: $(azuresdk-github-pat)
 
-  - ${{if ne(artifact.skipUpdatePackageJson, 'true')}}:
-    - task: PowerShell@2
-      displayName: 'Update Docs.MS CI Targeted Packages'
-      condition: and(succeededOrFailed(), eq('${{ parameters.OnboardingBranch }}',''), ne('${{ parameters.SkipPackageJson }}', true))
-      inputs:
-        targetType: filePath
-        filePath: ${{ parameters.ScriptDirectory }}/update-docs-ci.ps1
-        arguments: >
-          -ArtifactLocation ${{ parameters.ArtifactLocation }}
-          -WorkDirectory "${{ parameters.WorkingDirectory }}"
-          -RepoId ${{ parameters.RepoId }}
-          -Repository ${{ parameters.PackageRepository }}
-          -ReleaseSHA ${{ parameters.ReleaseSha }}
-          -DocRepoLocation "${{ parameters.WorkingDirectory }}/repo"
-          -Configs "${{ parameters.CIConfigs }}"
-        pwsh: true
-      env:
-        GH_TOKEN: $(azuresdk-github-pat)
+- task: PowerShell@2
+  displayName: 'Update Docs.MS CI Targeted Packages'
+  condition: and(succeededOrFailed(), eq('${{ parameters.OnboardingBranch }}',''), ne('${{ parameters.SkipPackageJson }}', true))
+  inputs:
+    targetType: filePath
+    filePath: ${{ parameters.ScriptDirectory }}/update-docs-ci.ps1
+    arguments: >
+      -ArtifactLocation ${{ parameters.ArtifactLocation }}
+      -WorkDirectory "${{ parameters.WorkingDirectory }}"
+      -RepoId ${{ parameters.RepoId }}
+      -Repository ${{ parameters.PackageRepository }}
+      -ReleaseSHA ${{ parameters.ReleaseSha }}
+      -DocRepoLocation "${{ parameters.WorkingDirectory }}/repo"
+      -Configs "${{ parameters.CIConfigs }}"
+    pwsh: true
+  env:
+    GH_TOKEN: $(azuresdk-github-pat)
 
 - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
   parameters:

--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -19,6 +19,7 @@ parameters:
   GHTeamReviewersVariable: '' # externally set, as eng-common does not have the identity-resolver. Run as pre-step
   OnboardingBranch: ''
   CloseAfterOpenForTesting: false
+  SkipPackageJson: false
 
 steps:
 - pwsh: |
@@ -56,7 +57,7 @@ steps:
   - ${{if ne(artifact.skipUpdatePackageJson, 'true')}}:
     - task: PowerShell@2
       displayName: 'Update Docs.MS CI Targeted Packages'
-      condition: and(succeededOrFailed(), eq('${{ parameters.OnboardingBranch }}',''))
+      condition: and(succeededOrFailed(), eq('${{ parameters.OnboardingBranch }}',''), ne('${{ parameters.SkipPackageJson }}', true))
       inputs:
         targetType: filePath
         filePath: ${{ parameters.ScriptDirectory }}/update-docs-ci.ps1


### PR DESCRIPTION
**Issue to solve**: Spring boot starter packages has no API documentations, so the Java Doc CI build failed to retrieve the documentation. Synced with Spring team, they expect to have readme only in Overview page without API. 
e.g: https://review.docs.microsoft.com/en-us/java/api/overview/azure/spring-boot-starter-cosmos-readme-pre?view=azure-java-preview&branch=smoke-test

Currently, we manually do the updates. 

**Purpose of the PR**: Add a variable which passes through `ci.yml` to skip updating `package.json`, so we only update readme through the release pipeline. That's how we pass the Java CI build and achieve the purpose of displaying readme only in Dos.Ms for spring boot starter packages.

Tested PR: https://github.com/Azure/azure-sdk-for-java/pull/18077
Tested in pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=650940&view=logs&j=df6dbc9d-9cb6-55ac-00c8-bc457d14297a&t=df6dbc9d-9cb6-55ac-00c8-bc457d14297a

The PR generated by pipeline: https://github.com/Azure/azure-docs-sdk-java/pull/1571/files