### PR TITLE
Support GZipped Responses

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
@@ -48,7 +48,7 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             string id = RecordingHandler.GetHeader(Request, "x-recording-id");
 
-            await _recordingHandler.Playback(id, Request, Response);
+            await _recordingHandler.HandlePlaybackRequest(id, Request, Response);
         }
 
     }


### PR DESCRIPTION
@kristapratico  also hit an issue with this with her perftests, so I ended up bumping priority.

This PR does the following:

1. Always unzips a `response.Body` if it is `gzip`
2. Within the test-proxy, the body will be handled uncompressed.
   - We do this such that our sanitizers, transforms, etc, can all work on the content itself. There is no possible way we can clean out data when we're looking at an opaque window.
3. Just prior to returning the response, check to see if Content-Encoding includes `gzip`. If it does, compress the body and send THAT back.

Now this is making me think that we need to handle this the same way for `request.Body` as well. Cross that bridge when we come to it!