### PR TITLE
Feature/disable release status check

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -121,10 +121,10 @@ if ($packages)
                 # Ignore API review status for prerelease version
                 Write-Host "Package version is not GA. Ignoring API view approval status"
             }
-            elseif (!$pkgInfo.ReleaseStatus -or $pkgInfo.ReleaseStatus -eq "Unreleased")
-            {
-                Write-Host "Release date is not set for current version in change log file for package. Ignoring API review approval status since package is not yet ready for release."
-            }
+            #elseif (!$pkgInfo.ReleaseStatus -or $pkgInfo.ReleaseStatus -eq "Unreleased")
+            #{
+            #    Write-Host "Release date is not set for current version in change log file for package. Ignoring API review approval status since package is not yet ready for release."
+            #}
             else
             {
                 # Return error code if status code is 201 for new data plane package

--- a/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
@@ -28,13 +28,13 @@ namespace APIViewWeb.Controllers
         }
 
         [HttpPost]
-        public async Task<ActionResult> UploadAutoReview([FromForm] IFormFile file, string label)
+        public async Task<ActionResult> UploadAutoReview([FromForm] IFormFile file, string label, bool checkAllRevisions = false)
         {
             if (file != null)
             {
                 using (var openReadStream = file.OpenReadStream())
                 {
-                    var review = await _reviewManager.CreateMasterReviewAsync(User, file.FileName, label, openReadStream, false);
+                    var review = await _reviewManager.CreateMasterReviewAsync(User, file.FileName, label, openReadStream, checkAllRevisions);
                     if(review != null)
                     {
                         var reviewUrl = $"{this.Request.Scheme}://{this.Request.Host}/Assemblies/Review/{review.ReviewId}";


### PR DESCRIPTION
Disable release status check. Java package got released without approval. Even though release date is present in change log, change log parser didn't find date and as a result API check didn't enforce approval.

Disabling this check so all GA version package requires approval.