### PR TITLE
Support default branch for the workflow. Part 1

### DIFF
--- a/doc/common/common_engsys.md
+++ b/doc/common/common_engsys.md
@@ -20,7 +20,7 @@ languages repos as they will be overwritten the next time an update is taken fro
 
 ## Workflow
 
-The 'Sync eng/common directory' PRs will be created in the language repositories when a pull request that touches the eng/common directory is submitted against the master branch. This will make it easier for changes to be tested in each individual language repo before merging the changes in the azure-sdk-tools repo. The workflow is explained below:
+The 'Sync eng/common directory' PRs will be created in the language repositories when a pull request that touches the eng/common directory is submitted against the default branch of the repositories. This will make it easier for changes to be tested in each individual language repo before merging the changes in the azure-sdk-tools repo. The workflow is explained below:
 
 1. Create a PR (**Tools PR**) in the `azure-sdk-tools` repo with changes to eng/common directory.
 2. `azure-sdk-tools - sync - eng-common` pipeline is triggered for the **Tools PR**

--- a/eng/common/pipelines/templates/steps/publish-blobs.yml
+++ b/eng/common/pipelines/templates/steps/publish-blobs.yml
@@ -8,6 +8,7 @@ parameters:
   RepoId: $(Build.Repository.Name)
 
 steps:
+- template: /eng/common/pipelines/templates/steps/set-default-branch.yml
 - pwsh: |
     Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://aka.ms/downloadazcopy-v10-windows" -OutFile "azcopy.zip" | Wait-Process;
     Expand-Archive -Path "azcopy.zip" -DestinationPath "$(Build.BinariesDirectory)/azcopy/"
@@ -23,7 +24,7 @@ steps:
       -SASKey "${{ parameters.BlobSASKey }}"
       -BlobName "${{ parameters.BlobName }}"
       -PublicArtifactLocation "${{ parameters.ArtifactLocation }}"
-      -RepoReplaceRegex "(https://github.com/${{ parameters.RepoId }}/(?:blob|tree)/)master"
+      -RepoReplaceRegex "(https://github.com/${{ parameters.RepoId }}/(?:blob|tree)/)$(DefaultBranch)"
     pwsh: true
     workingDirectory: $(Pipeline.Workspace)
   displayName: Copy Docs to Blob

--- a/eng/common/scripts/check-spelling-in-changed-files.ps1
+++ b/eng/common/scripts/check-spelling-in-changed-files.ps1
@@ -63,7 +63,7 @@ Uses cspell (from NPM) to check spelling of recently changed files
 
 .DESCRIPTION
 This script checks files that have changed relative to a base branch (default 
-`master`) for spelling errors. Dictionaries and spelling configurations reside 
+branch) for spelling errors. Dictionaries and spelling configurations reside 
 in a configurable `cspell.json` location.
 
 This script uses `npx` and assumes that NodeJS (and by extension `npm` and `npx`

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -8,7 +8,7 @@ param (
   $ExitOnError=1,
   $UploadLatest=1,
   $PublicArtifactLocation = "",
-  $RepoReplaceRegex = "(https://github.com/.*/(?:blob|tree)/)master"
+  $RepoReplaceRegex = ""
 )
 
 . (Join-Path $PSScriptRoot common.ps1)
@@ -199,7 +199,7 @@ function Upload-Blobs
     LogDebug "Final Dest $($DocDest)/$($PkgName)/$($DocVersion)"
     LogDebug "Release Tag $($ReleaseTag)"
 
-    # Use the step to replace master link to release tag link 
+    # Use the step to replace default branch link to release tag link 
     if ($ReleaseTag) {
         foreach ($htmlFile in (Get-ChildItem $DocDir -include *.html -r)) 
         {
@@ -211,7 +211,7 @@ function Upload-Blobs
         }
     } 
     else {
-        LogWarning "Not able to do the master link replacement, since no release tag found for the release. Please manually check."
+        LogWarning "Not able to do the default branch link replacement, since no release tag found for the release. Please manually check."
     } 
    
     LogDebug "Uploading $($PkgName)/$($DocVersion) to $($DocDest)..."

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -31,6 +31,7 @@ pr:
   branches:
     include:
       - master
+      - main
   paths:
     include:
       - eng/common

--- a/eng/pipelines/mirror-repos.yml
+++ b/eng/pipelines/mirror-repos.yml
@@ -1,4 +1,4 @@
-# Mirror the master branch for each repo folder to all subscribed langauge repos.
+# Mirror the default branch for each repo folder to all subscribed langauge repos.
 
 trigger: none
 pr: none
@@ -18,54 +18,46 @@ jobs:
         Repos:
 
           Azure/azure-rest-api-specs:
-            Branch: master
             TargetRepos: 
               Azure/azure-rest-api-specs-pr:
               azure-sdk/azure-rest-api-specs:
 
           Azure/azure-sdk-for-go:
-            Branch: master
             TargetRepos: 
               Azure/azure-sdk-for-go-pr:
               azure-sdk/azure-sdk-for-go:
               azure-sdk/azure-sdk-for-go-pr:
 
           Azure/azure-sdk-for-java:
-            Branch: master
             TargetRepos: 
               Azure/azure-sdk-for-java-pr:
               azure-sdk/azure-sdk-for-java:
               azure-sdk/azure-sdk-for-java-pr:
 
           Azure/azure-sdk-for-js:
-            Branch: master
             TargetRepos:
               Azure/azure-sdk-for-js-pr:
               azure-sdk/azure-sdk-for-js:
               azure-sdk/azure-sdk-for-js-pr:
 
           Azure/azure-sdk-for-net:
-            Branch: master
             TargetRepos: 
               Azure/azure-sdk-for-net-pr:
               azure-sdk/azure-sdk-for-net:
               azure-sdk/azure-sdk-for-net-pr:
 
           Azure/azure-sdk-for-python:
-            Branch: master
             TargetRepos: 
               Azure/azure-sdk-for-python-pr:
               azure-sdk/azure-sdk-for-python:
               azure-sdk/azure-sdk-for-python-pr:
 
           Azure/azure-sdk-for-ios:
-            Branch: master
             TargetRepos: 
               Azure/azure-sdk-for-ios-pr:
               azure-sdk/azure-sdk-for-ios:
 
           Azure/azure-sdk-for-android:
-            Branch: master
             TargetRepos: 
               Azure/azure-sdk-for-android-pr:
               azure-sdk/azure-sdk-for-android:
@@ -76,19 +68,16 @@ jobs:
               Azure/azure-cli-pr:
 
           Azure/azure-cli-extensions:
-            Branch: master
             TargetRepos: 
               Azure/azure-cli-extensions-pr:
               azure-sdk/azure-cli-extensions:
               azure-sdk/azure-cli-extensions-pr:
               
           Azure/azure-libraries-for-java:
-            Branch: master
             TargetRepos: 
               Azure/azure-libraries-for-java-pr:
               
           Microsoft/vcpkg:
-            Branch: master
             TargetRepos:
               azure-sdk/vcpkg:
 

--- a/eng/pipelines/templates/steps/ref-updater.yml
+++ b/eng/pipelines/templates/steps/ref-updater.yml
@@ -6,13 +6,12 @@ parameters:
   Repos: []
 
 steps:
-
 - ${{ each repo in parameters.Repos }}:
   - pwsh: |
-      git clone --branch master https://github.com/azure/${{ repo }}
+      git clone https://github.com/azure/${{ repo }}
     displayName: Clone ${{ repo }}
     workingDirectory: $(System.DefaultWorkingDirectory)
-
+  - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
   - task: Powershell@2
     inputs:
       targetType: 'filePath'
@@ -33,4 +32,4 @@ steps:
       PushArgs: -f
       WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
       ScriptDirectory: ${{ parameters.ToolsRepoPath }}/eng/common/scripts
-      BaseBranchName: refs/heads/master
+      BaseBranchName: "$(DefaultBranch)"

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -3,7 +3,7 @@ parameters:
   DirectoryToSync: eng/common
   CommitMessage: commit-message-not-set
   UpstreamBranchName: branch-name-not-set
-  BaseBranchName: master
+  BaseBranchName: $(DefaultBranch)
   Sync: pr-data-artifact-path-not-set
   SkipCheckingForChanges: false
   ScriptDirectory: eng/common/scripts
@@ -16,6 +16,10 @@ steps:
     - pwsh: |
         Set-PsDebug -Trace 1
         git clone --branch ${{ parameters.BaseBranchName }} https://github.com/azure/${{ repo }}
+      displayName: Clone ${{ repo }}
+      workingDirectory: $(System.DefaultWorkingDirectory)
+    - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+    - pwsh: |
         $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
         if (Test-Path '$(PatchFilesLocation)')
         {

--- a/eng/pipelines/templates/steps/sync-repo-branch.yml
+++ b/eng/pipelines/templates/steps/sync-repo-branch.yml
@@ -25,7 +25,6 @@ steps:
       Set-PsDebug -Trace 1
       $SourceRepo = '${{ repo.key }}'
       $SourceBranch = '${{ repo.value.Branch }}'
-
       if (-not (Test-Path ${{ repo.key }})) {
         New-Item -Path ${{ repo.key }} -ItemType Directory -Force
         Set-Location $SourceRepo
@@ -35,6 +34,13 @@ steps:
         Set-Location $SourceRepo
       }
 
+      # Check the default branch
+      if (!$SourceBranch) {
+        $defaultBranch = (git remote show Source | Out-String) -replace "(?ms).*HEAD branch: (\w+).*", '$1'
+        Write-Host "No source branch. Fetch default branch $defaultBranch."
+        $SourceBranch = $defaultBranch
+      }
+      
       git fetch --no-tags Source $SourceBranch
       if ($LASTEXITCODE -ne 0) {
         Write-Host "#`#vso[task.logissue type=error]Failed to fetch ${SourceRepo}:${SourceBranch}"
@@ -66,6 +72,13 @@ steps:
         try {
           git remote add Target "https://${{ parameters.GH_TOKEN }}@github.com/${TargetRepo}.git"
 
+          $defaultBranch = (git remote show Target | Out-String) -replace "(?ms).*HEAD branch: (\w+).*", '$1'
+          if (!$SourceBranch) {
+            $SourceBranch = $defaultBranch
+          }
+          if (!$TargetBranch) {
+            $TargetBranch = $defaultBranch
+          }
           if (-not '${{ target.value.Rebase }}') {
             git checkout -B target_branch source_branch
             git push Target "target_branch:refs/heads/${TargetBranch}"

--- a/packages/python-packages/doc-warden/warden/enforce_target_file_presence.py
+++ b/packages/python-packages/doc-warden/warden/enforce_target_file_presence.py
@@ -44,7 +44,7 @@ def find_missing_target_files(configuration):
 
     return missing_target_file_paths, ignored_missing_target_file_paths
 
-# check the root of the target_directory for a master README 
+# check the root of the target_directory for a default README 
 def check_repo_root(configuration):
     if configuration.root_check_enabled:
         # check root for readme.md

--- a/src/dotnet/Mgmt.CI.BuildTools/ci.yml
+++ b/src/dotnet/Mgmt.CI.BuildTools/ci.yml
@@ -2,6 +2,7 @@
 
 trigger:
   - master
+  - main
 
 resources:
   repositories:

--- a/tools/CreateRuleFabricBot/ci.yml
+++ b/tools/CreateRuleFabricBot/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*
@@ -14,6 +15,7 @@ pr:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*

--- a/tools/check-enforcer/ci.yml
+++ b/tools/check-enforcer/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*
@@ -14,6 +15,7 @@ pr:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*

--- a/tools/github-issues/ci.yml
+++ b/tools/github-issues/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*
@@ -14,6 +15,7 @@ pr:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*

--- a/tools/http-fault-injector/ci.yml
+++ b/tools/http-fault-injector/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*
@@ -14,6 +15,7 @@ pr:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*

--- a/tools/notification-configuration/ci.yml
+++ b/tools/notification-configuration/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*
@@ -14,6 +15,7 @@ pr:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*

--- a/tools/pipeline-generator/ci.yml
+++ b/tools/pipeline-generator/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*
@@ -14,6 +15,7 @@ pr:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*

--- a/tools/pipeline-witness/ci.yml
+++ b/tools/pipeline-witness/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*
@@ -14,6 +15,7 @@ pr:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*

--- a/tools/version-guard/ci.yml
+++ b/tools/version-guard/ci.yml
@@ -3,6 +3,7 @@ trigger:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*
@@ -14,6 +15,7 @@ pr:
   branches:
     include:
       - master
+      - main
       - feature/*
       - release/*
       - hotfix/*


### PR DESCRIPTION
Major purpose of the PR is to support master and main default branch instead of hard-coded master.
Changes includes:
1. Markdown files: description which mention master as default branch. Changed to default master.
2. Yaml files: Use set-default-branch.yml and use variables $(DefaultBranch) to replace hard code one.
3. powershell script: Try to use git command to fetch the default ones.
4. ci.yml: Added main as another trigger branch.


Test pipeline on mirror-repo:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=804414&view=logs&s=96ac2280-8cb4-5df5-99de-dd2da759617d
