### PR TITLE
Add diagnostic rules for module-info

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
@@ -7,6 +7,7 @@ import com.azure.tools.apiview.processor.diagnostics.rules.IllegalPackageAPIExpo
 import com.azure.tools.apiview.processor.diagnostics.rules.ImportsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.MissingAnnotationsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.MissingJavaDocDiagnosticRule;
+import com.azure.tools.apiview.processor.diagnostics.rules.ModuleInfoDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.NoLocalesInJavadocUrlDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.NoPublicFieldsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.PackageNameDiagnosticRule;
@@ -45,6 +46,7 @@ public class Diagnostics {
         ));
         diagnostics.add(new MissingJavaDocDiagnosticRule());
         diagnostics.add(new NoLocalesInJavadocUrlDiagnosticRule());
+        diagnostics.add(new ModuleInfoDiagnosticRule());
 
         // common APIs for all builders (below we will do rules for http or amqp builders)
         diagnostics.add(new RequiredBuilderMethodsDiagnosticRule(null)

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ModuleInfoDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ModuleInfoDiagnosticRule.java
@@ -1,0 +1,66 @@
+package com.azure.tools.apiview.processor.diagnostics.rules;
+
+import com.azure.tools.apiview.processor.analysers.ASTAnalyser;
+import com.azure.tools.apiview.processor.diagnostics.DiagnosticRule;
+import com.azure.tools.apiview.processor.model.APIListing;
+import com.azure.tools.apiview.processor.model.Diagnostic;
+import com.azure.tools.apiview.processor.model.DiagnosticKind;
+import com.azure.tools.apiview.processor.model.Token;
+import com.azure.tools.apiview.processor.model.TokenKind;
+import com.github.javaparser.ast.CompilationUnit;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
+
+/**
+ * This diagnostic rule checks that the module has `module-info.java` and also validates that the
+ * name of the module matches the base package name.
+ */
+public class ModuleInfoDiagnosticRule implements DiagnosticRule {
+    private String moduleName;
+    private List<String> packages = new ArrayList<>();
+
+    @Override
+    public void scanIndividual(CompilationUnit cu, APIListing listing) {
+        packages.add(cu.getPackageDeclaration().get().getNameAsString());
+    }
+
+    @Override
+    public void scanFinal(APIListing listing) {
+        // In this method, we first look for the presence of module-info.java.
+        // If not present, add a warning message at the base package level
+        // If present, validate that the module name is the same as the base package name
+
+        // Base package name is the package that has the shortest name in a module
+        String basePackageName = packages
+                .stream()
+                .min(Comparator.comparingInt(String::length))
+                .orElse("");
+
+        // Check for the presence of module-info
+        Optional<Token> moduleInfoToken = listing.getTokens().stream()
+                .filter(token -> token.getKind().equals(TokenKind.TYPE_NAME))
+                .filter(token -> token.getDefinitionId() != null && token.getDefinitionId().equals(ASTAnalyser.MODULE_INFO_KEY))
+                .findFirst();
+
+        if (!moduleInfoToken.isPresent()) {
+            listing.addDiagnostic(new Diagnostic(DiagnosticKind.WARNING, makeId(basePackageName),
+                    "This module is missing module-info.java"));
+            return;
+        }
+
+        moduleName = moduleInfoToken.get().getValue();
+        if (moduleName != null) {
+            if (!moduleName.equals(basePackageName)) {
+                // add warning message if the module name does not match the base package name
+                listing.addDiagnostic(new Diagnostic(DiagnosticKind.WARNING,
+                        makeId(ASTAnalyser.MODULE_INFO_KEY), "Module name should be the same as base package " +
+                        "name: " + basePackageName));
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds diagnostic rules for `module-info`. This validates the following two Java guidelines:
- [Do include module-info.java for each module you ship](https://azure.github.io/azure-sdk/java_introduction.html#java-module-info)
- [ DO name your module based on the root package of the client library it represents.](https://azure.github.io/azure-sdk/java_introduction.html#java-module-name)

![image](https://user-images.githubusercontent.com/51379715/107174573-6b7c3f80-697f-11eb-9d99-389f99c698ca.png)

![image](https://user-images.githubusercontent.com/51379715/107174588-759e3e00-697f-11eb-823a-4b7565650e36.png)
