### PR TITLE
Set default commitish to main for stress test release

### DIFF
--- a/eng/pipelines/stress-test-release.yml
+++ b/eng/pipelines/stress-test-release.yml
@@ -24,6 +24,9 @@ parameters:
     - net
     - python
     - go
+  - name: DeployFromBranchOrCommit
+    type: string
+    default: main
 
 jobs:
 - job:
@@ -62,10 +65,10 @@ jobs:
       parameters:
         Repositories:
           - Name: Azure/azure-sdk-tools
-            Commitish: $(Build.SourceVersion)
+            Commitish: ${{ parameters.DeployFromBranchOrCommit }}
             WorkingDirectory: $(System.DefaultWorkingDirectory)/Azure/azure-sdk-tools
           - Name: $(Repository)
-            Commitish: $(Build.SourceVersion)
+            Commitish: ${{ parameters.DeployFromBranchOrCommit }}
             WorkingDirectory: $(System.DefaultWorkingDirectory)/$(Repository)
         Paths:
           - '/tools'


### PR DESCRIPTION
In the stress test release pipeline, using sparse checkout off `$(Build.SourceVersion)` won't work for repos other than azure-sdk-tools, because the source version gets set as the HEAD commit for main on the tools repo, rather than the branch name itself.

Passing pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1023812&view=results