### PR TITLE
Improve TestResources docs and logging

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -201,9 +201,12 @@ try {
         $context = Get-AzContext;
         if (!$context) {
             $subscriptionName = $SubscriptionId
+
+            # Use cache of well-known team subs without having to be authenticated.
             $wellKnownSubscriptions = @{
                 'faa080af-c1d8-40ad-9cce-e1a450ca5b57' = 'Azure SDK Developer Playground'
                 'a18897a6-7e44-457d-9260-f2854c0aca42' = 'Azure SDK Engineering System'
+                '2cd617ea-1866-46b1-90e3-fffb087ebf9b' = 'Azure SDK Test Resources'
             }
 
             if ($wellKnownSubscriptions.ContainsKey($SubscriptionId)) {

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -200,7 +200,17 @@ try {
         # Make sure the user is logged in to create a service principal.
         $context = Get-AzContext;
         if (!$context) {
-            Log "You are not logged in; connecting to 'Azure SDK Developer Playground'"
+            $subscriptionName = $SubscriptionId
+            $wellKnownSubscriptions = @{
+                'faa080af-c1d8-40ad-9cce-e1a450ca5b57' = 'Azure SDK Developer Playground'
+                'a18897a6-7e44-457d-9260-f2854c0aca42' = 'Azure SDK Engineering System'
+            }
+
+            if ($wellKnownSubscriptions.ContainsKey($SubscriptionId)) {
+                $subscriptionName = '{0} ({1})' -f $wellKnownSubscriptions[$SubscriptionId], $SubscriptionId
+            }
+
+            Log "You are not logged in; connecting to $subscriptionName"
             $context = (Connect-AzAccount -Subscription $SubscriptionId).Context
         }
 
@@ -208,11 +218,11 @@ try {
         if (!$TestApplicationId) {
 
             # Cache the created service principal in this session for frequent reuse.
-            $servicePrincipal = if ($AzureTestPrincipal) {
-                Log "TestApplicationId was not specified; loading the cached service principal"
+            $servicePrincipal = if ($AzureTestPrincipal -and (Get-AzADServicePrincipal -ApplicationId $AzureTestPrincipal.ApplicationId)) {
+                Log "TestApplicationId was not specified; loading cached service principal '$($AzureTestPrincipal.ApplicationId)'"
                 $AzureTestPrincipal
             } else {
-                Log "TestApplicationId was not specified; creating a new service principal"
+                Log 'TestApplicationId was not specified; creating a new service principal'
                 $global:AzureTestPrincipal = New-AzADServicePrincipal -Role Owner
 
                 Log "Created service principal '$AzureTestPrincipal'"

--- a/eng/common/TestResources/README.md
+++ b/eng/common/TestResources/README.md
@@ -19,8 +19,9 @@ scenarios as well as on hosted agents for continuous integration testing.
 ## On the Desktop
 
 To set up your Azure account to run live tests, you'll need to log into Azure,
-create a service principal, and set up your resources defined in
-test-resources.json as shown in the following example using Azure Search.
+and set up your resources defined in test-resources.json as shown in the following
+example using Azure Search. The script will create a service principal automatically,
+or you may create a service principal you can save and reuse subsequently.
 
 Note that `-Subscription` is an optional parameter but recommended if your account
 is a member of multiple subscriptions.
@@ -78,13 +79,6 @@ you can remove the test resources you created above by running:
 
 ```powershell
 Remove-TestResources.ps1 -BaseName 'myusername' -Force
-```
-
-If you created a new service principal as shown above, you might also remove it:
-
-```powershell
-Remove-AzADServicePrincipal -ApplicationId $sp.ApplicationId -Force
-
 ```
 
 If you persisted environment variables, you should also remove those as well.


### PR DESCRIPTION
Resolves #1388
Resolves #1407

Also ignores cached service principal if it no longer exists. I ran into this while testing since I cleaned up old SPs.