### PR TITLE
Discovery/script path fixes for stress test release pipeline

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -25,8 +25,6 @@ steps:
       script: |
         function SparseCheckout([Array]$paths, [Hashtable]$repository)
         {
-            $paths = $paths -Join ' '
-
             $dir = $repository.WorkingDirectory
             if (!$dir) {
               $dir = "./$($repository.Name)"
@@ -50,7 +48,9 @@ steps:
               git sparse-checkout set '/*' '!/*/' '/eng'
             }
 
-            $gitsparsecmd = "git sparse-checkout add $paths"
+            # Prevent wildcard expansion in Invoke-Expression (e.g. for checkout path '/*')
+            $quotedPaths = $paths | ForEach-Object { "'$_'" }
+            $gitsparsecmd = "git sparse-checkout add $quotedPaths"
             Write-Host $gitsparsecmd
             Invoke-Expression -Command $gitsparsecmd
 

--- a/eng/pipelines/stress-test-release.yml
+++ b/eng/pipelines/stress-test-release.yml
@@ -68,8 +68,7 @@ jobs:
             Commitish: ${{ parameters.DeployFromBranchOrCommit }}
             WorkingDirectory: $(System.DefaultWorkingDirectory)/$(Repository)
         Paths:
-          - '/tools'
-          - '/sdk'
+          - '/*'
           - '!sdk/**/test-recordings'
           - '!sdk/**/session-records'
           - '!sdk/**/SessionRecords'

--- a/eng/pipelines/stress-test-release.yml
+++ b/eng/pipelines/stress-test-release.yml
@@ -72,6 +72,7 @@ jobs:
             WorkingDirectory: $(System.DefaultWorkingDirectory)/$(Repository)
         Paths:
           - '/tools'
+          - '/sdk'
           - '!sdk/**/test-recordings'
           - '!sdk/**/session-records'
           - '!sdk/**/SessionRecords'

--- a/eng/pipelines/stress-test-release.yml
+++ b/eng/pipelines/stress-test-release.yml
@@ -64,9 +64,6 @@ jobs:
     - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
       parameters:
         Repositories:
-          - Name: Azure/azure-sdk-tools
-            Commitish: ${{ parameters.DeployFromBranchOrCommit }}
-            WorkingDirectory: $(System.DefaultWorkingDirectory)/Azure/azure-sdk-tools
           - Name: $(Repository)
             Commitish: ${{ parameters.DeployFromBranchOrCommit }}
             WorkingDirectory: $(System.DefaultWorkingDirectory)/$(Repository)
@@ -82,7 +79,7 @@ jobs:
       inputs:
         azureSubscription: ${{ parameters.Subscription }}
         scriptType: pscore
-        scriptPath: $(System.DefaultWorkingDirectory)/Azure/azure-sdk-tools/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
+        scriptPath: $(System.DefaultWorkingDirectory)/$(Repository)/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
         arguments:
           -SearchDirectory '$(System.DefaultWorkingDirectory)/$(Repository)'
           -Filters $(Filters)


### PR DESCRIPTION
- Sparse checkout the `sdk` path so we discover stress tests in the language repositories
- Call the `deploy-stress-tests.ps1` script from `eng/common` in the language repository, so that we can skip checking out the tools repo AND so we can run the pipeline targeting custom branches (otherwise the branch needs to exist in the tools repo as well).