### PR TITLE
Automatic review should only have one revision in review pending state

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -395,6 +395,14 @@ namespace APIViewWeb.Respositories
             await AssertAutomaticReviewModifier(user, review);
             if (createNewRevision)
             {
+                // Delete last revision if it is not in approved state before adding new revision
+                // This is to keep only one pending revision since last approval or from initial review revision
+                var lastRevision = review.Revisions.LastOrDefault();
+                if (lastRevision != null && lastRevision.Approvers.Count == 0 && review.Revisions.Count > 1)
+                {
+                    review.Revisions.Remove(lastRevision);
+                }
+
                 // Update or insert review with new revision
                 var revision = new ReviewRevisionModel()
                 {


### PR DESCRIPTION
Delete last revision of automatic API review if it is in pending status to keep only one revision in pending status at any time. This will require a one time cleanup job to correct current revisions for all automatic review and change in this PR will ensure there is only one pending revision for each automatic API review.