### PR TITLE
API-based default branch script

### DIFF
--- a/eng/common/scripts/Set-DefaultBranchVariable.ps1
+++ b/eng/common/scripts/Set-DefaultBranchVariable.ps1
@@ -8,8 +8,8 @@ param (
 
 . (Join-Path $PSScriptRoot common.ps1)
 
-LogDebug "$$RepoOwner was: $RepoOwner"
-LogDebug "$$RepoName was: $RepoName"
+LogDebug "`$RepoOwner was: $RepoOwner"
+LogDebug "`$RepoName was: $RepoName"
 
 try
 {

--- a/eng/common/scripts/Set-DefaultBranchVariable.ps1
+++ b/eng/common/scripts/Set-DefaultBranchVariable.ps1
@@ -1,0 +1,36 @@
+param (
+    [Parameter(Mandatory = $true)]
+    [string]$RepoOwner,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoName
+)
+
+. (Join-Path $PSScriptRoot common.ps1)
+
+LogDebug "$$RepoOwner was: $RepoOwner"
+LogDebug "$$RepoName was: $RepoName"
+
+try
+{
+    if ($RepoName -like "*-pr") {
+        LogDebug "Assuming private repository, translating repository name to public version"
+        $publicRepositoryName = $RepoName.Substring(0, $RepoName.Length - 3)
+    } else {
+        LogDebug "Assuming public repository"
+        $publicRepositoryName = $RepoName
+    }
+
+    LogDebug "Computed repository name is: $publicRepositoryName"
+    $uri = "https://api.github.com/repos/$RepoOwner/$publicRepositoryName"
+    LogDebug "Computed request URI is: $uri"
+
+    $repository = Invoke-RestMethod -Uri $uri
+    Write-Host "##vso[task.setvariable variable=DefaultBranch;isOutput=true]$($repository.default_branch)"
+}
+catch
+{
+    Write-Error "Set-DefaultBranchVariable failed with exception:`n$_"
+    exit 1
+}
+

--- a/eng/common/scripts/Set-DefaultBranchVariable.ps1
+++ b/eng/common/scripts/Set-DefaultBranchVariable.ps1
@@ -3,34 +3,44 @@ param (
     [string]$RepoOwner,
 
     [Parameter(Mandatory = $true)]
-    [string]$RepoName
+    [string]$RepoName,
+
+    [Parameter(Mandatory = $true)]
+    [string]$RepoPath
 )
 
 . (Join-Path $PSScriptRoot common.ps1)
 
 LogDebug "`$RepoOwner was: $RepoOwner"
 LogDebug "`$RepoName was: $RepoName"
+LogDebug "`$RepoPath was: $RepoPath"
 
 try
 {
-    if ($RepoName -like "*-pr") {
-        LogDebug "Assuming private repository, translating repository name to public version"
-        $publicRepositoryName = $RepoName.Substring(0, $RepoName.Length - 3)
-    } else {
-        LogDebug "Assuming public repository"
-        $publicRepositoryName = $RepoName
-    }
+    $gitHubAuthorizationHeader = Get-GitHubAuthorizationHeaderFromRepository -RepoPath $RepoPath
 
-    LogDebug "Computed repository name is: $publicRepositoryName"
-    $uri = "https://api.github.com/repos/$RepoOwner/$publicRepositoryName"
+    if (!$gitHubAuthorizationHeader) {
+        # This might seem a bit wierd, but when we make a call to a public GitHub repo
+        # with a totally malformed credential it seems to work just fine (it looks like
+        # public repos don't even bother to check credentials for public API calls). There
+        # might be a rate limiting issue in the future but you would overcome that by
+        # using the persistCredentials: true option on the AzP checkout task.
+
+        LogWarn "No authorization header detected!"
+        $gitHubAuthorizationHeader = "Basic dummy-value-works-for-public-repos"
+    }
+    
+    $gitHubAuthorizationHeaderBytes = [System.Text.Encoding]::UTF8.GetBytes($gitHubAuthorizationHeader)
+    $base64EncodedGitHubAuthorizationHeader = [System.Convert]::ToBase64String($gitHubAuthorizationHeaderBytes)
+
+    $uri = "https://api.github.com/repos/$RepoOwner/$RepoName"
     LogDebug "Computed request URI is: $uri"
 
-    $repository = Invoke-RestMethod -Uri $uri
-    Write-Host "##vso[task.setvariable variable=DefaultBranch;isOutput=true]$($repository.default_branch)"
+    $defaultBranch = Get-GitHubDefaultBranch -RepoOwner $RepoOwner -RepoName $RepoName -AuthToken $base64EncodedGitHubAuthorizationHeader
+    Write-Host "##vso[task.setvariable variable=DefaultBranch;isOutput=true]$defaultBranch"
 }
 catch
 {
     Write-Error "Set-DefaultBranchVariable failed with exception:`n$_"
     exit 1
 }
-


### PR DESCRIPTION
This PR introduces a script which calls the public GitHub REST API to get the default branch name. In order to support running in PR on a private repo with no access token to query the private, I translate the URL to the public repo which _should_ have the same branch configuration.

At this point I'm just landing the script so that I can do some testing with the YAML in our real pipelines.

Script usage:

```pwsh
.\Set-DefaultBranchVariable.ps1 -RepoOwner Azure -RepoName azure-sdk-for-net-pr -Debug
```

Output:

```
DEBUG: $RepoOwner was: Azure
DEBUG: $RepoName was: azure-sdk-for-net-pr
DEBUG: Assuming private repository, translating repository name to public version
DEBUG: Computed repository name is: azure-sdk-for-net
DEBUG: Computed request URI is: https://api.github.com/repos/Azure/azure-sdk-for-net
```