### PR TITLE
Allow propogation of SetDevVersion.

### DIFF
--- a/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
+++ b/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
@@ -19,6 +19,7 @@ steps:
     if (('$(Build.Reason)' -in 'Schedule', 'IndividualCI') -and ('$(System.TeamProject)' -eq 'internal')) {
       $setDailyDevBuild = "true"
     }
-    echo "##vso[task.setvariable variable=SetDevVersion]$setDailyDevBuild"
+    echo "##vso[task.setvariable variable=SetDevVersion;isOutput=true]$setDailyDevBuild"
+  name: SetupVersioningProperties
   displayName: "Setup Versioning Properties"
   condition: eq(variables['SetDevVersion'], '')

--- a/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
+++ b/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
@@ -19,7 +19,10 @@ steps:
     if (('$(Build.Reason)' -in 'Schedule', 'IndividualCI') -and ('$(System.TeamProject)' -eq 'internal')) {
       $setDailyDevBuild = "true"
     }
-    echo "##vso[task.setvariable variable=SetDevVersion;isOutput=true]$setDailyDevBuild"
-  name: SetupVersioningProperties
+    echo "##vso[task.setvariable variable=SetDevVersion]$setDailyDevBuild"
   displayName: "Setup Versioning Properties"
   condition: eq(variables['SetDevVersion'], '')
+- pwsh: |
+    echo "##vso[task.setvariable variable=SetDevVersion;isOutput=true]$(SetDevVersion)"
+  name: VersioningProperties
+  displayName: "Export Versioning Properties"


### PR DESCRIPTION
This PR adds a task which takes the ```SetDevVersion``` property which is local to the job and exports so it can be used across jobs and stages. Example usage:

```yaml
- stage: Integration
  variables:
    SetDevVersion: $[stageDependencies.Build.Build.outputs['VersioningProperties.SetDevVersion']]
```