### PR TITLE
Release check should compare API review against all approved revisions.

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -15,7 +15,7 @@ Param (
 )
 
 # Submit API review request and return status whether current revision is approved or pending or failed to create review
-function Submit-APIReview($packagename, $filePath, $uri, $apiKey, $apiLabel)
+function Submit-APIReview($packagename, $filePath, $uri, $apiKey, $apiLabel, $releaseStatus)
 {
     $multipartContent = [System.Net.Http.MultipartFormDataContent]::new()
     $FileStream = [System.IO.FileStream]::new($filePath, [System.IO.FileMode]::Open)
@@ -33,6 +33,17 @@ function Submit-APIReview($packagename, $filePath, $uri, $apiKey, $apiLabel)
     $StringContent = [System.Net.Http.StringContent]::new($apiLabel)
     $StringContent.Headers.ContentDisposition = $stringHeader
     $multipartContent.Add($stringContent)
+    Write-Host "Request param, label: $apiLabel"
+
+    if ($releaseStatus -and ($releaseStatus -ne "Unreleased"))
+    {
+        $compareAllParam = [System.Net.Http.Headers.ContentDispositionHeaderValue]::new("form-data")
+        $compareAllParam.Name = "compareAllRevisions"
+        $compareAllParamContent = [System.Net.Http.StringContent]::new($true)
+        $compareAllParamContent.Headers.ContentDisposition = $compareAllParam
+        $multipartContent.Add($compareAllParamContent)
+        Write-Host "Request param, compareAllRevisions: true"
+    }
 
     $headers = @{
         "ApiKey" = $apiKey;
@@ -109,7 +120,7 @@ if ($packages)
         if ( ($SourceBranch -eq $DefaultBranch) -or (-not $version.IsPrerelease))
         {
             Write-Host "Submitting API Review for package $($pkg)"
-            $respCode = Submit-APIReview -packagename $pkg -filePath $pkgPath -uri $APIViewUri -apiKey $APIKey -apiLabel $APILabel
+            $respCode = Submit-APIReview -packagename $pkg -filePath $pkgPath -uri $APIViewUri -apiKey $APIKey -apiLabel $APILabel -releaseStatus $pkgInfo.ReleaseStatus
             Write-Host "HTTP Response code: $($respCode)"
             # HTTP status 200 means API is in approved status
             if ($respCode -eq '200')

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -359,15 +359,16 @@ namespace APIViewWeb.Respositories
             return lastRevisionTextLines.SequenceEqual(fileTextLines);
         }
 
-        public async Task<ReviewModel> CreateMasterReviewAsync(ClaimsPrincipal user, string originalName, string label, Stream fileStream, bool runAnalysis)
+        public async Task<ReviewRevisionModel> CreateMasterReviewAsync(ClaimsPrincipal user, string originalName, string label, Stream fileStream, bool compareAllRevisions)
         {
             //Generate code file from new uploaded package
             using var memoryStream = new MemoryStream();
-            var codeFile = await CreateCodeFile(originalName, fileStream, runAnalysis, memoryStream);
+            var codeFile = await CreateCodeFile(originalName, fileStream, false, memoryStream);
 
             //Get current master review for package and language
             var review = await _reviewsRepository.GetMasterReviewForPackageAsync(codeFile.Language, codeFile.PackageName);
             bool createNewRevision = true;
+            ReviewRevisionModel reviewRevision = null;
             if (review != null)
             {
                 // Delete pending revisions if it is not in approved state before adding new revision
@@ -380,10 +381,23 @@ namespace APIViewWeb.Respositories
                 }
 
                 var renderedCodeFile = new RenderedCodeFile(codeFile);
-                var noDiffFound = await IsReviewSame(review.Revisions.LastOrDefault(), renderedCodeFile);
-                if (noDiffFound)
+                // We should compare against only latest revision when calling this API from scheduled CI runs
+                // But any manual pipeline run at release time should compare against all approved revisions to ensure hotfix release doesn't have API change
+                // If review surface doesn't match with any approved revisions then we will create new revision if it doesn't match pending latest revision
+                if (compareAllRevisions)
                 {
-                    // No change is detected from last revision so no need to update this revision
+                    foreach (var approvedRevision in review.Revisions.Where(r => r.IsApproved).Reverse())
+                    {
+                        if (await IsReviewSame(approvedRevision, renderedCodeFile))
+                        {
+                            return approvedRevision;
+                        }
+                    }
+                }
+
+                if (await IsReviewSame(lastRevision, renderedCodeFile))
+                {
+                    reviewRevision = lastRevision;
                     createNewRevision = false;
                 }
             }
@@ -394,7 +408,7 @@ namespace APIViewWeb.Respositories
                 {
                     Author = user.GetGitHubLogin(),
                     CreationDate = DateTime.UtcNow,
-                    RunAnalysis = runAnalysis,
+                    RunAnalysis = false,
                     Name = originalName,
                     IsAutomatic = true
                 };
@@ -405,17 +419,17 @@ namespace APIViewWeb.Respositories
             if (createNewRevision)
             {
                 // Update or insert review with new revision
-                var revision = new ReviewRevisionModel()
+                reviewRevision = new ReviewRevisionModel()
                 {
                     Author = user.GetGitHubLogin(),
                     Label = label
                 };
-                var reviewCodeFileModel = await CreateReviewCodeFileModel(revision.RevisionId, memoryStream, codeFile);
+                var reviewCodeFileModel = await CreateReviewCodeFileModel(reviewRevision.RevisionId, memoryStream, codeFile);
                 reviewCodeFileModel.FileName = originalName;
-                revision.Files.Add(reviewCodeFileModel);
-                review.Revisions.Add(revision);
+                reviewRevision.Files.Add(reviewCodeFileModel);
+                review.Revisions.Add(reviewRevision);
             }
-            
+
             // Check if review can be marked as approved if another review with same surface level is in approved status
             if (review.Revisions.Last().Approvers.Count() == 0)
             {
@@ -429,7 +443,7 @@ namespace APIViewWeb.Respositories
                 }
             }
             await _reviewsRepository.UpsertReviewAsync(review);
-            return review;
+            return reviewRevision;
         }
 
         private async Task AssertAutomaticReviewModifier(ClaimsPrincipal user, ReviewModel reviewModel)


### PR DESCRIPTION
This is an interim fix until we have packages versions available for all reviews so that reviews are compared against only corresponding semver ranges.