### PR TITLE
Call bypass-local-dns.yml from verify-agent-os.yml

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-agent-os.yml
+++ b/eng/common/pipelines/templates/steps/verify-agent-os.yml
@@ -14,3 +14,5 @@ steps:
       filePath: ${{ parameters.ScriptDirectory }}/Verify-AgentOS.ps1
       arguments: >
         -AgentImage "${{ parameters.AgentImage }}"
+
+  - template: /eng/common/pipelines/templates/steps/bypass-local-dns.yml


### PR DESCRIPTION
- Easy way to ensure the DNS workaround is run in (almost) all pipelines