### PR TITLE
Revert to Checking only ci.yml

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -155,7 +155,7 @@ function Get-PkgPropsForEntireService ($serviceDirectoryPath)
         }
     }
 
-    $ciYmlFiles = Get-ChildItem $serviceDirectoryPath -filter "ci.*yml"
+    $ciYmlFiles = Get-ChildItem $serviceDirectoryPath -filter "ci.yml"
     foreach($ciYmlFile in $ciYmlFiles)
     {
         $activeArtifactList = Get-ArtifactListFromYml -ciYmlPath $ciYmlFile.FullName


### PR DESCRIPTION
Pull only artifacts from `ci.yml` to resolve issue with conflicting package names.