### PR TITLE
Add unique id to default base name

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -289,7 +289,7 @@ try {
                 $AzureTestPrincipal
             } else {
                 Log "TestApplicationId was not specified; creating a new service principal in subscription '$SubscriptionId'"
-		$suffix = (New-Guid).ToString('n').Substring(0, 4)
+                $suffix = (New-Guid).ToString('n').Substring(0, 4)
                 $global:AzureTestPrincipal = New-AzADServicePrincipal -Role Owner -Scope "/subscriptions/$SubscriptionId" -DisplayName "test-resources-$($baseName)$suffix.microsoft.com"
                 $global:AzureTestSubscription = $SubscriptionId
 

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -190,7 +190,7 @@ try {
         $BaseName = 't' + (New-Guid).ToString('n').Substring(0, 16)
         Log "Generated base name '$BaseName' for CI build"
     } elseif (!$BaseName) {
-        $BaseName = "$UserName$ServiceDirectory"
+        $BaseName = "$UserName$ServiceDirectory" + (New-Guid).ToString('n').Substring(0, 4)
         Log "BaseName was not set. Using default base name '$BaseName'"
     }
 

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -190,7 +190,7 @@ try {
         $BaseName = 't' + (New-Guid).ToString('n').Substring(0, 16)
         Log "Generated base name '$BaseName' for CI build"
     } elseif (!$BaseName) {
-        $BaseName = "$UserName$ServiceDirectory" + (New-Guid).ToString('n').Substring(0, 4)
+        $BaseName = "$UserName$ServiceDirectory"
         Log "BaseName was not set. Using default base name '$BaseName'"
     }
 
@@ -289,7 +289,8 @@ try {
                 $AzureTestPrincipal
             } else {
                 Log "TestApplicationId was not specified; creating a new service principal in subscription '$SubscriptionId'"
-                $global:AzureTestPrincipal = New-AzADServicePrincipal -Role Owner -Scope "/subscriptions/$SubscriptionId" -DisplayName "test-resources-$($baseName).microsoft.com"
+		$suffix = (New-Guid).ToString('n').Substring(0, 4)
+                $global:AzureTestPrincipal = New-AzADServicePrincipal -Role Owner -Scope "/subscriptions/$SubscriptionId" -DisplayName "test-resources-$($baseName)$suffix.microsoft.com"
                 $global:AzureTestSubscription = $SubscriptionId
 
                 Log "Created service principal '$($AzureTestPrincipal.ApplicationId)'"


### PR DESCRIPTION
Now that we are automatically marking new resources for deletion, we should be able to safely ensure that the base name is unique without worrying about creating too many resources.