### PR TITLE
Exclude macos from matrix generation by default

### DIFF
--- a/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
+++ b/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
@@ -35,7 +35,8 @@ parameters:
 jobs:
 - job: generate_matrix
   variables:
-    displayNameFilter: $[ coalesce(variables.jobMatrixFilter, '.*') ]
+    # Temporarily exclude macOS tests by default because of ongoing pool issues
+    displayNameFilter: $[ coalesce(variables.jobMatrixFilter, '^(?!.*macOS.*)') ]
   pool:
     name: ${{ parameters.Pool }}
     vmImage: ${{ parameters.OsVmImage }}


### PR DESCRIPTION
Due to temporary macos pool capacity issues from Azure Pipelines, many of our pipelines and releases are getting blocked. This adds a temporary workaround to mass-exclude ALL macOS test jobs for repositories using matrix generation (js/python/java/net).

To override the exclude, when running a pipeline manually, set a runtime variable named `jobMatrixFilter` with the value `.*`.