### PR TITLE
[matrix] Fix null check against matrix parameter array

### DIFF
--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -474,7 +474,7 @@ function GenerateFullMatrix(
     [Hashtable]$displayNamesLookup = @{}
 ) {
     # Handle when the config does not have a matrix specified (e.g. only the include field is specified)
-    if ($parameters.Count -eq 0) {
+    if (!$parameters) {
         return @()
     }
 

--- a/eng/common/scripts/job-matrix/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common/scripts/job-matrix/tests/job-matrix-functions.modification.tests.ps1
@@ -404,4 +404,26 @@ Describe "Platform Matrix Replace" -Tag "replace" {
         $matrix[1].name | Should -Be "foo2_barReplacedBar2"
         $matrix[1].parameters.Bar | Should -Be "barReplacedBar2"
     }
+
+    It "Should only fully match a string for replace" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "Foo": [ "foo1", "foo2" ],
+        "Bar": "bar1"
+    }
+}
+'@
+
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+
+        $replace = @("Foo=foo/shouldNotReplaceFoo", "B=bar1/shouldNotReplaceBar")
+        $matrix = GenerateMatrix -config $importConfig -selectFromMatrixType "sparse" -replace $replace
+
+        $matrix.Length | Should -Be 2
+        $matrix[0].parameters.Foo | Should -Be "foo1"
+        $matrix[0].parameters.Bar | Should -Be "bar1"
+        $matrix[1].parameters.Foo | Should -Be "foo2"
+        $matrix[1].parameters.Bar | Should -Be "bar1"
+    }
 }

--- a/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
+++ b/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
@@ -466,6 +466,40 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
         $matrix[7].parameters.operatingSystem | Should -Be "windows-2019"
         $matrix[7].parameters.additionalArguments | Should -Be "--enableWindowsFoo"
     }
+
+    It "Should parse a config with an empty base matrix" {
+        $matrixConfigForIncludeOnly = @"
+{
+    "include": [
+        {
+            "operatingSystem": "windows-2019",
+            "framework": "net461"
+        }
+    ]
+}
+"@
+
+        $config = GetMatrixConfigFromJson $matrixConfigForIncludeOnly
+        [Array]$matrix = GenerateMatrix $config "all"
+        $matrix.Length | Should -Be 1
+        $matrix[0].name | Should -Be "windows2019_net461"
+    }
+
+    It "Should parse a config with an empty include" {
+        $matrixConfigForIncludeOnly = @"
+{
+    "matrix": {
+        "operatingSystem": "windows-2019",
+        "framework": "net461"
+    }
+}
+"@
+
+        $config = GetMatrixConfigFromJson $matrixConfigForIncludeOnly
+        [Array]$matrix = GenerateMatrix $config "all"
+        $matrix.Length | Should -Be 1
+        $matrix[0].name | Should -Be "windows2019_net461"
+    }
 }
 
 Describe "Platform Matrix Generation With Object Fields" -Tag "objectfields" {


### PR DESCRIPTION
There is an error handling cases where the matrix config does not include a base matrix (e.g. only an `include` like [here](https://github.com/Azure/azure-sdk-for-js/blob/1d3632650ce08121b2cc5dc51910129b33b01c42/sdk/keyvault/keyvault-keys/platform-matrix.json)). This was introduced [in this PR](https://github.com/Azure/azure-sdk-tools/pull/1463) due to a type change from `OrderedDictionary` to `[MatrixParameter[]]`, while the empty check was not changed from `$parameters.Count -eq 0` to `!$parameters`.