### PR TITLE
Disable NuGet warning for tutorial setup.

### DIFF
--- a/eng/pipelines/setup-tutorial-branch.yml
+++ b/eng/pipelines/setup-tutorial-branch.yml
@@ -39,7 +39,8 @@ parameters:
 
 variables:
   skipComponentGovernanceDetection: true
-
+  NugetSecurityAnalysisWarningLevel: none
+  
 jobs:
 - job: SetupTutorialBranch
   pool:


### PR DESCRIPTION
Disabling the NuGet security warning since it doesn't apply to this pipeline.