### PR TITLE
Disable maven dependency properties from API review temporarily

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -303,6 +303,9 @@ public class ASTAnalyser implements Analyser {
         }
 
         // dependencies
+        // Disabling dependencies until we have a solution to avoid showing daily alpha version as dependency
+        // Alpha daily version number make each revision different and this leads to mismatch with approved review revision
+        /*
         addToken(INDENT, new Token(KEYWORD, "dependencies"), SPACE);
         addToken(new Token(PUNCTUATION, "{"), NEWLINE);
 
@@ -329,6 +332,7 @@ public class ASTAnalyser implements Analyser {
 
         unindent();
         addToken(INDENT, new Token(PUNCTUATION, "}"), NEWLINE);
+        */
 
         // allowed dependencies (in maven-enforcer)
 //        if (!mavenPom.getAllowedDependencies().isEmpty()) {


### PR DESCRIPTION
Temporary work around to unblock releases. We will make a permanent solution to support these maven properties in API review