### PR TITLE
Add capability to purge inmemory on playback stop

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
@@ -1,13 +1,10 @@
+using Azure.Sdk.Tools.TestProxy.Sanitizers;
+using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Razor.TagHelpers;
-using System;
 using System.IO;
-using Xunit;
-using Azure.Sdk.Tools.TestProxy;
 using System.Linq;
-using Azure.Sdk.Tools.TestProxy.Transforms;
-using Azure.Sdk.Tools.TestProxy.Sanitizers;
+using Xunit;
 
 namespace Azure.Sdk.Tools.TestProxy.Tests
 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Http;
+using System;
+using System.Linq;
 using Xunit;
 
 namespace Azure.Sdk.Tools.TestProxy.Tests
@@ -6,9 +8,31 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
     public class RecordingHandlerTests
     {
         [Fact]
-        public void Test1()
+        public async void TestInMemoryPurgesSucessfully()
         {
-            // TODO: populate
+            var recordingHandler = TestHelpers.LoadRecordSessionIntoInMemoryStore("Test.RecordEntries/post_delete_get_content.json");
+            var httpContext = new DefaultHttpContext();
+            var key = recordingHandler.InMemorySessions.Keys.First();
+
+            await recordingHandler.StartPlayback(key, httpContext.Response, Common.RecordingType.InMemory);
+            var playbackSession = httpContext.Response.Headers["x-recording-id"];
+            recordingHandler.StopPlayback(playbackSession, true);
+
+            Assert.True(0 == recordingHandler.InMemorySessions.Count);
+        }
+
+        [Fact]
+        public async void TestInMemoryDoesntPurgeErroneously()
+        {
+            var recordingHandler = TestHelpers.LoadRecordSessionIntoInMemoryStore("Test.RecordEntries/post_delete_get_content.json");
+            var httpContext = new DefaultHttpContext();
+            var key = recordingHandler.InMemorySessions.Keys.First();
+
+            await recordingHandler.StartPlayback(key, httpContext.Response, Common.RecordingType.InMemory);
+            var playbackSession = httpContext.Response.Headers["x-recording-id"];
+            recordingHandler.StopPlayback(playbackSession, false);
+
+            Assert.True(1 == recordingHandler.InMemorySessions.Count);
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.AspNetCore.Http;
-using System;
 using System.Linq;
 using Xunit;
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -29,6 +29,20 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             return new ModifiableRecordSession(RecordSession.Deserialize(doc.RootElement));
         }
 
+        public static RecordingHandler LoadRecordSessionIntoInMemoryStore(string path)
+        {
+            using var stream = System.IO.File.OpenRead(path);
+            using var doc = JsonDocument.Parse(stream);
+            var guid = Guid.NewGuid().ToString();
+
+            var session = new ModifiableRecordSession(RecordSession.Deserialize(doc.RootElement));
+
+            RecordingHandler handler = new RecordingHandler(Directory.GetCurrentDirectory());
+            handler.InMemorySessions.TryAdd(guid, session);
+
+            return handler;
+        }
+
         public static byte[] GenerateByteRequestBody(string s)
         {
             return Encoding.UTF8.GetBytes(s);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -1,11 +1,8 @@
 ﻿using Azure.Sdk.Tools.TestProxy.Common;
 using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Text;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace Azure.Sdk.Tools.TestProxy.Tests
 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -31,7 +31,6 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             using var stream = System.IO.File.OpenRead(path);
             using var doc = JsonDocument.Parse(stream);
             var guid = Guid.NewGuid().ToString();
-
             var session = new ModifiableRecordSession(RecordSession.Deserialize(doc.RootElement));
 
             RecordingHandler handler = new RecordingHandler(Directory.GetCurrentDirectory());

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ModifiableRecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ModifiableRecordSession.cs
@@ -20,5 +20,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
         public List<RecordedTestSanitizer> AdditionalSanitizers { get; }= new List<RecordedTestSanitizer>();
 
+        public string SourceRecordingId { get; set; }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
@@ -39,8 +39,9 @@ namespace Azure.Sdk.Tools.TestProxy
         public void Stop()
         {
             string id = RecordingHandler.GetHeader(Request, "x-recording-id");
+            bool.TryParse(RecordingHandler.GetHeader(Request, "x-purge-inmemory-recording", true), out var shouldPurgeRecording);
 
-            _recordingHandler.StopPlayback(id);
+            _recordingHandler.StopPlayback(id, purgeMemoryStore: shouldPurgeRecording);
         }
 
         public async Task HandleRequest()

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -3,7 +3,6 @@ using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using LibGit2Sharp;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Routing;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Concurrent;


### PR DESCRIPTION
Add header `x-purge-inmemory-recording` with a truthy value to your call to `/playback/stop`.

@mikeharder 
