### PR TITLE
Hide the package which set to true instead of putting to Other page

### DIFF
--- a/eng/common/docgeneration/Generate-DocIndex.ps1
+++ b/eng/common/docgeneration/Generate-DocIndex.ps1
@@ -65,16 +65,11 @@ function Get-TocMapping {
     $orderServiceMapping = @{}
 
     foreach ($artifact in $artifacts) {
-        $packageInfo = $metadata | ? { $_.Package -eq $artifact }
+        $packageInfo = $metadata | ? { $_.Package -eq $artifact -and $packageInfo.Hide -ne "true"}
         $serviceName = ""
         $displayName = ""
-        if ($packageInfo.Hide -eq "true") {
-            continue
-        }
         if (!$packageInfo) {
-            LogWarning "There is no artifact $artifact. Please check csv of Azure/azure-sdk/_data/release/latest repo if this is intended. "
-            # If no service name retrieved, print out warning message, and put it into Other page.
-            $serviceName = "Other"
+            continue
         }
         elseif (!$packageInfo[0].ServiceName) {
             LogWarning "There is no service name for artifact $artifact. Please check csv of Azure/azure-sdk/_data/release/latest repo if this is intended. "

--- a/eng/common/docgeneration/Generate-DocIndex.ps1
+++ b/eng/common/docgeneration/Generate-DocIndex.ps1
@@ -65,7 +65,7 @@ function Get-TocMapping {
     $orderServiceMapping = @{}
 
     foreach ($artifact in $artifacts) {
-        $packageInfo = $metadata | ? { $_.Package -eq $artifact -and $packageInfo.Hide -ne "true"}
+        $packageInfo = $metadata | ? { $_.Package -eq $artifact -and $_.Hide -ne "true"}
         $serviceName = ""
         $displayName = ""
         if (!$packageInfo) {

--- a/eng/common/docgeneration/Generate-DocIndex.ps1
+++ b/eng/common/docgeneration/Generate-DocIndex.ps1
@@ -65,7 +65,7 @@ function Get-TocMapping {
     $orderServiceMapping = @{}
 
     foreach ($artifact in $artifacts) {
-        $packageInfo = $metadata | ? { $_.Package -eq $artifact -and $_.Hide -ne "true"}
+        $packageInfo = $metadata | ? { $_.Package -eq $artifact -and $_.Hide -ne "true" }
         $serviceName = ""
         $displayName = ""
         if (!$packageInfo) {

--- a/eng/common/docgeneration/Generate-DocIndex.ps1
+++ b/eng/common/docgeneration/Generate-DocIndex.ps1
@@ -65,9 +65,12 @@ function Get-TocMapping {
     $orderServiceMapping = @{}
 
     foreach ($artifact in $artifacts) {
-        $packageInfo = $metadata | ? { $_.Package -eq $artifact -and $_.Hide -ne "true" }
+        $packageInfo = $metadata | ? { $_.Package -eq $artifact }
         $serviceName = ""
         $displayName = ""
+        if ($packageInfo.Hide -eq "true") {
+            continue
+        }
         if (!$packageInfo) {
             LogWarning "There is no artifact $artifact. Please check csv of Azure/azure-sdk/_data/release/latest repo if this is intended. "
             # If no service name retrieved, print out warning message, and put it into Other page.

--- a/eng/common/docgeneration/Generate-DocIndex.ps1
+++ b/eng/common/docgeneration/Generate-DocIndex.ps1
@@ -69,7 +69,7 @@ function Get-TocMapping {
         $serviceName = ""
         $displayName = ""
         if (!$packageInfo) {
-            LogWarning "There is no service name for artifact $artifact. Please check csv of Azure/azure-sdk/_data/release/latest repo if this is intended. "
+            LogDebug "There is no service name for artifact $artifact or it is marked as hidden. Please check csv of Azure/azure-sdk/_data/release/latest repo if this is intended. "
             continue
         }
         elseif (!$packageInfo[0].ServiceName) {

--- a/eng/common/docgeneration/Generate-DocIndex.ps1
+++ b/eng/common/docgeneration/Generate-DocIndex.ps1
@@ -69,6 +69,7 @@ function Get-TocMapping {
         $serviceName = ""
         $displayName = ""
         if (!$packageInfo) {
+            LogWarning "There is no service name for artifact $artifact. Please check csv of Azure/azure-sdk/_data/release/latest repo if this is intended. "
             continue
         }
         elseif (!$packageInfo[0].ServiceName) {


### PR DESCRIPTION
We currently expose the hide package out to other page. It is supposed to be hidden from github io.
This is the fix for the feature.