### PR TITLE
Sparse checkout docs repository in release step

### DIFF
--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -14,11 +14,13 @@ parameters:
   Language: ''
   DocRepoDestinationPath: '' #usually docs-ref-services/
   CIConfigs: '[]'
-  GHReviewersVariable: '' 
+  GHReviewersVariable: ''
   GHTeamReviewersVariable: '' # externally set, as eng-common does not have the identity-resolver. Run as pre-step
   OnboardingBranch: ''
   CloseAfterOpenForTesting: false
   SkipPackageJson: false
+  Paths:
+    - '/*'
 
 steps:
 - pwsh: |
@@ -30,14 +32,19 @@ steps:
       Write-Host "This script is not executing on Windows, skipping registry modification."
     }
   displayName: Enable Long Paths if Necessary
-  
-- pwsh: |
-    git clone https://github.com/${{ parameters.TargetDocRepoOwner }}/${{ parameters.TargetDocRepoName }} ${{ parameters.WorkingDirectory }}/repo
-  displayName: Clone Documentation Repository
-  ignoreLASTEXITCODE: false
+
+- template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+  parameters:
+    SkipDefaultCheckout: true
+    Repositories:
+      - Name: ${{ parameters.TargetDocRepoOwner }}/${{ parameters.TargetDocRepoName }}
+        Commitish: master
+        WorkingDirectory: ${{ parameters.WorkingDirectory }}/repo
+    Paths: ${{ parameters.Paths }}
+
 - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
   parameters:
-    WorkingDirectory: ${{ parameters.WorkingDirectory }}/repo 
+    WorkingDirectory: ${{ parameters.WorkingDirectory }}/repo
 - task: PowerShell@2
   displayName: 'Apply Documentation Updates From Artifact'
   inputs:

--- a/eng/common/pipelines/templates/steps/docs-metadata-release.yml
+++ b/eng/common/pipelines/templates/steps/docs-metadata-release.yml
@@ -1,26 +1,65 @@
 # intended to be used as part of a release process
 parameters:
-  ArtifactLocation: 'not-specified'
-  PackageRepository: 'not-specified'
-  ReleaseSha: 'not-specified'
-  RepoId: $(Build.Repository.Name)
-  WorkingDirectory: ''
-  ScriptDirectory: eng/common/scripts
-  TargetDocRepoName: ''
-  TargetDocRepoOwner: ''
-  PRBranchName: 'master-rdme'
-  PRLabels: 'auto-merge'
-  ArtifactName: ''
-  Language: ''
-  DocRepoDestinationPath: '' #usually docs-ref-services/
-  CIConfigs: '[]'
-  GHReviewersVariable: ''
-  GHTeamReviewersVariable: '' # externally set, as eng-common does not have the identity-resolver. Run as pre-step
-  OnboardingBranch: ''
-  CloseAfterOpenForTesting: false
-  SkipPackageJson: false
-  Paths:
-    - '/*'
+  - name: ArtifactLocation
+    type: string
+    default: 'not-specified'
+  - name: PackageRepository
+    type: string
+    default: 'not-specified'
+  - name: ReleaseSha
+    type: string
+    default: 'not-specified'
+  - name: RepoId
+    type: string
+    default: $(Build.Repository.Name)
+  - name: WorkingDirectory
+    type: string
+    default: ''
+  - name: ScriptDirectory
+    type: string
+    default: eng/common/scripts
+  - name: TargetDocRepoName
+    type: string
+    default: ''
+  - name: TargetDocRepoOwner
+    type: string
+    default: ''
+  - name: PRBranchName
+    type: string
+    default: 'master-rdme'
+  - name: PRLabels
+    type: string
+    default: 'auto-merge'
+  - name: ArtifactName
+    type: string
+    default: ''
+  - name: Language
+    type: string
+    default: ''
+  - name: DocRepoDestinationPath
+    type: string
+    default: '' #usually docs-ref-services/
+  - name: CIConfigs
+    type: string
+    default: '[]'
+  - name: GHReviewersVariable
+    type: string
+    default: ''
+  - name: GHTeamReviewersVariable
+    type: string
+    default: ''  # externally set, as eng-common does not have the identity-resolver. Run as pre-step
+  - name: OnboardingBranch
+    type: string
+    default: ''
+  - name: CloseAfterOpenForTesting
+    type: boolean
+    default: false
+  - name: SkipPackageJson
+    type: object
+    default: false
+  - name: SparseCheckoutPaths
+    type: object
+    default: null
 
 steps:
 - pwsh: |
@@ -33,14 +72,20 @@ steps:
     }
   displayName: Enable Long Paths if Necessary
 
-- template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-  parameters:
-    SkipDefaultCheckout: true
-    Repositories:
-      - Name: ${{ parameters.TargetDocRepoOwner }}/${{ parameters.TargetDocRepoName }}
-        Commitish: master
-        WorkingDirectory: ${{ parameters.WorkingDirectory }}/repo
-    Paths: ${{ parameters.Paths }}
+- ${{ if not(parameters.SparseCheckoutPaths) }}:
+  - pwsh: |
+      git clone https://github.com/${{ parameters.TargetDocRepoOwner }}/${{ parameters.TargetDocRepoName }} ${{ parameters.WorkingDirectory }}/repo
+    displayName: Clone Documentation Repository
+    ignoreLASTEXITCODE: false
+
+- ${{ if parameters.SparseCheckoutPaths }}:
+  - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+    parameters:
+      SkipDefaultCheckout: true
+      Repositories:
+        - Name: ${{ parameters.TargetDocRepoOwner }}/${{ parameters.TargetDocRepoName }}
+          WorkingDirectory: ${{ parameters.WorkingDirectory }}/repo
+      Paths: ${{ parameters.SparseCheckoutPaths }}
 
 - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
   parameters:

--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -32,6 +32,7 @@ steps:
       displayName: Init sparse checkout ${{ repo.Name }}
       workingDirectory: ${{ coalesce(repo.WorkingDirectory, format('{0}/{1}', '$(System.DefaultWorkingDirectory)', repo.Name)) }}
 
-    - pwsh: git checkout ${{ repo.Commitish }}
-      displayName: Sparse checkout at ${{ repo.Commitish }}
+    - pwsh: |
+        git checkout ${{ repo.Commitish }}  # this will use the default branch if repo.Commitish is empty
+      displayName: Sparse checkout at ${{ coalesce(repo.Commitish, 'default branch') }}
       workingDirectory: ${{ coalesce(repo.WorkingDirectory, format('{0}/{1}', '$(System.DefaultWorkingDirectory)', repo.Name)) }}

--- a/eng/pipelines/templates/steps/sync-repo-branch.yml
+++ b/eng/pipelines/templates/steps/sync-repo-branch.yml
@@ -3,14 +3,14 @@ parameters:
   # Example:
   #   Azure/azure-rest-api-specs:
   #     Branch: master
-  #     TargetRepos: 
+  #     TargetRepos:
   #       Azure/azure-rest-api-specs-pr:
   #       azure-sdk/azure-rest-api-specs:
   #         Branch: dev
   #         Rebase: true
   #   Azure/azure-sdk-for-go:
   #     Branch: master
-  #     TargetRepos: 
+  #     TargetRepos:
   #       Azure/azure-sdk-for-go-pr:
   - name: Repos
     type: object
@@ -40,7 +40,7 @@ steps:
         Write-Host "No source branch. Fetch default branch $defaultBranch."
         $SourceBranch = $defaultBranch
       }
-      
+
       git fetch --no-tags Source $SourceBranch
       if ($LASTEXITCODE -ne 0) {
         Write-Host "#`#vso[task.logissue type=error]Failed to fetch ${SourceRepo}:${SourceBranch}"


### PR DESCRIPTION
In our release stages, we do a full git clone of the docs repo. This can add up to 4 minutes of time to the release stage. Checking out only the files we need reduces that time to around 10 seconds.