### PR TITLE
Fix #725 & #1310

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
@@ -182,5 +182,22 @@ namespace RandomNamespace
                 .WithDisabledDiagnostics("AZC0015")
                 .RunAsync();
         }
+
+        [Fact]
+        public async Task AZC0002NotProducedForEvents()
+        {
+            const string code = @"
+using System;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public event Func<EventArgs, Task> EventAsync;
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0008Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0008Tests.cs
@@ -23,6 +23,19 @@ namespace RandomNamespace
         }
 
         [Fact]
+        public async Task AZC0008NotProducedForAbstractClientOptionsWithoutServiceVersionEnum()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public abstract class SomeClientOptions { 
+
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
         public async Task AZC0008NotProducedForClientOptionsWithServiceVersionEnum()
         {
             const string code = @"

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -116,7 +116,7 @@ namespace Azure.ClientSdk.Analyzers
             INamedTypeSymbol type = (INamedTypeSymbol)context.Symbol;
             foreach (var member in type.GetMembers())
             {
-                if (member is IMethodSymbol methodSymbol && methodSymbol.Name.EndsWith(AsyncSuffix) && member.DeclaredAccessibility == Accessibility.Public)
+                if (member is IMethodSymbol methodSymbol && IsMethod(methodSymbol) && methodSymbol.Name.EndsWith(AsyncSuffix) && member.DeclaredAccessibility == Accessibility.Public)
                 {
                     CheckClientMethod(context, methodSymbol);
 
@@ -134,6 +134,14 @@ namespace Azure.ClientSdk.Analyzers
                     }
                 }
             }
+
+            static bool IsMethod(IMethodSymbol methodSymbol) =>
+                methodSymbol.MethodKind switch
+                {
+                    MethodKind.Ordinary => true,
+                    MethodKind.ExplicitInterfaceImplementation => true,
+                    _ => false
+                };
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientOptionsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientOptionsAnalyzer.cs
@@ -25,7 +25,7 @@ namespace Azure.ClientSdk.Analyzers
         public override void Analyze(ISymbolAnalysisContext symbolAnalysisContext)
         {
             var typeSymbol = (INamedTypeSymbol)symbolAnalysisContext.Symbol;
-            if (typeSymbol.TypeKind != TypeKind.Class || !typeSymbol.Name.EndsWith(ClientOptionsSuffix) || typeSymbol.DeclaredAccessibility != Accessibility.Public)
+            if (typeSymbol.TypeKind != TypeKind.Class || !typeSymbol.Name.EndsWith(ClientOptionsSuffix) || typeSymbol.DeclaredAccessibility != Accessibility.Public || typeSymbol.IsAbstract)
             {
                 return;
             }


### PR DESCRIPTION
- Fix #725: AZC0008: ClientOptions should have a nested enum called ServiceVersion should not be triggered for abstract classes
- Fix #1310: Handle events that are part of client API surface