### PR TITLE
Add missing TestOptions matrix variable in pipeline-generation.yml

### DIFF
--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -4,6 +4,7 @@ trigger: none
 
 variables:
   skipComponentGovernanceDetection: true
+  TestOptions: ''
 
 parameters:
   - name: AzureSDK_Maven_Release_Pipeline_Secrets
@@ -52,7 +53,6 @@ jobs:
           --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
           --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
-        TestOptions: ''
       JavaScript:
         RepositoryName: azure-sdk-for-js
         Branch: master
@@ -98,7 +98,6 @@ jobs:
           --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
           --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
-        TestOptions: ''
   steps:
   - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
   - script: |

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -52,6 +52,7 @@ jobs:
           --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
           --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
+        TestOptions: ''
       JavaScript:
         RepositoryName: azure-sdk-for-js
         Branch: master
@@ -63,6 +64,7 @@ jobs:
           --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
           --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
+        TestOptions: '--variablegroup ${{ parameters.Secrets_for_Resource_Provisioner }}'
       Python:
         RepositoryName: azure-sdk-for-python
         Branch: master
@@ -96,6 +98,7 @@ jobs:
           --variablegroup ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
           --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
+        TestOptions: ''
   steps:
   - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
   - script: |


### PR DESCRIPTION
Because `TestOptions` was not defined as a matrix variable for all entries, it was causing the `$(TestOptions)` variable substitution to skip, and being treated as a literal argument, which was failing some pipelines. This adds TestOptions to all pipeline matrix entries, as empty for those that don't need access to the resource provisioning secrets, and as a variable group argument where needed (like the other matrix entries).