### PR TITLE
Use single quotes for matrix generator command line arguments

### DIFF
--- a/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
+++ b/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
@@ -63,10 +63,10 @@ jobs:
             arguments: >
               -ConfigPath ${{ config.Path }}
               -Selection ${{ config.Selection }}
-              -DisplayNameFilter "$(displayNameFilter)"
-              -Filters "${{ join('","', parameters.MatrixFilters) }}","container=^$","SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}"
-              -Replace "${{ join('","', parameters.MatrixReplace) }}"
-              -NonSparseParameters "${{ join('","', config.NonSparseParameters) }}"
+              -DisplayNameFilter '$(displayNameFilter)'
+              -Filters '${{ join(''',''', parameters.MatrixFilters) }}','container=^$','SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}'
+              -Replace '${{ join(''',''', parameters.MatrixReplace) }}'
+              -NonSparseParameters '${{ join(''',''', config.NonSparseParameters) }}'
           displayName: Generate VM Job Matrix ${{ config.Name }}
           name: generate_vm_job_matrix_${{ config.Name }}
 
@@ -78,9 +78,9 @@ jobs:
             arguments: >
               -ConfigPath ${{ config.Path }}
               -Selection ${{ config.Selection }}
-              -DisplayNameFilter "$(displayNameFilter)"
-              -Filters "${{ join('","', parameters.MatrixFilters) }}", "container=.*", "SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}"
-              -NonSparseParameters "${{ join('","', config.NonSparseParameters) }}"
+              -DisplayNameFilter '$(displayNameFilter)'
+              -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=.*', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}'
+              -NonSparseParameters '${{ join(''',''', config.NonSparseParameters) }}'
           displayName: Generate Container Job Matrix
           name: generate_container_job_matrix_${{ config.Name }}
 

--- a/eng/common/scripts/job-matrix/samples/matrix-test.yml
+++ b/eng/common/scripts/job-matrix/samples/matrix-test.yml
@@ -18,7 +18,7 @@ jobs:
         # Exclusion example
         - OSVmImage=^(?!macOS).*
       MatrixReplace:
-        - OsVmImage=.*ubuntu.*/ubuntu-20.04
+        - OsVmImage=(ubuntu).*/$1-20.04
         - .*Framework.*=net5.0/net5.1
       MatrixConfigs:
         - Name: base_product_matrix


### PR DESCRIPTION
The `replace` operator for matrix generation supports regex groupings, meaning you can pass something like `Pool=(.*)-general/$1-storage` to replace `"Pool": "ubuntu-general"` with `"Pool": "ubuntu-storage"`. However, we currently generate these command line arguments as being wrapped with double quotes, meaning the powershell script will try to interpret them as variables. On top of this, the [Azure Pipelines join operator](https://docs.microsoft.com/en-us/azure/devops/pipelines/process/expressions?view=azure-devops#join) does not support double quotes, but I've found that we can effectively escape a single quote join value with another single quote (e.g. the join value `','` must be declared as `''','''` as opposed to `"','"`).