### PR TITLE
Enable CI triggers on internal pipelines.

### DIFF
--- a/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
+++ b/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
@@ -16,7 +16,7 @@ steps:
     condition: succeeded()
 - pwsh: |
     $setDailyDevBuild = "false"
-    if (('$(Build.Reason)' -eq 'Schedule') -and ('$(System.TeamProject)' -eq 'internal')) {
+    if (('$(Build.Reason)' -in 'Schedule', 'IndividualCI') -and ('$(System.TeamProject)' -eq 'internal')) {
       $setDailyDevBuild = "true"
     }
     echo "##vso[task.setvariable variable=SetDevVersion]$setDailyDevBuild"

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
@@ -57,7 +57,7 @@ namespace PipelineGenerator.Conventions
                 RequireCommentsForNonTeamMembersOnly = false,
                 IsCommentRequiredForPullRequest = true,
             };
-            newTrigger.BranchFilters.Add("+master");
+            newTrigger.BranchFilters.Add($"+{Context.Branch}");
 
             return newTrigger;
         }
@@ -87,6 +87,12 @@ namespace PipelineGenerator.Conventions
             if (!target.IsCommentRequiredForPullRequest)
             {
                 target.IsCommentRequiredForPullRequest = true;
+                hasChanges = true;
+            }
+
+            if (!target.BranchFilters.Contains($"+{Context.Branch}"))
+            {
+                target.BranchFilters.Add($"+{Context.Branch}");
                 hasChanges = true;
             }
 

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -267,7 +267,7 @@ namespace PipelineGenerator.Conventions
                 StartMinutes = startMinutes * BucketSizeInMinutes,
                 TimeZoneId = "Pacific Standard Time",
             };
-            schedule.BranchFilters.Add("+master");
+            schedule.BranchFilters.Add($"+{Context.Branch}");
 
             return schedule;
         }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -70,6 +70,25 @@ namespace PipelineGenerator.Conventions
                 }
             }
 
+            var ciTrigger = definition.Triggers.OfType<ContinuousIntegrationTrigger>().SingleOrDefault();
+
+            if (ciTrigger == null)
+            {
+                definition.Triggers.Add(new ContinuousIntegrationTrigger()
+                {
+                    SettingsSourceType = 2
+                });
+                hasChanges = true;
+            }
+            else
+            {
+                if (ciTrigger.SettingsSourceType != 2)
+                {
+                    ciTrigger.SettingsSourceType = 2;
+                    hasChanges = true;
+                }
+            }
+
             return hasChanges;
         }
     }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
@@ -32,7 +32,7 @@ namespace PipelineGenerator.Conventions
                 StartMinutes = startMinutes * BucketSizeInMinutes,
                 TimeZoneId = "Pacific Standard Time",
             };
-            schedule.BranchFilters.Add("+master");
+            schedule.BranchFilters.Add($"+{Context.Branch}");
 
             return schedule;
         }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
@@ -52,7 +52,7 @@ namespace PipelineGenerator
             var patvarOption = app.Option("--patvar <env>", "Name of an environment variable which contains a PAT.", CommandOptionType.SingleValue).IsRequired();
             var endpointOption = app.Option("--endpoint <endpoint>", "Name of the service endpoint to configure repositories with.", CommandOptionType.SingleValue).IsRequired();
             var repositoryOption = app.Option("--repository <repository>", "Name of the GitHub repo in the form [org]/[repo].", CommandOptionType.SingleValue).IsRequired();
-            var branchOption = app.Option("--branch <branch>", "Typically refs/heads/master.", CommandOptionType.SingleValue).IsRequired();
+            var branchOption = app.Option("--branch <branch>", "Typically refs/heads/main.", CommandOptionType.SingleValue).IsRequired();
             var agentpoolOption = app.Option("--agentpool <agentpool>", "Name of the agent pool to use when pool isn't specified.", CommandOptionType.SingleValue).IsRequired();
             var conventionOption = app.Option("--convention <convention>", "What convention are you building pipelines for?", CommandOptionType.SingleValue).IsRequired();
             var variablegroupsOption = app.Option("--variablegroup <variablegroup>", "Variable groups. May specify multiple (e.g. --variablegroup 1 --variablegroup 2)", CommandOptionType.MultipleValue);


### PR DESCRIPTION
This PR adds the CI trigger creation logic to the internal pipelines. It also fixes an error with the live test pipeline creation where it was hardcoded to use ```master``` instead of the context that was passed in on the command-line. Adding @danieljurek and @benbp for review on this one since it impacts live test pipelines.