### PR TITLE
Do not add certain const types to token list

### DIFF
--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -107,7 +107,7 @@ func TestConst(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(p.Tokens) != 78 {
+	if len(p.Tokens) != 76 {
 		t.Fatal("unexpected token length, signals a change in the output")
 	}
 	if p.Name != "testconst" {

--- a/src/go/cmd/content.go
+++ b/src/go/cmd/content.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 )
 
+// skip adding the const type in the token list
+const skip = "skip"
+
 // newContent returns an initialized Content object.
 func newContent() content {
 	return content{
@@ -28,8 +31,6 @@ func (c content) isEmpty() bool {
 
 // adds the specified const declaration to the exports list
 func (c *content) addConst(pkg pkg, g *ast.GenDecl) {
-	// skip adding the const type in the token list
-	const skip = "skip"
 	for _, s := range g.Specs {
 		co := Const{}
 		vs := s.(*ast.ValueSpec)

--- a/src/go/cmd/content.go
+++ b/src/go/cmd/content.go
@@ -28,6 +28,8 @@ func (c content) isEmpty() bool {
 
 // adds the specified const declaration to the exports list
 func (c *content) addConst(pkg pkg, g *ast.GenDecl) {
+	// skip adding the const type in the token list
+	const skip = "skip"
 	for _, s := range g.Specs {
 		co := Const{}
 		vs := s.(*ast.ValueSpec)
@@ -48,7 +50,7 @@ func (c *content) addConst(pkg pkg, g *ast.GenDecl) {
 		} else {
 			// get the type from the token type
 			if bl, ok := vs.Values[0].(*ast.BasicLit); ok {
-				co.Type = strings.ToLower(bl.Kind.String())
+				co.Type = skip
 				v = bl.Value
 			} else if ce, ok := vs.Values[0].(*ast.CallExpr); ok {
 				// const FooConst = FooType("value")
@@ -56,11 +58,11 @@ func (c *content) addConst(pkg pkg, g *ast.GenDecl) {
 				v = pkg.getText(ce.Args[0].Pos(), ce.Args[0].End())
 			} else if ce, ok := vs.Values[0].(*ast.BinaryExpr); ok {
 				// const FooConst = "value" + Bar
-				co.Type = "*ast.BinaryExpr"
+				co.Type = skip
 				v = pkg.getText(ce.X.Pos(), ce.Y.End())
 			} else if ce, ok := vs.Values[0].(*ast.UnaryExpr); ok {
 				// const FooConst = -1
-				co.Type = "*ast.UnaryExpr"
+				co.Type = skip
 				v = pkg.getText(ce.Pos(), ce.End())
 			} else {
 				panic("unhandled case for adding constant")

--- a/src/go/cmd/content.go
+++ b/src/go/cmd/content.go
@@ -12,7 +12,7 @@ import (
 )
 
 // skip adding the const type in the token list
-const skip = "skip"
+const skip = "Untyped const"
 
 // newContent returns an initialized Content object.
 func newContent() content {

--- a/src/go/cmd/output/testconst.json
+++ b/src/go/cmd/output/testconst.json
@@ -56,114 +56,6 @@
    "Kind": 1
   },
   {
-   "DefinitionId": "const",
-   "NavigateToId": null,
-   "Value": "const",
-   "Kind": 6
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": " ",
-   "Kind": 2
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "(",
-   "Kind": 3
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "",
-   "Kind": 1
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "\t",
-   "Kind": 2
-  },
-  {
-   "DefinitionId": "Agent",
-   "NavigateToId": null,
-   "Value": "Agent",
-   "Kind": 4
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": " ",
-   "Kind": 2
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "",
-   "Kind": 7
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": " ",
-   "Kind": 2
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "=",
-   "Kind": 3
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": " ",
-   "Kind": 2
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "\"foo/\" + Version",
-   "Kind": 8
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "",
-   "Kind": 1
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": ")",
-   "Kind": 3
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "",
-   "Kind": 1
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "",
-   "Kind": 1
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": " ",
-   "Kind": 2
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "",
-   "Kind": 1
-  },
-  {
    "DefinitionId": "SomeChoice",
    "NavigateToId": null,
    "Value": "const",
@@ -326,6 +218,156 @@
    "Kind": 1
   },
   {
+   "DefinitionId": "Untyped const",
+   "NavigateToId": null,
+   "Value": "const",
+   "Kind": 6
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": " ",
+   "Kind": 2
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "(",
+   "Kind": 3
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "",
+   "Kind": 1
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "\t",
+   "Kind": 2
+  },
+  {
+   "DefinitionId": "Agent",
+   "NavigateToId": null,
+   "Value": "Agent",
+   "Kind": 4
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": " ",
+   "Kind": 2
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": " ",
+   "Kind": 2
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "=",
+   "Kind": 3
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": " ",
+   "Kind": 2
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "\"foo/\" + Version",
+   "Kind": 8
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "",
+   "Kind": 1
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "\t",
+   "Kind": 2
+  },
+  {
+   "DefinitionId": "Version",
+   "NavigateToId": null,
+   "Value": "Version",
+   "Kind": 4
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": " ",
+   "Kind": 2
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": " ",
+   "Kind": 2
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "=",
+   "Kind": 3
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": " ",
+   "Kind": 2
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "\"0.1.0\"",
+   "Kind": 8
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "",
+   "Kind": 1
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": ")",
+   "Kind": 3
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "",
+   "Kind": 1
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "",
+   "Kind": 1
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": " ",
+   "Kind": 2
+  },
+  {
+   "DefinitionId": null,
+   "NavigateToId": null,
+   "Value": "",
+   "Kind": 1
+  },
+  {
    "DefinitionId": "string",
    "NavigateToId": null,
    "Value": "const",
@@ -406,60 +448,6 @@
   {
    "DefinitionId": null,
    "NavigateToId": null,
-   "Value": "\t",
-   "Kind": 2
-  },
-  {
-   "DefinitionId": "Version",
-   "NavigateToId": null,
-   "Value": "Version",
-   "Kind": 4
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": " ",
-   "Kind": 2
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "string",
-   "Kind": 7
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": " ",
-   "Kind": 2
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "=",
-   "Kind": 3
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": " ",
-   "Kind": 2
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "\"0.1.0\"",
-   "Kind": 8
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
-   "Value": "",
-   "Kind": 1
-  },
-  {
-   "DefinitionId": null,
-   "NavigateToId": null,
    "Value": ")",
    "Kind": 3
   },
@@ -492,8 +480,8 @@
      }
     },
     {
-     "Text": "const",
-     "NavigationId": "const",
+     "Text": "Untyped const",
+     "NavigationId": "Untyped const",
      "ChildItems": [],
      "Tags": {
       "TypeKind": "enum"

--- a/src/go/cmd/token_builders.go
+++ b/src/go/cmd/token_builders.go
@@ -258,7 +258,7 @@ func makeConstTokens(name *string, c Const, list *[]Token) {
 	makeToken(nil, nil, "\t", whitespace, list)
 	makeToken(&n, nil, *name, typeName, list)
 	makeToken(nil, nil, " ", whitespace, list)
-	if c.Type == "*ast.BinaryExpr" {
+	if c.Type == "skip" {
 		makeToken(nil, nil, "", memberName, list)
 	} else {
 		makeToken(nil, nil, c.Type, memberName, list)

--- a/src/go/cmd/token_builders.go
+++ b/src/go/cmd/token_builders.go
@@ -258,7 +258,7 @@ func makeConstTokens(name *string, c Const, list *[]Token) {
 	makeToken(nil, nil, "\t", whitespace, list)
 	makeToken(&n, nil, *name, typeName, list)
 	makeToken(nil, nil, " ", whitespace, list)
-	if c.Type != "skip" {
+	if c.Type != skip {
 		makeToken(nil, nil, c.Type, memberName, list)
 	}
 	makeToken(nil, nil, " ", whitespace, list)

--- a/src/go/cmd/token_builders.go
+++ b/src/go/cmd/token_builders.go
@@ -258,9 +258,7 @@ func makeConstTokens(name *string, c Const, list *[]Token) {
 	makeToken(nil, nil, "\t", whitespace, list)
 	makeToken(&n, nil, *name, typeName, list)
 	makeToken(nil, nil, " ", whitespace, list)
-	if c.Type == "skip" {
-		makeToken(nil, nil, "", memberName, list)
-	} else {
+	if c.Type != "skip" {
 		makeToken(nil, nil, c.Type, memberName, list)
 	}
 	makeToken(nil, nil, " ", whitespace, list)


### PR DESCRIPTION
Skip adding const type for basic literals, unary and binary expressions. 