### PR TITLE
Refactor sparse checkout template: idempotency and no yaml loops

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -23,47 +23,52 @@ steps:
       # Define this inline, because of the chicken/egg problem with loading a script when nothing
       # has been checked out yet.
       script: |
-        function SparseCheckout([Array]$paths, [Array]$Repositories)
+        function SparseCheckout([Array]$paths, [Hashtable]$repository)
         {
             $paths = $paths -Join ' '
 
-            foreach ($repo in $Repositories) {
-                $dir = $repo.WorkingDirectory
-                if (!$dir) {
-                  $dir = "./$($repo.Name)"
-                }
-                New-Item $dir -ItemType Directory -Force
-                Push-Location $dir
-
-                if (Test-Path .git/info/sparse-checkout) {
-                  $hasInitialized = $true
-                  Write-Host "Repository $($repo.Name) has already been initialized. Skipping this step."
-                } else {
-                  Write-Host "Repository $($repo.Name) is being initialized."
-                  git clone --no-checkout --filter=tree:0 git://github.com/$($repo.Name) .
-                  git sparse-checkout init
-                  git sparse-checkout set eng
-                }
-
-                Invoke-Expression -Command "git sparse-checkout add $paths"
-
-                Write-Host "Set sparse checkout paths to:"
-                Get-Content .git/info/sparse-checkout
-
-                # sparse-checkout commands after initial checkout will auto-checkout again
-                if (!$hasInitialized) {
-                  git checkout $($repo.Commitish)  # this will use the default branch if repo.Commitish is empty
-                }
-
-                Pop-Location
+            $dir = $repository.WorkingDirectory
+            if (!$dir) {
+              $dir = "./$($repository.Name)"
             }
+            New-Item $dir -ItemType Directory -Force
+            Push-Location $dir
+
+            if (Test-Path .git/info/sparse-checkout) {
+              $hasInitialized = $true
+              Write-Host "Repository $($repository.Name) has already been initialized. Skipping this step."
+            } else {
+              Write-Host "Repository $($repository.Name) is being initialized."
+              git clone --no-checkout --filter=tree:0 git://github.com/$($repository.Name) .
+              git sparse-checkout init
+              git sparse-checkout set eng
+            }
+
+            $gitsparsecmd = "git sparse-checkout add $paths"
+            Write-Host $gitsparsecmd
+            Invoke-Expression -Command $gitsparsecmd
+
+            Write-Host "Set sparse checkout paths to:"
+            Get-Content .git/info/sparse-checkout
+
+            # sparse-checkout commands after initial checkout will auto-checkout again
+            if (!$hasInitialized) {
+              Write-Host "git checkout $($repository.Commitish)"
+              git checkout $($repository.Commitish)  # this will use the default branch if repo.Commitish is empty
+            } else {
+              Write-Host "Skipping checkout as repo has already been initialized"
+            }
+
+            Pop-Location
         }
 
         # Paths may be sourced as a yaml object literal OR a dynamically generated variable json string.
         # If the latter, convertToJson will wrap the 'string' in quotes, so remove them.
         $paths = '${{ convertToJson(parameters.Paths) }}'.Trim('"') | ConvertFrom-Json
-        # Escape windows backslash paths
-        $repositories = '${{ convertToJson(parameters.Repositories) }}' -replace '\\', '\\' | ConvertFrom-Json
-        SparseCheckout $paths $Repositories
+        # Replace windows backslash paths, as Azure Pipelines default directories are sometimes formatted like 'D:\a\1\s'
+        $repositories = '${{ convertToJson(parameters.Repositories) }}' -replace '\\', '/' | ConvertFrom-Json -AsHashtable
+        foreach ($repo in $Repositories) {
+          SparseCheckout $paths $repo
+        }
       pwsh: true
       workingDirectory: $(System.DefaultWorkingDirectory)

--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -16,23 +16,54 @@ steps:
   - ${{ if not(parameters.SkipDefaultCheckout) }}:
     - checkout: none
 
-  - ${{ each repo in parameters.Repositories }}:
-    - pwsh: |
-        $dir = "${{ coalesce(repo.WorkingDirectory, format('{0}/{1}', '$(System.DefaultWorkingDirectory)', repo.Name)) }}"
-        New-Item $dir -ItemType Directory -Force
-      displayName: Create ${{ repo.Name }} directories
+  - task: PowerShell@2
+    displayName: 'Sparse checkout repositories'
+    inputs:
+      targetType: inline
+      # Define this inline, because of the chicken/egg problem with loading a script when nothing
+      # has been checked out yet.
+      script: |
+        function SparseCheckout([Array]$paths, [Array]$Repositories)
+        {
+            $paths = $paths -Join ' '
 
-    - pwsh: |
-        git clone --no-checkout --filter=tree:0 git://github.com/${{ repo.Name }} .
-        git sparse-checkout init
-        $paths = ('${{ convertToJson(parameters.Paths) }}' | ConvertFrom-Json) -Join ' '
-        Invoke-Expression -Command "git sparse-checkout set eng $paths"
-        Write-Host "Set sparse checkout paths to:"
-        Get-Content .git/info/sparse-checkout
-      displayName: Init sparse checkout ${{ repo.Name }}
-      workingDirectory: ${{ coalesce(repo.WorkingDirectory, format('{0}/{1}', '$(System.DefaultWorkingDirectory)', repo.Name)) }}
+            foreach ($repo in $Repositories) {
+                $dir = $repo.WorkingDirectory
+                if (!$dir) {
+                  $dir = "./$($repo.Name)"
+                }
+                New-Item $dir -ItemType Directory -Force
+                Push-Location $dir
 
-    - pwsh: |
-        git checkout ${{ repo.Commitish }}  # this will use the default branch if repo.Commitish is empty
-      displayName: Sparse checkout at ${{ coalesce(repo.Commitish, 'default branch') }}
-      workingDirectory: ${{ coalesce(repo.WorkingDirectory, format('{0}/{1}', '$(System.DefaultWorkingDirectory)', repo.Name)) }}
+                if (Test-Path .git/info/sparse-checkout) {
+                  $hasInitialized = $true
+                  Write-Host "Repository $($repo.Name) has already been initialized. Skipping this step."
+                } else {
+                  Write-Host "Repository $($repo.Name) is being initialized."
+                  git clone --no-checkout --filter=tree:0 git://github.com/$($repo.Name) .
+                  git sparse-checkout init
+                  git sparse-checkout set eng
+                }
+
+                Invoke-Expression -Command "git sparse-checkout add $paths"
+
+                Write-Host "Set sparse checkout paths to:"
+                Get-Content .git/info/sparse-checkout
+
+                # sparse-checkout commands after initial checkout will auto-checkout again
+                if (!$hasInitialized) {
+                  git checkout $($repo.Commitish)  # this will use the default branch if repo.Commitish is empty
+                }
+
+                Pop-Location
+            }
+        }
+
+        # Paths may be sourced as a yaml object literal OR a dynamically generated variable json string.
+        # If the latter, convertToJson will wrap the 'string' in quotes, so remove them.
+        $paths = '${{ convertToJson(parameters.Paths) }}'.Trim('"') | ConvertFrom-Json
+        # Escape windows backslash paths
+        $repositories = '${{ convertToJson(parameters.Repositories) }}' -replace '\\', '\\' | ConvertFrom-Json
+        SparseCheckout $paths $Repositories
+      pwsh: true
+      workingDirectory: $(System.DefaultWorkingDirectory)


### PR DESCRIPTION
This updates the sparse checkout template to be able to be called multiple times with new paths/repositories, and handle already cloned/checked out repositories.

Running `git sparse-checkout add` multiple times, as opposed to a single time with multiple arguments, can take a significantly longer amount of time. Similarly, re-running `git sparse-checkout set` may or may not lose context from earlier pipeline steps which may have iteratively built up all required paths for a given build/test run.

The change to this script handles all above conditions, and also gets rid of all the template looping constructs. By only using powershell logic (aside from `convertToJson`), the script is easier to test locally, and also no longer adds many steps to the job output page when there are a lot of repositories to be checked out.

Finally, this code can't actually be stored as a separate script file, because then there is a chicken/egg problem with checkout out the script in order to run it in order to check out the repo.