### PR TITLE
Remove extra feed

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,7 +3,6 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
-    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
The pipeline is complaining:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=793057&view=results
All csprojes seem to build fine without it.

