### PR TITLE
Disable release date check

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -121,10 +121,10 @@ if ($packages)
                 # Ignore API review status for prerelease version
                 Write-Host "Package version is not GA. Ignoring API view approval status"
             }
-            #elseif (!$pkgInfo.ReleaseStatus -or $pkgInfo.ReleaseStatus -eq "Unreleased")
-            #{
-            #    Write-Host "Release date is not set for current version in change log file for package. Ignoring API review approval status since package is not yet ready for release."
-            #}
+            elseif (!$pkgInfo.ReleaseStatus -or $pkgInfo.ReleaseStatus -eq "Unreleased")
+            {
+                Write-Host "Release date is not set for current version in change log file for package. Ignoring API review approval status since package is not yet ready for release."
+            }
             else
             {
                 # Return error code if status code is 201 for new data plane package

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -121,10 +121,10 @@ if ($packages)
                 # Ignore API review status for prerelease version
                 Write-Host "Package version is not GA. Ignoring API view approval status"
             }
-            elseif (!$pkgInfo.ReleaseStatus -or $pkgInfo.ReleaseStatus -eq "Unreleased")
-            {
-                Write-Host "Release date is not set for current version in change log file for package. Ignoring API review approval status since package is not yet ready for release."
-            }
+            #elseif (!$pkgInfo.ReleaseStatus -or $pkgInfo.ReleaseStatus -eq "Unreleased")
+            #{
+            #    Write-Host "Release date is not set for current version in change log file for package. Ignoring API review approval status since package is not yet ready for release."
+            #}
             else
             {
                 # Return error code if status code is 201 for new data plane package

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -51,7 +51,7 @@ class PackageProps
             $this.ChangeLogPath = Join-Path $directoryPath "CHANGELOG.md"
             # Get release date for current version and set in package property
             $changeLogEntry = Get-ChangeLogEntry -ChangeLogLocation $this.ChangeLogPath -VersionString $this.Version
-            if ($changeLogEntry -and !$changeLogEntry.ReleaseStatus)
+            if ($changeLogEntry -and $changeLogEntry.ReleaseStatus)
             {
               $this.ReleaseStatus = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
             } 


### PR DESCRIPTION
Disable release date check when enforcing API review status. Java package got released without API approval even though release date is present. As per the analysis so far, change log parser didn't find the release date even though it was present so API check didn't enforce it. As a first step, disabling this new check to enforce API approval.

Update: Identified root cause and updated PR with actual fix to get the release date in package properties file. updated change is not disabling this check.