### PR TITLE
Disable NuGet sec analysis error.

### DIFF
--- a/eng/pipelines/pipeline-generation-single.yml
+++ b/eng/pipelines/pipeline-generation-single.yml
@@ -13,6 +13,7 @@ pr: none
 trigger: none
 
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   skipComponentGovernanceDetection: true
   DevOpsOrg: https://dev.azure.com/azure-sdk
   PathFilter: $(Pipeline.Workspace)/$(RepositoryName)/sdk/$(ServiceDirectory)

--- a/eng/pipelines/pipeline-generation-single.yml
+++ b/eng/pipelines/pipeline-generation-single.yml
@@ -13,7 +13,7 @@ pr: none
 trigger: none
 
 variables:
-  NugetSecurityAnalysisWarningLevel: warn
+  NugetSecurityAnalysisWarningLevel: none
   skipComponentGovernanceDetection: true
   DevOpsOrg: https://dev.azure.com/azure-sdk
   PathFilter: $(Pipeline.Workspace)/$(RepositoryName)/sdk/$(ServiceDirectory)

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -3,6 +3,7 @@ pr: none
 trigger: none
 
 variables:
+  NugetSecurityAnalysisWarningLevel: warn
   skipComponentGovernanceDetection: true
   TestOptions: ''
 

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -3,7 +3,7 @@ pr: none
 trigger: none
 
 variables:
-  NugetSecurityAnalysisWarningLevel: warn
+  NugetSecurityAnalysisWarningLevel: none
   skipComponentGovernanceDetection: true
   TestOptions: ''
 


### PR DESCRIPTION
This PR disables the security analysis warning about NuGet.config files. This is because this pipeline doesn't actually use NuGet.config to install packages. Instead it downloads from public Azure Artifacts registry (and the package is suffixed with Azure.*)