### PR TITLE
[Test-Proxy] Allow Version Flag. Output Json files explicitly.

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -10,7 +10,6 @@
   "profiles": {
     "Azure.Sdk.Tools.TestProxy": {
       "commandName": "Project",
-      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -10,6 +10,7 @@
   "profiles": {
     "Azure.Sdk.Tools.TestProxy": {
       "commandName": "Project",
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -23,6 +23,12 @@ After successful installation, run the tool:
 > test-proxy --storage-location <location>
 ```
 
+If you've already installed the tool, you can always check the installed version by invoking:
+
+```powershell
+> test-proxy --version
+```
+
 ### Via Docker Image
 
 Feel free to build the docker file locally within working directory `/tools/test-proxy/docker/`. All required resources are located within. There are additional helpful tips regarding the docker build and install in the [docker readme](../docker/README)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -419,7 +419,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public string GetRecordingPath(string file)
         {
-            return Path.Join(RepoPath, file);
+            return Path.Join(RepoPath, file + (!file.EndsWith(".json") ? ".json" : String.Empty));
         }
 
         public static string GetHeader(HttpRequest request, string name, bool allowNulls = false)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -12,6 +12,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Reflection;
 
 namespace Azure.Sdk.Tools.TestProxy
 {
@@ -34,8 +35,19 @@ namespace Azure.Sdk.Tools.TestProxy
 
         /// <param name="storageLocation">The path to the target local git repo. If not provided as an argument, Environment variable TEST_PROXY_FOLDER will be consumed. 
         /// Lacking both, the current working directory will be utilized.</param>
-        public static void Main(string storageLocation = null)
+        /// <param name="version">Flag. Invoke to get the version of the tool.</param>
+        public static void Main(string storageLocation = null, bool version = false)
         {
+            if (version)
+            {
+                var assembly = System.Reflection.Assembly.GetExecutingAssembly();
+                var nameVersion = assembly.GetName().Version;
+
+                Console.WriteLine(nameVersion);
+
+                Environment.Exit(0);
+            }
+
             Regex.CacheSize = 0;
 
             var statusThreadCts = new CancellationTokenSource();


### PR DESCRIPTION
1. Accept a `--version` flag at tool invocation that merely returns the version. I need to double check this returns the correct version on a built package. 
2. If the user provides a test-id that includes `.json` in the name, just keep it. Otherwise, we will always store and retrieve files that end in `.json` such that the recordings are syntax highlighted at rest.