### PR TITLE
Add Ubuntu 20 to local dns bypass template

### DIFF
--- a/eng/common/pipelines/templates/steps/bypass-local-dns.yml
+++ b/eng/common/pipelines/templates/steps/bypass-local-dns.yml
@@ -8,7 +8,9 @@ steps:
           succeededOrFailed(),
           or(
             eq(variables['OSVmImage'], 'ubuntu-18.04'),
-            eq(variables['OSVmImage'], 'MMSUbuntu18.04')
+            eq(variables['OSVmImage'], 'ubuntu-20.04'),
+            eq(variables['OSVmImage'], 'MMSUbuntu18.04'),
+            eq(variables['OSVmImage'], 'MMSUbuntu20.04')
           ),
           eq(variables['Container'], '')
         )


### PR DESCRIPTION
Live test is failing on Ubuntu with local DNS error we have faced in the past on Ubuntu 1804 image. We are facing this issue again on Ubuntu 20.04 image. PR is to run bypass DNS step on Ubuntu 20.04 as well.