### PR TITLE
Docs Gen Pulls Tools from Tag

### DIFF
--- a/eng/common/pipelines/templates/steps/get-pr-owners.yml
+++ b/eng/common/pipelines/templates/steps/get-pr-owners.yml
@@ -6,7 +6,7 @@ steps:
   - pwsh: |
       git clone https://github.com/Azure/azure-sdk-tools.git $(Build.SourcesDirectory)/tools_repo
       cd $(Build.SourcesDirectory)/tools_repo
-      git checkout latest-stable-tools
+      git checkout azure-sdk-tools_20210114.1
     displayName: Setup Identity Resolver
 
   - pwsh: |

--- a/eng/common/pipelines/templates/steps/get-pr-owners.yml
+++ b/eng/common/pipelines/templates/steps/get-pr-owners.yml
@@ -6,7 +6,7 @@ steps:
   - pwsh: |
       git clone https://github.com/Azure/azure-sdk-tools.git $(Build.SourcesDirectory)/tools_repo
       cd $(Build.SourcesDirectory)/tools_repo
-      git checkout 35ad98f821913eb0e8872f861ee60589b563c865
+      git checkout latest-stable-tools
     displayName: Setup Identity Resolver
 
   - pwsh: |


### PR DESCRIPTION
I want to update the build that generates [this release](https://github.com/Azure/azure-sdk-tools/releases/tag/azure-sdk-tools_20210106.1) to update the tag in place, but I need to run down the location.