### PR TITLE
SwiftAPIView: Fix `Any` type not supported and remove internal labels from parameter rendering

### DIFF
--- a/src/swift/Sources/Models/TokenFile.swift
+++ b/src/swift/Sources/Models/TokenFile.swift
@@ -613,20 +613,21 @@ class TokenFile: Codable {
     }
 
     private func handle(parameter: FunctionSignature.Parameter) {
-        // TODO: eliminate reliance on textDescription
-        let externalNameText = parameter.externalName.map { [$0.textDescription] } ?? []
-        let localNameText = parameter.localName.textDescription.isEmpty ? [] : [parameter.localName.textDescription]
-        let nameText = (externalNameText + localNameText).joined(separator: " ")
+        let name = parameter.externalName?.textDescription ?? parameter.localName.textDescription
         let typeModel = TypeModel(from: parameter.typeAnnotation)
-        let defaultText =
-            parameter.defaultArgumentClause.map { " = \($0.textDescription)" } ?? ""
-        let varargsText = parameter.isVarargs ? "..." : ""
-        member(name: nameText)
+        member(name: name)
         punctuation(":")
         whitespace()
         handle(typeModel: typeModel)
-        stringLiteral(defaultText)
-        text(varargsText)
+        if let defaultArgument = parameter.defaultArgumentClause {
+            whitespace()
+            punctuation("=")
+            whitespace()
+            stringLiteral(defaultArgument.textDescription)
+        }
+        if parameter.isVarargs {
+            text("...")
+        }
     }
 
     private func handle(modifiers: DeclarationModifiers) {

--- a/src/swift/Sources/Models/TypeModel.swift
+++ b/src/swift/Sources/Models/TypeModel.swift
@@ -101,6 +101,8 @@ struct TypeModel {
             self.init(from: src)
         case let src as MetatypeType:
             self.init(from: src.referenceType)
+        case let src as AnyType:
+            self.init(from: src.textDescription)
         default:
             SharedLogger.fail("Unsupported identifier: \(source)")
         }

--- a/src/swift/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
+++ b/src/swift/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
@@ -57,7 +57,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--source=/Users/travisprescott/repos/azure-sdk-for-ios/sdk/communication/AzureCommunicationChat/Source"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--source=/Users/travisprescott/repos/azure-sdk-tools/src/swift/Tests/TestSwiftFile.swift"

--- a/src/swift/Tests/TestSwiftFile.swift
+++ b/src/swift/Tests/TestSwiftFile.swift
@@ -136,6 +136,10 @@ public struct SomeStruct: Codable, Equatable {
     static var text = "Hello, World!"
     public static var staticVar = "initial value"
     public let const = "value"
+
+    public func myMethod(takes type: Any) -> Any {
+        return "" as Any
+    }
 }
 
 // MARK: Test Generic Class

--- a/src/swift/Tests/TestSwiftFile.swift
+++ b/src/swift/Tests/TestSwiftFile.swift
@@ -98,7 +98,7 @@ public final class ThirdClass: SomeOtherProtocol {
         return ""
     }
 
-    public init?(withName name: String) throws {
+    public init?(withName name: String = "Great Name!") throws {
         return nil
     }
 


### PR DESCRIPTION
See API view:
https://apiviewstaging.azurewebsites.net/Assemblies/Review/29dc0e0aec33421ea7a6728eb05178e5

Diff 73 against 71.