### PR TITLE
Update latest folder with one index.html includes the redirect links

### DIFF
--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -223,13 +223,15 @@ function Upload-Blobs
     if (!$latestVersion) {
         $latestVersion = $versionsObj.LatestPreviewPackage 
     }
-
+    LogDebug "Fetching the latest version. $latestVersion"
     # Prepare the index.html which can redirect to the latest GA whenever avaiable, otherwise point to latest preview.
     New-Item -Path $DocDir -Name "latest" -ItemType "directory"
-    New-Item -Path "$($DocDir)/latest" -Name "index.html" -ItemType "file" -Value "<meta http-equiv="refresh" content="0; URL=$($DocDest)/$($PkgName)/$($DocVersion)" />"
+    New-Item -Path "$($DocDir)/latest" -Name "index.html" -ItemType "file" -Value "<meta http-equiv=`"refresh`" content=`"0; URL=$($DocDest)/$($PkgName)/$($latestVersion)/index.html`" />"
     if ($UploadLatest -and $latestVersion)
     {
         LogDebug "Uploading $($PkgName) to latest folder in $($DocDest)..."
+        # Clean up existing folders, will remove this step once we have one or two release cycles.
+        & $($AzCopy) rm "$($DocDest)/$($PkgName)/latest$($SASKey)" --recursive=true
         & $($AzCopy) cp "$($DocDir)/latest/**" "$($DocDest)/$($PkgName)/latest$($SASKey)" --recursive=true --cache-control "max-age=300, must-revalidate"
     }
 }

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -224,18 +224,16 @@ function Upload-Blobs
         $latestVersion = $versionsObj.LatestPreviewPackage 
     }
     LogDebug "Fetching the latest version. $latestVersion"
-    # Prepare the index.html which can redirect to the latest GA whenever avaiable, otherwise point to latest preview.
-    New-Item -Path $DocDir -Name "latest" -ItemType "directory"
-    New-Item -Path "$($DocDir)/latest" -Name "index.html" -ItemType "file" -Value "<meta http-equiv=`"refresh`" content=`"0; URL=$($DocDest)/$($PkgName)/$($latestVersion)/index.html`" />"
+    
     if ($UploadLatest -and $latestVersion)
     {
+        # Prepare the index.html which can redirect to the latest GA whenever avaiable, otherwise point to latest preview.
+        New-Item -Path $DocDir -Name "latest" -ItemType "directory"
+        New-Item -Path "$($DocDir)/latest" -Name "index.html" -ItemType "file" -Value "<meta http-equiv=`"refresh`" content=`"0; URL=$($DocDest)/$($PkgName)/$($latestVersion)/index.html`" />"
         LogDebug "Uploading $($PkgName) to latest folder in $($DocDest)..."
-        # Clean up existing folders, will remove this step once we have one or two release cycles.
-        & $($AzCopy) rm "$($DocDest)/$($PkgName)/latest$($SASKey)" --recursive=true
         & $($AzCopy) cp "$($DocDir)/latest/**" "$($DocDest)/$($PkgName)/latest$($SASKey)" --recursive=true --cache-control "max-age=300, must-revalidate"
     }
 }
-
 
 if ($PublishGithubIODocsFn -and (Test-Path "Function:$PublishGithubIODocsFn"))
 {

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -223,15 +223,12 @@ function Upload-Blobs
     if (!$latestVersion) {
         $latestVersion = $versionsObj.LatestPreviewPackage 
     }
-    LogDebug "Fetching the latest version. $latestVersion"
+    LogDebug "Fetching the latest version $latestVersion"
     
-    if ($UploadLatest -and $latestVersion)
+    if ($UploadLatest -and ($latestVersion -eq $DocVersion))
     {
-        # Prepare the index.html which can redirect to the latest GA whenever avaiable, otherwise point to latest preview.
-        New-Item -Path $DocDir -Name "latest" -ItemType "directory"
-        New-Item -Path "$($DocDir)/latest" -Name "index.html" -ItemType "file" -Value "<meta http-equiv=`"refresh`" content=`"0; URL=$($DocDest)/$($PkgName)/$($latestVersion)/index.html`" />"
         LogDebug "Uploading $($PkgName) to latest folder in $($DocDest)..."
-        & $($AzCopy) cp "$($DocDir)/latest/**" "$($DocDest)/$($PkgName)/latest$($SASKey)" --recursive=true --cache-control "max-age=300, must-revalidate"
+        & $($AzCopy) cp "$($DocDir)/**" "$($DocDest)/$($PkgName)/latest$($SASKey)" --recursive=true --cache-control "max-age=300, must-revalidate"
     }
 }
 


### PR DESCRIPTION
We currently do not support one generic link for latest GA version doc.
The PR is to update the index.html to redirect to the latest GA version, if no GA version, then redirect to latest preview. 

The template has been updated.
https://azuresdkdocs.blob.core.windows.net/$web/java/azure-sdk-template/latest/index.html
https://azuresdkdocs.blob.core.windows.net/$web/python/azure-template/latest/index.html
https://azuresdkdocs.blob.core.windows.net/$web/dotnet/Azure.Template/latest/index.html
https://azuresdkdocs.blob.core.windows.net/$web/javascript/azure-template/latest/index.html