### PR TITLE
Actually pass the _content_ of the reviewers or teamreviewers variable to the Submit-Pullrequest.ps1 script

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -83,7 +83,7 @@ steps:
       -PRTitle "${{ parameters.PRTitle }}"
       -PRBody "${{ coalesce(parameters.PRBody, parameters.CommitMsg, parameters.PRTitle) }}"
       -PRLabels "${{ parameters.PRLabels }}"
-      -UserReviewers "${{ parameters.GHReviewersVariable }}"
-      -TeamReviewers "${{ parameters.GHTeamReviewersVariable }}"
+      -UserReviewers "$(${{ parameters.GHReviewersVariable }})"
+      -TeamReviewers "$(${{ parameters.GHTeamReviewersVariable }})"
       -Assignees "${{ parameters.GHAssignessVariable }}"
       -CloseAfterOpenForTesting $${{ coalesce(parameters.CloseAfterOpenForTesting, 'false') }}

--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -85,5 +85,5 @@ steps:
       -PRLabels "${{ parameters.PRLabels }}"
       -UserReviewers "$(${{ parameters.GHReviewersVariable }})"
       -TeamReviewers "$(${{ parameters.GHTeamReviewersVariable }})"
-      -Assignees "${{ parameters.GHAssignessVariable }}"
+      -Assignees "$(${{ parameters.GHAssignessVariable }})"
       -CloseAfterOpenForTesting $${{ coalesce(parameters.CloseAfterOpenForTesting, 'false') }}

--- a/eng/common/scripts/Invoke-GitHubAPI.ps1
+++ b/eng/common/scripts/Invoke-GitHubAPI.ps1
@@ -9,17 +9,25 @@ function Get-GitHubApiHeaders ($token) {
   return $headers
 }
 
+function SplitParameterArray($members) {
+    if ($null -ne $members) {
+      if ($members -is [array])
+      {
+        return $members
+      }
+      else {
+        return (@($members.Split(",") | % { $_.Trim() } | ? { return $_ }))
+      }
+    }
+    return $members
+}
+
 function Set-GitHubAPIParameters ($members,  $parameterName, $parameters, $allowEmptyMembers=$false) {
   if ($null -ne $members) {
-    if ($members -is [array])
-    {
-      $parameters[$parameterName] = $members
-    }
-    else {
-      $memberAdditions = @($members.Split(",") | % { $_.Trim() } | ? { return $_ })
-      if (($memberAdditions.Count -gt 0) -or $allowEmptyMembers) {
-        $parameters[$parameterName] = $memberAdditions
-      }
+    $memberAdditions = SplitParameterArray -members $members
+
+    if (($memberAdditions.Count -gt 0) -or $allowEmptyMembers) {
+      $parameters[$parameterName] = $memberAdditions
     }
   }
 

--- a/eng/common/scripts/Invoke-GitHubAPI.ps1
+++ b/eng/common/scripts/Invoke-GitHubAPI.ps1
@@ -24,7 +24,7 @@ function SplitParameterArray($members) {
 
 function Set-GitHubAPIParameters ($members,  $parameterName, $parameters, $allowEmptyMembers=$false) {
   if ($null -ne $members) {
-    $memberAdditions = SplitParameterArray -members $members
+    [array]$memberAdditions = SplitParameterArray -members $members
 
     if (($memberAdditions.Count -gt 0) -or $allowEmptyMembers) {
       $parameters[$parameterName] = $memberAdditions

--- a/eng/common/scripts/Invoke-GitHubAPI.ps1
+++ b/eng/common/scripts/Invoke-GitHubAPI.ps1
@@ -19,7 +19,6 @@ function SplitParameterArray($members) {
         return (@($members.Split(",") | % { $_.Trim() } | ? { return $_ }))
       }
     }
-    return $members
 }
 
 function Set-GitHubAPIParameters ($members,  $parameterName, $parameters, $allowEmptyMembers=$false) {

--- a/eng/common/scripts/Invoke-GitHubAPI.ps1
+++ b/eng/common/scripts/Invoke-GitHubAPI.ps1
@@ -21,11 +21,13 @@ function SplitParameterArray($members) {
     }
 }
 
-function Set-GitHubAPIParameters ($members,  $parameterName, $parameters) {
+function Set-GitHubAPIParameters ($members,  $parameterName, $parameters, $allowEmptyMembers = $false) {
   if ($null -ne $members) {
     [array]$memberAdditions = SplitParameterArray -members $members
 
-    if ($memberAdditions.Count -gt 0) {
+    if ($null -eq $memberAdditions -and $allowEmptyMembers){ $memberAdditions = @() }
+
+    if ($memberAdditions.Count -gt 0 -or $allowEmptyMembers) {
       $parameters[$parameterName] = $memberAdditions
     }
   }
@@ -318,10 +320,10 @@ function Update-GitHubIssue {
   if ($Milestone) { $parameters["milestone"] = $Milestone }
 
   $parameters = Set-GitHubAPIParameters -members $Labels -parameterName "labels" `
-  -parameters $parameters
+  -parameters $parameters -allowEmptyMembers $true
 
   $parameters = Set-GitHubAPIParameters -members $Assignees -parameterName "assignees" `
-  -parameters $parameters
+  -parameters $parameters -allowEmptyMembers $true
 
   return Invoke-RestMethod `
           -Method PATCH `

--- a/eng/common/scripts/Invoke-GitHubAPI.ps1
+++ b/eng/common/scripts/Invoke-GitHubAPI.ps1
@@ -21,11 +21,11 @@ function SplitParameterArray($members) {
     }
 }
 
-function Set-GitHubAPIParameters ($members,  $parameterName, $parameters, $allowEmptyMembers=$false) {
+function Set-GitHubAPIParameters ($members,  $parameterName, $parameters) {
   if ($null -ne $members) {
     [array]$memberAdditions = SplitParameterArray -members $members
 
-    if (($memberAdditions.Count -gt 0) -or $allowEmptyMembers) {
+    if ($memberAdditions.Count -gt 0) {
       $parameters[$parameterName] = $memberAdditions
     }
   }
@@ -318,10 +318,10 @@ function Update-GitHubIssue {
   if ($Milestone) { $parameters["milestone"] = $Milestone }
 
   $parameters = Set-GitHubAPIParameters -members $Labels -parameterName "labels" `
-  -parameters $parameters -allowEmptyMembers $true
+  -parameters $parameters
 
   $parameters = Set-GitHubAPIParameters -members $Assignees -parameterName "assignees" `
-  -parameters $parameters -allowEmptyMembers $true
+  -parameters $parameters
 
   return Invoke-RestMethod `
           -Method PATCH `

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -92,7 +92,7 @@ else {
     Write-Host "##vso[task.setvariable variable=Submitted.PullRequest.Number]$($resp.number)"
 
     # ensure that the user that was used to create the PR is not attempted to add as a reviewer
-    $cleanedUsers = (SplitParameterArray -members $TeamReviewers) | ? { $_ -ne $prOwnerUser }
+    $cleanedUsers = (SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser }
     $cleanedTeamReviewers = (SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser }
 
     if ($cleanedUsers -or $cleanedTeamReviewers) {

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -92,12 +92,12 @@ else {
     Write-Host "##vso[task.setvariable variable=Submitted.PullRequest.Number]$($resp.number)"
 
     # ensure that the user that was used to create the PR is not attempted to add as a reviewer
-    $usersCleaned = ($UserReviewers -split "," | % { $_.Trim() } | ? { $_ -ne $prOwnerUser })  -join ","
-    $teamReviewersCleaned = ($TeamReviewers -split "," | % { $_.Trim() } | ? { $_ -ne $prOwnerUser}) -join ","
+    $cleanedUsers = (SplitParameterArray -members $TeamReviewers) | ? { $_ -ne $prOwnerUser }
+    $cleanedTeamReviewers = (SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser }
 
-    if ($UserReviewers -or $TeamReviewers) {
+    if ($cleanedUsers -or $cleanedTeamReviewers) {
       Add-GitHubPullRequestReviewers -RepoOwner $RepoOwner -RepoName $RepoName -PrNumber $resp.number `
-      -Users $usersCleaned -Teams $teamReviewersCleaned -AuthToken $AuthToken
+      -Users $cleanedUsers -Teams $cleanedTeamReviewers -AuthToken $AuthToken
     }
 
     if ($CloseAfterOpenForTesting) {

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -86,12 +86,18 @@ else {
     $resp | Write-Verbose
     LogDebug "Pull request created https://github.com/$RepoOwner/$RepoName/pull/$($resp.number)"
   
+    $prOwnerUser = $resp.user.login
+
     # setting variable to reference the pull request by number
     Write-Host "##vso[task.setvariable variable=Submitted.PullRequest.Number]$($resp.number)"
 
+    # ensure that the user that was used to create the PR is not attempted to add as a reviewer
+    $usersCleaned = ($UserReviewers -split "," | ? { $_ -ne $prOwnerUser })  -join ","
+    $teamReviewersCleaned = ($TeamReviewers -split "," | ? { $_ -ne $prOwnerUser}) -join ","
+
     if ($UserReviewers -or $TeamReviewers) {
       Add-GitHubPullRequestReviewers -RepoOwner $RepoOwner -RepoName $RepoName -PrNumber $resp.number `
-      -Users $UserReviewers -Teams $TeamReviewers -AuthToken $AuthToken
+      -Users $usersCleaned -Teams $teamReviewersCleaned -AuthToken $AuthToken
     }
 
     if ($CloseAfterOpenForTesting) {

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -92,8 +92,8 @@ else {
     Write-Host "##vso[task.setvariable variable=Submitted.PullRequest.Number]$($resp.number)"
 
     # ensure that the user that was used to create the PR is not attempted to add as a reviewer
-    $usersCleaned = ($UserReviewers -split "," | ? { $_ -ne $prOwnerUser })  -join ","
-    $teamReviewersCleaned = ($TeamReviewers -split "," | ? { $_ -ne $prOwnerUser}) -join ","
+    $usersCleaned = ($UserReviewers -split "," | % { $_.Trim() } | ? { $_ -ne $prOwnerUser })  -join ","
+    $teamReviewersCleaned = ($TeamReviewers -split "," | % { $_.Trim() } | ? { $_ -ne $prOwnerUser}) -join ","
 
     if ($UserReviewers -or $TeamReviewers) {
       Add-GitHubPullRequestReviewers -RepoOwner $RepoOwner -RepoName $RepoName -PrNumber $resp.number `

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -92,12 +92,13 @@ else {
     Write-Host "##vso[task.setvariable variable=Submitted.PullRequest.Number]$($resp.number)"
 
     # ensure that the user that was used to create the PR is not attempted to add as a reviewer
-    $cleanedUsers = (SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser }
-    $cleanedTeamReviewers = (SplitParameterArray -members $TeamReviewers) | ? { $_ -ne $prOwnerUser }
+    # we cast to an array to ensure that length-1 arrays actually stay as array values
+    [array]$cleanedUsers = @(SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser }
+    [array]$cleanedTeamReviewers = @(SplitParameterArray -members $TeamReviewers) | ? { $_ -ne $prOwnerUser }
 
     if ($cleanedUsers -or $cleanedTeamReviewers) {
       Add-GitHubPullRequestReviewers -RepoOwner $RepoOwner -RepoName $RepoName -PrNumber $resp.number `
-      -Users $cleanedUsers -Teams $cleanedTeamReviewers -AuthToken $AuthToken
+      -Users $cleanedUsers ?? "" -Teams $cleanedTeamReviewers ?? "" -AuthToken $AuthToken
     }
 
     if ($CloseAfterOpenForTesting) {

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -93,7 +93,7 @@ else {
 
     # ensure that the user that was used to create the PR is not attempted to add as a reviewer
     $cleanedUsers = (SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser }
-    $cleanedTeamReviewers = (SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser }
+    $cleanedTeamReviewers = (SplitParameterArray -members $TeamReviewers) | ? { $_ -ne $prOwnerUser }
 
     if ($cleanedUsers -or $cleanedTeamReviewers) {
       Add-GitHubPullRequestReviewers -RepoOwner $RepoOwner -RepoName $RepoName -PrNumber $resp.number `

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -93,11 +93,8 @@ else {
 
     # ensure that the user that was used to create the PR is not attempted to add as a reviewer
     # we cast to an array to ensure that length-1 arrays actually stay as array values
-    [array]$cleanedUsers = @(SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser }
-    [array]$cleanedTeamReviewers = @(SplitParameterArray -members $TeamReviewers) | ? { $_ -ne $prOwnerUser }
-
-    if ($null -eq $cleanedUsers){ $cleanedUsers = "" }
-    if ($null -eq $cleanedTeamReviewers){ $cleanedUsers = "" }
+    $cleanedUsers = @(SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser -and $null -ne $_ }
+    $cleanedTeamReviewers = @(SplitParameterArray -members $TeamReviewers) | ? { $_ -ne $prOwnerUser -and $null -ne $_ }
 
     if ($cleanedUsers -or $cleanedTeamReviewers) {
       Add-GitHubPullRequestReviewers -RepoOwner $RepoOwner -RepoName $RepoName -PrNumber $resp.number `

--- a/eng/common/scripts/Submit-PullRequest.ps1
+++ b/eng/common/scripts/Submit-PullRequest.ps1
@@ -96,9 +96,12 @@ else {
     [array]$cleanedUsers = @(SplitParameterArray -members $UserReviewers) | ? { $_ -ne $prOwnerUser }
     [array]$cleanedTeamReviewers = @(SplitParameterArray -members $TeamReviewers) | ? { $_ -ne $prOwnerUser }
 
+    if ($null -eq $cleanedUsers){ $cleanedUsers = "" }
+    if ($null -eq $cleanedTeamReviewers){ $cleanedUsers = "" }
+
     if ($cleanedUsers -or $cleanedTeamReviewers) {
       Add-GitHubPullRequestReviewers -RepoOwner $RepoOwner -RepoName $RepoName -PrNumber $resp.number `
-      -Users $cleanedUsers ?? "" -Teams $cleanedTeamReviewers ?? "" -AuthToken $AuthToken
+      -Users $cleanedUsers -Teams $cleanedTeamReviewers -AuthToken $AuthToken
     }
 
     if ($CloseAfterOpenForTesting) {


### PR DESCRIPTION
Discovered while investigating [this release.](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=771475&view=logs&j=60e8c907-7852-5a6b-7760-57b7bd4eaa08&t=b6cbe1c5-d502-5d92-9f97-57a6a725de18) Notice that it's _finding_ the codeowners.

We simply [don't _assign_ the reviewers.](https://github.com/MicrosoftDocs/azure-docs-sdk-python/pull/1251)