### PR TITLE
Enable skip difference tag only for automatic revision diff

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Models/RenderedCodeFile.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/RenderedCodeFile.cs
@@ -19,47 +19,47 @@ namespace APIViewWeb.Models
 
         public CodeFile CodeFile { get; }
 
-        public CodeLine[] Render(bool showDocumentation)
+        public CodeLine[] Render(bool showDocumentation, bool skipDiff = false)
         {
             //Always render when documentation is requested to avoid cach thrashing
             if (showDocumentation)
             {
-                return CodeFileHtmlRenderer.Normal.Render(CodeFile, showDocumentation: true);
+                return CodeFileHtmlRenderer.Normal.Render(CodeFile, showDocumentation: showDocumentation, enableSkipDiff: skipDiff);
             }
 
             if (_rendered == null)
             {
-                _rendered = CodeFileHtmlRenderer.Normal.Render(CodeFile);
+                _rendered = CodeFileHtmlRenderer.Normal.Render(CodeFile, enableSkipDiff: skipDiff);
             }
 
             return _rendered;
         }
 
-        public CodeLine[] RenderReadOnly(bool showDocumentation)
+        public CodeLine[] RenderReadOnly(bool showDocumentation, bool skipDiff = false)
         {
             if (showDocumentation)
             {
-                return CodeFileHtmlRenderer.ReadOnly.Render(CodeFile, showDocumentation: true);
+                return CodeFileHtmlRenderer.ReadOnly.Render(CodeFile, showDocumentation: showDocumentation, enableSkipDiff: skipDiff);
             }
 
             if (_renderedReadOnly == null)
             {
-                _renderedReadOnly = CodeFileHtmlRenderer.ReadOnly.Render(CodeFile);
+                _renderedReadOnly = CodeFileHtmlRenderer.ReadOnly.Render(CodeFile, skipDiff);
             }
 
             return _renderedReadOnly;
         }
 
-        internal CodeLine[] RenderText(bool showDocumentation)
+        internal CodeLine[] RenderText(bool showDocumentation, bool skipDiff = false)
         {
             if (showDocumentation)
             {
-                return CodeFileRenderer.Instance.Render(CodeFile, showDocumentation: true, enableSkipDiff: true);
+                return CodeFileRenderer.Instance.Render(CodeFile, showDocumentation: showDocumentation, enableSkipDiff: skipDiff);
             }
 
             if (_renderedText == null)
             {
-                _renderedText = CodeFileRenderer.Instance.Render(CodeFile, enableSkipDiff: true);
+                _renderedText = CodeFileRenderer.Instance.Render(CodeFile, enableSkipDiff: skipDiff);
             }
 
             return _renderedText;

--- a/src/dotnet/APIView/APIViewWeb/Models/RenderedCodeFile.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/RenderedCodeFile.cs
@@ -52,14 +52,14 @@ namespace APIViewWeb.Models
 
         internal CodeLine[] RenderText(bool showDocumentation, bool skipDiff = false)
         {
-            if (showDocumentation)
+            if (showDocumentation || skipDiff)
             {
                 return CodeFileRenderer.Instance.Render(CodeFile, showDocumentation: showDocumentation, enableSkipDiff: skipDiff);
             }
 
             if (_renderedText == null)
             {
-                _renderedText = CodeFileRenderer.Instance.Render(CodeFile, enableSkipDiff: skipDiff);
+                _renderedText = CodeFileRenderer.Instance.Render(CodeFile);
             }
 
             return _renderedText;

--- a/src/dotnet/APIView/APIViewWeb/Models/RenderedCodeFile.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/RenderedCodeFile.cs
@@ -19,32 +19,32 @@ namespace APIViewWeb.Models
 
         public CodeFile CodeFile { get; }
 
-        public CodeLine[] Render(bool showDocumentation, bool skipDiff = false)
+        public CodeLine[] Render(bool showDocumentation)
         {
             //Always render when documentation is requested to avoid cach thrashing
             if (showDocumentation)
             {
-                return CodeFileHtmlRenderer.Normal.Render(CodeFile, showDocumentation: showDocumentation, enableSkipDiff: skipDiff);
+                return CodeFileHtmlRenderer.Normal.Render(CodeFile, showDocumentation: true);
             }
 
             if (_rendered == null)
             {
-                _rendered = CodeFileHtmlRenderer.Normal.Render(CodeFile, enableSkipDiff: skipDiff);
+                _rendered = CodeFileHtmlRenderer.Normal.Render(CodeFile);
             }
 
             return _rendered;
         }
 
-        public CodeLine[] RenderReadOnly(bool showDocumentation, bool skipDiff = false)
+        public CodeLine[] RenderReadOnly(bool showDocumentation)
         {
             if (showDocumentation)
             {
-                return CodeFileHtmlRenderer.ReadOnly.Render(CodeFile, showDocumentation: showDocumentation, enableSkipDiff: skipDiff);
+                return CodeFileHtmlRenderer.ReadOnly.Render(CodeFile, showDocumentation: true);
             }
 
             if (_renderedReadOnly == null)
             {
-                _renderedReadOnly = CodeFileHtmlRenderer.ReadOnly.Render(CodeFile, skipDiff);
+                _renderedReadOnly = CodeFileHtmlRenderer.ReadOnly.Render(CodeFile);
             }
 
             return _renderedReadOnly;

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
@@ -88,7 +88,6 @@ namespace APIViewWeb.Pages.Assemblies
             CodeFile = renderedCodeFile.CodeFile;
 
             var fileDiagnostics = CodeFile.Diagnostics ?? Array.Empty<CodeDiagnostic>();
-
             var fileHtmlLines = renderedCodeFile.Render(ShowDocumentation);
 
             if (DiffRevisionId != null)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -354,8 +354,8 @@ namespace APIViewWeb.Respositories
         {
             //This will compare and check if new code file content is same as revision in parameter
             var lastRevisionFile = await _codeFileRepository.GetCodeFileAsync(revision);
-            var lastRevisionTextLines = lastRevisionFile.RenderText(false, true);
-            var fileTextLines = renderedCodeFile.RenderText(false, true);
+            var lastRevisionTextLines = lastRevisionFile.RenderText(showDocumentation: false, skipDiff: true);
+            var fileTextLines = renderedCodeFile.RenderText(showDocumentation: false, skipDiff: true);
             return lastRevisionTextLines.SequenceEqual(fileTextLines);
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -354,8 +354,8 @@ namespace APIViewWeb.Respositories
         {
             //This will compare and check if new code file content is same as revision in parameter
             var lastRevisionFile = await _codeFileRepository.GetCodeFileAsync(revision);
-            var lastRevisionTextLines = lastRevisionFile.RenderText(false);
-            var fileTextLines = renderedCodeFile.RenderText(false);
+            var lastRevisionTextLines = lastRevisionFile.RenderText(false, true);
+            var fileTextLines = renderedCodeFile.RenderText(false, true);
             return lastRevisionTextLines.SequenceEqual(fileTextLines);
         }
 


### PR DESCRIPTION
Currently skip diff range only skips when rendering text but corresponding tokens are not skipped when rendering html lines. This causes inconsistency when showing diff. Incorrect lines are shown as removed or added. We don't want to skip any ranges for UI request and diff logic should ignore these tagged lines(lines within skip diff range) only when comparing automatic review revisions.