### PR TITLE
Update AutoRestCodeGenerationModule.psm1 default branch to 'main'

### DIFF
--- a/src/dotnet/Mgmt.CI.BuildTools/NugetToolsPackage/CI.Tools.Package/build/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
+++ b/src/dotnet/Mgmt.CI.BuildTools/NugetToolsPackage/CI.Tools.Package/build/psModules/CodeGenerationModules/AutoRestCodeGenerationModule/AutoRestCodeGenerationModule.psm1
@@ -422,7 +422,7 @@ function Start-AutoRestCodeGeneration {
         [string] $SpecsRepoName = "azure-rest-api-specs",
 
         [Parameter(Mandatory = $false)]
-        [string] $SpecsRepoBranch = "master",
+        [string] $SpecsRepoBranch = "main",
 
         [Parameter(Mandatory = $false)]
         [string] $AutoRestVersion = "latest",
@@ -566,7 +566,7 @@ function Start-CodeGeneration {
         [string] $ResourceProvider,
         [string] $SpecsRepoFork = "Azure",
         [string] $SpecsRepoName = "azure-rest-api-specs",
-        [string] $SpecsRepoBranch = "master",
+        [string] $SpecsRepoBranch = "main",
         [string] $AutoRestVersion = "latest",
         [string] $SdkRootDirectory,
         [string] $SdkDirectory,


### PR DESCRIPTION
Since default branch for `Azure/azure-rest-api-specs` is changed from `master` to `main`, update the script to fit this changing.