### PR TITLE
Update Prepare-Release script

### DIFF
--- a/eng/common/scripts/Prepare-Release.ps1
+++ b/eng/common/scripts/Prepare-Release.ps1
@@ -2,60 +2,67 @@
 
 [CmdletBinding()]
 param(
-    [Parameter(Mandatory=$true)]
-    [string]$PackageName,
-    [string]$ServiceDirectory,
-    [string]$ReleaseDate, # Pass Date in the form MM/dd/yyyy"
-    [string]$BuildType # For Java
+  [Parameter(Mandatory = $true)]
+  [string]$PackageName,
+  [string]$ServiceDirectory,
+  [string]$ReleaseDate # Pass Date in the form MM/dd/yyyy"
 )
+Set-StrictMode -Version 3
 
 . ${PSScriptRoot}\common.ps1
 
 function Get-ReleaseDay($baseDate)
 {
-    # Find first friday
-    while ($baseDate.DayOfWeek -ne 5)
-    {
-        $baseDate = $baseDate.AddDays(1)
-    }
-    
-    # Go to Tuesday
-    $baseDate = $baseDate.AddDays(4)
+  # Find first friday
+  while ($baseDate.DayOfWeek -ne 5)
+  {
+    $baseDate = $baseDate.AddDays(1)
+  }
 
-    return $baseDate;
+  # Go to Tuesday
+  $baseDate = $baseDate.AddDays(4)
+
+  return $baseDate;
 }
 
 $ErrorPreference = 'Stop'
 
 $packageProperties = Get-PkgProperties -PackageName $PackageName -ServiceDirectory $serviceDirectory
 
+if (!$packageProperties)
+{
+  Write-Error "Could not find a package with name [ $packageName ], please verify the package name matches the exact name."
+  exit 1
+}
+
+Write-Host "Package Name [ $($packageProperties.Name) ]"
 Write-Host "Source directory [ $serviceDirectory ]"
 
 if (!$ReleaseDate)
 {
-    $currentDate = Get-Date
-    $thisMonthReleaseDate = Get-ReleaseDay((Get-Date -Day 1));
-    $nextMonthReleaseDate = Get-ReleaseDay((Get-Date -Day 1).AddMonths(1));
+  $currentDate = Get-Date
+  $thisMonthReleaseDate = Get-ReleaseDay((Get-Date -Day 1));
+  $nextMonthReleaseDate = Get-ReleaseDay((Get-Date -Day 1).AddMonths(1));
 
-    if ($thisMonthReleaseDate -ge $currentDate)
-    {
-        # On track for this month release
-        $ParsedReleaseDate = $thisMonthReleaseDate
-    }
-    elseif ($currentDate.Day -lt 15)
-    {
-        # Catching up to this month release
-        $ParsedReleaseDate = $currentDate
-    }
-    else 
-    {
-        # Next month release
-        $ParsedReleaseDate = $nextMonthReleaseDate
-    }
+  if ($thisMonthReleaseDate -ge $currentDate)
+  {
+    # On track for this month release
+    $ParsedReleaseDate = $thisMonthReleaseDate
+  }
+  elseif ($currentDate.Day -lt 15)
+  {
+    # Catching up to this month release
+    $ParsedReleaseDate = $currentDate
+  }
+  else
+  {
+    # Next month release
+    $ParsedReleaseDate = $nextMonthReleaseDate
+  }
 }
 else
 {
-    $ParsedReleaseDate = [datetime]$ReleaseDate
+  $ParsedReleaseDate = [datetime]$ReleaseDate
 }
 
 $releaseDateString = $ParsedReleaseDate.ToString("MM/dd/yyyy")
@@ -70,40 +77,42 @@ $newVersion = Read-Host -Prompt "Input the new version, or press Enter to use us
 
 if (!$newVersion)
 {
-    $newVersion = $currentProjectVersion;
+  $newVersion = $currentProjectVersion;
 }
 
 $newVersionParsed = [AzureEngSemanticVersion]::ParseVersionString($newVersion)
 if ($null -eq $newVersionParsed)
 {
-    Write-Error "Invalid version $newVersion. Version must follow standard SemVer rules, see https://aka.ms/azsdk/engsys/packageversioning"
-    exit 1
+  Write-Error "Invalid version $newVersion. Version must follow standard SemVer rules, see https://aka.ms/azsdk/engsys/packageversioning"
+  exit 1
 }
 
 if (Test-Path "Function:SetPackageVersion")
 {
-    SetPackageVersion -PackageName $packageProperties.Name -Version $newVersion -ServiceDirectory $serviceDirectory -ReleaseDate $releaseDateString `
-    -BuildType $BuildType -GroupId $packageProperties.Group
+  SetPackageVersion -PackageName $packageProperties.Name -Version $newVersion -ServiceDirectory $serviceDirectory -ReleaseDate $releaseDateString `
+    -PackageProperties $packageProperties
 }
 else
 {
-    LogError "The function 'SetPackageVersion' was not found.`
+  LogError "The function 'SetPackageVersion' was not found.`
     Make sure it is present in eng/scripts/Language-Settings.ps1.`
     See https://github.com/Azure/azure-sdk-tools/blob/master/doc/common/common_engsys.md#code-structure"
-    exit 1
+  exit 1
 }
 
 &$EngCommonScriptsDir/Update-DevOps-Release-WorkItem.ps1 `
--language $LanguageDisplayName `
--packageName $packageProperties.Name `
--version $newVersion `
--plannedDate $releaseDateString `
--packageRepoPath $packageProperties.serviceDirectory
+  -language $LanguageDisplayName `
+  -packageName $packageProperties.Name `
+  -version $newVersion `
+  -plannedDate $releaseDateString `
+  -packageRepoPath $packageProperties.serviceDirectory `
+  -packageType $packageProperties.SDKType `
+  -packageNewLibrary $packageProperties.IsNewSDK
 
 git diff -s --exit-code $packageProperties.DirectoryPath
 if ($LASTEXITCODE -ne 0)
 {
-    git status
-    Write-Host "Some changes were made to the repo source" -ForegroundColor Green
-    Write-Host "Submit a pull request with the necessary changes to the repo" -ForegroundColor Green
+  git status
+  Write-Host "Some changes were made to the repo source" -ForegroundColor Green
+  Write-Host "Submit a pull request with the necessary changes to the repo" -ForegroundColor Green
 }

--- a/eng/common/scripts/common.ps1
+++ b/eng/common/scripts/common.ps1
@@ -25,12 +25,12 @@ if (Test-Path $EngScriptsLanguageSettings) {
   . $EngScriptsLanguageSettings
 }
 
-if (-not $LanguageShort)
+if (!(Get-Variable -Name "LangaugeShort" -ValueOnly -ErrorAction "Ignore"))
 {
   $LangaugeShort = $Language
 }
 
-if (-not $LanguageDisplayName)
+if (!(Get-Variable -Name "LanguageDisplayName" -ValueOnly -ErrorAction "Ignore"))
 {
   $LanguageDisplayName = $Language
 }

--- a/eng/common/scripts/logging.ps1
+++ b/eng/common/scripts/logging.ps1
@@ -1,7 +1,4 @@
-if (-not $isDevOpsRun)
-{
-  $isDevOpsRun = ($null -ne $env:SYSTEM_TEAMPROJECTID)
-}
+$isDevOpsRun = ($null -ne $env:SYSTEM_TEAMPROJECTID)
 
 function LogWarning
 {


### PR DESCRIPTION
- Remove BuildType parameter as we can default it from package properties
- Stop passing BuildType and GroupId and instead defaul them from package properties
- Enable StrictMode to help identify potential errors
- Start passing sdktype and isnewsdk properties to devops script
- Sync latest changes with devops work item to fix a couple bugs


Once https://github.com/Azure/azure-sdk-for-java/pull/19495 is merged and we merge this change the buildtype and groupid for java will come from the package properties. 