### PR TITLE
Set multiple sparse checkout paths in one command/job

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -24,14 +24,12 @@ steps:
     - pwsh: |
         git clone --no-checkout --filter=tree:0 git://github.com/${{ repo.Name }} .
         git sparse-checkout init
-        git sparse-checkout set eng
+        $paths = ('${{ convertToJson(parameters.Paths) }}' | ConvertFrom-Json) -Join ' '
+        Invoke-Expression -Command "git sparse-checkout set eng $paths"
+        Write-Host "Set sparse checkout paths to:"
+        Get-Content .git/info/sparse-checkout
       displayName: Init sparse checkout ${{ repo.Name }}
       workingDirectory: ${{ coalesce(repo.WorkingDirectory, format('{0}/{1}', '$(System.DefaultWorkingDirectory)', repo.Name)) }}
-
-    - ${{ each path in parameters.Paths }}:
-      - pwsh: git sparse-checkout add ${{ path }}
-        displayName: Add sparse checkout path ${{ path }}
-        workingDirectory: ${{ coalesce(repo.WorkingDirectory, format('{0}/{1}', '$(System.DefaultWorkingDirectory)', repo.Name)) }}
 
     - pwsh: git checkout ${{ repo.Commitish }}
       displayName: Sparse checkout at ${{ repo.Commitish }}


### PR DESCRIPTION
For pipelines with many paths (e.g. core ci), it can be annoying to have so many separate jobs show up in the UI, one for each path. Additionally, sometimes git tries to do garbage collection and it can take a lot longer to run many `git sparse-checkout add` commands as opposed to a single set command. This PR changes the behavior to parse the yaml paths parameter object into the script, and run a single command to set the sparse checkout paths. I use `invoke-expression` here because otherwise powershell treats the space-separated string as a single parameter and it all ends up on the same line in the sparse checkout config file.