### PR TITLE
Remove passing -Mode Complete to deployment

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -212,12 +212,12 @@ try {
             if ($currentSubcriptionId -ne $SubscriptionId) {
                 Log "Selecting subscription '$SubscriptionId'"
                 $null = Select-AzSubscription -Subscription $SubscriptionId
-        
+
                 $exitActions += {
                     Log "Selecting previous subscription '$currentSubcriptionId'"
                     $null = Select-AzSubscription -Subscription $currentSubcriptionId
                 }
-        
+
                 # Update the context.
                 $context = Get-AzContext
             }
@@ -459,7 +459,7 @@ try {
                 if ($CI) {
                     $DebugPreference = 'Continue'
                 }
-                New-AzResourceGroupDeployment -Name $BaseName -ResourceGroupName $resourceGroup.ResourceGroupName -TemplateFile $templateFile -TemplateParameterObject $templateFileParameters -Mode Complete -Force:$Force
+                New-AzResourceGroupDeployment -Name $BaseName -ResourceGroupName $resourceGroup.ResourceGroupName -TemplateFile $templateFile -TemplateParameterObject $templateFileParameters -Force:$Force
             } catch {
                 Write-Output @'
 #####################################################

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -38,7 +38,7 @@ param (
     [Parameter(ParameterSetName = 'ResourceGroup+Provisioner', Mandatory = $true)]
     [string] $ProvisionerApplicationSecret,
 
-    [Parameter(ParameterSetName = 'Default', Mandatory = $true, Position = 0)]
+    [Parameter(ParameterSetName = 'Default', Position = 0)]
     [Parameter(ParameterSetName = 'Default+Provisioner')]
     [Parameter(ParameterSetName = 'ResourceGroup')]
     [Parameter(ParameterSetName = 'ResourceGroup+Provisioner')]

--- a/eng/common/TestResources/Update-TestResources.ps1
+++ b/eng/common/TestResources/Update-TestResources.ps1
@@ -10,7 +10,7 @@
 
 [CmdletBinding(DefaultParameterSetName = 'Default')]
 param (
-    [Parameter(ParameterSetName = 'Default', Mandatory = $true, Position = 0)]
+    [Parameter(ParameterSetName = 'Default', Position = 0)]
     [string] $ServiceDirectory,
 
     [Parameter(ParameterSetName = 'Default')]


### PR DESCRIPTION
When passing Complete it will remove any resources
already in the resource group that weren't part
of the current deployment. That removal breaks a
lot of assumptions, like multiple deployments when
testing things like smoke-tests or if you are reusing
an existing resource group. We don't want that to happen.