### PR TITLE
Add report for issues that are marked with test-* labels in the repo.

### DIFF
--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindTestIssuesFunction.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindTestIssuesFunction.cs
@@ -11,7 +11,6 @@ namespace Azure.Sdk.Tools.GitHubIssues.Functions
 {
     public class FindTestIssuesFunction
     {
-
         public FindTestIssuesFunction(FindTestIssues report)
         {
             this.report = report;

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindTestIssuesFunction.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Functions/FindTestIssuesFunction.cs
@@ -1,0 +1,28 @@
+﻿using Azure.Sdk.Tools.GitHubIssues.Reports;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.GitHubIssues.Functions
+{
+    public class FindTestIssuesFunction
+    {
+
+        public FindTestIssuesFunction(FindTestIssues report)
+        {
+            this.report = report;
+        }
+
+        private FindTestIssues report;
+
+        [FunctionName("FindTestIssuesFunction")]
+        public async Task Run([TimerTrigger("0 0 13 * * WED")]TimerInfo timer)
+        {
+            await report.ExecuteAsync();
+        }
+    }
+}

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindTestIssues.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindTestIssues.cs
@@ -16,7 +16,6 @@ namespace Azure.Sdk.Tools.GitHubIssues.Reports
     {
         public FindTestIssues(IConfigurationService configurationService, ILogger<FindIssuesInPastDueMilestones> logger) : base(configurationService, logger)
         {
-
         }
 
         private string[] _labels = new string[] { "test-reliability", "test-manual-pass", "test-sovereign-cloud" };

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindTestIssues.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Reports/FindTestIssues.cs
@@ -1,0 +1,93 @@
+﻿using Azure.Sdk.Tools.GitHubIssues.Email;
+using Azure.Sdk.Tools.GitHubIssues.Services.Configuration;
+using Azure.Security.KeyVault.Secrets;
+using GitHubIssues.Helpers;
+using GitHubIssues.Html;
+using Microsoft.Extensions.Logging;
+using Octokit;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.GitHubIssues.Reports
+{
+    public class FindTestIssues : BaseReport
+    {
+        public FindTestIssues(IConfigurationService configurationService, ILogger<FindIssuesInPastDueMilestones> logger) : base(configurationService, logger)
+        {
+
+        }
+
+        private string[] _labels = new string[] { "test-reliability", "test-manual-pass", "test-sovereign-cloud" };
+
+        protected override async Task ExecuteCoreAsync(ReportExecutionContext context)
+        {
+            foreach (RepositoryConfiguration repositoryConfiguration in context.RepositoryConfigurations)
+            {
+                await ExecuteWithRetryAsync(3, async () =>
+                {
+                    HtmlPageCreator emailBody = new HtmlPageCreator($"Test related issues in {repositoryConfiguration.Name}");
+                    bool hasFoundIssues = FindIssuesWithLabel(context, repositoryConfiguration, emailBody);
+
+                    if (hasFoundIssues)
+                    {
+                        // send the email
+                        EmailSender.SendEmail(context.SendGridToken, context.FromAddress, emailBody.GetContent(), repositoryConfiguration.ToEmail, repositoryConfiguration.CcEmail,
+                            $"Issues with test-* labels for {repositoryConfiguration.Name}", Logger);
+                    }
+                });
+            }
+        }
+
+        private bool FindIssuesWithLabel(ReportExecutionContext context, RepositoryConfiguration repositoryConfig, HtmlPageCreator emailBody)
+        {
+            List<ReportIssue> testIssues = new List<ReportIssue>();
+            foreach (string label in _labels)
+            {
+                Logger.LogInformation($"Retrieve issues for label {label}");
+
+                foreach (Issue issue in context.GitHubClient.SearchForGitHubIssues(CreateQuery(repositoryConfig, label)))
+                {
+                    testIssues.Add(new ReportIssue()
+                    {
+                        Issue = issue,
+                        Note = $"Label: {label}"
+                    });
+                }
+            }
+
+            IEnumerable<IGrouping<string, ReportIssue>> groups = testIssues.GroupBy(g=>g.Note);
+
+            foreach (IGrouping<string, ReportIssue> group in groups.OrderBy(g => g.Key))
+            {
+                TableCreator tc = new TableCreator(group.Key);
+                tc.DefineTableColumn("Milestone", TableCreator.Templates.Milestone);
+                tc.DefineTableColumn("Title", TableCreator.Templates.Title);
+                tc.DefineTableColumn("Labels", TableCreator.Templates.Labels);
+                tc.DefineTableColumn("Author", TableCreator.Templates.Author);
+                tc.DefineTableColumn("Assigned", TableCreator.Templates.Assigned);
+
+                emailBody.AddContent(tc.GetContent(group));
+            }
+
+            return testIssues.Any();
+        }
+        private SearchIssuesRequest CreateQuery(RepositoryConfiguration repoInfo, string label)
+        {
+            // Find all open issues
+            //  That are marked with 'label'
+
+            SearchIssuesRequest requestOptions = new SearchIssuesRequest()
+            {
+                Repos = new RepositoryCollection(),
+                Labels = new string[] { label },
+                State = ItemState.Open
+            };
+
+            requestOptions.Repos.Add(repoInfo.Owner, repoInfo.Name);
+
+            return requestOptions;
+        }
+    }
+}

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Startup.cs
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Startup.cs
@@ -48,6 +48,7 @@ namespace Azure.Sdk.Tools.GitHubIssues
             builder.Services.AddSingleton<FindIssuesInPastDueMilestones>();
             builder.Services.AddSingleton<FindNewGitHubIssuesAndPRs>();
             builder.Services.AddSingleton<FindStalePRs>();
+            builder.Services.AddSingleton<FindTestIssues>();
         }
     }
 }


### PR DESCRIPTION
This creates a report that flags issues that are labeled with test-reliability, test-sovereign-cloud and test-manual-pass.

This will help us keep an eye on the test issues in our repo.

/cc @jongio @jsquire @kurtzeborn @praveenkuttappan @weshaggard 