### PR TITLE
[stress testing] Prevent secret logging from resource group deployment results

### DIFF
--- a/tools/stress-cluster/chaos/examples/network-stress-example/Chart.lock
+++ b/tools/stress-cluster/chaos/examples/network-stress-example/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.4
-digest: sha256:c463bfc41e22ce2d3e6ae19279297b3727fa1d76866fbcbd93dd4744c7b768bd
-generated: "2021-08-10T13:03:46.0104659-04:00"
+  version: 0.1.6
+digest: sha256:b97697ef5f303eec43e9a94fca8e312d20b8aed71318250499344aeca9880d31
+generated: "2021-08-16T12:57:01.466377-04:00"

--- a/tools/stress-cluster/chaos/examples/network-stress-example/Chart.yaml
+++ b/tools/stress-cluster/chaos/examples/network-stress-example/Chart.yaml
@@ -11,5 +11,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.4
+  version: 0.1.6
   repository: https://stresstestcharts.blob.core.windows.net/helm/

--- a/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.lock
+++ b/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.4
-digest: sha256:c463bfc41e22ce2d3e6ae19279297b3727fa1d76866fbcbd93dd4744c7b768bd
-generated: "2021-08-10T13:10:34.5201711-04:00"
+  version: 0.1.6
+digest: sha256:b97697ef5f303eec43e9a94fca8e312d20b8aed71318250499344aeca9880d31
+generated: "2021-08-13T17:24:51.4285458-04:00"

--- a/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.yaml
+++ b/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.yaml
@@ -11,5 +11,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.4
+  version: 0.1.6
   repository: https://stresstestcharts.blob.core.windows.net/helm/

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: stress-test-addons
 description: Baseline resources and templates for stress testing clusters
 
-version: 0.1.5
+version: 0.1.6
 appVersion: v0.1

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
@@ -3,6 +3,15 @@ entries:
   stress-test-addons:
   - apiVersion: v2
     appVersion: v0.1
+    created: "2021-08-13T17:23:40.9241683-04:00"
+    description: Baseline resources and templates for stress testing clusters
+    digest: 2e0e076ca62ea57d05624e74880717e7edf0cbeda4d878132344702b376c3b71
+    name: stress-test-addons
+    urls:
+    - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.6.tgz
+    version: 0.1.6
+  - apiVersion: v2
+    appVersion: v0.1
     created: "2021-08-11T19:44:41.2835291-04:00"
     description: Baseline resources and templates for stress testing clusters
     digest: 482c089b6181a17b1de3c741b8d503582af1d7ac93b13076f05d1bbf70ab5981
@@ -37,4 +46,4 @@ entries:
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.2.tgz
     version: 0.1.2
-generated: "2021-08-11T19:44:41.2821831-04:00"
+generated: "2021-08-13T17:23:40.9233485-04:00"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
@@ -16,7 +16,7 @@
           -n $groupName \
           -f /mnt/testresources/test-resources.json \
           --parameters /mnt/testresources/parameters.json \
-          --parameters testApplicationOid=$AZURE_CLIENT_OID &&
+          --parameters testApplicationOid=$AZURE_CLIENT_OID > /dev/null &&
       az deployment group show \
           -g $groupName \
           -n $groupName \


### PR DESCRIPTION
If any ARM template outputs or parameters container connection strings, etc. they will get printed in the container logs. This will hide stdout from the deployment.