### PR TITLE
Ensure bypass conditional template gets run for 1es ubuntu image

### DIFF
--- a/eng/common/pipelines/templates/steps/bypass-local-dns.yml
+++ b/eng/common/pipelines/templates/steps/bypass-local-dns.yml
@@ -6,6 +6,9 @@ steps:
       condition: |
         and(
           succeededOrFailed(),
-          eq(variables['OSVmImage'], 'ubuntu-18.04'),
+          or(
+            eq(variables['OSVmImage'], 'ubuntu-18.04'),
+            eq(variables['OSVmImage'], 'MMSUbuntu18.04')
+          ),
           eq(variables['Container'], '')
         )


### PR DESCRIPTION
This fixes an issue where the DNS bypass workaround was not getting run for the new 1es pool ubuntu images.

FYI @mitchdenny @alzimmermsft @samvaity 