### PR TITLE
Set default branch to master if not set from git

### DIFF
--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -41,7 +41,7 @@ steps:
 
 - task: PowerShell@2
   displayName: Push changes
-  condition: and(succeeded(), ne(variables['HasChanges'], 'false'))
+  condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
   inputs:
     pwsh: true
     workingDirectory: ${{ parameters.WorkingDirectory }}

--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -41,7 +41,7 @@ steps:
 
 - task: PowerShell@2
   displayName: Push changes
-  condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
+  condition: and(succeeded(), ne(variables['HasChanges'], 'false'))
   inputs:
     pwsh: true
     workingDirectory: ${{ parameters.WorkingDirectory }}

--- a/eng/common/pipelines/templates/steps/set-default-branch.yml
+++ b/eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -4,7 +4,11 @@ parameters:
 steps:
 - pwsh: |
     $setDefaultBranch = (git remote show ${{ parameters.RemoteRepo }} | Out-String) -replace "(?ms).*HEAD branch: (\w+).*", '$1'
+    if (!$setDefaultBranch) {
+      $setDefaultBranch = 'master'
+    }
     Write-Host "Setting DefaultBranch=$setDefaultBranch"
     echo "##vso[task.setvariable variable=DefaultBranch]$setDefaultBranch"
   displayName: "Setup Default Branch"
   workingDirectory: ${{ parameters.workingDirectory }}
+  continueOnError: true 

--- a/eng/common/pipelines/templates/steps/set-default-branch.yml
+++ b/eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -9,7 +9,7 @@ steps:
       $setDefaultBranch = 'master'
     }
     Write-Host "Setting DefaultBranch=$setDefaultBranch"
-    echo "##vso[task.setvariable variable=DefaultBranch]$setDefaultBranch"
+    Write-Host "##vso[task.setvariable variable=DefaultBranch]$setDefaultBranch"
   displayName: "Setup Default Branch"
   workingDirectory: ${{ parameters.workingDirectory }}
-  continueOnError: true 
+  ignoreLASTEXITCODE: true

--- a/eng/common/pipelines/templates/steps/set-default-branch.yml
+++ b/eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -4,7 +4,8 @@ parameters:
 steps:
 - pwsh: |
     $setDefaultBranch = (git remote show ${{ parameters.RemoteRepo }} | Out-String) -replace "(?ms).*HEAD branch: (\w+).*", '$1'
-    if (!$setDefaultBranch) {
+    if ($LASTEXITCODE -ne 0) {
+      Write-Host "Not able to fetch the default branch from git command. Set to master."
       $setDefaultBranch = 'master'
     }
     Write-Host "Setting DefaultBranch=$setDefaultBranch"


### PR DESCRIPTION
Two changes in PR:
1. Set default branch to master if not set from git command. Add `continueOnError: true` to unblock any failed places.
E.g. https://dev.azure.com/azure-sdk/internal/_build/results?buildId=838864&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=bdeefc16-b669-5ebd-ad94-a2c19ade53b0

Testing pipeline right here: https://dev.azure.com/azure-sdk/playground/_build/results?buildId=845015&view=logs&j=38d918fc-df5a-5870-2b80-6c17fdb13baf&t=489baed9-6f06-5266-9d0d-079a130738b4
2. `git-push-changes.yml` checked whether local has changes. Make the changes so if we need to skip checking changes somehow, we are able to execute the scripts. 
E.g: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=842830&view=logs&j=321fe29c-d6e3-5c98-996f-e7c628f12971&t=71fd3457-22c6-5475-4ae6-23dcf07ca155