### PR TITLE
Add new option to show only diff

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Client/src/main.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/main.ts
@@ -2,5 +2,5 @@ import "./comments.ts";
 import "./revisions.ts";
 import "./file-input.ts";
 import "./navbar.ts";
-import "./documentation.ts";
+import "./review.ts";
 import "./reviews.ts";

--- a/src/dotnet/APIView/APIViewWeb/Client/src/review.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/review.ts
@@ -3,6 +3,8 @@
   const SHOW_DOC_CHECK_COMPONENT = "#show-documentation-component";
   const SHOW_DOC_CHECKBOX = ".show-doc-checkbox";
   const SHOW_DOC_HREF = ".show-document";
+  const SHOW_DIFFONLY_CHECKBOX = ".show-diffonly-checkbox";
+  const SHOW_DIFFONLY_HREF = ".show-diffonly";
 
   hideCheckboxIfNoDocs();
 
@@ -15,4 +17,9 @@
   $(SHOW_DOC_CHECKBOX).on("click", e => {
     $(SHOW_DOC_HREF)[0].click();
   });
+
+  $(SHOW_DIFFONLY_CHECKBOX).on("click", e => {
+    $(SHOW_DIFFONLY_HREF)[0].click();
+  });
+
 });

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -40,14 +40,14 @@
                 }
                 else
                 {
-                    <a class="btn btn-sm btn-outline-secondary" asp-route-diffRevisionId="@Model.PreviousRevisions.Last().RevisionId" asp-route-doc="@Model.ShowDocumentation">Diff</a>
+                    <a class="btn btn-sm btn-outline-secondary" asp-all-route-data=@Model.GetRoutingData(diffRevisionId: Model.PreviousRevisions.Last().RevisionId, showDocumentation: Model.ShowDocumentation, showDiffOnly: Model.ShowDiffOnly)>Diff</a>
                 }
                 <button type="button" class="btn btn-sm btn-outline-secondary dropdown-toggle dropdown-toggle-split" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"></button>
 
                 <div class="dropdown-menu">
                     @foreach (var revision in Model.PreviousRevisions.Reverse())
                     {
-                        <a class="dropdown-item" asp-route-diffRevisionId="@revision.RevisionId" active-if="@(Model.DiffRevisionId == revision.RevisionId)" asp-route-doc="@Model.ShowDocumentation">
+                        <a class="dropdown-item" active-if="@(Model.DiffRevisionId == revision.RevisionId)" asp-all-route-data=@Model.GetRoutingData(diffRevisionId: revision.RevisionId, showDocumentation: Model.ShowDocumentation, showDiffOnly: Model.ShowDiffOnly)>
                             @revision.DisplayName
                         </a>
                     }
@@ -93,10 +93,19 @@
                 </span>
                 <span class="dropdown-item" id="show-documentation-component">
                     <input asp-for="@Model.ShowDocumentation" class="show-doc-checkbox">
-                    <a class="text-dark show-document" asp-route-diffRevisionId="@Model.DiffRevisionId" asp-route-doc="@(!Model.ShowDocumentation)">
+                    <a class="text-dark show-document" asp-all-route-data=@Model.GetRoutingData(diffRevisionId: Model.DiffRevisionId, showDocumentation: !Model.ShowDocumentation, showDiffOnly: Model.ShowDiffOnly)>
                         <label>Show documentation</label>
                     </a>
                 </span>
+                @if (!String.IsNullOrEmpty(Model.DiffRevisionId))
+                {
+                    <span class="dropdown-item">
+                        <input asp-for="@Model.ShowDiffOnly" class="show-diffonly-checkbox">
+                        <a class="text-dark show-diffonly" asp-all-route-data=@Model.GetRoutingData(diffRevisionId: Model.DiffRevisionId, showDocumentation: Model.ShowDocumentation, showDiffOnly: !Model.ShowDiffOnly)>
+                            <label>Show only diff</label>
+                        </a>
+                    </span>
+                }
             </div>
         </div>
         <div class="float-right">

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
@@ -122,41 +122,40 @@ namespace APIViewWeb.Pages.Assemblies
 
         private InlineDiffLine<CodeLine>[] CreateDiffOnlyLines(InlineDiffLine<CodeLine>[] lines)
         {
-            var unchangedQueue = new Queue<InlineDiffLine<CodeLine>>();
             var filteredLines = new List<InlineDiffLine<CodeLine>>();
+            int lastAddedLine = -1;
             for (int i = 0; i < lines.Count(); i++)
             {
-                if (lines[i].Kind == DiffLineKind.Unchanged)
+                if (lines[i].Kind != DiffLineKind.Unchanged)
                 {
-                    // Hold last two unchanged line in queue to create context
-                    unchangedQueue.Enqueue(lines[i]);
-                    if (unchangedQueue.Count > REVIEW_DIFF_CONTEXT_SIZE)
-                    {
-                        unchangedQueue.Dequeue();
-                    }
-                }
-                else
-                {
-                    if (unchangedQueue.Count > 0)
+                    // Find starting index for pre context
+                    int preContextIndx = Math.Max(lastAddedLine + 1, i - REVIEW_DIFF_CONTEXT_SIZE);
+                    if (preContextIndx < i)
                     {
                         // Add sepearator to show skipping lines. for e.g. .....
                         if (filteredLines.Count > 0)
                         {
                             filteredLines.Add(new InlineDiffLine<CodeLine>(new CodeLine(DIFF_CONTEXT_SEPERATOR, null), DiffLineKind.Unchanged));
                         }
-                        // Copy pre context
-                        filteredLines.AddRange(unchangedQueue);
-                        unchangedQueue.Clear();
+
+                        while (preContextIndx < i)
+                        {
+                            filteredLines.Add(lines[preContextIndx]);
+                            preContextIndx++;
+                        }
                     }
+                    //Add changed line
                     filteredLines.Add(lines[i]);
+                    lastAddedLine = i;
+
                     // Add post context
-                    int contextIndex = i + 1, contextEnd = i + REVIEW_DIFF_CONTEXT_SIZE;
-                    while (contextIndex <= contextEnd && contextIndex < lines.Count() && lines[contextIndex].Kind == DiffLineKind.Unchanged)
+                    int contextStart = i +1, contextEnd = i + REVIEW_DIFF_CONTEXT_SIZE;
+                    while (contextStart <= contextEnd && contextStart < lines.Count() && lines[contextStart].Kind == DiffLineKind.Unchanged)
                     {
-                        filteredLines.Add(lines[contextIndex]);
-                        contextIndex++;
+                        filteredLines.Add(lines[contextStart]);
+                        lastAddedLine = contextStart;
+                        contextStart++;
                     }
-                    unchangedQueue.Clear();
                 }
             }
             return filteredLines.ToArray();
@@ -243,8 +242,8 @@ namespace APIViewWeb.Pages.Assemblies
         {
             var routingData = new Dictionary<string, string>();
             routingData["diffRevisionId"] = diffRevisionId;
-            routingData["doc"] = (showDocumentation ?? showDocumentation) == true ? "true" : "false";
-            routingData["diffOnly"] = (showDiffOnly ?? showDiffOnly) == true ? "true" : "false";
+            routingData["doc"] = (showDocumentation ?? false).ToString();
+            routingData["diffOnly"] = (showDiffOnly ?? false).ToString();
             return routingData;
         }
     }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
@@ -60,6 +60,9 @@ namespace APIViewWeb.Pages.Assemblies
         [BindProperty(Name = "doc", SupportsGet = true)]
         public bool ShowDocumentation { get; set; }
 
+        [BindProperty(Name = "diffOnly", SupportsGet = true)]
+        public bool ShowDiffOnly { get; set; }
+
         public async Task<IActionResult> OnGetAsync(string id, string revisionId = null)
         {
             TempData["Page"] = "api";
@@ -115,6 +118,11 @@ namespace APIViewWeb.Pages.Assemblies
 
         private CodeLineModel[] CreateLines(CodeDiagnostic[] diagnostics, InlineDiffLine<CodeLine>[] lines, ReviewCommentsModel comments)
         {
+            if (ShowDiffOnly)
+            {
+                lines = lines.Where(l => l.Kind != DiffLineKind.Unchanged).ToArray();
+            }
+
             return lines.Select(
                 diffLine => new CodeLineModel(
                     diffLine.Kind,
@@ -184,6 +192,14 @@ namespace APIViewWeb.Pages.Assemblies
         {
             await _manager.ToggleApprovalAsync(User, id, revisionId);
             return RedirectToPage(new { id = id });
+        }
+        public Dictionary<string, string> GetRoutingData(string diffRevisionId = null, bool? showDocumentation = null, bool? showDiffOnly = null)
+        {
+            var routingData = new Dictionary<string, string>();
+            routingData["diffRevisionId"] = diffRevisionId;
+            routingData["doc"] = (showDocumentation ?? showDocumentation) == true ? "true" : "false";
+            routingData["diffOnly"] = (showDiffOnly ?? showDiffOnly) == true ? "true" : "false";
+            return routingData;
         }
     }
 }


### PR DESCRIPTION
Some packages has huge number APIs which makes it difficult to find the diff from different revision within these files when only few lines are changed. This enhancement is to add a new checkbox in options menu so user can select this option to see difference only.
