### PR TITLE
Restore pipeline output variable for Agent OS name

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-agent-os.yml
+++ b/eng/common/pipelines/templates/steps/verify-agent-os.yml
@@ -13,4 +13,4 @@ steps:
       workingDirectory: $(System.DefaultWorkingDirectory)
       filePath: ${{ parameters.ScriptDirectory }}/Verify-AgentOS.ps1
       arguments: >
-        -AgentImage ${{ parameters.AgentImage }}
+        -AgentImage "${{ parameters.AgentImage }}"

--- a/eng/common/scripts/Verify-AgentOS.ps1
+++ b/eng/common/scripts/Verify-AgentOS.ps1
@@ -8,6 +8,14 @@ function Throw-InvalidOperatingSystem {
     throw "Invalid operating system detected. Operating system was: $([System.Runtime.InteropServices.RuntimeInformation]::OSDescription), expected image was: $AgentImage"
 }
 
-if ($AgentImage -match "windows|win|MMS2019" -and !$IsWindows) { Throw-InvalidOperatingSystem }
-if ($AgentImage -match "ubuntu" -and !$IsLinux) { Throw-InvalidOperatingSystem }
-if ($AgentImage -match "macos" -and !$IsMacOs) { Throw-InvalidOperatingSystem }
+if ($IsWindows -and $AgentImage -match "windows|win|MMS2019") {
+    $osName = "Windows"
+} elseif ($IsLinux -and $AgentImage -match "ubuntu") {
+    $osName = "Linux"
+} elseif ($IsMacOs -and $AgentImage -match "macos") {
+    $osName = "macOS"
+} else {
+    Throw-InvalidOperatingSystem
+}
+
+Write-Host "##vso[task.setvariable variable=OSName]$osName"


### PR DESCRIPTION
The PR https://github.com/Azure/azure-sdk-tools/pull/1371 removed functionality that made the agent OS variable available to subsequent jobs in the pipeline. This variable is still used in several places for job and file display names, so this change re-introduces it.