### PR TITLE
Skip API create step when running from feature branch with non GA version

### DIFF
--- a/eng/common/pipelines/templates/steps/create-apireview.yml
+++ b/eng/common/pipelines/templates/steps/create-apireview.yml
@@ -4,6 +4,10 @@ parameters:
   ConfigFileDir: $(Build.ArtifactStagingDirectory)/PackageInfo
 
 steps:
+  # ideally this should be done as initial step of a job in caller template
+  # We can remove this step later once it is added in caller
+  - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+
   - ${{ each artifact in parameters.Artifacts }}:
     - task: Powershell@2
       inputs:
@@ -15,6 +19,7 @@ steps:
           -APILabel "Auto Review - $(Build.SourceVersion)"
           -PackageName ${{artifact.name}}
           -SourceBranch $(Build.SourceBranch)
+          -DefaultBranch $(DefaultBranch)
           -ConfigFileDir '${{parameters.ConfigFileDir}}'
         pwsh: true
         workingDirectory: $(Pipeline.Workspace)

--- a/eng/common/pipelines/templates/steps/create-apireview.yml
+++ b/eng/common/pipelines/templates/steps/create-apireview.yml
@@ -14,6 +14,7 @@ steps:
           -APIKey $(azuresdk-apiview-apikey)
           -APILabel "Auto Review - $(Build.SourceVersion)"
           -PackageName ${{artifact.name}}
+          -SourceBranch $(Build.SourceBranch)
           -ConfigFileDir '${{parameters.ConfigFileDir}}'
         pwsh: true
         workingDirectory: $(Pipeline.Workspace)

--- a/eng/common/pipelines/templates/steps/create-apireview.yml
+++ b/eng/common/pipelines/templates/steps/create-apireview.yml
@@ -18,7 +18,7 @@ steps:
           -APIKey $(azuresdk-apiview-apikey)
           -APILabel "Auto Review - $(Build.SourceVersion)"
           -PackageName ${{artifact.name}}
-          -SourceBranch $(Build.SourceBranch)
+          -SourceBranch $(Build.SourceBranchName)
           -DefaultBranch $(DefaultBranch)
           -ConfigFileDir '${{parameters.ConfigFileDir}}'
         pwsh: true

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -97,7 +97,7 @@ if ($packages)
         $version = [AzureEngSemanticVersion]::ParseVersionString($pkgInfo.Version)
         if ($version -eq $null)
         {
-            Write-Host "Version info is not available for package. Please check if version follows Azure SDK package versioning guielines."
+            Write-Host "Version info is not available for package $PackageName, because version '$(pkgInfo.Version)' is invalid. Please check if the version follows Azure SDK package versioning guidelines."
             exit 1
         }
 
@@ -122,7 +122,7 @@ if ($packages)
             }
             else
             {
-                # Return error code if status code is 201 for track2 data plane package
+                # Return error code if status code is 201 for new data plane package
                 if ($pkgInfo.SdkType -eq "client" -and $pkgInfo.IsNewSdk)
                 {
                     if ($respCode -eq '201')
@@ -140,7 +140,7 @@ if ($packages)
                 }
                 else
                 {
-                    Write-Host "API review is not approved for package $($PackageName). Management and track1 package can be released without API review approval."
+                    Write-Host "API review is not approved for package $($PackageName), however it is not required for this package type so it can still be released without API review approval."
                 }
             } 
         }

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -109,7 +109,8 @@ if ($packages)
         if ( ($SourceBranch -eq $DefaultBranch) -or (-not $version.IsPrerelease))
         {
             Write-Host "Submitting API Review for package $($pkg)"
-            $response = Submit-APIReview -packagename $pkg -filePath $pkgPath -uri $APIViewUri -apiKey $APIKey -apiLabel $APILabel
+            $respCode = Submit-APIReview -packagename $pkg -filePath $pkgPath -uri $APIViewUri -apiKey $APIKey -apiLabel $APILabel
+            Write-Host "HTTP Response code: $($respCode)"
             # HTTP status 200 means API is in approved status
             if ($respCode -eq '200')
             {

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -9,9 +9,9 @@ Param (
   [Parameter(Mandatory=$True)]
   [string] $APILabel,
   [string] $PackageName,
+  [string] $SourceBranch,
   [string] $ConfigFileDir = ""
 )
-
 
 # Submit API review request and return status whether current revision is approved or pending or failed to create review
 function Submit-APIReview($packagename, $filePath, $uri, $apiKey, $apiLabel)
@@ -55,6 +55,12 @@ function Submit-APIReview($packagename, $filePath, $uri, $apiKey, $apiLabel)
 
 
 . (Join-Path $PSScriptRoot common.ps1)
+
+Write-Host "Artifact path: $($ArtifactPath)"
+Write-Host "Package Name: $($PackageName)"
+Write-Host "Source branch: $($SourceBranch)"
+Write-Host "Config File directory: $($ConfigFileDir)"
+
 $packages = @{}
 if ($FindArtifactForApiReviewFn -and (Test-Path "Function:$FindArtifactForApiReviewFn"))
 {
@@ -68,67 +74,76 @@ else
     exit(1)
 }
 
-$responses = @{}
+# Check if package config file is present. This file has package version, SDK type etc info.
+if (-not $ConfigFileDir)
+{
+    $ConfigFileDir = Join-Path -Path $ArtifactPath "PackageInfo"
+}
+
 if ($packages)
 {
-    foreach($pkg in $packages.Keys)
+    foreach($pkgPath in $packages.Values)
     {
-        Write-Host "Submitting API Review for package $($pkg)"
-        Write-Host $packages[$pkg]
-        $responses[$pkg] = Submit-APIReview -packagename $pkg -filePath $packages[$pkg] -uri $APIViewUri -apiKey $APIKey -apiLabel $APILabel
+        $pkg = Split-Path -Leaf $pkgPath
+        $pkgPropPath = Join-Path -Path $ConfigFileDir "$PackageName.json"
+        if (-Not (Test-Path $pkgPropPath))
+        {
+            Write-Host " Package property file path $($pkgPropPath) is invalid."
+            continue
+        }
+        # Get package info from json file created before updating version to daily dev
+        $pkgInfo = Get-Content $pkgPropPath | ConvertFrom-Json
+        $version = [AzureEngSemanticVersion]::ParseVersionString($pkgInfo.Version)
+        Write-Host "Version: $($version)"
+        Write-Host "SDK Type: $($pkgInfo.SdkType)"
+
+        # Run create review step only if build is triggered from master branch or if version is GA.
+        # This is to avoid invalidating review status by a build triggered from feature branch
+        if ( ($SourceBranch -eq "master") -or (-not $version.IsPrerelease))
+        {
+            Write-Host "Submitting API Review for package $($pkg)"
+            $response = Submit-APIReview -packagename $pkg -filePath $pkgPath -uri $APIViewUri -apiKey $APIKey -apiLabel $APILabel
+            # HTTP status 200 means API is in approved status
+            if ($respCode -eq '200')
+            {
+                Write-Host "API review is in approved status."
+            }
+            elseif ($version.IsPrerelease -or ($version.Major -eq 0))
+            {
+                # Ignore API review status for prerelease version
+                Write-Host "Package version is not GA. Ignoring API view approval status"
+            }
+            else
+            {
+                # Return error code if status code is 201 for track2 data plane package
+                if ($pkgInfo.SdkType -eq "client" -and $pkgInfo.IsNewSdk)
+                {
+                    if ($respCode -eq '201')
+                    {
+                        Write-Host "Package version $($version) is GA and automatic API Review is not yet approved for package $($PackageName)."
+                        Write-Host "Build and release is not allowed for GA package without API review approval."
+                        Write-Host "You will need to queue another build to proceed further after API review is approved"
+                        Write-Host "You can check http://aka.ms/azsdk/engsys/apireview/faq for more details on API Approval."
+                    }
+                    else
+                    {
+                        Write-Host "Failed to create API Review for package $($PackageName). Please reach out to Azure SDK engineering systems on teams channel and share this build details."
+                    }
+                    exit 1
+                }
+                else
+                {
+                    Write-Host "API review is not approved for package $($PackageName). Management and track1 package can be released without API review approval."
+                }
+            } 
+        }
+        else
+        {
+            Write-Host "Build is triggered from $($SourceBranch) with prerelease version. Skipping API review status check."
+        }
     }
 }
 else
 {
     Write-Host "No package is found in artifact path to submit review request"
-}
-
-$FoundFailure = $False
-if (-not $ConfigFileDir)
-{
-    $ConfigFileDir = Join-Path -Path $ArtifactPath "PackageInfo"
-}
-foreach ($pkgName in $responses.Keys)
-{    
-    $respCode = $responses[$pkgName]
-    if ($respCode -ne '200')
-    {
-        $pkgPropPath = Join-Path -Path $ConfigFileDir "$PackageName.json"
-        if (-Not (Test-Path $pkgPropPath))
-        {
-            Write-Host " Package property file path $($pkgPropPath) is invalid."
-        }
-        else
-        {
-            $pkgInfo = Get-Content $pkgPropPath | ConvertFrom-Json
-            $version = [AzureEngSemanticVersion]::ParseVersionString($pkgInfo.Version)
-            Write-Host "Package name: $($PackageName)"
-            Write-Host "Version: $($version)"
-            Write-Host "SDK Type: $($pkgInfo.SdkType)"
-            if ($version.IsPrerelease)
-            {
-                Write-Host "Package version is not GA. Ignoring API view approval status"
-            }
-            elseif ($pkgInfo.SdkType -eq "client" -and $pkgInfo.IsNewSdk)
-            {
-                $FoundFailure = $True
-                if ($respCode -eq '201')
-                {
-                    Write-Host "Package version $($version) is GA and automatic API Review is not yet approved for package $($PackageName)."
-                    Write-Host "Build and release is not allowed for GA package without API review approval."
-                    Write-Host "You will need to queue another build to proceed further after API review is approved"
-                    Write-Host "You can check http://aka.ms/azsdk/engsys/apireview/faq for more details on API Approval."
-                }
-                else
-                {
-                    Write-Host "Failed to create API Review for package $($PackageName). Please reach out to Azure SDK engineering systems on teams channel and share this build details."
-                }
-                exit 1
-            }
-            else
-            {
-                Write-Host "API review is not approved for package $($PackageName). Management and track1 package can be released without API review approval."
-            }      
-        }
-    }
 }


### PR DESCRIPTION
Automatic review  is triggered whenever pipeline is triggered from internal project. This needs to be restricted to run from master or from other branch if version is GA.