### PR TITLE
Use generate matrix job name parameter as display name

### DIFF
--- a/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
+++ b/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
@@ -35,7 +35,7 @@ parameters:
 # When that occurs, provide a name other than the default value.
 - name: GenerateJobName
   type: string
-  default: 'generate_matrix'
+  default: 'generate_job_matrix'
 
 jobs:
 - job: ${{ parameters.GenerateJobName }}
@@ -44,7 +44,6 @@ jobs:
   pool:
     name: ${{ parameters.Pool }}
     vmImage: ${{ parameters.OsVmImage }}
-  displayName: Generate Job Matrix
   ${{ if parameters.DependsOn }}:
     dependsOn: ${{ parameters.DependsOn }}
   steps:


### PR DESCRIPTION
When multiple matrix generators are used, we require passing in separate job names, but don't plumb them through to the display name. The display names could be more descriptive than they currently are:

![image](https://user-images.githubusercontent.com/1020379/120405069-b7c80280-c315-11eb-814d-acc8a930b6eb.png)

CC @scbedd 
