### PR TITLE
Approve automatic reviews if approved manual review matches

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Models/ReviewRevisionModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/ReviewRevisionModel.cs
@@ -70,7 +70,5 @@ namespace APIViewWeb
         public int RevisionNumber => Review.Revisions.IndexOf(this);
 
         public HashSet<string> Approvers { get; set; } = new HashSet<string>();
-
-        public bool IsOutdated { get; set; }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Models/ReviewRevisionModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/ReviewRevisionModel.cs
@@ -70,5 +70,7 @@ namespace APIViewWeb
         public int RevisionNumber => Review.Revisions.IndexOf(this);
 
         public HashSet<string> Approvers { get; set; } = new HashSet<string>();
+
+        public bool IsOutdated { get; set; }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -14,6 +14,13 @@
         </form>
     </div>
 }
+
+@if (Model.Revision.IsOutdated)
+{
+    <div class="alert alert-warning" role="alert" asp-resource="@Model.Review">
+        Your code review is outdated due to changes in another approved review for the same package. Please sync your changes with latest changes in master branch and create a new revision of API review 
+    </div>
+}
 <div class="row">
     <div class="col my-2">
         <div class="dropdown float-left mr-2">
@@ -108,12 +115,15 @@
                 }
             </div>
         </div>
-        <div class="float-right">
-            <form asp-resource="@Model.Review" class="form-inline float-left ml-2" asp-page-handler="ToggleApproval" method="post" asp-requirement="@ApproverRequirement.Instance">
-                <input type="hidden" name="revisionId" value="@Model.Revision.RevisionId" />
-                <input type="submit" class="btn btn-sm btn-secondary" value="@(Model.Revision.Approvers.Contains(User.GetGitHubLogin()) ? "Revert Approval" : "Approve")"/>
-            </form>
-        </div>
+        @if (!Model.Revision.IsOutdated)
+        {
+            <div class="float-right">
+                <form asp-resource="@Model.Review" class="form-inline float-left ml-2" asp-page-handler="ToggleApproval" method="post" asp-requirement="@ApproverRequirement.Instance">
+                    <input type="hidden" name="revisionId" value="@Model.Revision.RevisionId" />
+                    <input type="submit" class="btn btn-sm btn-secondary" value="@(Model.Revision.Approvers.Contains(User.GetGitHubLogin()) ? "Revert Approval" : "Approve")" />
+                </form>
+            </div>
+        }
         <div class="float-right ml-2">
             <label>Approval Status:</label>
             @if (Model.Revision.Approvers.Count > 0)

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -15,12 +15,6 @@
     </div>
 }
 
-@if (Model.Revision.IsOutdated)
-{
-    <div class="alert alert-warning" role="alert" asp-resource="@Model.Review">
-        Your code review is outdated due to changes in another approved review for the same package. Please sync your changes with latest changes in master branch and create a new revision of API review 
-    </div>
-}
 <div class="row">
     <div class="col my-2">
         <div class="dropdown float-left mr-2">
@@ -115,15 +109,12 @@
                 }
             </div>
         </div>
-        @if (!Model.Revision.IsOutdated)
-        {
-            <div class="float-right">
-                <form asp-resource="@Model.Review" class="form-inline float-left ml-2" asp-page-handler="ToggleApproval" method="post" asp-requirement="@ApproverRequirement.Instance">
-                    <input type="hidden" name="revisionId" value="@Model.Revision.RevisionId" />
-                    <input type="submit" class="btn btn-sm btn-secondary" value="@(Model.Revision.Approvers.Contains(User.GetGitHubLogin()) ? "Revert Approval" : "Approve")" />
-                </form>
-            </div>
-        }
+        <div class="float-right">
+            <form asp-resource="@Model.Review" class="form-inline float-left ml-2" asp-page-handler="ToggleApproval" method="post" asp-requirement="@ApproverRequirement.Instance">
+                <input type="hidden" name="revisionId" value="@Model.Revision.RevisionId" />
+                <input type="submit" class="btn btn-sm btn-secondary" value="@(Model.Revision.Approvers.Contains(User.GetGitHubLogin()) ? "Revert Approval" : "Approve")" />
+            </form>
+        </div>
         <div class="float-right ml-2">
             <label>Approval Status:</label>
             @if (Model.Revision.Approvers.Count > 0)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
@@ -59,12 +59,7 @@ namespace APIViewWeb
         public async Task<ReviewModel> GetMasterReviewForPackageAsync(string language, string packageName)
         {
             var reviews = await GetReviewsAsync(language, packageName, true);
-            ReviewModel review = null;
-            if (reviews.Count() > 0)
-            {
-                review = reviews.FirstOrDefault();
-            }
-            return review;
+            return reviews.FirstOrDefault();
         }
 
         public async Task<IEnumerable<ReviewModel>> GetReviewsAsync(string language, string packageName, bool isAutomatic)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
@@ -58,24 +58,45 @@ namespace APIViewWeb
 
         public async Task<ReviewModel> GetMasterReviewForPackageAsync(string language, string packageName)
         {
-            var queryDefinition = new QueryDefinition("SELECT * FROM Reviews r WHERE " +
+            var reviews = await GetReviewsAsync(language, packageName, true);
+            ReviewModel review = null;
+            if (reviews.Count() > 0)
+            {
+                review = reviews.First();
+            }
+            return review;
+        }
+
+        public async Task<IEnumerable<ReviewModel>> GetReviewsAsync(string language, string packageName, bool? isAutomatic, bool? approvedOrPendingOnly = null)
+        {
+            var queryStringAutomaticFilter = "SELECT * FROM Reviews r WHERE " +
                                                       "r.IsClosed = false AND " +
-                                                      "r.IsAutomatic = true AND " +
+                                                      "(IS_DEFINED(r.IsAutomatic) ? r.IsAutomatic : false) = @isAutomatic AND " +
                                                       "EXISTS (SELECT VALUE revision FROM revision in r.Revisions WHERE " +
-                                                                                    "EXISTS (SELECT VALUE files from files in revision.Files WHERE files.Language = @language AND files.PackageName = @packageName))")
+                                                                                    "EXISTS (SELECT VALUE files from files in revision.Files WHERE files.Language = @language AND files.PackageName = @packageName))";
+            var queryStringAll = "SELECT * FROM Reviews r WHERE " +
+                                                      "r.IsClosed = false AND " +
+                                                      "EXISTS (SELECT VALUE revision FROM revision in r.Revisions WHERE " +
+                                                                                    "EXISTS (SELECT VALUE files from files in revision.Files WHERE files.Language = @language AND files.PackageName = @packageName))";
+
+            var allReviews = new List<ReviewModel>();
+            var queryDefinition = new QueryDefinition(isAutomatic == null? queryStringAll : queryStringAutomaticFilter)
                 .WithParameter("@language", language)
-                .WithParameter("@packageName", packageName);
+                .WithParameter("@packageName", packageName)
+                .WithParameter("@isAutomatic", isAutomatic);
 
             var itemQueryIterator = _reviewsContainer.GetItemQueryIterator<ReviewModel>(queryDefinition);
-            if (itemQueryIterator.HasMoreResults)
+            while (itemQueryIterator.HasMoreResults)
             {
                 var result = await itemQueryIterator.ReadNextAsync();
-                if (result.Resource.Any())
-                {
-                    return result.Resource.First();
-                }
+                allReviews.AddRange(result.Resource);
             }
-            return null;
+
+            if (approvedOrPendingOnly != null)
+            {
+                return allReviews.Where(r => approvedOrPendingOnly == true ? r.Revisions.Last().Approvers.Count() > 0 : r.Revisions.Last().Approvers.Count() == 0);
+            }
+            return allReviews;
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
@@ -62,7 +62,7 @@ namespace APIViewWeb
             ReviewModel review = null;
             if (reviews.Count() > 0)
             {
-                review = reviews.First();
+                review = reviews.FirstOrDefault();
             }
             return review;
         }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -427,9 +427,16 @@ namespace APIViewWeb.Respositories
                 var matchingApprovedReview = await FindMatchingApprovedReview(review);
                 if (matchingApprovedReview != null)
                 {
-                    review.Revisions.Last().Approvers.Add(user.GetGitHubLogin());
-                    reviewModified = true;
-                }                
+                    var approvers = matchingApprovedReview.Revisions.Last().Approvers;
+                    if (approvers != null && approvers.Count() > 0)
+                    {
+                        foreach (var approver in approvers)
+                        {
+                            review.Revisions.Last().Approvers.Add(approver);
+                        }
+                        reviewModified = true;
+                    }
+                }
             }
 
             if (reviewModified)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -418,13 +418,9 @@ namespace APIViewWeb.Respositories
                 var matchingApprovedRevision = await FindMatchingApprovedRevision(review);
                 if (matchingApprovedRevision != null)
                 {
-                    var approvers = matchingApprovedRevision.Approvers;
-                    if (approvers != null && approvers.Count() > 0)
+                    foreach (var approver in matchingApprovedRevision.Approvers)
                     {
-                        foreach (var approver in approvers)
-                        {
-                            review.Revisions.Last().Approvers.Add(approver);
-                        }
+                        review.Revisions.Last().Approvers.Add(approver);
                     }
                 }
             }


### PR DESCRIPTION
- Approve automatic review when manual review is approved if they match at API surface level
- Search for approved manual reviews whenever new automatic review is created and mark it as approved automatically.