### PR TITLE
Fix notification tools

### DIFF
--- a/tools/notification-configuration/common/Helpers/StringHelper.cs
+++ b/tools/notification-configuration/common/Helpers/StringHelper.cs
@@ -1,0 +1,12 @@
+﻿namespace common.Helpers
+{
+    public static class StringHelper
+    {
+        public static string MaxLength(string input, int maxLength)
+        {
+            return input.Length > maxLength
+                ? input.Substring(0, maxLength)
+                : input;
+        }
+    }
+}

--- a/tools/notification-configuration/common/Services/AzureDevOpsService.cs
+++ b/tools/notification-configuration/common/Services/AzureDevOpsService.cs
@@ -13,6 +13,7 @@ using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.Identity.Client;
 using Microsoft.VisualStudio.Services.Identity;
 using System.Threading;
+using System.Linq;
 
 namespace NotificationConfiguration.Services
 {
@@ -116,7 +117,7 @@ namespace NotificationConfiguration.Services
         {
             var client = await GetClientAsync<TeamHttpClient>();
 
-            logger.LogInformation("GetTeamsAsync ProjectName = {0}", projectName);
+            logger.LogInformation("GetTeamsAsync ProjectName = {0}, skip = {1}", projectName, skip);
             var teams = await client.GetTeamsAsync(projectName, skip: skip, top: top);
 
             return teams;
@@ -133,9 +134,10 @@ namespace NotificationConfiguration.Services
             var client = await GetClientAsync<TeamHttpClient>();
 
             logger.LogInformation("CreateTeamForProjectAsync TeamName = {0} ProjectId = {1}", team.Name, projectId);
-            var result = await client.CreateTeamAsync(team, projectId);
 
+            var result = await client.CreateTeamAsync(team, projectId);
             return result;
+
         }
 
         /// <summary>

--- a/tools/notification-configuration/common/common.csproj
+++ b/tools/notification-configuration/common/common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-     <TargetFramework>netcoreapp2.0</TargetFramework>
+     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/notification-configuration/github-codeowner-subscriber/github-codeowner-subscriber.csproj
+++ b/tools/notification-configuration/github-codeowner-subscriber/github-codeowner-subscriber.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>github_codeowner_subscriber</RootNamespace>
   </PropertyGroup>
 

--- a/tools/notification-configuration/identity-resolver/identity-resolver.csproj
+++ b/tools/notification-configuration/identity-resolver/identity-resolver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>identity_resolver</RootNamespace>
   </PropertyGroup>
 

--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -96,7 +96,7 @@ namespace NotificationConfiguration
                     Description = YamlHelper.Serialize(teamMetadata),
                     // Ensure team name fits within maximum 64 character limit
                     // https://docs.microsoft.com/en-us/azure/devops/organizations/settings/naming-restrictions?view=azure-devops#teams
-                    Name = StringHelper.MaxLength($"{pipeline.Name} -- {suffix}", 64),
+                    Name = StringHelper.MaxLength($"{pipeline.Name} -- {suffix}", MaxTeamNameLength),
                 };
 
                 logger.LogInformation("Create Team for Pipeline PipelineId = {0} Purpose = {1}", pipeline.Id, purpose);

--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -198,7 +198,7 @@ namespace NotificationConfiguration
                 }
 
                 accumulator.AddRange(teams);
-                skip += teams.Count();
+                skip = accumulator.Count;
             }
 
             return accumulator;

--- a/tools/notification-configuration/notification-creator/notification-creator.csproj
+++ b/tools/notification-configuration/notification-creator/notification-creator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <RootNamespace>NotificationConfiguration</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
Set TargetFramework netcoreapp2.0 -> netcoreapp3.1 so it builds on devops machines. There is no specific reason to keep using older versions.