### PR TITLE
Use sparse checkout for eng/common sync PRs

### DIFF
--- a/eng/common/pipelines/templates/steps/create-pull-request.yml
+++ b/eng/common/pipelines/templates/steps/create-pull-request.yml
@@ -13,7 +13,7 @@ parameters:
   PRTitle: not-specified
   PRBody: ''
   ScriptDirectory: eng/common/scripts
-  GHReviewersVariable: '' 
+  GHReviewersVariable: ''
   GHTeamReviewersVariable: ''
   GHAssignessVariable: ''
   # Multiple labels seperated by comma, e.g. "bug, APIView"
@@ -33,7 +33,7 @@ steps:
     PushArgs: ${{ parameters.PushArgs }}
     WorkingDirectory: ${{ parameters.WorkingDirectory }}
     ScriptDirectory: ${{ parameters.ScriptDirectory }}
-    SkipCheckingForChanges: ${{ parameters.SkipCheckingForChanges }} 
+    SkipCheckingForChanges: ${{ parameters.SkipCheckingForChanges }}
 
 - task: PowerShell@2
   displayName: Create pull request

--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -20,6 +20,7 @@ steps:
     - pwsh: |
         $dir = "${{ coalesce(repo.WorkingDirectory, format('{0}/{1}', '$(System.DefaultWorkingDirectory)', repo.Name)) }}"
         New-Item $dir -ItemType Directory -Force
+      displayName: Create ${{ repo.Name }} directories
 
     - pwsh: |
         git clone --no-checkout --filter=tree:0 git://github.com/${{ repo.Name }} .

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -47,6 +47,11 @@ stages:
           displayName: Sync ${{ parameters.DirectoryToSync }} Directory
 
           steps:
+            - template: /eng/common/pipelines/steps/sparse-checkout.yml
+              parameters:
+                Paths:
+                  - ${{ parameters.DirectoryToSync }}
+
             - pwsh: |
                 Set-PsDebug -Trace 1
                 $patchDir = "$(Build.ArtifactStagingDirectory)/patchfiles"

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -11,7 +11,7 @@ parameters:
   default: eng/common
 - name: BaseBranchName
   type: string
-  default: $(Build.SourceBranchName)
+  default: $(Build.SourceBranch)
 - name: Repos
   type: object
   default:

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -47,7 +47,7 @@ stages:
           displayName: Sync ${{ parameters.DirectoryToSync }} Directory
 
           steps:
-            - template: /eng/common/pipelines/steps/sparse-checkout.yml
+            - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
               parameters:
                 Paths:
                   - ${{ parameters.DirectoryToSync }}
@@ -140,13 +140,13 @@ stages:
                         Add-Content -Path "$(Build.ArtifactStagingDirectory)/${{ parameters.PRDataFileName }}" -Value $PRData
                       displayName: Write Sync PR Data to Artifact File
                       condition: succeeded()
-                  
+
                   - task: PublishPipelineArtifact@1
                     condition: succeeded()
-                    displayName: Publish ${{ parameters.PRDataFileName }} 
+                    displayName: Publish ${{ parameters.PRDataFileName }}
                     inputs:
                       artifactName: ${{ parameters.ArtifactName }}
-                      path: $(Build.ArtifactStagingDirectory)/${{ parameters.PRDataFileName }} 
+                      path: $(Build.ArtifactStagingDirectory)/${{ parameters.PRDataFileName }}
 
     - stage: VerifyAndMerge
       jobs:

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -12,12 +12,16 @@ parameters:
 
 steps:
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+    parameters:
+      Paths:
+        - ${{ parameters.DirectoryToSync }}
+      Repositories:
+        - ${{ each repo in parameters.Repos }}:
+          - Name: Azure/${{ repo }}
+            WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
+
   - ${{ each repo in parameters.Repos }}:
-    - pwsh: |
-        Set-PsDebug -Trace 1
-        git clone --branch ${{ parameters.BaseBranchName }} https://github.com/azure/${{ repo }}
-      displayName: Clone ${{ repo }}
-      workingDirectory: $(System.DefaultWorkingDirectory)
     - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     - pwsh: |
         $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
@@ -31,7 +35,7 @@ steps:
           {
              Write-Host $file.FullName
              git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" am -3 $file.FullName
-             if ($lastExitCode -ne 0) { 
+             if ($lastExitCode -ne 0) {
                git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" am --show-current-patch=diff
                Write-Error "##vso[task.LogIssue type=warning;]Failed to properly apply patch files to [https://github.com/azure/${{ repo }}]"
                exit 1
@@ -121,10 +125,19 @@ steps:
         -AuthToken "$(azuresdk-github-pat)"
 
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
+  - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+    parameters:
+      Paths:
+        - ${{ parameters.DirectoryToSync }}
+      Repositories:
+        - ${{ each repo in parameters.Repos }}:
+          - Name: Azure/${{ repo }}
+            Commitish: ${{ parameters.BaseBranchName }}
+            WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
+
   - ${{ each repo in parameters.Repos }}:
     - pwsh: |
         Set-PsDebug -Trace 1
-        git clone --branch ${{ parameters.BaseBranchName }} https://github.com/azure/${{ repo }}
         $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
         if (!(Test-Path $repoPath)) { mkdir $repoPath }
         Remove-Item -v -r $repoPath

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -153,6 +153,7 @@ steps:
     - template: /eng/common/pipelines/templates/steps/create-pull-request.yml
       parameters:
         RepoName: ${{ repo }}
+        BaseBranchName: ${{ parameters.BaseBranchName }}
         PRBranchName: sync-${{ parameters.DirectoryToSync }}
         CommitMsg: ${{ parameters.CommitMessage }}
         PRTitle: ${{ parameters.CommitMessage }}

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -16,6 +16,7 @@ steps:
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
   - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
     parameters:
+      SkipDefaultCheckout: true
       Paths:
         - ${{ parameters.DirectoryToSync }}
       Repositories:
@@ -129,6 +130,7 @@ steps:
 - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:
   - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
     parameters:
+      SkipDefaultCheckout: true
       Paths:
         - ${{ parameters.DirectoryToSync }}
       Repositories:

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -11,6 +11,8 @@ parameters:
   PushArgs: -f
 
 steps:
+- template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+
 - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
   - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
     parameters:
@@ -18,11 +20,11 @@ steps:
         - ${{ parameters.DirectoryToSync }}
       Repositories:
         - ${{ each repo in parameters.Repos }}:
-          - Name: Azure/${{ repo }}
+          - Name: ${{ parameters.PROwner }}/${{ repo }}
+            Commitish: ${{ parameters.BaseBranchName }}
             WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
 
   - ${{ each repo in parameters.Repos }}:
-    - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     - pwsh: |
         $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
         if (Test-Path '$(PatchFilesLocation)')
@@ -134,7 +136,7 @@ steps:
           Commitish: $(Build.SourceVersion)
           WorkingDirectory: $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)
         - ${{ each repo in parameters.Repos }}:
-          - Name: Azure/${{ repo }}
+          - Name: ${{ parameters.PROwner }}/${{ repo }}
             Commitish: ${{ parameters.BaseBranchName }}
             WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
 
@@ -159,4 +161,4 @@ steps:
         PRTitle: ${{ parameters.CommitMessage }}
         PushArgs: -f
         WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
-        ScriptDirectory: $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)/eng/common/scripts
+        ScriptDirectory: $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)/${{ parameters.ScriptDirectory }}

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -130,6 +130,9 @@ steps:
       Paths:
         - ${{ parameters.DirectoryToSync }}
       Repositories:
+        - Name: $(Build.Repository.Name)
+          Commitish: $(Build.SourceVersion)
+          WorkingDirectory: $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)
         - ${{ each repo in parameters.Repos }}:
           - Name: Azure/${{ repo }}
             Commitish: ${{ parameters.BaseBranchName }}
@@ -139,9 +142,10 @@ steps:
     - pwsh: |
         Set-PsDebug -Trace 1
         $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
-        if (!(Test-Path $repoPath)) { mkdir $repoPath }
-        Remove-Item -v -r $repoPath
-        Copy-Item -v -r $(Build.SourcesDirectory)/${{ parameters.DirectoryToSync }} $repoPath
+        Remove-Item -v -r -ErrorAction Ignore $repoPath
+        Copy-Item -v -r `
+          $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)/${{ parameters.DirectoryToSync }} `
+          $repoPath
         Get-ChildItem -r $repoPath
       displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}
       workingDirectory: $(System.DefaultWorkingDirectory)
@@ -154,4 +158,4 @@ steps:
         PRTitle: ${{ parameters.CommitMessage }}
         PushArgs: -f
         WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo }}
-        ScriptDirectory: $(System.DefaultWorkingDirectory)/eng/common/scripts
+        ScriptDirectory: $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)/eng/common/scripts


### PR DESCRIPTION
We're spending 10+ minutes sequentially cloning repos in order to create the patch files for our sync PRs, when those files are localized to a single directory. We could eliminate ~99% of this time by doing a sparse checkout instead.