### PR TITLE
Add DependsOn parameter to matrix job generation template

### DIFF
--- a/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
+++ b/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
@@ -1,6 +1,9 @@
 parameters:
 - name: AdditionalParameters
   type: object
+- name: DependsOn
+  type: object
+  default: null
 - name: CloudConfig
   type: object
   default: {}
@@ -37,6 +40,8 @@ jobs:
     name: ${{ parameters.Pool }}
     vmImage: ${{ parameters.OsVmImage }}
   displayName: Generate Job Matrix
+  ${{ if parameters.DependsOn }}:
+    dependsOn: ${{ parameters.DependsOn }}
   steps:
     # Skip sparse checkout for the `azure-sdk-for-<lang>-pr` private mirrored repositories
     # as we require the github service connection to be loaded.


### PR DESCRIPTION
This is a useful parameter for scenarios like CI pipelines where the test jobs make up a subset of jobs within a stage and need to depend on another job like `Build`.