### PR TITLE
[Java API view] Show all annotations by default

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -1004,7 +1004,6 @@ public class ASTAnalyser implements Analyser {
                 }
             };
 
-            // for now we will only include the annotations we care about
             nodeWithAnnotations.getAnnotations()
                     .stream()
                     .filter(annotationExpr -> !BLOCKED_ANNOTATIONS.contains(annotationExpr.getName().getIdentifier()))

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -55,9 +55,11 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
@@ -90,11 +92,12 @@ public class ASTAnalyser implements Analyser {
     public static final String MODULE_INFO_KEY = "module-info";
 
     private static final boolean SHOW_JAVADOC = true;
-    private static final List<String> BLOCKED_ANNOTATIONS = Arrays.asList(
-            "ServiceMethod",
-            "JsonCreator",
-            "JsonValue",
-            "SuppressWarnings");
+    private static final Set<String> BLOCKED_ANNOTATIONS = new HashSet<String>() {{
+        add("ServiceMethod");
+        add("JsonCreator");
+        add("JsonValue");
+        add("SuppressWarnings");
+    }};
 
     private final APIListing apiListing;
 


### PR DESCRIPTION
This PR makes all annotations visible on the API view by default. It filters a few known annotations that we don't want to include in the review.