### PR TITLE
Include AzureSasCredential as allowed type for credential builder method

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
@@ -51,7 +51,8 @@ public class Diagnostics {
             .add("configuration", new ExactTypeNameCheckFunction("Configuration"))
             .add("clientOptions", new ExactTypeNameCheckFunction("ClientOptions"))
             .add("connectionString", new ExactTypeNameCheckFunction("String"))
-            .add("credential", new ExactTypeNameCheckFunction(new ParameterAllowedTypes("TokenCredential", "AzureKeyCredential")))
+            .add("credential", new ExactTypeNameCheckFunction(new ParameterAllowedTypes("TokenCredential",
+                    "AzureKeyCredential", "AzureSasCredential")))
             .add("endpoint", new ExactTypeNameCheckFunction("String"))
             .add("serviceVersion", new DirectSubclassCheckFunction("ServiceVersion")));
         diagnostics.add(new RequiredBuilderMethodsDiagnosticRule("amqp")

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/RequiredBuilderMethodsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/RequiredBuilderMethodsDiagnosticRule.java
@@ -98,7 +98,7 @@ public class RequiredBuilderMethodsDiagnosticRule implements DiagnosticRule {
         private final ParameterAllowedTypes[] expectedTypes;
 
         // For each parameter that we check for, we allow for there to be multiple types allowed for it,
-        // e.g. credential(TokenCredential) or credential(AzureKeyCredential)
+        // e.g. credential(TokenCredential) or credential(AzureKeyCredential) or credential(AzureSasCredential)
         public ExactTypeNameCheckFunction(ParameterAllowedTypes... expectedTypes) {
             this.expectedTypes = expectedTypes;
         }


### PR DESCRIPTION
This PR adds `AzureSasCredential` as a valid type for `credential()` method overload on the client builder.