### PR TITLE
Revert "Remove extra feed"

### DIFF
--- a/NuGet.Config
+++ b/NuGet.Config
@@ -3,6 +3,7 @@
   <packageSources>
     <clear />
     <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+    <add key="dotnet-tools" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-tools/nuget/v3/index.json" />
   </packageSources>
   <disabledPackageSources>
     <clear />


### PR DESCRIPTION
Reverts Azure/azure-sdk-tools#1509

I was wrong, it was my local nuget cache that allowed calls to succeed.