### PR TITLE
Check for API review status only if release date is set in changelog

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -121,6 +121,10 @@ if ($packages)
                 # Ignore API review status for prerelease version
                 Write-Host "Package version is not GA. Ignoring API view approval status"
             }
+            elseif (!$pkgInfo.ReleaseDate -or $pkgInfo.ReleaseDate -eq "Unreleased")
+            {
+                Write-Host "Release date is not set for current version in change log file for package. Ignoring API review approval status since package is not yet ready for release."
+            }
             else
             {
                 # Return error code if status code is 201 for new data plane package

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -121,7 +121,7 @@ if ($packages)
                 # Ignore API review status for prerelease version
                 Write-Host "Package version is not GA. Ignoring API view approval status"
             }
-            elseif (!$pkgInfo.ReleaseDate -or $pkgInfo.ReleaseDate -eq "Unreleased")
+            elseif (!$pkgInfo.ReleaseStatus -or $pkgInfo.ReleaseStatus -eq "Unreleased")
             {
                 Write-Host "Release date is not set for current version in change log file for package. Ignoring API review approval status since package is not yet ready for release."
             }

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -13,6 +13,7 @@ class PackageProps
     [string]$SdkType
     [boolean]$IsNewSdk
     [string]$ArtifactName
+    [string]$ReleaseDate
 
     PackageProps([string]$name, [string]$version, [string]$directoryPath, [string]$serviceDirectory)
     {
@@ -48,6 +49,12 @@ class PackageProps
         if (Test-Path (Join-Path $directoryPath "CHANGELOG.md"))
         {
             $this.ChangeLogPath = Join-Path $directoryPath "CHANGELOG.md"
+            # Get release date for current version and set in package property
+            $changeLogEntry = Get-ChangeLogEntry -ChangeLogLocation $this.ChangeLogPath -VersionString $this.Version
+            if ($changeLogEntry -and ![System.String]::IsNullOrEmpty($changeLogEntry.ReleaseStatus))
+            {
+              $this.ReleaseDate = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
+            } 
         }
         else
         {

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -13,7 +13,7 @@ class PackageProps
     [string]$SdkType
     [boolean]$IsNewSdk
     [string]$ArtifactName
-    [string]$ReleaseDate
+    [string]$ReleaseStatus
 
     PackageProps([string]$name, [string]$version, [string]$directoryPath, [string]$serviceDirectory)
     {
@@ -51,9 +51,9 @@ class PackageProps
             $this.ChangeLogPath = Join-Path $directoryPath "CHANGELOG.md"
             # Get release date for current version and set in package property
             $changeLogEntry = Get-ChangeLogEntry -ChangeLogLocation $this.ChangeLogPath -VersionString $this.Version
-            if ($changeLogEntry -and ![System.String]::IsNullOrEmpty($changeLogEntry.ReleaseStatus))
+            if ($changeLogEntry -and !$changeLogEntry.ReleaseStatus)
             {
-              $this.ReleaseDate = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
+              $this.ReleaseStatus = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
             } 
         }
         else

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -22,7 +22,7 @@ if ($allPackageProperties)
             Write-Host "Package Version: $($pkg.Version)"
             Write-Host "Package SDK Type: $($pkg.SdkType)"
             Write-Host "Artifact Name: $($pkg.ArtifactName)"
-            Write-Host "Release date: $($pkg.ReleaseDate)"
+            Write-Host "Release date: $($pkg.ReleaseStatus)"
             $configFilePrefix = $pkg.Name
             if ($pkg.ArtifactName)
             {

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -22,6 +22,7 @@ if ($allPackageProperties)
             Write-Host "Package Version: $($pkg.Version)"
             Write-Host "Package SDK Type: $($pkg.SdkType)"
             Write-Host "Artifact Name: $($pkg.ArtifactName)"
+            Write-Host "Release date: $($pkg.ReleaseDate)"
             $configFilePrefix = $pkg.Name
             if ($pkg.ArtifactName)
             {


### PR DESCRIPTION
API review status is checked if package version is GA and this is causing issue for JA and Python packages which moves to new GA version after GA release. Any granular change in APIView forces architects to approve it even if release is weeks away to avoid build break  and this requires additional effort from approvers. This change is to validate API review status only if version is GA and release date is present in change log. So developer can set the release date(not required to be exact date) whenever they are are ready to get API review reviewed.