### PR TITLE
DNS resolution failure classifier.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DnsResolutionFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DnsResolutionFailureClassifier.cs
@@ -25,7 +25,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
             return line.Contains("EAI_AGAIN", StringComparison.OrdinalIgnoreCase)
                 || line.Contains("getaddrinfo", StringComparison.OrdinalIgnoreCase)
                 || line.Contains("Temporary failure in name resolution", StringComparison.OrdinalIgnoreCase)
-                || line.Contains("No such host is known", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("No such host is known", StringComparison.OrdinalIgnoreCase);
         }
 
         public async Task ClassifyAsync(FailureAnalyzerContext context)

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DnsResolutionFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DnsResolutionFailureClassifier.cs
@@ -1,0 +1,54 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class DnsResolutionFailureClassifier : IFailureClassifier
+    {
+        public DnsResolutionFailureClassifier(VssConnection vssConnection)
+        {
+            this.vssConnection = vssConnection;
+            buildClient = vssConnection.GetClient<BuildHttpClient>();
+        }
+
+        private VssConnection vssConnection;
+        private BuildHttpClient buildClient;
+
+        private bool IsDnsResolutionFailure(string line)
+        {
+            return (line.Contains("EAI_AGAIN") && line.Contains("getaddrinfo"))
+                || line.Contains("getaddrinfo EAI_AGAIN")
+                || line.Contains("Temporary failure in name resolution")
+                || line.Contains("No such host is known.");
+        }
+
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            var failedTasks = from r in context.Timeline.Records
+                                where r.Result == TaskResult.Failed
+                                where r.RecordType == "Task"
+                                where r.Log != null
+                                select r;
+
+            foreach (var failedTask in failedTasks)
+            {
+                var lines = await buildClient.GetBuildLogLinesAsync(
+                    context.Build.Project.Id,
+                    context.Build.Id,
+                    failedTask.Log.Id
+                    );
+
+                if (lines.Any(line => IsDnsResolutionFailure(line)))
+                {
+                    context.AddFailure(failedTask, "DNS Resolution Failure");
+                }
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DnsResolutionFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DnsResolutionFailureClassifier.cs
@@ -22,10 +22,10 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 
         private bool IsDnsResolutionFailure(string line)
         {
-            return (line.Contains("EAI_AGAIN") && line.Contains("getaddrinfo"))
-                || line.Contains("getaddrinfo EAI_AGAIN")
-                || line.Contains("Temporary failure in name resolution")
-                || line.Contains("No such host is known.");
+            return line.Contains("EAI_AGAIN", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("getaddrinfo", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("Temporary failure in name resolution", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("No such host is known", StringComparison.OrdinalIgnoreCase)
         }
 
         public async Task ClassifyAsync(FailureAnalyzerContext context)

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DnsResolutionFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DnsResolutionFailureClassifier.cs
@@ -25,7 +25,8 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
             return line.Contains("EAI_AGAIN", StringComparison.OrdinalIgnoreCase)
                 || line.Contains("getaddrinfo", StringComparison.OrdinalIgnoreCase)
                 || line.Contains("Temporary failure in name resolution", StringComparison.OrdinalIgnoreCase)
-                || line.Contains("No such host is known", StringComparison.OrdinalIgnoreCase);
+                || line.Contains("No such host is known", StringComparison.OrdinalIgnoreCase)
+                || line.Contains("Couldn't resolve host name", StringComparison.OrdinalIgnoreCase);
         }
 
         public async Task ClassifyAsync(FailureAnalyzerContext context)

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -89,6 +89,8 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, AzuriteInstallFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, MavenBrokenPipeFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, CodeSigningFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, AzureArtifactsServiceUnavailableClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, DnsResolutionFailureClassifier>();
         }
     }
 }


### PR DESCRIPTION
This classifier looks for DNS resolution failures on failed tasks. We've got a set of previously identified errors which we are using in our search patterns.

The PR also enables a previously added classifier which I had not enabled yet.