### PR TITLE
Move the mock attestation service to azure-sdk-tools

### DIFF
--- a/eng/containers/ci.yml
+++ b/eng/containers/ci.yml
@@ -8,6 +8,12 @@ parameters:
     dockerFile: 'tools/test-proxy/docker/dockerfile'
     stableTags:
     - 'latest'
+  - name: mock_attestation
+    pool: 'ubuntu-20.04'
+    dockerRepo: 'keyvault-mock-attestation'
+    dockerFile: 'tools/keyvault-mock-attestation/Dockerfile'
+    stableTags:
+    - 'latest'
   - name: test_proxy_windows
     pool: 'windows-2019'
     dockerRepo: 'engsys/testproxy-win'
@@ -23,6 +29,7 @@ trigger:
     include:
     - eng/containers/
     - tools/test-proxy/docker/
+    - tools/keyvault-mock-attestation/Dockerfile
 
 pr: none
 

--- a/tools/keyvault-mock-attestation/.dockerignore
+++ b/tools/keyvault-mock-attestation/.dockerignore
@@ -1,2 +1,1 @@
 node_modules
-npm-debug.log

--- a/tools/keyvault-mock-attestation/.dockerignore
+++ b/tools/keyvault-mock-attestation/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/tools/keyvault-mock-attestation/.gitignore
+++ b/tools/keyvault-mock-attestation/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/tools/keyvault-mock-attestation/Dockerfile
+++ b/tools/keyvault-mock-attestation/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:14-alpine
+
+WORKDIR /usr/src/app
+
+ENV NODE_ENV production
+ENV PORT 443
+
+COPY package.json ./
+COPY package-lock.json ./
+
+RUN npm install
+
+COPY . .
+
+EXPOSE 443
+
+CMD ["npm", "run", "start"]

--- a/tools/keyvault-mock-attestation/Dockerfile
+++ b/tools/keyvault-mock-attestation/Dockerfile
@@ -2,8 +2,10 @@ FROM node:14-alpine
 
 WORKDIR /usr/src/app
 
+# Set default environment variables
 ENV NODE_ENV production
-ENV PORT 443
+ENV PORT 5000
+ENV HOST 0.0.0.0
 
 COPY package.json ./
 COPY package-lock.json ./
@@ -12,6 +14,6 @@ RUN npm install
 
 COPY . .
 
-EXPOSE 443
+EXPOSE $PORT
 
 CMD ["npm", "run", "start"]

--- a/tools/keyvault-mock-attestation/README.md
+++ b/tools/keyvault-mock-attestation/README.md
@@ -1,0 +1,33 @@
+# Azure Key Vault Mock Attestation service
+
+This folder contains the source code for the Azure Key Vault Mock Attestation service
+which is used to run the Secure Key Release live tests for Azure Key Vault.
+
+Secure Key Release requires a signed attestation in order to release the key. In order
+to simluate the attestation we created this mock service that can generate a fake key
+for testing key release as well as provide endpoints for the Managed HSM to call out
+when verifying the attestation token.
+
+## Endpoints
+
+- `GET /generate-test-token`: called by the test itself, it returns a signed token that can be passed to the Managed HSM when releasing the key.
+- `GET /.well-known/openid-configuration`: the OIDC discovery document containing the `jwks_uri` as described in the [OIDC spec](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata). The service uses `/keys` as the `jwks_uri`.
+- `GET /keys`: The `jwks_uri` points to this endpoint, and is used to get the public key of the attestation service in order to verify the attestation token.
+
+## How to use the service
+
+This service is published as a Docker container to the Azure SDK Tools Docker container registry and the image can be used to deploy the service to an Azure
+App Service or Azure Container Instance as needed.
+
+> Note: The service is not intended to be used in production, it is only used for testing.
+
+<!-- TODO: link to JS usage when we migrate over to show an example -->
+
+Locally you can run the service by running the following command:
+
+```bash
+npm install
+npm run start
+```
+
+To start an express app service locally using port 5000.

--- a/tools/keyvault-mock-attestation/README.md
+++ b/tools/keyvault-mock-attestation/README.md
@@ -10,14 +10,19 @@ when verifying the attestation token.
 
 ## Endpoints
 
-- `GET /generate-test-token`: called by the test itself, it returns a signed token that can be passed to the Managed HSM when releasing the key.
-- `GET /.well-known/openid-configuration`: the OIDC discovery document containing the `jwks_uri` as described in the [OIDC spec](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata). The service uses `/keys` as the `jwks_uri`.
-- `GET /keys`: The `jwks_uri` points to this endpoint, and is used to get the public key of the attestation service in order to verify the attestation token.
+- `GET /generate-test-token`: called by the test itself, it returns a signed token that
+  can be passed to the Managed HSM when releasing the key.
+- `GET /.well-known/openid-configuration`: the OIDC discovery document containing the
+  `jwks_uri` as described in the [OIDC spec](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata).
+  The service uses `/keys` as the `jwks_uri`.
+- `GET /keys`: The `jwks_uri` points to this endpoint, and is used to get the public key of
+  the attestation service in order to verify the attestation token.
 
 ## How to use the service
 
-This service is published as a Docker container to the Azure SDK Tools Docker container registry and the image can be used to deploy the service to an Azure
-App Service or Azure Container Instance as needed.
+This service is published as a Docker container to the Azure SDK Tools Docker container
+registry and the image can be used to deploy the service to an Azure App Service or Azure
+Container Instance as needed.
 
 > Note: The service is not intended to be used in production, it is only used for testing.
 

--- a/tools/keyvault-mock-attestation/index.js
+++ b/tools/keyvault-mock-attestation/index.js
@@ -7,7 +7,7 @@ const url = require("url");
 
 const PORT = process.env.PORT || 5000;
 
-const fullUrl = (req) => `https://${req.get("host")}`;
+const baseUrl = (req) => `https://${req.get("host")}`;
 
 async function initKeys() {
   const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
@@ -32,7 +32,7 @@ function initApp({ keyStore, privateKey, signingKeyId }) {
 
   app.get("/.well-known/openid-configuration", (req, res) => {
     res.json({
-      jwks_uri: `${fullUrl(req)}/keys`
+      jwks_uri: `${baseUrl(req)}/keys`
     });
   });
 
@@ -49,7 +49,7 @@ function initApp({ keyStore, privateKey, signingKeyId }) {
 
     // sdk-test will be the claim used for tests.
     const tokenData = {
-      iss: `${fullUrl(req)}/`,
+      iss: `${baseUrl(req)}/`,
       "sdk-test": true,
       "x-ms-inittime": {},
       "x-ms-runtime": {
@@ -62,7 +62,7 @@ function initApp({ keyStore, privateKey, signingKeyId }) {
       algorithm: "RS256",
       expiresIn: "7 days",
       header: {
-        jku: `${fullUrl(req)}/keys`,
+        jku: `${baseUrl(req)}/keys`,
         kid: signingKeyId
       }
     });

--- a/tools/keyvault-mock-attestation/index.js
+++ b/tools/keyvault-mock-attestation/index.js
@@ -67,6 +67,9 @@ function initApp({ keyStore, privateKey, signingKeyId }) {
       }
     });
 
+    // TODO: some tests are still referencing `token` which is too generic.
+    // Let's move to attestationToken which is easier to understand and replace in a recorder.
+    // We can delete `token` once languages have moved over.
     res.json({ token, attestationToken: token });
   });
 

--- a/tools/keyvault-mock-attestation/index.js
+++ b/tools/keyvault-mock-attestation/index.js
@@ -1,0 +1,90 @@
+const express = require("express");
+const bodyParser = require("body-parser");
+const jwt = require("jsonwebtoken");
+const jose = require("node-jose");
+const crypto = require("crypto");
+
+const PORT = process.env.PORT || 8080;
+const HOST = process.env.HOST || "0.0.0.0";
+
+async function initKeys() {
+  const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
+    modulusLength: 2048,
+    publicKeyEncoding: { type: "spki", format: "pem" },
+    privateKeyEncoding: { type: "pkcs8", format: "pem" }
+  });
+  const keystore = jose.JWK.createKeyStore();
+
+  const key = await keystore.add(publicKey, "pem");
+  return {
+    signingKeyId: key.kid,
+    privateKey,
+    publicKey,
+    keyStore: keystore
+  };
+}
+
+function initApp({ keyStore, privateKey, signingKeyId }) {
+  const app = express();
+  app.use(bodyParser.json());
+
+  app.get("/.well-known/openid-configuration", (_req, res) => {
+    res.json({
+      jwks_uri: `${HOST}/keys`
+    });
+  });
+
+  app.get("/keys", (_req, res) => {
+    res.json(keyStore.toJSON(false));
+  });
+
+  app.get("/generate-test-token", async (req, res) => {
+    // create a fake release key to wrap a token with.
+    const releaseKey = await jose.JWK.createKey("RSA", 2048, {
+      use: "enc",
+      kid: "fake-release-key"
+    });
+    releaseKey.toJSON(false);
+
+    // sdk-test will be the claim used for tests.
+    const tokenData = {
+      iss: `${HOST}/`,
+      "sdk-test": true,
+      "x-ms-inittime": {},
+      "x-ms-runtime": {
+        keys: [releaseKey.toJSON(false)]
+      },
+      "maa-ehd": "sdk-test"
+    };
+
+    const token = jwt.sign(tokenData, privateKey, {
+      algorithm: "RS256",
+      expiresIn: "7 days",
+      header: {
+        jku: `${HOST}/keys`,
+        kid: signingKeyId
+      }
+    });
+
+    res.json({ token });
+  });
+
+  return app;
+}
+
+async function main() {
+  const { keyStore, privateKey, signingKeyId } = await initKeys();
+  const app = initApp({ keyStore, privateKey, signingKeyId });
+  await new Promise((resolve, reject) => {
+    app.listen(PORT, (err) => {
+      if (err) {
+        reject(err);
+      }
+
+      console.log(`Server listening on port ${PORT}`);
+
+      resolve();
+    });
+  });
+}
+main().catch(console.error);

--- a/tools/keyvault-mock-attestation/index.js
+++ b/tools/keyvault-mock-attestation/index.js
@@ -67,10 +67,7 @@ function initApp({ keyStore, privateKey, signingKeyId }) {
       }
     });
 
-    // TODO: some tests are still referencing `token` which is too generic.
-    // Let's move to attestationToken which is easier to understand and replace in a recorder.
-    // We can delete `token` once languages have moved over.
-    res.json({ token, attestationToken: token });
+    res.json({ token });
   });
 
   return app;

--- a/tools/keyvault-mock-attestation/index.js
+++ b/tools/keyvault-mock-attestation/index.js
@@ -4,7 +4,7 @@ const jwt = require("jsonwebtoken");
 const jose = require("node-jose");
 const crypto = require("crypto");
 
-const PORT = process.env.PORT || 8080;
+const PORT = process.env.PORT || 5000;
 const HOST = process.env.HOST || "0.0.0.0";
 
 async function initKeys() {
@@ -81,6 +81,7 @@ async function main() {
         reject(err);
       }
 
+      console.log("Host is:", HOST);
       console.log(`Server listening on port ${PORT}`);
 
       resolve();

--- a/tools/keyvault-mock-attestation/package.json
+++ b/tools/keyvault-mock-attestation/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "keyvault-mock-attestation",
+  "version": "1.0.0",
+  "description": "Azure ManagedHSM attestation service",
+  "main": "index.js",
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "body-parser": "^1.19.0",
+    "express": "^4.17.1",
+    "jsonwebtoken": "^8.5.1",
+    "node-jose": "^2.0.0"
+  },
+  "devDependencies": {}
+}


### PR DESCRIPTION
## What

- Add `keyvault-mock-attestation` code to the azure-sdk-tools
- Dockerize the code to prepare for adding it to the azsdktools ACR registry.

## Why

This mock service is needed to run live tests for a specific keyvault scenario. While we currently use the 
long-running test fixture that I deployed, that is not a sustainable solution. 

We want to make sure the code for this mock service is in a repo that is owned by Azure SDK team, 
and we want to enable test runs to deploy and tear down everything that need to run live tests. Depending
on a long running test fixture that is in my private repo violates both of these conditions. By moving the 
code here and ensuring that we can push updates to ACR we will be able to deploy the container for every
test run.

## TODO

- [x] README