### PR TITLE
Add root directory to list of sparse checkout paths

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -39,9 +39,15 @@ steps:
               Write-Host "Repository $($repository.Name) has already been initialized. Skipping this step."
             } else {
               Write-Host "Repository $($repository.Name) is being initialized."
+
+              Write-Host "git clone --no-checkout --filter=tree:0 git://github.com/$($repository.Name) ."
               git clone --no-checkout --filter=tree:0 git://github.com/$($repository.Name) .
+
+              Write-Host "git sparse-checkout init"
               git sparse-checkout init
-              git sparse-checkout set eng
+
+              Write-Host "git sparse-checkout set '/*' '!/*/' '/eng'"
+              git sparse-checkout set '/*' '!/*/' '/eng'
             }
 
             $gitsparsecmd = "git sparse-checkout add $paths"


### PR DESCRIPTION
Explicitly add '/*' '!/*/' to the list of paths so we include
the files in the root of the repo.

Added some extra command logging so we can easily repro locally without
needing to find the code that ran.

Update to '/eng' so that we only get paths that start with eng instead
of every path that has eng as a folder.