### PR TITLE
Add basic ga tag w/ settable campaignid

### DIFF
--- a/eng/common/docgeneration/Generate-DocIndex.ps1
+++ b/eng/common/docgeneration/Generate-DocIndex.ps1
@@ -27,7 +27,7 @@ function Get-BlobStorage-Artifacts($blobStorageUrl, $blobDirectoryRegex, $blobAr
         $blobStorageUrlPageToken = $blobStorageUrl + "&marker=$pageToken"
         $resp = Invoke-RestMethod -Method Get -Uri $blobStorageUrlPageToken
       }
-      # Convert to xml documents. 
+      # Convert to xml documents.
       $xmlDoc = [xml](removeBomFromString $resp)
       foreach ($elem in $xmlDoc.EnumerationResults.Blobs.BlobPrefix) {
         # What service return like "dotnet/Azure.AI.Anomalydetector/", needs to fetch out "Azure.AI.Anomalydetector"
@@ -39,8 +39,8 @@ function Get-BlobStorage-Artifacts($blobStorageUrl, $blobDirectoryRegex, $blobAr
     } while ($pageToken)
     return $returnedArtifacts
   }
-  
-# The sequence of Bom bytes differs by different encoding. 
+
+# The sequence of Bom bytes differs by different encoding.
 # The helper function here is only to strip the utf-8 encoding system as it is used by blob storage list api.
 # Return the original string if not in BOM utf-8 sequence.
 function RemoveBomFromString([string]$bomAwareString) {
@@ -55,8 +55,8 @@ function RemoveBomFromString([string]$bomAwareString) {
     }
     return $bomAwareString
 }
-  
-function Get-TocMapping { 
+
+function Get-TocMapping {
     Param (
         [Parameter(Mandatory = $true)] [Object[]] $metadata,
         [Parameter(Mandatory = $true)] [String[]] $artifacts
@@ -87,10 +87,10 @@ function Get-TocMapping {
         }
         $orderServiceMapping[$artifact] = @($serviceName, $displayName)
     }
-    return $orderServiceMapping                   
+    return $orderServiceMapping
 }
 
-function GenerateDocfxTocContent([Hashtable]$tocContent, [String]$lang) {
+function GenerateDocfxTocContent([Hashtable]$tocContent, [String]$lang, [String]$campaignId = "UA-62780441-46") {
     LogDebug "Start generating the docfx toc and build docfx site..."
 
     LogDebug "Initializing Default DocFx Site..."
@@ -100,6 +100,15 @@ function GenerateDocfxTocContent([Hashtable]$tocContent, [String]$lang) {
     LogDebug "Copying template and configuration..."
     New-Item -Path "${DocOutDir}" -Name "templates" -ItemType "directory" -Force
     Copy-Item "${DocGenDir}/templates/*" -Destination "${DocOutDir}/templates" -Force -Recurse
+
+    $headerTemplateLocation = "${DocOutDir}/templates/matthews/partials/head.tmpl.partial"
+
+    if ($campaignId -and (Test-Path $headerTemplateLocation)){
+        $headerTemplateContent = Get-Content -Path $headerTemplateLocation -Raw
+        $headerTemplateContent = $headerTemplateContent -replace "GA_CAMPAIGN_ID", $campaignId
+        Set-Content -Path $headerTemplateLocation -Value $headerTemplateContent -NoNewline
+    }
+
     Copy-Item "${DocGenDir}/docfx.json" -Destination "${DocOutDir}/" -Force
     $YmlPath = "${DocOutDir}/api"
     New-Item -Path $YmlPath -Name "toc.yml" -Force
@@ -109,7 +118,7 @@ function GenerateDocfxTocContent([Hashtable]$tocContent, [String]$lang) {
         $artifact = $serviceMapping.Key
         $serviceName = $serviceMapping.Value[0]
         $displayName = $serviceMapping.Value[1]
-        
+
         $fileName = ($serviceName -replace '\s', '').ToLower().Trim()
         if ($visitedService.ContainsKey($serviceName)) {
             if ($displayName) {
@@ -145,7 +154,7 @@ function GenerateDocfxTocContent([Hashtable]$tocContent, [String]$lang) {
     & $($DocFx) build "${DocOutDir}/docfx.json"
     # The line below is used for testing in local
     #docfx build "${DocOutDir}/docfx.json"
-    Copy-Item "${DocGenDir}/assets/logo.svg" -Destination "${DocOutDir}/_site/" -Force    
+    Copy-Item "${DocGenDir}/assets/logo.svg" -Destination "${DocOutDir}/_site/" -Force
 }
 
 function UpdateDocIndexFiles {
@@ -166,6 +175,7 @@ function UpdateDocIndexFiles {
     # Update main.js package regex and replacement
     $mainJsContent = $mainJsContent -replace "var PACKAGE_REGEX = ''", "var PACKAGE_REGEX = $packageRegex"
     $mainJsContent = $mainJsContent -replace "var PACKAGE_REPLACEMENT = ''", "var PACKAGE_REPLACEMENT = `"$regexReplacement`""
+
     Set-Content -Path $MainJsPath -Value $mainJsContent -NoNewline
 }
 

--- a/eng/common/docgeneration/templates/matthews/partials/head.tmpl.partial
+++ b/eng/common/docgeneration/templates/matthews/partials/head.tmpl.partial
@@ -19,10 +19,10 @@
   <!-- Global site tag (gtag.js) - Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=GA_CAMPAIGN_ID"></script>
   <script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
 
-  gtag('config', 'GA_CAMPAIGN_ID');
+    gtag('config', 'GA_CAMPAIGN_ID');
   </script>
 </head>

--- a/eng/common/docgeneration/templates/matthews/partials/head.tmpl.partial
+++ b/eng/common/docgeneration/templates/matthews/partials/head.tmpl.partial
@@ -1,0 +1,28 @@
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}</title>
+  <meta name="viewport" content="width=device-width">
+  <meta name="title" content="{{#title}}{{title}}{{/title}}{{^title}}{{>partials/title}}{{/title}} {{#_appTitle}}| {{_appTitle}} {{/_appTitle}}">
+  <meta name="generator" content="docfx {{_docfxVersion}}">
+  {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
+  <link rel="shortcut icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
+  <link rel="stylesheet" href="{{_rel}}styles/docfx.vendor.css">
+  <link rel="stylesheet" href="{{_rel}}styles/docfx.css">
+  <link rel="stylesheet" href="{{_rel}}styles/main.css">
+  <meta property="docfx:navrel" content="{{_navRel}}">
+  <meta property="docfx:tocrel" content="{{_tocRel}}">
+  {{#_noindex}}<meta name="searchOption" content="noindex">{{/_noindex}}
+  {{#_enableSearch}}<meta property="docfx:rel" content="{{_rel}}">{{/_enableSearch}}
+  {{#_enableNewTab}}<meta property="docfx:newtab" content="true">{{/_enableNewTab}}
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=GA_CAMPAIGN_ID"></script>
+  <script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'GA_CAMPAIGN_ID');
+  </script>
+</head>


### PR DESCRIPTION
Alrighty, I think this was about the cleanest as I could find to do this.

1. Add new header template that adds GA tag.
   - This header was generated by `docfx template export default` -> add my stuff -> copy into partials folder.
2. Add campaignId argument to GenerateDocFxToCConfig (which is really the function that builds the skeleton of the site)
   - This will optionally inject a specific campaignId if presented

Have run a test using the java folks as a guinea pig. To take advantage of this, merely update the call in `Language-Settings.ps1` -> `Get-<language>-GithubIODocIndex()`

![image](https://user-images.githubusercontent.com/45376673/127068076-ec8e164c-0c90-4568-a0d7-b45f3abab6a7.png)
