### PR TITLE
Add more partner subscriptions to live test cleanup pipeline

### DIFF
--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -55,10 +55,40 @@ stages:
 
       - pwsh: |
           $subscriptionConfiguration = @'
-            $(acs-subscription-configuration)
+            $(sub-config-communication-int-test-resources)
+          '@ | ConvertFrom-Json -AsHashtable
+
+          ./tools/live-test-cleanup/cleanup.ps1 `
+          @subscriptionConfiguration `
+          -Verbose
+        displayName: Clean up subscription resources (PreProduction ACS Subscription)
+
+      - template: /eng/common/TestResources/build-test-resource-config.yml
+        parameters:
+          SubscriptionConfigurations:
+            - $(sub-config-azure-cloud-test-resources)
+            - $(sub-config-communication-services-cloud-test-resources)
+      - pwsh: |
+          $subscriptionConfiguration = @'
+            $(SubscriptionConfiguration)
           '@ | ConvertFrom-Json -AsHashtable
 
           ./tools/live-test-cleanup/cleanup.ps1 `
           @subscriptionConfiguration `
           -Verbose
         displayName: Clean up subscription resources (AzureCloud ACS Subscription)
+
+      - template: /eng/common/TestResources/build-test-resource-config.yml
+        parameters:
+          SubscriptionConfigurations:
+            - $(sub-config-azure-cloud-test-resources)
+            - $(sub-config-cosmos-azure-cloud-test-resources)
+      - pwsh: |
+          $subscriptionConfiguration = @'
+            $(SubscriptionConfiguration)
+          '@ | ConvertFrom-Json -AsHashtable
+
+          ./tools/live-test-cleanup/cleanup.ps1 `
+          @subscriptionConfiguration `
+          -Verbose
+        displayName: Clean up subscription resources (AzureCloud Cosmos Subscription)

--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -13,7 +13,11 @@ stages:
       vmImage: ubuntu-16.04
 
     steps:
+      # Register the dogfood environment to clean up ACS custom subscription
+      - template: /eng/common/TestResources/setup-az-modules.yml
+
       - pwsh: |
+          eng/common/TestResources/Import-AzModules.ps1
           $subscriptionConfiguration = @'
             $(sub-config-azure-cloud-test-resources)
           '@ | ConvertFrom-Json -AsHashtable
@@ -24,6 +28,7 @@ stages:
         displayName: Clean up subscription resources (AzureCloud)
 
       - pwsh: |
+          eng/common/TestResources/Import-AzModules.ps1
           $subscriptionConfiguration = @'
             $(sub-config-azure-cloud-test-resources-preview)
           '@ | ConvertFrom-Json -AsHashtable
@@ -34,6 +39,7 @@ stages:
         displayName: Clean up subscription resources (AzureCloud-Preview)
 
       - pwsh: |
+          eng/common/TestResources/Import-AzModules.ps1
           $subscriptionConfiguration = @'
             $(sub-config-gov-test-resources)
           '@ | ConvertFrom-Json -AsHashtable
@@ -44,6 +50,7 @@ stages:
         displayName: Clean up subscription resources (AzureUSGovernment)
 
       - pwsh: |
+          eng/common/TestResources/Import-AzModules.ps1
           $subscriptionConfiguration = @'
             $(sub-config-cn-test-resources)
           '@ | ConvertFrom-Json -AsHashtable
@@ -54,6 +61,7 @@ stages:
         displayName: Clean up subscription resources (AzureChinaCloud)
 
       - pwsh: |
+          eng/common/TestResources/Import-AzModules.ps1
           $subscriptionConfiguration = @'
             $(sub-config-communication-int-test-resources)
           '@ | ConvertFrom-Json -AsHashtable
@@ -61,14 +69,15 @@ stages:
           ./tools/live-test-cleanup/cleanup.ps1 `
           @subscriptionConfiguration `
           -Verbose
-        displayName: Clean up subscription resources (PreProduction ACS Subscription)
+        displayName: Clean up subscription resources (Dogfood ACS)
 
       - template: /eng/common/TestResources/build-test-resource-config.yml
         parameters:
           SubscriptionConfigurations:
             - $(sub-config-azure-cloud-test-resources)
-            - $(sub-config-communication-services-cloud-test-resources)
+            - $(sub-config-communication-services-cloud-test-resources-common)
       - pwsh: |
+          eng/common/TestResources/Import-AzModules.ps1
           $subscriptionConfiguration = @'
             $(SubscriptionConfiguration)
           '@ | ConvertFrom-Json -AsHashtable
@@ -76,7 +85,7 @@ stages:
           ./tools/live-test-cleanup/cleanup.ps1 `
           @subscriptionConfiguration `
           -Verbose
-        displayName: Clean up subscription resources (AzureCloud ACS Subscription)
+        displayName: Clean up subscription resources (AzureCloud ACS)
 
       - template: /eng/common/TestResources/build-test-resource-config.yml
         parameters:
@@ -84,6 +93,7 @@ stages:
             - $(sub-config-azure-cloud-test-resources)
             - $(sub-config-cosmos-azure-cloud-test-resources)
       - pwsh: |
+          eng/common/TestResources/Import-AzModules.ps1
           $subscriptionConfiguration = @'
             $(SubscriptionConfiguration)
           '@ | ConvertFrom-Json -AsHashtable
@@ -91,4 +101,4 @@ stages:
           ./tools/live-test-cleanup/cleanup.ps1 `
           @subscriptionConfiguration `
           -Verbose
-        displayName: Clean up subscription resources (AzureCloud Cosmos Subscription)
+        displayName: Clean up subscription resources (AzureCloud Cosmos)


### PR DESCRIPTION
This adds two public cloud subscriptions managed by the ACS and Cosmos partner teams to our live test cleanup job.