### PR TITLE
Service version diagnostics

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/ASTAnalyser.java
@@ -47,6 +47,7 @@ import com.github.javaparser.ast.type.TypeParameter;
 import com.github.javaparser.ast.visitor.VoidVisitorAdapter;
 import com.github.javaparser.symbolsolver.JavaSymbolSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.CombinedTypeSolver;
+import com.github.javaparser.symbolsolver.resolution.typesolvers.JavaParserTypeSolver;
 import com.github.javaparser.symbolsolver.resolution.typesolvers.ReflectionTypeSolver;
 
 import java.io.File;
@@ -97,8 +98,6 @@ public class ASTAnalyser implements Analyser {
     private static final boolean SHOW_JAVADOC = true;
     private static final Set<String> BLOCKED_ANNOTATIONS = new HashSet<String>() {{
         add("ServiceMethod");
-        add("JsonCreator");
-        add("JsonValue");
         add("SuppressWarnings");
     }};
 
@@ -1011,7 +1010,7 @@ public class ASTAnalyser implements Analyser {
             nodeWithAnnotations.getAnnotations()
                     .stream()
                     .filter(annotationExpr -> !BLOCKED_ANNOTATIONS.contains(annotationExpr.getName().getIdentifier())
-                            || !annotationExpr.getName().getIdentifier().startsWith("Json"))
+                            && !annotationExpr.getName().getIdentifier().startsWith("Json"))
                     .forEach(consumer);
         }
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/Analyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/Analyser.java
@@ -1,6 +1,5 @@
 package com.azure.tools.apiview.processor.analysers;
 
-import com.azure.tools.apiview.processor.model.APIListing;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -9,7 +8,6 @@ import java.util.List;
  * We support multiple analysers, to serve different purposes.
  *
  * @see ASTAnalyser
- * @see ReflectiveAnalyser
  */
 @FunctionalInterface
 public interface Analyser {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
@@ -13,19 +13,26 @@ import com.azure.tools.apiview.processor.diagnostics.rules.NoLocalesInJavadocUrl
 import com.azure.tools.apiview.processor.diagnostics.rules.NoPublicFieldsDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.PackageNameDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.RequiredBuilderMethodsDiagnosticRule;
+import com.azure.tools.apiview.processor.diagnostics.rules.ServiceVersionDiagnosticRule;
 import com.azure.tools.apiview.processor.diagnostics.rules.UpperCaseNamingDiagnosticRule;
 import com.azure.tools.apiview.processor.model.APIListing;
+import com.azure.tools.apiview.processor.model.Diagnostic;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.type.ClassOrInterfaceType;
+import com.github.javaparser.ast.type.Type;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
 import static com.azure.tools.apiview.processor.diagnostics.rules.RequiredBuilderMethodsDiagnosticRule.ExactTypeNameCheckFunction;
 import static com.azure.tools.apiview.processor.diagnostics.rules.RequiredBuilderMethodsDiagnosticRule.DirectSubclassCheckFunction;
 
 import static com.azure.tools.apiview.processor.diagnostics.rules.RequiredBuilderMethodsDiagnosticRule.ParameterAllowedTypes;
 
 import static com.azure.tools.apiview.processor.diagnostics.rules.IllegalMethodNamesDiagnosticRule.Rule;
+import static com.azure.tools.apiview.processor.model.DiagnosticKind.WARNING;
 
 public class Diagnostics {
     private final List<DiagnosticRule> diagnostics = new ArrayList<>();
@@ -40,15 +47,16 @@ public class Diagnostics {
         diagnostics.add(new FluentSetterReturnTypeDiagnosticRule());
         diagnostics.add(new ConsiderFinalClassDiagnosticRule());
         diagnostics.add(new IllegalMethodNamesDiagnosticRule(
-            new Rule("Builder$", "tokenCredential"), // it should just be 'credential'
-            new Rule("Builder$", "^set"),            // we shouldn't have setters in the builder
-            new Rule("^isHas"),
-            new Rule("^setHas")
+                new Rule("Builder$", "tokenCredential"), // it should just be 'credential'
+                new Rule("Builder$", "^set"),            // we shouldn't have setters in the builder
+                new Rule("^isHas"),
+                new Rule("^setHas")
         ));
         diagnostics.add(new MissingJavaDocDiagnosticRule());
         diagnostics.add(new MissingJavadocCodeSnippetsRule());
         diagnostics.add(new NoLocalesInJavadocUrlDiagnosticRule());
         diagnostics.add(new ModuleInfoDiagnosticRule());
+        diagnostics.add(new ServiceVersionDiagnosticRule());
 
         // common APIs for all builders (below we will do rules for http or amqp builders)
         diagnostics.add(new RequiredBuilderMethodsDiagnosticRule(null)
@@ -56,9 +64,19 @@ public class Diagnostics {
             .add("clientOptions", new ExactTypeNameCheckFunction("ClientOptions"))
             .add("connectionString", new ExactTypeNameCheckFunction("String"))
             .add("credential", new ExactTypeNameCheckFunction(new ParameterAllowedTypes("TokenCredential",
-                    "AzureKeyCredential", "AzureSasCredential")))
+                    "AzureKeyCredential", "AzureSasCredential", "AzureNamedKeyCredential")))
             .add("endpoint", new ExactTypeNameCheckFunction("String"))
-            .add("serviceVersion", new DirectSubclassCheckFunction("ServiceVersion")));
+            .add("serviceVersion", methodDeclaration -> {
+                Type parameterType = methodDeclaration.getParameter(0).getType();
+                ClassOrInterfaceType classOrInterfaceType = parameterType.asClassOrInterfaceType();
+                if (!classOrInterfaceType.getNameAsString().endsWith("ServiceVersion")) {
+                    return Optional.of(
+                            new Diagnostic(WARNING, makeId(methodDeclaration),
+                                    "Incorrect type being supplied to this builder method. Expected an enum "
+                                    + "implementing ServiceVersion but was " + classOrInterfaceType.getNameAsString() + "."));
+                }
+                return Optional.empty();
+            }));
         diagnostics.add(new RequiredBuilderMethodsDiagnosticRule("amqp")
             .add("proxyOptions", new ExactTypeNameCheckFunction("ProxyOptions"))
             .add("retry", new ExactTypeNameCheckFunction("AmqpRetryOptions"))

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ModuleInfoDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ModuleInfoDiagnosticRule.java
@@ -9,10 +9,8 @@ import com.azure.tools.apiview.processor.model.Token;
 import com.azure.tools.apiview.processor.model.TokenKind;
 import com.github.javaparser.ast.CompilationUnit;
 
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ServiceVersionDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ServiceVersionDiagnosticRule.java
@@ -1,0 +1,53 @@
+package com.azure.tools.apiview.processor.diagnostics.rules;
+
+import com.azure.tools.apiview.processor.diagnostics.DiagnosticRule;
+import com.azure.tools.apiview.processor.model.APIListing;
+import com.azure.tools.apiview.processor.model.Diagnostic;
+import com.azure.tools.apiview.processor.model.DiagnosticKind;
+import com.github.javaparser.ast.CompilationUnit;
+
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
+import static com.azure.tools.apiview.processor.model.DiagnosticKind.WARNING;
+
+/**
+ * This diagnostic rule checks that a track 2 client library defines an enum that implements ServiceVersion.
+ */
+public class ServiceVersionDiagnosticRule implements DiagnosticRule {
+    private boolean foundServiceVersion;
+    private String serviceClientPackage;
+
+    @Override
+    public void scanIndividual(CompilationUnit cu, APIListing listing) {
+        if (cu.getPrimaryTypeName().get().endsWith("Client")) {
+            serviceClientPackage = cu.getPackageDeclaration().get().getNameAsString();
+        }
+
+        if (cu.getPrimaryTypeName().get().endsWith("ServiceVersion")) {
+            foundServiceVersion = true;
+            cu.getTypes().forEach(typeDeclaration -> {
+                if (!typeDeclaration.isEnumDeclaration()) {
+                    listing.addDiagnostic(new Diagnostic(WARNING, makeId(typeDeclaration), "Service version should be" +
+                            " an enum and must implement 'ServiceVersion' interface."));
+                    return;
+                }
+
+                boolean implementsServiceVersion = typeDeclaration.asEnumDeclaration().getImplementedTypes().stream()
+                        .anyMatch(type -> type.getNameAsString().equals("ServiceVersion"));
+                if (!implementsServiceVersion) {
+                    listing.addDiagnostic(new Diagnostic(WARNING, makeId(typeDeclaration), "This type " +
+                            "should implement 'ServiceVersion' interface."));
+                }
+            });
+        }
+    }
+
+    @Override
+    public void scanFinal(APIListing listing) {
+        // If ServiceVersion type is not found and the module contains a client
+        // show a diagnostic warning about missing service version type.
+        if (!foundServiceVersion && serviceClientPackage != null) {
+            listing.addDiagnostic(new Diagnostic(DiagnosticKind.WARNING, makeId(serviceClientPackage),
+                    "ServiceVersion type is missing."));
+        }
+    }
+}

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ServiceVersionDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ServiceVersionDiagnosticRule.java
@@ -5,6 +5,10 @@ import com.azure.tools.apiview.processor.model.APIListing;
 import com.azure.tools.apiview.processor.model.Diagnostic;
 import com.azure.tools.apiview.processor.model.DiagnosticKind;
 import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.expr.MemberValuePair;
+
+import java.util.Optional;
 
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
 import static com.azure.tools.apiview.processor.model.DiagnosticKind.WARNING;
@@ -15,11 +19,26 @@ import static com.azure.tools.apiview.processor.model.DiagnosticKind.WARNING;
 public class ServiceVersionDiagnosticRule implements DiagnosticRule {
     private boolean foundServiceVersion;
     private String serviceClientPackage;
+    private boolean isHttpService;
 
     @Override
     public void scanIndividual(CompilationUnit cu, APIListing listing) {
-        if (cu.getPrimaryTypeName().get().endsWith("Client")) {
+        if (cu.getPrimaryTypeName().get().endsWith("ClientBuilder")) {
             serviceClientPackage = cu.getPackageDeclaration().get().getNameAsString();
+            cu.getTypes().forEach(typeDeclaration -> {
+                Optional<AnnotationExpr> clientBuilderAnnotation = typeDeclaration
+                        .getAnnotationByName("ServiceClientBuilder");
+                if (clientBuilderAnnotation.isPresent()) {
+                    Optional<MemberValuePair> protocol = clientBuilderAnnotation.get()
+                            .asAnnotationExpr()
+                            .toNormalAnnotationExpr().get()
+                            .getPairs()
+                            .stream()
+                            .filter(pair -> pair.getNameAsString().equals("protocol"))
+                            .findFirst();
+                    this.isHttpService = !protocol.isPresent() || protocol.get().getNameAsString().contains("HTTP");
+                }
+            });
         }
 
         if (cu.getPrimaryTypeName().get().endsWith("ServiceVersion")) {
@@ -45,7 +64,7 @@ public class ServiceVersionDiagnosticRule implements DiagnosticRule {
     public void scanFinal(APIListing listing) {
         // If ServiceVersion type is not found and the module contains a client
         // show a diagnostic warning about missing service version type.
-        if (!foundServiceVersion && serviceClientPackage != null) {
+        if (!foundServiceVersion && serviceClientPackage != null && isHttpService) {
             listing.addDiagnostic(new Diagnostic(DiagnosticKind.WARNING, makeId(serviceClientPackage),
                     "ServiceVersion type is missing."));
         }


### PR DESCRIPTION
Added a new diagnostic rule to check that a track 2 client library defines an enum that implements ServiceVersion and is used in the builder method.