### PR TITLE
Support sub directory for artifact location

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -9,7 +9,7 @@ Param (
   [Parameter(Mandatory=$True)]
   [string] $APILabel,
   [string] $PackageName,
-  [string] $ArtifactSubDir = ""
+  [string] $ConfigFileDir = ""
 )
 
 
@@ -57,12 +57,7 @@ function Submit-APIReview($packagename, $filePath, $uri, $apiKey, $apiLabel)
 $packages = @{}
 if ($FindArtifactForApiReviewFn -and (Test-Path "Function:$FindArtifactForApiReviewFn"))
 {
-    $artifactLoc = $ArtifactPath
-    if ($ArtifactSubDir)
-    {
-        $artifactLoc = Join-Path -Path $artifactLoc $ArtifactSubDir
-    }
-    $packages = &$FindArtifactForApiReviewFn $artifactLoc $PackageName
+    $packages = &$FindArtifactForApiReviewFn $ArtifactPath $PackageName
 }
 else
 {
@@ -88,7 +83,12 @@ else
 }
 
 $FoundFailure = $False
-$pkgInfoPath = Join-Path -Path $ArtifactPath "PackageInfo"
+# Default config file path to artifact path to support backward compatibility until those scripts are modified
+if (-not $ConfigFileDir)
+{
+    $ConfigFileDir = $ArtifactPath
+}
+$pkgInfoPath = Join-Path -Path $ConfigFileDir "PackageInfo"
 foreach ($pkgName in $responses.Keys)
 {    
     $respCode = $responses[$pkgName]

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -92,7 +92,7 @@ foreach ($pkgName in $responses.Keys)
     $respCode = $responses[$pkgName]
     if ($respCode -ne '200')
     {
-        $pkgPropPath = Join-Path -Path $ConfigFileDir ($PackageName + ".json")
+        $pkgPropPath = Join-Path -Path $ConfigFileDir "$PackageName.json"
         if (-Not (Test-Path $pkgPropPath))
         {
             Write-Host " Package property file path $($pkgPropPath) is invalid."

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -84,11 +84,11 @@ else
 
 $FoundFailure = $False
 # Default config file path to artifact path to support backward compatibility until those scripts are modified
-if (-not $ConfigFileDir)
+$pkgInfoPath = Join-Path -Path $ArtifactPath "PackageInfo"
+if ($ConfigFileDir)
 {
-    $ConfigFileDir = $ArtifactPath
+    $pkgInfoPath = Join-Path -Path $ConfigFileDir "PackageInfo"
 }
-$pkgInfoPath = Join-Path -Path $ConfigFileDir "PackageInfo"
 foreach ($pkgName in $responses.Keys)
 {    
     $respCode = $responses[$pkgName]

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -83,7 +83,6 @@ else
 }
 
 $FoundFailure = $False
-# Default config file path to artifact path to support backward compatibility until those scripts are modified
 $pkgInfoPath = Join-Path -Path $ArtifactPath "PackageInfo"
 if ($ConfigFileDir)
 {

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -83,17 +83,16 @@ else
 }
 
 $FoundFailure = $False
-$pkgInfoPath = Join-Path -Path $ArtifactPath "PackageInfo"
-if ($ConfigFileDir)
+if (-not $ConfigFileDir)
 {
-    $pkgInfoPath = Join-Path -Path $ConfigFileDir "PackageInfo"
+    $ConfigFileDir = Join-Path -Path $ArtifactPath "PackageInfo"
 }
 foreach ($pkgName in $responses.Keys)
 {    
     $respCode = $responses[$pkgName]
     if ($respCode -ne '200')
     {
-        $pkgPropPath = Join-Path -Path $pkgInfoPath ($PackageName + ".json")
+        $pkgPropPath = Join-Path -Path $ConfigFileDir ($PackageName + ".json")
         if (-Not (Test-Path $pkgPropPath))
         {
             Write-Host " Package property file path $($pkgPropPath) is invalid."

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -98,7 +98,6 @@ foreach ($pkgName in $responses.Keys)
         if (-Not (Test-Path $pkgPropPath))
         {
             Write-Host " Package property file path $($pkgPropPath) is invalid."
-            $FoundFailure = $True
         }
         else
         {

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -8,7 +8,8 @@ Param (
   [string] $APIKey,
   [Parameter(Mandatory=$True)]
   [string] $APILabel,
-  [string] $PackageName = ""
+  [string] $PackageName,
+  [string] $ArtifactSubDir = ""
 )
 
 
@@ -56,7 +57,12 @@ function Submit-APIReview($packagename, $filePath, $uri, $apiKey, $apiLabel)
 $packages = @{}
 if ($FindArtifactForApiReviewFn -and (Test-Path "Function:$FindArtifactForApiReviewFn"))
 {
-    $packages = &$FindArtifactForApiReviewFn $ArtifactPath $PackageName
+    $artifactLoc = $ArtifactPath
+    if ($ArtifactSubDir)
+    {
+        $artifactLoc = Join-Path -Path $artifactLoc $ArtifactSubDir
+    }
+    $packages = &$FindArtifactForApiReviewFn $artifactLoc $PackageName
 }
 else
 {

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -13,7 +13,7 @@ if ($allPackageProperties)
     New-Item -ItemType Directory -Force -Path $outDirectory
     foreach($pkg in $allPackageProperties)
     {
-        if ($pkg.IsNewSDK)
+        if ($pkg.IsNewSdk)
         {
             Write-Host "Package Name: $($pkg.Name)"
             Write-Host "Package Version: $($pkg.Version)"


### PR DESCRIPTION
Java API review create step requires additional artifact sub directory param. This will help in using generic artifact path to look for config files.