### PR TITLE
Update-DocsMsPackages.ps1 Explicitly exits 0 

### DIFF
--- a/eng/common/scripts/Update-DocsMsPackages.ps1
+++ b/eng/common/scripts/Update-DocsMsPackages.ps1
@@ -133,3 +133,7 @@ if ($UpdateDocsMsPackagesFn -and (Test-Path "Function:$UpdateDocsMsPackagesFn"))
   See https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/common_engsys.md#code-structure"
   exit 1
 }
+
+# Exit 0 so DevOps doesn't fail the build when the last command called by the
+# domain-specific function exited with a non-zero exit code.
+exit 0


### PR DESCRIPTION
Exit 0 so DevOps doesn't fail the build when the last command called by the domain-specific function exited with a non-zero exit code.

Specifically this mitigates issues in Java where the docindex pipeline fails because an inner `mvn` command failed during validation. The whole script succeeds because we properly handle errors but PowerShell just reads `$LASTEXITCODE` 