### PR TITLE
Fix two Java APIView issues

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -7,7 +7,7 @@
     <AssemblyName>APIViewWeb</AssemblyName>
     <UserSecretsId>79cceff6-d533-4370-a0ee-f3321a343907</UserSecretsId>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <JavaProcessor>..\..\..\java\apiview-java-processor\target\apiview-java-processor-1.22.0.jar</JavaProcessor>
+    <JavaProcessor>..\..\..\java\apiview-java-processor\target\apiview-java-processor-1.23.0.jar</JavaProcessor>
     <PythonProcessor>..\..\..\..\packages\python-packages\api-stub-generator\dist\api_stub_generator-0.1.0-py3-none-any.whl</PythonProcessor>
     <JavaScriptProcessor>..\..\..\ts\ts-genapi\</JavaScriptProcessor>
     <TypeScriptToolsVersion>latest</TypeScriptToolsVersion>

--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
@@ -10,7 +10,7 @@ namespace APIViewWeb
         public override string Name { get; } = "Java";
         public override string Extension { get; } = ".jar";
         public override string ProcessName { get; } = "java";
-        public override string VersionString { get; } = "apiview-java-processor-1.22.0.jar";
+        public override string VersionString { get; } = "apiview-java-processor-1.23.0.jar";
 
         public override string GetProcessorArguments(string originalName, string tempDirectory, string jsonPath)
         {

--- a/src/java/apiview-java-processor/pom.xml
+++ b/src/java/apiview-java-processor/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.azure</groupId>
     <artifactId>apiview-java-processor</artifactId>
-    <version>1.22.0</version>
+    <version>1.23.0</version>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
1) duplicate maven output when a shaded jar is uploaded for review (we only want to see the jar related to our library, not the jar details of all shaded libraries)
2) inclusion of unintended comments into the APIView when the comment was in a certain format, notably:

```java
@Override
//TODO: enable create KeyVaultTrustManager with ManagerFactoryParameters
protected void engineInit(ManagerFactoryParameters spec) {
    LOGGER.entering("KeyVaultKeyManagerFactory", "engineInit", spec);
    trustManagers.add(new KeyVaultTrustManager());
}
```