### PR TITLE
Add template to merge multiple subscription configurations

### DIFF
--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -31,7 +31,7 @@ steps:
   - ${{ if parameters.SubscriptionConfigurations }}:
     - pwsh: |
         Write-Host "##vso[task.setvariable variable=SubscriptionConfiguration;]{}"
-      displayName: Initialize SubscriptionConfiguration variable
+      displayName: Initialize SubscriptionConfiguration variable for merging
       condition: eq(variables['SubscriptionConfiguration'], '')
 
     - ${{ each config in parameters.SubscriptionConfigurations }}:

--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -1,0 +1,65 @@
+parameters:
+  - name: SubscriptionConfiguration
+    type: string
+    default: $(sub-config-azure-cloud-test-resources)
+  - name: SubscriptionConfigurations
+    type: object
+    default: null
+
+steps:
+  - ${{ if parameters.SubscriptionConfiguration }}:
+    - pwsh: |
+        $config = @'
+          ${{ parameters.SubscriptionConfiguration }}
+        '@ | ConvertFrom-Json -AsHashtable
+
+        foreach($pair in $config.GetEnumerator()) {
+          if ($pair.Value -is [Hashtable]) {
+            foreach($nestedPair in $pair.Value.GetEnumerator()) {
+              Write-Host "##vso[task.setvariable variable=$($nestedPair.Name);issecret=true;]$($nestedPair.Value)"
+            }
+          } else {
+            Write-Host "##vso[task.setvariable variable=$($pair.Name);issecret=true;]$($pair.Value)"
+          }
+        }
+
+        Write-Host ($config | ConvertTo-Json)
+        $serialized = $config | ConvertTo-Json -Compress
+        Write-Host "##vso[task.setvariable variable=SubscriptionConfiguration;]$serialized"
+      displayName: Initialize SubscriptionConfiguration variable
+
+  - ${{ if parameters.SubscriptionConfigurations }}:
+    - pwsh: |
+        Write-Host "##vso[task.setvariable variable=SubscriptionConfiguration;]{}"
+      displayName: Initialize SubscriptionConfiguration variable
+      condition: eq(variables['SubscriptionConfiguration'], '')
+
+    - ${{ each config in parameters.SubscriptionConfigurations }}:
+      - pwsh: |
+          $config = @'
+            $(SubscriptionConfiguration)
+          '@ | ConvertFrom-Json -AsHashtable
+          $addToConfig = @'
+            ${{ config }}
+          '@ | ConvertFrom-Json -AsHashtable
+
+          foreach ($pair in $addToConfig.GetEnumerator()) {
+            if ($pair.Value -is [Hashtable]) {
+              if (!$config.ContainsKey($pair.Name)) {
+                $config[$pair.Name] = @{}
+              }
+              foreach($nestedPair in $pair.Value.GetEnumerator()) {
+                Write-Host "##vso[task.setvariable variable=$($nestedPair.Name);issecret=true;]$($nestedPair.Value)"
+                $config[$pair.Name][$nestedPair.Name] = $nestedPair.Value
+              }
+            } else {
+              Write-Host "##vso[task.setvariable variable=$($pair.Name);issecret=true;]$($pair.Value)"
+              $config[$pair.Name] = $pair.Value
+            }
+          }
+
+          $serialized = $config | ConvertTo-Json -Compress
+          Write-Host ($config | ConvertTo-Json)
+          Write-Host "##vso[task.setvariable variable=SubscriptionConfiguration;]$serialized"
+
+        displayName: Merge Test Resource Configurations


### PR DESCRIPTION
This PR adds a new step that will merge multiple subscription configuration objects (initially sourced as json from keyvault via devops variable groups), and output a single object as a devops variable. This will allow service owners to manage additional subscription configurations independent of the ones we maintain. For example, the communication service has the need for their own config to store strings that vary per-cloud (e.g. static testing phone number assets and connection strings), but that also must be combined with our base configs. Right now we have to keep a separate config that, since it contains our testing principal, only the azure sdk engsys team has access to. Making it easier to maintain multiple configurations will reduce our config duplication, and also lay groundwork for keeping access credential configs separate from cloud configs for environment variables and arm template parameters.

The usage in the live.tests.yml files changes slightly to:

```
      - template: /eng/common/TestResources/build-test-resource-config.yml
        parameters:
          SubscriptionConfiguration: ${{ parameters.CloudConfig.SubscriptionConfiguration }}

      - template: /eng/common/TestResources/deploy-test-resources.yml
        parameters:
          ${{ if or(parameters.Location, parameters.CloudConfig.Location) }}:
            Location: ${{ coalesce(parameters.Location, parameters.CloudConfig.Location) }}
          ServiceDirectory: '${{ parameters.ServiceDirectory }}'
          SubscriptionConfiguration: $(SubscriptionConfiguration)
          ArmTemplateParameters: $(ArmTemplateParameters)

      ... test job stuff ...

      - template: /eng/common/TestResources/remove-test-resources.yml
        parameters:
          ServiceDirectory: '${{ parameters.ServiceDirectory }}'
          SubscriptionConfiguration: $(SubscriptionConfiguration)
```

The usage for a service owner tests.yml file looks like below, showing an example of both single and multiple subscription configurations for a cloud:

```
parameters:
  CloudConfig:
    Public:
      SubscriptionConfigurations:
        - $(sub-config-azure-test-resources)
        - $(sub-config-myservice-test-resources)
    PreProd:
      SubscriptionConfiguration: $(sub-config-myservice-preprod-test-resources)
```





