### PR TITLE
[test-proxy] Add short timestamp to status logs

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -43,7 +43,7 @@ namespace Azure.Sdk.Tools.TestProxy
             TargetLocation = resolveRepoLocation(storageLocation);
 
             var statusThread = PrintStatus(
-                () => $"Recorded: {RequestsRecorded}\tPlayed Back: {RequestsPlayedBack}",
+                () => $"[{DateTime.Now.ToString("HH:mm:ss")}] Recorded: {RequestsRecorded}\tPlayed Back: {RequestsPlayedBack}",
                 newLine: true, statusThreadCts.Token);
 
             var host = Host.CreateDefaultBuilder();

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -2,7 +2,7 @@
 trigger:
   branches:
     include:
-      - master
+      - main
       - feature/*
       - release/*
       - hotfix/*
@@ -13,7 +13,7 @@ trigger:
 pr:
   branches:
     include:
-      - master
+      - main
       - feature/*
       - release/*
       - hotfix/*


### PR DESCRIPTION
Without a timestamp, it's hard to tell from the console logs if the app is still running.  Changes output from:

```
Recorded: 0  Played Back: 0
Recorded: 0  Played Back: 0
Recorded: 0  Played Back: 0
```

to:

```
[16:49:11] Recorded: 0  Played Back: 0
[16:49:12] Recorded: 0  Played Back: 0
[16:49:13] Recorded: 0  Played Back: 0
```