### PR TITLE
Support building and deploying bicep templates

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -126,8 +126,7 @@ function BuildBicepFile([System.IO.FileSystemInfo] $file) {
     }
 
     $tmp = $env:TEMP ? $env:TEMP : [System.IO.Path]::GetTempPath()
-    $prefix = ($file | Resolve-Path -Relative) -replace '\.|/', '_'
-    $templateFilePath = Join-Path $tmp ($prefix + '.test-resources.compiled.json')
+    $templateFilePath = Join-Path $tmp "test-resources.$(New-Guid).compiled.json"
 
     # Az can deploy bicep files natively, but by compiling here it becomes easier to parse the
     # outputted json for mismatched parameter declarations.
@@ -579,6 +578,11 @@ try {
         if (Test-Path $postDeploymentScript) {
             Log "Invoking post-deployment script '$postDeploymentScript'"
             &$postDeploymentScript -ResourceGroupName $ResourceGroupName -DeploymentOutputs $deploymentOutputs @PSBoundParameters
+        }
+
+        if ($templateFile.EndsWith('.compiled.json')) {
+            Write-Verbose "Removing compiled bicep file $templateFile"
+            Remove-Item $templateFile
         }
     }
 

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -147,7 +147,7 @@ try {
         Get-ChildItem -Path $root -Filter "$_" -Recurse | ForEach-Object {
             Write-Verbose "Found template '$($_.FullName)'"
             if ($_.Extension -eq '.bicep' -and !(Get-Command bicep)) {
-                Write-Error "A bicep file was found at '$($_.FullName)' but the Azure Bicep CLI is not installed"
+                Write-Error "A bicep file was found at '$($_.FullName)' but the Azure Bicep CLI is not installed. See https://aka.ms/install-bicep-pwsh"
                 throw
             }
             $templateFiles += $_

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -119,6 +119,22 @@ function MergeHashes([hashtable] $source, [psvariable] $dest) {
     }
 }
 
+function BuildBicepFile([System.IO.FileSystemInfo] $file) {
+    $tmp = $env:TEMP ? $env:TEMP : [System.IO.Path]::GetTempPath()
+    $prefix = ($file | Resolve-Path -Relative) -replace '\.|/', '_'
+    $templateFilePath = Join-Path $tmp ($prefix + '.test-resources.compiled.json')
+
+    # Az can deploy bicep files natively, but by compiling here it becomes easier to parse the
+    # outputted json for mismatched parameter declarations.
+    bicep build $templateFileObject.FullName --outfile $templateFilePath
+    if ($LASTEXITCODE) {
+        Write-Error "Failure building bicep file '$($templateFileObject.FullName)'"
+        throw
+    }
+
+    return $templateFilePath
+}
+
 # Support actions to invoke on exit.
 $exitActions = @({
     if ($exitActions.Count -gt 1) {
@@ -146,7 +162,7 @@ try {
         Write-Verbose "Checking for '$_' files under '$root'"
         Get-ChildItem -Path $root -Filter "$_" -Recurse | ForEach-Object {
             Write-Verbose "Found template '$($_.FullName)'"
-            if ($_.Extension -eq '.bicep' -and !(Get-Command bicep)) {
+            if ($_.Extension -eq '.bicep' -and !(Get-Command bicep -ErrorAction Ignore)) {
                 Write-Error "A bicep file was found at '$($_.FullName)' but the Azure Bicep CLI is not installed. See https://aka.ms/install-bicep-pwsh"
                 throw
             }
@@ -437,14 +453,7 @@ try {
     # Deploy the templates
     foreach ($templateFileObject in $templateFiles) {
         if ($templateFileObject.Extension -eq '.bicep') {
-            $templateFile = $templateFileObject.DirectoryName + '/test-resources.compiled.json'
-            # Az can deploy bicep files natively, but by compiling here it becomes easier to parse the
-            # outputted json for mismatched parameter declarations.
-            bicep build $templateFileObject.FullName --outfile $templateFile
-            if ($LASTEXITCODE) {
-                Write-Error "Failure building bicep file '$($templateFileObject.FullName)'"
-                throw
-            }
+            $templateFile = BuildBicepFile $templateFileObject
         } else {
             $templateFile = $templateFileObject.FullName
         }

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -58,3 +58,5 @@ steps:
         -Force `
         -Verbose | Out-Null
     displayName: Deploy test resources
+    env:
+      TEMP: $(Agent.TempDirectory)


### PR DESCRIPTION
This adds support to our common ARM deployment script to compile and deploy [Azure bicep](https://docs.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview) files.

Resolves #1712 