### PR TITLE
[GitHub Labels] CXP Attention

### DIFF
--- a/tools/github-labels/common-labels.csv
+++ b/tools/github-labels/common-labels.csv
@@ -76,6 +76,7 @@ Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
 Label,CycleCloud,,e99695
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
 Label,Data Factory,,e99695
@@ -113,6 +114,7 @@ Label,IoT/CLI,,e99695
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
+Label,LLC,,e99695
 Label,LOUIS,,e99695
 Label,Lab Services,,e99695
 Label,Logic App,,e99695
@@ -122,6 +124,7 @@ Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695

--- a/tools/github-labels/repository-snapshots/autorest.csharp.csv
+++ b/tools/github-labels/repository-snapshots/autorest.csharp.csv
@@ -1,35 +1,15 @@
 Processing Azure\autorest.csharp repo.
-Label,Mgmt,This issue is related to a management-plane library.,ffeb77
-Label,💥 API Impact,Changes that would result in API changes in default cases (customization excluded),c64539
-Label,Epic,,3E4B9E
-Label,blocking-release,Blocks release,d73a49
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,dependencies,Pull requests that update a dependency file,0366d6
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,javascript,Pull requests that update Javascript code,168700
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,triage,,22B1F2
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,playbook,A step-by-step checklist of a manual operation,B94D9B
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,proposal,Proposed action with description,3B776C
-Label,infrastructure,Required infrastructure work that is not a feature persay but required to keep things running,F0D42A
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,Service Attention,This issue is responsible by Azure service team.,10066b
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -38,26 +18,25 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
 Label,Azure.Identity,,e99695
+Label,backlog,Planned future work.,c5def5
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
@@ -71,8 +50,8 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
@@ -84,6 +63,7 @@ Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
 Label,Compute,,e99695
 Label,Compute - Extensions,,e99695
 Label,Compute - Images,,e99695
@@ -101,6 +81,9 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,customization,AutoRest C# language generator customization option.,91fc74
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -114,41 +97,57 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,dependencies,Pull requests that update a dependency file,0366d6
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
 Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
+Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
+Label,infrastructure,Required infrastructure work that is not a feature persay but required to keep things running,F0D42A
 Label,Insights,,e99695
+Label,instances<5,Less than 5 instances that need a workaround.,a04060
+Label,instances>50,More than 50 instances that need a workaround.,a04060
+Label,instances5-50,Between 5 and 50 instances that need a workaround.,a04060
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
+Label,javascript,Pull requests that update Javascript code,168700
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
+Label,Mgmt,This issue is related to a management-plane library.,ffeb77
 Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
 Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
@@ -166,7 +165,13 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-design,,FBCA04
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -181,19 +186,27 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
+Label,playbook,A step-by-step checklist of a manual operation,B94D9B
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,proposal,Proposed action with description,3B776C
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -203,13 +216,6 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -217,42 +223,40 @@ Label,Security,,e99695
 Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
+Label,Service Attention,This issue is responsible by Azure service team.,10066b
 Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
+Label,test-server,AutoRest test server related issue.,f7ae9e
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
+Label,triage,,22B1F2
+Label,v2,Version 2 of AutoRest C# generator.,213f7f
+Label,v3,Version 3 of AutoRest C# generator.,e993ff
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,breaking-change,,d73a49
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,backlog,Planned future work.,c5def5
-Label,customization,AutoRest C# language generator customization option.,91fc74
-Label,EngSys,This issue is impacting the engineering system.,e99695
-Label,instances<5,Less than 5 instances that need a workaround.,a04060
-Label,instances>50,More than 50 instances that need a workaround.,a04060
-Label,instances5-50,Between 5 and 50 instances that need a workaround.,a04060
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
-Label,test-server,AutoRest test server related issue.,f7ae9e
-Label,v2,Version 2 of AutoRest C# generator.,213f7f
-Label,v3,Version 3 of AutoRest C# generator.,e993ff
 Label,workaround-easy,Working around the problem is easy.,1d76db
 Label,workaround-hard,Working around the problem is difficult.,1d76db
 Label,workaround-medium,Working around the problem is somewhat difficult.,1d76db
+Label,💥 API Impact,Changes that would result in API changes in default cases (customization excluded),c64539

--- a/tools/github-labels/repository-snapshots/autorest.csv
+++ b/tools/github-labels/repository-snapshots/autorest.csv
@@ -1,26 +1,10 @@
 Processing Azure\autorest repo.
 Label,AutoRest v2,Related to AutoRest v2 Core,7ae80d
-Label,Generator v2,Using an AutoRest v2 generator,0a607f
-Label,Rust,,8ef29f
-Label,OpenAPI 2 to 3 Converter,,71ed6a
-Label,Schema Validator,,98aae2
+Label,AutoRest v3,Related to AutoRest v3 Core,7ae80d
+Label,blocking-release,Blocks release,d73a49
+Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,Epic,,3E4B9E
-Label,Publish,,8B442E
-Label,next minor,Tag to add on PR to say they should go in the next minor version,E37045
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,triage,,22B1F2
-Label,Nickel,,fef2c0
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,needs-attention,This issue needs attention from the service team or the SDK team.,3BA0F8
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,Service Attention,This issue is responsible by Azure service team.,10066b
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
+Label,C#,,c4cbfc
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cognitive - QnA Maker,,e99695
@@ -31,6 +15,7 @@ Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
 Label,Compute,,e99695
 Label,Compute - Extensions,,e99695
 Label,Compute - Images,,e99695
@@ -44,17 +29,57 @@ Label,Consumption,,e99695
 Label,Container Instances,,e99695
 Label,Container Registry,,e99695
 Label,Container Service,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
+Label,DataPlane Feature,,5319e7
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Do Not Merge,,b60205
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,documentation,,c5def5
+Label,duplicate,This issue is the duplicate of another issue,e4c288
+Label,Epic,,3E4B9E
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
+Label,Generator v2,Using an AutoRest v2 generator,0a607f
+Label,Go,,c4cbfc
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
+Label,Invalid Specification,Caused by invalid OpenAPI or Swagger specification,c12028
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
+Label,LLC,,e99695
+Label,Maps,,e99695
 Label,Mgmt,This issue is related to a management-plane library.,ffeb77
 Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
+Label,Modeler,,90f4cc
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,needs-attention,This issue needs attention from the service team or the SDK team.,3BA0F8
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
+Label,next minor,Tag to add on PR to say they should go in the next minor version,E37045
+Label,Nickel,,fef2c0
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
+Label,OpenAPI 2,OpenAPI 2 (Swagger),fbca04
+Label,OpenAPI 2 to 3 Converter,,71ed6a
+Label,OpenAPI 3,OpenAPI 3,fbca04
+Label,P0 - Critical,Critical Issue - blocking,d83c59
+Label,P1 - Required,Required functionality - not blocking,e8db7d
+Label,P2 - Requested,Feature Request,5635a8
 Label,Peering,,e99695
+Label,PHP,,c4cbfc
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,PowerShell,PowerShell Generator Incubator,c4cbfc
+Label,Publish,,8B442E
 Label,Purview,,e99695
+Label,Python,,c4cbfc
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -64,6 +89,21 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
+Label,Ruby,,c4cbfc
+Label,Rust,,8ef29f
+Label,Scheduler,,e99695
+Label,Schema Registry,,e99695
+Label,Schema Validator,,98aae2
+Label,Search,,e99695
+Label,Security,,e99695
+Label,SecurityInsights,,e99695
+Label,Server Management,,e99695
+Label,Service,This issue points to a problem in the service.,ffeb77
+Label,Service Attention,This issue is responsible by Azure service team.,10066b
+Label,Service Bus,,e99695
+Label,Service Fabric,,e99695
+Label,Service Map,,e99695
+Label,SignalR,,e99695
 Label,SQL,,e99695
 Label,SQL - Backup & Restore,,e99695
 Label,SQL - Data Security,,e99695
@@ -71,52 +111,15 @@ Label,SQL - Elastic Jobs,,e99695
 Label,SQL - Managed Instance,,e99695
 Label,SQL - Replication & Failover,,e99695
 Label,SQL - VM,,e99695
-Label,Scheduler,,e99695
-Label,Schema Registry,,e99695
-Label,Search,,e99695
-Label,Security,,e99695
-Label,SecurityInsights,,e99695
-Label,Server Management,,e99695
-Label,Service,This issue points to a problem in the service.,ffeb77
-Label,Service Bus,,e99695
-Label,Service Fabric,,e99695
-Label,Service Map,,e99695
-Label,SignalR,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,test-enhancement,,7365c9
 Label,test-manual-pass,,c0eaf9
-Label,AutoRest v3,Related to AutoRest v3 Core,7ae80d
-Label,C#,,c4cbfc
-Label,DataPlane Feature,,5319e7
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,documentation,,c5def5
-Label,Go,,c4cbfc
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,Invalid Specification,Caused by invalid OpenAPI or Swagger specification,c12028
-Label,Modeler,,90f4cc
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,OpenAPI 2,OpenAPI 2 (Swagger),fbca04
-Label,OpenAPI 3,OpenAPI 3,fbca04
-Label,P0 - Critical,Critical Issue - blocking,d83c59
-Label,P1 - Required,Required functionality - not blocking,e8db7d
-Label,P2 - Requested,Feature Request,5635a8
-Label,PHP,,c4cbfc
-Label,PowerShell,PowerShell Generator Incubator,c4cbfc
-Label,Python,,c4cbfc
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,Ruby,,c4cbfc
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
+Label,triage,,22B1F2
 Label,TypeScript,,c4cbfc

--- a/tools/github-labels/repository-snapshots/autorest.go.csv
+++ b/tools/github-labels/repository-snapshots/autorest.go.csv
@@ -1,25 +1,15 @@
 Processing Azure\autorest.go repo.
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,Epic,,3E4B9E
-Label,Track1,,c2e0c6
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,Service Attention,This issue is responsible by Azure service team.,10066b
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,infrastructure,Required infrastructure work that is not a feature persay but required to keep things running,FBCA04
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -28,17 +18,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -46,8 +31,11 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
@@ -61,8 +49,8 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
@@ -74,6 +62,7 @@ Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
 Label,Compute,,e99695
 Label,Compute - Extensions,,e99695
 Label,Compute - Images,,e99695
@@ -91,6 +80,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -104,6 +95,7 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
@@ -111,32 +103,39 @@ Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
 Label,Docs,,e99695
 Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
+Label,infrastructure,Required infrastructure work that is not a feature persay but required to keep things running,FBCA04
 Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -158,7 +157,12 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -173,19 +177,25 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -195,13 +205,6 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -209,39 +212,33 @@ Label,Security,,e99695
 Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
+Label,Service Attention,This issue is responsible by Azure service team.,10066b
 Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
+Label,Track1,,c2e0c6
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,invalid,,e6e6e6
-Label,planned,,e6e6e6
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,review,,ededed
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
-Label,Track2,,ed7f44
-Label,wontfix,,ffffff

--- a/tools/github-labels/repository-snapshots/autorest.java.csv
+++ b/tools/github-labels/repository-snapshots/autorest.java.csv
@@ -1,30 +1,16 @@
 Processing Azure\autorest.java repo.
-Label,ChatReleaseVersion,,71eda5
-Label,ChatOct6Beta.2,,2505c1
-Label,Chat Preview3 Generator,This is the version used to generate Chat preview3 version,db06cd
-Label,Epic,,3E4B9E
-Label,blocking-partner-adoption,,D93F0B
-Label,Codegen Customizations,,def740
-Label,low-level-client,,fef2c0
-Label,needs-author feedback,,f72598
-Label,needs-team attention,,5319e7
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,Service Attention,This issue is responsible by Azure service team.,10066b
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
+Label,2.0-Preview,,d93f0b
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -33,17 +19,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -51,12 +32,25 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocked,Issues that are blocked by others,ff0000
+Label,blocking-partner-adoption,,D93F0B
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Chat Preview3 Generator,This is the version used to generate Chat preview3 version,db06cd
+Label,ChatOct6Beta.2,,2505c1
+Label,ChatReleaseVersion,,71eda5
+Label,cla-already-signed,,009800
+Label,cla-not-required,,009800
+Label,cla-required,,e11d21
+Label,cla-signed,,207de5
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
+Label,Codegen Customizations,,def740
 Label,Cognitive - Anomaly Detector,,e99695
 Label,Cognitive - Bing,,e99695
 Label,Cognitive - Computer Vision,,e99695
@@ -66,8 +60,8 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
@@ -79,6 +73,7 @@ Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
 Label,Compute,,e99695
 Label,Compute - Extensions,,e99695
 Label,Compute - Images,,e99695
@@ -96,6 +91,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -109,38 +106,53 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,dependencies,Pull requests that update a dependency file,0366d6
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
+Label,Do Not Merge,,b60205
 Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
+Label,FluentGen,,def740
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
+Label,in progress,,d93f0b
 Label,Insights,,e99695
 Label,Intune,,e99695
+Label,invalid,,e6e6e6
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
+Label,Javadoc,,f9d0c4
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
+Label,low-level-client,,fef2c0
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -162,7 +174,14 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-author feedback,,f72598
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team attention,,5319e7
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -177,19 +196,28 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,priority-0,,ed9ca0
+Label,priority-1,,db6478
+Label,priority-2,,f990f9
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -199,13 +227,6 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -213,54 +234,36 @@ Label,Security,,e99695
 Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
+Label,Service Attention,This issue is responsible by Azure service team.,10066b
 Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
+Label,to do,,ededed
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
+Label,v2,,40aef7
+Label,v3,,12506d
+Label,v4,,c389dd
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,2.0-Preview,,d93f0b
-Label,blocked,Issues that are blocked by others,ff0000
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,cla-already-signed,,009800
-Label,cla-not-required,,009800
-Label,cla-required,,e11d21
-Label,cla-signed,,207de5
-Label,dependencies,Pull requests that update a dependency file,0366d6
-Label,Do Not Merge,,b60205
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,FluentGen,,def740
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,in progress,,d93f0b
-Label,invalid,,e6e6e6
-Label,Javadoc,,f9d0c4
-Label,priority-0,,ed9ca0
-Label,priority-1,,db6478
-Label,priority-2,,f990f9
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
-Label,to do,,ededed
-Label,v2,,40aef7
-Label,v3,,12506d
-Label,v4,,c389dd

--- a/tools/github-labels/repository-snapshots/autorest.python.csv
+++ b/tools/github-labels/repository-snapshots/autorest.python.csv
@@ -1,35 +1,15 @@
 Processing Azure\autorest.python repo.
-Label,Epic,,3E4B9E
-Label,MyPy,,fbca04
-Label,Docs,,e99695
-Label,Warnings and error message,,ddc6ff
-Label,MultiAPI,,ecfc94
-Label,breaking-change,,d73a49
-Label,Non breaking change,,4fffcd
-Label,Paging,,006b75
-Label,Low Level Client,,0052cc
-Label,P1,,0FE2A8
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,needs-attention,This issue needs attention from the service team or the SDK team.,3BA0F8
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,Service Attention,This issue is responsible by Azure service team.,10066b
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,P2,,586505
-Label,Hybrid LLC,LLC + top generated,5A0068
-Label,Pinfinity,,ED79FE
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -38,17 +18,13 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,Autorest v3 refactoring,,bfd4f2
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -56,8 +32,11 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
@@ -71,8 +50,8 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
@@ -84,6 +63,7 @@ Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
 Label,Compute,,e99695
 Label,Compute - Extensions,,e99695
 Label,Compute - Images,,e99695
@@ -101,6 +81,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -114,38 +96,49 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
+Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
+Label,Hybrid LLC,LLC + top generated,5A0068
 Label,Import Export,,e99695
 Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
+Label,Low Level Client,,0052cc
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -154,6 +147,7 @@ Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
 Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
 Label,Mobile Engagement,,e99695
+Label,Modeler four issue,,d93f0b
 Label,Monitor,"Monitor, Operational Insights",e99695
 Label,Monitor - ActionGroups,,e99695
 Label,Monitor - ActivityLogs,,e99695
@@ -167,7 +161,15 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,MultiAPI,,ecfc94
+Label,MyPy,,fbca04
 Label,MySQL,,e99695
+Label,needs-attention,This issue needs attention from the service team or the SDK team.,3BA0F8
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -182,19 +184,31 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
+Label,Non breaking change,,4fffcd
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
+Label,P0,,c41d5d
+Label,P1,,0FE2A8
+Label,P2,,586505
+Label,Paging,,006b75
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
+Label,Pinfinity,,ED79FE
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -204,13 +218,6 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -218,37 +225,33 @@ Label,Security,,e99695
 Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
+Label,Service Attention,This issue is responsible by Azure service team.,10066b
 Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
+Label,Warnings and error message,,ddc6ff
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,blocking-release,Blocks release,d73a49
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,Autorest v3 refactoring,,bfd4f2
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,Modeler four issue,,d93f0b
-Label,P0,,c41d5d
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9

--- a/tools/github-labels/repository-snapshots/autorest.swift.csv
+++ b/tools/github-labels/repository-snapshots/autorest.swift.csv
@@ -1,37 +1,15 @@
 Processing Azure\autorest.swift repo.
-Label,Track 1,Legacy issue with old C#-based generator.,d93f0b
-Label,Epic,,3E4B9E
-Label,blocked,Blocked by another issue or pull request.,dddddd
-Label,blocking,Blocking another issue or pull request,cd2431
-Label,Do Not Merge,,b60205
-Label,Docs,,e99695
-Label,EngSys,This issue is impacting the engineering system.,e99695
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,triage,Incoming issue that requires triage,ededed
-Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
-Label,Mgmt,This issue is related to a management-plane library.,ffeb77
-Label,Service,This issue points to a problem in the service.,ffeb77
-Label,Service Attention,This issue is responsible by Azure service team.,10066b
-Label,needs-attention,Issue that needs attention from the SDK team,3BA0F8
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,workaround,A workaround is in place for the bug.,f792fc
-Label,needs-team attention,,ededed
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -40,17 +18,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -58,9 +31,15 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocked,Blocked by another issue or pull request.,dddddd
+Label,blocking,Blocking another issue or pull request,cd2431
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
 Label,Cognitive - Anomaly Detector,,e99695
@@ -72,8 +51,8 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
@@ -85,6 +64,7 @@ Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
 Label,Compute,,e99695
 Label,Compute - Extensions,,e99695
 Label,Compute - Images,,e99695
@@ -102,6 +82,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -115,39 +97,51 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
+Label,Do Not Merge,,b60205
+Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
+Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
 Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
+Label,Mgmt,This issue is related to a management-plane library.,ffeb77
 Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
 Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
@@ -165,7 +159,14 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-attention,Issue that needs attention from the SDK team,3BA0F8
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team attention,,ededed
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -180,19 +181,25 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -202,6 +209,18 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
+Label,Scheduler,,e99695
+Label,Schema Registry,,e99695
+Label,Search,,e99695
+Label,Security,,e99695
+Label,SecurityInsights,,e99695
+Label,Server Management,,e99695
+Label,Service,This issue points to a problem in the service.,ffeb77
+Label,Service Attention,This issue is responsible by Azure service team.,10066b
+Label,Service Bus,,e99695
+Label,Service Fabric,,e99695
+Label,Service Map,,e99695
+Label,SignalR,,e99695
 Label,SQL,,e99695
 Label,SQL - Backup & Restore,,e99695
 Label,SQL - Data Security,,e99695
@@ -209,39 +228,23 @@ Label,SQL - Elastic Jobs,,e99695
 Label,SQL - Managed Instance,,e99695
 Label,SQL - Replication & Failover,,e99695
 Label,SQL - VM,,e99695
-Label,Scheduler,,e99695
-Label,Schema Registry,,e99695
-Label,Search,,e99695
-Label,Security,,e99695
-Label,SecurityInsights,,e99695
-Label,Server Management,,e99695
-Label,Service Bus,,e99695
-Label,Service Fabric,,e99695
-Label,Service Map,,e99695
-Label,SignalR,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
+Label,Track 1,Legacy issue with old C#-based generator.,d93f0b
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
+Label,triage,Incoming issue that requires triage,ededed
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
+Label,workaround,A workaround is in place for the bug.,f792fc

--- a/tools/github-labels/repository-snapshots/autorest.typescript.csv
+++ b/tools/github-labels/repository-snapshots/autorest.typescript.csv
@@ -1,33 +1,15 @@
 Processing Azure\autorest.typescript repo.
-Label,v6,,be46e2
-Label,test-coverage,,69e833
-Label,feature,,085faa
-Label,Epic,,3E4B9E
-Label,blocked,,000000
-Label,optional-coverage,,EEEEEE
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,needs-investigation,,fbca04
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,v4,,c5def5
-Label,LowLevelClient,,ED3AB5
-Label,Do Not Merge,,b60205
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,RestLevelClient,,281152
-Label,Docs,,e99695
-Label,Service Attention,This issue is responsible by Azure service team.,10066b
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -36,17 +18,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -54,11 +31,20 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocked,,000000
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,cla-already-signed,,009800
+Label,cla-not-required,,009800
+Label,cla-required,,e11d21
+Label,cla-signed,,207de5
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
+Label,Code size,,fef2c0
 Label,CodeGen,Issues that relate to code generation,e99695
 Label,Cognitive - Anomaly Detector,,e99695
 Label,Cognitive - Bing,,e99695
@@ -69,8 +55,8 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
@@ -82,6 +68,7 @@ Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
 Label,Compute,,e99695
 Label,Compute - Extensions,,e99695
 Label,Compute - Images,,e99695
@@ -99,6 +86,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -112,37 +101,54 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,dependencies,Pull requests that update a dependency file,0366d6
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
+Label,Do Not Merge,,b60205
+Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature,,085faa
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
+Label,in progress,,ededed
+Label,in pull request,,e6e6e6
+Label,in review,,e6e6e6
 Label,Insights,,e99695
 Label,Intune,,e99695
+Label,invalid,,e6e6e6
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
+Label,LowLevelClient,,ED3AB5
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -164,7 +170,14 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,MVP,,DEBCF6
 Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-investigation,,fbca04
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -179,19 +192,33 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
+Label,optional-coverage,,EEEEEE
+Label,P1,,c2e0c6
+Label,P2,,1FBD72
+Label,P3,,F86723
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
+Label,Portal,,e6e6e6
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,priority-0,,a3030d
+Label,priority-1,,9cfcce
+Label,priority-2,,fbffaf
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -201,13 +228,7 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
+Label,RestLevelClient,,281152
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -215,53 +236,37 @@ Label,Security,,e99695
 Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
+Label,Service Attention,This issue is responsible by Azure service team.,10066b
 Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
+Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
+Label,stretch goal,,e6e6e6
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-coverage,,69e833
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
+Label,v4,,c5def5
+Label,v6,,be46e2
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,ApiManagement,,DDDDDD
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,cla-already-signed,,009800
-Label,cla-not-required,,009800
-Label,cla-required,,e11d21
-Label,cla-signed,,207de5
-Label,Code size,,fef2c0
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,dependencies,Pull requests that update a dependency file,0366d6
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,in progress,,ededed
-Label,in pull request,,e6e6e6
-Label,in review,,e6e6e6
-Label,invalid,,e6e6e6
-Label,MVP,,DEBCF6
-Label,Portal,,e6e6e6
-Label,priority-0,,a3030d
-Label,priority-1,,9cfcce
-Label,priority-2,,fbffaf
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
-Label,stretch goal,,e6e6e6
 Label,wontfix,,ffffff

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-android-pr.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-android-pr.csv
@@ -81,6 +81,7 @@ Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
 Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -126,6 +127,7 @@ Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
 Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
@@ -133,6 +135,7 @@ Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-android.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-android.csv
@@ -1,242 +1,245 @@
 Processing Azure\azure-sdk-for-android repo.
-Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
-Label,Mgmt,This issue is related to a management-plane library.,ffeb77
-Label,Service,This issue points to a problem in the service.,ffeb77
-Label,Service Attention,This issue is responsible by Azure service team.,10066b
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,Communication,,e99695
-Label,Network - Private Link,,e99695
-Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
-Label,Azure.Core,,e99695
-Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
-Label,ACS,,e99695
 Label,AAD,,e99695
-Label,AKS,,e99695
-Label,AVS,,e99695
-Label,Analysis Services,,e99695
-Label,ARM,,e99695
-Label,Azure Arc enabled servers,,e99695
-Label,Authorization,,e99695
-Label,App Services,,e99695
-Label,ARO,Azure Redhat OpenShift,e99695
-Label,ArchApproved,This API addition or change has been reviewed and approved by a language architect.,33bb00
-Label,Alerts Management,,e99695
-Label,Authentication,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,ACS,,e99695
 Label,Advisor,,e99695
-Label,Automation,,e99695
-Label,API Management,,e99695
-Label,Cognitive - Content Moderator,,e99695
-Label,Cognitive - Bing,,e99695
-Label,Batch,,e99695
-Label,Cognitive - Ink Recognizer,,e99695
-Label,Azure Stack,,e99695
-Label,Cognitive - Computer Vision,,e99695
-Label,Blueprint,,e99695
-Label,Cloud Shell,,e99695
-Label,Attestation,,e99695
-Label,Azure.Identity,,e99695
-Label,Cognitive - Text Analytics,,e99695
-Label,Compute - Managed Disks,,e99695
-Label,Cognitive - Speech,,e99695
-Label,Cognitive - Vision,,e99695
-Label,CodeGen,Issues that relate to code generation,e99695
-Label,Cognitive - Immersive Reader,,e99695
-Label,Cognitive - Face,,e99695
-Label,Cognitive Services,,e99695
-Label,Cognitive - QnA Maker,,e99695
-Label,Bot Service,,e99695
-Label,Compute,,e99695
-Label,BatchAI,,e99695
-Label,Cognitive - Form Recognizer,,e99695
-Label,Billing,,e99695
-Label,Cognitive - Mgmt,,e99695
-Label,Compute - Images,,e99695
-Label,Cognitive - Personalizer,,e99695
-Label,Data Lake Store,,e99695
-Label,Cost Management,,e99695
-Label,Cognitive - Translator,,e99695
-Label,Cognitive - LUIS,,e99695
-Label,Data Catalog,,e99695
-Label,Data Migration,,e99695
-Label,Container Instances,,e99695
-Label,Compute - Extensions,,e99695
-Label,Consumption,,e99695
-Label,Event Hubs,,e99695
-Label,Compute - VM,,e99695
-Label,Compute - RDFE,,e99695
-Label,Commerce,,e99695
-Label,Connected Kubernetes,,e99695
-Label,Data Lake,,e99695
-Label,CycleCloud,,e99695
-Label,Data Bricks,,e99695
-Label,DevOps,,e99695
-Label,Container Registry,,e99695
-Label,Digital Twins,,e99695
-Label,Data Lake Analytics,,e99695
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,Compute - VMSS,,e99695
-Label,Cosmos,,e99695
-Label,Data Lake Storage Gen1,,e99695
-Label,Event Grid,,e99695
-Label,Cognitive - Custom Vision,,e99695
-Label,Custom Providers,,e99695
-Label,Data Share,,e99695
-Label,Devtestlab,,e99695
-Label,Guest Configuration,,e99695
-Label,DataBox Edge,,e99695
-Label,Cognitive - Metrics Advisor,,e99695
-Label,HPC Cache,,e99695
-Label,Graph,,e99695
-Label,Lab Services,,e99695
-Label,HDInsight,,e99695
-Label,Data Lake Storage Gen2,,e99695
-Label,Monitor - ApplicationInsights,,e99695
-Label,Functions,,e99695
-Label,Graph.Microsoft,,e99695
-Label,Managed Identity,,e99695
-Label,Container Service,,e99695
-Label,Import Export,,e99695
-Label,Machine Learning Experimentation,,e99695
-Label,LOUIS,,e99695
-Label,Machine Learning Compute,,e99695
-Label,Dev Spaces,,e99695
-Label,MariaDB,,e99695
-Label,Data Factory,,e99695
-Label,Monitor - ActionGroups,,e99695
-Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
-Label,Machine Learning,,e99695
-Label,Monitor - Autoscale,,e99695
-Label,Logic App,,e99695
-Label,KeyVault,,e99695
-Label,Migrate,,e99695
-Label,Monitor,"Monitor, Operational Insights",e99695
-Label,Marketplace Ordering,,e99695
-Label,Kusto,,e99695
-Label,Network - Traffic Manager,,e99695
-Label,IoT/CLI,,e99695
-Label,Network - CDN,,e99695
-Label,Monitor - ActivityLogs,,e99695
-Label,Network - Front Door,Service: Azure Front Door,e99695
-Label,Network - Network Watcher,,e99695
-Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
-Label,Kubernetes Configuration,,e99695
-Label,Graph.Windows,,e99695
-Label,Network - Load Balancer,,e99695
-Label,Network - DNS,,e99695
-Label,Network - DDoS Protection,,e99695
-Label,Network - Virtual WAN,,e99695
-Label,Network - Network Virtual Appliance,,e99695
-Label,Network - Virtual Network,,e99695
-Label,Mobile Engagement,,e99695
-Label,MySQL,,e99695
-Label,Monitor - Metrics,,e99695
-Label,Network - Bastion,,e99695
-Label,Network - Application Gateway,,e99695
-Label,Monitor - Alerts,,e99695
-Label,Network - Firewall,,e99695
-Label,Monitor - Diagnostic Settings,,e99695
-Label,Network - VPN Gateway,,e99695
-Label,Relay,,e99695
-Label,ManagedServices,,e99695
-Label,SQL,,e99695
-Label,Recovery Services Backup,,e99695
-Label,Peering,,e99695
-Label,Operations Management,,e99695
-Label,SQL - VM,,e99695
-Label,Resource Authorization,,e99695
-Label,Resource Graph,,e99695
-Label,PostgreSQL,,e99695
-Label,PowerBI,,e99695
-Label,Network - ExpressRoute,,e99695
-Label,SQL - Data Security,,e99695
-Label,Policy Insights,,e99695
-Label,Notification Hub,,e99695
-Label,Recovery Services Site-Recovery,,e99695
-Label,SecurityInsights,,e99695
-Label,Stream Analytics,,e99695
-Label,Redis Cache,,e99695
-Label,DataBox,,e99695
-Label,Scheduler,,e99695
-Label,Service Bus,,e99695
-Label,Monitor - Operational Insights,,e99695
-Label,Network - Virtual Network NAT,,e99695
-Label,Reservations,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,Service Map,,e99695
-Label,Security,,e99695
-Label,Support,,e99695
-Label,Search,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SignalR,,e99695
-Label,Web Apps,,e99695
-Label,Storsimple,,e99695
-Label,Schema Registry,,e99695
-Label,Tables,,e99695
-Label,Synapse,,e99695
-Label,Server Management,,e99695
-Label,test-enhancement,,7365c9
-Label,Cognitive - Anomaly Detector,,e99695
-Label,Resource Health,,e99695
-Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
-Label,Subscription,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,Network,,e99695
-Label,test-manual-pass,,c0eaf9
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,Visual Studio,,e99695
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,Customer Insights,,e99695
-Label,TimeseriesInsights,,e99695
-Label,blocking-release,Blocks release,d73a49
-Label,Insights,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,Media Services,,e99695
-Label,Intune,,e99695
-Label,Policy,,e99695
-Label,Service Fabric,,e99695
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
 Label,AgriFood,,e99695
+Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
+Label,API Management,,e99695
+Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
+Label,ArchApproved,This API addition or change has been reviewed and approved by a language architect.,33bb00
+Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
 Label,ARM - RBAC,,e99695
 Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
+Label,ARO,Azure Redhat OpenShift,e99695
+Label,Attestation,,e99695
+Label,Authentication,,e99695
+Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
+Label,Automation,,e99695
+Label,AVS,,e99695
+Label,Azure Arc enabled servers,,e99695
+Label,Azure Stack,,e99695
+Label,Azure.Core,,e99695
+Label,Azure.Identity,,e99695
+Label,Batch,,e99695
+Label,BatchAI,,e99695
+Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
+Label,Blueprint,,e99695
+Label,Bot Service,,e99695
 Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
+Label,Cloud Shell,,e99695
+Label,CodeGen,Issues that relate to code generation,e99695
+Label,Cognitive - Anomaly Detector,,e99695
+Label,Cognitive - Bing,,e99695
+Label,Cognitive - Computer Vision,,e99695
+Label,Cognitive - Content Moderator,,e99695
+Label,Cognitive - Custom Vision,,e99695
+Label,Cognitive - Face,,e99695
+Label,Cognitive - Form Recognizer,,e99695
+Label,Cognitive - Immersive Reader,,e99695
+Label,Cognitive - Ink Recognizer,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
+Label,Cognitive - Mgmt,,e99695
+Label,Cognitive - Personalizer,,e99695
+Label,Cognitive - QnA Maker,,e99695
+Label,Cognitive - Speech,,e99695
+Label,Cognitive - Text Analytics,,e99695
+Label,Cognitive - Translator,,e99695
+Label,Cognitive - Vision,,e99695
+Label,Cognitive Services,,e99695
+Label,Commerce,,e99695
+Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
+Label,Compute,,e99695
+Label,Compute - Extensions,,e99695
+Label,Compute - Images,,e99695
+Label,Compute - Managed Disks,,e99695
+Label,Compute - RDFE,,e99695
+Label,Compute - VM,,e99695
+Label,Compute - VMSS,,e99695
 Label,Confidential Ledger,,e99695
+Label,Connected Kubernetes,,e99695
+Label,Consumption,,e99695
+Label,Container Instances,,e99695
+Label,Container Registry,,e99695
+Label,Container Service,,e99695
+Label,Cosmos,,e99695
+Label,Cost Management,,e99695
+Label,Custom Providers,,e99695
+Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
+Label,CycleCloud,,e99695
+Label,Data Bricks,,e99695
+Label,Data Catalog,,e99695
+Label,Data Factory,,e99695
+Label,Data Lake,,e99695
+Label,Data Lake Analytics,,e99695
+Label,Data Lake Storage Gen1,,e99695
+Label,Data Lake Storage Gen2,,e99695
+Label,Data Lake Store,,e99695
+Label,Data Migration,,e99695
+Label,Data Share,,e99695
+Label,DataBox,,e99695
+Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
+Label,Dev Spaces,,e99695
+Label,DevOps,,e99695
+Label,Devtestlab,,e99695
+Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
 Label,Docs,,e99695
 Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
 Label,Epic,,3E4B9E
+Label,Event Grid,,e99695
+Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
+Label,Functions,,e99695
 Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
+Label,Graph,,e99695
+Label,Graph.Microsoft,,e99695
+Label,Graph.Windows,,e99695
+Label,Guest Configuration,,e99695
+Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
+Label,HPC Cache,,e99695
+Label,Import Export,,e99695
+Label,Insights,,e99695
+Label,Intune,,e99695
 Label,IoT,,e99695
+Label,IoT/CLI,,e99695
 Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
+Label,KeyVault,,e99695
+Label,Kubernetes Configuration,,e99695
+Label,Kusto,,e99695
+Label,Lab Services,,e99695
+Label,LLC,,e99695
+Label,Logic App,,e99695
+Label,LOUIS,,e99695
+Label,Machine Learning,,e99695
+Label,Machine Learning Compute,,e99695
+Label,Machine Learning Experimentation,,e99695
+Label,Managed Identity,,e99695
+Label,ManagedServices,,e99695
+Label,Maps,,e99695
+Label,MariaDB,,e99695
+Label,Marketplace Ordering,,e99695
+Label,Media Services,,e99695
+Label,Mgmt,This issue is related to a management-plane library.,ffeb77
+Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
+Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
+Label,Mobile Engagement,,e99695
+Label,Monitor,"Monitor, Operational Insights",e99695
+Label,Monitor - ActionGroups,,e99695
+Label,Monitor - ActivityLogs,,e99695
+Label,Monitor - Alerts,,e99695
+Label,Monitor - ApplicationInsights,,e99695
+Label,Monitor - Autoscale,,e99695
+Label,Monitor - Diagnostic Settings,,e99695
+Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
 Label,Monitor - Log,Monitor Log Analytics,e99695
 Label,Monitor - Log Analytics,,e99695
+Label,Monitor - Metrics,,e99695
+Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
 Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
+Label,Network,,e99695
+Label,Network - Application Gateway,,e99695
+Label,Network - Bastion,,e99695
+Label,Network - CDN,,e99695
+Label,Network - DDoS Protection,,e99695
+Label,Network - DNS,,e99695
+Label,Network - ExpressRoute,,e99695
+Label,Network - Firewall,,e99695
+Label,Network - Front Door,Service: Azure Front Door,e99695
+Label,Network - Load Balancer,,e99695
+Label,Network - Network Virtual Appliance,,e99695
+Label,Network - Network Watcher,,e99695
+Label,Network - Private Link,,e99695
+Label,Network - Traffic Manager,,e99695
+Label,Network - Virtual Network,,e99695
+Label,Network - Virtual Network NAT,,e99695
+Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
+Label,Notification Hub,,e99695
+Label,Operations Management,,e99695
+Label,Peering,,e99695
 Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
 Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
 Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
 Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
+Label,Policy,,e99695
+Label,Policy Insights,,e99695
+Label,PostgreSQL,,e99695
+Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
 Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
+Label,Recovery Services Backup,,e99695
+Label,Recovery Services Site-Recovery,,e99695
+Label,Redis Cache,,e99695
+Label,Relay,,e99695
+Label,Reservations,,e99695
+Label,Resource Authorization,,e99695
+Label,Resource Graph,,e99695
+Label,Resource Health,,e99695
+Label,Scheduler,,e99695
+Label,Schema Registry,,e99695
+Label,Search,,e99695
+Label,Security,,e99695
+Label,SecurityInsights,,e99695
+Label,Server Management,,e99695
+Label,Service,This issue points to a problem in the service.,ffeb77
+Label,Service Attention,This issue is responsible by Azure service team.,10066b
+Label,Service Bus,,e99695
+Label,Service Fabric,,e99695
+Label,Service Map,,e99695
+Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
+Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
+Label,Storsimple,,e99695
+Label,Stream Analytics,,e99695
 Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
+Label,Subscription,,e99695
+Label,Support,,e99695
+Label,Synapse,,e99695
+Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
+Label,TimeseriesInsights,,e99695
 Label,Track 1,,96d8f2
+Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
+Label,Visual Studio,,e99695
+Label,Web Apps,,e99695
 Label,WebPubSub,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-c-pr.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-c-pr.csv
@@ -1,18 +1,15 @@
 Processing Azure\azure-sdk-for-c-pr repo.
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,Docs,,e99695
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,Epic,,3E4B9E
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,IoT,,e99695
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -21,17 +18,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -39,8 +31,11 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
@@ -54,8 +49,8 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
@@ -85,6 +80,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -98,37 +95,47 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
+Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
 Label,Insights,,e99695
 Label,Intune,,e99695
+Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -150,7 +157,12 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -165,19 +177,25 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -187,13 +205,6 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -206,35 +217,27 @@ Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-c.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-c.csv
@@ -1,11 +1,4 @@
 Processing Azure\azure-sdk-for-c repo.
-Label,blocking-release,Blocks release,d73a49
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,Network - Private Link,,e99695
-Label,Azure Sphere,This issue affects Azure Sphere.,e99695
-Label,VideoAnalyzer,Azure Video Analyzer,e99695
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,AAD,,e99695
 Label,ACS,,e99695
 Label,Advisor,,e99695
@@ -28,19 +21,23 @@ Label,ARO,Azure Redhat OpenShift,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
 Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
+Label,Azure Sphere,This issue affects Azure Sphere.,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
 Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
 Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
@@ -85,6 +82,7 @@ Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
 Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -125,10 +123,12 @@ Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
 Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
@@ -136,6 +136,7 @@ Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -175,6 +176,7 @@ Label,Network - Front Door,Service: Azure Front Door,e99695
 Label,Network - Load Balancer,,e99695
 Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
+Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
@@ -236,6 +238,7 @@ Label,test-manual-pass,,c0eaf9
 Label,test-reliability,Issue that causes tests to be unreliable,7365c9
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
+Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-cpp.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-cpp.csv
@@ -1,16 +1,4 @@
 Processing Azure\azure-sdk-for-cpp repo.
-Label,blocking-release,Blocks release,d73a49
-Label,Azure.Identity,,e99695
-Label,KeyVault,,e99695
-Label,Cognitive - Speech,,e99695
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,Network - Private Link,,e99695
-Label,Service Bus,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,VideoAnalyzer,Azure Video Analyzer,e99695
-Label,Cognitive - Language,,e99695
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,AAD,,e99695
 Label,ACS,,e99695
 Label,Advisor,,e99695
@@ -20,6 +8,7 @@ Label,Alerts Management,,e99695
 Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
 Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
@@ -32,18 +21,22 @@ Label,ARO,Azure Redhat OpenShift,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
 Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
+Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
 Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
@@ -56,11 +49,13 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
+Label,Cognitive - Language,,e99695
 Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
 Label,Cognitive - QnA Maker,,e99695
+Label,Cognitive - Speech,,e99695
 Label,Cognitive - Text Analytics,,e99695
 Label,Cognitive - Translator,,e99695
 Label,Cognitive - Vision,,e99695
@@ -86,6 +81,7 @@ Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
 Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -126,9 +122,12 @@ Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
+Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
 Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
@@ -136,6 +135,7 @@ Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -175,6 +175,7 @@ Label,Network - Front Door,Service: Azure Front Door,e99695
 Label,Network - Load Balancer,,e99695
 Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
+Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
@@ -212,6 +213,7 @@ Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
 Label,Service Attention,This issue is responsible by Azure service team.,10066b
+Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
@@ -235,6 +237,7 @@ Label,test-manual-pass,,c0eaf9
 Label,test-reliability,Issue that causes tests to be unreliable,7365c9
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
+Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-go-pr.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-go-pr.csv
@@ -1,9 +1,15 @@
 Processing Azure\azure-sdk-for-go-pr repo.
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -12,17 +18,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -30,8 +31,11 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
@@ -45,8 +49,8 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
@@ -76,6 +80,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -89,40 +95,47 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
 Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
 Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
 Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -144,7 +157,12 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -159,19 +177,25 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -181,13 +205,6 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -200,41 +217,27 @@ Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-go.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-go.csv
@@ -1,78 +1,15 @@
 Processing Azure\azure-sdk-for-go repo.
-Label,Import Export,,e99695
-Label,Machine Learning Compute,,e99695
-Label,Machine Learning Experimentation,,e99695
-Label,Migrate,,e99695
-Label,Recovery Services Backup,,e99695
-Label,Recovery Services Site-Recovery,,e99695
-Label,Resource Health,,e99695
-Label,Support,,e99695
-Label,Kubernetes Configuration,,e99695
-Label,Connected Kubernetes,,e99695
-Label,DevOps,,e99695
-Label,Graph.Microsoft,,e99695
-Label,Graph.Windows,,e99695
-Label,MariaDB,,e99695
-Label,Network - Firewall,,e99695
-Label,Cognitive - Form Recognizer,,e99695
-Label,Cognitive - Text Analytics,,e99695
-Label,Cognitive - Anomaly Detector,,e99695
-Label,Cognitive - Custom Vision,,e99695
-Label,Cognitive - Computer Vision,,e99695
-Label,Cognitive - Face,,e99695
-Label,Cognitive - QnA Maker,,e99695
-Label,Cognitive - Translator,,e99695
-Label,Cognitive - Speech,,e99695
-Label,Cognitive - LUIS,,e99695
-Label,Cognitive - Content Moderator,,e99695
-Label,Cognitive - Personalizer,,e99695
-Label,Cognitive - Immersive Reader,,e99695
-Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - Bing,,e99695
-Label,Cognitive - Mgmt,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,Alerts Management,,e99695
-Label,Attestation,,e99695
-Label,AVS,,e99695
-Label,Container Service,,e99695
-Label,DataBox,,e99695
-Label,Data Share,,e99695
-Label,Dev Spaces,,e99695
-Label,Digital Twins,,e99695
-Label,LOUIS,,e99695
-Label,HPC Cache,,e99695
-Label,Peering,,e99695
-Label,DataBox Edge,,e99695
-Label,Schema Registry,,e99695
-Label,Network - Virtual WAN,,e99695
-Label,Network - Network Virtual Appliance,,e99695
-Label,Network - Bastion,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,Network - Private Link,,e99695
-Label,Azure Arc enabled servers,,e99695
-Label,SecurityInsights,,e99695
-Label,Azure Data Explorer,,e99695
-Label,IoT/CLI,,e99695
-Label,Quota,Quota Service,e99695
-Label,Cognitive - Language,,e99695
-Label,ADO,,e99695
-Label,Cost Management-RIandShowBack,All issues in cost management and Consumption for query API associated to Ri and showback,e99695
-Label,Cost Management-UsageDetailsAndExport,All issues in cost management and Consumption for usage details api and export,e99695
-Label,Cost Management-Billing,All issues in cost management and Consumption API where billing/price related data is shown,e99695
-Label,Cost Management-Query,"All issues in cost management and Consumption for query API associated to tags, dimensions and forec",e99695
-Label,Cost Management-Budget,"This label is for all issues under Costs Management where we see budget, alerts, notification",e99695
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,Track1,Work related to track1 and track1.5 SDKs,006b75
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,ADO,,e99695
 Label,Advisor,,e99695
 Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
 Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
 Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
@@ -82,9 +19,14 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
+Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
+Label,Azure Arc enabled servers,,e99695
+Label,Azure Data Explorer,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
 Label,Azure.Identity,,e99695
@@ -97,10 +39,28 @@ Label,Blueprint,,e99695
 Label,Bot Service,,e99695
 Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
+Label,Cognitive - Anomaly Detector,,e99695
+Label,Cognitive - Bing,,e99695
+Label,Cognitive - Computer Vision,,e99695
+Label,Cognitive - Content Moderator,,e99695
+Label,Cognitive - Custom Vision,,e99695
+Label,Cognitive - Face,,e99695
+Label,Cognitive - Form Recognizer,,e99695
+Label,Cognitive - Immersive Reader,,e99695
+Label,Cognitive - Ink Recognizer,,e99695
+Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
+Label,Cognitive - Mgmt,,e99695
+Label,Cognitive - Personalizer,,e99695
+Label,Cognitive - QnA Maker,,e99695
+Label,Cognitive - Speech,,e99695
+Label,Cognitive - Text Analytics,,e99695
+Label,Cognitive - Translator,,e99695
 Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
@@ -114,14 +74,23 @@ Label,Compute - RDFE,,e99695
 Label,Compute - VM,,e99695
 Label,Compute - VMSS,,e99695
 Label,Confidential Ledger,,e99695
+Label,Connected Kubernetes,,e99695
 Label,Consumption,,e99695
 Label,Container Instances,,e99695
 Label,Container Registry,,e99695
+Label,Container Service,,e99695
 Label,Cosmos,,e99695
 Label,Cost Management,,e99695
+Label,Cost Management-Billing,All issues in cost management and Consumption API where billing/price related data is shown,e99695
+Label,Cost Management-Budget,"This label is for all issues under Costs Management where we see budget, alerts, notification",e99695
+Label,Cost Management-Query,"All issues in cost management and Consumption for query API associated to tags, dimensions and forec",e99695
+Label,Cost Management-RIandShowBack,All issues in cost management and Consumption for query API associated to Ri and showback,e99695
+Label,Cost Management-UsageDetailsAndExport,All issues in cost management and Consumption for usage details api and export,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
 Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,customer-response-expected,,ffffff
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -132,36 +101,56 @@ Label,Data Lake Storage Gen1,,e99695
 Label,Data Lake Storage Gen2,,e99695
 Label,Data Lake Store,,e99695
 Label,Data Migration,,e99695
+Label,Data Share,,e99695
+Label,DataBox,,e99695
+Label,DataBox Edge,,e99695
 Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
+Label,Dev Spaces,,e99695
 Label,Device Provisioning Service,,e99695
+Label,DevOps,,e99695
 Label,Devtestlab,,e99695
+Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
 Label,Docs,,e99695
-Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
 Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
 Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
+Label,Graph.Microsoft,,e99695
+Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
 Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
+Label,HPC Cache,,e99695
+Label,Import Export,,e99695
 Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
+Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
+Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
+Label,Machine Learning Compute,,e99695
+Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
+Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
 Label,Mgmt,This issue is related to a management-plane library.,ffeb77
 Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
+Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
 Label,Mobile Engagement,,e99695
 Label,Monitor,"Monitor, Operational Insights",e99695
@@ -186,20 +175,26 @@ Label,needs-triage,This is a new issue that needs to be triaged to the appropria
 Label,NetApp,,e99695
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
+Label,Network - Bastion,,e99695
 Label,Network - CDN,,e99695
 Label,Network - DDoS Protection,,e99695
 Label,Network - DNS,,e99695
 Label,Network - ExpressRoute,,e99695
+Label,Network - Firewall,,e99695
 Label,Network - Front Door,Service: Azure Front Door,e99695
 Label,Network - Load Balancer,,e99695
+Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
+Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
+Label,Network - Virtual WAN,,e99695
 Label,Network - VPN Gateway,,e99695
 Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
+Label,Peering,,e99695
 Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
 Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
 Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
@@ -211,14 +206,22 @@ Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
 Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
+Label,Quota,Quota Service,e99695
+Label,Recovery Services,,e99695
+Label,Recovery Services Backup,,e99695
+Label,Recovery Services Site-Recovery,,e99695
 Label,Redis Cache,,e99695
+Label,refresh,,7FB742
 Label,Relay,,e99695
 Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
+Label,Resource Health,,e99695
 Label,Scheduler,,e99695
+Label,Schema Registry,,e99695
 Label,Search,,e99695
 Label,Security,,e99695
+Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
 Label,Service Attention,This issue is responsible by Azure service team.,10066b
@@ -238,16 +241,16 @@ Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
 Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
+Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
 Label,test-enhancement,,7365c9
 Label,test-manual-pass,,c0eaf9
 Label,test-reliability,Issue that causes tests to be unreliable,7365c9
 Label,TimeseriesInsights,,e99695
-Label,Track2,Work related to track 2 SDK,006b75
+Label,Track1,Work related to track1 and track1.5 SDKs,006b75
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,wontfix,,ffffff

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-ios-pr.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-ios-pr.csv
@@ -81,6 +81,7 @@ Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
 Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -126,6 +127,7 @@ Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
 Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
@@ -133,6 +135,7 @@ Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-ios.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-ios.csv
@@ -1,241 +1,244 @@
 Processing Azure\azure-sdk-for-ios repo.
-Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
-Label,Mgmt,This issue is related to a management-plane library.,ffeb77
-Label,Service,This issue points to a problem in the service.,ffeb77
-Label,Service Attention,This issue is responsible by Azure service team.,10066b
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,Communication,,e99695
-Label,Network - Private Link,,e99695
-Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
-Label,SecurityInsights,,e99695
-Label,IoT/CLI,,e99695
-Label,Azure.Core,,e99695
-Label,Azure.Identity,,e99695
-Label,ArchApproved,This API addition or change has been reviewed and approved by a language architect.,33bb00
-Label,ACS,,e99695
-Label,App Services,,e99695
-Label,AKS,,e99695
-Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
-Label,AVS,,e99695
-Label,Authorization,,e99695
-Label,Attestation,,e99695
-Label,ARO,Azure Redhat OpenShift,e99695
-Label,Alerts Management,,e99695
-Label,ARM,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,Analysis Services,,e99695
-Label,Automation,,e99695
 Label,AAD,,e99695
-Label,API Management,,e99695
-Label,Cognitive - Face,,e99695
-Label,Billing,,e99695
-Label,Cognitive - Form Recognizer,,e99695
-Label,Cognitive - Content Moderator,,e99695
-Label,CodeGen,Issues that relate to code generation,e99695
-Label,Authentication,,e99695
-Label,Batch,,e99695
-Label,Cloud Shell,,e99695
-Label,Cognitive - Metrics Advisor,,e99695
-Label,Cognitive - Custom Vision,,e99695
-Label,Bot Service,,e99695
-Label,Cognitive - Computer Vision,,e99695
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,BatchAI,,e99695
-Label,Azure Arc enabled servers,,e99695
-Label,Cognitive - Personalizer,,e99695
-Label,Container Service,,e99695
-Label,Blueprint,,e99695
-Label,Cognitive - Bing,,e99695
-Label,Cognitive - Text Analytics,,e99695
-Label,Cognitive - QnA Maker,,e99695
-Label,Cognitive - Translator,,e99695
-Label,Commerce,,e99695
-Label,Cognitive - LUIS,,e99695
-Label,Compute - Images,,e99695
-Label,Cognitive Services,,e99695
-Label,Compute - RDFE,,e99695
-Label,Data Lake,,e99695
-Label,Data Bricks,,e99695
-Label,Data Factory,,e99695
-Label,Cognitive - Speech,,e99695
-Label,Data Share,,e99695
-Label,Consumption,,e99695
-Label,Compute - VM,,e99695
-Label,Devtestlab,,e99695
-Label,Dev Spaces,,e99695
-Label,Data Lake Analytics,,e99695
-Label,Guest Configuration,,e99695
-Label,Event Hubs,,e99695
-Label,Digital Twins,,e99695
-Label,Custom Providers,,e99695
-Label,Cognitive - Anomaly Detector,,e99695
-Label,CycleCloud,,e99695
-Label,Migrate,,e99695
-Label,Machine Learning Experimentation,,e99695
-Label,Insights,,e99695
-Label,Data Catalog,,e99695
-Label,HDInsight,,e99695
-Label,Customer Insights,,e99695
-Label,Compute,,e99695
-Label,Graph,,e99695
-Label,DataBox,,e99695
-Label,Cognitive - Ink Recognizer,,e99695
-Label,Machine Learning Compute,,e99695
-Label,Data Lake Store,,e99695
-Label,DevOps,,e99695
-Label,Intune,,e99695
-Label,Event Grid,,e99695
-Label,Container Instances,,e99695
-Label,Lab Services,,e99695
-Label,Container Registry,,e99695
-Label,Data Migration,,e99695
-Label,ManagedServices,,e99695
-Label,Compute - Managed Disks,,e99695
-Label,Network,,e99695
-Label,Compute - Extensions,,e99695
-Label,Kubernetes Configuration,,e99695
-Label,MariaDB,,e99695
-Label,Data Lake Storage Gen1,,e99695
-Label,HPC Cache,,e99695
-Label,Functions,,e99695
-Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
-Label,Network - CDN,,e99695
-Label,Network - Bastion,,e99695
-Label,Monitor - Operational Insights,,e99695
-Label,Monitor,"Monitor, Operational Insights",e99695
-Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
-Label,Monitor - ActionGroups,,e99695
-Label,Compute - VMSS,,e99695
-Label,Graph.Microsoft,,e99695
-Label,Logic App,,e99695
-Label,Network - DNS,,e99695
-Label,Monitor - Autoscale,,e99695
-Label,Network - Firewall,,e99695
-Label,Peering,,e99695
-Label,Network - ExpressRoute,,e99695
-Label,Reservations,,e99695
-Label,KeyVault,,e99695
-Label,Cognitive - Immersive Reader,,e99695
-Label,Import Export,,e99695
-Label,Graph.Windows,,e99695
-Label,Resource Authorization,,e99695
-Label,Security,,e99695
-Label,Network - Virtual Network,,e99695
-Label,Policy,,e99695
-Label,Network - Network Watcher,,e99695
-Label,Recovery Services Backup,,e99695
-Label,Network - Network Virtual Appliance,,e99695
-Label,Managed Identity,,e99695
-Label,PostgreSQL,,e99695
-Label,Recovery Services Site-Recovery,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,Resource Graph,,e99695
-Label,Mobile Engagement,,e99695
-Label,DataBox Edge,,e99695
-Label,Marketplace Ordering,,e99695
-Label,SQL - VM,,e99695
-Label,Service Fabric,,e99695
-Label,Kusto,,e99695
-Label,Resource Health,,e99695
-Label,Monitor - Diagnostic Settings,,e99695
-Label,Network - Application Gateway,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,Schema Registry,,e99695
-Label,Service Map,,e99695
-Label,Relay,,e99695
-Label,TimeseriesInsights,,e99695
-Label,MySQL,,e99695
-Label,Policy Insights,,e99695
-Label,Network - DDoS Protection,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,Redis Cache,,e99695
-Label,Azure Stack,,e99695
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,SQL - Data Security,,e99695
-Label,Monitor - Metrics,,e99695
-Label,Service Bus,,e99695
-Label,Cosmos,,e99695
-Label,Network - Front Door,Service: Azure Front Door,e99695
-Label,Server Management,,e99695
-Label,Monitor - ApplicationInsights,,e99695
-Label,Machine Learning,,e99695
-Label,Stream Analytics,,e99695
-Label,LOUIS,,e99695
-Label,Search,,e99695
-Label,test-enhancement,,7365c9
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,Network - Virtual WAN,,e99695
-Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
-Label,Storsimple,,e99695
-Label,Synapse,,e99695
-Label,SQL,,e99695
-Label,Network - Virtual Network NAT,,e99695
-Label,Network - VPN Gateway,,e99695
-Label,Support,,e99695
-Label,Web Apps,,e99695
-Label,Tables,,e99695
-Label,Scheduler,,e99695
-Label,Subscription,,e99695
-Label,Visual Studio,,e99695
+Label,ACS,,e99695
 Label,Advisor,,e99695
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,Cost Management,,e99695
-Label,test-manual-pass,,c0eaf9
-Label,Cognitive - Mgmt,,e99695
-Label,Data Lake Storage Gen2,,e99695
-Label,Network - Load Balancer,,e99695
-Label,Notification Hub,,e99695
-Label,Cognitive - Vision,,e99695
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,Media Services,,e99695
-Label,Monitor - Alerts,,e99695
-Label,Monitor - ActivityLogs,,e99695
-Label,Operations Management,,e99695
-Label,PowerBI,,e99695
-Label,SignalR,,e99695
-Label,Network - Traffic Manager,,e99695
-Label,Connected Kubernetes,,e99695
 Label,AgriFood,,e99695
+Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
+Label,API Management,,e99695
+Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
+Label,ArchApproved,This API addition or change has been reviewed and approved by a language architect.,33bb00
+Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
 Label,ARM - RBAC,,e99695
 Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
+Label,ARO,Azure Redhat OpenShift,e99695
+Label,Attestation,,e99695
+Label,Authentication,,e99695
+Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
+Label,Automation,,e99695
+Label,AVS,,e99695
+Label,Azure Arc enabled servers,,e99695
+Label,Azure Stack,,e99695
+Label,Azure.Core,,e99695
+Label,Azure.Identity,,e99695
+Label,Batch,,e99695
+Label,BatchAI,,e99695
+Label,Billing,,e99695
 Label,blocking-release,Blocks release,d73a49
+Label,Blueprint,,e99695
+Label,Bot Service,,e99695
 Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
+Label,Cloud Shell,,e99695
+Label,CodeGen,Issues that relate to code generation,e99695
+Label,Cognitive - Anomaly Detector,,e99695
+Label,Cognitive - Bing,,e99695
+Label,Cognitive - Computer Vision,,e99695
+Label,Cognitive - Content Moderator,,e99695
+Label,Cognitive - Custom Vision,,e99695
+Label,Cognitive - Face,,e99695
+Label,Cognitive - Form Recognizer,,e99695
+Label,Cognitive - Immersive Reader,,e99695
+Label,Cognitive - Ink Recognizer,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
+Label,Cognitive - Mgmt,,e99695
+Label,Cognitive - Personalizer,,e99695
+Label,Cognitive - QnA Maker,,e99695
+Label,Cognitive - Speech,,e99695
+Label,Cognitive - Text Analytics,,e99695
+Label,Cognitive - Translator,,e99695
+Label,Cognitive - Vision,,e99695
+Label,Cognitive Services,,e99695
+Label,Commerce,,e99695
+Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
+Label,Compute,,e99695
+Label,Compute - Extensions,,e99695
+Label,Compute - Images,,e99695
+Label,Compute - Managed Disks,,e99695
+Label,Compute - RDFE,,e99695
+Label,Compute - VM,,e99695
+Label,Compute - VMSS,,e99695
 Label,Confidential Ledger,,e99695
+Label,Connected Kubernetes,,e99695
+Label,Consumption,,e99695
+Label,Container Instances,,e99695
+Label,Container Registry,,e99695
+Label,Container Service,,e99695
+Label,Cosmos,,e99695
+Label,Cost Management,,e99695
+Label,Custom Providers,,e99695
+Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
+Label,CycleCloud,,e99695
+Label,Data Bricks,,e99695
+Label,Data Catalog,,e99695
+Label,Data Factory,,e99695
+Label,Data Lake,,e99695
+Label,Data Lake Analytics,,e99695
+Label,Data Lake Storage Gen1,,e99695
+Label,Data Lake Storage Gen2,,e99695
+Label,Data Lake Store,,e99695
+Label,Data Migration,,e99695
+Label,Data Share,,e99695
+Label,DataBox,,e99695
+Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
+Label,Dev Spaces,,e99695
+Label,DevOps,,e99695
+Label,Devtestlab,,e99695
+Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
 Label,Docs,,e99695
 Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
 Label,Epic,,3E4B9E
+Label,Event Grid,,e99695
+Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
+Label,Functions,,e99695
 Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
+Label,Graph,,e99695
+Label,Graph.Microsoft,,e99695
+Label,Graph.Windows,,e99695
+Label,Guest Configuration,,e99695
+Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
+Label,HPC Cache,,e99695
+Label,Import Export,,e99695
+Label,Insights,,e99695
+Label,Intune,,e99695
 Label,IoT,,e99695
+Label,IoT/CLI,,e99695
 Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
+Label,KeyVault,,e99695
+Label,Kubernetes Configuration,,e99695
+Label,Kusto,,e99695
+Label,Lab Services,,e99695
+Label,LLC,,e99695
+Label,Logic App,,e99695
+Label,LOUIS,,e99695
+Label,Machine Learning,,e99695
+Label,Machine Learning Compute,,e99695
+Label,Machine Learning Experimentation,,e99695
+Label,Managed Identity,,e99695
+Label,ManagedServices,,e99695
+Label,Maps,,e99695
+Label,MariaDB,,e99695
+Label,Marketplace Ordering,,e99695
+Label,Media Services,,e99695
+Label,Mgmt,This issue is related to a management-plane library.,ffeb77
+Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
+Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
+Label,Mobile Engagement,,e99695
+Label,Monitor,"Monitor, Operational Insights",e99695
+Label,Monitor - ActionGroups,,e99695
+Label,Monitor - ActivityLogs,,e99695
+Label,Monitor - Alerts,,e99695
+Label,Monitor - ApplicationInsights,,e99695
+Label,Monitor - Autoscale,,e99695
+Label,Monitor - Diagnostic Settings,,e99695
+Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
 Label,Monitor - Log,Monitor Log Analytics,e99695
 Label,Monitor - Log Analytics,,e99695
+Label,Monitor - Metrics,,e99695
+Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
 Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
+Label,Network,,e99695
+Label,Network - Application Gateway,,e99695
+Label,Network - Bastion,,e99695
+Label,Network - CDN,,e99695
+Label,Network - DDoS Protection,,e99695
+Label,Network - DNS,,e99695
+Label,Network - ExpressRoute,,e99695
+Label,Network - Firewall,,e99695
+Label,Network - Front Door,Service: Azure Front Door,e99695
+Label,Network - Load Balancer,,e99695
+Label,Network - Network Virtual Appliance,,e99695
+Label,Network - Network Watcher,,e99695
+Label,Network - Private Link,,e99695
+Label,Network - Traffic Manager,,e99695
+Label,Network - Virtual Network,,e99695
+Label,Network - Virtual Network NAT,,e99695
+Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
+Label,Notification Hub,,e99695
+Label,Operations Management,,e99695
+Label,Peering,,e99695
 Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
 Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
 Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
 Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
+Label,Policy,,e99695
+Label,Policy Insights,,e99695
+Label,PostgreSQL,,e99695
+Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
 Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
+Label,Recovery Services Backup,,e99695
+Label,Recovery Services Site-Recovery,,e99695
+Label,Redis Cache,,e99695
+Label,Relay,,e99695
+Label,Reservations,,e99695
+Label,Resource Authorization,,e99695
+Label,Resource Graph,,e99695
+Label,Resource Health,,e99695
+Label,Scheduler,,e99695
+Label,Schema Registry,,e99695
+Label,Search,,e99695
+Label,Security,,e99695
+Label,SecurityInsights,,e99695
+Label,Server Management,,e99695
+Label,Service,This issue points to a problem in the service.,ffeb77
+Label,Service Attention,This issue is responsible by Azure service team.,10066b
+Label,Service Bus,,e99695
+Label,Service Fabric,,e99695
+Label,Service Map,,e99695
+Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
+Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
+Label,Storsimple,,e99695
+Label,Stream Analytics,,e99695
 Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
+Label,Subscription,,e99695
+Label,Support,,e99695
+Label,Synapse,,e99695
+Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
+Label,TimeseriesInsights,,e99695
+Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
+Label,Visual Studio,,e99695
+Label,Web Apps,,e99695
 Label,WebPubSub,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-java-pr.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-java-pr.csv
@@ -1,10 +1,15 @@
 Processing Azure\azure-sdk-for-java-pr repo.
-Label,Cognitive - Metrics Advisor,,e99695
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -13,16 +18,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -30,9 +31,14 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,Blocked,,e10c02
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
 Label,Cognitive - Anomaly Detector,,e99695
@@ -44,8 +50,9 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
 Label,Cognitive - QnA Maker,,e99695
@@ -74,6 +81,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -87,41 +96,55 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
 Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
+Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
+Label,In Progress,,02e10c
+Label,In Test,,02e10c
+Label,Infrastructure,,DDDDDD
 Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,Live Streaming,,5319e7
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
+Label,Mgmt,This issue is related to a management-plane library.,ffeb77
 Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
 Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
@@ -139,7 +162,12 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -154,20 +182,31 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
+Label,P0,,e10c02
+Label,P1,,d7e102
+Label,P2,,02d7e1
 Label,Peering,,e99695
+Label,Pending,,02e10c
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
+Label,Ready for test,,02e10c
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
 Label,Redis Cache,,e99695
@@ -176,13 +215,6 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -195,56 +227,27 @@ Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,Blocked,,e10c02
-Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
-Label,EngSys,This issue is impacting the engineering system.,e99695
-Label,Epic,,3E4B9E
-Label,In Progress,,02e10c
-Label,In Test,,02e10c
-Label,Infrastructure,,DDDDDD
-Label,Live Streaming,,5319e7
-Label,Mgmt,This issue is related to a management-plane library.,ffeb77
-Label,P0,,e10c02
-Label,P1,,d7e102
-Label,P2,,02d7e1
-Label,Pending,,02e10c
-Label,Ready for test,,02e10c
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-java.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-java.csv
@@ -1,119 +1,13 @@
 Processing Azure\azure-sdk-for-java repo.
-Label,Support,,e99695
-Label,Kubernetes Configuration,,e99695
-Label,Connected Kubernetes,,e99695
-Label,DevOps,,e99695
-Label,Graph.Windows,,e99695
-Label,Schema Registry,,e99695
-Label,Fulcrum,,8bc12c
-Label,MariaDB,,e99695
-Label,Network - Front Door,Service: Azure Front Door,e99695
-Label,Network - Firewall,,e99695
-Label,Cognitive - Text Analytics,,e99695
-Label,Cognitive - Form Recognizer,,e99695
-Label,Cognitive - Anomaly Detector,,e99695
-Label,Cognitive - Custom Vision,,e99695
-Label,Cognitive - Computer Vision,,e99695
-Label,Cognitive - Face,,e99695
-Label,Cognitive - QnA Maker,,e99695
-Label,Cognitive - Translator,,e99695
-Label,Cognitive - Speech,,e99695
-Label,Cognitive - LUIS,,e99695
-Label,Cognitive - Content Moderator,,e99695
-Label,Cognitive - Personalizer,,e99695
-Label,Cognitive - Immersive Reader,,e99695
-Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - Bing,,e99695
-Label,Cognitive - Mgmt,,e99695
-Label,blocking-customer-adoption,Issue is blocking the migration from Track 1 to Track 2,d73a49
-Label,azure-spring,All azure-spring related issues,e99695
-Label,azure-spring-keyvault,Spring keyvault related issues.,0000FF
-Label,azure-spring-aad,Spring active directory related issues.,0000FF
-Label,azure-spring-aad-b2c,Spring active directory b2c related issues.,0000FF
-Label,azure-spring-servicebus,Spring service bus related issues.,0000FF
-Label,azure-spring-eventhubs,Spring event hubs related issues.,0000FF
-Label,azure-spring-storage,Spring storage releated issues.,0000FF
-Label,azure-spring-cosmos,Spring cosmos related issues.,0000FF
-Label,azure-spring-gremlin,Spring data gremlin related issues.,0000FF
-Label,azure-spring-app-configuration,Spring app configuration related issues.,0000FF
-Label,Alerts Management,,e99695
-Label,Attestation,,e99695
-Label,AVS,,e99695
-Label,Container Service,,e99695
-Label,Custom Providers,,e99695
-Label,DataBox,,e99695
-Label,DataBox Edge,,e99695
-Label,Data Share,,e99695
-Label,Dev Spaces,,e99695
-Label,LOUIS,,e99695
-Label,HPC Cache,,e99695
-Label,Peering,,e99695
-Label,manual-test-pass,,e8a884
-Label,Checkstyle,Label for tracking tasks related to checkstyle rules,bfd4f2
-Label,Spotbugs,Label for tracking tasks related to spotbugs issues,244cc1
-Label,cosmos-integration-test-failures,Integration Tests that are failing intermittently on live CI,db993d
-Label,Samples,,0e8a16
-Label,Network - Virtual Network NAT,,e99695
-Label,Network - Virtual WAN,,e99695
-Label,Network - Network Virtual Appliance,,e99695
-Label,Network - Bastion,,e99695
-Label,amqp,Label for tracking issues related to AMQP,0e53cc
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,test-manual-pass,,c0eaf9
-Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,Communication,,e99695
-Label,Network - Private DNS,,e99695
-Label,Network - Private Link,,e99695
-Label,azure-cosmos-diagnostics-improvements,This label categorizes issues related to diagnostics improvements for azure-cosmos,d4c5f9
-Label,Azure Arc enabled servers,,e99695
-Label,dependencies,Pull requests that update a dependency file,0366d6
-Label,suggestion,,85e5cf
-Label,SecurityInsights,,e99695
-Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
-Label,Cognitive - Metrics Advisor,,e99695
-Label,IoT/CLI,,e99695
-Label,Docs-Hackathon,,e99695
-Label,cosmos:spark3,Cosmos DB Spark3 OLTP Connector,f7efa5
-Label,Android,,F7FE8E
-Label,azure-spring-eventhubs-kafka,Spring event hubs kafka related issues.,0000FF
-Label,azure-spring-kubernetes,,3DD258
-Label,Quota,Quota Service,e99695
-Label,Remote Rendering,,e99695
-Label,dependency-issue,Issue that is caused by dependency conflicts,0366d6
-Label,azure-cosmos-encryption,Issues related to azure cosmos encryption project,EC02A7
-Label,cosmos:spark3-GA,,bfdadc
-Label,azure-spring-dependency,Spring dependency related issues.,d4c5f9
-Label,bom,,e99695
-Label,Digital Twins,,e99695
-Label,azure-spring-jca,,0000FF
-Label,azure-spring-samples,,33C8E6
-Label,azure-spring-docs,,33C8E6
-Label,VideoAnalyzer,Azure Video Analyzer,e99695
-Label,Purview,,e99695
-Label,Confidential Ledger,,e99695
-Label,AgriFood,,e99695
-Label,Quantum,,e99695
-Label,Cognitive - Language,,e99695
-Label,WebPubSub,,e99695
-Label,graalvm,Label for tracking issues related to graalvm,683178
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,Cognitive - Vision,,e99695
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,Graph.Microsoft,,e99695
-Label,Kusto,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
-Label,Mixed Reality,,e99695
-Label,Monitor - Log Analytics,,e99695
-Label,Monitor - Query,,e99695
-Label,dependency-issue-jackson,Issue caused by dependency version mismatch with one of the Jackson libraries,0366d6
 Label,AAD,,e99695
 Label,ACS,,e99695
 Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,amqp,Label for tracking issues related to AMQP,0e53cc
 Label,Analysis Services,,e99695
+Label,Android,,F7FE8E
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
 Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
@@ -129,29 +23,77 @@ Label,ARM - Templates,,e99695
 Label,ARM Core-Review,,d8f74c
 Label,ARM-Core Triaged,,e8f279
 Label,ARO,Azure Redhat OpenShift,e99695
+Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
+Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
+Label,azure-cosmos-diagnostics-improvements,This label categorizes issues related to diagnostics improvements for azure-cosmos,d4c5f9
+Label,azure-cosmos-encryption,Issues related to azure cosmos encryption project,EC02A7
+Label,azure-sdk-bom,Azure Java SDK BOM (Bill of Materials),e99695
+Label,azure-spring,All azure-spring related issues,e99695
+Label,azure-spring-aad,Spring active directory related issues.,0000FF
+Label,azure-spring-aad-b2c,Spring active directory b2c related issues.,0000FF
+Label,azure-spring-app-configuration,Spring app configuration related issues.,0000FF
+Label,azure-spring-cosmos,Spring cosmos related issues.,0000FF
+Label,azure-spring-dependency,Spring dependency related issues.,d4c5f9
+Label,azure-spring-docs,,33C8E6
+Label,azure-spring-eventhubs,Spring event hubs related issues.,0000FF
+Label,azure-spring-eventhubs-kafka,Spring event hubs kafka related issues.,0000FF
+Label,azure-spring-gremlin,Spring data gremlin related issues.,0000FF
+Label,azure-spring-jca,,0000FF
+Label,azure-spring-keyvault,Spring keyvault related issues.,0000FF
+Label,azure-spring-kubernetes,,3DD258
+Label,azure-spring-samples,,33C8E6
+Label,azure-spring-servicebus,Spring service bus related issues.,0000FF
+Label,azure-spring-storage,Spring storage releated issues.,0000FF
 Label,azure-spring-track2-migration,This label indicate that it is for Spring Module to migrate to using track2 libraries.,35cc6e
 Label,Azure.Core,,e99695
+Label,Azure.Core.V2,Contains issues to consider when desiging Azure Core V2,B8DED2
 Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,behavioral-change,,f7f440
 Label,Billing,,e99695
 Label,blocked,Issue/PR is blocked on something - see comments,d73a49
+Label,blocking-customer-adoption,Issue is blocking the migration from Track 1 to Track 2,d73a49
 Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
 Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Checkstyle,Label for tracking tasks related to checkstyle rules,bfd4f2
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
+Label,Cognitive - Anomaly Detector,,e99695
+Label,Cognitive - Bing,,e99695
+Label,Cognitive - Computer Vision,,e99695
+Label,Cognitive - Content Moderator,,e99695
+Label,Cognitive - Custom Vision,,e99695
+Label,Cognitive - Face,,e99695
+Label,Cognitive - Form Recognizer,,e99695
+Label,Cognitive - Immersive Reader,,e99695
+Label,Cognitive - Ink Recognizer,,e99695
+Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
+Label,Cognitive - Mgmt,,e99695
+Label,Cognitive - Personalizer,,e99695
+Label,Cognitive - QnA Maker,,e99695
+Label,Cognitive - Speech,,e99695
+Label,Cognitive - Text Analytics,,e99695
+Label,Cognitive - Translator,,e99695
+Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,common,"common module used by all azure SDKs (e.g. client, Mgmt)",3a71f2
+Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
 Label,compat breaks,,d93f0b
 Label,Compute,,e99695
 Label,Compute - Extensions,,e99695
@@ -160,18 +102,24 @@ Label,Compute - Managed Disks,,e99695
 Label,Compute - RDFE,,e99695
 Label,Compute - VM,,e99695
 Label,Compute - VMSS,,e99695
-Label,Consumption,,e99695
+Label,Confidential Ledger,,e99695
+Label,Connected Kubernetes,,e99695
 Label,Container Instances,,e99695
 Label,Container Registry,,e99695
+Label,Container Service,,e99695
 Label,Cosmos,,e99695
+Label,cosmos-integration-test-failures,Integration Tests that are failing intermittently on live CI,db993d
 Label,cosmos:needs-v2-port,Indicates we need to port the associated fix to V2 (which is in a different repo),d64fb6
 Label,cosmos:needs-v3-port,Indicates we need to port the associated fix to V3,c0cff7
 Label,cosmos:needs-v4-port,Need to port this to V4,bf151d
+Label,cosmos:spark3,Cosmos DB Spark3 OLTP Connector,f7efa5
+Label,cosmos:spark3-GA,,bfdadc
 Label,cosmos:v3-item,Indicates this feature will be shipped as part of V3 release train,0052cc
 Label,cosmos:v4-item,Indicates this feature will be shipped as part of V4 release train,3bdd64
-Label,Cost Management,,e99695
+Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
 Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -182,11 +130,22 @@ Label,Data Lake Storage Gen1,,e99695
 Label,Data Lake Storage Gen2,,e99695
 Label,Data Lake Store,,e99695
 Label,Data Migration,,e99695
+Label,Data Share,,e99695
+Label,DataBox,,e99695
+Label,DataBox Edge,,e99695
+Label,dependencies,Pull requests that update a dependency file,0366d6
+Label,dependency-issue,Issue that is caused by dependency conflicts,0366d6
+Label,dependency-issue-jackson,Issue caused by dependency version mismatch with one of the Jackson libraries,0366d6
 Label,deprecation,,c4c6fc
 Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
+Label,Dev Spaces,,e99695
+Label,DevOps,,e99695
 Label,Devtestlab,,e99695
+Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
+Label,do-not-merge,,ededed
 Label,Docs,,e99695
+Label,Docs-Hackathon,,e99695
 Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
 Label,EntitySearch,,e99695
@@ -195,12 +154,18 @@ Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
 Label,FaceAPI,,e99695
 Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
+Label,Fulcrum,,8bc12c
 Label,Functions,,e99695
 Label,GenerationPR,,ff5900
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
+Label,graalvm,Label for tracking issues related to graalvm,683178
 Label,Graph,,e99695
+Label,Graph.Microsoft,,e99695
+Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
 Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
+Label,HPC Cache,,e99695
 Label,HttpClient,,e99695
 Label,Import Export,,e99695
 Label,in progress,,efcfaa
@@ -210,22 +175,32 @@ Label,IntegrationPR,,008cff
 Label,Intune,,e99695
 Label,Investigate,The issue needs investigation to get to the root cause,dafc2f
 Label,IoT,,e99695
+Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,Java Source Code Rules,,fef2c0
 Label,KeyVault,,e99695
+Label,Kubernetes Configuration,,e99695
+Label,Kusto,,e99695
 Label,Lab Services,,e99695
 Label,Live Test Failure,,bc4244
+Label,LLC,,e99695
 Label,Logic App,,e99695
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,manual-test-pass,,e8a884
+Label,Maps,,e99695
+Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
 Label,Mgmt,This issue is related to a management-plane library.,ffeb77
 Label,Mgmt - Track 2,,63b9d8
 Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
 Label,Migrate,,e99695
+Label,Mixed Reality,,e99695
 Label,Mobile Engagement,,e99695
 Label,Monitor,"Monitor, Operational Insights",e99695
 Label,Monitor - ActionGroups,,e99695
@@ -234,9 +209,13 @@ Label,Monitor - Alerts,,e99695
 Label,Monitor - ApplicationInsights,,e99695
 Label,Monitor - Autoscale,,e99695
 Label,Monitor - Diagnostic Settings,,e99695
+Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
 Label,Monitor - Log,Monitor Log Analytics,e99695
+Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
+Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MQ-Storage,"Storage ""Milestone Quality"" investments.",5df772
 Label,MQ-Testing,Testing milestone quality,207de5
 Label,MySQL,,e99695
@@ -246,18 +225,28 @@ Label,needs-team-triage,This issue needs the team to triage.,ededed
 Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
+Label,Network - Bastion,,e99695
 Label,Network - CDN,,e99695
 Label,Network - DDoS Protection,,e99695
 Label,Network - DNS,,e99695
 Label,Network - ExpressRoute,,e99695
+Label,Network - Firewall,,e99695
+Label,Network - Front Door,Service: Azure Front Door,e99695
 Label,Network - Load Balancer,,e99695
+Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
+Label,Network - Private DNS,,e99695
+Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
 Label,Network - Virtual Network,,e99695
+Label,Network - Virtual Network NAT,,e99695
+Label,Network - Virtual WAN,,e99695
 Label,Network - VPN Gateway,,e99695
 Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
+Label,OpenTelemetry,OpenTelemetry instrumentation/tracing,7E99DA
 Label,Operations Management,,e99695
+Label,Peering,,e99695
 Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
 Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
 Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
@@ -267,11 +256,15 @@ Label,Policy Insights,,e99695
 Label,ported,,bfd4f2
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,Purview,,e99695
+Label,Quantum,,e99695
 Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
+Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
 Label,Redis Cache,,e99695
 Label,Relay,,e99695
+Label,Remote Rendering,,e99695
 Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
@@ -279,9 +272,12 @@ Label,Resource Health,,e99695
 Label,RestPRInProgress,,fbca04
 Label,RestPRMerged,,0e8a16
 Label,RestPRRefused,,b60205
+Label,Samples,,0e8a16
 Label,Scheduler,,e99695
+Label,Schema Registry,,e99695
 Label,Search,,e99695
 Label,Security,,e99695
+Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
 Label,Service Attention,This issue is responsible by Azure service team.,10066b
@@ -295,6 +291,7 @@ Label,SignalR,,e99695
 Label,SpecPRClosed,,b60205
 Label,SpecPRInProgress,,fbca04
 Label,SpecPRMerged,,0e8a16
+Label,Spotbugs,Label for tracking tasks related to spotbugs issues,244cc1
 Label,SQL,,e99695
 Label,SQL - Backup & Restore,,e99695
 Label,SQL - Data Security,,e99695
@@ -307,14 +304,21 @@ Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
 Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
+Label,suggestion,,85e5cf
+Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
 Label,test bug,Problem in test source code (most likely),207de5
 Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,test-sovereign-cloud,,AA6C89
 Label,TimeseriesInsights,,e99695
 Label,Track 1,,d93f0b
 Label,tracking-external-issue,The issue is caused by external problem (e.g. OS) - nothing we can do to fix it directly,b60205
+Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,vFXT,,e99695
+Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
+Label,WebPubSub,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-js-pr.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-js-pr.csv
@@ -1,14 +1,15 @@
 Processing Azure\azure-sdk-for-js-pr repo.
-Label,Epic,,3E4B9E
-Label,Cognitive - Metrics Advisor,,e99695
-Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
-Label,Do Not Merge,,b60205
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -17,17 +18,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -35,9 +31,13 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
 Label,Cognitive - Anomaly Detector,,e99695
@@ -49,8 +49,9 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
 Label,Cognitive - QnA Maker,,e99695
@@ -79,6 +80,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -92,40 +95,51 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
+Label,Do Not Merge,,b60205
 Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
+Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
 Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
+Label,Mgmt,This issue is related to a management-plane library.,ffeb77
 Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
 Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
@@ -143,7 +157,12 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -158,19 +177,25 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -180,13 +205,6 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -199,43 +217,28 @@ Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
+Label,triage,,ededed
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,EngSys,This issue is impacting the engineering system.,e99695
-Label,Mgmt,This issue is related to a management-plane library.,ffeb77
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
-Label,triage,,ededed

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-js.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-js.csv
@@ -1,10 +1,166 @@
 Processing Azure\azure-sdk-for-js repo.
-Label,Support,,e99695
-Label,Kubernetes Configuration,,e99695
+Label,AAD,,e99695
+Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
+Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
+Label,API Management,,e99695
+Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
+Label,ARM,,e99695
+Label,ARM - Core,,e99695
+Label,ARM - Managed Applications,,e99695
+Label,ARM - RBAC,,e99695
+Label,ARM - Service Catalog,,e99695
+Label,ARM - Tags,,e99695
+Label,ARM - Templates,,e99695
+Label,ARO,Azure Redhat OpenShift,e99695
+Label,Attestation,,e99695
+Label,Authentication,,e99695
+Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
+Label,Automation,,e99695
+Label,AVS,,e99695
+Label,Azure Arc enabled servers,,e99695
+Label,Azure Stack,,e99695
+Label,Azure.Core,,e99695
+Label,Azure.Identity,,e99695
+Label,Azure.Spring - Cosmos,,e99695
+Label,Batch,,e99695
+Label,BatchAI,,e99695
+Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
+Label,Blueprint,,e99695
+Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
+Label,Cloud Shell,,e99695
+Label,CodeGen,Issues that relate to code generation,e99695
+Label,Cognitive - Anomaly Detector,,e99695
+Label,Cognitive - Bing,,e99695
+Label,Cognitive - Computer Vision,,e99695
+Label,Cognitive - Content Moderator,,e99695
+Label,Cognitive - Custom Vision,,e99695
+Label,Cognitive - Face,,e99695
+Label,Cognitive - Form Recognizer,,e99695
+Label,Cognitive - Immersive Reader,,e99695
+Label,Cognitive - Ink Recognizer,,e99695
+Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
+Label,Cognitive - Mgmt,,e99695
+Label,Cognitive - Personalizer,,e99695
+Label,Cognitive - QnA Maker,,e99695
+Label,Cognitive - Speech,,e99695
+Label,Cognitive - Text Analytics,,e99695
+Label,Cognitive - Translator,,e99695
+Label,Cognitive - Vision,,e99695
+Label,Cognitive Services,,e99695
+Label,Commerce,,e99695
+Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
+Label,Compute,,e99695
+Label,Compute - Extensions,,e99695
+Label,Compute - Images,,e99695
+Label,Compute - Managed Disks,,e99695
+Label,Compute - RDFE,,e99695
+Label,Compute - VM,,e99695
+Label,Compute - VMSS,,e99695
+Label,Confidential Ledger,,e99695
 Label,Connected Kubernetes,,e99695
+Label,Consumption,,e99695
+Label,Consumption- RIandShowBack,All issues in cost management and Consumption for query API associated to Ri and showback,e99695
+Label,Consumption-Billing,All issues in cost management and Consumption API where billing/price related data is shown,e99695
+Label,Consumption-Budget,"This label is for all issues under Costs Management where we see budget, alerts, notification",e99695
+Label,Consumption-Query,"All issues in cost management and Consumption for query API associated to tags, dimensions and forec",e99695
+Label,Consumption-UsageDetailsandExport,All issues in cost management and Consumption for usage details api and export,e99695
+Label,Container Instances,,e99695
+Label,Container Registry,,e99695
+Label,Container Service,,e99695
+Label,Cosmos,,e99695
+Label,Cost Management,,e99695
+Label,Cost Management-Billing,All issues in cost management and Consumption API where billing/price related data is shown,e99695
+Label,Cost Management-Budget,"This label is for all issues under Costs Management where we see budget, alerts, notification",e99695
+Label,Cost Management-Query,"All issues in cost management and Consumption for query API associated to tags, dimensions and forec",e99695
+Label,Cost Management-RIandShowBack,All issues in cost management and Consumption for query API associated to Ri and showback,e99695
+Label,Cost Management-UsageDetailsAndExport,All issues in cost management and Consumption for usage details api and export,e99695
+Label,cross-language alignment,mark issues need to be aligned across different languages,abd159
+Label,Custom Providers,,e99695
+Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
+Label,CycleCloud,,e99695
+Label,Data Bricks,,e99695
+Label,Data Catalog,,e99695
+Label,Data Factory,,e99695
+Label,Data Lake,,e99695
+Label,Data Lake Analytics,,e99695
+Label,Data Lake Storage Gen1,,e99695
+Label,Data Lake Storage Gen2,,e99695
+Label,Data Lake Store,,e99695
+Label,Data Migration,,e99695
+Label,Data Share,,e99695
+Label,DataBox,,e99695
+Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
+Label,Dev Spaces,,e99695
+Label,dev-tool,Issues related to the Azure SDK for JS dev-tool,0052cc
 Label,DevOps,,e99695
+Label,Devtestlab,,e99695
+Label,Digital Twins,,e99695
+Label,Do Not Merge,,b60205
+Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
+Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,enhancement,,84b6eb
+Label,Epic,,3E4B9E
+Label,eslint plugin,,50AEEC
+Label,Event Grid,,e99695
+Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
+Label,Functions,,e99695
+Label,GenerationPR,,ff5900
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
+Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
+Label,Guest Configuration,,e99695
+Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
+Label,HPC Cache,,e99695
+Label,Import Export,,e99695
+Label,Insights,,e99695
+Label,IntegrationPR,,008cff
+Label,Intune,,e99695
+Label,IoT,,e99695
+Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
+Label,KeyVault,,e99695
+Label,Kubernetes Configuration,,e99695
+Label,Kusto,,e99695
+Label,Lab Services,,e99695
+Label,LLC,,e99695
+Label,Logic App,,e99695
+Label,LOUIS,,e99695
+Label,Machine Learning,,e99695
+Label,Machine Learning Compute,,e99695
+Label,Machine Learning Experimentation,,e99695
+Label,Managed Identity,,e99695
+Label,ManagedServices,,e99695
+Label,manual-test-pass,,f733d0
+Label,Maps,,e99695
+Label,MariaDB,,e99695
+Label,Marketplace Ordering,,e99695
+Label,Media Services,,e99695
+Label,Mgmt,This issue is related to a management-plane library.,ffeb77
+Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
+Label,Migrate,,e99695
+Label,Mixed Reality,,e99695
 Label,ML-AutoML,AreaPath,e99695
 Label,ML-Compute,AreaPath,e99695
 Label,ML-CoreUI,AreaPath,e99695
@@ -21,190 +177,6 @@ Label,ML-Reinforcement Learning,AreaPath,e99695
 Label,ML-Responsible AI,AreaPath,e99695
 Label,ML-Training,AreaPath,e99695
 Label,ML-Workspace Management,AreaPath,e99695
-Label,MariaDB,,e99695
-Label,Network - Firewall,,e99695
-Label,Cognitive - Text Analytics,,e99695
-Label,Cognitive - Form Recognizer,,e99695
-Label,Cognitive - Anomaly Detector,,e99695
-Label,Cognitive - Custom Vision,,e99695
-Label,Cognitive - Computer Vision,,e99695
-Label,Cognitive - Face,,e99695
-Label,Cognitive - QnA Maker,,e99695
-Label,Cognitive - Translator,,e99695
-Label,Cognitive - Speech,,e99695
-Label,Cognitive - LUIS,,e99695
-Label,Cognitive - Content Moderator,,e99695
-Label,Cognitive - Personalizer,,e99695
-Label,Cognitive - Immersive Reader,,e99695
-Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - Bing,,e99695
-Label,Cognitive - Mgmt,,e99695
-Label,Alerts Management,,e99695
-Label,Attestation,,e99695
-Label,AVS,,e99695
-Label,Container Service,,e99695
-Label,Custom Providers,,e99695
-Label,DataBox,,e99695
-Label,DataBox Edge,,e99695
-Label,Data Share,,e99695
-Label,Dev Spaces,,e99695
-Label,Digital Twins,,e99695
-Label,LOUIS,,e99695
-Label,HPC Cache,,e99695
-Label,Peering,,e99695
-Label,Schema Registry,,e99695
-Label,manual-test-pass,,f733d0
-Label,Network - Virtual Network NAT,,e99695
-Label,Network - Virtual WAN,,e99695
-Label,Network - Network Virtual Appliance,,e99695
-Label,Network - Bastion,,e99695
-Label,test enhancement,,2c509e
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,test-manual-pass,,c0eaf9
-Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
-Label,tracking-external-issue,,b60205
-Label,dev-tool,Issues related to the Azure SDK for JS dev-tool,0052cc
-Label,Azure.Spring - Cosmos,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,Prettier config,Prettier setup and configurations,f74ca7
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,Communication,,e99695
-Label,Network - Private Link,,e99695
-Label,Cognitive - Metrics Advisor,,e99695
-Label,Azure Arc enabled servers,,e99695
-Label,cross-language alignment,mark issues need to be aligned across different languages,abd159
-Label,SecurityInsights,,e99695
-Label,IoT/CLI,,e99695
-Label,test-utils-multi-version,Utility to test multi-service-version support,50AEEC
-Label,Quota,Quota Service,e99695
-Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
-Label,Monitor - Log,Monitor Log Analytics,e99695
-Label,Do Not Merge,,b60205
-Label,breaking-change,,d73a49
-Label,VideoAnalyzer,Azure Video Analyzer,e99695
-Label,Monitor - Query,,e99695
-Label,Quantum,,e99695
-Label,Cognitive - Language,,e99695
-Label,Purview,,e99695
-Label,WebPubSub,,e99695
-Label,Cost Management-Budget,"This label is for all issues under Costs Management where we see budget, alerts, notification",e99695
-Label,Consumption-Budget,"This label is for all issues under Costs Management where we see budget, alerts, notification",e99695
-Label,Cost Management-Query,"All issues in cost management and Consumption for query API associated to tags, dimensions and forec",e99695
-Label,Consumption-Query,"All issues in cost management and Consumption for query API associated to tags, dimensions and forec",e99695
-Label,Cost Management-Billing,All issues in cost management and Consumption API where billing/price related data is shown,e99695
-Label,Consumption-Billing,All issues in cost management and Consumption API where billing/price related data is shown,e99695
-Label,Cost Management-UsageDetailsAndExport,All issues in cost management and Consumption for usage details api and export,e99695
-Label,Consumption-UsageDetailsandExport,All issues in cost management and Consumption for usage details api and export,e99695
-Label,Cost Management-RIandShowBack,All issues in cost management and Consumption for query API associated to Ri and showback,e99695
-Label,Consumption- RIandShowBack,All issues in cost management and Consumption for query API associated to Ri and showback,e99695
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,AgriFood,,e99695
-Label,Cognitive - Vision,,e99695
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,Confidential Ledger,,e99695
-Label,Kusto,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
-Label,Mixed Reality,,e99695
-Label,Monitor - Log Analytics,,e99695
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,AAD,,e99695
-Label,ACS,,e99695
-Label,Advisor,,e99695
-Label,AKS,,e99695
-Label,Analysis Services,,e99695
-Label,API Management,,e99695
-Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
-Label,ARM,,e99695
-Label,ARM - Core,,e99695
-Label,ARM - Managed Applications,,e99695
-Label,ARM - RBAC,,e99695
-Label,ARM - Service Catalog,,e99695
-Label,ARM - Tags,,e99695
-Label,ARM - Templates,,e99695
-Label,ARO,Azure Redhat OpenShift,e99695
-Label,Authentication,,e99695
-Label,Authorization,,e99695
-Label,Automation,,e99695
-Label,Azure Stack,,e99695
-Label,Azure.Core,,e99695
-Label,Azure.Identity,,e99695
-Label,Batch,,e99695
-Label,BatchAI,,e99695
-Label,Billing,,e99695
-Label,blocking-release,Blocks release,d73a49
-Label,Blueprint,,e99695
-Label,Bot Service,,e99695
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
-Label,Cloud Shell,,e99695
-Label,CodeGen,Issues that relate to code generation,e99695
-Label,Cognitive Services,,e99695
-Label,Commerce,,e99695
-Label,Compute,,e99695
-Label,Compute - Extensions,,e99695
-Label,Compute - Images,,e99695
-Label,Compute - Managed Disks,,e99695
-Label,Compute - RDFE,,e99695
-Label,Compute - VM,,e99695
-Label,Compute - VMSS,,e99695
-Label,Consumption,,e99695
-Label,Container Instances,,e99695
-Label,Container Registry,,e99695
-Label,Cosmos,,e99695
-Label,Cost Management,,e99695
-Label,Customer Insights,,e99695
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,CycleCloud,,e99695
-Label,Data Bricks,,e99695
-Label,Data Catalog,,e99695
-Label,Data Factory,,e99695
-Label,Data Lake,,e99695
-Label,Data Lake Analytics,,e99695
-Label,Data Lake Storage Gen1,,e99695
-Label,Data Lake Storage Gen2,,e99695
-Label,Data Lake Store,,e99695
-Label,Data Migration,,e99695
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,Devtestlab,,e99695
-Label,Docs,,e99695
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,EngSys,This issue is impacting the engineering system.,e99695
-Label,enhancement,,84b6eb
-Label,Epic,,3E4B9E
-Label,eslint plugin,,50AEEC
-Label,Event Grid,,e99695
-Label,Event Hubs,,e99695
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,Functions,,e99695
-Label,GenerationPR,,ff5900
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,Graph,,e99695
-Label,Guest Configuration,,e99695
-Label,HDInsight,,e99695
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,Import Export,,e99695
-Label,Insights,,e99695
-Label,IntegrationPR,,008cff
-Label,Intune,,e99695
-Label,IoT,,e99695
-Label,KeyVault,,e99695
-Label,Lab Services,,e99695
-Label,Logic App,,e99695
-Label,Machine Learning,,e99695
-Label,Machine Learning Compute,,e99695
-Label,Machine Learning Experimentation,,e99695
-Label,Managed Identity,,e99695
-Label,ManagedServices,,e99695
-Label,Marketplace Ordering,,e99695
-Label,Media Services,,e99695
-Label,Mgmt,This issue is related to a management-plane library.,ffeb77
-Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
-Label,Migrate,,e99695
 Label,Mobile Engagement,,e99695
 Label,Monitor,"Monitor, Operational Insights",e99695
 Label,Monitor - ActionGroups,,e99695
@@ -213,9 +185,14 @@ Label,Monitor - Alerts,,e99695
 Label,Monitor - ApplicationInsights,,e99695
 Label,Monitor - Autoscale,,e99695
 Label,Monitor - Diagnostic Settings,,e99695
+Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
+Label,Monitor - Log,Monitor Log Analytics,e99695
+Label,Monitor - Log Analytics,,e99695
 Label,Monitor - LogAnalytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
+Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
 Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
 Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
@@ -223,29 +200,44 @@ Label,needs-team-triage,This issue needs the team to triage.,ededed
 Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
+Label,Network - Bastion,,e99695
 Label,Network - CDN,,e99695
 Label,Network - DDoS Protection,,e99695
 Label,Network - DNS,,e99695
 Label,Network - ExpressRoute,,e99695
+Label,Network - Firewall,,e99695
 Label,Network - Front Door,Service: Azure Front Door,e99695
 Label,Network - Load Balancer,,e99695
+Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
+Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
 Label,Network - Virtual Network,,e99695
+Label,Network - Virtual Network NAT,,e99695
+Label,Network - Virtual WAN,,e99695
 Label,Network - VPN Gateway,,e99695
 Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
+Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
 Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,Prettier config,Prettier setup and configurations,f74ca7
+Label,Purview,,e99695
+Label,Quantum,,e99695
 Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
+Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
 Label,Redis Cache,,e99695
 Label,Relay,,e99695
+Label,Remote Rendering,,e99695
 Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
@@ -254,8 +246,10 @@ Label,RestPRInProgress,,fbca04
 Label,RestPRMerged,,0e8a16
 Label,RestPRRefused,,b60205
 Label,Scheduler,,e99695
+Label,Schema Registry,,e99695
 Label,Search,,e99695
 Label,Security,,e99695
+Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
 Label,Service Attention,This issue is responsible by Azure service team.,10066b
@@ -279,14 +273,23 @@ Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
 Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
+Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,test-sovereign-cloud,,7004D0
+Label,test-utils-multi-version,Utility to test multi-service-version support,50AEEC
 Label,test-utils-recorder,Label for the issues related to the common recorder,50AEEC
 Label,TimeseriesInsights,,e99695
 Label,track2,,FD8194
+Label,tracking-external-issue,,b60205
+Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,triage,,ededed
 Label,vFXT,,e99695
+Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,vTBD,,e8a4d9
 Label,Web Apps,,e99695
+Label,WebPubSub,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-net-pr.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-net-pr.csv
@@ -1,22 +1,16 @@
 Processing Azure\azure-sdk-for-net-pr repo.
-Label,Cognitive - Metrics Advisor,,e99695
-Label,Epic,,3E4B9E
-Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
-Label,blocking-release,Blocks release,d73a49
-Label,Docs,,e99695
-Label,Cognitive - Vision,,e99695
-Label,Cognitive - Body Tracking,,e99695
-Label,Cognitive - Custom Vision,,e99695
-Label,Cognitive - Computer Vision,,e99695
-Label,Cognitive - Face,,e99695
-Label,Cognitive - Speech,,e99695
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,ADFV2,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -25,17 +19,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -43,23 +32,35 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
 Label,Cognitive - Anomaly Detector,,e99695
 Label,Cognitive - Bing,,e99695
+Label,Cognitive - Body Tracking,,e99695
+Label,Cognitive - Computer Vision,,e99695
 Label,Cognitive - Content Moderator,,e99695
+Label,Cognitive - Custom Vision,,e99695
+Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
 Label,Cognitive - QnA Maker,,e99695
+Label,Cognitive - Speech,,e99695
 Label,Cognitive - Text Analytics,,e99695
 Label,Cognitive - Translator,,e99695
+Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
@@ -81,6 +82,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -94,39 +97,51 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
+Label,Do Not Merge,,b60205
+Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
+Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
 Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
+Label,Mgmt,This issue is related to a management-plane library.,ffeb77
 Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
 Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
@@ -144,7 +159,13 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-revision,,faaa04
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -159,19 +180,25 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -181,13 +208,6 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -200,44 +220,27 @@ Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,breaking-change,,d73a49
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,ADFV2,,e99695
-Label,Do Not Merge,,b60205
-Label,EngSys,This issue is impacting the engineering system.,e99695
-Label,Mgmt,This issue is related to a management-plane library.,ffeb77
-Label,needs-revision,,faaa04
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-net.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-net.csv
@@ -1,127 +1,21 @@
 Processing Azure\azure-sdk-for-net repo.
-Label,AAD,,e99695
-Label,AKS,,e99695
-Label,ARM,,e99695
-Label,Advisor,,e99695
-Label,App Services,,e99695
-Label,Authorization,,e99695
-Label,BatchAI,,e99695
-Label,Cosmos,,e99695
-Label,Customer Insights,,e99695
-Label,Data Catalog,,e99695
-Label,Data Migration,,e99695
-Label,Import Export,,e99695
-Label,Intune,,e99695
-Label,IoT,,e99695
-Label,Machine Learning,,e99695
-Label,Marketplace Ordering,,e99695
-Label,Migrate,,e99695
-Label,Mobile Engagement,,e99695
-Label,MySQL,,e99695
-Label,Operations Management,,e99695
-Label,Policy Insights,,e99695
-Label,PostgreSQL,,e99695
-Label,Recovery Services Backup,,e99695
-Label,Recovery Services Site-Recovery,,e99695
-Label,Relay,,e99695
-Label,Reservations,,e99695
-Label,Resource Health,,e99695
-Label,Security,,e99695
-Label,Service Fabric,,e99695
-Label,Service Map,,e99695
-Label,Visual Studio,,e99695
-Label,Support,,e99695
-Label,Kubernetes Configuration,,e99695
-Label,Connected Kubernetes,,e99695
-Label,DevOps,,e99695
-Label,Graph.Microsoft,,e99695
-Label,Graph.Windows,,e99695
-Label,MariaDB,,e99695
-Label,Network - Firewall,,e99695
-Label,Azure.Template,Issues related to the Azure.Template project that can be used as a starting point for our libraries.,e99695
-Label,Cognitive - Text Analytics,,e99695
-Label,Cognitive - Form Recognizer,,e99695
-Label,Cognitive - Anomaly Detector,,e99695
-Label,Cognitive - Custom Vision,,e99695
-Label,Cognitive - Computer Vision,,e99695
-Label,Cognitive - Face,,e99695
-Label,Cognitive - QnA Maker,,e99695
-Label,Cognitive - Translator,,e99695
-Label,Cognitive - Speech,,e99695
-Label,Cognitive - LUIS,,e99695
-Label,Cognitive - Content Moderator,,e99695
-Label,Cognitive - Personalizer,,e99695
-Label,Cognitive - Immersive Reader,,e99695
-Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - Bing,,e99695
-Label,Cognitive - Mgmt,,e99695
-Label,Alerts Management,,e99695
-Label,Attestation,,e99695
-Label,AVS,,e99695
-Label,Container Service,,e99695
-Label,Custom Providers,,e99695
-Label,DataBox,,e99695
-Label,DataBox Edge,,e99695
-Label,Data Share,,e99695
-Label,Dev Spaces,,e99695
-Label,Digital Twins,,e99695
-Label,LOUIS,,e99695
-Label,HPC Cache,,e99695
-Label,Peering,,e99695
-Label,Schema Registry,,e99695
-Label,Network - Virtual Network NAT,,e99695
-Label,Network - Virtual WAN,,e99695
-Label,Network - Network Virtual Appliance,,e99695
-Label,Network - Bastion,,e99695
-Label,test-enhancement,,7365c9
 Label,.NET Fluent SDK,,3BA0F8
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,test-manual-pass,,c0eaf9
-Label,test-sovereign-cloud,,ddd716
-Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
-Label,Azure.Spring - Cosmos,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,Cognitive - Vision,,e99695
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
-Label,Communication,,e99695
-Label,Network - Private Link,,e99695
-Label,Cognitive - Metrics Advisor,,e99695
-Label,Azure Arc enabled servers,,e99695
-Label,SecurityInsights,,e99695
-Label,Azure Data Explorer,,e99695
-Label,Kusto,,e99695
-Label,IoT/CLI,,e99695
-Label,Mixed Reality,,e99695
-Label,Quota,Quota Service,e99695
-Label,Monitor - Log,Monitor Log Analytics,e99695
-Label,Quantum,,e99695
-Label,WebPubSub,,e99695
-Label,Confidential Ledger,,e99695
-Label,needs-review,,7B322C
-Label,VideoAnalyzer,Azure Video Analyzer,e99695
-Label,Purview,,e99695
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,Cognitive - Language,,e99695
-Label,HaTS,Feedback from the HaTS survey,F3BA4C
-Label,Remote Rendering,,e99695
-Label,AgriFood,,e99695
-Label,Azure.Core.TestFramework,,e99695
-Label,Monitor - Query,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
 Label,0 - Backlog,,131aa3
+Label,AAD,,e99695
 Label,ACS,,e99695
+Label,ADO,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
+Label,AKS,,e99695
+Label,Alerts Management,,e99695
 Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
 Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,AppAuthentication,"App Authentication, MSI",e99695
 Label,ArchApproved,This API addition or change has been reviewed and approved by a language architect.,5df772
+Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
 Label,ARM - RBAC,,e99695
@@ -129,24 +23,55 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
+Label,Attestation,,e99695
 Label,Authentication,,e99695
+Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
 Label,AutoRest Runtime,,e99695
+Label,AVS,,e99695
+Label,Azure Arc enabled servers,,e99695
+Label,Azure Data Explorer,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
+Label,Azure.Core.TestFramework,,e99695
 Label,Azure.Identity,,e99695
+Label,Azure.Spring - Cosmos,,e99695
+Label,Azure.Template,Issues related to the Azure.Template project that can be used as a starting point for our libraries.,e99695
 Label,Batch,,e99695
+Label,BatchAI,,e99695
 Label,Billing,,e99695
 Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
 Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
+Label,Cognitive - Anomaly Detector,,e99695
+Label,Cognitive - Bing,,e99695
+Label,Cognitive - Computer Vision,,e99695
+Label,Cognitive - Content Moderator,,e99695
+Label,Cognitive - Custom Vision,,e99695
+Label,Cognitive - Face,,e99695
+Label,Cognitive - Form Recognizer,,e99695
+Label,Cognitive - Immersive Reader,,e99695
+Label,Cognitive - Ink Recognizer,,e99695
+Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
+Label,Cognitive - Mgmt,,e99695
+Label,Cognitive - Personalizer,,e99695
+Label,Cognitive - QnA Maker,,e99695
+Label,Cognitive - Speech,,e99695
+Label,Cognitive - Text Analytics,,e99695
+Label,Cognitive - Translator,,e99695
+Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
+Label,Communication,,e99695
 Label,Community Contribution,Community members are working on the issue,1aa874
 Label,Compute,,e99695
 Label,Compute - Extensions,,e99695
@@ -155,23 +80,38 @@ Label,Compute - Managed Disks,,e99695
 Label,Compute - RDFE,,e99695
 Label,Compute - VM,,e99695
 Label,Compute - VMSS,,e99695
-Label,Consumption,,e99695
+Label,Confidential Ledger,,e99695
+Label,Connected Kubernetes,,e99695
 Label,Container Instances,,e99695
 Label,Container Registry,,e99695
+Label,Container Service,,e99695
+Label,Cosmos,,e99695
 Label,Cost Management,,e99695
+Label,Custom Providers,,e99695
+Label,Customer Insights,,e99695
 Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
+Label,Data Catalog,,e99695
 Label,Data Factory,,e99695
 Label,Data Lake,,e99695
 Label,Data Lake Analytics,,e99695
 Label,Data Lake Storage Gen1,,e99695
 Label,Data Lake Storage Gen2,,e99695
 Label,Data Lake Store,,e99695
+Label,Data Migration,,e99695
+Label,Data Share,,e99695
+Label,DataBox,,e99695
+Label,DataBox Edge,,e99695
 Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
+Label,Dev Spaces,,e99695
+Label,DevOps,,e99695
 Label,Devtestlab,,e99695
+Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
 Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
 Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
@@ -179,20 +119,42 @@ Label,Event Hubs,,e99695
 Label,Extensions,ASP.NET Core extensions,e99695
 Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
+Label,Graph.Microsoft,,e99695
+Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
+Label,HaTS,Feedback from the HaTS survey,F3BA4C
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
+Label,HPC Cache,,e99695
+Label,Import Export,,e99695
 Label,Insights,,e99695
+Label,Intune,,e99695
+Label,IoT,,e99695
+Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
+Label,Kubernetes Configuration,,e99695
+Label,Kusto,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
+Label,LOUIS,,e99695
+Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
+Label,MariaDB,,e99695
+Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
 Label,Mgmt,This issue is related to a management-plane library.,ffeb77
 Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
+Label,Migrate,,e99695
+Label,Mixed Reality,,e99695
+Label,Mobile Engagement,,e99695
 Label,Monitor,"Monitor, Operational Insights",e99695
 Label,Monitor - ActionGroups,,e99695
 Label,Monitor - ActivityLogs,,e99695
@@ -200,42 +162,74 @@ Label,Monitor - Alerts,,e99695
 Label,Monitor - ApplicationInsights,,e99695
 Label,Monitor - Autoscale,,e99695
 Label,Monitor - Diagnostic Settings,,e99695
+Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
+Label,Monitor - Log,Monitor Log Analytics,e99695
 Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
+Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,MySQL,,e99695
 Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-review,,7B322C
 Label,needs-revision,,fd8c00
 Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
 Label,needs-team-triage,This issue needs the team to triage.,ededed
 Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
+Label,Network - Bastion,,e99695
 Label,Network - CDN,,e99695
 Label,Network - DDoS Protection,,e99695
 Label,Network - DNS,,e99695
 Label,Network - ExpressRoute,,e99695
+Label,Network - Firewall,,e99695
 Label,Network - Front Door,Service: Azure Front Door,e99695
 Label,Network - Load Balancer,,e99695
+Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
+Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
 Label,Network - Virtual Network,,e99695
+Label,Network - Virtual Network NAT,,e99695
+Label,Network - Virtual WAN,,e99695
 Label,Network - VPN Gateway,,e99695
 Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
+Label,Operations Management,,e99695
+Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
 Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
 Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars.  (includes stress testing)",65a5c9
 Label,Policy,,e99695
+Label,Policy Insights,,e99695
+Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,Purview,,e99695
+Label,Quantum,,e99695
 Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
+Label,Quota,Quota Service,e99695
+Label,Recovery Services Backup,,e99695
+Label,Recovery Services Site-Recovery,,e99695
 Label,Redis Cache,,e99695
+Label,Relay,,e99695
+Label,Remote Rendering,,e99695
+Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
+Label,Resource Health,,e99695
 Label,Scheduler,,e99695
+Label,Schema Registry,,e99695
 Label,Search,,e99695
+Label,Security,,e99695
+Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
 Label,Service Attention,This issue is responsible by Azure service team.,10066b
 Label,Service Bus,,e99695
+Label,Service Fabric,,e99695
+Label,Service Map,,e99695
 Label,SignalR,,e99695
 Label,SQL,,e99695
 Label,SQL - Backup & Restore,,e99695
@@ -249,8 +243,17 @@ Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
 Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
+Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
+Label,test-sovereign-cloud,,ddd716
 Label,TimeseriesInsights,,e99695
+Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
+Label,VideoAnalyzer,Azure Video Analyzer,e99695
+Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
+Label,WebPubSub,,e99695
 Label,Websites,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-python-pr.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-python-pr.csv
@@ -1,16 +1,15 @@
 Processing Azure\azure-sdk-for-python-pr repo.
-Label,Cognitive - Metrics Advisor,,e99695
-Label,Epic,,3E4B9E
-Label,Do Not Merge,,b60205
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,Low Level Client,,e99695
-Label,Python,,5524AE
-Label,CredScan,,8C287E
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -19,17 +18,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -37,8 +31,11 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
@@ -52,8 +49,9 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
 Label,Cognitive - QnA Maker,,e99695
@@ -80,8 +78,11 @@ Label,Container Registry,,e99695
 Label,Container Service,,e99695
 Label,Cosmos,,e99695
 Label,Cost Management,,e99695
+Label,CredScan,,8C287E
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -95,40 +96,52 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
+Label,Do Not Merge,,b60205
 Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
+Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
 Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
+Label,Low Level Client,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
+Label,Mgmt,This issue is related to a management-plane library.,ffeb77
 Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
 Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
@@ -146,7 +159,12 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -161,19 +179,26 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
 Label,Purview,,e99695
+Label,Python,,5524AE
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -183,13 +208,9 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
+Label,RestPRInProgress,,fbca04
+Label,RestPRMerged,,0e8a16
+Label,RestPRRefused,,b60205
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -198,51 +219,33 @@ Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
 Label,Service Attention,This issue is responsible by Azure service team.,10066b
+Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
+Label,ServicePR,,1d76db
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,EngSys,This issue is impacting the engineering system.,e99695
-Label,Mgmt,This issue is related to a management-plane library.,ffeb77
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,RestPRInProgress,,fbca04
-Label,RestPRMerged,,0e8a16
-Label,RestPRRefused,,b60205
-Label,Service Bus,,e99695
-Label,ServicePR,,1d76db
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,wontfix,,ffffff

--- a/tools/github-labels/repository-snapshots/azure-sdk-for-python.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-for-python.csv
@@ -1,10 +1,178 @@
 Processing Azure\azure-sdk-for-python repo.
-Label,Support,,e99695
-Label,Kubernetes Configuration,,e99695
+Label,AAD,,e99695
+Label,ACS,,e99695
+Label,ADO,Issue is documented on MSFT ADO for internal tracking,D93F0B
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
+Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,AMQP Python,,bfdadc
+Label,Analysis Services,,e99695
+Label,API Management,,e99695
+Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
+Label,ArchApproved,This API addition or change has been reviewed and approved by a language architect.,33bb00
+Label,ARM,,e99695
+Label,ARM - Core,,e99695
+Label,ARM - Managed Applications,,e99695
+Label,ARM - RBAC,,e99695
+Label,ARM - Service Catalog,,e99695
+Label,ARM - Tags,,e99695
+Label,ARM - Templates,,e99695
+Label,ARM-Core Review,,d8f74c
+Label,ARM-Core Triaged,,f7ec25
+Label,ARO,Azure Redhat OpenShift,e99695
+Label,ASM,,5319e7
+Label,Attestation,,e99695
+Label,Authentication,,e99695
+Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
+Label,Automation,,e99695
+Label,Autorest Issue,,fef2c0
+Label,autorestv3 generation,,32ba91
+Label,AVS,,e99695
+Label,Azure Arc enabled servers,,e99695
+Label,Azure Communication Service TNM,Azure Communication Service Phone Number Management (TNM),e99695
+Label,Azure Data Explorer,,e99695
+Label,Azure Stack,,e99695
+Label,Azure.Core,,e99695
+Label,Azure.Identity,,e99695
+Label,Azure.Mgmt.Core,Azure management core,f9d0c4
+Label,Azure.Spring - Cosmos,,e99695
+Label,Batch,,e99695
+Label,BatchAI,,e99695
+Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
+Label,Blueprint,,e99695
+Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
+Label,Cloud Shell,,e99695
+Label,CodeGen,Issues that relate to code generation,e99695
+Label,Cognitive - Anomaly Detector,,e99695
+Label,Cognitive - Bing,,e99695
+Label,Cognitive - Computer Vision,,e99695
+Label,Cognitive - Content Moderator,,e99695
+Label,Cognitive - Custom Vision,,e99695
+Label,Cognitive - Face,,e99695
+Label,Cognitive - Form Recognizer,,e99695
+Label,Cognitive - Immersive Reader,,e99695
+Label,Cognitive - Ink Recognizer,,e99695
+Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
+Label,Cognitive - Mgmt,,e99695
+Label,Cognitive - Personalizer,,e99695
+Label,Cognitive - QnA Maker,,e99695
+Label,Cognitive - Speech,,e99695
+Label,Cognitive - Text Analytics,,e99695
+Label,Cognitive - Translator,,e99695
+Label,Cognitive - Vision,,e99695
+Label,Cognitive Services,,e99695
+Label,Commerce,,e99695
+Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
+Label,Compute,,e99695
+Label,Compute - Extensions,,e99695
+Label,Compute - Images,,e99695
+Label,Compute - Managed Disks,,e99695
+Label,Compute - RDFE,,e99695
+Label,Compute - VM,,e99695
+Label,Compute - VMSS,,e99695
+Label,Confidential Ledger,,e99695
 Label,Connected Kubernetes,,e99695
+Label,Consumption,,e99695
+Label,Consumption- RIandShowBack,All issues in cost management and Consumption for query API associated to Ri and showback,e99695
+Label,Consumption-Billing,All issues in cost management and Consumption API where billing/price related data is shown,e99695
+Label,Consumption-Budget,"This label is for all issues under Costs Management where we see budget, alerts, notification",e99695
+Label,Consumption-Query,"All issues in cost management and Consumption for query API associated to tags, dimensions and forec",e99695
+Label,Consumption-UsageDetailsandExport,All issues in cost management and Consumption for usage details api and export,e99695
+Label,Container Instances,,e99695
+Label,Container Registry,,e99695
+Label,Container Service,,e99695
+Label,Cosmos,,e99695
+Label,Cost Management,,e99695
+Label,Cost Management-Billing,All issues in cost management and Consumption API where billing/price related data is shown,e99695
+Label,Cost Management-Budget,"This label is for all issues under Costs Management where we see budget, alerts, notification",e99695
+Label,Cost Management-Query,"All issues in cost management and Consumption for query API associated to tags, dimensions and forec",e99695
+Label,Cost Management-RIandShowBack,All issues in cost management and Consumption for query API associated to Ri and showback,e99695
+Label,Cost Management-UsageDetailsAndExport,All issues in cost management and Consumption for usage details api and export,e99695
+Label,Custom Providers,,e99695
+Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
+Label,CycleCloud,,e99695
+Label,Data Bricks,,e99695
+Label,Data Catalog,,e99695
+Label,Data Factory,,e99695
+Label,Data Lake,,e99695
+Label,Data Lake Analytics,,e99695
+Label,Data Lake Storage Gen1,,e99695
+Label,Data Lake Storage Gen2,,e99695
+Label,Data Lake Store,,e99695
+Label,Data Migration,,e99695
+Label,Data Share,,e99695
+Label,DataBox,,e99695
+Label,DataBox Edge,,e99695
+Label,dependencies,Pull requests that update a dependency file,0366d6
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
+Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
-Label,Graph.Windows,,e99695
+Label,Devtestlab,,e99695
+Label,DiagnosticSettings,,9a34d1
+Label,Digital Twins,,e99695
+Label,Do Not Merge,,b60205
+Label,Docs,,e99695
+Label,Docs-Hackathon,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
+Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
+Label,Event Grid,,e99695
+Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
+Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
+Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
+Label,Graph.Windows,,e99695
+Label,Guest Configuration,,e99695
+Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
+Label,HPC Cache,,e99695
+Label,Import Export,,e99695
+Label,Insights,,e99695
+Label,Intune,,e99695
+Label,IoT,,e99695
+Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
+Label,KeyVault,,e99695
+Label,Kubernetes Configuration,,e99695
+Label,Kusto,,e99695
+Label,Lab Services,,e99695
+Label,LiveTestFailure,,cb6eea
+Label,LLC,,e99695
+Label,Logic App,,e99695
+Label,LOUIS,,e99695
+Label,Low Level Client,,0052cc
+Label,Machine Learning,,e99695
+Label,Machine Learning Compute,,e99695
+Label,Machine Learning Experimentation,,e99695
+Label,Managed Identity,,e99695
+Label,ManagedServices,,e99695
+Label,manual-test-pass,Issue found during manual test pass,3bacb5
+Label,Maps,,e99695
+Label,MariaDB,,e99695
+Label,Marketplace Ordering,,e99695
+Label,Media Services,,e99695
+Label,Messaging,Messaging crew,5BA2B3
+Label,Metrics,,fc71b4
+Label,Mgmt,This issue is related to a management-plane library.,ffeb77
+Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
+Label,Migrate,,e99695
+Label,Mixed Reality,,e99695
 Label,ML-AutoML,AreaPath,e99695
 Label,ML-Compute,AreaPath,e99695
 Label,ML-CoreUI,AreaPath,e99695
@@ -21,204 +189,6 @@ Label,ML-Reinforcement Learning,AreaPath,e99695
 Label,ML-Responsible AI,AreaPath,e99695
 Label,ML-Training,AreaPath,e99695
 Label,ML-Workspace Management,AreaPath,e99695
-Label,MariaDB,,e99695
-Label,Network - Firewall,,e99695
-Label,Network - VPN Gateway,,e99695
-Label,Cognitive - Text Analytics,,e99695
-Label,Cognitive - Form Recognizer,,e99695
-Label,Cognitive - Anomaly Detector,,e99695
-Label,Cognitive - Custom Vision,,e99695
-Label,Cognitive - Computer Vision,,e99695
-Label,Cognitive - Face,,e99695
-Label,Cognitive - QnA Maker,,e99695
-Label,Cognitive - Translator,,e99695
-Label,Cognitive - Speech,,e99695
-Label,Cognitive - LUIS,,e99695
-Label,Cognitive - Content Moderator,,e99695
-Label,Cognitive - Personalizer,,e99695
-Label,Cognitive - Immersive Reader,,e99695
-Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - Bing,,e99695
-Label,Cognitive - Mgmt,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,Alerts Management,,e99695
-Label,Attestation,,e99695
-Label,AVS,,e99695
-Label,Container Service,,e99695
-Label,Custom Providers,,e99695
-Label,DataBox,,e99695
-Label,DataBox Edge,,e99695
-Label,Data Share,,e99695
-Label,Dev Spaces,,e99695
-Label,Digital Twins,,e99695
-Label,LOUIS,,e99695
-Label,HPC Cache,,e99695
-Label,Peering,,e99695
-Label,manual-test-pass,Issue found during manual test pass,3bacb5
-Label,Schema Registry,,e99695
-Label,Network - Virtual WAN,,e99695
-Label,Network - Network Virtual Appliance,,e99695
-Label,Network - Bastion,,e99695
-Label,test enhancement,,77ffdf
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,test-manual-pass,,c0eaf9
-Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
-Label,Azure.Spring - Cosmos,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,Communication,,e99695
-Label,Network - Private Link,,e99695
-Label,Cognitive - Metrics Advisor,,e99695
-Label,Azure Arc enabled servers,,e99695
-Label,Track1,,e99695
-Label,Track2,,ddea88
-Label,Recovery Services,,e99695
-Label,SecurityInsights,,e99695
-Label,Azure Data Explorer,,e99695
-Label,Azure Communication Service TNM,Azure Communication Service Phone Number Management (TNM),e99695
-Label,IoT/CLI,,e99695
-Label,Docs-Hackathon,,e99695
-Label,RDBMS,,bfd4f2
-Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
-Label,Track 2 Migration,,1d76db
-Label,Quota,Quota Service,e99695
-Label,Monitor - Log,Monitor Log Analytics,e99695
-Label,uAMQP,,C1863B
-Label,Low Level Client,,0052cc
-Label,Messaging,Messaging crew,5BA2B3
-Label,ADO,Issue is documented on MSFT ADO for internal tracking,D93F0B
-Label,Confidential Ledger,,e99695
-Label,VideoAnalyzer,Azure Video Analyzer,e99695
-Label,Purview,,e99695
-Label,AMQP Python,,bfdadc
-Label,Quantum,,e99695
-Label,dependencies,Pull requests that update a dependency file,0366d6
-Label,Cognitive - Language,,e99695
-Label,WebPubSub,,e99695
-Label,Consumption-Budget,"This label is for all issues under Costs Management where we see budget, alerts, notification",e99695
-Label,Cost Management-Budget,"This label is for all issues under Costs Management where we see budget, alerts, notification",e99695
-Label,Cost Management-Query,"All issues in cost management and Consumption for query API associated to tags, dimensions and forec",e99695
-Label,Consumption-Query,"All issues in cost management and Consumption for query API associated to tags, dimensions and forec",e99695
-Label,Consumption-Billing,All issues in cost management and Consumption API where billing/price related data is shown,e99695
-Label,Cost Management-Billing,All issues in cost management and Consumption API where billing/price related data is shown,e99695
-Label,Cost Management-UsageDetailsAndExport,All issues in cost management and Consumption for usage details api and export,e99695
-Label,Consumption-UsageDetailsandExport,All issues in cost management and Consumption for usage details api and export,e99695
-Label,Cost Management-RIandShowBack,All issues in cost management and Consumption for query API associated to Ri and showback,e99695
-Label,Consumption- RIandShowBack,All issues in cost management and Consumption for query API associated to Ri and showback,e99695
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,AgriFood,,e99695
-Label,Cognitive - Vision,,e99695
-Label,Community Contribution,Community members are working on the issue,1aa874
-Label,Kusto,,e99695
-Label,Mixed Reality,,e99695
-Label,Monitor - Log Analytics,,e99695
-Label,Monitor - Query,,e99695
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,AAD,,e99695
-Label,ACS,,e99695
-Label,Advisor,,e99695
-Label,AKS,,e99695
-Label,Analysis Services,,e99695
-Label,API Management,,e99695
-Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
-Label,App Services,,e99695
-Label,ArchApproved,This API addition or change has been reviewed and approved by a language architect.,33bb00
-Label,ARM,,e99695
-Label,ARM - Core,,e99695
-Label,ARM - Managed Applications,,e99695
-Label,ARM - RBAC,,e99695
-Label,ARM - Service Catalog,,e99695
-Label,ARM - Tags,,e99695
-Label,ARM - Templates,,e99695
-Label,ARM-Core Review,,d8f74c
-Label,ARM-Core Triaged,,f7ec25
-Label,ARO,Azure Redhat OpenShift,e99695
-Label,ASM,,5319e7
-Label,Authentication,,e99695
-Label,Authorization,,e99695
-Label,Automation,,e99695
-Label,Autorest Issue,,fef2c0
-Label,autorestv3 generation,,32ba91
-Label,Azure Stack,,e99695
-Label,Azure.Core,,e99695
-Label,Azure.Identity,,e99695
-Label,Azure.Mgmt.Core,Azure management core,f9d0c4
-Label,Batch,,e99695
-Label,BatchAI,,e99695
-Label,Billing,,e99695
-Label,blocking-release,Blocks release,d73a49
-Label,Blueprint,,e99695
-Label,Bot Service,,e99695
-Label,breaking-change,,d73a49
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
-Label,Cloud Shell,,e99695
-Label,CodeGen,Issues that relate to code generation,e99695
-Label,Cognitive Services,,e99695
-Label,Commerce,,e99695
-Label,Compute,,e99695
-Label,Compute - Extensions,,e99695
-Label,Compute - Images,,e99695
-Label,Compute - Managed Disks,,e99695
-Label,Compute - RDFE,,e99695
-Label,Compute - VM,,e99695
-Label,Compute - VMSS,,e99695
-Label,Consumption,,e99695
-Label,Container Instances,,e99695
-Label,Container Registry,,e99695
-Label,Cosmos,,e99695
-Label,Cost Management,,e99695
-Label,Customer Insights,,e99695
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,CycleCloud,,e99695
-Label,Data Bricks,,e99695
-Label,Data Catalog,,e99695
-Label,Data Factory,,e99695
-Label,Data Lake,,e99695
-Label,Data Lake Analytics,,e99695
-Label,Data Lake Storage Gen1,,e99695
-Label,Data Lake Storage Gen2,,e99695
-Label,Data Lake Store,,e99695
-Label,Data Migration,,e99695
-Label,Devtestlab,,e99695
-Label,DiagnosticSettings,,9a34d1
-Label,Do Not Merge,,b60205
-Label,Docs,,e99695
-Label,EngSys,This issue is impacting the engineering system.,e99695
-Label,Epic,,3E4B9E
-Label,Event Grid,,e99695
-Label,Event Hubs,,e99695
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,Functions,,e99695
-Label,Graph,,e99695
-Label,Guest Configuration,,e99695
-Label,HDInsight,,e99695
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,Import Export,,e99695
-Label,Insights,,e99695
-Label,Intune,,e99695
-Label,IoT,,e99695
-Label,KeyVault,,e99695
-Label,Lab Services,,e99695
-Label,LiveTestFailure,,cb6eea
-Label,Logic App,,e99695
-Label,Machine Learning,,e99695
-Label,Machine Learning Compute,,e99695
-Label,Machine Learning Experimentation,,e99695
-Label,Managed Identity,,e99695
-Label,ManagedServices,,e99695
-Label,Marketplace Ordering,,e99695
-Label,Media Services,,e99695
-Label,Metrics,,fc71b4
-Label,Mgmt,This issue is related to a management-plane library.,ffeb77
-Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
-Label,Migrate,,e99695
 Label,Mobile Engagement,,e99695
 Label,Monitor,"Monitor, Operational Insights",e99695
 Label,Monitor - ActionGroups,,e99695
@@ -227,9 +197,13 @@ Label,Monitor - Alerts,,e99695
 Label,Monitor - ApplicationInsights,,e99695
 Label,Monitor - Autoscale,,e99695
 Label,Monitor - Diagnostic Settings,,e99695
+Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
+Label,Monitor - Log,Monitor Log Analytics,e99695
+Label,Monitor - Log Analytics,,e99695
 Label,Monitor - LogAnalytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
+Label,Monitor - Query,,e99695
 Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MQ-Storage,"Storage ""Milestone Quality"" investments.",5df772
 Label,MySQL,,e99695
@@ -239,16 +213,22 @@ Label,needs-team-triage,This issue needs the team to triage.,ededed
 Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
+Label,Network - Bastion,,e99695
 Label,Network - CDN,,e99695
 Label,Network - DDoS Protection,,e99695
 Label,Network - DNS,,e99695
 Label,Network - ExpressRoute,,e99695
+Label,Network - Firewall,,e99695
 Label,Network - Front Door,Service: Azure Front Door,e99695
 Label,Network - Load Balancer,,e99695
+Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
+Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
+Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
 Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
@@ -257,14 +237,23 @@ Label,P1,,d7e102
 Label,P2,,02d7e1
 Label,P3,,e102d8
 Label,Packaging,,bfdadc
+Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
 Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
 Label,Preview,,5776bf
+Label,Purview,,e99695
 Label,Python,,c6753f
+Label,Quantum,,e99695
 Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
+Label,Quota,Quota Service,e99695
+Label,RDBMS,,bfd4f2
+Label,Recovery Services,,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
 Label,Redis Cache,,e99695
@@ -278,8 +267,10 @@ Label,RestPRInProgress,,fbca04
 Label,RestPRMerged,,0e8a16
 Label,RestPRRefused,,b60205
 Label,Scheduler,,e99695
+Label,Schema Registry,,e99695
 Label,Search,,e99695
 Label,Security,,e99695
+Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
 Label,Service Attention,This issue is responsible by Azure service team.,10066b
@@ -304,10 +295,23 @@ Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
 Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
+Label,Support,,e99695
 Label,Swagger,,fbca04
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test enhancement,,77ffdf
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
+Label,test-sovereign-cloud,,BF2B6C
 Label,TimeseriesInsights,,e99695
+Label,Track 2 Migration,,1d76db
+Label,Track1,,e99695
+Label,Track2,,ddea88
+Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
+Label,uAMQP,,C1863B
 Label,vFXT,,e99695
+Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
+Label,WebPubSub,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-pr.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-pr.csv
@@ -1,44 +1,5 @@
 Processing Azure\azure-sdk-pr repo.
-Label,Partner Ask,Dependencies from outside of Azure SDK,3E4B9E
-Label,Epic,,3E4B9E
-Label,Our Ask,Dependencies we have against other teams,3E4B9E
-Label,Docs,,e99695
-Label,API,"Items related to tooling, process, or education of building good APIs in Azure",3E4B9E
-Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
-Label,Quality,,0b097a
-Label,Library Implementation,,3E4B9E
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,Cosmos,,e99695
-Label,Event Hubs,,e99695
-Label,JavaScript,,c2e0c6
-Label,Java,,c2e0c6
-Label,Python,,c2e0c6
 Label,.NET,,c2e0c6
-Label,Service Bus,,e99695
-Label,Cognitive - Text Analytics,,e99695
-Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
-Label,KeyVault,,e99695
-Label,Cognitive - Form Recognizer,,e99695
-Label,Cognitive - Metrics Advisor,,e99695
-Label,Cognitive - Vision,,e99695
-Label,Cognitive - Anomaly Detector,,e99695
-Label,Training - Reference,,c5def5
-Label,Training - Videos,,fef2c0
-Label,Training - Activities,,e99695
-Label,Training - Navigability,,c2e0c6
-Label,Training - Effective Transition,,d4c5f9
-Label,Training - Small,,c5def5
-Label,Training - Medium,,bfdadc
-Label,Training - Large,,f9d0c4
-Label,Training - Lower Prio,,1d76db
-Label,Training - Higher Prio,,e50688
-Label,Training - .NET,,5319e7
-Label,Training - Python,,1d76db
-Label,Training - JS/TS,,fbca04
-Label,Training - Java,,d93f0b
-Label,Monitor,"Monitor, Operational Insights",e99695
-Label,Event Grid,,e99695
-Label,C++,,c2e0c6
 Label,AAD,,e99695
 Label,ACS,,e99695
 Label,Advisor,,e99695
@@ -46,6 +7,7 @@ Label,AgriFood,,e99695
 Label,AKS,,e99695
 Label,Alerts Management,,e99695
 Label,Analysis Services,,e99695
+Label,API,"Items related to tooling, process, or education of building good APIs in Azure",3E4B9E
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
 Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
@@ -65,6 +27,7 @@ Label,Authorization,,e99695
 Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
 Label,AVS,,e99695
+Label,AwaitingGAsignoff,,C70CC9
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -77,23 +40,30 @@ Label,Blueprint,,e99695
 Label,Bot Service,,e99695
 Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,C++,,c2e0c6
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
+Label,Cognitive - Anomaly Detector,,e99695
 Label,Cognitive - Bing,,e99695
 Label,Cognitive - Computer Vision,,e99695
 Label,Cognitive - Content Moderator,,e99695
 Label,Cognitive - Custom Vision,,e99695
 Label,Cognitive - Face,,e99695
+Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
 Label,Cognitive - Language,,e99695
 Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
 Label,Cognitive - QnA Maker,,e99695
 Label,Cognitive - Speech,,e99695
+Label,Cognitive - Text Analytics,,e99695
 Label,Cognitive - Translator,,e99695
+Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
@@ -111,10 +81,12 @@ Label,Consumption,,e99695
 Label,Container Instances,,e99695
 Label,Container Registry,,e99695
 Label,Container Service,,e99695
+Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
 Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -134,10 +106,15 @@ Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
+Label,Docs,,e99695
 Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
+Label,Epic,,3E4B9E
+Label,Event Grid,,e99695
+Label,Event Hubs,,e99695
 Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,GAsignoffcomplete,APEX Launch,6DFDEC
 Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
@@ -152,9 +129,14 @@ Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
 Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
+Label,Java,,c2e0c6
+Label,JavaScript,,c2e0c6
+Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
 Label,Lab Services,,e99695
+Label,Library Implementation,,3E4B9E
+Label,LLC,,e99695
 Label,Logic App,,e99695
 Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
@@ -162,6 +144,7 @@ Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -171,6 +154,7 @@ Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
 Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
 Label,Mobile Engagement,,e99695
+Label,Monitor,"Monitor, Operational Insights",e99695
 Label,Monitor - ActionGroups,,e99695
 Label,Monitor - ActivityLogs,,e99695
 Label,Monitor - Alerts,,e99695
@@ -210,6 +194,8 @@ Label,Network - VPN Gateway,,e99695
 Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
+Label,Our Ask,Dependencies we have against other teams,3E4B9E
+Label,Partner Ask,Dependencies from outside of Azure SDK,3E4B9E
 Label,Peering,,e99695
 Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
 Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
@@ -219,7 +205,10 @@ Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,PublicPreviewSignoffComplete,APEX LAUNCH,BD35A8
 Label,Purview,,e99695
+Label,Python,,c2e0c6
+Label,Quality,,0b097a
 Label,Quantum,,e99695
 Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
@@ -231,6 +220,7 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
+Label,Revised Engagement Model,,b60205
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -239,9 +229,11 @@ Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
 Label,Service Attention,This issue is responsible by Azure service team.,10066b
+Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,signoffwithexception,APEX Launch,254F0A
 Label,SQL,,e99695
 Label,SQL - Backup & Restore,,e99695
 Label,SQL - Data Security,,e99695
@@ -249,6 +241,7 @@ Label,SQL - Elastic Jobs,,e99695
 Label,SQL - Managed Instance,,e99695
 Label,SQL - Replication & Failover,,e99695
 Label,SQL - VM,,e99695
+Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
 Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
@@ -260,6 +253,21 @@ Label,test-enhancement,,7365c9
 Label,test-manual-pass,,c0eaf9
 Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
+Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
+Label,Training - .NET,,5319e7
+Label,Training - Activities,,e99695
+Label,Training - Effective Transition,,d4c5f9
+Label,Training - Higher Prio,,e50688
+Label,Training - Java,,d93f0b
+Label,Training - JS/TS,,fbca04
+Label,Training - Large,,f9d0c4
+Label,Training - Lower Prio,,1d76db
+Label,Training - Medium,,bfdadc
+Label,Training - Navigability,,c2e0c6
+Label,Training - Python,,1d76db
+Label,Training - Reference,,c5def5
+Label,Training - Small,,c5def5
+Label,Training - Videos,,fef2c0
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk-tools.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk-tools.csv
@@ -1,19 +1,4 @@
 Processing Azure\azure-sdk-tools repo.
-Label,Check Enforcer,,e99695
-Label,Pipeline Witness,,e99695
-Label,Webhook Router,,e99695
-Label,GitHub Issues,,e99695
-Label,Pull Request Labeler,,e99695
-Label,Fabric Bot,Issues about creating rules for the fabric bot,e99695
-Label,Docs,,e99695
-Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,C99,C Language,c2e0c6
-Label,C++,C++ Language,c2e0c6
-Label,Network - Private Link,,e99695
-Label,LLCView,,e99695
 Label,.NET,,c2e0c6
 Label,AAD,,e99695
 Label,ACS,,e99695
@@ -39,6 +24,7 @@ Label,ARO,Azure Redhat OpenShift,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
 Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
@@ -53,6 +39,11 @@ Label,Blueprint,,e99695
 Label,Bot Service,,e99695
 Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
+Label,C++,C++ Language,c2e0c6
+Label,C99,C Language,c2e0c6
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
+Label,Check Enforcer,,e99695
+Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
 Label,Cognitive - Anomaly Detector,,e99695
@@ -96,6 +87,7 @@ Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
 Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -115,14 +107,17 @@ Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
+Label,Docs,,e99695
 Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
 Label,enhancement,New feature or request,a2eeef
 Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,Fabric Bot,Issues about creating rules for the fabric bot,e99695
 Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
 Label,Functions,,e99695
+Label,GitHub Issues,,e99695
 Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
@@ -142,6 +137,8 @@ Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
+Label,LLCView,,e99695
 Label,Logic App,,e99695
 Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
@@ -149,6 +146,7 @@ Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -175,6 +173,7 @@ Label,MySQL,,e99695
 Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
 Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
 Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -187,6 +186,7 @@ Label,Network - Front Door,Service: Azure Front Door,e99695
 Label,Network - Load Balancer,,e99695
 Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
+Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
@@ -201,10 +201,12 @@ Label,pillar-compatibility,"This issue is related to compatibility between versi
 Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
 Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Pipeline Generator,,e99695
+Label,Pipeline Witness,,e99695
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,Pull Request Labeler,,e99695
 Label,Purview,,e99695
 Label,Quantum,,e99695
 Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
@@ -252,4 +254,5 @@ Label,Training,Work items that track the work to build training materials for bu
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
+Label,Webhook Router,,e99695
 Label,WebPubSub,,e99695

--- a/tools/github-labels/repository-snapshots/azure-sdk.csv
+++ b/tools/github-labels/repository-snapshots/azure-sdk.csv
@@ -1,38 +1,4 @@
 Processing Azure\azure-sdk repo.
-Label,Partner Ask,Dependencies from outside of Azure SDK,3E4B9E
-Label,Tables,,e99695
-Label,Event Grid,,e99695
-Label,Cognitive - Vision,,e99695
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
-Label,Network - Private Link,,e99695
-Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
-Label,ApiView,,e99695
-Label,ArchBoard Guidelines,Apply to PRs or Issues relating Archboard Guidelines,edcd1c
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
-Label,Go,,c2e0c6
-Label,iOS,,c2e0c6
-Label,Android,,c2e0c6
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,Attestation,,e99695
-Label,Container Registry,,e99695
-Label,Functions,,e99695
-Label,Synapse,,e99695
-Label,Cognitive - Form Recognizer,,e99695
-Label,Cognitive - Translator,,e99695
-Label,Cognitive - Metrics Advisor,,e99695
-Label,Cognitive - Text Analytics,,e99695
-Label,Schema Registry,,e99695
-Label,GitHub IO Site,Applied for updates to our github.io site.,c2e0c6
-Label,Quota,Quota Service,e99695
-Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
-Label,Monitor - Log,Monitor Log Analytics,e99695
-Label,Batch,,e99695
-Label,Purview,,e99695
-Label,WebPubSub,,e99695
-Label,Cognitive Services,,e99695
-Label,Cognitive - Speech,,e99695
 Label,.NET,,c2e0c6
 Label,AAD,,e99695
 Label,ACS,,e99695
@@ -41,9 +7,13 @@ Label,AgriFood,,e99695
 Label,AKS,,e99695
 Label,Alerts Management,,e99695
 Label,Analysis Services,,e99695
+Label,Android,,c2e0c6
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,ApiView,,e99695
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
 Label,App Services,,e99695
+Label,ArchBoard Guidelines,Apply to PRs or Issues relating Archboard Guidelines,edcd1c
 Label,architecture,,3db1e2
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
@@ -53,14 +23,17 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
+Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
 Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
 Label,Azure.Identity,,e99695
+Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
 Label,blocking-release,Blocks release,d73a49
@@ -71,6 +44,7 @@ Label,breaking-change,,d73a49
 Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,C++,C++ Language,c2e0c6
 Label,C99,C99 Language,c2e0c6
+Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
 Label,CodeGen,Issues that relate to code generation,e99695
@@ -80,13 +54,20 @@ Label,Cognitive - Computer Vision,,e99695
 Label,Cognitive - Content Moderator,,e99695
 Label,Cognitive - Custom Vision,,e99695
 Label,Cognitive - Face,,e99695
+Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
 Label,Cognitive - Language,,e99695
 Label,Cognitive - LUIS,,e99695
+Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
 Label,Cognitive - QnA Maker,,e99695
+Label,Cognitive - Speech,,e99695
+Label,Cognitive - Text Analytics,,e99695
+Label,Cognitive - Translator,,e99695
+Label,Cognitive - Vision,,e99695
+Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
 Label,Community Contribution,Community members are working on the issue,1aa874
@@ -101,12 +82,14 @@ Label,Confidential Ledger,,e99695
 Label,Connected Kubernetes,,e99695
 Label,Consumption,,e99695
 Label,Container Instances,,e99695
+Label,Container Registry,,e99695
 Label,Container Service,,e99695
 Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
 Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -120,6 +103,7 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,dependencies,Pull requests that update a dependency file,0366d6
 Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
@@ -131,8 +115,12 @@ Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
 Label,enhancement,New feature or request,7365c9
 Label,Epic,,3E4B9E
+Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
 Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
+Label,Functions,,e99695
+Label,GitHub IO Site,Applied for updates to our github.io site.,c2e0c6
+Label,Go,,c2e0c6
 Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
@@ -144,6 +132,7 @@ Label,HPC Cache,,e99695
 Label,Import Export,,e99695
 Label,Insights,,e99695
 Label,Intune,,e99695
+Label,iOS,,c2e0c6
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
 Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
@@ -152,6 +141,7 @@ Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
 Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
@@ -159,10 +149,12 @@ Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
 Label,Mgmt,This issue is related to a management-plane library.,ffeb77
+Label,Mgmt-EngSys,Engineering System (Management Plane Specific),ffeb77
 Label,Migrate,,e99695
 Label,Mixed Reality,,e99695
 Label,Mobile Engagement,,e99695
@@ -173,14 +165,18 @@ Label,Monitor - Alerts,,e99695
 Label,Monitor - ApplicationInsights,,e99695
 Label,Monitor - Autoscale,,e99695
 Label,Monitor - Diagnostic Settings,,e99695
+Label,Monitor - Exporter,Monitor OpenTelemetry Exporter,e99695
+Label,Monitor - Log,Monitor Log Analytics,e99695
 Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
 Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
 Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
 Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -193,6 +189,7 @@ Label,Network - Front Door,Service: Azure Front Door,e99695
 Label,Network - Load Balancer,,e99695
 Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
+Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
@@ -201,6 +198,7 @@ Label,Network - VPN Gateway,,e99695
 Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
+Label,Partner Ask,Dependencies from outside of Azure SDK,3E4B9E
 Label,Peering,,e99695
 Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
 Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
@@ -210,9 +208,11 @@ Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,Purview,,e99695
 Label,Python,,c2e0c6
 Label,Quantum,,e99695
 Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
+Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
 Label,Redis Cache,,e99695
@@ -222,6 +222,7 @@ Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
 Label,Scheduler,,e99695
+Label,Schema Registry,,e99695
 Label,Search,,e99695
 Label,Security,,e99695
 Label,SecurityInsights,,e99695
@@ -245,6 +246,8 @@ Label,Stream Analytics,,e99695
 Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
+Label,Synapse,,e99695
+Label,Tables,,e99695
 Label,test-enhancement,,7365c9
 Label,test-manual-pass,,c0eaf9
 Label,test-reliability,Issue that causes tests to be unreliable,e04545
@@ -254,3 +257,4 @@ Label,Typescript,Typescript language,c2e0c6
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
+Label,WebPubSub,,e99695

--- a/tools/github-labels/repository-snapshots/perks.csv
+++ b/tools/github-labels/repository-snapshots/perks.csv
@@ -1,26 +1,15 @@
 Processing Azure\perks repo.
-Label,P2 - Requested,Feature Request,5635a8
-Label,P0 - Critical,Critical Issue - blocking,d83c59
-Label,fixed-please-confirm,"Fix is released, waiting for confirmation",58f913
-Label,P1 - Required,Required functionality - not blocking,e8db7d
-Label,Publish,,A47039
-Label,Service Attention,This issue is responsible by Azure service team.,10066b
-Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
-Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
-Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
-Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
-Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
-Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
-Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
-Label,needs-team-triage,This issue needs the team to triage.,ededed
-Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
-Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
-Label,Community Contribution,Community members are working on the issue,1aa874
 Label,AAD,,e99695
 Label,ACS,,e99695
+Label,Advisor,,e99695
+Label,AgriFood,,e99695
 Label,AKS,,e99695
+Label,Alerts Management,,e99695
+Label,Analysis Services,,e99695
 Label,API Management,,e99695
 Label,APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c
+Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
+Label,App Services,,e99695
 Label,ARM,,e99695
 Label,ARM - Core,,e99695
 Label,ARM - Managed Applications,,e99695
@@ -29,17 +18,12 @@ Label,ARM - Service Catalog,,e99695
 Label,ARM - Tags,,e99695
 Label,ARM - Templates,,e99695
 Label,ARO,Azure Redhat OpenShift,e99695
-Label,AVS,,e99695
-Label,Advisor,,e99695
-Label,AgriFood,,e99695
-Label,Alerts Management,,e99695
-Label,Analysis Services,,e99695
-Label,App Configuration,Azure.ApplicationModel.Configuration,e99695
-Label,App Services,,e99695
 Label,Attestation,,e99695
 Label,Authentication,,e99695
 Label,Authorization,,e99695
+Label,auto-merge,Apply to PR's that we want to auto-merge when green,5df772
 Label,Automation,,e99695
+Label,AVS,,e99695
 Label,Azure Arc enabled servers,,e99695
 Label,Azure Stack,,e99695
 Label,Azure.Core,,e99695
@@ -47,8 +31,11 @@ Label,Azure.Identity,,e99695
 Label,Batch,,e99695
 Label,BatchAI,,e99695
 Label,Billing,,e99695
+Label,blocking-release,Blocks release,d73a49
 Label,Blueprint,,e99695
 Label,Bot Service,,e99695
+Label,breaking-change,,d73a49
+Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
 Label,Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Label,Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Label,Cloud Shell,,e99695
@@ -62,8 +49,8 @@ Label,Cognitive - Face,,e99695
 Label,Cognitive - Form Recognizer,,e99695
 Label,Cognitive - Immersive Reader,,e99695
 Label,Cognitive - Ink Recognizer,,e99695
-Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Language,,e99695
+Label,Cognitive - LUIS,,e99695
 Label,Cognitive - Metrics Advisor,,e99695
 Label,Cognitive - Mgmt,,e99695
 Label,Cognitive - Personalizer,,e99695
@@ -75,6 +62,7 @@ Label,Cognitive - Vision,,e99695
 Label,Cognitive Services,,e99695
 Label,Commerce,,e99695
 Label,Communication,,e99695
+Label,Community Contribution,Community members are working on the issue,1aa874
 Label,Compute,,e99695
 Label,Compute - Extensions,,e99695
 Label,Compute - Images,,e99695
@@ -92,6 +80,8 @@ Label,Cosmos,,e99695
 Label,Cost Management,,e99695
 Label,Custom Providers,,e99695
 Label,Customer Insights,,e99695
+Label,customer-reported,Issues that are reported by GitHub users external to the Azure organization.,3800e0
+Label,CXP Attention,The Azure CXP Support Team is responsible for this issue.,10066b
 Label,CycleCloud,,e99695
 Label,Data Bricks,,e99695
 Label,Data Catalog,,e99695
@@ -105,40 +95,48 @@ Label,Data Migration,,e99695
 Label,Data Share,,e99695
 Label,DataBox,,e99695
 Label,DataBox Edge,,e99695
+Label,design-discussion,An area of design currently under discussion and open to team and community feedback.,0BABDF
 Label,Dev Spaces,,e99695
 Label,DevOps,,e99695
 Label,Devtestlab,,e99695
 Label,Digital Twins,,e99695
 Label,Do Not Merge,,b60205
 Label,Docs,,e99695
+Label,duplicate,This issue is the duplicate of another issue,e4c288
 Label,EngSys,This issue is impacting the engineering system.,e99695
 Label,Epic,,3E4B9E
 Label,Event Grid,,e99695
 Label,Event Hubs,,e99695
+Label,feature-request,This issue requires a new behavior in the product in order be resolved.,eaa875
+Label,fixed-please-confirm,"Fix is released, waiting for confirmation",58f913
 Label,Functions,,e99695
+Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
 Label,Graph,,e99695
 Label,Graph.Microsoft,,e99695
 Label,Graph.Windows,,e99695
 Label,Guest Configuration,,e99695
 Label,HDInsight,,e99695
+Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
 Label,HPC Cache,,e99695
 Label,Import Export,,e99695
 Label,Insights,,e99695
 Label,Intune,,e99695
 Label,IoT,,e99695
 Label,IoT/CLI,,e99695
+Label,issue-addressed,The Azure SDK team member assisting with this issue believes it to be addressed and ready to close.,5df772
 Label,KeyVault,,e99695
 Label,Kubernetes Configuration,,e99695
 Label,Kusto,,e99695
-Label,LOUIS,,e99695
 Label,Lab Services,,e99695
+Label,LLC,,e99695
 Label,Logic App,,e99695
-Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
+Label,LOUIS,,e99695
 Label,Machine Learning,,e99695
 Label,Machine Learning Compute,,e99695
 Label,Machine Learning Experimentation,,e99695
 Label,Managed Identity,,e99695
 Label,ManagedServices,,e99695
+Label,Maps,,e99695
 Label,MariaDB,,e99695
 Label,Marketplace Ordering,,e99695
 Label,Media Services,,e99695
@@ -160,7 +158,12 @@ Label,Monitor - Log Analytics,,e99695
 Label,Monitor - Metrics,,e99695
 Label,Monitor - Operational Insights,,e99695
 Label,Monitor - Query,,e99695
+Label,MQ,"This issue is part of a ""milestone of quality"" initiative.",7365c9
 Label,MySQL,,e99695
+Label,needs-author-feedback,More information is needed from author to address the issue.,f72598
+Label,needs-team-attention,This issue needs attention from Azure service team or SDK team,3BA0F8
+Label,needs-team-triage,This issue needs the team to triage.,ededed
+Label,needs-triage,This is a new issue that needs to be triaged to the appropriate team.,ededed
 Label,Network,,e99695
 Label,Network - Application Gateway,,e99695
 Label,Network - Bastion,,e99695
@@ -175,19 +178,29 @@ Label,Network - Network Virtual Appliance,,e99695
 Label,Network - Network Watcher,,e99695
 Label,Network - Private Link,,e99695
 Label,Network - Traffic Manager,,e99695
-Label,Network - VPN Gateway,,e99695
 Label,Network - Virtual Network,,e99695
 Label,Network - Virtual Network NAT,,e99695
 Label,Network - Virtual WAN,,e99695
+Label,Network - VPN Gateway,,e99695
+Label,no-recent-activity,There has been no recent activity on this issue.,bbbbbb
 Label,Notification Hub,,e99695
 Label,Operations Management,,e99695
+Label,P0 - Critical,Critical Issue - blocking,d83c59
+Label,P1 - Required,Required functionality - not blocking,e8db7d
+Label,P2 - Requested,Feature Request,5635a8
 Label,Peering,,e99695
+Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
+Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
+Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
+Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
 Label,Policy,,e99695
 Label,Policy Insights,,e99695
 Label,PostgreSQL,,e99695
 Label,PowerBI,,e99695
+Label,Publish,,A47039
 Label,Purview,,e99695
 Label,Quantum,,e99695
+Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
 Label,Quota,Quota Service,e99695
 Label,Recovery Services Backup,,e99695
 Label,Recovery Services Site-Recovery,,e99695
@@ -197,13 +210,6 @@ Label,Reservations,,e99695
 Label,Resource Authorization,,e99695
 Label,Resource Graph,,e99695
 Label,Resource Health,,e99695
-Label,SQL,,e99695
-Label,SQL - Backup & Restore,,e99695
-Label,SQL - Data Security,,e99695
-Label,SQL - Elastic Jobs,,e99695
-Label,SQL - Managed Instance,,e99695
-Label,SQL - Replication & Failover,,e99695
-Label,SQL - VM,,e99695
 Label,Scheduler,,e99695
 Label,Schema Registry,,e99695
 Label,Search,,e99695
@@ -211,35 +217,32 @@ Label,Security,,e99695
 Label,SecurityInsights,,e99695
 Label,Server Management,,e99695
 Label,Service,This issue points to a problem in the service.,ffeb77
+Label,Service Attention,This issue is responsible by Azure service team.,10066b
 Label,Service Bus,,e99695
 Label,Service Fabric,,e99695
 Label,Service Map,,e99695
 Label,SignalR,,e99695
+Label,SQL,,e99695
+Label,SQL - Backup & Restore,,e99695
+Label,SQL - Data Security,,e99695
+Label,SQL - Elastic Jobs,,e99695
+Label,SQL - Managed Instance,,e99695
+Label,SQL - Replication & Failover,,e99695
+Label,SQL - VM,,e99695
 Label,Storage,"Storage Service (Queues, Blobs, Files)",e99695
 Label,Storsimple,,e99695
 Label,Stream Analytics,,e99695
+Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9
 Label,Subscription,,e99695
 Label,Support,,e99695
 Label,Synapse,,e99695
 Label,Tables,,e99695
+Label,test-enhancement,,7365c9
+Label,test-manual-pass,,c0eaf9
+Label,test-reliability,Issue that causes tests to be unreliable,e04545
 Label,TimeseriesInsights,,e99695
 Label,Training,Work items that track the work to build training materials for building Client libraries,e99695
 Label,VideoAnalyzer,Azure Video Analyzer,e99695
 Label,Visual Studio,,e99695
 Label,Web Apps,,e99695
 Label,WebPubSub,,e99695
-Label,blocking-release,Blocks release,d73a49
-Label,breaking-change,,d73a49
-Label,pillar-acquisition,"This issue is related to the ability to acquire new customers, one of our core engineering pillars.",65a5c9
-Label,pillar-compatibility,"This issue is related to compatibility between versions, one of our core engineering pillars.",65a5c9
-Label,pillar-performance,"The issue is related to performance, one of our core engineering pillars.",65a5c9
-Label,pillar-reliability,"The issue is related to reliability, one of our core engineering pillars. (includes stress testing)",65a5c9
-Label,test-enhancement,,7365c9
-Label,test-manual-pass,,c0eaf9
-Label,test-reliability,Issue that causes tests to be unreliable,e04545
-Label,bug,This issue requires a change to an existing behavior in the product in order to be resolved.,eaa875
-Label,duplicate,This issue is the duplicate of another issue,e4c288
-Label,good first issue,This issue tracks work that may be a good starting point for a first-time contributor,64c170
-Label,help wanted,This issue is tracking work for which community contributions would be welcomed and appreciated,64c170
-Label,question,The issue doesn't require a change to the product in order to be resolved. Most issues start as that,eaa875
-Label,Stress,"This issue is related to stress testing, part of our reliability pillar.",65a5c9


### PR DESCRIPTION
# Summary

The focus of these changes is to add a new "CXP Attention" label to all repositories for use in the pilot of onboarding the CXP support team to help triage/handle issues
normally marked for service attention.   Also added were common service labels for "LLC" and "Maps".