### PR TITLE
Add prerlease number to version only if it is valid

### DIFF
--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -132,8 +132,12 @@ class AzureEngSemanticVersion {
 
     if ($this.IsPrerelease)
     {
-      $versionString += $this.PrereleaseLabelSeparator + $this.PrereleaseLabel + `
-                        $this.PrereleaseNumberSeparator + $this.PrereleaseNumber
+      $versionString += $this.PrereleaseLabelSeparator + $this.PrereleaseLabel
+      # Do not add prerelease number if it is 0. Change log for few packages has older prerelease versions without prerelease numbers
+      # for e.g. 10.2.0-preview for js storage-blob package
+      if ($this.PrereleaseNumber) {
+          $versionString += $this.PrereleaseNumberSeparator + $this.PrereleaseNumber
+      }
       if ($this.BuildNumber) {
           $versionString += $this.BuildNumberSeparator + $this.BuildNumber
       }


### PR DESCRIPTION
Automatic version increment tool runs code to update change log and this step has removed older change logs for JS storage-blob package. These old logs doesn't follow current SDK versioning guidelines and has prerelease versions without a prerelease numbers. Update change log sorts the versions and it expects as prerelease number for prerelease versions. If version doesn't have a prerelease number then it appends '0' as prelease number and this causes a mismatch when new change log is created in sorted order.

Here is an autogenerated PR which removed older change log.
https://github.com/Azure/azure-sdk-for-js/pull/13217/files

