### PR TITLE
Fix SemVer.ToString to handle v0 case

### DIFF
--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -136,7 +136,7 @@ class AzureEngSemanticVersion : IComparable {
   {
     $versionString = "{0}.{1}.{2}" -F $this.Major, $this.Minor, $this.Patch
 
-    if ($this.IsPrerelease)
+    if ($this.IsPrerelease -and $this.PrereleaseLabel -ne "zzz")
     {
       $versionString += $this.PrereleaseLabelSeparator + $this.PrereleaseLabel + `
                         $this.PrereleaseNumberSeparator + $this.PrereleaseNumber


### PR DESCRIPTION
Since we are treating v0 versions as prerelease we need to make sure
we don't accidently start to add the bogus prerelease label in cases where
we call ToString() on the version.