### PR TITLE
Fix retain runs auth.

### DIFF
--- a/eng/common/pipelines/templates/steps/retain-run.yml
+++ b/eng/common/pipelines/templates/steps/retain-run.yml
@@ -18,5 +18,5 @@ steps:
         -RunId $(Build.BuildId)
         -OwnerId Pipeline
         -DaysValid ${{parameters.DaysValid}}
-        -Base64EncodedAuthToken $env:SYSTEM_ACCESSTOKEN
+        -AccessToken $env:SYSTEM_ACCESSTOKEN
         -Debug

--- a/eng/common/scripts/Add-RetentionLease.ps1
+++ b/eng/common/scripts/Add-RetentionLease.ps1
@@ -19,24 +19,28 @@ param(
   [int]$DaysValid,
 
   [Parameter(Mandatory = $true)]
-  [string]$Base64EncodedAuthToken
+  [string]$AccessToken
 )
+
+$unencodedAuthToken = "nobody:$AccessToken"
+$unencodedAuthTokenBytes = [System.Text.Encoding]::UTF8.GetBytes($unencodedAuthToken)
+$encodedAuthToken = [System.Convert]::ToBase64String($unencodedAuthTokenBytes)
 
 . (Join-Path $PSScriptRoot common.ps1)
 
 LogDebug "Checking for existing leases on run: $RunId"
-$existingLeases = Get-RetentionLeases -Organization $Organization -Project $Project -DefinitionId $DefinitionId -RunId $RunId -OwnerId $OwnerId -Base64EncodedAuthToken $Base64EncodedAuthToken
+$existingLeases = Get-RetentionLeases -Organization $Organization -Project $Project -DefinitionId $DefinitionId -RunId $RunId -OwnerId $OwnerId -Base64EncodedAuthToken $encodedAuthToken
 
 if ($existingLeases.count -ne 0) {
     LogDebug "Found $($existingLeases.count) leases, will delete them first."
 
     foreach ($lease in $existingLeases.value) {
         LogDebug "Deleting lease: $($lease.leaseId)"
-        Delete-RetentionLease -Organization $Organization -Project $Project -LeaseId $lease.leaseId -Base64EncodedAuthToken $Base64EncodedAuthToken
+        Delete-RetentionLease -Organization $Organization -Project $Project -LeaseId $lease.leaseId -Base64EncodedAuthToken $encodedAuthToken
     }
 
 }
 
 LogDebug "Creating new lease on run: $RunId"
-$lease = Add-RetentionLease -Organization $Organization -Project $Project -DefinitionId $DefinitionId -RunId $RunId -OwnerId $OwnerId -DaysValid $DaysValid -Base64EncodedAuthToken $Base64EncodedAuthToken
+$lease = Add-RetentionLease -Organization $Organization -Project $Project -DefinitionId $DefinitionId -RunId $RunId -OwnerId $OwnerId -DaysValid $DaysValid -Base64EncodedAuthToken $encodedAuthToken
 LogDebug "Lease ID is: $($lease.value.leaseId)"

--- a/eng/common/scripts/Add-RetentionLease.ps1
+++ b/eng/common/scripts/Add-RetentionLease.ps1
@@ -26,6 +26,13 @@ $unencodedAuthToken = "nobody:$AccessToken"
 $unencodedAuthTokenBytes = [System.Text.Encoding]::UTF8.GetBytes($unencodedAuthToken)
 $encodedAuthToken = [System.Convert]::ToBase64String($unencodedAuthTokenBytes)
 
+# We are doing this here so that there is zero chance that this token is emitted in Azure Pipelines
+# build logs. Azure Pipelines will see this text and register the secret as a value it should *** out
+# before being transmitted to the server (and shown in logs). It means if the value is accidentally
+# leaked anywhere else that it won't be visible. The downside is that when the script is executed
+# on a local development box, it will be visible.
+Write-Host "##vso[task.setvariable variable=_throwawayencodedaccesstoken;issecret=true;]$($encodedAuthToken)"
+
 . (Join-Path $PSScriptRoot common.ps1)
 
 LogDebug "Checking for existing leases on run: $RunId"


### PR DESCRIPTION
This PR fixes the auth on the retains run script. The mistake I was making was assuming that the token that the devops API plumbing took was a straight access token when instead it is a ```base64(username:access_token)``` string.