### PR TITLE
Use underscore-prefixed variable name when setting sub config values as secrets

### DIFF
--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -16,10 +16,13 @@ steps:
         foreach($pair in $config.GetEnumerator()) {
           if ($pair.Value -is [Hashtable]) {
             foreach($nestedPair in $pair.Value.GetEnumerator()) {
-              Write-Host "##vso[task.setvariable variable=$($nestedPair.Name);issecret=true;]$($nestedPair.Value)"
+              # Mark values as secret so we don't print json blobs containing secrets in the logs.
+              # Prepend underscore to the variable name, so we can still access the variable names via environment
+              # variables if they get set subsequently.
+              Write-Host "##vso[task.setvariable variable=_$($nestedPair.Name);issecret=true;]$($nestedPair.Value)"
             }
           } else {
-            Write-Host "##vso[task.setvariable variable=$($pair.Name);issecret=true;]$($pair.Value)"
+            Write-Host "##vso[task.setvariable variable=_$($pair.Name);issecret=true;]$($pair.Value)"
           }
         }
 
@@ -49,11 +52,14 @@ steps:
                 $config[$pair.Name] = @{}
               }
               foreach($nestedPair in $pair.Value.GetEnumerator()) {
-                Write-Host "##vso[task.setvariable variable=$($nestedPair.Name);issecret=true;]$($nestedPair.Value)"
+                # Mark values as secret so we don't print json blobs containing secrets in the logs.
+                # Prepend underscore to the variable name, so we can still access the variable names via environment
+                # variables if they get set subsequently.
+                Write-Host "##vso[task.setvariable variable=_$($nestedPair.Name);issecret=true;]$($nestedPair.Value)"
                 $config[$pair.Name][$nestedPair.Name] = $nestedPair.Value
               }
             } else {
-              Write-Host "##vso[task.setvariable variable=$($pair.Name);issecret=true;]$($pair.Value)"
+              Write-Host "##vso[task.setvariable variable=_$($pair.Name);issecret=true;]$($pair.Value)"
               $config[$pair.Name] = $pair.Value
             }
           }


### PR DESCRIPTION
The way we are setting subscription configuration values as secrets causes Azure Pipelines to exclude them from the environment variables available to tasks when they are set by the deployment script. Prefix any subscription configuration keys with an underscore to avoid this problem.