### PR TITLE
enable public spec repo main to master sync

### DIFF
--- a/eng/pipelines/mirror-repos.yml
+++ b/eng/pipelines/mirror-repos.yml
@@ -20,7 +20,7 @@ jobs:
           Azure/azure-rest-api-specs:
             TargetRepos: 
               Azure/azure-rest-api-specs:
-                Branch: main
+                Branch: master
               Azure/azure-rest-api-specs-pr:
               azure-sdk/azure-rest-api-specs:
 

--- a/eng/pipelines/mirror-repos.yml
+++ b/eng/pipelines/mirror-repos.yml
@@ -24,11 +24,6 @@ jobs:
               Azure/azure-rest-api-specs-pr:
               azure-sdk/azure-rest-api-specs:
 
-          Azure/azure-rest-api-specs-pr:
-            TargetRepos: 
-              Azure/azure-rest-api-specs-pr:
-                Branch: main
-
           Azure/azure-sdk-for-go:
             TargetRepos: 
               Azure/azure-sdk-for-go-pr:


### PR DESCRIPTION
changelog:
1. Enable public spec repo main to master sync, RPaaS sides needs this for their transition
2. Remove old private spec repo main branch sync, as main is now default branch, will be auto synced from public spec repo main branch