### PR TITLE
Pass subscription id to New-TestResources.ps1

### DIFF
--- a/eng/common/TestResources/README.md
+++ b/eng/common/TestResources/README.md
@@ -28,7 +28,7 @@ is a member of multiple subscriptions.
 
 ```powershell
 Connect-AzAccount -Subscription 'YOUR SUBSCRIPTION ID'
-eng\common\TestResources\New-TestResources.ps1 -ServiceDirectory 'search'
+eng\common\TestResources\New-TestResources.ps1 -ServiceDirectory 'search' -SubscriptionId 'YOUR SUBSCRIPTION ID'
 ```
 
 The `OutFile` switch will be set by default if you are running this for a .NET project on Windows. This will save test environment settings


### PR DESCRIPTION
Replaces https://github.com/Azure/azure-sdk-for-net/pull/19725

When you don't specify the subscription id it takes the default value `faa080af-c1d8-40ad-9cce-e1a450ca5b57` and then you get these errors. Took me a while to spot the default value there :(

```
WARNING: The access token is from the wrong issuer 'https://sts.windows.net/../'. It must match the tenant 'https://sts.windows.net/..47/' associated with this subscription. Please use the authority (URL) 'https://login.windows.net/..47' to get the token. Note, if the subscription is transferred to another tenant there is no impact to the services, but information about new tenant could take time to propagate (up to an hour). If you just transferred your subscription and see this error message, please try back later.
WARNING: Attempt 1 failed: Exception calling "Invoke" with "0" argument(s): "The running command stopped because the preference variable "ErrorActionPreference" or common parameter is set to Stop: The provided account ..e65 does not have access to subscription ID "faa080af-c1d8-40ad-9cce-e1a450ca5b57". Please try logging in with different credentials or a different subscription ID.". Trying again in 10 seconds...
```