### PR TITLE
Add resource provisioning variables to UP pipelines and improve readability

### DIFF
--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -5,6 +5,24 @@ trigger: none
 variables:
   skipComponentGovernanceDetection: true
 
+parameters:
+  - name: AzureSDK_Maven_Release_Pipeline_Secrets
+    default: 1
+  - name: AzureSDK_Nuget_Release_Pipeline_Secrets
+    default: 13
+  - name: NPM_Registry_Authentication
+    default: 24
+  - name: Secrets_for_DevOps_Notification_Configuration_and_User_Resolution
+    default: 56
+  - name: Release_Secrets_for_GitHub
+    default: 58
+  - name: Secrets_for_Resource_Provisioner
+    default: 64
+  - name: Release_Secrets_for_GitHubIO_Publishing
+    default: 76
+  - name: APIReview_AutoCreate_Configurations
+    default: 93
+
 jobs:
 - job: GeneratePipelines
   pool:
@@ -16,40 +34,68 @@ jobs:
         Branch: master
         Prefix: java
         PublicOptions: ''
-        InternalOptions: '--variablegroup 1 --variablegroup 58 --variablegroup 76 --variablegroup 56 --variablegroup 93'
-        TestOptions: '--variablegroup 64'
+        InternalOptions: >-
+          --variablegroup ${{ parameters.AzureSDK_Maven_Release_Pipeline_Secrets }}
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHub }}
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
+          --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
+        TestOptions: '--variablegroup ${{ parameters.Secrets_for_Resource_Provisioner }}'
       Android:
         RepositoryName: azure-sdk-for-android
         Branch: master
         Prefix: android
         PublicOptions: ''
-        InternalOptions: '--variablegroup 1 --variablegroup 58 --variablegroup 76 --variablegroup 56 --variablegroup 93'
+        InternalOptions: >-
+          --variablegroup ${{ parameters.AzureSDK_Maven_Release_Pipeline_Secrets }}
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHub }}
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
+          --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
       JavaScript:
         RepositoryName: azure-sdk-for-js
         Branch: master
         Prefix: js
         PublicOptions: ''
-        InternalOptions: '--variablegroup 24 --variablegroup 58 --variablegroup 76 --variablegroup 56 --variablegroup 93'
+        InternalOptions: >-
+          --variablegroup ${{ parameters.NPM_Registry_Authentication }}
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHub }}
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
+          --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
       Python:
         RepositoryName: azure-sdk-for-python
         Branch: master
         Prefix: python
         PublicOptions: ''
-        InternalOptions: '--variablegroup 58 --variablegroup 76 --variablegroup 56 --variablegroup 93'
-        TestOptions: '--variablegroup 64'
+        InternalOptions: >-
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHub }}
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
+          --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
+        TestOptions: '--variablegroup ${{ parameters.Secrets_for_Resource_Provisioner }}'
       Net:
         RepositoryName: azure-sdk-for-net
         Branch: master
         Prefix: net
         PublicOptions: ''
-        InternalOptions: '--variablegroup 13 --variablegroup 58 --variablegroup 76 --variablegroup 56 --variablegroup 93'
-        TestOptions: '--variablegroup 64'
+        InternalOptions: >-
+          --variablegroup ${{ parameters.AzureSDK_Nuget_Release_Pipeline_Secrets }}
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHub }}
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
+          --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
+        TestOptions: '--variablegroup ${{ parameters.Secrets_for_Resource_Provisioner }}'
       Cpp:
         RepositoryName: azure-sdk-for-cpp
         Branch: master
         Prefix: cpp
         PublicOptions: ''
-        InternalOptions: '--variablegroup 58 --variablegroup 76 --variablegroup 56 --variablegroup 93'
+        InternalOptions: >-
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHub }}
+          --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
+          --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
   steps:
   - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
   - script: |

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -109,7 +109,7 @@ jobs:
     env:
       PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
   - script: |
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator --organization https://dev.azure.com/azure-sdk --project internal --prefix $(Prefix) --path $(Pipeline.Workspace)/$(RepositoryName)/sdk --endpoint Azure --repository Azure/$(RepositoryName) --convention up --agentpool Hosted --branch refs/heads/$(Branch) --patvar PATVAR --debug $(InternalOptions)
+      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator --organization https://dev.azure.com/azure-sdk --project internal --prefix $(Prefix) --path $(Pipeline.Workspace)/$(RepositoryName)/sdk --endpoint Azure --repository Azure/$(RepositoryName) --convention up --agentpool Hosted --branch refs/heads/$(Branch) --patvar PATVAR --debug $(InternalOptions) $(TestOptions)
     displayName: 'Generate internal pipelines for: $(RepositoryName)'
     env:
       PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)


### PR DESCRIPTION
This PR does two things:

1. Adds the resource provisioning secrets to the unified pipeline, in order to enable running smoke tests after release via this pipeline.
2. Adds a sanitized keyvault name mapping to the variable groups, so it's a little easier to see which pipelines need which variables (as opposed to just variable group numbers).

In support of https://github.com/Azure/azure-sdk/issues/1999