### PR TITLE
[Test-Proxy] Resolve cross-plat path writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -461,7 +461,7 @@ src/dotnet/Mgmt.CI.BuildTools/NugetToolsPackage/CI.Tools.Package/build/tasks/net
 tools/test-proxy/**/recordings/
 
 # ensure local build directory for test-proxy dockerfiles remains ignored
-tools/test-proxy/docker/dev_certificate
+tools/test-proxy/docker/docker_build
 
 # local settings
 .DS_Store

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -419,7 +419,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public string GetRecordingPath(string file)
         {
-            return Path.Join(RepoPath, file + (!file.EndsWith(".json") ? ".json" : String.Empty));
+            return Path.Join(RepoPath, file + (!file.EndsWith(".json") ? ".json" : String.Empty)).Replace("\\", "/");
         }
 
         public static string GetHeader(HttpRequest request, string name, bool allowNulls = false)

--- a/tools/test-proxy/docker/dockerfile
+++ b/tools/test-proxy/docker/dockerfile
@@ -15,9 +15,9 @@ RUN apt-get update \
 # prep the machine dev certificate
 RUN mkdir $CERT_FOLDER
 
-ADD dev_certificate/$CERT_IMPORT_SH $CERT_FOLDER
-ADD dev_certificate/dotnet-devcert.pfx $CERT_FOLDER
-ADD dev_certificate/dotnet-devcert.crt $CERT_FOLDER
+ADD docker_build/$CERT_IMPORT_SH $CERT_FOLDER
+ADD docker_build/dotnet-devcert.pfx $CERT_FOLDER
+ADD docker_build/dotnet-devcert.crt $CERT_FOLDER
 
 RUN sed -i -e 's/\r$//' $CERT_FOLDER/$CERT_IMPORT_SH
 
@@ -25,12 +25,11 @@ RUN chmod +x $CERT_FOLDER/$CERT_IMPORT_SH \
     && $CERT_FOLDER/$CERT_IMPORT_SH \
     && rm $CERT_FOLDER/$CERT_IMPORT_SH
 
-# install the package
-RUN dotnet tool install azure.sdk.tools.testproxy \
-    --global \
-    --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json \
-    --version 1.0.0-dev.20210811.2 \
-    && mkdir /etc/testproxy
+# copy the code
+COPY docker_build/Azure.Sdk.Tools.TestProxy/ /proxyservercode
+
+# publish the package
+RUN cd /proxyservercode && dotnet publish -c Release -o /proxyserver -f net5.0
 
 EXPOSE 5001
 EXPOSE 5000
@@ -39,4 +38,4 @@ EXPOSE 5000
 # default URL of localhost:5000 or localhost:50001 are not usable from outside the container
 ENV DOTNET_URLS="http://0.0.0.0:5000;https://0.0.0.0:5001"
 
-ENTRYPOINT ["/root/.dotnet/tools/test-proxy", "--storage-location", "/etc/testproxy"]
+ENTRYPOINT ["/proxyserver/Azure.Sdk.Tools.TestProxy", "--storage-location", "/etc/testproxy"]

--- a/tools/test-proxy/docker/dockerfile-win
+++ b/tools/test-proxy/docker/dockerfile-win
@@ -57,8 +57,8 @@ RUN pwsh \
 
 RUN mkdir certwork
 
-ADD dev_certificate/dotnet-devcert.pfx certwork
-ADD dev_certificate/dotnet-devcert.crt certwork
+ADD docker_build/dotnet-devcert.pfx certwork
+ADD docker_build/dotnet-devcert.crt certwork
 
 USER ContainerAdministrator
 RUN dotnet dev-certs https --clean --import /certwork/dotnet-devcert.pfx -p "password"
@@ -80,11 +80,11 @@ SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference
 # the methodology from the primary container, which is linux.
 RUN mkdir -p etc/testproxy
 
-# install the package
-RUN dotnet tool install azure.sdk.tools.testproxy \
-    --tool-path /proxyserver \
-    --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json \
-    --version 1.0.0-dev.20210811.2 
+# copy the code
+COPY docker_build/Azure.Sdk.Tools.TestProxy/ /proxyservercode
+
+# publish the package
+RUN cd /proxyservercode && dotnet publish -c Release -o /proxyserver -f net5.0
 
 EXPOSE 5001
 EXPOSE 5000
@@ -93,4 +93,4 @@ EXPOSE 5000
 # default URL of localhost:5000 or localhost:50001 are not usable from outside the container
 ENV DOTNET_URLS="http://0.0.0.0:5000;https://0.0.0.0:5001"
 
-ENTRYPOINT ["/proxyserver/test-proxy.exe", "--storage-location", "/etc/testproxy"]
+ENTRYPOINT ["/proxyserver/Azure.Sdk.Tools.TestProxy.exe", "--storage-location", "/etc/testproxy"]

--- a/tools/test-proxy/docker/prepare.ps1
+++ b/tools/test-proxy/docker/prepare.ps1
@@ -1,5 +1,6 @@
 $copyDirectory = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../../../eng/common/testproxy/")
-$targetDirectory = "$PsScriptRoot/dev_certificate"
+$codeDirectory = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../Azure.Sdk.Tools.TestProxy/")
+$targetDirectory = "$PsScriptRoot/docker_build"
 
 if (-not (Test-Path $targetDirectory))
 {
@@ -9,3 +10,5 @@ if (-not (Test-Path $targetDirectory))
 # copy all files other than .yml from eng/common/scripts/testproxy into local directory dev_certificate
 Get-ChildItem $copyDirectory -Exclude "*.yml" | % { Copy-Item -Path $_ -Destination "$targetDirectory/${$_.Name}" }
 
+# get a local copy of the source
+Copy-Item -Path $codeDirectory -Destination $targetDirectory -Force -Recurse

--- a/tools/test-proxy/sample-clients/net/storage-blob/Program.cs
+++ b/tools/test-proxy/sample-clients/net/storage-blob/Program.cs
@@ -17,7 +17,7 @@ namespace Azure.Sdk.Tools.TestProxy.StorageBlobSample
         private const string _blobName = "sample";
 
         private static readonly Uri _proxy = new Uri("https://localhost:5001");
-        private static readonly string _recordingFile = Path.Combine("test-proxy", "net-storage-blob-sample.json");
+        private static readonly string _recordingFile = Path.Combine("recordings", "test-proxy", "net-storage-blob-sample.json");
 
         private static readonly HttpClient _httpClient = new HttpClient(new HttpClientHandler()
         {


### PR DESCRIPTION
The standard test-proxy that folks are going to run on is linux based. However, we don't want it to handle it badly if we pass it a `windows-style` path to the `ubuntu` image. It should be _entirely_ transparent to the user.

Also removing reliance on the dev feed. Let's build this thing on the image!
