### PR TITLE
Support variants in test pipelines

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,14 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<packageSources>
-		<add key="NugetOfficialV3" value="https://api.nuget.org/v3/index.json" />
-		<add key="Local" value="tools/LocalNugetFeed" />
-		<add key="roslyn-analyzers" value="https://dotnet.myget.org/F/roslyn-analyzers/api/v3/index.json" />
-		<add key="AzArtifactsFeed" value="https://azuresdkartifacts.blob.core.windows.net/azure-sdk-tools/index.json" />
-	</packageSources>
-	
-	<config>
-		<add key="globalPackagesFolder" value="restoredPackages" />
-		<add key="RestorePackagesPath" value="restoredPackages" />
-	</config>
+  <packageSources>
+    <clear />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
+  </packageSources>
+  <disabledPackageSources>
+    <clear />
+  </disabledPackageSources>
 </configuration>

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
@@ -20,7 +20,7 @@ namespace PipelineGenerator.Conventions
 
         protected override string GetDefinitionName(SdkComponent component)
         {
-            return $"{Context.Prefix} - {component.Name} - tests";
+            return component.Variant == null ? $"{Context.Prefix} - {component.Name} - tests" : $"{Context.Prefix} - {component.Name} - tests.{component.Variant}";
         }
 
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
@@ -19,7 +19,7 @@ namespace PipelineGenerator.Conventions
             return component.Variant == null ? $"{Context.Prefix} - {component.Name} - ci" : $"{Context.Prefix} - {component.Name} - ci.{component.Variant}";
         }
 
-        public override string SearchPattern => "ci*.yml";
+        public override string SearchPattern => "ci.yml";
         public override bool IsScheduled => false;
         public override bool RemoveCITriggers => true;
 

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -19,7 +19,7 @@ namespace PipelineGenerator.Conventions
             return component.Variant == null ? $"{Context.Prefix} - {component.Name}" : $"{Context.Prefix} - {component.Name} - {component.Variant}";
         }
 
-        public override string SearchPattern => "ci*.yml";
+        public override string SearchPattern => "ci.yml";
         public override bool IsScheduled => !Context.NoSchedule;
         public override bool RemoveCITriggers => true;
 

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
@@ -11,7 +11,7 @@ namespace PipelineGenerator.Conventions
 
         protected override string GetDefinitionName(SdkComponent component)
         {
-            return $"{Context.Prefix} - {component.Name} - tests-weekly";
+            return component.Variant == null ? $"{Context.Prefix} - {component.Name} - tests" : $"{Context.Prefix} - {component.Name} - tests-weekly.{component.Variant}";
         }
 
         protected override Schedule CreateScheduleFromDefinition(BuildDefinition definition)


### PR DESCRIPTION
This change adds variant support for our existing tests pipelines that @jsquire is trying to use to split up T1 and T2 tests in .NET eventhubs and servicebus.
