### PR TITLE
[Test-Proxy] Need to access raw uri string instead of `request.Path` when creating upstream request

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -448,7 +448,7 @@ namespace Azure.Sdk.Tools.TestProxy
             // to give us some amount of safety, but note that we explicitly disable escaping in that combination.
             var rawTarget = request.HttpContext.Features.Get<IHttpRequestFeature>().RawTarget;
             var host = new Uri(GetHeader(request, "x-recording-upstream-base-uri"));
-            return new Uri(host, rawTarget, dontEscape: true);
+            return new Uri(host, rawTarget);
         }
 
         private static bool IncludeHeader(string header)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -441,13 +441,9 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public static Uri GetRequestUri(HttpRequest request)
         {
-            var uri = new RequestUriBuilder();
-            uri.Reset(new Uri(GetHeader(request, "x-recording-upstream-base-uri")));
-            uri.Path = request.HttpContext.Features.Get<IHttpRequestFeature>().RawTarget;
-            uri.Query = request.QueryString.ToUriComponent();
-            var result = uri.ToUri();
-
-            return result;
+            var rawTarget = request.HttpContext.Features.Get<IHttpRequestFeature>().RawTarget;
+            var host = new Uri(GetHeader(request, "x-recording-upstream-base-uri"));
+            return new Uri(host, rawTarget, dontEscape: true);
         }
 
         private static bool IncludeHeader(string header)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -444,7 +444,6 @@ namespace Azure.Sdk.Tools.TestProxy
             var uri = new RequestUriBuilder();
             uri.Reset(new Uri(GetHeader(request, "x-recording-upstream-base-uri")));
             uri.Path = request.HttpContext.Features.Get<IHttpRequestFeature>().RawTarget;
-            
             uri.Query = request.QueryString.ToUriComponent();
             var result = uri.ToUri();
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -441,6 +441,11 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public static Uri GetRequestUri(HttpRequest request)
         {
+            // Instead of obtaining the Path of the request from request.Path, we use this
+            // more complicated method obtaining the raw string from the httpcontext. Unfortunately,
+            // The native request functions implicitly decode the Path value. EG: "aa%27bb" is decoded into 'aa'bb'.
+            // Using the RawTarget PREVENTS this automatic decode. We still lean on the URI constructors
+            // to give us some amount of safety, but note that we explicitly disable escaping in that combination.
             var rawTarget = request.HttpContext.Features.Get<IHttpRequestFeature>().RawTarget;
             var host = new Uri(GetHeader(request, "x-recording-upstream-base-uri"));
             return new Uri(host, rawTarget, dontEscape: true);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -2,6 +2,7 @@
 using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Concurrent;
@@ -442,7 +443,8 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             var uri = new RequestUriBuilder();
             uri.Reset(new Uri(GetHeader(request, "x-recording-upstream-base-uri")));
-            uri.Path = request.Path;
+            uri.Path = request.HttpContext.Features.Get<IHttpRequestFeature>().RawTarget;
+            
             uri.Query = request.QueryString.ToUriComponent();
             var result = uri.ToUri();
 


### PR DESCRIPTION
This is because `request.Path` implicitly _decodes_ the URI.

`/mytable(PartitionKey='aa%27%27bb')`

becomes

`/mytable(PartitionKey='aa''bb')`

However, when we fire this request upstream, that URI _matters_ as it's part of the canonicalized resource string encoded into the shared key!

We need to store this _raw_ or as close to raw as we can get it, to prevent auth failures like this in the future.
