### PR TITLE
Update format of new Changelog Entry

### DIFF
--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -195,7 +195,19 @@ function New-ChangeLogEntry {
     return $null
   }
 
-  if (!$Content) { $Content = @() }
+  if (!$Content) { 
+    $Content = @()
+    $Content += ""
+    $Content += "### Features Added"
+    $Content += ""
+    $Content += "### Breaking Changes"
+    $Content += ""
+    $Content += "### Key Bugs Fixed"
+    $Content += ""
+    $Content += "### Fixed"
+    $Content += ""
+    $Content += ""
+  }
 
   $newChangeLogEntry = [pscustomobject]@{ 
     ReleaseVersion = $Version

--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -47,37 +47,33 @@ function Get-ChangeLogEntriesFromContent {
           ReleaseStatus  =  $matches["releaseStatus"]
           ReleaseTitle   = "## {0} {1}" -f $matches["version"], $matches["releaseStatus"]
           ReleaseContent = @()
-          FeaturesAdded = @()
-          BreakingChanges = @()
-          KeyBugsFixed = @()
-          Fixed = @()
+          Sections = @{}
         }
         $changeLogEntries[$changeLogEntry.ReleaseVersion] = $changeLogEntry
       }
       else {
         if ($changeLogEntry) {
-          if ($line.Trim() -match "###\s(?<sectionName>.*)")
+          if ($line.Trim() -match "^###\s(?<sectionName>.*)")
           {
-            $sectionName = $matches["sectionName"]
+            $sectionName = $matches["sectionName"].Trim()
+            $changeLogEntry.Sections[$sectionName] = @()
             $changeLogEntry.ReleaseContent += $line
             continue
           }
 
-          if (-not [System.String]::IsNullOrEmpty($line))
+          if ($sectionName)
           {
-            switch ($sectionName)
-            {
-              "Features Added" { $changeLogEntry.FeaturesAdded += $line }
-              "Breaking Changes" { $changeLogEntry.BreakingChanges += $line }
-              "Key Bugs Fixed" { $changeLogEntry.KeyBugsFixed += $line }
-              "Fixed" { $changeLogEntry.Fixed += $line }
-            }
+            $changeLogEntry.Sections[$sectionName] += $line
           }
 
           $changeLogEntry.ReleaseContent += $line
         }
       }
     }
+  }
+  catch {
+    Write-Host "Error parsing Changelog."
+    Write-Host $_.Exception.Message
   }
   return $changeLogEntries
 }


### PR DESCRIPTION
Update changelog entry to match updated guidance https://azure.github.io/azure-sdk/policies_releases.html#change-logs

New Changelog entries will now look like
```
# Release History

## 1.15.0 (Unreleased)

### Features Added

### Breaking Changes

### Key Bugs Fixed

### Fixed


## 1.15.0-beta.1 (Unreleased)

### Features Added

- Types to represent `GeoJson` primitives.
```