### PR TITLE
Add diagnostic rule for checking existence of codesnippets in javadocs

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -1009,7 +1009,8 @@ public class ASTAnalyser implements Analyser {
 
             nodeWithAnnotations.getAnnotations()
                     .stream()
-                    .filter(annotationExpr -> !BLOCKED_ANNOTATIONS.contains(annotationExpr.getName().getIdentifier()))
+                    .filter(annotationExpr -> !BLOCKED_ANNOTATIONS.contains(annotationExpr.getName().getIdentifier())
+                            || !annotationExpr.getName().getIdentifier().startsWith("Json"))
                     .forEach(consumer);
         }
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
@@ -7,6 +7,7 @@ import com.azure.tools.apiview.processor.diagnostics.rules.IllegalPackageAPIExpo
 import com.azure.tools.apiview.processor.diagnostics.rules.ImportsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.MissingAnnotationsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.MissingJavaDocDiagnosticRule;
+import com.azure.tools.apiview.processor.diagnostics.rules.MissingJavadocCodeSnippetsRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.ModuleInfoDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.NoLocalesInJavadocUrlDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.NoPublicFieldsDiagnosticRule;
@@ -45,6 +46,7 @@ public class Diagnostics {
             new Rule("^setHas")
         ));
         diagnostics.add(new MissingJavaDocDiagnosticRule());
+        diagnostics.add(new MissingJavadocCodeSnippetsRule());
         diagnostics.add(new NoLocalesInJavadocUrlDiagnosticRule());
         diagnostics.add(new ModuleInfoDiagnosticRule());
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavadocCodeSnippetsRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavadocCodeSnippetsRule.java
@@ -34,7 +34,8 @@ public class MissingJavadocCodeSnippetsRule implements DiagnosticRule {
                     listing.addDiagnostic((new Diagnostic(
                             INFO,
                             makeId(cu),
-                            "JavaDoc for clients and builders should include code samples to instantiate clients."
+                            "JavaDoc for clients and builders should include code samples to instantiate clients.",
+                            "https://github.com/Azure/azure-sdk-for-java/wiki/JavaDoc-with-CodeSnippet"
                     )));
                 }
             }
@@ -59,7 +60,8 @@ public class MissingJavadocCodeSnippetsRule implements DiagnosticRule {
                     listing.addDiagnostic((new Diagnostic(
                             INFO,
                             makeId(cu),
-                            "JavaDoc for service methods should include code samples."
+                            "JavaDoc for service methods should include code samples.",
+                            "https://github.com/Azure/azure-sdk-for-java/wiki/JavaDoc-with-CodeSnippet"
                     )));
                 }
             }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavadocCodeSnippetsRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavadocCodeSnippetsRule.java
@@ -17,7 +17,6 @@ import static com.azure.tools.apiview.processor.model.DiagnosticKind.INFO;
  */
 public class MissingJavadocCodeSnippetsRule implements DiagnosticRule {
     public static final String CODE_SNIPPET_TAG = "{@codesnippet";
-    private static boolean IGNORE_OVERRIDES = true;
 
     @Override
     public void scanIndividual(final CompilationUnit cu, final APIListing listing) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavadocCodeSnippetsRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavadocCodeSnippetsRule.java
@@ -1,0 +1,68 @@
+package com.azure.tools.apiview.processor.diagnostics.rules;
+
+import com.azure.tools.apiview.processor.diagnostics.DiagnosticRule;
+import com.azure.tools.apiview.processor.model.APIListing;
+import com.azure.tools.apiview.processor.model.Diagnostic;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.comments.JavadocComment;
+
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getClasses;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPublicOrProtectedMethods;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
+import static com.azure.tools.apiview.processor.model.DiagnosticKind.INFO;
+
+/**
+ * This diagnostic rule checks that the client builders and clients have codesnippets in their JavaDocs. This also
+ * checks to see if any of service methods have codesnippets.
+ */
+public class MissingJavadocCodeSnippetsRule implements DiagnosticRule {
+    public static final String CODE_SNIPPET_TAG = "{@codesnippet";
+    private static boolean IGNORE_OVERRIDES = true;
+
+    @Override
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
+        getClasses(cu).forEach(typeDeclaration -> {
+            String className = typeDeclaration.getNameAsString();
+
+            // Check for codesnippets in class level javadoc for clients and client builders
+            if (typeDeclaration.getJavadocComment().isPresent()
+                    && (className.endsWith("Client") || className.endsWith("Builder"))) {
+                JavadocComment javadocComment = typeDeclaration.getJavadocComment().get();
+                String javadoc = javadocComment.getContent();
+
+                if (!javadoc.contains(CODE_SNIPPET_TAG)) {
+                    listing.addDiagnostic((new Diagnostic(
+                            INFO,
+                            makeId(cu),
+                            "JavaDoc for clients and builders should include code samples to instantiate clients."
+                    )));
+                }
+            }
+
+            // check for codesnippets in javadoc for service methods
+            if (className.endsWith("Client")) {
+                // Check if at least one service method has codesnippets in the JavaDoc.
+                // Ideally, all service methods should have codesnippets but due to the number of overloads,
+                // adding codesnippet for each variant can be a lot. So, this check is to find cases where none of the
+                // service methods have codesnippets. If we find at least one service method with codesnippets, we
+                // assume library developers have picked the methods that are most useful to provide code samples.
+                boolean serviceMethodHasCodesnippets = getPublicOrProtectedMethods(cu)
+                        .filter(methodDeclaration -> methodDeclaration.isAnnotationPresent("ServiceMethod"))
+                        .filter(methodDeclaration -> methodDeclaration.getJavadocComment().isPresent())
+                        .anyMatch(methodDeclaration -> methodDeclaration
+                                .getJavadocComment()
+                                .get()
+                                .getContent()
+                                .contains(CODE_SNIPPET_TAG));
+
+                if (!serviceMethodHasCodesnippets) {
+                    listing.addDiagnostic((new Diagnostic(
+                            INFO,
+                            makeId(cu),
+                            "JavaDoc for service methods should include code samples."
+                    )));
+                }
+            }
+        });
+    }
+}


### PR DESCRIPTION
This PR adds a diagnostic rule to check existence of codesnippets in:
- javadocs of client and client builder
- javadocs of service methods