### PR TITLE
Swift APIView: add support for Objective-C and Mixed Source frameworks

### DIFF
--- a/src/swift/README.md
+++ b/src/swift/README.md
@@ -1,6 +1,6 @@
 # APIView for Swift
 
-SwiftAPIView is a plugin that converts `.swift` source code or `.swiftinterface` files to an APIView-compatible token file.
+SwiftAPIView is a plugin that converts `.swift` source code and `.h` Objective-C files to an APIView-compatible token file for the Swift language.
 
 ## Getting started
 
@@ -20,15 +20,16 @@ You may run the tool directly in Xcode or from the command line.
 
 Parameters:
   `--source`: May target a folder, which will collect all `*.swift` files, or a single `*.swift` or `*.swiftinterface` file.
-  `--dest`:  (Optional) The path and desired JSON filename. If not provided, it will output as `SwiftAPIView.json` inside your documents directory. 
+  `--dest`:  (Optional) The path and desired JSON filename. If not provided, it will output as `SwiftAPIView.json` inside your documents directory.
+  `--package-name`: (Optional) The top-level package name to use. If not provided, Swift APIView will attempt to determine the package name. If unsuccessful, supply the value.
 
 #### Xcode
 
-Edit `SwiftAPIView`'s "Run" scheme. This will allow you to pass `--source` and/or `--dest` as arguments using the "Arguments Passed on Launch" section in the "Arguments" tab.
+Edit `SwiftAPIView`'s "Run" scheme. This will allow you to pass command line arguments using the "Arguments Passed on Launch" section in the "Arguments" tab.
 
 #### Command Line
 
 Navigate to the build artifacts folder from Xcode and then run:
 ```
-./SwiftAPIView --source=<PATH_TO_SOURCE> --dest=<PATH_TO_DESTINATION_FILE>`
+./SwiftAPIView --source=<PATH_TO_SOURCE> [--dest=<PATH_TO_DESTINATION_FILE>] [--package-name=<NAME>]`
 ```

--- a/src/swift/Sources/APIViewManager.swift
+++ b/src/swift/Sources/APIViewManager.swift
@@ -112,12 +112,11 @@ class APIViewManager {
         throw ToolError.client("Unsupported file type: \(sourceUrl.absoluteString)")
     }
 
-    func extractPackageName(from sourceUrl: URL) -> String? {
+    func extractPackageName(from sourceUrl: URL) -> String {
         let sourcePath = sourceUrl.path
         let pattern = #"sdk\/[^\/]*\/([^\/]*)"#
         let regex = try! NSRegularExpression(pattern: pattern, options: [])
         let result = regex.matches(in: sourcePath, range: NSMakeRange(0, sourcePath.utf16.count))
-        guard result.count > 0 else { return nil }
         let matchRange = Range(result[0].range(at: 1), in: sourcePath)!
         return String(sourcePath[matchRange])
     }
@@ -134,7 +133,7 @@ class APIViewManager {
 
         // collect all swift files in a directory (and subdirectories)
         if isDir.boolValue {
-            packageName = extractPackageName(from: sourceUrl) ?? "TestItem"
+            packageName = args.packageName ?? extractPackageName(from: sourceUrl)
             let fileEnumerator = FileManager.default.enumerator(atPath: sourceUrl.path)
             while let itemPath = fileEnumerator?.nextObject() as? String {
                 let itemUrl = sourceUrl.appendingPathComponent(itemPath)
@@ -142,7 +141,7 @@ class APIViewManager {
                     let sourceFile = try process(url: itemUrl)
                     let topLevelDecl = try Parser(source: sourceFile).parse()
                     declarations.append(topLevelDecl)
-                } catch let err {
+                } catch {
                     continue
                 }
             }

--- a/src/swift/Sources/APIViewManager.swift
+++ b/src/swift/Sources/APIViewManager.swift
@@ -25,11 +25,10 @@
 // --------------------------------------------------------------------------
 
 import AST
-import SwiftSemantics
-import SwiftSyntax
 import Foundation
 import Parser
 import Source
+import SourceKittenFramework
 
 /// Handles the generation of APIView JSON files.
 class APIViewManager {
@@ -73,49 +72,52 @@ class APIViewManager {
 
     /// Handles automatic processing of swiftinterface file, if supplied
     func process(url sourceUrl: URL) throws -> SourceFile {
-//        guard sourceUrl.absoluteString.hasSuffix("swiftinterface") else {
-        return try SourceReader.read(at: sourceUrl.absoluteString)
-//        }
+        if sourceUrl.absoluteString.hasSuffix("swift") {
+            return try SourceReader.read(at: sourceUrl.absoluteString)
+        }
+        if sourceUrl.absoluteString.hasSuffix("h") {
+            let args = [String]()
+            let generated = try Request.interface(file: sourceUrl.absoluteString, uuid: NSUUID().uuidString, arguments: args).send()
+            if let match = generated.first(where: { key, _ in
+                return key == "key.sourcetext"
+            }) {
+                let sourceCode = match.value as! String
 
-//        func check(line: String) -> String {
-//            var newLine = line
-//            let needsBodyPatterns = [" init(", " init?(", " func ", " deinit"] //"\tget", " get", " set", " set("]
-//            for pattern in needsBodyPatterns {
-//                if newLine.contains(pattern) && !newLine.contains("{}") {
-//                    newLine = "\(newLine) {}"
-//                }
-//            }
-//
-//            let duplicatePatterns = ["@discardableResult"]
-//            for pattern in duplicatePatterns {
-//                let dupePattern = "\(pattern) \(pattern)"
-//                if newLine.contains(dupePattern) {
-//                    newLine = newLine.replacingOccurrences(of: dupePattern, with: pattern)
-//                }
-//            }
-//            return newLine
-//        }
-//
-//        var newLines = [String]()
-//        let interfaceContents = try String(contentsOfFile: sourceUrl.absoluteString, encoding: .utf8)
-//        for line in interfaceContents.components(separatedBy: .newlines) {
-//            newLines.append(check(line: line))
-//        }
-//        // write modified swiftinterface file to temp location
-//        let sourceDir = sourceUrl.deletingLastPathComponent()
-//        let filename = sourceUrl.lastPathComponent
-//        let tempFilename = "\(UUID().uuidString)_\(filename)"
-//        let tempUrl = sourceDir.appendingPathComponent(tempFilename)
-//        try newLines.joined(separator: "\n").write(toFile: tempUrl.absoluteString, atomically: true, encoding: .utf8)
-//        defer { try! FileManager.default.removeItem(atPath: tempUrl.absoluteString) }
-//        return try SourceReader.read(at: tempUrl.absoluteString)
+                func check(line: String) -> String {
+                    var newLine = line
+                    let needsBodyPatterns = [" init(", " init?(", " func ", " deinit"]
+                    for pattern in needsBodyPatterns {
+                        if newLine.contains(pattern) && !newLine.contains("{}") {
+                            newLine = "\(newLine) {}"
+                        }
+                    }
+                    return newLine
+                }
+
+                var newLines = [String]()
+                for line in sourceCode.components(separatedBy: .newlines) {
+                    newLines.append(check(line: line))
+                }
+
+                // write modified swiftinterface file to temp location
+                let sourceDir = sourceUrl.deletingLastPathComponent()
+                let filename = sourceUrl.lastPathComponent
+                let tempFilename = "\(UUID().uuidString)_\(filename)"
+                let tempUrl = sourceDir.appendingPathComponent(tempFilename)
+                try newLines.joined(separator: "\n").write(toFile: tempUrl.absoluteString, atomically: true, encoding: .utf8)
+                defer { try! FileManager.default.removeItem(atPath: tempUrl.absoluteString) }
+                return try SourceReader.read(at: tempUrl.absoluteString)
+            }
+        }
+        throw ToolError.client("Unsupported file type: \(sourceUrl.absoluteString)")
     }
 
-    func extractPackageName(from sourceUrl: URL) -> String {
+    func extractPackageName(from sourceUrl: URL) -> String? {
         let sourcePath = sourceUrl.path
         let pattern = #"sdk\/[^\/]*\/([^\/]*)"#
         let regex = try! NSRegularExpression(pattern: pattern, options: [])
         let result = regex.matches(in: sourcePath, range: NSMakeRange(0, sourcePath.utf16.count))
+        guard result.count > 0 else { return nil }
         let matchRange = Range(result[0].range(at: 1), in: sourcePath)!
         return String(sourcePath[matchRange])
     }
@@ -132,27 +134,24 @@ class APIViewManager {
 
         // collect all swift files in a directory (and subdirectories)
         if isDir.boolValue {
-            packageName = extractPackageName(from: sourceUrl)
+            packageName = extractPackageName(from: sourceUrl) ?? "TestItem"
             let fileEnumerator = FileManager.default.enumerator(atPath: sourceUrl.path)
             while let itemPath = fileEnumerator?.nextObject() as? String {
-                guard itemPath.hasSuffix(".swift") else { continue }
                 let itemUrl = sourceUrl.appendingPathComponent(itemPath)
-                let sourceFile = try SourceReader.read(at: itemUrl.absoluteString)
-                let topLevelDecl = try Parser(source: sourceFile).parse()
-                declarations.append(topLevelDecl)
+                do {
+                    let sourceFile = try process(url: itemUrl)
+                    let topLevelDecl = try Parser(source: sourceFile).parse()
+                    declarations.append(topLevelDecl)
+                } catch let err {
+                    continue
+                }
             }
         } else {
             // otherwise load a single file
             packageName = sourceUrl.lastPathComponent
             let sourceFile = try process(url: sourceUrl)
-            if sourceUrl.absoluteString.hasSuffix("swift") {
-                let topLevelDecl = try Parser(source: sourceFile).parse()
-                declarations.append(topLevelDecl)
-            } else if sourceUrl.absoluteString.hasSuffix("swiftinterface") {
-                var collector = DeclarationCollector()
-                let tree = try SyntaxParser.parse(source: sourceUrl.absoluteString)
-                let test = "best"
-            }
+            let topLevelDecl = try Parser(source: sourceFile).parse()
+            declarations.append(topLevelDecl)
         }
         tokenFile = TokenFile(name: packageName, packageName: packageName, versionString: version)
         tokenFile.process(declarations)

--- a/src/swift/Sources/CommandLineArguments.swift
+++ b/src/swift/Sources/CommandLineArguments.swift
@@ -33,6 +33,7 @@ class CommandLineArguments: Encodable {
     private let supportedKeys: [String] = [
         "source",
         "dest",
+        "package-name",
     ]
 
     // MARK: Computed properties

--- a/src/swift/Sources/CommandLineArguments.swift
+++ b/src/swift/Sources/CommandLineArguments.swift
@@ -47,6 +47,10 @@ class CommandLineArguments: Encodable {
         return rawArgs["dest"]
     }
 
+    var packageName: String? {
+        return rawArgs["package-name"]
+    }
+
     // MARK: Initializers
 
     init() {

--- a/src/swift/Sources/Models/TokenFile.swift
+++ b/src/swift/Sources/Models/TokenFile.swift
@@ -38,9 +38,8 @@ class TokenFile: Codable {
     /// The version string
     var versionString: String
 
-    // TODO: Should be switched to Swift once APIView supports
     /// Language string.
-    let language = "Json"
+    let language = "Swift"
 
     /// List of APIVIew tokens to render
     var tokens: [TokenItem]

--- a/src/swift/Sources/Models/TypeModel.swift
+++ b/src/swift/Sources/Models/TypeModel.swift
@@ -103,6 +103,10 @@ struct TypeModel {
             self.init(from: src.referenceType)
         case let src as AnyType:
             self.init(from: src.textDescription)
+        case let src as TupleType:
+            self.init(from: src.textDescription)
+        case let src as ImplicitlyUnwrappedOptionalType:
+            self.init(from: src.textDescription)
         default:
             SharedLogger.fail("Unsupported identifier: \(source)")
         }

--- a/src/swift/Sources/Util/Errors.swift
+++ b/src/swift/Sources/Util/Errors.swift
@@ -1,0 +1,31 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+enum ToolError: Error {
+    case client(String)
+}

--- a/src/swift/SwiftAPIView.xcodeproj/project.pbxproj
+++ b/src/swift/SwiftAPIView.xcodeproj/project.pbxproj
@@ -19,12 +19,13 @@
 		0A6A545B269CAD5A001006AF /* TypeModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A545A269CAD59001006AF /* TypeModel.swift */; };
 		0A6A545E269CE223001006AF /* DeclarationModifier+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A545D269CE223001006AF /* DeclarationModifier+Extensions.swift */; };
 		0A6A546C269E2AE8001006AF /* SwiftAPIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A546B269E2AE8001006AF /* SwiftAPIViewTests.swift */; };
-		0A6A5474269E2B83001006AF /* SwiftAST in Frameworks */ = {isa = PBXBuildFile; productRef = 0A6A5473269E2B83001006AF /* SwiftAST */; };
-		0A6A5476269E2B83001006AF /* SwiftAST+Tooling in Frameworks */ = {isa = PBXBuildFile; productRef = 0A6A5475269E2B83001006AF /* SwiftAST+Tooling */; };
 		0A6A5478269F775B001006AF /* TestSwiftFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A5477269F775B001006AF /* TestSwiftFile.swift */; };
 		0A6A547A269F8DA3001006AF /* Kind+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A5479269F8DA3001006AF /* Kind+Extensions.swift */; };
 		0A6A547C269F9A41001006AF /* PatternInitializer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A547B269F9A41001006AF /* PatternInitializer+Extensions.swift */; };
 		0A6A547F26A0D296001006AF /* NavigationTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A547E26A0D296001006AF /* NavigationTokens.swift */; };
+		0AA97B4026CECCAD0040A744 /* SwiftSemantics in Frameworks */ = {isa = PBXBuildFile; productRef = 0AA97B3F26CECCAD0040A744 /* SwiftSemantics */; settings = {ATTRIBUTES = (Required, ); }; };
+		0AA97B4326CECD1B0040A744 /* SwiftAST in Frameworks */ = {isa = PBXBuildFile; productRef = 0AA97B4226CECD1B0040A744 /* SwiftAST */; };
+		0AA97B4826CED01D0040A744 /* SwiftSyntax in Frameworks */ = {isa = PBXBuildFile; productRef = 0AA97B4726CED01D0040A744 /* SwiftSyntax */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -61,6 +62,7 @@
 		0A6A5479269F8DA3001006AF /* Kind+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Kind+Extensions.swift"; sourceTree = "<group>"; };
 		0A6A547B269F9A41001006AF /* PatternInitializer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PatternInitializer+Extensions.swift"; sourceTree = "<group>"; };
 		0A6A547E26A0D296001006AF /* NavigationTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTokens.swift; sourceTree = "<group>"; };
+		0AA97B4526CECFD00040A744 /* swift-syntax */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "swift-syntax"; path = "/Users/travisprescott/Library/Developer/Xcode/DerivedData/SwiftAPIView-bimyfzoutgsebyanxqovckhujwsb/SourcePackages/checkouts/swift-syntax"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -68,8 +70,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0A6A5476269E2B83001006AF /* SwiftAST+Tooling in Frameworks */,
-				0A6A5474269E2B83001006AF /* SwiftAST in Frameworks */,
+				0AA97B4026CECCAD0040A744 /* SwiftSemantics in Frameworks */,
+				0AA97B4826CED01D0040A744 /* SwiftSyntax in Frameworks */,
+				0AA97B4326CECD1B0040A744 /* SwiftAST in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -91,7 +94,7 @@
 				0A6A5432268B82D0001006AF /* Sources */,
 				0A6A546A269E2AE8001006AF /* Tests */,
 				0A6A5431268B82D0001006AF /* Products */,
-				6F4C0E2E04E03C6B3145C4A1 /* Frameworks */,
+				0AA97B4426CECFD00040A744 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -167,9 +170,10 @@
 			path = TokenGeneration;
 			sourceTree = "<group>";
 		};
-		6F4C0E2E04E03C6B3145C4A1 /* Frameworks */ = {
+		0AA97B4426CECFD00040A744 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0AA97B4526CECFD00040A744 /* swift-syntax */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -191,8 +195,9 @@
 			);
 			name = SwiftAPIView;
 			packageProductDependencies = (
-				0A6A5473269E2B83001006AF /* SwiftAST */,
-				0A6A5475269E2B83001006AF /* SwiftAST+Tooling */,
+				0AA97B3F26CECCAD0040A744 /* SwiftSemantics */,
+				0AA97B4226CECD1B0040A744 /* SwiftAST */,
+				0AA97B4726CED01D0040A744 /* SwiftSyntax */,
 			);
 			productName = SwiftAPIView;
 			productReference = 0A6A5430268B82D0001006AF /* SwiftAPIView */;
@@ -242,7 +247,9 @@
 			);
 			mainGroup = 0A6A5427268B82D0001006AF;
 			packageReferences = (
-				0A6A5472269E2B83001006AF /* XCRemoteSwiftPackageReference "swift-ast" */,
+				0AA97B3E26CECCAD0040A744 /* XCRemoteSwiftPackageReference "SwiftSemantics" */,
+				0AA97B4126CECD1B0040A744 /* XCRemoteSwiftPackageReference "swift-ast" */,
+				0AA97B4626CED01D0040A744 /* XCRemoteSwiftPackageReference "swift-syntax" */,
 			);
 			productRefGroup = 0A6A5431268B82D0001006AF /* Products */;
 			projectDirPath = "";
@@ -349,6 +356,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
@@ -404,6 +412,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
@@ -418,7 +427,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = ZQB5E94758;
+				DEVELOPMENT_TEAM = UBF8T346G9;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
@@ -433,7 +442,7 @@
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = ZQB5E94758;
+				DEVELOPMENT_TEAM = UBF8T346G9;
 				ENABLE_HARDENED_RUNTIME = YES;
 				INFOPLIST_FILE = "$(SRCROOT)/Info.plist";
 				MACOSX_DEPLOYMENT_TARGET = 10.14;
@@ -513,7 +522,15 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		0A6A5472269E2B83001006AF /* XCRemoteSwiftPackageReference "swift-ast" */ = {
+		0AA97B3E26CECCAD0040A744 /* XCRemoteSwiftPackageReference "SwiftSemantics" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SwiftDocOrg/SwiftSemantics";
+			requirement = {
+				branch = main;
+				kind = branch;
+			};
+		};
+		0AA97B4126CECD1B0040A744 /* XCRemoteSwiftPackageReference "swift-ast" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/yanagiba/swift-ast";
 			requirement = {
@@ -521,18 +538,31 @@
 				minimumVersion = 0.19.9;
 			};
 		};
+		0AA97B4626CED01D0040A744 /* XCRemoteSwiftPackageReference "swift-syntax" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-syntax";
+			requirement = {
+				branch = release/5.4;
+				kind = branch;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0A6A5473269E2B83001006AF /* SwiftAST */ = {
+		0AA97B3F26CECCAD0040A744 /* SwiftSemantics */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0A6A5472269E2B83001006AF /* XCRemoteSwiftPackageReference "swift-ast" */;
+			package = 0AA97B3E26CECCAD0040A744 /* XCRemoteSwiftPackageReference "SwiftSemantics" */;
+			productName = SwiftSemantics;
+		};
+		0AA97B4226CECD1B0040A744 /* SwiftAST */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0AA97B4126CECD1B0040A744 /* XCRemoteSwiftPackageReference "swift-ast" */;
 			productName = SwiftAST;
 		};
-		0A6A5475269E2B83001006AF /* SwiftAST+Tooling */ = {
+		0AA97B4726CED01D0040A744 /* SwiftSyntax */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0A6A5472269E2B83001006AF /* XCRemoteSwiftPackageReference "swift-ast" */;
-			productName = "SwiftAST+Tooling";
+			package = 0AA97B4626CED01D0040A744 /* XCRemoteSwiftPackageReference "swift-syntax" */;
+			productName = SwiftSyntax;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/src/swift/SwiftAPIView.xcodeproj/project.pbxproj
+++ b/src/swift/SwiftAPIView.xcodeproj/project.pbxproj
@@ -23,9 +23,9 @@
 		0A6A547A269F8DA3001006AF /* Kind+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A5479269F8DA3001006AF /* Kind+Extensions.swift */; };
 		0A6A547C269F9A41001006AF /* PatternInitializer+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A547B269F9A41001006AF /* PatternInitializer+Extensions.swift */; };
 		0A6A547F26A0D296001006AF /* NavigationTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A6A547E26A0D296001006AF /* NavigationTokens.swift */; };
-		0AA97B4026CECCAD0040A744 /* SwiftSemantics in Frameworks */ = {isa = PBXBuildFile; productRef = 0AA97B3F26CECCAD0040A744 /* SwiftSemantics */; settings = {ATTRIBUTES = (Required, ); }; };
-		0AA97B4326CECD1B0040A744 /* SwiftAST in Frameworks */ = {isa = PBXBuildFile; productRef = 0AA97B4226CECD1B0040A744 /* SwiftAST */; };
-		0AA97B4826CED01D0040A744 /* SwiftSyntax in Frameworks */ = {isa = PBXBuildFile; productRef = 0AA97B4726CED01D0040A744 /* SwiftSyntax */; };
+		0AD8C85C26D42F1F00491D59 /* SourceKittenFramework in Frameworks */ = {isa = PBXBuildFile; productRef = 0AD8C85B26D42F1F00491D59 /* SourceKittenFramework */; };
+		0AD8C85F26D430C400491D59 /* SwiftAST in Frameworks */ = {isa = PBXBuildFile; productRef = 0AD8C85E26D430C400491D59 /* SwiftAST */; };
+		0AD8C86126D4314800491D59 /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AD8C86026D4314800491D59 /* Errors.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -63,6 +63,9 @@
 		0A6A547B269F9A41001006AF /* PatternInitializer+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PatternInitializer+Extensions.swift"; sourceTree = "<group>"; };
 		0A6A547E26A0D296001006AF /* NavigationTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationTokens.swift; sourceTree = "<group>"; };
 		0AA97B4526CECFD00040A744 /* swift-syntax */ = {isa = PBXFileReference; lastKnownFileType = folder; name = "swift-syntax"; path = "/Users/travisprescott/Library/Developer/Xcode/DerivedData/SwiftAPIView-bimyfzoutgsebyanxqovckhujwsb/SourcePackages/checkouts/swift-syntax"; sourceTree = "<absolute>"; };
+		0AA97B5F26CEFEAC0040A744 /* SwiftSemantics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftSemantics.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0AA97B6326CEFEB00040A744 /* SwiftSyntax.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SwiftSyntax.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0AD8C86026D4314800491D59 /* Errors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Errors.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,9 +73,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0AA97B4026CECCAD0040A744 /* SwiftSemantics in Frameworks */,
-				0AA97B4826CED01D0040A744 /* SwiftSyntax in Frameworks */,
-				0AA97B4326CECD1B0040A744 /* SwiftAST in Frameworks */,
+				0AD8C85C26D42F1F00491D59 /* SourceKittenFramework in Frameworks */,
+				0AD8C85F26D430C400491D59 /* SwiftAST in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -124,6 +126,7 @@
 		0A6A543F268B8862001006AF /* Util */ = {
 			isa = PBXGroup;
 			children = (
+				0AD8C86026D4314800491D59 /* Errors.swift */,
 				0A6A5440268B886D001006AF /* Logger.swift */,
 				0A6A5442268B88AE001006AF /* URL+Extensions.swift */,
 			);
@@ -173,6 +176,8 @@
 		0AA97B4426CECFD00040A744 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				0AA97B6326CEFEB00040A744 /* SwiftSyntax.framework */,
+				0AA97B5F26CEFEAC0040A744 /* SwiftSemantics.framework */,
 				0AA97B4526CECFD00040A744 /* swift-syntax */,
 			);
 			name = Frameworks;
@@ -188,6 +193,7 @@
 				0A6A542C268B82D0001006AF /* Sources */,
 				0A6A542D268B82D0001006AF /* Frameworks */,
 				0A6A542E268B82D0001006AF /* CopyFiles */,
+				0AA97B6926CF03B40040A744 /* Link InternalSwiftSyntaxParser.dylib */,
 			);
 			buildRules = (
 			);
@@ -195,9 +201,8 @@
 			);
 			name = SwiftAPIView;
 			packageProductDependencies = (
-				0AA97B3F26CECCAD0040A744 /* SwiftSemantics */,
-				0AA97B4226CECD1B0040A744 /* SwiftAST */,
-				0AA97B4726CED01D0040A744 /* SwiftSyntax */,
+				0AD8C85B26D42F1F00491D59 /* SourceKittenFramework */,
+				0AD8C85E26D430C400491D59 /* SwiftAST */,
 			);
 			productName = SwiftAPIView;
 			productReference = 0A6A5430268B82D0001006AF /* SwiftAPIView */;
@@ -247,9 +252,8 @@
 			);
 			mainGroup = 0A6A5427268B82D0001006AF;
 			packageReferences = (
-				0AA97B3E26CECCAD0040A744 /* XCRemoteSwiftPackageReference "SwiftSemantics" */,
-				0AA97B4126CECD1B0040A744 /* XCRemoteSwiftPackageReference "swift-ast" */,
-				0AA97B4626CED01D0040A744 /* XCRemoteSwiftPackageReference "swift-syntax" */,
+				0AD8C85A26D42F1F00491D59 /* XCRemoteSwiftPackageReference "SourceKitten" */,
+				0AD8C85D26D430C400491D59 /* XCRemoteSwiftPackageReference "swift-ast" */,
 			);
 			productRefGroup = 0A6A5431268B82D0001006AF /* Products */;
 			projectDirPath = "";
@@ -271,6 +275,27 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		0AA97B6926CF03B40040A744 /* Link InternalSwiftSyntaxParser.dylib */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Link InternalSwiftSyntaxParser.dylib";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "for path in ~/Library/Developer/Xcode/DerivedData/*/Build/Products/Debug/; do\n    cp \"$(xcode-select -p)/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/lib_InternalSwiftSyntaxParser.dylib\" $path\ndone\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		0A6A542C268B82D0001006AF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -280,6 +305,7 @@
 				0A6A547C269F9A41001006AF /* PatternInitializer+Extensions.swift in Sources */,
 				0A6A547F26A0D296001006AF /* NavigationTokens.swift in Sources */,
 				0A6A5450268B91FC001006AF /* NavigationTags.swift in Sources */,
+				0AD8C86126D4314800491D59 /* Errors.swift in Sources */,
 				0A6A5447268B8B4F001006AF /* CommandLineArguments.swift in Sources */,
 				0A6A544A268B8EF9001006AF /* TokenFile.swift in Sources */,
 				0A6A544C268B8F67001006AF /* TokenItem.swift in Sources */,
@@ -522,47 +548,34 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		0AA97B3E26CECCAD0040A744 /* XCRemoteSwiftPackageReference "SwiftSemantics" */ = {
+		0AD8C85A26D42F1F00491D59 /* XCRemoteSwiftPackageReference "SourceKitten" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/SwiftDocOrg/SwiftSemantics";
+			repositoryURL = "https://github.com/jpsim/SourceKitten";
 			requirement = {
-				branch = main;
-				kind = branch;
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.31.0;
 			};
 		};
-		0AA97B4126CECD1B0040A744 /* XCRemoteSwiftPackageReference "swift-ast" */ = {
+		0AD8C85D26D430C400491D59 /* XCRemoteSwiftPackageReference "swift-ast" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/yanagiba/swift-ast";
+			repositoryURL = "https://github.com/yanagiba/swift-ast.git";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.19.9;
 			};
 		};
-		0AA97B4626CED01D0040A744 /* XCRemoteSwiftPackageReference "swift-syntax" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/apple/swift-syntax";
-			requirement = {
-				branch = release/5.4;
-				kind = branch;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		0AA97B3F26CECCAD0040A744 /* SwiftSemantics */ = {
+		0AD8C85B26D42F1F00491D59 /* SourceKittenFramework */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0AA97B3E26CECCAD0040A744 /* XCRemoteSwiftPackageReference "SwiftSemantics" */;
-			productName = SwiftSemantics;
+			package = 0AD8C85A26D42F1F00491D59 /* XCRemoteSwiftPackageReference "SourceKitten" */;
+			productName = SourceKittenFramework;
 		};
-		0AA97B4226CECD1B0040A744 /* SwiftAST */ = {
+		0AD8C85E26D430C400491D59 /* SwiftAST */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 0AA97B4126CECD1B0040A744 /* XCRemoteSwiftPackageReference "swift-ast" */;
+			package = 0AD8C85D26D430C400491D59 /* XCRemoteSwiftPackageReference "swift-ast" */;
 			productName = SwiftAST;
-		};
-		0AA97B4726CED01D0040A744 /* SwiftSyntax */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 0AA97B4626CED01D0040A744 /* XCRemoteSwiftPackageReference "swift-syntax" */;
-			productName = SwiftSyntax;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/src/swift/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
+++ b/src/swift/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
@@ -52,16 +52,16 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--source=/Users/jairmyree/Desktop/azure-sdk-for-ios/sdk/communication/AzureCommunicationChat/Source"
-            isEnabled = "NO">
-         </CommandLineArgument>
-         <CommandLineArgument
             argument = "--source=/Users/travisprescott/repos/azure-sdk-for-ios/sdk/communication/AzureCommunicationChat/Source"
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--source=/Users/travisprescott/repos/azure-sdk-tools/src/swift/Tests/TestSwiftFile.swift"
+            argument = "--source=/Users/travisprescott/Documents/generated-interface.swiftinterface"
             isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--source=/Users/travisprescott/repos/azure-sdk-tools/src/swift/Tests/TestSwiftFile.swift"
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
       <LocationScenarioReference

--- a/src/swift/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
+++ b/src/swift/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
@@ -56,7 +56,11 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--source=/Users/travisprescott/Documents/generated-interface.swiftinterface"
+            argument = "--source=/Users/travisprescott/repos/MixedCodeDemo/Sources"
+            isEnabled = "NO">
+         </CommandLineArgument>
+         <CommandLineArgument
+            argument = "--source=/Users/travisprescott/repos/SpeechSDK/source/bindings/objective-c/public"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument


### PR DESCRIPTION
Closes #1823.

Change:
- Adds support for `--package-name` when automatic detection of package name is unsuccessful.
- Adds support for generating Swift APIView from Objective-C and mixed-source (ObjC+Swift) frameworks.
- Changes language from "Json" to "Swift" for generated files.