### PR TITLE
Update docs metadata mutation logic

### DIFF
--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -50,10 +50,16 @@ $releaseReplaceRegex = "(https://github.com/$RepoId/(?:blob|tree)/)(?:master|mai
 $TITLE_REGEX = "(\#\s+(?<filetitle>Azure .+? (?:client|plugin|shared) library for (?:JavaScript|Java|Python|\.NET|C)))"
 
 function GetAdjustedReadmeContent($ReadmeContent, $PackageInfo, $PackageMetadata) {
-  # Normalize service name "Key Vault" -> "keyvault"
-  # TODO: Use taxonomy for service name -- https://github.com/Azure/azure-sdk-tools/issues/1442
-  # probably from metadata
-  $service = $PackageMetadata.ServiceName.ToLower().Replace(" ", "")
+  # The $PackageMetadata could be $null if there is no associated metadata entry
+  # based on how the metadata CSV is filtered
+  $service = $PackageInfo.ServiceDirectory.ToLower()
+  if ($PackageMetadata -and $PackageMetadata.ServiceName) {
+    # Normalize service name "Key Vault" -> "keyvault"
+    # TODO: Use taxonomy for service name -- https://github.com/Azure/azure-sdk-tools/issues/1442
+    # probably from metadata
+    $service = $PackageMetadata.ServiceName.ToLower().Replace(" ", "")
+  }
+
   # Generate the release tag for use in link substitution
   $tag = "$($PackageInfo.Name)_$($PackageInfo.Version)"
   $date = Get-Date -Format "MM/dd/yyyy"
@@ -110,11 +116,14 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation) {
 
   $packageMetadataArray = (Get-CSVMetadata).Where({ $_.Package -eq $packageInfo.Name -and $_.GroupId -eq $packageInfo.Group -and $_.Hide -ne 'true' -and $_.New -eq 'true' })
   if ($packageMetadataArray.Count -eq 0) { 
-    LogError "Could not retrieve metadata for $($packageInfo.Name) from metadata CSV"
+    LogWarning "Could not retrieve metadata for $($packageInfo.Name) from metadata CSV. Using best effort defaults."
+    $packageMetadata = $null
   } elseif ($packageMetadataArray.Count -gt 1) { 
     LogWarning "Multiple metadata entries for $($packageInfo.Name) in metadata CSV. Using first entry."
+    $packageMetadata = $packageMetadataArray[0]
+  } else {
+    $packageMetadata = $packageMetadataArray[0]
   }
-  $packageMetadata = $packageMetadataArray[0]
 
   $readmeContent = Get-Content $packageInfo.ReadMePath -Raw
   $outputReadmeContent = "" 


### PR DESCRIPTION
Example success with template project metadata ambiguity: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=976427&view=logs&j=ceb84d66-6af3-5d95-9875-cd812f26b59e&t=3a6002d8-5197-536e-765b-7e51c84fd258&l=144