### PR TITLE
APIStubGen skips public classes defined in internal modules

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
@@ -189,7 +189,7 @@ class StubGenerator:
 
             logging.debug("Importing module {}".format(m))
             module_obj = importlib.import_module(m)
-            self.module_dict[m] = ModuleNode(m, module_obj, nodeindex)
+            self.module_dict[m] = ModuleNode(m, module_obj, nodeindex, namespace)
 
         # Create navigation info to navigate within APIreview tool
         navigation = Navigation(package_name, None)

--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.2.2"
+VERSION = "0.2.3"

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
@@ -21,10 +21,11 @@ class ModuleNode(NodeEntityBase):
     :param dict: nodeindex
     """
 
-    def __init__(self, namespace, module, nodeindex):
+    def __init__(self, namespace, module, nodeindex, pkg_root_namespace):
         super().__init__(namespace, None, module)
         self.namespace_id = self.generate_id()
         self.nodeindex = nodeindex
+        self.pkg_root_namespace = pkg_root_namespace
         self._inspect()
 
     def _inspect(self):
@@ -68,7 +69,7 @@ class ModuleNode(NodeEntityBase):
 
         # Skip any member in module level that is defined in external or built in package
         if hasattr(member_obj, "__module__"):
-            return not getattr(member_obj, "__module__").startswith(self.namespace)
+            return not getattr(member_obj, "__module__").startswith(self.pkg_root_namespace)
         # Don't skip member if module name is not available. This is just to be on safer side
         return False
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -11,7 +11,7 @@ namespace APIViewWeb
     {
         public override string Name { get; } = "Python";
         public override string Extension { get; } = ".whl";
-        public override string VersionString { get; } = "0.2.2";
+        public override string VersionString { get; } = "0.2.3";
 
         private readonly string _apiViewPythonProcessor;
         public override string ProcessName => _apiViewPythonProcessor;


### PR DESCRIPTION
API stub generator includes classes in stub file only if class's module name matches module name space. This causes APIview to skip any classes defined in internal modules but added them in __all__ of public module to make it publicly accessible. Fix in this PR is to ensure module of class starts with package root name rather than namespace of module itself.


For e.g. SearchIndexerSkill is defined in `azure.search.documents.indexes._internal._generated.models._models_py3.SearchIndexerSkill` But this class is added in __all__ `azure.search.documents.indexes.models`. Currently this class is not included because comparison is between `azure.search.documents.indexes._internal._generated.models._models_py3` and `azure.search.documents.indexes.models`.

Fix in this PR will change it to ensure `azure.search.documents.indexes._internal._generated.models._models_py3` starts with `azure.search.documents`