### PR TITLE
Updating the common props to respect SymbolPackageFormat

### DIFF
--- a/src/dotnet/Mgmt.CI.BuildTools/NugetToolsPackage/CI.Tools.Package/build/targets/common.Build.props
+++ b/src/dotnet/Mgmt.CI.BuildTools/NugetToolsPackage/CI.Tools.Package/build/targets/common.Build.props
@@ -2,6 +2,7 @@
 	<PropertyGroup>
 		<Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
 		<NoWarn>1591;1701;1573;CS1591;MSB3245;3245</NoWarn>
+		<SymbolPackageFormat Condition=" '$(SymbolPackageFormat)' == ''">snupkg</SymbolPackageFormat>
 	</PropertyGroup>
 	
 	<PropertyGroup Condition=" '$(TargetFramework)'=='net452' ">

--- a/src/dotnet/Mgmt.CI.BuildTools/NugetToolsPackage/CI.Tools.Package/build/targets/common.targets
+++ b/src/dotnet/Mgmt.CI.BuildTools/NugetToolsPackage/CI.Tools.Package/build/targets/common.targets
@@ -75,7 +75,7 @@
     <Message Text="Target ==> CleaningNugetPackages Initiated....." Importance="Low" />
     <ItemGroup>
       <_SDKPackageFilesToDelete Include="$(PackageOutputPath)\*.nupkg"/>
-      <_SDKPackageFilesToDelete Include="$(PackageOutputPath)\*.snupkg"/>
+      <_SDKPackageFilesToDelete Include="$(PackageOutputPath)\*.$(SymbolPackageFormat)"/>
       <_SDKPackageFilesToDelete Include="$(BaseIntermediateOutputPath)\*.nuspec"/>
     </ItemGroup>
     <Message Text="Cleaning Packages..... @(_SDKPackageFilesToDelete)" Condition=" '@(_SDKPackageFilesToDelete)' != '' " />
@@ -160,7 +160,7 @@
         PackageOutputPath=$(NugPkgOutPutDirPath); 
         NoPackageAnalysis=true; 
         IncludeSymbols=true;
-        SymbolPackageFormat=snupkg;
+        SymbolPackageFormat=$(SymbolPackageFormat);
         IsPackable=true;
         NoBuild=true;" Condition=" ('@(ProjectsToPackage)' != '') OR ('$(WhatIf)' != 'true') ">
       <Output TaskParameter="TargetOutputs" ItemName="SdkNuGetPackages" />


### PR DESCRIPTION
Track 1 mgmt depends on these common props/targets. The `SymbolPackageFormat` was hardcoded.

I left the default still be snupkg to avoid breakage of any unknown reference. The .NET mgmt.proj will be updated after this to set to symbol.nupkg after this tool is updated. 