### PR TITLE
Add ReleaseVersionSemVer to ensure version can be sorted

### DIFF
--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -193,7 +193,8 @@ function Set-ChangeLogContent {
 
   try
   {
-    $ChangeLogEntries = $ChangeLogEntries.Values | Sort-Object -Descending -Property ReleaseStatus, ReleaseVersion
+    $ChangeLogEntries = $ChangeLogEntries.Values | Sort-Object -Descending -Property ReleaseStatus, `
+      @{e = {[AzureEngSemanticVersion]::new($_.ReleaseVersion)}}
   }
   catch {
     LogError "Problem sorting version in ChangeLogEntries"


### PR DESCRIPTION
Add a SemVer string to extracted changelog entries do that we can later sort by SemVer versions.