### PR TITLE
Fix non-variant default name for tests-weekly

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
@@ -11,7 +11,11 @@ namespace PipelineGenerator.Conventions
 
         protected override string GetDefinitionName(SdkComponent component)
         {
-            return component.Variant == null ? $"{Context.Prefix} - {component.Name} - tests" : $"{Context.Prefix} - {component.Name} - tests-weekly.{component.Variant}";
+            var definitionName = $"{Context.Prefix} - {component.Name} - tests-weekly";
+            if (component.Variant != null) {
+                definitionName += $".{component.Variant}";
+            }
+            return definitionName;
         }
 
         protected override Schedule CreateScheduleFromDefinition(BuildDefinition definition)


### PR DESCRIPTION
The default non-variant suffix is `tests` when it should be `tests-weekly` in the pipeline generator weekly convention.