### PR TITLE
[Test-Proxy] Need to expose all headers, not just allow them

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -66,7 +66,8 @@ namespace Azure.Sdk.Tools.TestProxy
                     {
                         builder.AllowAnyHeader()
                                .AllowAnyMethod()
-                               .AllowAnyOrigin();
+                               .AllowAnyOrigin()
+                               .WithExposedHeaders("*");
                     });
             });
 


### PR DESCRIPTION
`AllowAnyHeader` is for the preflight `Access-Control-Allow-Headers: <requested headers>`.

`WithExposedHeaders` adds `Access-Control-Expose-Headers`. These restrictions were causing karma tests to not have access due to the xhr headers being filtered out by security restrictions.