### PR TITLE
Revert "Update repos sub parameters"

### DIFF
--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -21,16 +21,16 @@ parameters:
     azure-sdk-for-go:
     azure-sdk-for-ios:
     azure-sdk-for-java:
-      DefinitionId: 731
-      TestsDefinitionId: 2106
+      definition-id: 731
+      tests-definition-id: 2106
     azure-sdk-for-js:
-      DefinitionId: 832
+      definition-id: 832
     azure-sdk-for-net:
-      DefinitionId: 1191
-      TestsDefinitionId: 1936
+      definition-id: 1191
+      tests-definition-id: 1936
     azure-sdk-for-python:
-      DefinitionId: 1036
-      TestsDefinitionId: 2097
+      definition-id: 1036
+      tests-definition-id: 2097
 
 trigger: none
 

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -70,7 +70,7 @@ steps:
 
     - task: PowerShell@2
       displayName: Queue template pipeline
-      condition: and(succeeded(), ne('${{ repo.value.DefinitionId }}', ''))
+      condition: and(succeeded(), ne('${{ repo.value.definition-id }}', ''))
       inputs:
         pwsh: true
         workingDirectory: ${{ parameters.WorkingDirectory }}
@@ -79,14 +79,14 @@ steps:
           -Organization "azure-sdk"
           -Project "internal"
           -SourceBranch "${{ parameters.UpstreamBranchName }}-ForTestPipeline"
-          -DefinitionId '${{ repo.value.DefinitionId }}'
+          -DefinitionId '${{ repo.value.definition-id }}'
           -VsoQueuedPipelines "QueuedPipelines"
           -CancelPreviousBuilds $True
           -Base64EncodedAuthToken "$(azuresdk-azure-sdk-devops-build-queuing-pat)"
 
     - task: PowerShell@2
       displayName: Queue live-test template pipeline
-      condition: and(succeeded(), ne('${{ repo.value.TestsDefinitionId }}', ''))
+      condition: and(succeeded(), ne('${{ repo.value.tests-definition-id }}', ''))
       inputs:
         pwsh: true
         workingDirectory: ${{ parameters.WorkingDirectory }}
@@ -95,7 +95,7 @@ steps:
           -Organization "azure-sdk"
           -Project "internal"
           -SourceBranch "${{ parameters.UpstreamBranchName }}-ForTestPipeline"
-          -DefinitionId '${{ repo.value.TestsDefinitionId }}'
+          -DefinitionId '${{ repo.value.tests-definition-id }}'
           -VsoQueuedPipelines "QueuedPipelines"
           -CancelPreviousBuilds $True
           -Base64EncodedAuthToken "$(azuresdk-azure-sdk-devops-build-queuing-pat)"


### PR DESCRIPTION
Reverts Azure/azure-sdk-tools#1398
For some reason this seems to have cause the PR validations stop triggering
e.g https://github.com/Azure/azure-sdk-tools/pull/1307