### PR TITLE
[matrix] Handle null values when generating display names

### DIFF
--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -350,7 +350,7 @@ function ProcessImport([MatrixParameter[]]$matrix, [String]$selection, [Hashtabl
             $importPath = $_.Value
         }
     }
-    if (!$matrix -or !$importPath) {
+    if ((!$matrix -and !$importPath) -or !$importPath) {
         return $matrix, @()
     }
 

--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -65,9 +65,12 @@ class MatrixParameter {
 
     [String]CreateDisplayName([Hashtable]$displayNamesLookup)
     {
-        $displayName = $this.Value.ToString()
-        if ($this.Value -is [PSCustomObject]) {
+        if ($null -eq $this.Value) {
+            $displayName = ""
+        } elseif ($this.Value -is [PSCustomObject]) {
             $displayName = $this.Name
+        } else {
+            $displayName = $this.Value.ToString()
         }
 
         if ($displayNamesLookup.ContainsKey($displayName)) {

--- a/eng/common/scripts/job-matrix/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common/scripts/job-matrix/tests/job-matrix-functions.modification.tests.ps1
@@ -86,6 +86,49 @@ Describe "Platform Matrix nonSparse" -Tag "nonsparse" {
 }
 
 Describe "Platform Matrix Import" -Tag "import" {
+    It "Should generate a sparse matrix where the entire base matrix is imported" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "$IMPORT": "./test-import-matrix.json"
+    },
+    "include": [
+        {
+            "fooinclude": "fooinclude"
+        }
+    ]
+}
+'@
+
+        $expectedMatrix = @'
+[
+  {
+    "parameters": { "Foo": "foo1", "Bar": "bar1" },
+    "name": "foo1_bar1"
+  },
+  {
+    "parameters": { "Foo": "foo2", "Bar": "bar2" },
+    "name": "foo2_bar2"
+  },
+  {
+    "parameters": { "Baz": "importedBaz" },
+    "name": "importedBazName"
+  },
+  {
+    "parameters": { "fooinclude": "fooinclude" },
+    "name": "fooinclude"
+  },
+]
+'@
+
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+        $matrix = GenerateMatrix $importConfig "sparse"
+        $expected = $expectedMatrix | ConvertFrom-Json -AsHashtable
+
+        $matrix.Length | Should -Be 4
+        CompareMatrices $matrix $expected
+    }
+
     It "Should generate a matrix with nonSparseParameters and an imported sparse matrix" {
         $matrixJson = @'
 {

--- a/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
+++ b/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
@@ -324,22 +324,6 @@ Describe "Platform Matrix Generation" -Tag "generate" {
         $element.name | Should -Be "macOS1015_netcoreapp21_withFoo"
     }
 
-    It "Should enforce valid display name format" {
-        $generateconfig.displayNamesLookup["net461"] = '123.Some.456.Invalid_format-name$(foo)'
-        $generateconfig.displayNamesLookup["netcoreapp2.1"] = (New-Object string[] 150) -join "a"
-        $dimensions = GetMatrixDimensions $generateConfig.matrixParameters
-        $matrix = GenerateFullMatrix $generateconfig.matrixParameters $generateconfig.displayNamesLookup
-
-        $element = GetNdMatrixElement @(0, 0, 0) $matrix $dimensions
-        $element.name | Should -Be "windows2019_123some456invalid_formatnamefoo"
-
-        $element = GetNdMatrixElement @(1, 1, 1) $matrix $dimensions
-        $element.name.Length | Should -Be 100
-        # The withfoo part of the argument gets cut off at the character limit
-        $element.name | Should -BeLike "ubuntu1804_aaaaaaaaaaaaaaaaa*"
-    }
-
-
     It "Should initialize an N-dimensional matrix from all parameter permutations" {
         $dimensions = GetMatrixDimensions $generateConfig.matrixParameters
         $matrix = GenerateFullMatrix $generateConfig.matrixParameters $generateConfig.displayNamesLookup
@@ -585,5 +569,50 @@ Describe "Platform Matrix Generation With Object Fields" -Tag "objectfields" {
         $matrix[4].parameters.testObjectValue1 | Should -Be "1"
         $matrix[4].parameters.testObjectValue2 | Should -Be "2"
         $matrix[4].parameters.Count | Should -Be 3
+    }
+}
+
+Describe "Platform Matrix Display Names" -Tag "displaynames" {
+    BeforeEach {
+        $matrixConfigForGenerate = @"
+{
+    "displayNames": {
+        "--enableFoo": "withfoo"
+    },
+    "matrix": {
+        "operatingSystem": "ubuntu-18.04",
+        "framework": [
+          "net461",
+          "netcoreapp2.1"
+        ],
+        "TestNullField": null,
+        "TestObjectField": {
+            "TestObjectValueName": {
+                "foo": "bar",
+                "baz": "qux"
+            }
+        }
+    }
+}
+"@
+        $generateConfig = GetMatrixConfigFromJson $matrixConfigForGenerate
+    }
+
+    It "Should enforce valid display name format" {
+        $generateconfig.displayNamesLookup["net461"] = '123.Some.456.Invalid_format-name$(foo)'
+        $generateconfig.displayNamesLookup["netcoreapp2.1"] = (New-Object string[] 150) -join "a"
+        $dimensions = GetMatrixDimensions $generateConfig.matrixParameters
+        $matrix = GenerateFullMatrix $generateconfig.matrixParameters $generateconfig.displayNamesLookup
+
+        $matrix[0].name | Should -Be "ubuntu1804_123some456invalid_formatnamefoo_TestObjectValueName"
+
+        $matrix[1].name.Length | Should -Be 100
+        # The withfoo part of the argument gets cut off at the character limit
+        $matrix[1].name | Should -BeLike "ubuntu1804_aaaaaaaaaaaaaaaaa*"
+    }
+
+    It "Should generate a display name with null and object values" {
+        $matrix = GenerateMatrix $generateConfig "sparse"
+        $matrix[0].name | Should -Be "ubuntu1804_net461_TestObjectValueName"
     }
 }


### PR DESCRIPTION
With the latest update to generate display names more dynamically, we ended up trying to call `ToString()` on values that could be null.