### PR TITLE
[TestResources] Parameter Addition and Doc Updates

### DIFF
--- a/eng/common/TestResources/README.md
+++ b/eng/common/TestResources/README.md
@@ -1,8 +1,8 @@
 # Live Test Resource Management
 
 Running and recording live tests often requires first creating some resources
-in Azure. Service directories that include a test-resources.json file require
-running [New-TestResources.ps1][] to create these resources and output
+in Azure. Service directories that include a `test-resources.json` or `test-resources.bicep` 
+file require running [New-TestResources.ps1][] to create these resources and output
 environment variables you must set.
 
 The following scripts can be used both in on your desktop for developer
@@ -19,9 +19,10 @@ scenarios as well as on hosted agents for continuous integration testing.
 ## On the Desktop
 
 To set up your Azure account to run live tests, you'll need to log into Azure,
-and set up your resources defined in test-resources.json as shown in the following
-example using Azure Key Vault. The script will create a service principal automatically,
-or you may create a service principal you can save and reuse subsequently.
+and create the resources defined in your `test-resources.json` or `test-resources.bicep` 
+template as shown in the following example using Azure Key Vault. The script will create 
+a service principal automatically,or you may create a service principal you can save and 
+reuse subsequently.
 
 Note that `-Subscription` is an optional parameter but recommended if your account
 is a member of multiple subscriptions. If you didn't specify it when logging in,
@@ -33,8 +34,9 @@ Connect-AzAccount -Subscription 'YOUR SUBSCRIPTION ID'
 eng\common\TestResources\New-TestResources.ps1 keyvault
 ```
 
-The `OutFile` switch will be set by default if you are running this for a .NET project on Windows. This will save test environment settings
-into a test-resources.json.env file next to test-resources.json. The file is protected via DPAPI.
+The `OutFile` switch will be set by default if you are running this for a .NET project on Windows. 
+This will save test environment settings into a `test-resources.json.env` file next to `test-resources.json` 
+or a `test-resources.bicep.env` file next to `test-resources.bicep`. The file is protected via DPAPI.
 The environment file would be scoped to the current repository directory and avoids the need to
 set environment variables or restart your IDE to recognize them.
 


### PR DESCRIPTION
# Summary 

The focus of these changes is to add an additional parameter to the `New-TestResources.ps1` script to allow more flexibility when using it to create resources for local testing, where automatically cleaning up may not be desired.  Additionally, documentation was updated to reflect some of the enhancements that have been added to the script recently.