### PR TITLE
Strip empty changelog sections before release

### DIFF
--- a/eng/common/scripts/Prepare-Release.ps1
+++ b/eng/common/scripts/Prepare-Release.ps1
@@ -184,6 +184,13 @@ else
   exit 1
 }
 
+$changelogIsValid = Confirm-ChangeLogEntry -ChangeLogLocation $packageProperties.ChangeLogPath -VersionString $newVersion -ForRelease $true
+
+if (!$changelogIsValid)
+{
+  Write-Host "The changelog [$($packageProperties.ChangeLogPath)] is not valid for release. Please make sure it is valid before queuing release build." -ForegroundColor Red
+}
+
 git diff -s --exit-code $packageProperties.DirectoryPath
 if ($LASTEXITCODE -ne 0)
 {

--- a/eng/common/scripts/Update-ChangeLog.ps1
+++ b/eng/common/scripts/Update-ChangeLog.ps1
@@ -106,7 +106,47 @@ if ($LatestsSorted[0] -ne $Version) {
 
 if ($ReplaceLatestEntryTitle)
 {
-    $newChangeLogEntry = New-ChangeLogEntry -Version $Version -Status $ReleaseStatus -Content $ChangeLogEntries[$LatestVersion].ReleaseContent
+    # Remove empty sections from content
+    $sanitizedContent = @()
+    $sectionContent = @()
+    $sectionContentCount = 0
+    $latesVersionContent = $ChangeLogEntries[$LatestVersion].ReleaseContent
+
+    foreach ($line in $latesVersionContent)
+    {
+        if ($line.StartsWith("### ") -or $sectionContentCount -gt 0)
+        {
+            if ($line.StartsWith("#") -and $sectionContentCount -gt 1)
+            {
+                $sanitizedContent += $sectionContent
+                $sectionContent = @()
+                $sectionContentCount = 0
+            }
+    
+            if ($line.StartsWith("#") -and $sectionContentCount -eq 1)
+            {
+                $sectionContent = @()
+                $sectionContentCount = 0
+            }
+
+            $sectionContent += $line
+            if (-not [System.String]::IsNullOrWhiteSpace($line))
+            {
+                $sectionContentCount++
+            }
+        }
+        elseif ($sectionContent.Count -eq 0)
+        {
+            $sanitizedContent += $line
+        }
+    }
+    
+    if ($sectionContentCount -gt 1)
+    {
+        $sanitizedContent += $sectionContent
+    }
+
+    $newChangeLogEntry = New-ChangeLogEntry -Version $Version -Status $ReleaseStatus -Content $sanitizedContent
     LogDebug "Resetting latest entry title to [$($newChangeLogEntry.ReleaseTitle)]"
     $ChangeLogEntries.Remove($LatestVersion)
     if ($newChangeLogEntry) {


### PR DESCRIPTION
When updating the CHANGELOG.md for release, this will strip out all the headers with empty sections.
Should fix https://github.com/Azure/azure-sdk-tools/issues/1878 and https://github.com/Azure/azure-sdk-tools/issues/1895