### PR TITLE
Fixed the bug of replacing img src with href text

### DIFF
--- a/eng/common/docgeneration/templates/matthews/styles/main.js
+++ b/eng/common/docgeneration/templates/matthews/styles/main.js
@@ -76,7 +76,7 @@ $(function () {
     // Add text to empty links
     $("p > a").each(function () {
         var link = $(this).attr('href')
-        if ($(this).text() === "") {
+        if ($(this).text() === "" && $(this).children().attr("src") === "") {
             $(this).html(link)
         }
     });


### PR DESCRIPTION
The page currently looks like:
![image](https://user-images.githubusercontent.com/48036328/102380787-335b1080-3f7d-11eb-98cb-7b947915c63c.png)

The changes applied to all lang repo.
After apply the fix:
![image](https://user-images.githubusercontent.com/48036328/102320380-0f71dd80-3f31-11eb-8a31-4158ff334ee7.png)
