### PR TITLE
Add Get-ChangeLogEntriesFromContent

### DIFF
--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -13,17 +13,35 @@ function Get-ChangeLogEntries {
     [String]$ChangeLogLocation
   )
 
-  $changeLogEntries = [Ordered]@{}
   if (!(Test-Path $ChangeLogLocation)) {
     LogError "ChangeLog[${ChangeLogLocation}] does not exist"
     return $null
   }
+  LogDebug "Extracting entries from [${ChangeLogLocation}]."
+  return Get-ChangeLogEntriesFromContent (Get-Content -Path $ChangeLogLocation)
+}
 
+function Get-ChangeLogEntriesFromContent {
+  param (
+    [Parameter(Mandatory = $true)]
+    $changeLogContent
+  )
+
+  if ($changeLogContent -is [string])
+  {
+    $changeLogContent = $changeLogContent.Split("`n")
+  }
+  elseif($changeLogContent -isnot [array])
+  {
+    LogError "Invalid ChangelogContent passed"
+    return $null
+  }
+
+  $changeLogEntries = [Ordered]@{}
   try {
-    $contents = Get-Content $ChangeLogLocation
     # walk the document, finding where the version specifiers are and creating lists
     $changeLogEntry = $null
-    foreach ($line in $contents) {
+    foreach ($line in $changeLogContent) {
       if ($line -match $RELEASE_TITLE_REGEX) {
         $changeLogEntry = [pscustomobject]@{ 
           ReleaseVersion = $matches["version"]
@@ -41,7 +59,7 @@ function Get-ChangeLogEntries {
     }
   }
   catch {
-    Write-Host "Error parsing $ChangeLogLocation."
+    Write-Host "Error parsing Changelog."
     Write-Host $_.Exception.Message
   }
   return $changeLogEntries


### PR DESCRIPTION
Add method to support extracting changelog entries from changelog content as string or array of strings.