### PR TITLE
Add Go links to cache to enable faster validation

### DIFF
--- a/eng/pipelines/githubio-linkcheck.yml
+++ b/eng/pipelines/githubio-linkcheck.yml
@@ -1,6 +1,8 @@
 trigger: none
 pr: none
 
+timeoutInMinutes: 120
+
 pool:
   vmImage: 'ubuntu-18.04'
 
@@ -75,6 +77,18 @@ steps:
     filePath: eng/common/scripts/Verify-Links.ps1
     arguments: >
       -urls "https://azure.github.io/azure-sdk-for-python/index.html"
+      -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+      -inputCacheFile "$(cachefile)"
+      -outputCacheFile "$(cachefile)"
+      -devOpsLogging: $true
+
+- task: PowerShell@2
+  displayName: 'go link check'
+  inputs:
+    pwsh: true
+    filePath: eng/common/scripts/Verify-Links.ps1
+    arguments: >
+      -urls "https://raw.githubusercontent.com/Azure/azure-sdk-for-go/master/CHANGELOG.md"
       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
       -inputCacheFile "$(cachefile)"
       -outputCacheFile "$(cachefile)"


### PR DESCRIPTION
This changed depends on the fix in https://github.com/Azure/azure-sdk-tools/pull/1580 to fully enable caching of the MD file links in the go repo. 

This PR also increases the timeout of the pipeline because we have been very close to the default 60 mins for a while and this new caching will likely push it over the limit. 