### PR TITLE
Hide approve button if diff is not against approved version

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Models/ReviewRevisionModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/ReviewRevisionModel.cs
@@ -70,5 +70,7 @@ namespace APIViewWeb
         public int RevisionNumber => Review.Revisions.IndexOf(this);
 
         public HashSet<string> Approvers { get; set; } = new HashSet<string>();
+
+        public bool IsApproved => Approvers.Count() > 0;
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -25,7 +25,7 @@
             <div class="dropdown-menu">
                 @foreach (var revision in Model.Review.Revisions.Reverse())
                 {
-                    var colorCss =  revision.Approvers.Count() > 0 ? "text-success" : "";
+                    var colorCss =  revision.IsApproved ? "text-success" : "";
                     <a class="dropdown-item @colorCss" asp-route-id="@Model.Review.ReviewId" asp-route-revisionId="@revision.RevisionId" asp-route-doc="@Model.ShowDocumentation">
                         @revision.DisplayName
                     </a>
@@ -49,7 +49,7 @@
                 <div class="dropdown-menu">
                     @foreach (var revision in Model.PreviousRevisions.Reverse())
                     {
-                        var colorCss = revision.Approvers.Count() > 0 ? "text-success" : "";
+                        var colorCss = revision.IsApproved ? "text-success" : "";
                         <a class="dropdown-item @colorCss" active-if="@(Model.DiffRevisionId == revision.RevisionId)" asp-all-route-data=@Model.GetRoutingData(diffRevisionId: revision.RevisionId, showDocumentation: Model.ShowDocumentation, showDiffOnly: Model.ShowDiffOnly)>
                             @revision.DisplayName
                         </a>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -109,12 +109,16 @@
                 }
             </div>
         </div>
-        <div class="float-right">
-            <form asp-resource="@Model.Review" class="form-inline float-left ml-2" asp-page-handler="ToggleApproval" method="post" asp-requirement="@ApproverRequirement.Instance">
-                <input type="hidden" name="revisionId" value="@Model.Revision.RevisionId" />
-                <input type="submit" class="btn btn-sm btn-secondary" value="@(Model.Revision.Approvers.Contains(User.GetGitHubLogin()) ? "Revert Approval" : "Approve")" />
-            </form>
-        </div>
+        @if (Model.DiffRevision == null || Model.DiffRevision.Approvers.Count > 0)
+        {
+            <div class="float-right">
+                <form asp-resource="@Model.Review" class="form-inline float-left ml-2" asp-page-handler="ToggleApproval" method="post" asp-requirement="@ApproverRequirement.Instance">
+                    <input type="hidden" name="revisionId" value="@Model.Revision.RevisionId" />
+                    <input type="submit" class="btn btn-sm btn-secondary" value="@(Model.Revision.Approvers.Contains(User.GetGitHubLogin()) ? "Revert Approval" : "Approve")" />
+                </form>
+            </div>
+        }
+
         <div class="float-right ml-2">
             <label>Approval Status:</label>
             @if (Model.Revision.Approvers.Count > 0)

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -25,7 +25,8 @@
             <div class="dropdown-menu">
                 @foreach (var revision in Model.Review.Revisions.Reverse())
                 {
-                    <a class="dropdown-item" asp-route-id="@Model.Review.ReviewId" asp-route-revisionId="@revision.RevisionId" asp-route-doc="@Model.ShowDocumentation">
+                    var colorCss =  revision.Approvers.Count() > 0 ? "text-success" : "";
+                    <a class="dropdown-item @colorCss" asp-route-id="@Model.Review.ReviewId" asp-route-revisionId="@revision.RevisionId" asp-route-doc="@Model.ShowDocumentation">
                         @revision.DisplayName
                     </a>
                 }
@@ -48,7 +49,8 @@
                 <div class="dropdown-menu">
                     @foreach (var revision in Model.PreviousRevisions.Reverse())
                     {
-                        <a class="dropdown-item" active-if="@(Model.DiffRevisionId == revision.RevisionId)" asp-all-route-data=@Model.GetRoutingData(diffRevisionId: revision.RevisionId, showDocumentation: Model.ShowDocumentation, showDiffOnly: Model.ShowDiffOnly)>
+                        var colorCss = revision.Approvers.Count() > 0 ? "text-success" : "";
+                        <a class="dropdown-item @colorCss" active-if="@(Model.DiffRevisionId == revision.RevisionId)" asp-all-route-data=@Model.GetRoutingData(diffRevisionId: revision.RevisionId, showDocumentation: Model.ShowDocumentation, showDiffOnly: Model.ShowDiffOnly)>
                             @revision.DisplayName
                         </a>
                     }
@@ -109,15 +111,20 @@
                 }
             </div>
         </div>
-        @if (Model.DiffRevision == null || Model.DiffRevision.Approvers.Count > 0)
-        {
-            <div class="float-right">
-                <form asp-resource="@Model.Review" class="form-inline float-left ml-2" asp-page-handler="ToggleApproval" method="post" asp-requirement="@ApproverRequirement.Instance">
-                    <input type="hidden" name="revisionId" value="@Model.Revision.RevisionId" />
+        <div class="float-right">
+            <form asp-resource="@Model.Review" class="form-inline float-left ml-2" asp-page-handler="ToggleApproval" method="post" asp-requirement="@ApproverRequirement.Instance">
+                <input type="hidden" name="revisionId" value="@Model.Revision.RevisionId" />
+                @if (Model.DiffRevision == null || Model.DiffRevision.Approvers.Count > 0)
+                {
                     <input type="submit" class="btn btn-sm btn-secondary" value="@(Model.Revision.Approvers.Contains(User.GetGitHubLogin()) ? "Revert Approval" : "Approve")" />
-                </form>
-            </div>
-        }
+                }
+                else
+                {
+
+                    <input type="submit" class="btn btn-sm btn-secondary" disabled title="API review cannot be approved when comparing against unapproved revision." value="@(Model.Revision.Approvers.Contains(User.GetGitHubLogin()) ? "Revert Approval" : "Approve")" />
+                }
+            </form>
+        </div>
 
         <div class="float-right ml-2">
             <label>Approval Status:</label>

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -453,7 +453,7 @@ namespace APIViewWeb.Respositories
             var reviews = await _reviewsRepository.GetReviewsAsync(false, revisionFile.Language, revisionFile.PackageName, false);
             foreach (var r in reviews)
             {
-                var approvedRevision = r.Revisions.Where(r => r.Approvers.Count() > 0).LastOrDefault();
+                var approvedRevision = r.Revisions.Where(r => r.IsApproved).LastOrDefault();
                 if (approvedRevision != null)
                 {
                     bool isReviewSame = await IsReviewSame(approvedRevision, codeFile);


### PR DESCRIPTION
Approve button is visible even when comparing diff against two unapproved revisions. This can lead to accidental approval of unwanted changes that are in diff revision. Approve button should not be shown in diff when comparing against another unapproved revision.