### PR TITLE
Use ILogger instead of Console.Writeline for status logging

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/appsettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Warning",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }


### PR DESCRIPTION
In `main`, it doesn't obey the standard `logging` levels because they _aren't_ logs. They're just `Console.Writelines`.

So if I just set loglevel in `appsettings.json` or `appsettings.development.json`, the log level doesn't set properly, and it's always a bit muted.

If, I set the debug variable like what is in `launchSettings.json`, I get the output.

![image](https://user-images.githubusercontent.com/45376673/131574903-9464bc4f-8444-44b8-a898-d52ddad20533.png)

