### PR TITLE
Stop filtering projects by ci.yml files

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -39,7 +39,7 @@ class PackageProps
         if (Test-Path (Join-Path $directoryPath "README.md"))
         {
             $this.ReadMePath = Join-Path $directoryPath "README.md"
-        } 
+        }
         else
         {
             $this.ReadMePath = $null
@@ -48,7 +48,7 @@ class PackageProps
         if (Test-Path (Join-Path $directoryPath "CHANGELOG.md"))
         {
             $this.ChangeLogPath = Join-Path $directoryPath "CHANGELOG.md"
-        } 
+        }
         else
         {
             $this.ChangeLogPath = $null
@@ -81,17 +81,19 @@ function Get-PkgProperties
         [string]$ServiceDirectory
     )
 
-    $AllPkgProps = Get-AllPkgProperties -ServiceDirectory $ServiceDirectory
+    $allPkgProps = Get-AllPkgProperties -ServiceDirectory $ServiceDirectory
+    $pkgProps = $allPkgProps.Where({ $_.Name -eq $PackageName -or $_.ArtifactName -eq $PackageName });
 
-    foreach ($pkgProp in $AllPkgProps)
+    if ($pkgProps.Count -ge 1)
     {
-        if(($pkgProp.Name -eq $PackageName) -or ($pkgProp.ArtifactName -eq $PackageName))
+        if ($pkgProps.Count -gt 1)
         {
-            return $pkgProp
+            Write-Host "Found more than one project with the name [$PackageName], choosing the first one under $($pkgProps[0].DirectoryPath)"
         }
+        return $pkgProps[0]
     }
 
-    LogError "Failed to retrive Properties for [ $PackageName ]"
+    LogError "Failed to retrive Properties for [$PackageName]"
     return $null
 }
 
@@ -114,7 +116,7 @@ function Get-AllPkgProperties ([string]$ServiceDirectory = $null)
             {
                 $pkgPropsResult += Get-PkgPropsForEntireService -serviceDirectoryPath $dir.FullName
             }
-        } 
+        }
         else
         {
             $pkgPropsResult = Get-PkgPropsForEntireService -serviceDirectoryPath (Join-Path $RepoRoot "sdk" $ServiceDirectory)
@@ -124,7 +126,7 @@ function Get-AllPkgProperties ([string]$ServiceDirectory = $null)
     return $pkgPropsResult
 }
 
-# Given the metadata url under https://github.com/Azure/azure-sdk/tree/master/_data/releases/latest, 
+# Given the metadata url under https://github.com/Azure/azure-sdk/tree/master/_data/releases/latest,
 # the function will return the csv metadata back as part of response.
 function Get-CSVMetadata ([string]$MetadataUri=$MetadataUri)
 {
@@ -135,8 +137,7 @@ function Get-CSVMetadata ([string]$MetadataUri=$MetadataUri)
 function Get-PkgPropsForEntireService ($serviceDirectoryPath)
 {
     $projectProps = @() # Properties from very project inthe service
-    $packageProps = @() # Properties for artifacts specified in ci.yml
-    $serviceDirectory = (Split-Path -Path $serviceDirectoryPath -Leaf)
+    $serviceDirectory = $serviceDirectoryPath -replace '^.*[\\/]+sdk[\\/]+([^\\/]+).*$', '$1'
 
     if (!$GetPackageInfoFromRepoFn -or !(Test-Path "Function:$GetPackageInfoFromRepoFn"))
     {
@@ -147,49 +148,12 @@ function Get-PkgPropsForEntireService ($serviceDirectoryPath)
 
     foreach ($directory in (Get-ChildItem $serviceDirectoryPath -Directory))
     {
-        $pkgDirectoryPath = Join-Path $serviceDirectoryPath $directory.Name
-        $pkgProps = &$GetPackageInfoFromRepoFn $pkgDirectoryPath $serviceDirectory
-        if ($null -ne  $pkgProps)
+        $pkgProps = &$GetPackageInfoFromRepoFn $directory.FullName $serviceDirectory
+        if ($null -ne $pkgProps)
         {
             $projectProps += $pkgProps
         }
     }
 
-    $ciYmlFiles = Get-ChildItem $serviceDirectoryPath -filter "ci.yml"
-    foreach($ciYmlFile in $ciYmlFiles)
-    {
-        $activeArtifactList = Get-ArtifactListFromYml -ciYmlPath $ciYmlFile.FullName
-        foreach ($artifact in $activeArtifactList)
-        {
-            $packageProps += $projectProps | Where-Object { $_.ArtifactName -eq $artifact["name"] -and $_.Group -eq $artifact["groupId"] }
-        }
-    }
-
-    return $packageProps
-}
-
-function Get-ArtifactListFromYml ($ciYmlPath)
-{
-    $ProgressPreference = "SilentlyContinue"
-    if ((Get-PSRepository).Where({$_.Name -eq "PSGallery"}).Count -eq 0)
-    {
-        Register-PSRepository -Default -ErrorAction:SilentlyContinue
-    }
-
-    if ((Get-Module -ListAvailable -Name powershell-yaml).Where({ $_.Version -eq "0.4.2"} ).Count -eq 0)
-    {
-        Install-Module -Name powershell-yaml -RequiredVersion 0.4.2 -Force -Scope CurrentUser
-    }
-
-    $ciYmlContent = Get-Content $ciYmlPath -Raw
-    $ciYmlObj = ConvertFrom-Yaml $ciYmlContent -Ordered
-    if ($ciYmlObj.Contains("stages"))
-    {
-        $artifactsInCI = $ciYmlObj["stages"][0]["parameters"]["Artifacts"]
-    }
-    elseif ($ciYmlObj.Contains("extends")) 
-    {
-        $artifactsInCI = $ciYmlObj["extends"]["parameters"]["Artifacts"]
-    }
-    return $artifactsInCI
+    return $projectProps
 }


### PR DESCRIPTION
- This removes the ci.yml filtering which means all projects can be discovered
- This eliminates the need for the yml parsing module for most common scenarios
- This does introduce some potential issues with duplicate package names for
  languages like java. The only known case currently is azure-storage-blobs and
  if there is ever a need to explicitly pick the correct one someone can pass
  in the ServiceDirectory filter similar to "storage/azure*" for new and "storage/microsoft*"
  for the older sdk. By default azure usually comes first so the new one gets discovered
  which is likely all we need for now. If this turns out not to be true we might
  need another way to disambiguate.