### PR TITLE
Update Changelog Logic to accommodate older entries 

### DIFF
--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -13,7 +13,7 @@ function Get-ChangeLogEntries {
     [String]$ChangeLogLocation
   )
 
-  $changeLogEntries = @{}
+  $changeLogEntries = [Ordered]@{}
   if (!(Test-Path $ChangeLogLocation)) {
     LogError "ChangeLog[${ChangeLogLocation}] does not exist"
     return $null
@@ -191,16 +191,7 @@ function Set-ChangeLogContent {
   $changeLogContent += "# Release History"
   $changeLogContent += ""
 
-  try
-  {
-    $VersionsSorted = [AzureEngSemanticVersion]::SortVersionStrings($ChangeLogEntries.Keys)
-  }
-  catch {
-    LogError "Problem sorting version in ChangeLogEntries"
-    return
-  }
-
-  foreach ($version in $VersionsSorted) {
+  foreach ($version in $ChangeLogEntries.Keys) {
     $changeLogEntry = $ChangeLogEntries[$version]
     $changeLogContent += $changeLogEntry.ReleaseTitle
     if ($changeLogEntry.ReleaseContent.Count -eq 0) {
@@ -212,4 +203,24 @@ function Set-ChangeLogContent {
   }
 
   Set-Content -Path $ChangeLogLocation -Value $changeLogContent
+}
+
+function Add-ChangelogEntry {
+  param (
+    [Parameter(Mandatory = $true)]
+    $ChangeLogEntries,
+    [Parameter(Mandatory = $true)]
+    $NewChangeLogEntry,
+    [Parameter(Mandatory = $true)]
+    $Version
+  )
+
+  $results = [Ordered]@{}
+  $results.Add($Version, $NewChangeLogEntry)
+
+  foreach ($entryVersion in $ChangeLogEntries.Keys) {
+    $results.Add($entryVersion, $ChangeLogEntries[$entryVersion])
+  }
+
+  return $results
 }

--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -2,7 +2,7 @@
 . "${PSScriptRoot}\logging.ps1"
 . "${PSScriptRoot}\SemVer.ps1"
 
-$RELEASE_TITLE_REGEX = "(?<releaseNoteTitle>^\#+.*(?<version>\b\d+\.\d+\.\d+([^0-9\s][^\s:]+)?)(\s+(?<releaseStatus>\(Unreleased\)|\(\d{4}-\d{2}-\d{2}\)))?)"
+$RELEASE_TITLE_REGEX = "(?<releaseNoteTitle>^\#+.*(?<version>\b\d+\.\d+\.\d+([^0-9\s][^\s:]+)?)(\s+(?<releaseStatus>\(.*\)))?)"
 $CHANGELOG_UNRELEASED_STATUS = "(Unreleased)"
 $CHANGELOG_DATE_FORMAT = "yyyy-MM-dd"
 

--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -57,7 +57,7 @@ function Get-ChangeLogEntry {
   )
   $changeLogEntries = Get-ChangeLogEntries -ChangeLogLocation $ChangeLogLocation
 
-  if ($changeLogEntries -and $changeLogEntries.ContainsKey($VersionString)) {
+  if ($changeLogEntries -and $changeLogEntries.Contains($VersionString)) {
     return $changeLogEntries[$VersionString]
   }
   return $null
@@ -191,7 +191,16 @@ function Set-ChangeLogContent {
   $changeLogContent += "# Release History"
   $changeLogContent += ""
 
-  foreach ($version in $ChangeLogEntries.Keys) {
+  try
+  {
+    $VersionsSorted = [AzureEngSemanticVersion]::SortVersionStrings($ChangeLogEntries.Keys)
+  }
+  catch {
+    LogError "Problem sorting version in ChangeLogEntries"
+    return
+  }
+
+  foreach ($version in $VersionsSorted) {
     $changeLogEntry = $ChangeLogEntries[$version]
     $changeLogContent += $changeLogEntry.ReleaseTitle
     if ($changeLogEntry.ReleaseContent.Count -eq 0) {
@@ -203,24 +212,4 @@ function Set-ChangeLogContent {
   }
 
   Set-Content -Path $ChangeLogLocation -Value $changeLogContent
-}
-
-function Add-ChangelogEntry {
-  param (
-    [Parameter(Mandatory = $true)]
-    $ChangeLogEntries,
-    [Parameter(Mandatory = $true)]
-    $NewChangeLogEntry,
-    [Parameter(Mandatory = $true)]
-    $Version
-  )
-
-  $results = [Ordered]@{}
-  $results.Add($Version, $NewChangeLogEntry)
-
-  foreach ($entryVersion in $ChangeLogEntries.Keys) {
-    $results.Add($entryVersion, $ChangeLogEntries[$entryVersion])
-  }
-
-  return $results
 }

--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -181,7 +181,7 @@ class AzureEngSemanticVersion {
   {
     $versions = $versionStrings | ForEach-Object { [AzureEngSemanticVersion]::ParseVersionString($_) }
     $sortedVersions = [AzureEngSemanticVersion]::SortVersions($versions)
-    return ($sortedVersions | ForEach-Object { $_.ToString() })
+    return ($sortedVersions | ForEach-Object { $_.RawVersion })
   }
 
   static [AzureEngSemanticVersion[]] SortVersions([AzureEngSemanticVersion[]] $versions)

--- a/eng/common/scripts/Update-ChangeLog.ps1
+++ b/eng/common/scripts/Update-ChangeLog.ps1
@@ -82,8 +82,7 @@ if ($ChangeLogEntries.Contains($Version))
     }
 }
 
-$PresentVersionsSorted = [AzureEngSemanticVersion]::SortVersionStrings($ChangeLogEntries.Keys)
-$LatestVersion = $PresentVersionsSorted[0]
+$LatestVersion = $ChangeLogEntries[0].ReleaseVersion
 
 LogDebug "The latest release note entry in the changelog is for version [$($LatestVersion)]"
 
@@ -99,7 +98,9 @@ if ($ReplaceLatestEntryTitle)
     LogDebug "Resetting latest entry title to [$($newChangeLogEntry.ReleaseTitle)]"
     $ChangeLogEntries.Remove($LatestVersion)
     if ($newChangeLogEntry) {
-        $ChangeLogEntries[$Version] = $newChangeLogEntry
+        $ChangeLogEntries = Add-ChangelogEntry -ChangeLogEntries $ChangeLogEntries `
+        -NewChangeLogEntry $newChangeLogEntry `
+        -Version $Version
     }
     else {
         LogError "Failed to create new changelog entry"
@@ -117,7 +118,9 @@ else
     LogDebug "Adding new ChangeLog entry for Version [$Version]"
     $newChangeLogEntry = New-ChangeLogEntry -Version $Version -Status $ReleaseStatus
     if ($newChangeLogEntry) {
-        $ChangeLogEntries[$Version] = $newChangeLogEntry
+        $ChangeLogEntries = Add-ChangelogEntry -ChangeLogEntries $ChangeLogEntries `
+        -NewChangeLogEntry $newChangeLogEntry `
+        -Version $Version
     }
     else {
         LogError "Failed to create new changelog entry"

--- a/eng/common/scripts/Update-ChangeLog.ps1
+++ b/eng/common/scripts/Update-ChangeLog.ps1
@@ -82,14 +82,14 @@ if ($ChangeLogEntries.Contains($Version))
     }
 }
 
-$LatestVersion = $ChangeLogEntries[0].ReleaseVersion
+$PresentVersionsSorted = [AzureEngSemanticVersion]::SortVersionStrings($ChangeLogEntries.Keys)
+$LatestVersion = $PresentVersionsSorted[0]
 
 LogDebug "The latest release note entry in the changelog is for version [$($LatestVersion)]"
 
 $LatestsSorted = [AzureEngSemanticVersion]::SortVersionStrings(@($LatestVersion, $Version))
 if ($LatestsSorted[0] -ne $Version) {
-    LogWarning "Version [$Version] is older than the latestversion [$LatestVersion] in the changelog. Please use a more recent version."
-    exit(0)
+    LogWarning "Version [$Version] is older than the latestversion [$LatestVersion] in the changelog. Consider using a more recent version."
 }
 
 if ($ReplaceLatestEntryTitle) 
@@ -98,9 +98,7 @@ if ($ReplaceLatestEntryTitle)
     LogDebug "Resetting latest entry title to [$($newChangeLogEntry.ReleaseTitle)]"
     $ChangeLogEntries.Remove($LatestVersion)
     if ($newChangeLogEntry) {
-        $ChangeLogEntries = Add-ChangelogEntry -ChangeLogEntries $ChangeLogEntries `
-        -NewChangeLogEntry $newChangeLogEntry `
-        -Version $Version
+        $ChangeLogEntries.Insert(0, $Version, $newChangeLogEntry)
     }
     else {
         LogError "Failed to create new changelog entry"
@@ -118,9 +116,7 @@ else
     LogDebug "Adding new ChangeLog entry for Version [$Version]"
     $newChangeLogEntry = New-ChangeLogEntry -Version $Version -Status $ReleaseStatus
     if ($newChangeLogEntry) {
-        $ChangeLogEntries = Add-ChangelogEntry -ChangeLogEntries $ChangeLogEntries `
-        -NewChangeLogEntry $newChangeLogEntry `
-        -Version $Version
+        $ChangeLogEntries.Insert(0, $Version, $newChangeLogEntry)
     }
     else {
         LogError "Failed to create new changelog entry"


### PR DESCRIPTION
This change is to accommodate parts of the changelog that does not properly indicate the release status as specified in the [changelog guideline](https://aka.ms/azsdk/changelogguide).
This also switched the logic to use Ordered HashTable so as not to rely on SemVer sorting. This allows us accommodate version that are not SemVer compliant.