### PR TITLE
Auto API review should only have one pending review since last approval

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -370,6 +370,15 @@ namespace APIViewWeb.Respositories
             bool createNewRevision = true;
             if (review != null)
             {
+                // Delete pending revisions if it is not in approved state before adding new revision
+                // This is to keep only one pending revision since last approval or from initial review revision
+                var lastRevision = review.Revisions.LastOrDefault();
+                while (lastRevision.Approvers.Count == 0 && review.Revisions.Count > 1)
+                {
+                    review.Revisions.Remove(lastRevision);
+                    lastRevision = review.Revisions.LastOrDefault();
+                }
+
                 var renderedCodeFile = new RenderedCodeFile(codeFile);
                 var noDiffFound = await IsReviewSame(review.Revisions.LastOrDefault(), renderedCodeFile);
                 if (noDiffFound)
@@ -395,14 +404,6 @@ namespace APIViewWeb.Respositories
             await AssertAutomaticReviewModifier(user, review);
             if (createNewRevision)
             {
-                // Delete last revision if it is not in approved state before adding new revision
-                // This is to keep only one pending revision since last approval or from initial review revision
-                var lastRevision = review.Revisions.LastOrDefault();
-                if (lastRevision != null && lastRevision.Approvers.Count == 0 && review.Revisions.Count > 1)
-                {
-                    review.Revisions.Remove(lastRevision);
-                }
-
                 // Update or insert review with new revision
                 var revision = new ReviewRevisionModel()
                 {


### PR DESCRIPTION
Last pending revision is removed after comparison and this causes issue if any accidental change is merged to master branch since last API approval and then reverted.

For e.g. API review has following api in revision 0 and it's approved
`void test()`

Now someone merged a PR with an additional API `void test1()`. CI will create a new revision since it mismatches from last revision.

Developer realizes the mistake and reverts changes to remove `void test1()`. Review system still find this new revision as different since comparison is against last pending revision, not approved revision.

Ideally API review should have found the match against previously approved revision and should not create a new revision and this PR is to achieve this goal.
