### PR TITLE
Allow automatic triggering to public PR pipelines

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
@@ -25,7 +25,7 @@ namespace PipelineGenerator.Conventions
         {
             var hasChanges = await base.ApplyConventionAsync(definition, component);
 
-            if (EnsureDefautPullRequestTrigger(definition, overrideYaml: true))
+            if (EnsureDefautPullRequestTrigger(definition, overrideYaml: true, securePipeline: true))
             {
                 hasChanges = true;
             }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -313,7 +313,7 @@ namespace PipelineGenerator.Conventions
             return Task.FromResult(hasChanges);
         }
 
-        protected bool EnsureDefautPullRequestTrigger(BuildDefinition definition, bool overrideYaml = true)
+        protected bool EnsureDefautPullRequestTrigger(BuildDefinition definition, bool overrideYaml = true, bool securePipeline = true)
         {
             bool hasChanges = false;
             var prTriggers = definition.Triggers.OfType<PullRequestTrigger>();
@@ -333,11 +333,12 @@ namespace PipelineGenerator.Conventions
 
                 newTrigger.Forks = new Forks
                 {
-                    AllowSecrets = true,
+                    AllowSecrets = securePipeline,
                     Enabled = true
                 };
+
                 newTrigger.RequireCommentsForNonTeamMembersOnly = false;
-                newTrigger.IsCommentRequiredForPullRequest = true;
+                newTrigger.IsCommentRequiredForPullRequest = securePipeline;
 
                 definition.Triggers.Add(newTrigger);
                 hasChanges = true;
@@ -366,16 +367,16 @@ namespace PipelineGenerator.Conventions
                         }
 
                     }
-                    if (trigger.RequireCommentsForNonTeamMembersOnly ||
-                       !trigger.Forks.AllowSecrets ||
-                       !trigger.Forks.Enabled ||
-                       !trigger.IsCommentRequiredForPullRequest
+                    if (trigger.RequireCommentsForNonTeamMembersOnly != false ||
+                       trigger.Forks.AllowSecrets != securePipeline ||
+                       trigger.Forks.Enabled != true ||
+                       trigger.IsCommentRequiredForPullRequest != securePipeline
                        )
                     {
-                        trigger.Forks.AllowSecrets = true;
+                        trigger.Forks.AllowSecrets = securePipeline;
                         trigger.Forks.Enabled = true;
                         trigger.RequireCommentsForNonTeamMembersOnly = false;
-                        trigger.IsCommentRequiredForPullRequest = true;
+                        trigger.IsCommentRequiredForPullRequest = securePipeline;
    
                         hasChanges = true;
                     }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
@@ -25,7 +25,7 @@ namespace PipelineGenerator.Conventions
         {
             var hasChanges = await base.ApplyConventionAsync(definition, component);
 
-            if (EnsureDefautPullRequestTrigger(definition, overrideYaml: false))
+            if (EnsureDefautPullRequestTrigger(definition, overrideYaml: false, securePipeline: false))
             {
                 hasChanges = true;
             }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -25,7 +25,7 @@ namespace PipelineGenerator.Conventions
         {
             var hasChanges = await base.ApplyConventionAsync(definition, component);
 
-            if (EnsureDefautPullRequestTrigger(definition, overrideYaml: true))
+            if (EnsureDefautPullRequestTrigger(definition, overrideYaml: true, securePipeline: true))
             {
                 hasChanges = true;
             }


### PR DESCRIPTION
As part of https://github.com/Azure/azure-sdk-tools/pull/1708 I broke the automatic triggers for public pipelines as they now required a comment. This change fixes that. 