### PR TITLE
Creation of tools - git-tasks pipeline

### DIFF
--- a/eng/common/scripts/Delete-RemoteTag.ps1
+++ b/eng/common/scripts/Delete-RemoteTag.ps1
@@ -6,4 +6,28 @@ param(
 
 . (Join-Path $PSScriptRoot common.ps1)
 
-Write-Host "Pretending to delete $Tag from $Repository."
+$repositoryParts = $Repository.Split("/")
+
+if (repositoryParts.Length -ne 2)
+{
+    LogError "Repository is not a valid format."
+}
+
+$repositoryOwner = $repositoryParts[0]
+LogDebug "Repository owner is: $repositoryOwner"
+
+$repositoryName = $repositoryParts[1]
+LogDebug "Reposiory name is: $repositoryName"
+
+$ref = "refs/tags/$Tag"
+LogDebug "Calculated ref is: $ref"
+
+try
+{
+    Remove-GitHubSourceReferences -RepoOwner $repositoryOwner -RepoName $repositoryName -Ref $ref -AuthToken $AuthToken
+}
+catch
+{
+  LogError "Remove-GitHubSourceReferences failed with exception:`n$_"
+  exit 1
+}

--- a/eng/common/scripts/Delete-RemoteTag.ps1
+++ b/eng/common/scripts/Delete-RemoteTag.ps1
@@ -8,7 +8,7 @@ param(
 
 $repositoryParts = $Repository.Split("/")
 
-if (repositoryParts.Length -ne 2)
+if ($repositoryParts.Length -ne 2)
 {
     LogError "Repository is not a valid format."
 }

--- a/eng/common/scripts/Delete-RemoteTag.ps1
+++ b/eng/common/scripts/Delete-RemoteTag.ps1
@@ -1,0 +1,9 @@
+param(
+  $Repository,
+  $Tag,
+  $AuthToken
+)
+
+. (Join-Path $PSScriptRoot common.ps1)
+
+Write-Host "Pretending to delete $Tag from $Repository."

--- a/eng/common/scripts/Delete-RemoteTag.ps1
+++ b/eng/common/scripts/Delete-RemoteTag.ps1
@@ -19,7 +19,7 @@ LogDebug "Repository owner is: $repositoryOwner"
 $repositoryName = $repositoryParts[1]
 LogDebug "Reposiory name is: $repositoryName"
 
-$ref = "ref/tags/$Tag"
+$ref = "tags/$Tag"
 LogDebug "Calculated ref is: $ref"
 
 try

--- a/eng/common/scripts/Delete-RemoteTag.ps1
+++ b/eng/common/scripts/Delete-RemoteTag.ps1
@@ -19,7 +19,7 @@ LogDebug "Repository owner is: $repositoryOwner"
 $repositoryName = $repositoryParts[1]
 LogDebug "Reposiory name is: $repositoryName"
 
-$ref = "refs/tags/$Tag"
+$ref = "ref/tags/$Tag"
 LogDebug "Calculated ref is: $ref"
 
 try

--- a/eng/pipelines/git-tasks.yml
+++ b/eng/pipelines/git-tasks.yml
@@ -1,0 +1,41 @@
+parameters:
+  - name: TaskType
+    displayName: Task Task
+    type: string
+    default: DeleteTag
+    values:
+      - DeleteTag
+
+  - name: Repository
+    displayName: Repository
+    type: string
+    values:
+      - Azure/azure-sdk-for-android
+      - Azure/azure-sdk-for-c
+      - Azure/azure-sdk-for-cpp
+      - Azure/azure-sdk-for-go
+      - Azure/azure-sdk-for-ios
+      - Azure/azure-sdk-for-java
+      - Azure/azure-sdk-for-js
+      - Azure/azure-sdk-for-net
+      - Azure/azure-sdk-for-python
+      - Azure/azure-sdk-tools
+
+  - name: TagName
+    displayName: "Tag Name"
+    type: string
+    default: ''
+
+jobs:
+- ${{if eq(parameters.TaskType, 'DeleteTag')}}:
+  - deployment: DeleteTag
+    displayName: "Delete ${{parameters.TagName}} tag from ${{parameters.Repository}}"
+    environment: git
+    pool:
+      name: azsdk-pool-mms-ubuntu-1804-general
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - script: |
+                echo Hello, world!

--- a/eng/pipelines/git-tasks.yml
+++ b/eng/pipelines/git-tasks.yml
@@ -20,6 +20,7 @@ parameters:
       - Azure/azure-sdk-for-net
       - Azure/azure-sdk-for-python
       - Azure/azure-sdk-tools
+      - Azure/azure-sdk
 
   - name: TagName
     displayName: "Tag Name"
@@ -30,7 +31,7 @@ jobs:
 - ${{if eq(parameters.TaskType, 'DeleteTag')}}:
   - deployment: DeleteTag
     displayName: "Delete ${{parameters.TagName}} tag from ${{parameters.Repository}} repository"
-    environment: git
+    environment: github-operation-approvals
     pool:
       name: azsdk-pool-mms-ubuntu-1804-general
     strategy:

--- a/eng/pipelines/git-tasks.yml
+++ b/eng/pipelines/git-tasks.yml
@@ -37,13 +37,14 @@ jobs:
       runOnce:
         deploy:
           steps:
+            - checkout: self
             - task: PowerShell@2
               displayName: Delete remote tag
               condition: succeeded()
               inputs:
                 pwsh: true
-                workingDirectory: $(Build.SourcesDirectory)
-                filePath: eng/common/scripts/Delete-RemoteTag.ps1
+                workingDirectory: $(Pipeline.Workspace)
+                filePath: $(Build.SourcesDirectory)/eng/common/scripts/Delete-RemoteTag.ps1
                 arguments: >
                   -Repository ${{parameters.Repository}}
                   -Tag ${{parameters.TagName}}

--- a/eng/pipelines/git-tasks.yml
+++ b/eng/pipelines/git-tasks.yml
@@ -29,7 +29,7 @@ parameters:
 jobs:
 - ${{if eq(parameters.TaskType, 'DeleteTag')}}:
   - deployment: DeleteTag
-    displayName: "Delete ${{parameters.TagName}} tag from ${{parameters.Repository}}"
+    displayName: "Delete ${{parameters.TagName}} tag from ${{parameters.Repository}} repository"
     environment: git
     pool:
       name: azsdk-pool-mms-ubuntu-1804-general
@@ -37,5 +37,14 @@ jobs:
       runOnce:
         deploy:
           steps:
-            - script: |
-                echo Hello, world!
+            - task: PowerShell@2
+              displayName: Delete remote tag
+              condition: succeeded()
+              inputs:
+                pwsh: true
+                workingDirectory: $(Build.SourcesDirectory)
+                filePath: eng/common/scripts/Delete-RemoteTag.ps1
+                arguments: >
+                  -Repository ${{parameters.Repository}}
+                  -Tag ${{parameters.TagName}}
+                  -AuthToken "$(azuresdk-github-pat)"


### PR DESCRIPTION
This PR contains the YAML and supporting script for a new pipeline called ```tools - git-tasks``` which can be used to perform privileged operations against our Git repositories. This closes the following issue: https://github.com/Azure/azure-sdk-tools/issues/1101

The approach I've taken is a single centralized pipeline in the ```azure-sdk-tools``` repository where you can select the task you want to perform (currently the only one present is _DeleteTag) then provide the appropriate arguments to support that operation (in this case the repo and tag name).

This YAML file then calls a PowerShell script which in turn makes use of the existing ```Remove-GitHubSourceReferences``` implementation in the ```Invoke-GithubAPI.ps``` script.

Finally - because this is a destructive operation, I've put an approval gate on it limited to members of the EngSys team (for now).