### PR TITLE
[http-fault-injector] Replace X-Upstream-Host with X-Upstream-Base-Uri

### DIFF
--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <Version>0.1.1</Version>
+    <Version>0.2.0</Version>
 
     <TargetFramework>netcoreapp3.1</TargetFramework>
 

--- a/tools/http-fault-injector/sample-clients/java/http-fault-injector-client/src/main/java/httpfaultinjectorclient/App.java
+++ b/tools/http-fault-injector/sample-clients/java/http-fault-injector-client/src/main/java/httpfaultinjectorclient/App.java
@@ -7,14 +7,15 @@ import reactor.netty.http.client.HttpClient;
 import reactor.netty.http.client.HttpClientResponse;
 
 public class App {
+    private static String _scheme = "http";
     private static String _host = "localhost";
-    private static int _port = 7778;
+    private static int _port = 7777;
 
     public static void main(String[] args) throws Exception {
         HttpClient httpClient = HttpClient.create();
 
-        // You must either add the .NET developer certificate to the Java cacerts keystore, or uncomment the following
-        // lines to disable SSL validation.
+        // When using HTTPS to the fault injector, you must either add the .NET developer certificate to the Java cacerts keystore,
+        // or uncomment the following lines to disable SSL validation.
         //
         // io.netty.handler.ssl.SslContext sslContext = io.netty.handler.ssl.SslContextBuilder
         //     .forClient().trustManager(io.netty.handler.ssl.util.InsecureTrustManagerFactory.INSTANCE).build();
@@ -30,8 +31,17 @@ public class App {
     private static Mono<HttpClientResponse> get(HttpClient httpClient, String uri) throws Exception {
         URI upstream = new URI(uri);
 
-        URI faultInjector = new URI(
+        URI upstreamBase = new URI(
             upstream.getScheme(),
+            upstream.getUserInfo(),
+            upstream.getHost(),
+            upstream.getPort(),
+            null,
+            null,
+            null);
+
+        URI faultInjector = new URI(
+            _scheme,
             upstream.getUserInfo(),
             _host,
             _port,
@@ -40,8 +50,8 @@ public class App {
             upstream.getFragment());
 
         return httpClient
-            // Set "X-Upstream-Host" header to upstream host
-            .headers(headers -> headers.add("X-Upstream-Host", upstream.getHost()))
+            // Set "X-Upstream-Base-Uri" header to upstream host
+            .headers(headers -> headers.add("X-Upstream-Base-Uri", upstreamBase.toString()))
             .get()
             // Set URI to fault injector
             .uri(faultInjector.toString())

--- a/tools/http-fault-injector/sample-clients/java/storage-blobs/src/main/java/FaultInjectorHttpClient.java
+++ b/tools/http-fault-injector/sample-clients/java/storage-blobs/src/main/java/FaultInjectorHttpClient.java
@@ -15,17 +15,20 @@ import java.util.Objects;
  */
 public final class FaultInjectorHttpClient implements HttpClient {
     private final HttpClient httpClient;
+    private final String scheme;
     private final String host;
     private final int port;
 
     /**
-     * Default constructor for {@link FaultInjectorHttpClient} which expects the HTTP fault injector to use {@link
-     * Utils#DEFAULT_HTTP_FAULT_INJECTOR_HOST} and running on port {@link Utils#DEFAULT_HTTP_FAULT_INJECTOR_HTTPS_PORT}.
+     * Default constructor for {@link FaultInjectorHttpClient} which expects the HTTP fault injector to use
+     * {@link Utils#DEFAULT_HTTP_FAULT_INJECTOR_SCHEME}, {@link Utils#DEFAULT_HTTP_FAULT_INJECTOR_HOST}
+     * and running on port {@link Utils#DEFAULT_HTTP_FAULT_INJECTOR_HTTP_PORT}.
      *
      * @param httpClient The underlying {@link HttpClient} used to make network requests.
      */
     public FaultInjectorHttpClient(HttpClient httpClient) {
-        this(httpClient, Utils.DEFAULT_HTTP_FAULT_INJECTOR_HOST, Utils.DEFAULT_HTTP_FAULT_INJECTOR_HTTPS_PORT);
+        this(httpClient, Utils.DEFAULT_HTTP_FAULT_INJECTOR_SCHEME,
+             Util.DEFAULT_HTTP_FAULT_INJECTOR_HOST, Utils.DEFAULT_HTTP_FAULT_INJECTOR_HTTP_PORT);
     }
 
     /**
@@ -38,10 +41,11 @@ public final class FaultInjectorHttpClient implements HttpClient {
      * @throws NullPointerException If {@code httpClient} or {@code host} is null.
      * @throws IllegalArgumentException If {@code host} is an empty string or {@code port} is an invalid port.
      */
-    public FaultInjectorHttpClient(HttpClient httpClient, String host, int port) {
+    public FaultInjectorHttpClient(HttpClient httpClient, String scheme, String host, int port) {
         this.httpClient = Objects.requireNonNull(httpClient, "'httpClient' cannot be null.");
-        Utils.validateHostAndPort(host, port);
+        Utils.validateSchemeHostAndPort(scheme, host, port);
 
+        this.scheme = scheme;
         this.host = host;
         this.port = port;
     }
@@ -53,7 +57,7 @@ public final class FaultInjectorHttpClient implements HttpClient {
 
     @Override
     public Mono<HttpResponse> send(HttpRequest request, Context context) {
-        return Mono.defer(() -> Mono.fromCallable(() -> Utils.rewriteUrlToUseFaultInjector(request, host, port)))
+        return Mono.defer(() -> Mono.fromCallable(() -> Utils.rewriteUrlToUseFaultInjector(request, scheme, host, port)))
             .flatMap(rewrittenHttpRequest -> httpClient.send(rewrittenHttpRequest, context));
     }
 }

--- a/tools/http-fault-injector/sample-clients/java/storage-blobs/src/main/java/FaultInjectorUrlRewriterPolicy.java
+++ b/tools/http-fault-injector/sample-clients/java/storage-blobs/src/main/java/FaultInjectorUrlRewriterPolicy.java
@@ -12,16 +12,18 @@ import reactor.core.publisher.Mono;
  * General purpose {@link HttpPipelinePolicy} which re-writes the request URL to send it to the HTTP fault injector.
  */
 public final class FaultInjectorUrlRewriterPolicy implements HttpPipelinePolicy {
+    private final String scheme;
     private final String host;
     private final int port;
 
     /**
      * Default constructor for {@link FaultInjectorUrlRewriterPolicy} which expects the HTTP fault injector to use
-     * {@link Utils#DEFAULT_HTTP_FAULT_INJECTOR_HOST} and running on port
-     * {@link Utils#DEFAULT_HTTP_FAULT_INJECTOR_HTTPS_PORT}.
+     * {@link Utils#DEFAULT_HTTP_FAULT_INJECTOR_SCHEME}, {@link Utils#DEFAULT_HTTP_FAULT_INJECTOR_HOST}
+     * and running on port {@link Utils#DEFAULT_HTTP_FAULT_INJECTOR_HTTP_PORT}.
      */
     public FaultInjectorUrlRewriterPolicy() {
-        this(Utils.DEFAULT_HTTP_FAULT_INJECTOR_HOST, Utils.DEFAULT_HTTP_FAULT_INJECTOR_HTTPS_PORT);
+        this(Utils.DEFAULT_HTTP_FAULT_INJECTOR_SCHEME, Utils.DEFAULT_HTTP_FAULT_INJECTOR_HOST,
+             Utils.DEFAULT_HTTP_FAULT_INJECTOR_HTTP_PORT);
     }
 
     /**
@@ -32,16 +34,17 @@ public final class FaultInjectorUrlRewriterPolicy implements HttpPipelinePolicy 
      * @throws NullPointerException If {@code host} is null.
      * @throws IllegalArgumentException If {@code host} is an empty string or {@code port} is an invalid port.
      */
-    public FaultInjectorUrlRewriterPolicy(String host, int port) {
-        Utils.validateHostAndPort(host, port);
+    public FaultInjectorUrlRewriterPolicy(String scheme, String host, int port) {
+        Utils.validateSchemeHostAndPort(scheme, host, port);
 
+        this.scheme = scheme;
         this.host = host;
         this.port = port;
     }
 
     @Override
     public Mono<HttpResponse> process(HttpPipelineCallContext context, HttpPipelineNextPolicy next) {
-        context.setHttpRequest(Utils.rewriteUrlToUseFaultInjector(context.getHttpRequest(), host, port));
+        context.setHttpRequest(Utils.rewriteUrlToUseFaultInjector(context.getHttpRequest(), scheme, host, port));
 
         return next.process();
     }

--- a/tools/http-fault-injector/sample-clients/net/http-client/Program.cs
+++ b/tools/http-fault-injector/sample-clients/net/http-client/Program.cs
@@ -9,7 +9,7 @@ namespace Azure.Sdk.Tools.HttpFaultInjector.HttpClientSample
     {
         static async Task Main(string[] args)
         {
-            var httpClient = new HttpClient(new FaultInjectionClientHandler(new Uri("https://localhost:7778")));
+            var httpClient = new HttpClient(new FaultInjectionClientHandler(new Uri("http://localhost:7777")));
 
             Console.WriteLine("Sending request...");
             var response = await httpClient.GetAsync("https://www.example.org");
@@ -24,23 +24,30 @@ namespace Azure.Sdk.Tools.HttpFaultInjector.HttpClientSample
             {
                 _uri = uri;
 
-                // You must either trust the .NET developer certificate, or uncomment the following line to disable SSL validation.
+                // When using an HTTPS Uri, you must either trust the .NET developer certificate,
+                // or uncomment the following line to disable SSL validation.
                 // ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true;
             }
 
             protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
             {
-                // Set "X-Upstream-Host" header to upstream host:port
-                request.Headers.Add("X-Upstream-Host", $"{request.RequestUri.Host}:{request.RequestUri.Port}");
+                // Set "X-Upstream-Base-Uri" header to upstream scheme://host:port
+                var upstreamBaseUriBuilder = new UriBuilder()
+                {
+                    Scheme = request.RequestUri.Scheme,
+                    Host = request.RequestUri.Host,
+                    Port = request.RequestUri.Port,
+                };
+                request.Headers.Add("X-Upstream-Base-Uri", upstreamBaseUriBuilder.ToString());
 
                 // Set URI to fault injector
-                var builder = new UriBuilder(request.RequestUri)
+                var faultInjectorUriBuilder = new UriBuilder(request.RequestUri)
                 {
                     Scheme = _uri.Scheme,
                     Host = _uri.Host,
                     Port = _uri.Port,
                 };
-                request.RequestUri = builder.Uri;
+                request.RequestUri = faultInjectorUriBuilder.Uri;
 
                 return base.SendAsync(request, cancellationToken);
             }

--- a/tools/http-fault-injector/sample-clients/net/storage-blobs/Program.cs
+++ b/tools/http-fault-injector/sample-clients/net/storage-blobs/Program.cs
@@ -9,7 +9,7 @@ namespace Azure.Sdk.Tools.HttpFaultInjector.StorageBlobsSample
 {
     class Program
     {
-        private static readonly Uri _faultInjectorUri = new Uri("https://localhost:7778");
+        private static readonly Uri _faultInjectorUri = new Uri("http://localhost:7777");
 
         static async Task Main(string[] args)
         {
@@ -17,7 +17,8 @@ namespace Azure.Sdk.Tools.HttpFaultInjector.StorageBlobsSample
 
             var blobClientOptions = new BlobClientOptions();
 
-            // You must either trust the .NET developer certificate, or uncomment the following lines to disable SSL validation.
+            // When using an HTTPS _faultInjectorUri, you must either trust the .NET developer certificate,
+            // or uncomment the following line to disable SSL validation.
             // blobClientOptions.Transport = new HttpClientTransport(new System.Net.Http.HttpClient(new System.Net.Http.HttpClientHandler()
             // {
             //     ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
@@ -68,12 +69,20 @@ namespace Azure.Sdk.Tools.HttpFaultInjector.StorageBlobsSample
 
             protected void RedirectToFaultInjector(HttpMessage message)
             {
-                // Ensure X-Upstream-Host header is only set once, since the same HttpMessage will be reused on retries
-                if (!message.Request.Headers.Contains("X-Upstream-Host"))
+                // Ensure X-Upstream-Base-Uri header is only set once, since the same HttpMessage will be reused on retries
+                if (!message.Request.Headers.Contains("X-Upstream-Base-Uri"))
                 {
-                    message.Request.Headers.SetValue("X-Upstream-Host", $"{message.Request.Uri.Host}:{message.Request.Uri.Port}");
+                    var upstreamBaseUriBuilder = new UriBuilder()
+                    {
+                        Scheme = message.Request.Uri.Scheme,
+                        Host = message.Request.Uri.Host,
+                        Port = message.Request.Uri.Port,
+                    };
+
+                    message.Request.Headers.SetValue("X-Upstream-Base-Uri", upstreamBaseUriBuilder.ToString());
                 }
 
+                message.Request.Uri.Scheme = _uri.Scheme;
                 message.Request.Uri.Host = _uri.Host;
                 message.Request.Uri.Port = _uri.Port;
             }
@@ -109,12 +118,20 @@ namespace Azure.Sdk.Tools.HttpFaultInjector.StorageBlobsSample
 
             protected void RedirectToFaultInjector(HttpMessage message)
             {
-                // Ensure X-Upstream-Host header is only set once, since the same HttpMessage will be reused on retries
-                if (!message.Request.Headers.Contains("X-Upstream-Host"))
+                // Ensure X-Upstream-Base-Uri header is only set once, since the same HttpMessage will be reused on retries
+                if (!message.Request.Headers.Contains("X-Upstream-Base-Uri"))
                 {
-                    message.Request.Headers.SetValue("X-Upstream-Host", $"{message.Request.Uri.Host}:{message.Request.Uri.Port}");
+                    var upstreamBaseUriBuilder = new UriBuilder()
+                    {
+                        Scheme = message.Request.Uri.Scheme,
+                        Host = message.Request.Uri.Host,
+                        Port = message.Request.Uri.Port,
+                    };
+
+                    message.Request.Headers.SetValue("X-Upstream-Base-Uri", upstreamBaseUriBuilder.ToString());
                 }
 
+                message.Request.Uri.Scheme = _uri.Scheme;
                 message.Request.Uri.Host = _uri.Host;
                 message.Request.Uri.Port = _uri.Port;
             }


### PR DESCRIPTION
- Allows using HTTP to fault-injector and HTTPS to upstream