### PR TITLE
Auto update all reviews in the background after parser is updated

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
@@ -17,28 +19,6 @@ namespace APIViewWeb
         {
             var client = new CosmosClient(configuration["Cosmos:ConnectionString"]);
             _reviewsContainer = client.GetContainer("APIView", "Reviews");
-        }
-
-        public async Task<IEnumerable<ReviewModel>> GetReviewsAsync(bool closed, string language, bool automatic)
-        {
-            var allReviews = new List<ReviewModel>();
-            var queryDefinition = new QueryDefinition("SELECT * FROM Reviews r WHERE" +
-                                                      "(IS_DEFINED(r.IsClosed) ? r.IsClosed : false) = @isClosed AND " +
-                                                      "(IS_DEFINED(r.IsAutomatic) ? r.IsAutomatic : false) = @isAutomatic AND " +
-                                                      "('All' = @language OR EXISTS (SELECT VALUE revision FROM revision in r.Revisions WHERE " +
-                                                                                    "EXISTS (SELECT VALUE files from files in revision.Files WHERE files.Language = @language)))")
-                .WithParameter("@isClosed", closed)
-                .WithParameter("@language", language)
-                .WithParameter("@isAutomatic", automatic);
-
-            var itemQueryIterator = _reviewsContainer.GetItemQueryIterator<ReviewModel>(queryDefinition);
-            while (itemQueryIterator.HasMoreResults)
-            {
-                var result = await itemQueryIterator.ReadNextAsync();
-                allReviews.AddRange(result.Resource);
-            }
-
-            return allReviews.OrderByDescending(r => r.LastUpdated);
         }
 
         public async Task UpsertReviewAsync(ReviewModel reviewModel)
@@ -58,22 +38,38 @@ namespace APIViewWeb
 
         public async Task<ReviewModel> GetMasterReviewForPackageAsync(string language, string packageName)
         {
-            var reviews = await GetReviewsAsync(language, packageName, true);
+            var reviews = await GetReviewsAsync(false, language, packageName, true);
             return reviews.FirstOrDefault();
         }
 
-        public async Task<IEnumerable<ReviewModel>> GetReviewsAsync(string language, string packageName = "", bool? isAutomatic = null)
+        public async Task<IEnumerable<ReviewModel>> GetReviewsAsync(bool isClosed, string language, string packageName = "", bool? isAutomatic = null)
         {
-            var queryStringAutomaticFilter = "SELECT * FROM Reviews r WHERE " +
-                                                      "r.IsClosed = false AND " +
-                                                      "(IS_NULL(@isAutomatic) OR (IS_DEFINED(r.IsAutomatic) ? r.IsAutomatic : false) = @isAutomatic) AND " +
-                                                      "('All' = @language OR EXISTS (SELECT VALUE revision FROM revision in r.Revisions WHERE " +
-                                                                                    "EXISTS (SELECT VALUE files from files in revision.Files WHERE files.Language = @language AND files.PackageName = @packageName)))";
+            var queryStringBuilder = new StringBuilder("SELECT * FROM Reviews r WHERE (IS_DEFINED(r.IsClosed) ? r.IsClosed : false) = @isClosed ");
+
+            //Add filter if looking for automatic or manual reviews only
+            if (isAutomatic != null)
+            {
+                queryStringBuilder.Append("AND (IS_DEFINED(r.IsAutomatic) ? r.IsAutomatic : false) = @isAutomatic ");
+            }
+
+            // Add language and package name clause
+            // Currently we don't have any use case of searching for a package name across languages
+            if (language != "All")
+            {
+                queryStringBuilder.Append("AND EXISTS (SELECT VALUE revision FROM revision in r.Revisions WHERE EXISTS (SELECT VALUE files from files in revision.Files WHERE files.Language = @language");
+                if (!String.IsNullOrEmpty(packageName))
+                {
+                    queryStringBuilder.Append(" AND files.PackageName = @packageName");
+                }
+                queryStringBuilder.Append("))");
+            }
+
             var allReviews = new List<ReviewModel>();
-            var queryDefinition = new QueryDefinition(queryStringAutomaticFilter)
+            var queryDefinition = new QueryDefinition(queryStringBuilder.ToString())
                 .WithParameter("@language", language)
                 .WithParameter("@packageName", packageName)
-                .WithParameter("@isAutomatic", isAutomatic);
+                .WithParameter("@isAutomatic", isAutomatic)
+                .WithParameter("@isClosed", isClosed);
 
             var itemQueryIterator = _reviewsContainer.GetItemQueryIterator<ReviewModel>(queryDefinition);
             while (itemQueryIterator.HasMoreResults)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
@@ -66,17 +66,11 @@ namespace APIViewWeb
         {
             var queryStringAutomaticFilter = "SELECT * FROM Reviews r WHERE " +
                                                       "r.IsClosed = false AND " +
-                                                      "(IS_DEFINED(r.IsAutomatic) ? r.IsAutomatic : false) = @isAutomatic AND " +
+                                                      "(IS_NULL(@isAutomatic) OR (IS_DEFINED(r.IsAutomatic) ? r.IsAutomatic : false) = @isAutomatic) AND " +
                                                       "('All' = @language OR EXISTS (SELECT VALUE revision FROM revision in r.Revisions WHERE " +
                                                                                     "EXISTS (SELECT VALUE files from files in revision.Files WHERE files.Language = @language AND files.PackageName = @packageName)))";
-            var queryStringLanguagePackageFilter = "SELECT * FROM Reviews r WHERE " +
-                                                      "r.IsClosed = false AND " +
-                                                      "EXISTS (SELECT VALUE revision FROM revision in r.Revisions WHERE " +
-                                                                                    "EXISTS (SELECT VALUE files from files in revision.Files " +
-                                                                                    "WHERE ('All' = @language OR files.Language = @language) AND (@packageName = '' OR files.PackageName = @packageName)))";
-
             var allReviews = new List<ReviewModel>();
-            var queryDefinition = new QueryDefinition(isAutomatic != null? queryStringAutomaticFilter : queryStringLanguagePackageFilter)
+            var queryDefinition = new QueryDefinition(queryStringAutomaticFilter)
                 .WithParameter("@language", language)
                 .WithParameter("@packageName", packageName)
                 .WithParameter("@isAutomatic", isAutomatic);

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -68,7 +68,7 @@ namespace APIViewWeb.Respositories
 
         public Task<IEnumerable<ReviewModel>> GetReviewsAsync(bool closed, string language, bool automatic)
         {
-            return _reviewsRepository.GetReviewsAsync(closed, language, automatic);
+            return _reviewsRepository.GetReviewsAsync(closed, language, isAutomatic: automatic);
         }
 
         public async Task DeleteReviewAsync(ClaimsPrincipal user, string id)
@@ -442,7 +442,7 @@ namespace APIViewWeb.Respositories
             var codeFile = await _codeFileRepository.GetCodeFileAsync(revisionModel);
 
             // Get manual reviews to check if a matching review is in approved state
-            var reviews = await _reviewsRepository.GetReviewsAsync(revisionFile.Language, revisionFile.PackageName, false);
+            var reviews = await _reviewsRepository.GetReviewsAsync(false, revisionFile.Language, revisionFile.PackageName, false);
             foreach (var r in reviews)
             {
                 var approvedRevision = r.Revisions.Where(r => r.Approvers.Count() > 0).LastOrDefault();
@@ -465,7 +465,7 @@ namespace APIViewWeb.Respositories
             // Enabling this only for manual reviews in the beginning to check impact on system performance
             // We will enable it for all reviews based on the perf details
             // Automatic reviews are already updated as part of scheduled upload daily
-            var reviews = await _reviewsRepository.GetReviewsAsync("All");
+            var reviews = await _reviewsRepository.GetReviewsAsync(false, "All");
             foreach(var review in reviews.Where(r => IsUpdateAvailable(r)))
             {
                 var requestTelemetry = new RequestTelemetry { Name = "Updating Review " + review.ReviewId };

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -350,22 +350,6 @@ namespace APIViewWeb.Respositories
                .Any(f => f.HasOriginal && GetLanguageService(f.Language).CanUpdate(f.VersionString));
         }
 
-        private async Task<ReviewModel> GetMasterReviewAsync(ClaimsPrincipal user, string language, string packageName)
-        {
-            if (user == null)
-            {
-                throw new UnauthorizedAccessException();
-            }
-
-            var review = await _reviewsRepository.GetMasterReviewForPackageAsync(language, packageName);
-            if (review != null)
-            {
-                review.UpdateAvailable = IsUpdateAvailable(review);
-            }
-
-            return review;
-        }
-
         private async Task<bool> IsReviewSame(ReviewRevisionModel revision, RenderedCodeFile renderedCodeFile)
         {
             //This will compare and check if new code file content is same as revision in parameter
@@ -382,16 +366,10 @@ namespace APIViewWeb.Respositories
             var codeFile = await CreateCodeFile(originalName, fileStream, runAnalysis, memoryStream);
 
             //Get current master review for package and language
-            var review = await GetMasterReviewAsync(user, codeFile.Language, codeFile.PackageName);
+            var review = await _reviewsRepository.GetMasterReviewForPackageAsync(codeFile.Language, codeFile.PackageName);
             bool createNewRevision = true;
             if (review != null)
             {
-                // Check if current review needs to be updated to rebuild using latest language processor
-                if (review.UpdateAvailable)
-                {
-                    await UpdateReviewAsync(user, review.ReviewId);
-                }
-
                 var renderedCodeFile = new RenderedCodeFile(codeFile);
                 var noDiffFound = await IsReviewSame(review.Revisions.LastOrDefault(), renderedCodeFile);
                 if (noDiffFound)
@@ -487,7 +465,7 @@ namespace APIViewWeb.Respositories
             // Enabling this only for manual reviews in the beginning to check impact on system performance
             // We will enable it for all reviews based on the perf details
             // Automatic reviews are already updated as part of scheduled upload daily
-            var reviews = await _reviewsRepository.GetReviewsAsync(false, "All", false);
+            var reviews = await _reviewsRepository.GetReviewsAsync("All");
             foreach(var review in reviews.Where(r => IsUpdateAvailable(r)))
             {
                 var requestTelemetry = new RequestTelemetry { Name = "Updating Review " + review.ReviewId };


### PR DESCRIPTION
Update automatic reviews also in the background. This is one time update after system restart(which is usually after new deployment)

Automatic reviews are currently attempted to update during auto review creation and this leads to longer delay and request time out. This PR has a change to update automatic reviews in background to latest parser version in the same way manual reviews are handled and avoids attempting to update again during auto review creation.