### PR TITLE
Add Skip.SetTestPipelineVersion

### DIFF
--- a/eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
+++ b/eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
@@ -4,10 +4,10 @@ parameters:
   TestPipeline: false
 
 steps:
-- ${{if eq(parameters.TestPipeline, 'true')}}:
+- ${{ if eq(parameters.TestPipeline, 'true') }}:
     - task: PowerShell@2
       displayName: Prep template pipeline for release
-      condition: succeeded()
+      condition: and(succeeded(), ne(variables['Skip.SetTestPipelineVersion'], 'true')) 
       inputs:
         pwsh: true
         workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
Add Skip.SetTestPipelineVersion to allow overiding the `SetTestPipelineVersion` step for template pipelines.
Resolves https://github.com/Azure/azure-sdk-tools/issues/1664