### PR TITLE
Fix BaseName initialization

### DIFF
--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -37,7 +37,7 @@ param (
     [Parameter(ParameterSetName = 'Default+Provisioner', Mandatory = $true)]
     [Parameter(ParameterSetName = 'ResourceGroup+Provisioner', Mandatory = $true)]
     [string] $ProvisionerApplicationSecret,
-    
+
     [Parameter(ParameterSetName = 'Default', Mandatory = $true, Position = 0)]
     [Parameter(ParameterSetName = 'Default+Provisioner')]
     [Parameter(ParameterSetName = 'ResourceGroup')]
@@ -122,18 +122,17 @@ if ($ProvisionerApplicationId) {
 
 $context = Get-AzContext
 
-# Make sure $BaseName is set.
-if (!$BaseName) {
-
-    $UserName =  if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
-    # Remove spaces, etc. that may be in $UserName
-    $UserName = $UserName -replace '\W'
-
-    $BaseName = "$UserName$ServiceDirectory"
-    Log "BaseName was not set. Using default base name '$BaseName'"
-}
-
 if (!$ResourceGroupName) {
+    # Make sure $BaseName is set.
+    if (!$BaseName) {
+        $UserName = if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
+        # Remove spaces, etc. that may be in $UserName
+        $UserName = $UserName -replace '\W'
+
+        $BaseName = "$UserName$ServiceDirectory"
+        Log "BaseName was not set. Using default base name '$BaseName'"
+    }
+
     # Format the resource group name like in New-TestResources.ps1.
     $ResourceGroupName = "rg-$BaseName"
 }

--- a/eng/common/TestResources/Update-TestResources.ps1
+++ b/eng/common/TestResources/Update-TestResources.ps1
@@ -67,18 +67,18 @@ $exitActions = @({
     }
 })
 
-# Make sure $BaseName is set.
-if (!$BaseName) {
-    $UserName = if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
-    # Remove spaces, etc. that may be in $UserName
-    $UserName = $UserName -replace '\W'
-
-    $BaseName = "$UserName$ServiceDirectory"
-    Log "BaseName was not set. Using default base name '$BaseName'"
-}
-
 # Make sure $ResourceGroupName is set.
 if (!$ResourceGroupName) {
+    # Make sure $BaseName is set.
+    if (!$BaseName) {
+        $UserName = if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
+        # Remove spaces, etc. that may be in $UserName
+        $UserName = $UserName -replace '\W'
+
+        $BaseName = "$UserName$ServiceDirectory"
+        Log "BaseName was not set. Using default base name '$BaseName'"
+    }
+
     $ResourceGroupName = "rg-$BaseName"
 }
 


### PR DESCRIPTION
Initializing the BaseName with a ServiceDirectory that contains
a "/", because it is a multiple level path, causes the BaseName
initialization code to fail because it doesn't support the
validation pattern.

In all the known cases we already pass the ResourceGroupName
explicitly so don't need to set the BaseName so we can
skip the initialization in those cases.