### PR TITLE
Enable API review approval check for Java spring packages

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -140,7 +140,9 @@ if ($packages)
             else
             {
                 # Return error code if status code is 201 for new data plane package
-                if ($pkgInfo.SdkType -eq "client" -and $pkgInfo.IsNewSdk)
+                # Temporarily enable API review for spring SDK types. Ideally this should be done be using 'IsReviewRequired' method in language side
+                # to override default check of SDK type client 
+                if (($pkgInfo.SdkType -eq "client" -or $pkgInfo.SdkType -eq "spring") -and $pkgInfo.IsNewSdk)
                 {
                     if ($respCode -eq '201')
                     {


### PR DESCRIPTION
API review status check is done only for GA version of client SDK packages. Java team has asked to enable api review check for spring SDK also. I will make a change to add a function in individual language function script to override standard check of sdkType client. This PR is only a temp work around until language side override function is ready.