### PR TITLE
[stresswatcher] Improve reconnect, logging, auth, deployment

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -15,9 +15,17 @@ parameters:
   - name: SkipDotNetInstall
     type: boolean
     default: false
+  - name: NoWarn
+    type: boolean
+    default: false
 
 variables:
   - template: ../variables/globals.yml
+  - name: Warn
+    ${{ if parameters.NoWarn }}:
+      value: ''
+    ${{ if not(parameters.NoWarn) }}:
+      value: -warnaserror
 
 stages:
   - stage: BuildTestAndPackage
@@ -30,13 +38,13 @@ stages:
       - job: BuildAndPackage
 
         steps:
-          - task: UseDotNet@2 
+          - task: UseDotNet@2
             condition: eq(${{ parameters.SkipDotNetInstall }}, false)
             displayName: 'Use .NET Core sdk ${{ coalesce( parameters.DotNetCoreVersion, variables.DotNetCoreVersion) }}'
             inputs:
               version: '${{ coalesce( parameters.DotNetCoreVersion, variables.DotNetCoreVersion) }}'
 
-          - script: 'dotnet pack -o $(Build.ArtifactStagingDirectory) -warnaserror -c Release'
+          - script: 'dotnet pack -o $(Build.ArtifactStagingDirectory) $(Warn) -c Release'
             displayName: 'Build and Package'
             workingDirectory: $(Build.SourcesDirectory)/${{parameters.ToolDirectory}}
             env:
@@ -52,7 +60,7 @@ stages:
       - job: Test
 
         steps:
-          - task: UseDotNet@2 
+          - task: UseDotNet@2
             condition: eq(${{ parameters.SkipDotNetInstall }}, false)
             displayName: 'Use .NET Core sdk ${{ coalesce( parameters.DotNetCoreVersion, variables.DotNetCoreVersion) }}'
             inputs:

--- a/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/templates/stresswatcher.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/templates/stresswatcher.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: stress-watcher
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: stress-watcher
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: stress-watcher
+  template:
+    metadata:
+      namespace: {{ .Release.Namespace }}
+      labels:
+        app: stress-watcher
+    spec:
+      containers:
+      - name: stresswatcher
+        image: stress{{ .Values.repository }}registry.azurecr.io/services/stresswatcher:{{ .Values.tag }}
+        command: ["dotnet", "Stress.Watcher.dll"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: stress-writer
+rules:
+- apiGroups:
+  - '*'
+  resources:
+  - '*'
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - patch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: stress-watcher-cluster-role-binding
+subjects:
+- namespace: {{ .Release.Namespace }}
+  kind: ServiceAccount
+  name: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: stress-writer

--- a/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/values.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/values.yaml
@@ -1,3 +1,6 @@
+repository: test
+tag: latest
+
 chaos-mesh:
   dashboard:
     securityMode: false

--- a/tools/stress-cluster/services/Stress.Watcher/Dockerfile
+++ b/tools/stress-cluster/services/Stress.Watcher/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build
+
+COPY ./src /src
+
+RUN cd /src && dotnet publish -c Release -o /stresswatcher -f net5.0
+
+FROM mcr.microsoft.com/dotnet/runtime:5.0
+
+COPY --from=build /stresswatcher /stresswatcher
+
+WORKDIR /stresswatcher
+ENTRYPOINT ["dotnet", "Stress.Watcher.dll"]

--- a/tools/stress-cluster/services/Stress.Watcher/ci.yml
+++ b/tools/stress-cluster/services/Stress.Watcher/ci.yml
@@ -26,3 +26,4 @@ extends:
   parameters:
     ToolDirectory: tools/stress-cluster/services/Stress.Watcher
     DotNetCoreVersion: "5.0.100"
+    NoWarn: true

--- a/tools/stress-cluster/services/Stress.Watcher/ci.yml
+++ b/tools/stress-cluster/services/Stress.Watcher/ci.yml
@@ -1,0 +1,28 @@
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+trigger:
+  branches:
+    include:
+      - main
+      - feature/*
+      - release/*
+      - hotfix/*
+  paths:
+    include:
+      - tools/stress-cluster/services/Stress.Watcher
+
+pr:
+  branches:
+    include:
+      - main
+      - feature/*
+      - release/*
+      - hotfix/*
+  paths:
+    include:
+      - tools/stress-cluster/services/Stress.Watcher
+
+extends:
+  template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+  parameters:
+    ToolDirectory: tools/stress-cluster/services/Stress.Watcher
+    DotNetCoreVersion: "5.0.100"

--- a/tools/stress-cluster/services/Stress.Watcher/publish.ps1
+++ b/tools/stress-cluster/services/Stress.Watcher/publish.ps1
@@ -10,5 +10,5 @@ docker tag stresswatcher stressprodregistry.azurecr.io/services/stresswatcher:$T
 az acr login -n stresstestregistry
 docker push stresstestregistry.azurecr.io/services/stresswatcher:$Tag
 
-#az acr login -n stressprodregistry
-#docker push stressprodregistry.azurecr.io/services/stresswatcher:$Tag
+az acr login -n stressprodregistry
+docker push stressprodregistry.azurecr.io/services/stresswatcher:$Tag

--- a/tools/stress-cluster/services/Stress.Watcher/publish.ps1
+++ b/tools/stress-cluster/services/Stress.Watcher/publish.ps1
@@ -9,5 +9,6 @@ docker tag stresswatcher stressprodregistry.azurecr.io/services/stresswatcher:$T
 
 az acr login -n stresstestregistry
 docker push stresstestregistry.azurecr.io/services/stresswatcher:$Tag
-az acr login -n stressprodregistry
-docker push stressprodregistry.azurecr.io/services/stresswatcher:$Tag
+
+#az acr login -n stressprodregistry
+#docker push stressprodregistry.azurecr.io/services/stresswatcher:$Tag

--- a/tools/stress-cluster/services/Stress.Watcher/publish.ps1
+++ b/tools/stress-cluster/services/Stress.Watcher/publish.ps1
@@ -1,0 +1,13 @@
+param(
+    [string] $Tag = "latest",
+    [bool] $Login = $true
+)
+
+docker build . -t stresswatcher
+docker tag stresswatcher stresstestregistry.azurecr.io/services/stresswatcher:$Tag
+docker tag stresswatcher stressprodregistry.azurecr.io/services/stresswatcher:$Tag
+
+az acr login -n stresstestregistry
+docker push stresstestregistry.azurecr.io/services/stresswatcher:$Tag
+az acr login -n stressprodregistry
+docker push stressprodregistry.azurecr.io/services/stresswatcher:$Tag

--- a/tools/stress-cluster/services/Stress.Watcher/src/Extensions.cs
+++ b/tools/stress-cluster/services/Stress.Watcher/src/Extensions.cs
@@ -12,12 +12,5 @@ namespace Stress.Watcher.Extensions
             pod.Metadata.Labels.TryGetValue("testInstance", out instance);
             return instance;
         }
-
-        public static bool HasChaosStarted(this V1Pod pod)
-        {
-            var started = "";
-            pod.Metadata.Annotations?.TryGetValue("stress/chaos.started", out started);
-            return started == "true";
-        }
     }
 }

--- a/tools/stress-cluster/services/Stress.Watcher/src/PodEventHandler.cs
+++ b/tools/stress-cluster/services/Stress.Watcher/src/PodEventHandler.cs
@@ -138,7 +138,14 @@ namespace Stress.Watcher
                 return false;
             }
 
-            if (!pod.Metadata.Labels.ContainsKey("chaos") || pod.Metadata.Labels["chaos"] != "true")
+            var autoStart = "";
+            pod.Metadata.Annotations?.TryGetValue("stress/chaos.autoStart", out autoStart);
+            if (autoStart == "false")
+            {
+                return false;
+            }
+
+            if (!pod.Metadata.Labels.TryGetValue("chaos", out var chaos) || chaos != "true")
             {
                 return false;
             }
@@ -149,7 +156,9 @@ namespace Stress.Watcher
                 return false;
             }
 
-            if (pod.HasChaosStarted())
+            var started = "";
+            pod.Metadata.Annotations?.TryGetValue("stress/chaos.started", out started);
+            if (started == "true")
             {
                 Log($"Pod {pod.NamespacedName()} chaos has started.");
                 return false;

--- a/tools/stress-cluster/services/Stress.Watcher/src/Program.cs
+++ b/tools/stress-cluster/services/Stress.Watcher/src/Program.cs
@@ -25,7 +25,18 @@ namespace Stress.Watcher
 
         static void Main(Options options)
         {
-            var config = KubernetesClientConfiguration.BuildConfigFromConfigFile();
+            KubernetesClientConfiguration config;
+
+            try
+            {
+                config = KubernetesClientConfiguration.BuildConfigFromConfigFile();
+            }
+            catch (Exception)
+            {
+                Console.WriteLine("Failure loading kubeconfig, falling back to in cluster config.");
+                config = KubernetesClientConfiguration.InClusterConfig();
+            }
+
             var client = new Kubernetes(config);
             var chaosClient = new GenericChaosClient(config);
 

--- a/tools/stress-cluster/services/Stress.Watcher/src/Program.cs
+++ b/tools/stress-cluster/services/Stress.Watcher/src/Program.cs
@@ -2,18 +2,34 @@
 using System.Threading;
 using k8s;
 using k8s.Models;
+using CommandLine;
 
 namespace Stress.Watcher
 {
     class ChaosWatcher
     {
+        public class Options
+        {
+            [Option('n', "namespace", Required = false, HelpText = "Watch specified namespace only.")]
+            public string Namespace { get; set; }
+        }
+
         static void Main(string[] args)
+        {
+            Parser.Default.ParseArguments<Options>(args)
+                .WithParsed<Options>(o =>
+                {
+                    Main(o);
+                });
+        }
+
+        static void Main(Options options)
         {
             var config = KubernetesClientConfiguration.BuildConfigFromConfigFile();
             var client = new Kubernetes(config);
             var chaosClient = new GenericChaosClient(config);
 
-            var podEventHandler = new PodEventHandler(client, chaosClient);
+            var podEventHandler = new PodEventHandler(client, chaosClient, options.Namespace);
             using Watcher<V1Pod> watcher = podEventHandler.Watch();
 
             var ctrlc = new ManualResetEventSlim(false);

--- a/tools/stress-cluster/services/Stress.Watcher/src/Program.cs
+++ b/tools/stress-cluster/services/Stress.Watcher/src/Program.cs
@@ -19,21 +19,22 @@ namespace Stress.Watcher
             Parser.Default.ParseArguments<Options>(args)
                 .WithParsed<Options>(o =>
                 {
-                    Main(o);
+                    Program(o);
                 });
         }
 
-        static void Main(Options options)
+        static void Program(Options options)
         {
             KubernetesClientConfiguration config;
 
+            // Try to load kubeconfig file, if running locally,
+            // otherwise try in cluster config (running in k8s container)
             try
             {
                 config = KubernetesClientConfiguration.BuildConfigFromConfigFile();
             }
             catch (Exception)
             {
-                Console.WriteLine("Failure loading kubeconfig, falling back to in cluster config.");
                 config = KubernetesClientConfiguration.InClusterConfig();
             }
 

--- a/tools/stress-cluster/services/Stress.Watcher/src/Stress.Watcher.csproj
+++ b/tools/stress-cluster/services/Stress.Watcher/src/Stress.Watcher.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="KubernetesClient" Version="6.0.1" />
   </ItemGroup>
 

--- a/tools/stress-cluster/services/Stress.Watcher/src/Stress.Watcher.csproj
+++ b/tools/stress-cluster/services/Stress.Watcher/src/Stress.Watcher.csproj
@@ -9,6 +9,8 @@
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="KubernetesClient" Version="6.0.1" />
+    <PackageReference Include="Serilog" Version="2.10.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/stress-cluster/services/Stress.Watcher/tests/PodEventHandlerTest.cs
+++ b/tools/stress-cluster/services/Stress.Watcher/tests/PodEventHandlerTest.cs
@@ -94,6 +94,10 @@ namespace Stress.Watcher.Tests
             pod.Metadata.Annotations["stress/chaos.started"] = "true";
             handler.ShouldStartPodChaos(WatchEventType.Modified, pod).Should().BeFalse();
 
+            pod.Metadata.Annotations.Remove("stress/chaos.started");
+            pod.Metadata.Annotations["stress/chaos.autoStart"] = "false";
+            handler.ShouldStartPodChaos(WatchEventType.Modified, pod).Should().BeFalse();
+
             pod = CreatePod("testns", "");
             handler.ShouldStartPodChaos(WatchEventType.Modified, pod).Should().BeFalse();
 


### PR DESCRIPTION
- Add namespace filtering to stress event watcher
- Add stress watcher dockerfile
- Load in cluster config when stress watcher runs in a k8s container
- Add stress watcher ignore annotation
- Add better log handling for stress watcher
- Handle stress watcher re-connect on connection timeout/close
- Add stress watcher deployment and roles to infrastructure templates