### PR TITLE
Return review URL in response to auto API review create request

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
@@ -30,8 +30,9 @@ namespace APIViewWeb.Controllers
                     var review = await _reviewManager.CreateMasterReviewAsync(User, file.FileName, label, openReadStream, false);
                     if(review != null)
                     {
+                        var reviewUrl = $"{this.Request.Scheme}://{this.Request.Host}/Assemblies/Review/{review.ReviewId}";
                         //Return 200 OK if last revision is approved and 201 if revision is not yet approved.
-                        var result = review.Revisions.Last().Approvers.Count > 0 ? Ok() : StatusCode(statusCode: StatusCodes.Status201Created);
+                        var result = review.Revisions.Last().Approvers.Count > 0 ? Ok(reviewUrl) : StatusCode(statusCode: StatusCodes.Status201Created, reviewUrl);
                         return result;
                     }
                 }


### PR DESCRIPTION
Return created or pending review URL in response so it can be shown in CI logs. This will be helpful to pinpoint which review needs to be approved.