### PR TITLE
Retain file name and handle older reviews without file name when upda…

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Models/ReviewCodeFileModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/ReviewCodeFileModel.cs
@@ -10,6 +10,9 @@ namespace APIViewWeb
         private string _language;
 
         public string ReviewFileId { get; set; } = IdHelper.GenerateId();
+
+        // This is field is more of a display name. It is set to name value returned by parser which has package name and version in following format
+        // Package name ( Version )
         public string Name { get; set; }
 
         public string Language
@@ -27,8 +30,10 @@ namespace APIViewWeb
         [Obsolete("Back compat don't use directly")]
         public bool RunAnalysis { get; set; }
 
+        // Field is used to store package name returned by parser. This is used to lookup review for a specific package
         public string PackageName { get; set; }
 
+        // This field stores original file name uploaded to create review
         public string FileName { get; set; }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Models/ReviewCodeFileModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/ReviewCodeFileModel.cs
@@ -28,5 +28,7 @@ namespace APIViewWeb
         public bool RunAnalysis { get; set; }
 
         public string PackageName { get; set; }
+
+        public string FileName { get; set; }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -133,9 +133,15 @@ namespace APIViewWeb.Respositories
                     var fileOriginal = await _originalsRepository.GetOriginalAsync(file.ReviewFileId);
                     var languageService = GetLanguageService(file.Language);
 
-                    var codeFile = await languageService.GetCodeFileAsync(file.Name, fileOriginal, review.RunAnalysis);
+                    // file.Name property has been repurposed to store parse name and version string
+                    // This is causing issue when updating review using latest parser since it expects Name field as file name
+                    // We have added a new property FileName which is only set for new reviews
+                    // All older reviews needs to be handled by checking Name field
+                    // If name field has no extension and File Name is Emtpy then use review.Name
+                    var fileName = file.FileName ?? (Path.HasExtension(file.Name)? file.Name : review.Name);
+                    var codeFile = await languageService.GetCodeFileAsync(fileName, fileOriginal, review.RunAnalysis);
                     await _codeFileRepository.UpsertCodeFileAsync(revision.RevisionId, file.ReviewFileId, codeFile);
-
+                    file.FileName = fileName;
                     InitializeFromCodeFile(file, codeFile);
                 }
             }
@@ -192,7 +198,7 @@ namespace APIViewWeb.Respositories
             using var memoryStream = new MemoryStream();
             var codeFile = await CreateCodeFile(originalName, fileStream, runAnalysis, memoryStream);
             var reviewCodeFileModel = await CreateReviewCodeFileModel(revisionId, memoryStream, codeFile);
-
+            reviewCodeFileModel.FileName = originalName;
             return reviewCodeFileModel;
         }
 
@@ -408,6 +414,7 @@ namespace APIViewWeb.Respositories
                     Label = label
                 };
                 var reviewCodeFileModel = await CreateReviewCodeFileModel(revision.RevisionId, memoryStream, codeFile);
+                reviewCodeFileModel.FileName = originalName;
                 revision.Files.Add(reviewCodeFileModel);
                 review.Revisions.Add(revision);
             }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -133,7 +133,7 @@ namespace APIViewWeb.Respositories
                     var fileOriginal = await _originalsRepository.GetOriginalAsync(file.ReviewFileId);
                     var languageService = GetLanguageService(file.Language);
 
-                    // file.Name property has been repurposed to store parse name and version string
+                    // file.Name property has been repurposed to store package name and version string
                     // This is causing issue when updating review using latest parser since it expects Name field as file name
                     // We have added a new property FileName which is only set for new reviews
                     // All older reviews needs to be handled by checking Name field

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -141,8 +141,8 @@ namespace APIViewWeb.Respositories
                     var fileName = file.FileName ?? (Path.HasExtension(file.Name)? file.Name : review.Name);
                     var codeFile = await languageService.GetCodeFileAsync(fileName, fileOriginal, review.RunAnalysis);
                     await _codeFileRepository.UpsertCodeFileAsync(revision.RevisionId, file.ReviewFileId, codeFile);
-                    file.FileName = fileName;
                     InitializeFromCodeFile(file, codeFile);
+                    file.FileName = fileName;
                 }
             }
 


### PR DESCRIPTION
Review can be updated to reprocess whenever a new parser is available. This uses original file stored in blob and creates a file using the Name property in cosmos. But name property was repurposed to store package name and version info so it breaks update functionality for some of the recently created reviews. Fix in this PR is to add a new FileName property in cosmos to retain original file name and also to create temp file using original file name if FileName is empty.