### PR TITLE
APIview misc fixes

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
@@ -330,8 +330,9 @@ code-inner {
     margin: -8px -16px;
 }
 
-.btn-upvote {
+.btn-upvote span {
     filter: grayscale(100%) opacity(30%);
+
     &.active {
         filter: unset;
     }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -58,7 +58,7 @@
             </div>
         }
 
-        <form asp-resource="@Model.Review" asp-requirement="@ReviewOwnerRequirement.Instance" class="form-inline float-right ml-2" method="post" asp-page-handler="ToggleClosed">
+        <form asp-resource="@Model.Review" class="form-inline float-right ml-2" method="post" asp-page-handler="ToggleClosed">
             <input type="submit" class="btn btn-sm btn-secondary" value="@(Model.Review.IsClosed ? "Reopen": "Close")" />
         </form>
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
@@ -21,7 +21,15 @@
                             <div class="comment-actions">
                                 <form data-post-update="comments" asp-controller="Comments" asp-action="ToggleUpvote" method="post" asp-route-reviewId="@Model.ReviewId">
                                     <input type="hidden" name="commentId" value="@comment.CommentId" />
-                                    <button type="submit" class="btn btn-light btn-sm btn-upvote" title="@string.Join(", ", comment.Upvotes) " active-if="@comment.Upvotes.Any()">
+                                    @{
+                                        var upvoteclass = "btn-upvote";
+                                        //btn-upvote shows btn in grey when not active
+                                        //not adding this class to show upvotes clearly when someoen else upvoted
+                                        if (comment.Upvotes.Any() && !comment.Upvotes.Contains(User.GetGitHubLogin())) {
+                                            upvoteclass = "";
+                                        }
+                                    }
+                                    <button type="submit" class="btn btn-light btn-sm @upvoteclass" title="@string.Join(", ", comment.Upvotes) " active-if="@comment.Upvotes.Contains(User.GetGitHubLogin())">
                                         @if (comment.Upvotes.Any())
                                         {
                                             @comment.Upvotes.Count

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
@@ -21,7 +21,7 @@
                             <div class="comment-actions">
                                 <form data-post-update="comments" asp-controller="Comments" asp-action="ToggleUpvote" method="post" asp-route-reviewId="@Model.ReviewId">
                                     <input type="hidden" name="commentId" value="@comment.CommentId" />
-                                    <button type="submit" class="btn btn-light btn-sm btn-upvote" title="@string.Join(", ", comment.Upvotes)">
+                                    <button type="submit" class="btn btn-light btn-sm btn-upvote" title="@string.Join(", ", comment.Upvotes)" active-if="@comment.Upvotes.Contains(User.GetGitHubLogin())">
                                         @{
                                             if (comment.Upvotes.Any())
                                             {
@@ -29,7 +29,8 @@
                                             }
                                             var upvoteclass = comment.Upvotes.Contains(User.GetGitHubLogin()) ? "active" : "";
                                             //Direct use of active-if is throwing null pointer exception when clicking the button
-                                            <span class = "@upvoteclass">👍</span>
+                                            //Reason: this span has no predefined class so it doesn't find class resource to add active dynamically
+                                            <span class="@upvoteclass">👍</span>
                                         }
                                     </button>
                                 </form>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
@@ -27,10 +27,7 @@
                                             {
                                                 @comment.Upvotes.Count
                                             }
-                                            var upvoteclass = comment.Upvotes.Contains(User.GetGitHubLogin()) ? "active" : "";
-                                            //Direct use of active-if is throwing null pointer exception when clicking the button
-                                            //Reason: this span has no predefined class so it doesn't find class resource to add active dynamically
-                                            <span class="@upvoteclass">👍</span>
+                                            <span active-if="@comment.Upvotes.Contains(User.GetGitHubLogin())">👍</span>
                                         }
                                     </button>
                                 </form>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
@@ -21,20 +21,16 @@
                             <div class="comment-actions">
                                 <form data-post-update="comments" asp-controller="Comments" asp-action="ToggleUpvote" method="post" asp-route-reviewId="@Model.ReviewId">
                                     <input type="hidden" name="commentId" value="@comment.CommentId" />
-                                    @{
-                                        var upvoteclass = "btn-upvote";
-                                        //btn-upvote shows btn in grey when not active
-                                        //not adding this class to show upvotes clearly when someoen else upvoted
-                                        if (comment.Upvotes.Any() && !comment.Upvotes.Contains(User.GetGitHubLogin())) {
-                                            upvoteclass = "";
+                                    <button type="submit" class="btn btn-light btn-sm btn-upvote" title="@string.Join(", ", comment.Upvotes)">
+                                        @{
+                                            if (comment.Upvotes.Any())
+                                            {
+                                                @comment.Upvotes.Count
+                                            }
+                                            var upvoteclass = comment.Upvotes.Contains(User.GetGitHubLogin()) ? "active" : "";
+                                            //Direct use of active-if is throwing null pointer exception when clicking the button
+                                            <span class = "@upvoteclass">👍</span>
                                         }
-                                    }
-                                    <button type="submit" class="btn btn-light btn-sm @upvoteclass" title="@string.Join(", ", comment.Upvotes) " active-if="@comment.Upvotes.Contains(User.GetGitHubLogin())">
-                                        @if (comment.Upvotes.Any())
-                                        {
-                                            @comment.Upvotes.Count
-                                        }
-                                        👍
                                     </button>
                                 </form>
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
@@ -21,7 +21,7 @@
                             <div class="comment-actions">
                                 <form data-post-update="comments" asp-controller="Comments" asp-action="ToggleUpvote" method="post" asp-route-reviewId="@Model.ReviewId">
                                     <input type="hidden" name="commentId" value="@comment.CommentId" />
-                                    <button type="submit" class="btn btn-light btn-sm btn-upvote" title="@string.Join(", ", comment.Upvotes) " active-if="@comment.Upvotes.Contains(User.GetGitHubLogin())">
+                                    <button type="submit" class="btn btn-light btn-sm btn-upvote" title="@string.Join(", ", comment.Upvotes) " active-if="@comment.Upvotes.Any()">
                                         @if (comment.Upvotes.Any())
                                         {
                                             @comment.Upvotes.Count

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
@@ -27,7 +27,7 @@
                                             {
                                                 @comment.Upvotes.Count
                                             }
-                                            <span active-if="@comment.Upvotes.Contains(User.GetGitHubLogin())">👍</span>
+                                            <span active-if="@comment.Upvotes.Any()">👍</span>
                                         }
                                     </button>
                                 </form>

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -270,11 +270,6 @@ namespace APIViewWeb.Respositories
 
         public async Task ToggleIsClosedAsync(ClaimsPrincipal user, string id)
         {
-            if (user == null)
-            {
-                throw new UnauthorizedAccessException();
-            }
-
             var review = await GetReviewAsync(user, id);
             review.IsClosed = !review.IsClosed;
             await _reviewsRepository.UpsertReviewAsync(review);

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -270,11 +270,13 @@ namespace APIViewWeb.Respositories
 
         public async Task ToggleIsClosedAsync(ClaimsPrincipal user, string id)
         {
+            if (user == null)
+            {
+                throw new UnauthorizedAccessException();
+            }
+
             var review = await GetReviewAsync(user, id);
-            await AssertReviewOwnerAsync(user, review);
-
             review.IsClosed = !review.IsClosed;
-
             await _reviewsRepository.UpsertReviewAsync(review);
         }
 

--- a/src/dotnet/APIView/APIViewWeb/TagHelpers/ActiveIfTagHelper.cs
+++ b/src/dotnet/APIView/APIViewWeb/TagHelpers/ActiveIfTagHelper.cs
@@ -14,7 +14,7 @@ namespace APIViewWeb.TagHelpers
         {
             if (ActiveIf)
             {
-                output.Attributes.SetAttribute("class", output.Attributes["class"].Value + " active");
+                output.Attributes.SetAttribute("class", output.Attributes["class"]?.Value + " active");
             }
         }
     }


### PR DESCRIPTION
Python team and architects have asked for change to allow closing reviews by anyone. Currently only owner is allowed to close the reviews and this causes some stale reviews to be present in system. This change is to make it similar to github where other developers are allowed to close a PR.

Second change in this PR is to show upvote button in comments as active if at least one has upvoted it. 