### PR TITLE
Improve rule bot code

### DIFF
--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/CreateRuleFabricBot.csproj
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/CreateRuleFabricBot.csproj
@@ -12,7 +12,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLine.Net" Version="2.2.1" />
-    <PackageReference Include="System.Text.Json" Version="4.7.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnerEntry.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Helpers/CodeOwnerEntry.cs
@@ -20,9 +20,9 @@ namespace CreateRuleFabricBot
         internal const string ServiceLabelMoniker = "ServiceLabel";
         internal const string MissingFolder = "#/<NotInRepo>/";
 
-        public string PathExpression { get; set; }
+        public string PathExpression { get; set; } = "";
 
-        public bool ContainsWildcard { get; set; }
+        public bool ContainsWildcard => PathExpression.Contains("*");
 
         public List<string> Owners { get; set; } = new List<string>();
 
@@ -128,7 +128,6 @@ namespace CreateRuleFabricBot
             string path = line.Substring(0, ownerStartPosition).Trim();
             // the first entry is the path/regex
             PathExpression = path;
-            ContainsWildcard = path.Contains('*');
 
             // remove the path from the string.
             return line.Substring(ownerStartPosition);

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/BaseCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/BaseCapability.cs
@@ -2,6 +2,23 @@
 {
     public abstract class BaseCapability
     {
+        protected readonly string _repo;
+        protected readonly string _owner;
+        private readonly string _configurationFile;
+
+        public BaseCapability(string org, string repo, string configurationFile)
+        {
+            _repo = repo;
+            _owner = org;
+            _configurationFile = configurationFile;
+
+            if (!string.IsNullOrEmpty(configurationFile))
+            {
+                ReadConfigurationFromFile(configurationFile);
+            }
+        }
+
+        internal abstract void ReadConfigurationFromFile(string configurationFile);
         public abstract string GetPayload();
         public abstract string GetTaskId();
     }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/IssueRouting/TriageConfig.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/IssueRouting/TriageConfig.cs
@@ -1,4 +1,6 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace CreateRuleFabricBot.Rules.IssueRouting
 {
@@ -9,13 +11,19 @@ namespace CreateRuleFabricBot.Rules.IssueRouting
 
         public override string ToString()
         {
-            string labels = "\"" + string.Join("\",\"", Labels) + "\"";
-            string mentionee = "\"" + string.Join("\",\"", Mentionee) + "\"";
+            var array = Labels.Select(label => new JValue(label)).ToArray();
+            var arr = new JArray(array);
 
-            return $"{{ " +
-                $"\"labels\": [  {labels}  ], " +
-                $"\"mentionees\": [ {mentionee}  ]" +
-                $" }}";
+            return GetJsonPayload().ToString();
+        }
+
+        public JObject GetJsonPayload()
+        {
+            return new JObject(
+                new JProperty("labels",
+                    new JArray(Labels.Select(label => new JValue(label)).ToArray())),
+                new JProperty("mentionees",
+                    new JArray(Mentionee.Select(ment => new JValue(ment)).ToArray())));
         }
     }
 }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PathConfig.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PathConfig.cs
@@ -24,7 +24,6 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
 
         public override string ToString()
         {
-            // Note: By using an empty string in the exclude portion above, the rule we create will allow multiple labels (from different folders) to be applied to the same PR.
             return GetJsonPayload().ToString();
         }
 
@@ -34,6 +33,8 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
                 new JProperty("labels", new JArray(new JValue(Label))),
                 new JProperty("pathFilter", new JArray(new JValue(Path))),
                 new JProperty("exclude", new JArray(new JValue(""))));
+            // Note: By using an empty string in the exclude property above, 
+            // the rule we create will allow multiple labels (from different folders) to be applied to the same PR.
         }
     }
 }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PathConfig.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PathConfig.cs
@@ -1,4 +1,6 @@
 ﻿using System.Collections.Generic;
+using System.IO;
+using System.Text.Json;
 
 namespace CreateRuleFabricBot.Rules.PullRequestLabel
 {
@@ -16,12 +18,13 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
             Label = label;
         }
 
-
         public string Label { get; set; } = "";
         public string Path { get; set; } = "";
 
         public override string ToString()
         {
+            // Note: By using an empty string in the exclude portion above, the rule we create will allow multiple labels (from different folders) to be applied to the same PR.
+
             return $"{{ " +
                 $"\"labels\": [\"{Label}\"], " +
                 $"\"pathFilter\": [\"{Path}\"], " +

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PathConfig.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PathConfig.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace CreateRuleFabricBot.Rules.PullRequestLabel
+{
+    public class PathConfig
+    {
+        public PathConfig(string pathExpression, string label)
+        {
+            // at this point we should remove the leading '/' if any
+            if (pathExpression.StartsWith("/"))
+            {
+                pathExpression = pathExpression.Substring(1);
+            }
+
+            Path = pathExpression;
+            Label = label;
+        }
+
+
+        public string Label { get; set; } = "";
+        public string Path { get; set; } = "";
+
+        public override string ToString()
+        {
+            return $"{{ " +
+                $"\"labels\": [\"{Label}\"], " +
+                $"\"pathFilter\": [\"{Path}\"], " +
+                "\"exclude\": [ \"\" ] " +
+                $" }}";
+        }
+    }
+}

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PathConfig.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PathConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using Newtonsoft.Json.Linq;
+using System.Collections.Generic;
 using System.IO;
 using System.Text.Json;
 
@@ -24,12 +25,15 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
         public override string ToString()
         {
             // Note: By using an empty string in the exclude portion above, the rule we create will allow multiple labels (from different folders) to be applied to the same PR.
+            return GetJsonPayload().ToString();
+        }
 
-            return $"{{ " +
-                $"\"labels\": [\"{Label}\"], " +
-                $"\"pathFilter\": [\"{Path}\"], " +
-                "\"exclude\": [ \"\" ] " +
-                $" }}";
+        public JObject GetJsonPayload()
+        {
+            return new JObject(
+                new JProperty("labels", new JArray(new JValue(Label))),
+                new JProperty("pathFilter", new JArray(new JValue(Path))),
+                new JProperty("exclude", new JArray(new JValue(""))));
         }
     }
 }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -28,15 +28,6 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
     }
 ";
 
-        private static readonly string s_configTemplate = @"
-          {
-            ""label"": ""###label###"",
-            ""pathFilter"": [ ###srcFolders### ],
-            ""exclude"": [ """" ]
-          }
-";
-        // Note: By using an empty string in the exclude portion above, the rule we create will allow multiple labels (from different folders) to be applied to the same PR.
-
         public PullRequestLabelFolderCapability(string org, string name, string configurationFile)
             : base(org, name, configurationFile)
         {
@@ -123,22 +114,6 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
         public override string GetTaskId()
         {
             return $"AzureSDKPullRequestLabelFolder_{_owner}_{_repo}";
-        }
-
-        private string ToConfigString(CodeOwnerEntry entry)
-        {
-            string result = s_configTemplate;
-
-            result = result.Replace("###label###", entry.PRLabels.First());
-
-            // at this point we should remove the leading '/' if any
-            if (entry.PathExpression.StartsWith("/"))
-            {
-                entry.PathExpression = entry.PathExpression.Substring(1);
-            }
-            result = result.Replace("###srcFolders###", $"\"{entry.PathExpression}\"");
-
-            return result;
         }
     }
 }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -37,24 +37,48 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
 ";
         // Note: By using an empty string in the exclude portion above, the rule we create will allow multiple labels (from different folders) to be applied to the same PR.
 
-        private readonly string _repo;
-        private readonly string _owner;
-        private readonly string _codeownersFile;
-
-        public PullRequestLabelFolderCapability(string org, string name, string codeownersFile)
+        public PullRequestLabelFolderCapability(string org, string name, string configurationFile)
+            : base(org, name, configurationFile)
         {
-            _repo = org;
-            _owner = name;
-            _codeownersFile = codeownersFile;
         }
+
+        private List<PathConfig> _entriesToCreate = new List<PathConfig>();
 
         public override string GetPayload()
         {
-            List<CodeOwnerEntry> entries = CodeOwnersFile.ParseFile(_codeownersFile);
-
             StringBuilder configPayload = new StringBuilder();
+            Colorizer.WriteLine("Found the following rules:");
 
-            List<CodeOwnerEntry> entriesToCreate = new List<CodeOwnerEntry>();
+            // Create the payload.
+            foreach (var entry in _entriesToCreate)
+            {
+                // get the payload
+                Colorizer.WriteLine("[Cyan!{0}] => [Magenta!{1}]", entry.Path, entry.Label);
+
+                configPayload.Append(entry.ToString());
+                configPayload.Append(',');
+            }
+
+            // remove the trailing ','
+            configPayload.Remove(configPayload.Length - 1, 1);
+
+            // create the payload from the template
+            return s_template
+                .Replace("###taskId###", GetTaskId())
+                .Replace("###labelConfig###", configPayload.ToString());
+        }
+
+        /// <summary>
+        /// Add an entry for a folder with a specified label
+        /// </summary>
+        public void AddEntry(string pathExpression, string label)
+        {
+            _entriesToCreate.Add(new PathConfig(pathExpression, label));
+        }
+
+        internal override void ReadConfigurationFromFile(string configurationFile)
+        {
+            List<CodeOwnerEntry> entries = CodeOwnersFile.ParseFile(configurationFile);
 
             // Filter our the list of entries that we want to create.
             for (int i = 0; i < entries.Count; i++)
@@ -72,11 +96,11 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
                     continue; //TODO: regex expressions are not yet supported
                 }
 
-                if (entries[i].PathExpression.IndexOf(CodeOwnerEntry.MissingFolder, StringComparison.OrdinalIgnoreCase) !=-1)
+                if (entries[i].PathExpression.IndexOf(CodeOwnerEntry.MissingFolder, StringComparison.OrdinalIgnoreCase) != -1)
                 {
                     Colorizer.WriteLine("[Yellow!Warning]: The path '[Cyan!{0}]' is marked with the non-existing path marker.", entries[i].PathExpression);
 
-                    continue; 
+                    continue;
                 }
 
                 // Entries with more than one label are not yet supported.
@@ -92,34 +116,13 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
                     continue;
                 }
 
-                entriesToCreate.Add(entries[i]);
+                _entriesToCreate.Add(new PathConfig(entries[i].PathExpression, entries[i].PRLabels.First()));
             }
+        }
 
-            Colorizer.WriteLine("Found the following rules:");
-
-            // Create the payload.
-            foreach (var entry in entriesToCreate)
-            {
-                // get the payload
-                string entryPayload = ToConfigString(entry);
-
-                Colorizer.WriteLine("[Cyan!{0}] => [Magenta!{1}]", entry.PathExpression, entry.PRLabels.FirstOrDefault());
-
-                configPayload.Append(ToConfigString(entry));
-                configPayload.Append(',');
-            }
-
-
-            // remove the trailing ','
-            configPayload.Remove(configPayload.Length - 1, 1);
-
-            // Log the set of paths we are creating.
-
-
-            // create the payload from the template
-            return s_template
-                .Replace("###taskId###", GetTaskId())
-                .Replace("###labelConfig###", configPayload.ToString());
+        public override string GetTaskId()
+        {
+            return $"AzureSDKPullRequestLabelFolder_{_owner}_{_repo}";
         }
 
         private string ToConfigString(CodeOwnerEntry entry)
@@ -136,11 +139,6 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
             result = result.Replace("###srcFolders###", $"\"{entry.PathExpression}\"");
 
             return result;
-        }
-
-        public override string GetTaskId()
-        {
-            return $"AzureSDKPullRequestLabelFolder_{_owner}_{_repo}";
         }
     }
 }

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Rules/PullRequestLabel/PullRequestLabelFolderCapability.cs
@@ -13,12 +13,12 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
 {
     public class PullRequestLabelFolderCapability : BaseCapability
     {
+        private List<PathConfig> _entriesToCreate = new List<PathConfig>();
+
         public PullRequestLabelFolderCapability(string org, string name, string configurationFile)
             : base(org, name, configurationFile)
         {
         }
-
-        private List<PathConfig> _entriesToCreate = new List<PathConfig>();
 
         public override string GetPayload()
         {
@@ -93,7 +93,7 @@ namespace CreateRuleFabricBot.Rules.PullRequestLabel
                     continue;
                 }
 
-                _entriesToCreate.Add(new PathConfig(entries[i].PathExpression, entries[i].PRLabels.First()));
+                AddEntry(entries[i].PathExpression, entries[i].PRLabels.First());
             }
         }
 

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBot/Service/RequestSender.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBot/Service/RequestSender.cs
@@ -83,7 +83,7 @@ namespace CreateRuleFabricBot.Service
             string requestUri = $"https://portal.fabricbot.ms/api/bot/getBotConfig?githubKey={_owner}/{_repo}";
             List<string> elements = new List<string>();
             var response = SendRequestAsync(HttpMethod.Get, requestUri).GetAwaiter().GetResult();
-
+            
             // retrieve the information from the response.
             var configJson = JsonDocument.Parse(response.Content.ReadAsByteArrayAsync().GetAwaiter().GetResult());
             // get the config

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/CreateRuleFabricBotTests.csproj
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/CreateRuleFabricBotTests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
@@ -10,6 +10,7 @@
     <PackageReference Include="nunit" Version="3.10.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
+    <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/PayloadTests.cs
+++ b/tools/CreateRuleFabricBot/CreateRuleFabricBotTests/PayloadTests.cs
@@ -1,0 +1,67 @@
+using CreateRuleFabricBot;
+using CreateRuleFabricBot.Rules.IssueRouting;
+using CreateRuleFabricBot.Rules.PullRequestLabel;
+using CreateRuleFabricBot.Service;
+using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Tests
+{
+    public class PayloadTests
+    {
+        [Test]
+        public void ValidateIssueRouting()
+        {
+            IssueRoutingCapability irc = new IssueRoutingCapability("test", "repo", null);
+            irc.AddRoute(new string[] { "label1", "label2" }, new string[] { "user1", "user2" });
+
+            string expectedPayload = @"
+{
+  ""taskType"" : ""scheduledAndTrigger"",
+  ""capabilityId"" : ""IssueRouting"",
+  ""version"" : ""1.0"",
+  ""subCapability"": ""@Mention"",
+  ""config"": { 
+    ""labelsAndMentions"": [
+        { ""labels"": [  ""label1"",""label2""  ], ""mentionees"": [ ""user1"",""user2""  ] }
+    ],
+    ""replyTemplate"": ""Thanks for the feedback! We are routing this to the appropriate team for follow-up. cc ${mentionees}."",
+    ""taskName"" :""Triage issues to the service team""
+  },
+  ""id"": ""###taskId###""
+}";
+
+            Assert.AreEqual(expectedPayload, irc.GetPayload());
+        }
+
+
+        [Test]
+        public void ValidatePullRequestRouting()
+        {
+            PullRequestLabelFolderCapability irc = new PullRequestLabelFolderCapability("test", "repo", null);
+            irc.AddEntry("/test", "Label1");
+
+            string expectedPayload = @"
+{
+      ""taskType"": ""trigger"",
+      ""capabilityId"": ""PrAutoLabel"",
+      ""subCapability"": ""Path"",
+      ""version"": ""1.0"",
+      ""id"": ""AzureSDKPullRequestLabelFolder_test_repo"",
+      ""config"": {
+        ""configs"": [
+            { ""labels"": [""Label1""], ""pathFilter"": [""test""], ""exclude"": [ """" ]  }
+        ],
+      ""taskName"" :""Auto PR based on folder paths ""
+      }
+    }
+";
+
+            Assert.AreEqual(expectedPayload, irc.GetPayload());
+        }
+    }
+}


### PR DESCRIPTION
The following improvements have been made:
  - Introduce a base class for the capabilities types
    - This base class is responsible for calling the method to read the configuration from the configuration file. Each derived class will need to implement that method.
 - Tests have been added to ensure that the payloads that we generate are in the expected shape.
 - Simplify the code to generate the payload. Instead of using string templates and doing string replacement for tokens, we are now generating `JObject` objects that represent the payload
    - This does mean that we are taking a dependency to Newtonsoft.Json for creating JSON objects but there isn't a good alternative to do the same using System.Text.Json
  -  The code for describing an entry for the PR labeler is moved to a new file, similar to `TriageConfig`.
  - Change the ContainsWildcard from a stand-alone property to a calculated one. This means that when a new `CodeOwnerEntry` object is created you only need to specify the `pathExpression`
