### PR TITLE
Fix bug where imported matrix parameter duplicates are not overrided

### DIFF
--- a/eng/common/scripts/job-matrix/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common/scripts/job-matrix/tests/job-matrix-functions.modification.tests.ps1
@@ -216,4 +216,25 @@ Describe "Platform Matrix Import" -Tag "import" {
         $matrix.Length | Should -Be 7
         CompareMatrices $matrix $expected
     }
+
+    It "Should generate a sparse matrix with an imported a sparse matrix" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "$IMPORT": "./test-import-matrix.json",
+        "Foo": [ "fooOverride1", "fooOverride2" ],
+    }
+}
+'@
+
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+        $matrix = GenerateMatrix $importConfig "sparse"
+
+        $matrix[0].parameters["Foo"] | Should -Be "fooOverride1"
+        $matrix[0].name | Should -Be "fooOverride1_bar1"
+        $matrix[3].parameters["Foo"] | Should -Be "fooOverride2"
+        $matrix[3].name | Should -Be "fooOverride2_bar1"
+        $matrix[5].parameters["Foo"] | Should -Be "fooOverride2"
+        $matrix[5].name | Should -Be "fooOverride2_importedBaz"
+    }
 }


### PR DESCRIPTION
When importing a matrix from another matrix, the intended behavior is that any duplicate parameter keys favor the value in the matrix doing the import. This PR fixes a bug where this did not happen (instead the imported matrix's value is favored). 