### PR TITLE
Update pipeline generator version to include weekly convention name fix

### DIFF
--- a/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
+++ b/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
@@ -9,7 +9,7 @@ steps:
   - script: >
       dotnet tool install
       Azure.Sdk.Tools.PipelineGenerator
-      --version 1.0.2-dev.20210112.1
+      --version 1.0.2-dev.20210219.1
       --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk/nuget/v3/index.json
       --tool-path ${{parameters.ToolPath}}
     workingDirectory: $(Pipeline.Workspace)/pipeline-generator


### PR DESCRIPTION
Updating the pipeline install tool to use the version published for https://github.com/Azure/azure-sdk-tools/pull/1435