### PR TITLE
Add replace operation to matrix config

### DIFF
--- a/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
+++ b/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
@@ -10,6 +10,9 @@ parameters:
 - name: MatrixFilters
   type: object
   default: []
+- name: MatrixReplace
+  type: object
+  default: {}
 - name: JobTemplatePath
   type: string
 # Set this to false to do a full checkout for private repositories with the azure pipelines service connection
@@ -57,6 +60,7 @@ jobs:
               -Selection ${{ config.Selection }}
               -DisplayNameFilter "$(displayNameFilter)"
               -Filters "${{ join('","', parameters.MatrixFilters) }}","container=^$","SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}"
+              -Replace "${{ join('","', parameters.MatrixReplace) }}"
               -NonSparseParameters "${{ join('","', config.NonSparseParameters) }}"
           displayName: Generate VM Job Matrix ${{ config.Name }}
           name: generate_vm_job_matrix_${{ config.Name }}

--- a/eng/common/scripts/job-matrix/Create-JobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-JobMatrix.ps1
@@ -13,6 +13,7 @@ param (
     [Parameter(Mandatory=$True)][string] $Selection,
     [Parameter(Mandatory=$False)][string] $DisplayNameFilter,
     [Parameter(Mandatory=$False)][array] $Filters,
+    [Parameter(Mandatory=$False)][array] $Replace,
     [Parameter(Mandatory=$False)][array] $NonSparseParameters
 )
 
@@ -27,6 +28,7 @@ $Filters = $Filters | Where-Object { $_ }
     -selectFromMatrixType $Selection `
     -displayNameFilter $DisplayNameFilter `
     -filters $Filters `
+    -replace $Replace `
     -nonSparseParameters $NonSparseParameters
 
 $serialized = SerializePipelineMatrix $matrix

--- a/eng/common/scripts/job-matrix/README.md
+++ b/eng/common/scripts/job-matrix/README.md
@@ -400,11 +400,12 @@ named "ExcludedKey", a framework variable containing either "461" or "5.0", and 
 #### Replace values
 
 Replacements for values can be passed to the matrix as an array of strings, each matching the format of `<keyRegex>=<valueRegex>/<replacementValue>`.
-The replace argument will find any permutations where the key matches the key regex and the value matches the value regex, and replace the value with
+The replace argument will find any permutations where the key fully matches the key regex and the value fully matches the value regex, and replace the value with
 the replacement specified.
 
 NOTE:
-- For each value, the first replacement provided that matches will be the only one applied.
+- The replacement value supports regex capture groups, enabling substring transformations, e.g. `Foo=(.*)-replaceMe/$1-replaced`. See the below examples for usage.
+- For each key/value, the first replacement provided that matches will be the only one applied.
 - If `=` or `/` characters need to be part of the regex or replacement, escape them with `\`.
 
 For example, given a matrix config like below:
@@ -442,17 +443,20 @@ $ ./Create-JobMatrix.ps1 -ConfigPath <test> -Selection all
 Passing in multiple replacements, the output will look like below. Note that replacing key/values that appear nested within a grouping
 will not affect that segment of the job name, since the job takes the grouping name (in this case "ubuntu1804").
 
+The below example includes samples of regex grouping references, and wildcard key/value regexes:
+
 ```
-$ ./Create-JobMatrix.ps1 -ConfigPath <test> -Selection all -Replace @("Java.*Version=1.11/2.0", "Pool=.*ubuntu.*/custom-ubuntu-pool")
+$ $replacements = @('.*Version=1.11/2.0', 'Pool=(.*ubuntu.*)-general/$1-custom')
+$ ../Create-JobMatrix.ps1 -ConfigPath ./test.Json -Selection all -Replace $replacements
 {
   "ubuntu1804_18": {
     "OSVmImage": "MMSUbuntu18.04",
-    "Pool": "custom-ubuntu-pool",
+    "Pool": "azsdk-pool-mms-ubuntu-1804-custom",
     "JavaTestVersion": "1.8"
   },
   "ubuntu1804_20": {
     "OSVmImage": "MMSUbuntu18.04",
-    "Pool": "custom-ubuntu-pool",
+    "Pool": "azsdk-pool-mms-ubuntu-1804-custom",
     "JavaTestVersion": "2.0"
   }
 }

--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -4,39 +4,98 @@ class MatrixConfig {
     [PSCustomObject]$displayNames
     [Hashtable]$displayNamesLookup
     [PSCustomObject]$matrix
-    [System.Collections.Specialized.OrderedDictionary]$orderedMatrix
+    [MatrixParameter[]]$matrixParameters
     [Array]$include
     [Array]$exclude
 }
 
-$IMPORT_KEYWORD = '$IMPORT'
-
-function CreateDisplayName([string]$parameter, [Hashtable]$displayNamesLookup)
-{
-    $name = $parameter.ToString()
-
-    if ($displayNamesLookup.ContainsKey($parameter)) {
-        $name = $displayNamesLookup[$parameter]
+class MatrixParameter {
+    MatrixParameter([String]$name, [System.Object]$value) {
+        $this.Value = $value
+        $this.Name = $name
     }
 
-    # Matrix naming restrictions:
-    # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#multi-job-configuration
-    $name = $name -replace "[^A-Za-z0-9_]", ""
-    return $name
+    [System.Object]$Value
+    [System.Object]$Name
+
+    Set($value, [String]$key = '')
+    {
+        if ($this.Value -is [PSCustomObject]) {
+            $set = $false
+            foreach ($prop in $this.Value.PSObject.Properties) {
+                if ($prop.Name -eq $key) {
+                    $prop.Value = $value
+                    $set = $true
+                    break
+                }
+            }
+            if (!$set) {
+                throw "Property `"$key`" does not exist for MatrixParameter."
+            }
+        } else {
+            $this.Value = $value
+        }
+    }
+
+    [System.Object]Flatten()
+    {
+        if ($this.Value -is [PSCustomObject]) {
+            return $this.Value.PSObject.Properties | ForEach-Object {
+                [MatrixParameter]::new($_.Name, $_.Value)
+            }
+        } elseif ($this.Value -is [Array]) {
+            return $this.Value | ForEach-Object {
+                [MatrixParameter]::new($this.Name, $_)
+            }
+        } else {
+            return $this
+        }
+    }
+
+    [Int]Length()
+    {
+        if ($this.Value -is [PSCustomObject]) {
+            return ($this.Value.PSObject.Properties | Measure-Object).Count
+        } elseif ($this.Value -is [Array]) {
+            return $this.Value.Length
+        } else {
+            return 1
+        }
+    }
+
+    [String]CreateDisplayName([Hashtable]$displayNamesLookup)
+    {
+        $displayName = $this.Value.ToString()
+        if ($this.Value -is [PSCustomObject]) {
+            $displayName = $this.Name
+        }
+
+        if ($displayNamesLookup.ContainsKey($displayName)) {
+            $displayName = $displayNamesLookup[$displayName]
+        }
+
+        # Matrix naming restrictions:
+        # https://docs.microsoft.com/en-us/azure/devops/pipelines/process/phases?view=azure-devops&tabs=yaml#multi-job-configuration
+        $displayName = $displayName -replace "[^A-Za-z0-9_]", ""
+        return $displayName
+    }
 }
+
+$IMPORT_KEYWORD = '$IMPORT'
 
 function GenerateMatrix(
     [MatrixConfig]$config,
     [String]$selectFromMatrixType,
     [String]$displayNameFilter = ".*",
     [Array]$filters = @(),
+    [Array]$replace = @(),
     [Array]$nonSparseParameters = @()
 ) {
-    $orderedMatrix, $importedMatrix, $importedDisplayNamesLookup = ProcessImport $config.orderedMatrix $selectFromMatrixType
+    $matrixParameters, $importedMatrix, $importedDisplayNamesLookup = ProcessImport $config.matrixParameters $selectFromMatrixType
     if ($selectFromMatrixType -eq "sparse") {
-        [Array]$matrix = GenerateSparseMatrix $orderedMatrix $config.displayNamesLookup $nonSparseParameters
+        $matrix = GenerateSparseMatrix $matrixParameters $config.displayNamesLookup $nonSparseParameters
     } elseif ($selectFromMatrixType -eq "all") {
-        [Array]$matrix = GenerateFullMatrix $orderedMatrix $config.displayNamesLookup
+        $matrix = GenerateFullMatrix $matrixParameters $config.displayNamesLookup
     } else {
         throw "Matrix generator not implemented for selectFromMatrixType: $($platform.selectFromMatrixType)"
     }
@@ -44,37 +103,37 @@ function GenerateMatrix(
     # Combine with imported after matrix generation, since a sparse selection should result in a full combination of the
     # top level and imported sparse matrices (as opposed to a sparse selection of both matrices).
     if ($importedMatrix) {
-        [Array]$matrix = CombineMatrices $matrix $importedMatrix $importedDisplayNamesLookup
+        $matrix = CombineMatrices $matrix $importedMatrix $importedDisplayNamesLookup
     }
-
     if ($config.exclude) {
-        [Array]$matrix = ProcessExcludes $matrix $config.exclude
+        $matrix = ProcessExcludes $matrix $config.exclude
     }
     if ($config.include) {
-        [Array]$matrix = ProcessIncludes $config $matrix $selectFromMatrixType
+        $matrix = ProcessIncludes $config $matrix $selectFromMatrixType
     }
 
-    [Array]$matrix = FilterMatrixDisplayName $matrix $displayNameFilter
-    [Array]$matrix = FilterMatrix $matrix $filters
+    $matrix = FilterMatrix $matrix $filters
+    $matrix = ProcessReplace $matrix $replace $config.displayNamesLookup
+    $matrix = FilterMatrixDisplayName $matrix $displayNameFilter
     return $matrix
 }
 
 function ProcessNonSparseParameters(
-    [System.Collections.Specialized.OrderedDictionary]$parameters,
+    [MatrixParameter[]]$parameters,
     [Array]$nonSparseParameters
 ) {
     if (!$nonSparseParameters) {
         return $parameters, $null
     }
 
-    $sparse = [ordered]@{}
-    $nonSparse = [ordered]@{}
+    $sparse = [MatrixParameter[]]@()
+    $nonSparse = [MatrixParameter[]]@()
 
-    foreach ($param in $parameters.GetEnumerator()) {
+    foreach ($param in $parameters) {
         if ($param.Name -in $nonSparseParameters) {
-            $nonSparse[$param.Name] = $param.Value
+            $nonSparse += $param
         } else {
-            $sparse[$param.Name] = $param.Value
+            $sparse += $param
         }
     }
 
@@ -82,7 +141,7 @@ function ProcessNonSparseParameters(
 }
 
 function FilterMatrixDisplayName([array]$matrix, [string]$filter) {
-    return $matrix | ForEach-Object {
+    return $matrix | Where-Object { $_ } | ForEach-Object {
         if ($_.Name -match $filter) {
             return $_
         }
@@ -132,35 +191,40 @@ function ParseFilter([string]$filter) {
 function GetMatrixConfigFromJson([String]$jsonConfig)
 {
     [MatrixConfig]$config = $jsonConfig | ConvertFrom-Json
-    $config.orderedMatrix = [ordered]@{}
+    $config.matrixParameters = @()
     $config.displayNamesLookup = @{}
+    $include = [MatrixParameter[]]@()
+    $exclude = [MatrixParameter[]]@()
 
-    if ($null -ne $config.matrix) {
-        $config.matrix.PSObject.Properties | ForEach-Object {
-            $config.orderedMatrix.Add($_.Name, $_.Value)
-        }
-    }
     if ($null -ne $config.displayNames) {
         $config.displayNames.PSObject.Properties | ForEach-Object {
             $config.displayNamesLookup.Add($_.Name, $_.Value)
         }
     }
-    $config.include = $config.include | Where-Object { $null -ne $_ } | ForEach-Object {
-        $ordered = [ordered]@{}
-        $_.PSObject.Properties | ForEach-Object {
-            $ordered.Add($_.Name, $_.Value)
-        }
-        return $ordered
+    if ($null -ne $config.matrix) {
+        $config.matrixParameters = PsObjectToMatrixParameterArray $config.matrix
     }
-    $config.exclude = $config.exclude | Where-Object { $null -ne $_ } | ForEach-Object {
-        $ordered = [ordered]@{}
-        $_.PSObject.Properties | ForEach-Object {
-            $ordered.Add($_.Name, $_.Value)
-        }
-        return $ordered
+    foreach ($includeMatrix in $config.include) {
+        $include += ,@(PsObjectToMatrixParameterArray $includeMatrix)
+    }
+    foreach ($excludeMatrix in $config.exclude) {
+        $exclude += ,@(PsObjectToMatrixParameterArray $excludeMatrix)
     }
 
+    $config.include = $include
+    $config.exclude = $exclude
+
     return $config
+}
+
+function PsObjectToMatrixParameterArray([PSCustomObject]$obj)
+{
+    if ($obj -eq $null) {
+        return $null
+    }
+    return $obj.PSObject.Properties | ForEach-Object {
+        [MatrixParameter]::new($_.Name, $_.Value)
+    }
 }
 
 function ProcessExcludes([Array]$matrix, [Array]$excludes)
@@ -196,14 +260,93 @@ function ProcessIncludes([MatrixConfig]$config, [Array]$matrix)
     return $matrix + $inclusionMatrix
 }
 
-function ProcessImport([System.Collections.Specialized.OrderedDictionary]$matrix, [String]$selection)
-{
-    if (!$matrix -or !$matrix.Contains($IMPORT_KEYWORD)) {
-        return $matrix, @(), @{}
+function ParseReplacement([String]$replacement) {
+    $parsed = '', '', ''
+    $idx = 0
+    $escaped = $false
+    $operators = '=', '/'
+    $err = "Invalid replacement syntax, expecting <key>=<value>/<replace>"
+
+    foreach ($c in $replacement -split '') {
+        if ($idx -ge $parsed.Length) {
+            throw $err
+        }
+        if (!$escaped -and $c -in $operators) {
+            $idx++
+        } else {
+            $parsed[$idx] += $c
+        }
+        $escaped = $c -eq '\'
     }
 
-    $importPath = $matrix[$IMPORT_KEYWORD]
-    $matrix.Remove($IMPORT_KEYWORD)
+    if ($idx -lt $parsed.Length - 1) {
+        throw $err
+    }
+
+    $replace = $parsed[2]
+    $replace = $replace -replace '\\=', '='
+    $replace = $replace -replace '\\/', '/'
+
+    return @{
+        "key" = $parsed[0]
+        "value" = $parsed[1]
+        "replace" = $replace
+    }
+}
+
+function ProcessReplace
+{
+    param(
+        [Array]$matrix,
+        [Array]$replacements,
+        [Hashtable]$displayNamesLookup
+    )
+
+    if (!$replacements) {
+        return $matrix
+    }
+
+    $replaceMatrix = @()
+
+    foreach ($element in $matrix) {
+        $replacement = [MatrixParameter[]]@()
+
+        foreach ($perm in $element._permutation) {
+            $replace = $perm
+
+            # Iterate nested permutations or run once for singular values (int, string, bool)
+            foreach ($flattened in $perm.Flatten()) {
+                foreach ($query in $replacements) {
+                    $parsed = ParseReplacement $query
+                    if ($flattened.Name -match $parsed.key -and $flattened.Value -match $parsed.value) {
+                        $perm.Set($parsed.replace, $parsed.key)
+                        break
+                    }
+                }
+            }
+
+            $replacement += $perm
+        }
+
+        $replaceMatrix += CreateMatrixCombinationScalar $replacement $displayNamesLookup
+    }
+
+    return $replaceMatrix
+}
+
+function ProcessImport([MatrixParameter[]]$matrix, [String]$selection)
+{
+    $importPath = ""
+    $matrix = $matrix | ForEach-Object {
+        if ($_.Name -ne $IMPORT_KEYWORD) {
+            return $_
+        } else {
+            $importPath = $_.Value
+        }
+    }
+    if (!$matrix -or !$importPath) {
+        return $matrix, @()
+    }
 
     $importedMatrixConfig = GetMatrixConfigFromJson (Get-Content $importPath)
     $importedMatrix = GenerateMatrix $importedMatrixConfig $selection
@@ -223,27 +366,7 @@ function CombineMatrices([Array]$matrix1, [Array]$matrix2, [Hashtable]$displayNa
 
     foreach ($entry1 in $matrix1) {
         foreach ($entry2 in $matrix2) {
-            $entry2name = @()
-            $newEntry = @{
-                name = $entry1.name
-                parameters = CloneOrderedDictionary $entry1.parameters
-            }
-            foreach($param in $entry2.parameters.GetEnumerator()) {
-                if (!$newEntry.parameters.Contains($param.Name)) {
-                    $newEntry.parameters[$param.Name] = $param.Value
-                    $entry2name += CreateDisplayName $param.Value $displayNamesLookup
-                } else {
-                    Write-Warning "Skipping duplicate parameter `"$($param.Name)`" when combining matrix."
-                }
-            }
-
-            # The maximum allowed matrix name length is 100 characters
-            $newEntry.name = @($newEntry.name, ($entry2name -join "_")) -join "_"
-            if ($newEntry.name.Length -gt 100) {
-                $newEntry.name = $newEntry.name[0..99] -join ""
-            }
-
-            $combined += $newEntry
+            $combined += CreateMatrixCombinationScalar ($entry1._permutation + $entry2._permutation) $displayNamesLookup
         }
     }
 
@@ -277,6 +400,10 @@ function SerializePipelineMatrix([Array]$matrix)
 {
     $pipelineMatrix = [Ordered]@{}
     foreach ($entry in $matrix) {
+        if ($pipelineMatrix.Contains($entry.Name)) {
+            Write-Warning "Found duplicate configurations for job `"$($entry.name)`". Multiple values may have been replaced with the same value."
+            continue
+        }
         $pipelineMatrix.Add($entry.name, [Ordered]@{})
         foreach ($key in $entry.parameters.Keys) {
             $pipelineMatrix[$entry.name].Add($key, $entry.parameters[$key])
@@ -290,13 +417,13 @@ function SerializePipelineMatrix([Array]$matrix)
 }
 
 function GenerateSparseMatrix(
-    [System.Collections.Specialized.OrderedDictionary]$parameters,
+    [MatrixParameter[]]$parameters,
     [Hashtable]$displayNamesLookup,
     [Array]$nonSparseParameters = @()
 ) {
     $parameters, $nonSparse = ProcessNonSparseParameters $parameters $nonSparseParameters
-    [Array]$dimensions = GetMatrixDimensions $parameters
-    [Array]$matrix = GenerateFullMatrix $parameters $displayNamesLookup
+    $dimensions = GetMatrixDimensions $parameters
+    $matrix = GenerateFullMatrix $parameters $displayNamesLookup
 
     $sparseMatrix = @()
     $indexes = GetSparseMatrixIndexes $dimensions
@@ -305,7 +432,7 @@ function GenerateSparseMatrix(
     }
 
     if ($nonSparse) {
-        [Array]$allOfMatrix = GenerateFullMatrix $nonSparse $displayNamesLookup
+        $allOfMatrix = GenerateFullMatrix $nonSparse $displayNamesLookup
         return CombineMatrices $allOfMatrix $sparseMatrix $displayNamesLookup
     }
 
@@ -335,7 +462,7 @@ function GetSparseMatrixIndexes([Array]$dimensions)
 }
 
 function GenerateFullMatrix(
-    [System.Collections.Specialized.OrderedDictionary] $parameters,
+    [MatrixParameter[]] $parameters,
     [Hashtable]$displayNamesLookup = @{}
 ) {
     # Handle when the config does not have a matrix specified (e.g. only the include field is specified)
@@ -343,32 +470,29 @@ function GenerateFullMatrix(
         return @()
     }
 
-    $parameterArray = $parameters.GetEnumerator() | ForEach-Object { $_ }
-
     $matrix = [System.Collections.ArrayList]::new()
-    InitializeMatrix $parameterArray $displayNamesLookup $matrix
+    InitializeMatrix $parameters $displayNamesLookup $matrix
 
     return $matrix
 }
 
-function CreateMatrixEntry([System.Collections.Specialized.OrderedDictionary]$permutation, [Hashtable]$displayNamesLookup = @{})
+function CreateMatrixCombinationScalar([MatrixParameter[]]$permutation, [Hashtable]$displayNamesLookup = @{})
 {
     $names = @()
-    $splattedParameters = [Ordered]@{}
+    $flattenedParameters = [Ordered]@{}
 
-    foreach ($entry in $permutation.GetEnumerator()) {
+    foreach ($entry in $permutation) {
         $nameSegment = ""
 
-        if ($entry.Value -is [PSCustomObject]) {
-            $nameSegment = CreateDisplayName $entry.Name $displayNamesLookup
-            foreach ($toSplat in $entry.Value.PSObject.Properties) {
-                $splattedParameters.Add($toSplat.Name, $toSplat.Value)
+        # Unwind nested permutations or run once for singular values (int, string, bool)
+        foreach ($param in $entry.Flatten()) {
+            if ($flattenedParameters.Contains($param.Name)) {
+                throw "Found duplicate parameter `"$($param.Name)`" when creating matrix combination."
             }
-        } else {
-            $nameSegment = CreateDisplayName $entry.Value $displayNamesLookup
-            $splattedParameters.Add($entry.Name, $entry.Value)
+            $flattenedParameters.Add($param.Name, $param.Value)
         }
 
+        $nameSegment = $entry.CreateDisplayName($displayNamesLookup)
         if ($nameSegment) {
             $names += $nameSegment
         }
@@ -388,53 +512,40 @@ function CreateMatrixEntry([System.Collections.Specialized.OrderedDictionary]$pe
 
     return @{
         name = $name
-        parameters = $splattedParameters
+        parameters = $flattenedParameters
+        # Keep the original permutation around in case we need to re-process this entry when transforming the matrix
+        _permutation = $permutation
     }
 }
 
 function InitializeMatrix
 {
     param(
-        [Array]$parameters,
+        [MatrixParameter[]]$parameters,
         [Hashtable]$displayNamesLookup,
         [System.Collections.ArrayList]$permutations,
-        $permutation = [Ordered]@{}
+        $permutation = [MatrixParameter[]]@()
     )
     $head, $tail = $parameters
 
     if (!$head) {
-        $entry = CreateMatrixEntry $permutation $displayNamesLookup
+        $entry = CreateMatrixCombinationScalar $permutation $displayNamesLookup
         $permutations.Add($entry) | Out-Null
         return
     }
 
     # This behavior implicitly treats non-array values as single elements
-    foreach ($value in $head.Value) {
-        $newPermutation = CloneOrderedDictionary $permutation
-        if ($value -is [PSCustomObject]) {
-            foreach ($nestedParameter in $value.PSObject.Properties) {
-                $nestedPermutation = CloneOrderedDictionary $newPermutation
-                $nestedPermutation[$nestedParameter.Name] = $nestedParameter.Value
-                InitializeMatrix $tail $displayNamesLookup $permutations $nestedPermutation
-            }
-        } else {
-            $newPermutation[$head.Name] = $value
-            InitializeMatrix $tail $displayNamesLookup $permutations $newPermutation
-        }
+    foreach ($param in $head.Flatten()) {
+        $newPermutation = $permutation + $param
+        InitializeMatrix $tail $displayNamesLookup $permutations $newPermutation
     }
 }
 
-function GetMatrixDimensions([System.Collections.Specialized.OrderedDictionary]$parameters)
+function GetMatrixDimensions([MatrixParameter[]]$parameters)
 {
     $dimensions = @()
-    foreach ($param in $parameters.GetEnumerator()) {
-        if ($param.Value -is [PSCustomObject]) {
-            $dimensions += ($param.Value.PSObject.Properties | Measure-Object).Count
-        } elseif ($param.Value -is [Array]) {
-            $dimensions += $param.Value.Length
-        } else {
-            $dimensions += 1
-        }
+    foreach ($param in $parameters) {
+        $dimensions += $param.Length()
     }
 
     return $dimensions

--- a/eng/common/scripts/job-matrix/samples/matrix-test.yml
+++ b/eng/common/scripts/job-matrix/samples/matrix-test.yml
@@ -14,7 +14,12 @@ jobs:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: eastus2
         Cloud: Public
-      MatrixFilters: []
+      MatrixFilters:
+        # Exclusion example
+        - OSVmImage=^(?!macOS).*
+      MatrixReplace:
+        - OsVmImage=.*ubuntu.*/ubuntu-20.04
+        - .*Framework.*=net5.0/net5.1
       MatrixConfigs:
         - Name: base_product_matrix
           Path: eng/common/scripts/job-matrix/samples/matrix.json

--- a/eng/common/scripts/job-matrix/samples/matrix.json
+++ b/eng/common/scripts/job-matrix/samples/matrix.json
@@ -4,16 +4,16 @@
   },
   "matrix": {
     "Agent": {
-      "ubuntu-18.04": { "OSVmImage": "ubuntu-18.04", "Pool": "Azure Pipelines" },
-      "windows-2019": { "OSVmImage": "windows-2019", "Pool": "Azure Pipelines" },
-      "macOS-10.15": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
+      "ubuntu": { "OSVmImage": "ubuntu-18.04", "Pool": "Azure Pipelines" },
+      "windows": { "OSVmImage": "windows-2019", "Pool": "Azure Pipelines" },
+      "macOS": { "OSVmImage": "macOS-10.15", "Pool": "Azure Pipelines" }
     },
     "TestTargetFramework": [ "netcoreapp2.1", "net461", "net5.0" ]
   },
   "include": [
     {
       "Agent": {
-        "windows-2019": { "OSVmImage": "windows-2019", "Pool": "Azure Pipelines" }
+        "windows": { "OSVmImage": "windows-2019", "Pool": "Azure Pipelines" }
       },
       "TestTargetFramework": [ "net461", "net5.0" ],
       "AdditionalTestArguments": "/p:UseProjectReferenceToAzureClients=true"

--- a/eng/common/scripts/job-matrix/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common/scripts/job-matrix/tests/job-matrix-functions.modification.tests.ps1
@@ -103,12 +103,32 @@ Describe "Platform Matrix Import" -Tag "import" {
         $matrix[0].name | Should -Be test1_foo1_bar1
         $matrix[0].parameters.testField | Should -Be "test1"
         $matrix[0].parameters.Foo | Should -Be "foo1"
-        $matrix[2].name | Should -Be test1_importedBaz
+        $matrix[2].name | Should -Be test1_importedBazName
         $matrix[2].parameters.testField | Should -Be "test1"
         $matrix[2].parameters.Baz | Should -Be "importedBaz"
         $matrix[4].name | Should -Be test2_foo2_bar2
         $matrix[4].parameters.testField | Should -Be "test2"
         $matrix[4].parameters.Foo | Should -Be "foo2"
+    }
+
+    It "Should source imported display name lookups" {
+        $matrixJson = @'
+{
+    "displayNames": {
+        "test1": "test1DisplayName",
+        "importedBaz": "importedBazNameOverride"
+    },
+    "matrix": {
+        "$IMPORT": "./test-import-matrix.json",
+        "testField": [ "test1", "test2" ]
+    }
+}
+'@
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+        $matrix = GenerateMatrix $importConfig "sparse" -nonSparseParameters "testField"
+
+        $matrix[0].name | Should -Be test1DisplayName_foo1_bar1
+        $matrix[2].name | Should -Be test1DisplayName_importedBazNameOverride
     }
 
     It "Should generate a sparse matrix with an imported sparse matrix" {
@@ -134,7 +154,7 @@ Describe "Platform Matrix Import" -Tag "import" {
   },
   {
     "parameters": { "testField1": "test11", "testField2": "test21", "Baz": "importedBaz" },
-    "name": "test11_test21_importedBaz"
+    "name": "test11_test21_importedBazName"
   },
   {
     "parameters": { "testField1": "test12", "testField2": "test22", "Foo": "foo1", "Bar": "bar1" },
@@ -146,7 +166,7 @@ Describe "Platform Matrix Import" -Tag "import" {
   },
   {
     "parameters": { "testField1": "test12", "testField2": "test22", "Baz": "importedBaz" },
-    "name": "test12_test22_importedBaz"
+    "name": "test12_test22_importedBazName"
   }
 ]
 '@
@@ -195,7 +215,7 @@ Describe "Platform Matrix Import" -Tag "import" {
   },
   {
     "parameters": { "testField": "test2", "Baz": "importedBaz" },
-    "name": "test2_importedBaz"
+    "name": "test2_importedBazName"
   },
   {
     "parameters": { "testField": "test3", "Foo": "foo1", "Bar": "bar1" },

--- a/eng/common/scripts/job-matrix/tests/test-import-matrix.json
+++ b/eng/common/scripts/job-matrix/tests/test-import-matrix.json
@@ -1,4 +1,7 @@
 {
+  "displayNames": {
+    "importedBaz": "importedBazName"
+  },
   "matrix": {
     "Foo": [ "foo1", "foo2" ],
     "Bar": [ "bar1", "bar2" ]


### PR DESCRIPTION
This PR adds a replace operator to the matrix config, enabling flexible ways to replace values from a matrix via a command line syntax similar to the `-filter` syntax: `<keyRegex>=<valueRegex>/<replaceWith>`, e.g.

```
MatrixReplace:
  - OsVmImage=.*ubuntu.*/ubuntu-20.04
  - .*Framework.*=net5.0/net5.1
```

See the [README updates](https://github.com/Azure/azure-sdk-tools/blob/d213525/eng/common/scripts/job-matrix/README.md#replace-values) for more details.

This is also a large code update due to some much-needed refactoring. In the course of this work, I found some challenges with what data structure we output the matrix as in cases where we need to do more processing on it (for replace, import, nonSparse, etc.). I had been surfacing the final matrix data structure, which was an array of name+parameter dictionaries, but if any replacements needed to be made to parameter values, we wouldn't know how to update the job name since it had already been rendered from the initial parameters.

To handle the job name/parameter scope problem, I made some changes to bubble up the inner data structure we use to generate the final matrix combination, that way we can always re-generate the name and parameters after transformation at any stage before serialization. I also added a new MatrixParameter class which handles the dynamic parameter types we encounter in a matrix config (string/int/bool, array, nested object). This has simplified the code in a lot of cases where we had to do type checking to figure out which logic to use.