### PR TITLE
Add powershell script for validating pipelines yaml

### DIFF
--- a/scripts/powershell/Validate-PipelineYaml.ps1
+++ b/scripts/powershell/Validate-PipelineYaml.ps1
@@ -1,0 +1,115 @@
+#!/usr/bin/env pwsh
+
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+param(
+    [Parameter(Mandatory=$True)]
+    [String]$Path,
+
+    [Parameter(Mandatory=$True)]
+    [String]$PipelineId,
+
+    [Parameter(Mandatory=$False)]
+    [String]$Branch = "master",
+
+    [Parameter(Mandatory=$False)]
+    [String]$Project = "internal",
+
+    [Parameter(Mandatory=$False)]
+    [String]$OutputPath = "output.yml"
+)
+
+function GetAuthString() {
+    $pass = $env:PATVAR
+    if (!$pass) {
+        throw "PATVAR environment variable must contain azure pipelines personal access token"
+    }
+    $pair = ":$($pass)"
+    $encodedCreds = [System.Convert]::ToBase64String([System.Text.Encoding]::ASCII.GetBytes($pair))
+    $basicAuthValue = "Basic $encodedCreds"
+    return $basicAuthValue
+}
+
+function BuildBody() {
+    $body = @{
+        resources = @{
+            repositories = @{
+                self = @{ refName = "$($Branch)" }
+            }
+        };
+        PreviewRun = $true;
+        YamlOverride = [string](Get-Content -Raw $Path)
+    }
+
+    return $body | ConvertTo-Json -Depth 10
+}
+
+function BuildRequest() {
+    $basicAuthValue = GetAuthString
+    $headers = @{ Authorization = $basicAuthValue }
+    $uri = "https://dev.azure.com/azure-sdk/$($Project)/_apis/pipelines/$($PipelineId)/runs?api-version=6.0-preview.1"
+    $body = BuildBody
+    $contentType = "application/json"
+    return $headers, $uri, $body, $contentType
+}
+
+
+$headers, $uri, $body, $contentType = BuildRequest
+
+try {
+    $resp = Invoke-WebRequest -Headers $headers -Uri $uri -Body $body -ContentType $contentType -Method Post
+} catch {
+    Write-Error ($_.ErrorDetails.Message | ConvertFrom-Json | Select-Object -ExpandProperty message)
+    exit 1
+}
+
+$resp.Content | ConvertFrom-Json | Select-Object -ExpandProperty finalYaml | Out-File $($OutputPath)
+Write-Host "YAML is valid! Generated pipeline written to $($OutputPath)"
+
+<#
+.SYNOPSIS
+Validates a Azure Pipelines yaml file via the Azure Pipelines API.
+
+.DESCRIPTION
+This script submits pipelines yaml to the server-side API for advanced validation which includes parameter expansion.
+It writes the generated yaml to a file.
+For basic pipelines yaml schema validation, see the VSCode extension: https://github.com/Microsoft/azure-pipelines-vscode
+
+.PARAMETER Path
+Path to the pipelines yaml file
+
+.PARAMETER PipelineId
+The Pipeline ID (number) that the pipeline yaml is defined for. You can retrieve the numeric ID by navigating
+to the pipeline in the UI, and grabbing it from the url: https://dev.azure.com/azure-sdk/internal/_build?definitionId=<PIPELINE_ID>&_a=summary
+
+.PARAMETER Branch
+The Pipelines API supports validating any additional yaml templates included by the pipeline file.
+In order to do so, these files must be checked in to the repository.
+In this case -Branch must be specified to reference those changes.
+Referencing external repositories for validation is not supported by the Pipelines API.
+
+.PARAMETER Project
+Optional Azure DevOps project the pipeline is defined under. Defaults to 'internal'.
+
+.PARAMETER OutputPath
+Optional output path for the generated pipeline yaml. Defaults to 'output.yml'.
+
+.EXAMPLE
+Test changes to a pipeline file against master:
+
+$env:PATVAR = "<personal access token>"
+./scripts/powershell/Validate-PipelineYaml.ps1 `
+    -Path ./eng/pipelines/pipeline-generation.yml `
+    -Pipeline 773
+
+.EXAMPLE
+Test changes to a pipeline file against a branch with extra template changes:
+
+$env:PATVAR = "<personal access token>"
+./scripts/powershell/Validate-PipelineYaml.ps1 `
+    -Path ./eng/pipelines/pipeline-generation.yml `
+    -Pipeline 773 `
+    -Branch <your branch>
+
+#>

--- a/scripts/powershell/Validate-PipelineYaml.ps1.md
+++ b/scripts/powershell/Validate-PipelineYaml.ps1.md
@@ -1,0 +1,141 @@
+---
+external help file: -help.xml
+Module Name:
+online version:
+schema: 2.0.0
+---
+
+# Validate-PipelineYaml.ps1
+
+## SYNOPSIS
+Validates a Azure Pipelines yaml file via the Azure Pipelines API.
+
+## SYNTAX
+
+```
+Validate-PipelineYaml.ps1 [-Path] <String> [-PipelineId] <String> [[-Branch] <String>] [[-Project] <String>]
+ [[-OutputPath] <String>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+This script submits pipelines yaml to the server-side API for advanced validation which includes parameter expansion.
+It writes the generated yaml to a file.
+For basic pipelines yaml schema validation, see the VSCode extension: https://github.com/Microsoft/azure-pipelines-vscode
+
+## EXAMPLES
+
+### EXAMPLE 1
+```
+Test changes to a pipeline file against master:
+```
+
+$env:PATVAR = "\<personal access token\>"
+./scripts/powershell/Validate-PipelineYaml.ps1 \`
+    -Path ./eng/pipelines/pipeline-generation.yml \`
+    -Pipeline 773
+
+### EXAMPLE 2
+```
+Test changes to a pipeline file against a branch with extra template changes:
+```
+
+$env:PATVAR = "\<personal access token\>"
+./scripts/powershell/Validate-PipelineYaml.ps1 \`
+    -Path ./eng/pipelines/pipeline-generation.yml \`
+    -Pipeline 773 \`
+    -Branch \<your branch\>
+
+## PARAMETERS
+
+### -Path
+Path to the pipelines yaml file
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -PipelineId
+The Pipeline ID (number) that the pipeline yaml is defined for.
+You can retrieve the numeric ID by navigating
+to the pipeline in the UI, and grabbing it from the url: https://dev.azure.com/azure-sdk/internal/_build?definitionId=\<PIPELINE_ID\>&_a=summary
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: True
+Position: 2
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Branch
+The Pipelines API supports validating any additional yaml templates included by the pipeline file.
+In order to do so, these files must be checked in to the repository.
+In this case -Branch must be specified to reference those changes.
+Referencing external repositories for validation is not supported by the Pipelines API.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 3
+Default value: Master
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Project
+Optional Azure DevOps project the pipeline is defined under.
+Defaults to 'internal'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 4
+Default value: Internal
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputPath
+Optional output path for the generated pipeline yaml.
+Defaults to 'output.yml'.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 5
+Default value: Output.yml
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+## OUTPUTS
+
+## NOTES
+
+## RELATED LINKS


### PR DESCRIPTION
This PR adds a script to enable a quicker dev loop when validating azure pipelines yaml. While there is already a [VSCode extension](https://github.com/Microsoft/azure-pipelines-vscode) that helps do basic schema validation, it does not do any of the server side operations required for expanding parameters, and generating complex templates.

The script can work for quick changes to one file, or for referencing a larger change against a branch. If the pipeline definition is not valid, it will print any processing errors. If it IS valid, then the generated pipeline will be saved to disk for inspection.

Currently, in order to do this, you need to load the pipeline in the browser, click edit, select your branch, then click validate OR download, then navigate to the downloaded file and open it. This script should save quite a bit of iteration time for people doing lots of development with pipelines (like me 😄).

```
$ ./scripts/powershell/Validate-PipelineYaml.ps1  -Path ./eng/pipelines/mirror-repos.yml -Pipeline 1752  -Branch "benbp/test"
Write-Error: /eng/pipelines/templates/steps/sync-repo-branch.yml (Line: 22, Col: 3): Unexpected value 'badvalue'

$ ./scripts/powershell/Validate-PipelineYaml.ps1  -Path ./eng/pipelines/mirror-repos.yml -Pipeline 1752
YAML is valid! Generated pipeline written to output.yml
```

Note: The pipelines API does not support referencing forked repositories, so any branch references must be in the source repository that the pipeline lives in. It likely could on the server side, but the code paths underneath the API don't pass that information along sadly. There may be a way to use the repository reference in the yaml itself, but I haven't gotten it to work yet.