### PR TITLE
Make ServiceName optional for verify-changelog

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-changelog.yml
+++ b/eng/common/pipelines/templates/steps/verify-changelog.yml
@@ -17,8 +17,8 @@ steps:
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/common/scripts/Verify-ChangeLog.ps1
       arguments: >
-        -PackageName ${{ parameters.PackageName }}
-        -ServiceDirectory ${{ coalesce(parameters.ServiceDirectory, parameters.ServiceName) }}
+        -PackageName '${{ parameters.PackageName }}'
+        -ServiceDirectory '${{ coalesce(parameters.ServiceDirectory, parameters.ServiceName) }}'
         -ForRelease $${{ parameters.ForRelease }}
       pwsh: true
       workingDirectory: $(Pipeline.Workspace)

--- a/eng/common/pipelines/templates/steps/verify-changelog.yml
+++ b/eng/common/pipelines/templates/steps/verify-changelog.yml
@@ -4,7 +4,7 @@ parameters:
   default: 'not-specified'
 - name: ServiceName
   type: string
-  default: 'not-specified'
+  default: ''
 - name: ServiceDirectory
   type: string
   default: ''


### PR DESCRIPTION
In cases like go where we don't pass a service name having this default to "not-specified" breaks things so we should allow for ServiceName and/or ServiceDirectory to be empty.

@chidozieononiwu we should also still go and get ServiceName cleaned up from the repos so that parameter can be removed. 