### PR TITLE
Use latest pipeline generator

### DIFF
--- a/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
+++ b/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
@@ -9,7 +9,7 @@ steps:
   - script: >
       dotnet tool install
       Azure.Sdk.Tools.PipelineGenerator
-      --version 1.0.2-dev.20210219.1
+      --version 1.0.2-dev.20210309.1
       --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk/nuget/v3/index.json
       --tool-path ${{parameters.ToolPath}}
     workingDirectory: $(Pipeline.Workspace)/pipeline-generator


### PR DESCRIPTION
Pipeline Generator has been updated to support generating CI triggers for public pipelines. This PR moves the version of pipeline generator we use to this new version. This will impact the scheduled pipeline generation job, as well as the single generation job and the prepare pipelines jobs.