### PR TITLE
Pass package name from calling pipeline to uniquely identify pull req…

### DIFF
--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -112,5 +112,5 @@ foreach ($artifact in $ArtifactList)
 
 foreach($pkg in $responses.keys)
 {
-    Write-Host "API detectiopn request status for $pkg: $($responses[$pkg])"
+    Write-Host "API detectiopn request status for $($pkg) : $($responses[$pkg])"
 }

--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -112,5 +112,5 @@ foreach ($artifact in $ArtifactList)
 
 foreach($pkg in $responses.keys)
 {
-    Write-Host "API detectiopn request status for $($pkg) : $($responses[$pkg])"
+    Write-Host "API detection request status for $($pkg) : $($responses[$pkg])"
 }

--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -30,14 +30,15 @@ namespace APIViewWeb.Controllers
             string filePath, 
             int pullRequestNumber, 
             string commitSha,
-            string repoName)
+            string repoName,
+            string packageName)
         {
             if (!ValidateInputParams())
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
             }
 
-            await _pullRequestManager.DetectApiChanges(buildId, artifactName, filePath, pullRequestNumber, commitSha, repoName);
+            await _pullRequestManager.DetectApiChanges(buildId, artifactName, filePath, pullRequestNumber, commitSha, repoName, packageName);
             return Ok();
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Models/PullRequestModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/PullRequestModel.cs
@@ -17,5 +17,6 @@ namespace APIViewWeb.Models
         public bool IsOpen { get; set; } = true;
         public string ReviewId { get; set; }
         public string Author { get; set; }
+        public string PackageName { get; set; }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
@@ -19,9 +19,9 @@ namespace APIViewWeb
             _pullRequestsContainer = client.GetContainer("APIView", "PullRequests");
         }
 
-        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string repoName, string filePath)
+        public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string repoName, string packageName)
         {
-            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.RepoName = '{repoName}' and c.FilePath = '{filePath}'";
+            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.RepoName = '{repoName}' and c.PackageName = '{packageName}'";
             return await GetPullRequestFromQueryAsync(query);
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -60,14 +60,14 @@ namespace APIViewWeb.Repositories
         }
 
         // API change detection for PR will pull artifact from devops artifact
-        public async Task DetectApiChanges(string buildId, string artifactName, string filePath, int prNumber, string commitSha, string repoName)
+        public async Task DetectApiChanges(string buildId, string artifactName, string filePath, int prNumber, string commitSha, string repoName, string packageName)
         {
             var requestTelemetry = new RequestTelemetry { Name = "Detecting API changes for PR: " + prNumber };
             var operation = _telemetryClient.StartOperation(requestTelemetry);
             try
             {
                 string[] repoInfo = repoName.Split("/");
-                var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, repoName, filePath);
+                var pullRequestModel = await _pullRequestsRepository.GetPullRequestAsync(prNumber, repoName, packageName);
                 if (pullRequestModel == null)
                 {
                     var issue = await _githubClient.Issue.Get(repoInfo[0], repoInfo[1], prNumber);
@@ -76,7 +76,8 @@ namespace APIViewWeb.Repositories
                         RepoName = repoName,
                         PullRequestNumber = prNumber,
                         FilePath = filePath,
-                        Author = issue.User.Login
+                        Author = issue.User.Login,
+                        PackageName = packageName
                     };
                 }
                 else


### PR DESCRIPTION
Currently file name is used to query API review document from cosmos DB within same PR. But .Net file path is different across each build due to generated version number for each build. This PR will submit a package name to API view to be used in query.