### PR TITLE
Include all classes in namespace and skip only Details namespace

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/CppLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CppLanguageService.cs
@@ -188,7 +188,6 @@ namespace APIViewWeb
 
                         if (!namespaceLeafMap.ContainsKey(nameSpace))
                         {
-                        {
                             namespaceLeafMap[nameSpace] = new List<CppAstNode>();
                         }
                         namespaceLeafMap[nameSpace].Add(leafNamespaceNode);

--- a/src/dotnet/APIView/APIViewWeb/Languages/CppLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CppLanguageService.cs
@@ -178,30 +178,29 @@ namespace APIViewWeb
                     namespacebldr.Append(currentNode.name);
                     leafNamespaceNode = currentNode;
                     currentNode = currentNode.inner?.FirstOrDefault(n => n.kind == NamespaceDeclKind);
-                }
+                    if (leafNamespaceNode.inner?.Any(n => n.kind != NamespaceDeclKind) == true)
+                    {
+                        var nameSpace = namespacebldr.ToString();
+                        if (!foundFilterNamespace && nameSpace.StartsWith(packageNamespace))
+                        {
+                            foundFilterNamespace = true;
+                        }
 
-                var nameSpace = namespacebldr.ToString();
-                // Skip <partialnamespace>::Details namespace
-                if (nameSpace.EndsWith(DetailsNamespacePostfix))
-                    continue;
-
-                if (!foundFilterNamespace && nameSpace.StartsWith(packageNamespace))
-                {
-                    foundFilterNamespace = true;
+                        if (!namespaceLeafMap.ContainsKey(nameSpace))
+                        {
+                        {
+                            namespaceLeafMap[nameSpace] = new List<CppAstNode>();
+                        }
+                        namespaceLeafMap[nameSpace].Add(leafNamespaceNode);
+                    }
                 }
-
-                if (!namespaceLeafMap.ContainsKey(nameSpace))
-                {
-                    namespaceLeafMap[nameSpace] = new List<CppAstNode>();
-                }
-                namespaceLeafMap[nameSpace].Add(leafNamespaceNode);
             }
 
             foreach (var nameSpace in namespaceLeafMap.Keys)
             {
                 // Filter namespace based on file name if any of the namespace matches file name pattern
                 // If no namespace matches file name then allow all namespaces to be part of review to avoid mandating file name convention
-                if (!foundFilterNamespace || nameSpace.StartsWith(packageNamespace))
+                if ((!foundFilterNamespace || nameSpace.StartsWith(packageNamespace)) && !nameSpace.EndsWith(DetailsNamespacePostfix))
                 {
                     ProcessNamespaceNode(nameSpace);
                     builder.NewLine();
@@ -237,6 +236,11 @@ namespace APIViewWeb
                     {
                         foreach (var member in leafNamespaceNode.inner)
                         {
+                            // Name space has mix of details namespace and classes
+                            // API View should skip those sub details namespaces also
+                            if (member.kind == NamespaceDeclKind)
+                                continue;
+
                             builder.IncrementIndent();
                             ProcessNode(member, currentNamespaceMembers, nameSpace);
                             builder.DecrementIndent();


### PR DESCRIPTION
C++ namespace has sub namespaces and class definitions at same level in some cases For e.g. Azure::Keyvault:Keys has a sub namespace ::Details as well as some class definitions. Currently code is skipping this subtree when it finds "Details" namespace. Fix in this PR is to fix only Details subtree and add remaining definitions at that level.