### PR TITLE
Include methods defined in different namespace in same package

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.2.3"
+VERSION = "0.2.4"

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
@@ -54,13 +54,14 @@ class ClassNode(NodeEntityBase):
     """Class node to represent parsed class node and children
     """
 
-    def __init__(self, namespace, parent_node, obj):
+    def __init__(self, namespace, parent_node, obj, pkg_root_namespace):
         super().__init__(namespace, parent_node, obj)
         self.base_class_names = []
         self.errors = []
         self.namespace_id = self.generate_id()
         self.full_name = self.namespace_id
         self.implements = []
+        self.pkg_root_namespace = pkg_root_namespace
         self._inspect()
         self._set_abc_implements()
         self._sort_elements()
@@ -101,7 +102,7 @@ class ClassNode(NodeEntityBase):
             return False
         if hasattr(func_obj, "__module__"):
             function_module = getattr(func_obj, "__module__")
-            return function_module and function_module.startswith(self.namespace)
+            return function_module and function_module.startswith(self.pkg_root_namespace)
 
         return False
 

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
@@ -42,7 +42,7 @@ class ModuleNode(NodeEntityBase):
                 continue
 
             if inspect.isclass(member_obj):
-                class_node = ClassNode(self.namespace, self, member_obj)
+                class_node = ClassNode(self.namespace, self, member_obj, self.pkg_root_namespace)
                 key = "{0}.{1}".format(self.namespace, class_node.name)
                 self.nodeindex.add(key, class_node)
                 self.child_nodes.append(class_node)

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -11,7 +11,7 @@ namespace APIViewWeb
     {
         public override string Name { get; } = "Python";
         public override string Extension { get; } = ".whl";
-        public override string VersionString { get; } = "0.2.3";
+        public override string VersionString { get; } = "0.2.4";
 
         private readonly string _apiViewPythonProcessor;
         public override string ProcessName => _apiViewPythonProcessor;


### PR DESCRIPTION
Few classes in a package inherits DictMixin which is in a different namespace within same package root. Currently API view list only functions defined in same namespace as the class itself so it omits any functions defined in parent class. This PR is to ensure functions listed within same package root are listed in API View as long as it is defined in same package root.