### PR TITLE
Chunk ordering error classifier.

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CacheChunkOrderingFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CacheChunkOrderingFailureClassifier.cs
@@ -1,0 +1,44 @@
+﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
+    public class CacheChunkOrderingFailureClassifier : IFailureClassifier
+    {
+        public CacheChunkOrderingFailureClassifier(VssConnection vssConnection)
+        {
+            this.vssConnection = vssConnection;
+            buildClient = vssConnection.GetClient<BuildHttpClient>();
+        }
+
+        private VssConnection vssConnection;
+        private BuildHttpClient buildClient;
+
+        private bool IsChunkOrderingError(string message)
+        {
+            return message.StartsWith("Chunks are not arriving in order or sizes are not matched up");
+        }
+
+        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        {
+            var failedTasks = from r in context.Timeline.Records
+                                where r.Result == TaskResult.Failed
+                                where r.RecordType == "Task"
+                                where r.Task != null
+                                where r.Task.Name == "Cache"
+                                where r.Log != null
+                                select r;
+
+            foreach (var failedTask in failedTasks.Where(t => t.Issues.Any(i => IsChunkOrderingError(i.Message))))
+            {
+                context.AddFailure(failedTask, "Cache Chunk Ordering");
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -91,6 +91,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<IFailureClassifier, CodeSigningFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, AzureArtifactsServiceUnavailableClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, DnsResolutionFailureClassifier>();
+            builder.Services.AddSingleton<IFailureClassifier, CacheChunkOrderingFailureClassifier>();
         }
     }
 }


### PR DESCRIPTION
This classifier looks for a chunk ordering error in our build pipelines. It was observed on this build:

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=866560&view=logs&j=32afe1f3-cae1-5682-187c-9a515535777f&t=eb790175-775e-5b46-331b-d42a59e01ffd&l=107