### PR TITLE
Skip PSModule caching in container jobs

### DIFF
--- a/eng/common/pipelines/templates/steps/cache-ps-modules.yml
+++ b/eng/common/pipelines/templates/steps/cache-ps-modules.yml
@@ -3,8 +3,12 @@ steps:
     . ./eng/common/scripts/Helpers/PSModule-Helpers.ps1
     Write-Host "##vso[task.setvariable variable=CachedPSModulePath]$global:CurrentUserModulePath"
   displayName: Set PS Modules Cache Directory
+  # Containers should bake modules into the image to save on pipeline time
+  condition: eq(variables['Container'], '')
 - task: Cache@2
   inputs:
     key: 'PSModulePath | $(CacheSalt) | $(Agent.OS) | $(Build.SourcesDirectory)/eng/common/scripts/Import-AzModules.ps1'
     path: $(CachedPSModulePath)
   displayName: Cache PS Modules
+  # Containers should bake modules into the image to save on pipeline time
+  condition: eq(variables['Container'], '')

--- a/eng/common/pipelines/templates/steps/cache-ps-modules.yml
+++ b/eng/common/pipelines/templates/steps/cache-ps-modules.yml
@@ -4,11 +4,11 @@ steps:
     Write-Host "##vso[task.setvariable variable=CachedPSModulePath]$global:CurrentUserModulePath"
   displayName: Set PS Modules Cache Directory
   # Containers should bake modules into the image to save on pipeline time
-  condition: eq(variables['Container'], '')
+  condition: and(succeeded(), eq(variables['Container'], ''))
 - task: Cache@2
   inputs:
     key: 'PSModulePath | $(CacheSalt) | $(Agent.OS) | $(Build.SourcesDirectory)/eng/common/scripts/Import-AzModules.ps1'
     path: $(CachedPSModulePath)
   displayName: Cache PS Modules
   # Containers should bake modules into the image to save on pipeline time
-  condition: eq(variables['Container'], '')
+  condition: and(succeeded(), eq(variables['Container'], ''))


### PR DESCRIPTION
Containers should bake modules into the image to save on pipeline time.