### PR TITLE
Add ability to leave SourceBranch empty when queueing a build 

### DIFF
--- a/eng/common/scripts/Invoke-DevOpsAPI.ps1
+++ b/eng/common/scripts/Invoke-DevOpsAPI.ps1
@@ -13,7 +13,6 @@ function Start-DevOpsBuild {
   param (
     $Organization="azure-sdk",
     $Project="internal",
-    [Parameter(Mandatory = $true)]
     $SourceBranch,
     [Parameter(Mandatory = $true)]
     $DefinitionId,


### PR DESCRIPTION
An empty string uses the default branch