### PR TITLE
Allow Multiple Invocations of `archetype-sdk-tests-generate` within the same stage

### DIFF
--- a/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
+++ b/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
@@ -31,9 +31,14 @@ parameters:
 - name: OsVmImage
   type: string
   default: MMSUbuntu18.04
+# This parameter is only necessary if there are multiple invocations of this template within the SAME STAGE.
+# When that occurs, provide a name other than the default value.
+- name: GenerateJobName
+  type: string
+  default: 'generate_matrix'
 
 jobs:
-- job: generate_matrix
+- job: ${{ parameters.GenerateJobName }}
   variables:
     displayNameFilter: $[ coalesce(variables.jobMatrixFilter, '.*') ]
   pool:
@@ -89,8 +94,8 @@ jobs:
     - template: ${{ parameters.JobTemplatePath }}
       parameters:
         UsePlatformContainer: false
-        Matrix: dependencies.generate_matrix.outputs['generate_vm_job_matrix_${{ config.Name }}.matrix']
-        DependsOn: generate_matrix
+        Matrix: dependencies.${{ parameters.GenerateJobName }}.outputs['generate_vm_job_matrix_${{ config.Name }}.matrix']
+        DependsOn: ${{ parameters.GenerateJobName }}
         CloudConfig: ${{ parameters.CloudConfig }}
         ${{ each param in parameters.AdditionalParameters }}:
           ${{ param.key }}: ${{ param.value }}
@@ -99,8 +104,8 @@ jobs:
     - template: ${{ parameters.JobTemplatePath }}
       parameters:
         UsePlatformContainer: true
-        Matrix: dependencies.generate_matrix.outputs['generate_container_job_matrix_${{ config.Name }}.matrix']
-        DependsOn: generate_matrix
+        Matrix: dependencies.${{ parameters.GenerateJobName }}.outputs['generate_container_job_matrix_${{ config.Name }}.matrix']
+        DependsOn: ${{ parameters.GenerateJobName }}
         CloudConfig: ${{ parameters.CloudConfig }}
         ${{ each param in parameters.AdditionalParameters }}:
           ${{ param.key }}: ${{ param.value }}


### PR DESCRIPTION
This is a super useful template, but I need to run it twice!

See example PR [over here](https://github.com/Azure/azure-sdk-for-python/pull/18478)

And example run of what I want in an example run [here](https://dev.azure.com/azure-sdk/public/_build/results?buildId=885368&view=logs&j=b4945417-8893-551a-3bcc-9c043455cb7a).

Without these changes, we run into "duplicate job id" when we attempt to run it in the same stage. Discussion for the `why` I want to run it twice in the same stage is also present on the linked PR.