### PR TITLE
Create API review only when running CI on master branch

### DIFF
--- a/eng/common/pipelines/templates/steps/create-apireview.yml
+++ b/eng/common/pipelines/templates/steps/create-apireview.yml
@@ -3,11 +3,8 @@ parameters:
   Artifacts: []
   ConfigFileDir: $(Build.ArtifactStagingDirectory)/PackageInfo
 
-variables:
-  BaseReleaseBranch: 'master'
-
 steps:
-  - ${{ if eq(variables['Build.SourceBranch'], variables['BaseReleaseBranch']) }}:
+  - ${{ if eq(variables['Build.SourceBranch'], 'master') }}:
     - ${{ each artifact in parameters.Artifacts }}:
       - task: Powershell@2
         inputs:

--- a/eng/common/pipelines/templates/steps/create-apireview.yml
+++ b/eng/common/pipelines/templates/steps/create-apireview.yml
@@ -3,19 +3,23 @@ parameters:
   Artifacts: []
   ConfigFileDir: $(Build.ArtifactStagingDirectory)/PackageInfo
 
+variables:
+  BaseReleaseBranch: 'master'
+
 steps:
-  - ${{ each artifact in parameters.Artifacts }}:
-    - task: Powershell@2
-      inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/scripts/Create-APIReview.ps1
-        arguments: >
-          -ArtifactPath ${{parameters.ArtifactPath}}
-          -APIViewUri $(azuresdk-apiview-uri)
-          -APIKey $(azuresdk-apiview-apikey)
-          -APILabel "Auto Review - $(Build.SourceVersion)"
-          -PackageName ${{artifact.name}}
-          -ConfigFileDir '${{parameters.ConfigFileDir}}'
-        pwsh: true
-        workingDirectory: $(Pipeline.Workspace)
-      displayName: Create API Review for ${{ artifact.name}}
-      condition: and(succeededOrFailed(), ne(variables['Skip.CreateApiReview'], 'true') , ne(variables['Build.Reason'],'PullRequest'), eq(variables['System.TeamProject'], 'internal'))
+  - ${{ if eq(variables['Build.SourceBranch'], variables['BaseReleaseBranch']) }}:
+    - ${{ each artifact in parameters.Artifacts }}:
+      - task: Powershell@2
+        inputs:
+          filePath: $(Build.SourcesDirectory)/eng/common/scripts/Create-APIReview.ps1
+          arguments: >
+            -ArtifactPath ${{parameters.ArtifactPath}}
+            -APIViewUri $(azuresdk-apiview-uri)
+            -APIKey $(azuresdk-apiview-apikey)
+            -APILabel "Auto Review - $(Build.SourceVersion)"
+            -PackageName ${{artifact.name}}
+            -ConfigFileDir '${{parameters.ConfigFileDir}}'
+          pwsh: true
+          workingDirectory: $(Pipeline.Workspace)
+        displayName: Create API Review for ${{ artifact.name}}
+        condition: and(succeededOrFailed(), ne(variables['Skip.CreateApiReview'], 'true') , ne(variables['Build.Reason'],'PullRequest'), eq(variables['System.TeamProject'], 'internal'))


### PR DESCRIPTION
Automatic API reviews are created when CI runs on internal pipeline and this causes issue when its triggered against any feature branch. Feature branch may have different set of API changes than in master and this creates a new revision of API review in pending status and causes issue when next CI runs from master branch. API tool finds a difference in API surface level since comparison is against feature branch instead of previously approved master branch.

This PR is to temporarily disable automatic API review creation from feature branch. Long term fix will be to maintain only one revision in pending status which will only have delta against approved version. So irrespective of source of CI trigger, this will always match against last approved revision.