### PR TITLE
[stress testing] Use UTC 'Z' zone designator to work with powershell DateTime parsing

### DIFF
--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: stress-test-addons
 description: Baseline resources and templates for stress testing clusters
 
-version: 0.1.4
+version: 0.1.5
 appVersion: v0.1

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/deploy.sh
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/deploy.sh
@@ -1,3 +1,5 @@
+set -ex
+
 export AZURE_STORAGE_ACCOUNT=stresstestcharts
 export AZURE_STORAGE_KEY=$(az storage account keys list --account-name $AZURE_STORAGE_ACCOUNT -o tsv --query '[0].value')
 
@@ -15,4 +17,4 @@ az storage blob upload --container-name helm --file *.tgz --name *.tgz
 # index.yaml must be kept up to date, otherwise when helm generates the file, it will not
 # merge it with previous entries, and those packages will become inaccessible as they are no
 # longer index.
-echo "COMMIT CHANGES MADE TO `index.yaml`"
+echo "COMMIT CHANGES MADE TO 'index.yaml'"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
@@ -3,6 +3,15 @@ entries:
   stress-test-addons:
   - apiVersion: v2
     appVersion: v0.1
+    created: "2021-08-11T19:44:41.2835291-04:00"
+    description: Baseline resources and templates for stress testing clusters
+    digest: 482c089b6181a17b1de3c741b8d503582af1d7ac93b13076f05d1bbf70ab5981
+    name: stress-test-addons
+    urls:
+    - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.5.tgz
+    version: 0.1.5
+  - apiVersion: v2
+    appVersion: v0.1
     created: "2021-08-10T12:25:32.7932615-04:00"
     description: Baseline resources and templates for stress testing clusters
     digest: 40c564cf2fdc37d4cccdd8529b4df0a4f4acabb4d81f9e86d738e7a88cd26081
@@ -28,4 +37,4 @@ entries:
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.2.tgz
     version: 0.1.2
-generated: "2021-08-10T12:25:32.7923949-04:00"
+generated: "2021-08-11T19:44:41.2821831-04:00"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
@@ -10,7 +10,7 @@
       groupName='{{ lower .Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}'
       az group create -l westus2 -g $groupName &&
       group=$(az group show -g $groupName -o tsv --query "id") &&
-      az tag create --resource-id $group --tags DeleteAfter="$(date -d '+192:00:00' -Iseconds -u)" &&
+      az tag create --resource-id $group --tags DeleteAfter="$(date -d '+192:00:00' -Iseconds -u | sed 's/UTC/Z/')" &&
       az deployment group create \
           -g $groupName \
           -n $groupName \


### PR DESCRIPTION
I can't figure out whether the `UTC` suffix is or is not valid with the [ISO 8601](https://en.wikipedia.org/wiki/ISO_8601) spec, but either way, busybox won't output `Z` and powershell `DateTime` won't parse `UTC`. The date string is parsed by the resource group cleanup scripts [here](https://github.com/Azure/azure-sdk-tools/blob/e4689bdefa9511950eaf77ebd7fc710d01d4e7b2/eng/scripts/live-test-resource-cleanup.ps1#L58).