### PR TITLE
Detect any public API changes in pull request

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
     <PackageReference Include="Markdig.Signed" Version="0.17.1" />
+    <PackageReference Include="Octokit" Version="0.50.0" />
     <PackageReference Include="Sendgrid" Version="9.12.0" />
   </ItemGroup>
 

--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -15,9 +15,9 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <NoWarn>$(NoWarn);8002</NoWarn>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors>NU5105</WarningsAsErrors>
-	<NoWarn>$(NoWarn);8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -17,6 +17,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors>NU5105</WarningsAsErrors>
+	<NoWarn>$(NoWarn);8002</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -29,16 +29,8 @@ namespace APIViewWeb.Controllers
             string commitSha,
             string repoName)
         {
-            try
-            {
-                await _pullRequestManager.DetectApiChanges(buildId, artifactName, filePath, pullRequestNumber, commitSha, repoName);
-                return Ok();
-            }
-            catch
-            {
-                // Return internal server error for any unknown error
-                return StatusCode(statusCode: StatusCodes.Status500InternalServerError);
-            }           
+            await _pullRequestManager.DetectApiChanges(buildId, artifactName, filePath, pullRequestNumber, commitSha, repoName);
+            return Ok();
         }
 
         

--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -27,11 +27,11 @@ namespace APIViewWeb.Controllers
             string filePath, 
             int pullRequestNumber, 
             string commitSha,
-            string language)
+            string repoName)
         {
             try
             {
-                await _pullRequestManager.DetectApiChanges(buildId, artifactName, filePath, pullRequestNumber, commitSha, language);
+                await _pullRequestManager.DetectApiChanges(buildId, artifactName, filePath, pullRequestNumber, commitSha, repoName);
                 return Ok();
             }
             catch

--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using APIViewWeb.Repositories;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using System.Threading.Tasks;
+
+namespace APIViewWeb.Controllers
+{
+    public class PullRequestController : Controller
+    {
+        private readonly PullRequestManager _pullRequestManager;
+        private readonly ILogger _logger;
+
+        public PullRequestController(PullRequestManager pullRequestManager, ILogger<AutoReviewController> logger)
+        {
+            _pullRequestManager = pullRequestManager;
+            _logger = logger;
+        }
+                
+        [HttpGet]
+        public async Task<ActionResult> DetectApiChanges(
+            string buildId, 
+            string artifactName, 
+            string filePath, 
+            int pullRequestNumber, 
+            string commitSha,
+            string language)
+        {
+            try
+            {
+                await _pullRequestManager.DetectApiChanges(buildId, artifactName, filePath, pullRequestNumber, commitSha, language);
+                return Ok();
+            }
+            catch
+            {
+                // Return internal server error for any unknown error
+                return StatusCode(statusCode: StatusCodes.Status500InternalServerError);
+            }           
+        }
+
+        
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Models/PullRequestModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/PullRequestModel.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace APIViewWeb.Models
+{
+    public class PullRequestModel
+    {
+        [JsonProperty("id")]
+        public string PullRequestId { get; set; } = IdHelper.GenerateId();
+        public int PullRequestNumber { get; set; }
+        public string CommitSha { get; set; }
+        public string Language { get; set; }
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Models/PullRequestModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/PullRequestModel.cs
@@ -9,8 +9,8 @@ namespace APIViewWeb.Models
         [JsonProperty("id")]
         public string PullRequestId { get; set; } = IdHelper.GenerateId();
         public int PullRequestNumber { get; set; }
-        public string CommitSha { get; set; }
-        public string Language { get; set; }
+        public List<string> Commits { get; set; } = new List<string>();
+        public string RepoName { get; set; }
         public string FilePath { get; set; }
         public bool IsOpen { get; set; } = true;
     }

--- a/src/dotnet/APIView/APIViewWeb/Models/PullRequestModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/PullRequestModel.cs
@@ -11,5 +11,7 @@ namespace APIViewWeb.Models
         public int PullRequestNumber { get; set; }
         public string CommitSha { get; set; }
         public string Language { get; set; }
+        public string FilePath { get; set; }
+        public bool IsOpen { get; set; } = true;
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
@@ -1,0 +1,51 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using APIViewWeb.Models;
+using Microsoft.Azure.Cosmos;
+using Microsoft.Extensions.Configuration;
+
+namespace APIViewWeb
+{
+    public class CosmosPullRequestsRepository
+    {
+        private readonly Container _pullRequestsContainer;
+
+        public CosmosPullRequestsRepository(IConfiguration configuration)
+        {
+            var client = new CosmosClient(configuration["Cosmos:ConnectionString"]);
+            _pullRequestsContainer = client.GetContainer("APIView", "PullRequests");
+        }
+
+        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string language, string commitSha)
+        {
+            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.Language = '{language}' and c.CommitSha = '{commitSha}'";
+            return await GetPullRequestFromQueryAsync(query);
+        }
+
+        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string language)
+        {
+            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.Language = '{language}'";
+            return await GetPullRequestFromQueryAsync(query);
+        }
+
+        public async Task UpsertPullRequestAsync(PullRequestModel pullRequestModel)
+        {
+            await _pullRequestsContainer.UpsertItemAsync(pullRequestModel, new PartitionKey(pullRequestModel.PullRequestNumber));
+        }
+
+        private async Task<PullRequestModel> GetPullRequestFromQueryAsync(string query)
+        {
+            var itemQueryIterator = _pullRequestsContainer.GetItemQueryIterator<PullRequestModel>(query);
+            if (itemQueryIterator.HasMoreResults)
+            {
+                var result = await itemQueryIterator.ReadNextAsync();
+                return result.Resource?.GetEnumerator()?.Current;
+            }
+
+            return null;
+        }
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
@@ -19,15 +19,15 @@ namespace APIViewWeb
             _pullRequestsContainer = client.GetContainer("APIView", "PullRequests");
         }
 
-        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string language, string commitSha)
+        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string language, string commitSha, string filePath)
         {
-            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.Language = '{language}' and c.CommitSha = '{commitSha}'";
+            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.Language = '{language}' and c.CommitSha = '{commitSha}' and c.FilePath = '{filePath}'";
             return await GetPullRequestFromQueryAsync(query);
         }
 
-        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string language)
+        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string language, string filePath)
         {
-            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.Language = '{language}'";
+            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.Language = '{language}' and c.FilePath = '{filePath}'";
             return await GetPullRequestFromQueryAsync(query);
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
@@ -19,15 +19,9 @@ namespace APIViewWeb
             _pullRequestsContainer = client.GetContainer("APIView", "PullRequests");
         }
 
-        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string language, string commitSha, string filePath)
+        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string repoName, string filePath)
         {
-            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.Language = '{language}' and c.CommitSha = '{commitSha}' and c.FilePath = '{filePath}'";
-            return await GetPullRequestFromQueryAsync(query);
-        }
-
-        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string language, string filePath)
-        {
-            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.Language = '{language}' and c.FilePath = '{filePath}'";
+            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.RepoName = '{repoName}' and c.FilePath = '{filePath}'";
             return await GetPullRequestFromQueryAsync(query);
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -1,0 +1,58 @@
+﻿using Microsoft.Extensions.Configuration;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading.Tasks;
+
+namespace APIViewWeb.Repositories
+{
+    public class DevopsArtifactRepository
+    {
+        static readonly HttpClient devopsClient = new();
+        private readonly IConfiguration _configuration;
+
+        public DevopsArtifactRepository(IConfiguration configuration)
+        {
+            _configuration = configuration;
+        }
+
+        public async Task<Stream> DownloadPackageArtifact(string repoName, string buildId, string artifactName, string filePath)
+        {
+            var downloadUrl = await GetDownloadArtifactUrl(repoName, buildId, artifactName);
+            if (!string.IsNullOrEmpty(downloadUrl))
+            {
+                downloadUrl = downloadUrl.Split("?")[0] + "?format=file&subPath=" + filePath;
+                var downloadResp = await devopsClient.GetAsync(downloadUrl);
+                downloadResp.EnsureSuccessStatusCode();
+                return await downloadResp.Content.ReadAsStreamAsync();
+            }
+            return null;
+        }
+
+        private async Task<string> GetDownloadArtifactUrl(string repoName, string buildId, string artifactName)
+        {
+            var artifactGetReq = GetArtifactRestAPIForRepo(repoName).Replace("{buildId}", buildId).Replace("{artifactName}", artifactName);
+            var response = await devopsClient.GetAsync(artifactGetReq);
+            response.EnsureSuccessStatusCode();
+            var buildResource = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            if (buildResource == null)
+            {
+                return null;
+            }
+            return buildResource.RootElement.GetProperty("resource").GetProperty("downloadUrl").GetString();
+        }
+
+        private string GetArtifactRestAPIForRepo(string repoName)
+        {
+            var downloadARtifactRestApi = _configuration["download-artifact-rest-api-for-" + repoName];
+            if (downloadARtifactRestApi == null)
+            {
+                downloadARtifactRestApi = _configuration["download-artifact-rest-api"];
+            }
+            return downloadARtifactRestApi;
+        }
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -11,7 +11,7 @@ namespace APIViewWeb.Repositories
 {
     public class DevopsArtifactRepository
     {
-        static readonly HttpClient devopsClient = new();
+        static readonly HttpClient _devopsClient = new();
         private readonly IConfiguration _configuration;
 
         public DevopsArtifactRepository(IConfiguration configuration)
@@ -25,7 +25,7 @@ namespace APIViewWeb.Repositories
             if (!string.IsNullOrEmpty(downloadUrl))
             {
                 downloadUrl = downloadUrl.Split("?")[0] + "?format=file&subPath=" + filePath;
-                var downloadResp = await devopsClient.GetAsync(downloadUrl);
+                var downloadResp = await _devopsClient.GetAsync(downloadUrl);
                 downloadResp.EnsureSuccessStatusCode();
                 return await downloadResp.Content.ReadAsStreamAsync();
             }
@@ -35,7 +35,7 @@ namespace APIViewWeb.Repositories
         private async Task<string> GetDownloadArtifactUrl(string repoName, string buildId, string artifactName)
         {
             var artifactGetReq = GetArtifactRestAPIForRepo(repoName).Replace("{buildId}", buildId).Replace("{artifactName}", artifactName);
-            var response = await devopsClient.GetAsync(artifactGetReq);
+            var response = await _devopsClient.GetAsync(artifactGetReq);
             response.EnsureSuccessStatusCode();
             var buildResource = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
             if (buildResource == null)
@@ -47,12 +47,12 @@ namespace APIViewWeb.Repositories
 
         private string GetArtifactRestAPIForRepo(string repoName)
         {
-            var downloadARtifactRestApi = _configuration["download-artifact-rest-api-for-" + repoName];
-            if (downloadARtifactRestApi == null)
+            var downloadArtifactRestApi = _configuration["download-artifact-rest-api-for-" + repoName];
+            if (downloadArtifactRestApi == null)
             {
-                downloadARtifactRestApi = _configuration["download-artifact-rest-api"];
+                downloadArtifactRestApi = _configuration["download-artifact-rest-api"];
             }
-            return downloadARtifactRestApi;
+            return downloadArtifactRestApi;
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -1,14 +1,13 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Text.Json;
+using System.Text;
 using System.Threading.Tasks;
 using ApiView;
+using APIView.DIff;
 using APIViewWeb.Models;
 using APIViewWeb.Repositories;
 using APIViewWeb.Respositories;
@@ -16,74 +15,78 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 using Octokit;
 
 namespace APIViewWeb.Repositories
 {
     public class PullRequestManager
-    {
-        static readonly HttpClient devopsClient = new();
+    {        
         static readonly GitHubClient githubClient = new(new Octokit.ProductHeaderValue("apiview"));
-        static readonly string ARTIFACT_GET_URL = "https://dev.azure.com/azure-sdk/public/_apis/build/builds/{buildId}/artifacts?artifactName={artifactName}&api-version=4.1";
-
+        
         private readonly ReviewManager _reviewManager;
         private readonly CosmosPullRequestsRepository _pullRequestsRepository;
+        private readonly IConfiguration _configuration;
+        private readonly CosmosReviewRepository _reviewsRepository;
+        private readonly BlobCodeFileRepository _codeFileRepository;
+        private readonly DevopsArtifactRepository _devopsArtifactRepository;
 
         public PullRequestManager(
             ReviewManager reviewManager,
             CosmosReviewRepository reviewsRepository,
             CosmosPullRequestsRepository pullRequestsRepository,
+            BlobCodeFileRepository codeFileRepository,
+            DevopsArtifactRepository devopsArtifactRepository,
             IConfiguration configuration
             )
         {
             _reviewManager = reviewManager;
             _pullRequestsRepository = pullRequestsRepository;
-            githubClient.Credentials = new Credentials(configuration["github-access-token"]);
+            _configuration = configuration;
+            _reviewsRepository = reviewsRepository;
+            _codeFileRepository = codeFileRepository;
+            _devopsArtifactRepository = devopsArtifactRepository;
+            githubClient.Credentials = new Credentials(_configuration["github-access-token"]);
         }
 
         // API change detection for PR will pull artifact from devops artifact
-        // This will be changed to a different component in the future based on the implementation for SDK automation
-        public async Task DetectApiChanges(string buildId, string artifactName, string filePath, int prNumber, string commitSha, string language)
+        public async Task DetectApiChanges(string buildId, string artifactName, string filePath, int prNumber, string commitSha, string repoName)
         {
             TelemetryClient telemetryClient = new(TelemetryConfiguration.CreateDefault());
             var requestTelemetry = new RequestTelemetry { Name = "Detecting API changes for PR: " + prNumber };
             var operation = telemetryClient.StartOperation(requestTelemetry);
             try
             {
-                if (await IsShaAlreadyProcessed(language, prNumber, commitSha, filePath))
-                {
-                    return;
-                }
-
-                var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, language, filePath);
+                var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, repoName, filePath);
                 if (pullRequestModel == null)
                 {
                     pullRequestModel = new PullRequestModel()
                     {
-                        Language = language,
-                        CommitSha = commitSha,
+                        RepoName = repoName,
                         PullRequestNumber = prNumber,
                         FilePath = filePath
                     };
                 }
                 else
                 {
-                    pullRequestModel.CommitSha = commitSha;
+                    if (pullRequestModel.Commits.Any(c=> c== commitSha))
+                    {
+                        // PR commit is already processed. No need to reprocess it again.
+                        return;
+                    }
                 }
+                pullRequestModel.Commits.Add(commitSha);
 
-                // Download code file from devops artifact location
-                // We have opted for pull option instead of passing artifact in request since these validations are done for PR pipeline
-                using var stream = await DownloadPackageArtifact(buildId, artifactName, filePath, telemetryClient);
+                using var stream = await _devopsArtifactRepository.DownloadPackageArtifact(repoName, buildId, artifactName, filePath);
                 if (stream != null)
                 {
                     using var memoryStream = new MemoryStream();
                     var codeFile = await _reviewManager.CreateCodeFile(Path.GetFileName(filePath), stream, false, memoryStream);
-                    var apiDiff = await _reviewManager.GetApiDiffFromAutomaticReview(codeFile);
-                    // Add API change detection label and comment to PR if there are API changes
+                    var apiDiff = await GetApiDiffFromAutomaticReview(codeFile);
                     if (apiDiff != "")
                     {
-                        UpdatedPullRequest(apiDiff, prNumber, language, telemetryClient);
+                        var repoOwner = _configuration["default-source-repo-owner"];
+                        //Consider adding option to override owner when required
+                        await githubClient.Issue.Comment.Create(repoOwner, repoName, prNumber, apiDiff);
                     }
                     await _pullRequestsRepository.UpsertPullRequestAsync(pullRequestModel);
                 }
@@ -102,82 +105,56 @@ namespace APIViewWeb.Repositories
             }
         }
 
-        // Make sure we are not processing same commit by repeated run of build pipeline
-        private async Task<bool> IsShaAlreadyProcessed(string language, int prNumber, string commitSha, string filePath)
+        public async Task<string> GetApiDiffFromAutomaticReview(CodeFile codeFile)
         {
-            var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, language, commitSha, filePath);
-            return pullRequestModel != null;
-        }
+            // Get automatically generated master review for package
+            var review = await _reviewsRepository.GetMasterReviewForPackageAsync(codeFile.Language, codeFile.PackageName);
+            if (review == null)
+            {
+                return "";
+            }
 
-        private async Task<Stream> DownloadPackageArtifact(string buildId, string artifactName, string filePath, TelemetryClient telemetryClient)
-        {
-            try
+            // Check if API surface level matches with any revisions
+            var renderedCodeFile = new RenderedCodeFile(codeFile);
+            foreach (var approvedRevision in review.Revisions.Reverse())
             {
-                var artifactGetReq = ARTIFACT_GET_URL.Replace("{buildId}", buildId).Replace("{artifactName}", artifactName);
-                var response = await devopsClient.GetAsync(artifactGetReq);
-                response.EnsureSuccessStatusCode();
-                var buildResource = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
-                if (buildResource == null)
+                if (await _reviewManager.IsReviewSame(approvedRevision, renderedCodeFile))
                 {
-                    telemetryClient.TrackTrace("Artifact get response is invalid. Check REST api to get devops artifacts for any changes.");
-                    return null;
-                }
-                var downloadUrl = buildResource.RootElement.GetProperty("resource").GetProperty("downloadUrl").GetString();
-                if (!string.IsNullOrEmpty(downloadUrl))
-                {
-                    downloadUrl = downloadUrl.Split("?")[0] + "?format=file&subPath=" + filePath;
-                    var downloadResp = await devopsClient.GetAsync(downloadUrl);
-                    downloadResp.EnsureSuccessStatusCode();
-                    return await downloadResp.Content.ReadAsStreamAsync();
-                }
-                else
-                {
-                    telemetryClient.TrackTrace("Artifact get response does not have download URL. Check REST api response to get devops artifacts for any changes.");
-                    return null;
-                }
-            }
-            catch (Exception ex)
-            {
-                telemetryClient.TrackException(ex);
-            }
-            return null;
-        }
-
-        private async void UpdatedPullRequest(string diff, int prNumber, string language, TelemetryClient telemetryClient)
-        {
-            var repoName = GetGitHubRepoForLanguage(language);
-            if (repoName != "")
-            {
-                try
-                {
-                    // We should add handling of GH rate limiting here in next revision
-                    await githubClient.Issue.Comment.Create("azure", repoName, prNumber, diff);
-                }
-                catch (Exception ex)
-                {
-                    telemetryClient.TrackException(ex);
-                }
-            }
-            else
-            {
-                telemetryClient.TrackTrace("API change detection is not enabled for language " + language);
-            }
-            
-        }
-
-        private string GetGitHubRepoForLanguage(string language)
-        {
-            // API change detection is currently only supported for 4 languages.
-            switch (language)
-            {
-                case "java":
-                case "python":
-                case "js":
-                case "dotnet":
-                    return "azure-sdk-for-"+language;
-                default:
                     return "";
+                }
             }
+            // If review doesn't match with any revisions then generate formatted diff against last revision of automatic review
+            return await GetFormattedDiff(renderedCodeFile, review.Revisions.Last());
+        }
+
+        private async Task<string> GetFormattedDiff(RenderedCodeFile renderedCodeFile, ReviewRevisionModel lastRevision)
+        {
+            RenderedCodeFile autoReview = await _codeFileRepository.GetCodeFileAsync(lastRevision);
+            var autoReviewTextFile = autoReview.RenderText(showDocumentation: false, skipDiff: true);
+            var prCodeTextFile = renderedCodeFile.RenderText(showDocumentation: false, skipDiff: true);
+            var diffLines = InlineDiff.Compute(autoReviewTextFile, prCodeTextFile, autoReviewTextFile, prCodeTextFile);
+            if (diffLines == null || diffLines.Length == 0)
+            {
+                return "";
+            }
+
+            var stringBuilder = new StringBuilder();
+            stringBuilder.Append("Following API change(s) have been detected in this PR by APIView system.").Append(Environment.NewLine);
+            stringBuilder.Append("```").Append(Environment.NewLine);
+            foreach (var line in diffLines)
+            {
+                if (line.Kind == DiffLineKind.Added)
+                {
+                    stringBuilder.Append("+ ").Append(line.Line.DisplayString).Append(Environment.NewLine);
+                }
+                else if (line.Kind == DiffLineKind.Removed)
+                {
+                    stringBuilder.Append("- ").Append(line.Line.DisplayString).Append(Environment.NewLine);
+                }
+                //No need to include unchanged lines for now. We will enhance this in next revision to include context.
+            }
+            stringBuilder.Append("```");
+            return stringBuilder.ToString();
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -84,9 +84,8 @@ namespace APIViewWeb.Repositories
                     var apiDiff = await GetApiDiffFromAutomaticReview(codeFile);
                     if (apiDiff != "")
                     {
-                        var repoOwner = _configuration["default-source-repo-owner"];
-                        //Consider adding option to override owner when required
-                        await _githubClient.Issue.Comment.Create(repoOwner, repoName, prNumber, apiDiff);
+                        var repoInfo = repoName.Split("/");
+                        await _githubClient.Issue.Comment.Create(repoInfo[0], repoInfo[1], prNumber, apiDiff);
                     }
                     await _pullRequestsRepository.UpsertPullRequestAsync(pullRequestModel);
                 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -1,0 +1,182 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text.Json;
+using System.Threading.Tasks;
+using ApiView;
+using APIViewWeb.Models;
+using APIViewWeb.Repositories;
+using APIViewWeb.Respositories;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Octokit;
+
+namespace APIViewWeb.Repositories
+{
+    public class PullRequestManager
+    {
+        static readonly HttpClient devopsClient = new();
+        static readonly GitHubClient githubClient = new(new Octokit.ProductHeaderValue("apiview"));
+        static readonly string ARTIFACT_GET_URL = "https://dev.azure.com/azure-sdk/public/_apis/build/builds/{buildId}/artifacts?artifactName={artifactName}&api-version=4.1";
+
+        private readonly ReviewManager _reviewManager;
+        private readonly CosmosPullRequestsRepository _pullRequestsRepository;
+
+        public PullRequestManager(
+            ReviewManager reviewManager,
+            CosmosReviewRepository reviewsRepository,
+            CosmosPullRequestsRepository pullRequestsRepository,
+            IConfiguration configuration
+            )
+        {
+            _reviewManager = reviewManager;
+            _pullRequestsRepository = pullRequestsRepository;
+            githubClient.Credentials = new Credentials(configuration["github-access-token"]);
+        }
+
+        // API change detection for PR will pull artifact from devops artifact
+        // This will be changed to a different component in the future based on the implementation for SDK automation
+        public async Task DetectApiChanges(string buildId, string artifactName, string filePath, int prNumber, string commitSha, string language)
+        {
+            TelemetryClient telemetryClient = new(TelemetryConfiguration.CreateDefault());
+            var requestTelemetry = new RequestTelemetry { Name = "Detecting API changes for PR: " + prNumber };
+            var operation = telemetryClient.StartOperation(requestTelemetry);
+            try
+            {
+                if (await IsShaAlreadyProcessed(language, prNumber, commitSha))
+                {
+                    return;
+                }
+
+                var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, language);
+                if (pullRequestModel == null)
+                {
+                    pullRequestModel = new PullRequestModel()
+                    {
+                        Language = language,
+                        CommitSha = commitSha,
+                        PullRequestNumber = prNumber
+                    };
+                }
+                else
+                {
+                    pullRequestModel.CommitSha = commitSha;
+                }
+
+                // Download code file from devops artifact location
+                // We have opted for pull option instead of passing artifact in request since these validations are done for PR pipeline
+                using var stream = await DownloadPackageArtifact(buildId, artifactName, filePath, telemetryClient);
+                if (stream != null)
+                {
+                    using var memoryStream = new MemoryStream();
+                    var codeFile = await _reviewManager.CreateCodeFile(Path.GetFileName(filePath), stream, false, memoryStream);
+                    var apiDiff = await _reviewManager.GetApiDiffFromAutomaticReview(codeFile);
+                    // Add API change detection label and comment to PR if there are API changes
+                    if (apiDiff != "")
+                    {
+                        UpdatedPullRequest(apiDiff, prNumber, language, telemetryClient);
+                    }
+                    await _pullRequestsRepository.UpsertPullRequestAsync(pullRequestModel);
+                }
+                else
+                {
+                    telemetryClient.TrackTrace("Failed to download artifact. Please recheck build id and artifact path values in API change detection request.");
+                }                
+            }
+            catch (Exception ex)
+            {
+                telemetryClient.TrackException(ex);
+            }
+            finally
+            {
+                telemetryClient.StopOperation(operation);
+            }
+        }
+
+        // Make sure we are not processing same commit by repeated run of build pipeline
+        private async Task<bool> IsShaAlreadyProcessed(string language, int prNumber, string commitSha)
+        {
+            var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, language, commitSha);
+            return pullRequestModel != null;
+        }
+
+        private async Task<Stream> DownloadPackageArtifact(string buildId, string artifactName, string filePath, TelemetryClient telemetryClient)
+        {
+            try
+            {
+                var artifactGetReq = ARTIFACT_GET_URL.Replace("{buildId}", buildId).Replace("{artifactName}", artifactName);
+                var response = await devopsClient.GetAsync(artifactGetReq);
+                response.EnsureSuccessStatusCode();
+                var buildResource = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+                if (buildResource == null)
+                {
+                    telemetryClient.TrackTrace("Artifact get response is invalid. Check REST api to get devops artifacts for any changes.");
+                    return null;
+                }
+                var downloadUrl = buildResource.RootElement.GetProperty("resource").GetProperty("downloadUrl").GetString();
+                if (!string.IsNullOrEmpty(downloadUrl))
+                {
+                    downloadUrl = downloadUrl.Split("?")[0] + "?format=file&subPath=" + filePath;
+                    var downloadResp = await devopsClient.GetAsync(downloadUrl);
+                    downloadResp.EnsureSuccessStatusCode();
+                    return await downloadResp.Content.ReadAsStreamAsync();
+                }
+                else
+                {
+                    telemetryClient.TrackTrace("Artifact get response does not have download URL. Check REST api response to get devops artifacts for any changes.");
+                    return null;
+                }
+            }
+            catch (Exception ex)
+            {
+                telemetryClient.TrackException(ex);
+            }
+            return null;
+        }
+
+        private async void UpdatedPullRequest(string diff, int prNumber, string language, TelemetryClient telemetryClient)
+        {
+            var repoName = GetGitHubRepoForLanguage(language);
+            if (repoName != "")
+            {
+                try
+                {
+                    // We should add handling of GH rate limiting here in next revision
+                    await githubClient.Issue.Comment.Create("azure", repoName, prNumber, diff);
+                }
+                catch (Exception ex)
+                {
+                    telemetryClient.TrackException(ex);
+                }
+            }
+            else
+            {
+                telemetryClient.TrackTrace("API change detection is not enabled for language " + language);
+            }
+            
+        }
+
+        private string GetGitHubRepoForLanguage(string language)
+        {
+            // API change detection is currently only supported for 4 languages.
+            switch (language)
+            {
+                case "java":
+                case "python":
+                case "js":
+                case "dotnet":
+                    return "azure-sdk-for-"+language;
+                default:
+                    return "";
+            }
+        }
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -51,19 +51,20 @@ namespace APIViewWeb.Repositories
             var operation = telemetryClient.StartOperation(requestTelemetry);
             try
             {
-                if (await IsShaAlreadyProcessed(language, prNumber, commitSha))
+                if (await IsShaAlreadyProcessed(language, prNumber, commitSha, filePath))
                 {
                     return;
                 }
 
-                var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, language);
+                var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, language, filePath);
                 if (pullRequestModel == null)
                 {
                     pullRequestModel = new PullRequestModel()
                     {
                         Language = language,
                         CommitSha = commitSha,
-                        PullRequestNumber = prNumber
+                        PullRequestNumber = prNumber,
+                        FilePath = filePath
                     };
                 }
                 else
@@ -102,9 +103,9 @@ namespace APIViewWeb.Repositories
         }
 
         // Make sure we are not processing same commit by repeated run of build pipeline
-        private async Task<bool> IsShaAlreadyProcessed(string language, int prNumber, string commitSha)
+        private async Task<bool> IsShaAlreadyProcessed(string language, int prNumber, string commitSha, string filePath)
         {
-            var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, language, commitSha);
+            var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, language, commitSha, filePath);
             return pullRequestModel != null;
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -21,7 +21,6 @@ namespace APIViewWeb.Respositories
 {
     public class ReviewManager
     {
-
         private readonly IAuthorizationService _authorizationService;
 
         private readonly CosmosReviewRepository _reviewsRepository;

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -543,6 +543,7 @@ namespace APIViewWeb.Respositories
             }
 
             var stringBuilder = new StringBuilder();
+            stringBuilder.Append("Following API change(s) have been detected in this PR by APIView system.").Append(Environment.NewLine);
             stringBuilder.Append("```").Append(Environment.NewLine);
             foreach( var line in diffLines)
             {

--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -75,10 +75,12 @@ namespace APIViewWeb
             services.AddSingleton<BlobOriginalsRepository>();
             services.AddSingleton<CosmosReviewRepository>();
             services.AddSingleton<CosmosCommentsRepository>();
+            services.AddSingleton<CosmosPullRequestsRepository>();
 
             services.AddSingleton<ReviewManager>();
             services.AddSingleton<CommentsManager>();
             services.AddSingleton<NotificationManager>();
+            services.AddSingleton<PullRequestManager>();
 
             services.AddSingleton<LanguageService, JsonLanguageService>();
             services.AddSingleton<LanguageService, CSharpLanguageService>();

--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -76,6 +76,7 @@ namespace APIViewWeb
             services.AddSingleton<CosmosReviewRepository>();
             services.AddSingleton<CosmosCommentsRepository>();
             services.AddSingleton<CosmosPullRequestsRepository>();
+            services.AddSingleton<DevopsArtifactRepository>();
 
             services.AddSingleton<ReviewManager>();
             services.AddSingleton<CommentsManager>();


### PR DESCRIPTION
We currently do not have any API change detection using APIView as part of pull request validation. This PR is a first step towards adding this capability. Public pipeline doesn't have access to any KV to authenticate request. So instead of sending the file from pipeline, pr pipeline will send a request informing about a PR that needs to be verified for API changes. APIView will pull artifact from devops and look for any API changes and add it as comment in PR if it finds any API changes. This PR is a first step towards verifying API changes earlier in the cycle and some of these changes will be incorporated into SDK automation to support creating a connected reviews from swagger files.