### PR TITLE
Add CI trigger back to pipeline generator

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
@@ -58,6 +58,25 @@ namespace PipelineGenerator.Conventions
                 }
             }
 
+            var ciTrigger = definition.Triggers.OfType<ContinuousIntegrationTrigger>().SingleOrDefault();
+
+            if (ciTrigger == null)
+            {
+                definition.Triggers.Add(new ContinuousIntegrationTrigger()
+                {
+                    SettingsSourceType = 2
+                });
+                hasChanges = true;
+            }
+            else
+            {
+                if (ciTrigger.SettingsSourceType != 2)
+                {
+                    ciTrigger.SettingsSourceType = 2;
+                    hasChanges = true;
+                }
+            }
+
             return hasChanges;
         }
     }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -70,6 +70,25 @@ namespace PipelineGenerator.Conventions
                 }
             }
 
+            var ciTrigger = definition.Triggers.OfType<ContinuousIntegrationTrigger>().SingleOrDefault();
+
+            if (ciTrigger == null)
+            {
+                definition.Triggers.Add(new ContinuousIntegrationTrigger()
+                {
+                    SettingsSourceType = 2
+                });
+                hasChanges = true;
+            }
+            else
+            {
+                if (ciTrigger.SettingsSourceType != 2)
+                {
+                    ciTrigger.SettingsSourceType = 2;
+                    hasChanges = true;
+                }
+            }
+
             return hasChanges;
         }
     }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -70,25 +70,6 @@ namespace PipelineGenerator.Conventions
                 }
             }
 
-            var ciTrigger = definition.Triggers.OfType<ContinuousIntegrationTrigger>().SingleOrDefault();
-
-            if (ciTrigger == null)
-            {
-                definition.Triggers.Add(new ContinuousIntegrationTrigger()
-                {
-                    SettingsSourceType = 2
-                });
-                hasChanges = true;
-            }
-            else
-            {
-                if (ciTrigger.SettingsSourceType != 2)
-                {
-                    ciTrigger.SettingsSourceType = 2;
-                    hasChanges = true;
-                }
-            }
-
             return hasChanges;
         }
     }


### PR DESCRIPTION
Now that we have the majority of Azure SDK pipelines running on the 1ES pools and we have better capacity to scale, this PR adds back the CI triggers so that once a merge is completed that we get a CI run. This will help narrow down build failures in pipelines that occur post merge whereas at the moment it can sometimes take some digging to figure out what particular change introduced a problem.