### PR TITLE
[Test-Proxy] Address Memory Leak 

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -299,6 +299,8 @@ namespace Azure.Sdk.Tools.TestProxy
                 {
                     throw new InvalidOperationException("Unexpected failure to remove in-memory session.");
                 }
+
+                GC.Collect();
             }
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -11,6 +11,7 @@ using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.IO;
+using System.Text.RegularExpressions;
 
 namespace Azure.Sdk.Tools.TestProxy
 {
@@ -35,6 +36,8 @@ namespace Azure.Sdk.Tools.TestProxy
         /// Lacking both, the current working directory will be utilized.</param>
         public static void Main(string storageLocation = null)
         {
+            Regex.CacheSize = 0;
+
             var statusThreadCts = new CancellationTokenSource();
 
             TargetLocation = resolveRepoLocation(storageLocation);


### PR DESCRIPTION
This is the profiler graph now. @HarshaNalluru my claim is this should stabilize. However, during repros on this I DID hit a crash that resulted in the `0` outputs for each run on the js perf tests. That crash may be responsible for the hangs as well.

Looks like `(process 11048) exited with code -1073741819.` After I did some searches...

> The exit code -1073741819 in hex is 0xC0000005. If you look up this code in Microsoft's documentation (NTSTATUS Values) you will see that it indicates that your program was terminated due to an access violation. This error can occur for a variety of reasons, including de-referencing a NULL pointer or referencing an invalid address.

So I'm still tracking that. It may have been caused by AV but I doubt it.

Either way, I'm happy to have improved the allocations here.

![image](https://user-images.githubusercontent.com/45376673/129112632-88be246e-5a87-4bdd-bfe3-daf04d147f52.png)

This is what it **was**. Notice the increases of the "resting" state every time.

![image](https://user-images.githubusercontent.com/45376673/129113265-1f2cefd9-be7b-46c0-9f11-450043e3e82e.png)
