### PR TITLE
[Test-Proxy] Documentation Updates

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -25,22 +25,15 @@ After successful installation, run the tool:
 
 ### Via Docker Image
 
-Feel free to build the docker file locally within working directory `/tools/test-proxy/docker/`. All required resources are located within. There are additional helpful tips regarding the docker build and install in the [docker readme](../docker/README)
+The Azure SDK Team maintains a public Azure Container Registry.
 
 ```powershell
-> docker build . -t test-proxy
-> docker run -v <your-volume-name-or-location>:/etc/testproxy -p 5001:5001 -p 5000:5000 -t test-proxy
+> docker run -v <your-volume-name-or-location>:/etc/testproxy -p 5001:5001 -p 5000:5000 azsdkengsys.azurecr.io/engsys/testproxy-lin:latest
 ```
 
-Or, leverage the azure sdk eng sys container registry.
+Note the **port and volume mapping** as arguments! Any files that exist in this volume locally will only be appended to/updated in place. It is a non-destructive initialize.
 
-```powershell
-> docker run -v <your-volume-name-or-location>:/etc/testproxy -p 5001:5001 -p 5000:5000 azsdkengsys.azurecr.io/engsys/testproxy:latest
-```
-
-Note in both cases you will need to provide the port and volume mapping as arguments.
-
-Within the container, recording outputs are written within the directory `/etc/testproxy`. It is a non-destructive initialize. Any files that exist in this volume locally will only be appended to/updated in place.
+Within the container, recording outputs are written within the directory `/etc/testproxy`.
 
 ## Command line arguments
 

--- a/tools/test-proxy/docker/README.md
+++ b/tools/test-proxy/docker/README.md
@@ -47,7 +47,7 @@ docker build . -f dockerfile-win -t test-proxy
 
 ### Certificates
 
-All necessary components for dev-certificate usage are present within the `dev_certificate` directory. Reference [trusting-cert-per-language.md](../documentation/trusting-cert-per-language.md) to learn how to add and trust with the toolchain of your choice.
+All necessary components for dev-certificate usage are present within the `eng/common/testproxy` directory. Reference [trusting-cert-per-language.md](../documentation/trusting-cert-per-language.md) to learn how to add and trust with the toolchain of your choice.
 
 Please note that each language + its SSL stack will provide different mechanisms for validating SSL certificates. Again, reference [trusting-cert-per-language.md](../documentation/trusting-cert-per-language.md) to understand the process beyond the most general case.
 
@@ -68,8 +68,8 @@ Most issues we've seen are related to having a prior `az acr login` or the like.
 If your error looks something like this:
 
 ```
-> docker pull azsdkengsys.azurecr.io/engsys/testproxy:latest
-Error response from daemon: Head https://azsdkengsys.azurecr.io/v2/engsys/testproxy/manifests/latest: unauthorized: authentication required
+> docker pull azsdkengsys.azurecr.io/engsys/testproxy-lin:latest
+Error response from daemon: Head https://azsdkengsys.azurecr.io/v2/engsys/testproxy-lin/manifests/latest: unauthorized: authentication required
 ```
 
 Need to clear multiple sets of credentials.
@@ -83,7 +83,7 @@ This occurs when a user has a **prior login** to `azsdkengsys.azurecr.io`. `az a
 For errors that look like:
 
 ```
-> docker pull azsdkengsys.azurecr.io/engsys/testproxy:latest
+> docker pull azsdkengsys.azurecr.io/engsys/testproxy-lin:latest
 Error response from daemon: Get https://azsdkengsys.azurecr.io/v2/: x509: certificate has expired or is not yet valid
 ```
 

--- a/tools/test-proxy/documentation/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/trusting-cert-per-language.md
@@ -43,6 +43,21 @@ To trust this certificate...
    3. Set `REQUESTS_CA_BUNDLE` to the location of the newly combined pemfile.
 3. Ensure SSL verification is enabled still, notice that your requests to the test proxy still succeed!
 
+## Java
+
+A given certificate must be added to the `Java Certificate Store`.
+
+1. Grab the `dotnet-devcert.crt` from the `eng/common/testproxy` directory of any azure-sdk language repo. Keep its location handy.
+2. Find the Java install that you will be using to run your tests. EG: `C:\Program Files\Java\jre1.8.0_301`.
+   1. Within your Java install folder, ensure that `lib/security/cacerts` exists.
+3. Open your preferred shell in `admin` mode.
+4. Run `keytool.exe -import -file <path-to-dotnet-devcert.crt> -keystore <location of ca-certs file> -alias DotNetDevCert
+   1. `keytool.exe` is part of the the `bin` folder within your Java install.
+5. When prompted, the default password to the `Java Certificate Store` is `changeit`.
+
+[Private OneNote for Reference](https://microsoft.sharepoint.com/teams/AzureDeveloperExperience/_layouts/OneNote.aspx?id=%2Fteams%2FAzureDeveloperExperience%2FShared%20Documents%2FLanguage%20-%20Java%2FAzure%20SDK%20-%20Language%20-%20Java&wd=target%28Engineering%20System.one%7C2E590CA4-A12F-4AF0-9AC0-42AF66D54510%2FUsing%20Fiddler%20as%20a%20Proxy%7C2060B735-F0F0-4059-BD5F-711031550B46%2F%29
+onenote:https://microsoft.sharepoint.com/teams/AzureDeveloperExperience/Shared%20Documents/Language%20-%20Java/Azure%20SDK%20-%20Language%20-%20Java/Engineering%20System.one#Using%20Fiddler%20as%20a%20Proxy&section-id={2E590CA4-A12F-4AF0-9AC0-42AF66D54510}&page-id={2060B735-F0F0-4059-BD5F-711031550B46}&end)
+
 ## .NET
 
 Use the `dotnet dev-certs` approach as recommended in [general section](#generally).

--- a/tools/test-proxy/documentation/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/trusting-cert-per-language.md
@@ -55,9 +55,6 @@ A given certificate must be added to the `Java Certificate Store`.
 5. When prompted, the default password to the `Java Certificate Store` is `changeit`.
 6. To clean up, run `keytool.exe -cacerts -delete -alias DotNetDevCert`.
 
-[Private OneNote for Reference](https://microsoft.sharepoint.com/teams/AzureDeveloperExperience/_layouts/OneNote.aspx?id=%2Fteams%2FAzureDeveloperExperience%2FShared%20Documents%2FLanguage%20-%20Java%2FAzure%20SDK%20-%20Language%20-%20Java&wd=target%28Engineering%20System.one%7C2E590CA4-A12F-4AF0-9AC0-42AF66D54510%2FUsing%20Fiddler%20as%20a%20Proxy%7C2060B735-F0F0-4059-BD5F-711031550B46%2F%29
-onenote:https://microsoft.sharepoint.com/teams/AzureDeveloperExperience/Shared%20Documents/Language%20-%20Java/Azure%20SDK%20-%20Language%20-%20Java/Engineering%20System.one#Using%20Fiddler%20as%20a%20Proxy&section-id={2E590CA4-A12F-4AF0-9AC0-42AF66D54510}&page-id={2060B735-F0F0-4059-BD5F-711031550B46}&end)
-
 ## .NET
 
 Use the `dotnet dev-certs` approach as recommended in [general section](#generally).

--- a/tools/test-proxy/documentation/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/trusting-cert-per-language.md
@@ -49,11 +49,11 @@ A given certificate must be added to the `Java Certificate Store`.
 
 1. Grab the `dotnet-devcert.crt` from the `eng/common/testproxy` directory of any azure-sdk language repo. Keep its location handy.
 2. Find the Java install that you will be using to run your tests. EG: `C:\Program Files\Java\jre1.8.0_301`.
-   1. Within your Java install folder, ensure that `lib/security/cacerts` exists.
 3. Open your preferred shell in `admin` mode.
-4. Run `keytool.exe -import -file <path-to-dotnet-devcert.crt> -keystore <location of ca-certs file> -alias DotNetDevCert
+4. Run `keytool.exe -cacerts -importcert -file <path-to-dotnet-devcert.crt> -alias DotNetDevCert`
    1. `keytool.exe` is part of the the `bin` folder within your Java install.
 5. When prompted, the default password to the `Java Certificate Store` is `changeit`.
+6. To clean up, run `keytool.exe -cacerts -delete -alias DotNetDevCert`.
 
 [Private OneNote for Reference](https://microsoft.sharepoint.com/teams/AzureDeveloperExperience/_layouts/OneNote.aspx?id=%2Fteams%2FAzureDeveloperExperience%2FShared%20Documents%2FLanguage%20-%20Java%2FAzure%20SDK%20-%20Language%20-%20Java&wd=target%28Engineering%20System.one%7C2E590CA4-A12F-4AF0-9AC0-42AF66D54510%2FUsing%20Fiddler%20as%20a%20Proxy%7C2060B735-F0F0-4059-BD5F-711031550B46%2F%29
 onenote:https://microsoft.sharepoint.com/teams/AzureDeveloperExperience/Shared%20Documents/Language%20-%20Java/Azure%20SDK%20-%20Language%20-%20Java/Engineering%20System.one#Using%20Fiddler%20as%20a%20Proxy&section-id={2E590CA4-A12F-4AF0-9AC0-42AF66D54510}&page-id={2060B735-F0F0-4059-BD5F-711031550B46}&end)

--- a/tools/test-proxy/documentation/using-in-devops.md
+++ b/tools/test-proxy/documentation/using-in-devops.md
@@ -32,3 +32,23 @@ A couple notes about the above:
 - `test-proxy-docker.yml`: This yml pulls down the relevant docker image and runs _that_ instead of directly running the tool.
 
 Note that both `.yml` files can be used to start the proxy. It is up to the user to determine which methodology they wish to use. It is recommended that one uses the same method as they would recommend to the team for local testing.
+
+### SSL Support In Devops
+
+When running on DevOps, it is unlikely that the certificate will be trusted appropriately to ensure SSL during playback. Both the yml files provided in `eng/common/testproxy/` are intended to easily support this however.
+
+To add this to your appropriate repository, open `Language-Settings.ps1` (wherever it may be in your repo) and add a function of the form:
+
+```powershell
+function Import-Dev-Cert-<lowercase-language>
+{
+  Write-Host "Certificate action here!"
+  ...
+}
+```
+
+If you're a bit confused as to what is meant by `<lowercase-language>`, refer to the variable value of `$Language` within the `Language-Settings.ps1`. Here's an example [from .NET](https://github.com/Azure/azure-sdk-for-net/blob/912d936723967bb4943437ab8bf284737b312ce8/eng/scripts/Language-Settings.ps1#L1). Here's another example [from Java.](https://github.com/Azure/azure-sdk-for-java/blob/main/eng/scripts/Language-Settings.ps1#L1)
+
+A bunch of the "common" functions are defined and called this way.
+
+This function will be _automatically picked up_ during all your builds once it's merged! How? Check in [eng/common/scripts/trust-proxy-certificate.ps1](../../../eng/common/scripts/trust-proxy-certificate.ps1) if you wish to understand.

--- a/tools/test-proxy/documentation/using-in-devops.md
+++ b/tools/test-proxy/documentation/using-in-devops.md
@@ -10,50 +10,25 @@ Check out [tools/test-proxy/startup-scripts/](../startup-scripts/) for a few exa
 
 ### With Docker
 
-Docker is obviously the preferred methodology, as there are less moving parts that can be affected by the devops hosts.
+Test-proxy has been shipped within the `eng/common/testproxy` folder for any repo owned by the azure-sdk team.
 
-There are a couple options here. Discussed above are `start-up scripts` that can be referenced to make your _test framework_ spin up the appropriate docker container for testing. However, if that is not possible, one can manually do the same thing with a couple devops tasks. Something like the following...
+Important Files:
 
-```yml
-  - pwsh: |
-      choco install docker-desktop --version=2.1.0.3
-    displayName: 'Install docker desktop'
-
-  - pwsh: |
-      docker run `
-      --detach `
-      -v $(Build.SourcesDirectory):/etc/testproxy `
-      -p 5001:5001 `
-      -p 5000:5000 `
-      azsdkengsys.azurecr.io/engsys/testproxy:latest
-    displayName: 'Run the docker container'
+```
+eng/common/testproxy/
+  dotnet-devcert.crt
+  dotnet-devcert.pfx
+  docker-start-proxy.ps1
+  test-proxy-tool.yml
+  test-proxy-docker.yml
 ```
 
-### Without Docker
+A couple notes about the above:
 
-If `docker` is not an option for your unit tests, there will need to be a manual installation and invocation of the test-proxy. It should be noted, that the below, while working on Linux and Windows, can be extremely finicky. Use with caution.
+- `dotnet-devcert.crt` is NOT DER encoded. This means if you need a `pem` file, you can just rename it. No binary to deal with.
+- `dotnet-devcert.pfx` can be imported with password `password` (this fact is also highlighted in [trusting-cert-per-language.md](trusting-cert-per-language.md))
+- `docker-start-proxy.ps1`: This can also be used locally to start and stop a singular instance of the test-proxy docker image.
+- `test-proxy-tool.yml`: This one installs and runs the test-proxy as a dotnet tool.
+- `test-proxy-docker.yml`: This yml pulls down the relevant docker image and runs _that_ instead of directly running the tool.
 
-Something along the lines of...
-
-```yml
-  - pwsh: |
-      dotnet tool install `
-        azure.sdk.tools.testproxy `
-        --tool-path $(Build.BinariesDirectory)/test-proxy `
-        --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json `
-        --version <version>
-    displayName: "Install TestProxy"
-
-  - pwsh: |
-      if ($IsWindows) {
-        Start-Process $(Build.BinariesDirectory)/test-proxy/test-proxy.exe -ArgumentList "--storage-location '$(Build.SourcesDirectory)'" -NoNewWindow -PassThru
-      }
-      else {
-        $(Build.BinariesDirectory)/test-proxy/test-proxy --storage-location "$(Build.SourcesDirectory)" &
-      }
-
-      <start your tests>
-    displayName: "Run Tests"
-```
-
-The key factor at play is that on linux/mac machines, one cannot leverage `Start-Process` like if you're on a Windows host. This is due to the fact that the terminal _owns_ any processes that are started within it. In DevOps, each step _is its own process_. This entirely precludes any simple `fire and forget` options. The recommended methodology is to use the `nohup` (No Hang Up) command to ensure that the test-proxy continues running after the fact.
+Note that both `.yml` files can be used to start the proxy. It is up to the user to determine which methodology they wish to use. It is recommended that one uses the same method as they would recommend to the team for local testing.


### PR DESCRIPTION
- Address some basic ordering in test-proxy readme.
- Update `trusting-cert-per-language` to reflect Java methodology.
- Update `using-in-devops` to reflect the presence of the common pattern.

