### PR TITLE
Bug fix: Storing .env file for bicep file at service dir

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -478,7 +478,8 @@ try {
         }
 
         $msg = if ($templateFile.jsonFilePath -ne $templateFile.originalFilePath) {
-            "Deployment template $($templateFile.jsonFilePath) $($templateFile.originalFilePath) to resource group $($resourceGroup.ResourceGroupName)"} else {
+            "Deployment template $($templateFile.jsonFilePath) from $($templateFile.originalFilePath) to resource group $($resourceGroup.ResourceGroupName)"
+        } else {
             "Deployment template $($templateFile.jsonFilePath) to resource group $($resourceGroup.ResourceGroupName)"
         }
         Log $msg

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -477,7 +477,12 @@ try {
             &$preDeploymentScript -ResourceGroupName $ResourceGroupName @PSBoundParameters
         }
 
-        Log "Deploying template '$($templateFile.originalFilePath)' to resource group '$($resourceGroup.ResourceGroupName)'"
+        $msg = if ($templateFile.jsonFilePath -ne $templateFile.originalFilePath) {
+            "Deployment template $($templateFile.jsonFilePath) $($templateFile.originalFilePath) to resource group $($resourceGroup.ResourceGroupName)"} else {
+            "Deployment template $($templateFile.jsonFilePath) to resource group $($resourceGroup.ResourceGroupName)"
+        }
+        Log $msg
+        
         $deployment = Retry {
             $lastDebugPreference = $DebugPreference
             try {
@@ -538,7 +543,7 @@ try {
                 Write-Host 'File option is supported only on Windows'
             }
 
-            $outputFile = "$($templateFile.jsonFilePath).env"
+            $outputFile = "$($templateFile.originalFilePath).env"
 
             $environmentText = $deploymentOutputs | ConvertTo-Json;
             $bytes = ([System.Text.Encoding]::UTF8).GetBytes($environmentText)


### PR DESCRIPTION
New-TestResources.ps1 was storing the .env file at the temp folder if the service uses bicep files. This bug fix stores the .env file at the correct service directory.

(also pushed in logging request in https://github.com/Azure/azure-sdk-tools/pull/1876)