### PR TITLE
Fix Missing README Code Fence Bug

### DIFF
--- a/packages/java-packages/codesnippet-maven-plugin/pom.xml
+++ b/packages/java-packages/codesnippet-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.azure.tools</groupId>
   <artifactId>codesnippet-maven-plugin</artifactId>
-  <version>1.0.0-beta.1</version>
+  <version>1.0.0-beta.2</version>
   <packaging>maven-plugin</packaging>
 
   <name>Codesnippet Maven Plugin</name>

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
@@ -289,6 +289,10 @@ public final class SnippetReplacer {
                     modifiedLines.append(line).append(lineSep);
                     needsAmend = true;
                     inSnippet = false;
+                } else {
+                    // Hit an end code fence without being in a snippet, just append the line.
+                    // This can happen in README files with non-Java code fences.
+                    modifiedLines.append(line).append(lineSep);
                 }
             } else if (!inSnippet) {
                 // Only modify the lines if not in the codesnippet.

--- a/packages/java-packages/codesnippet-maven-plugin/src/test/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacerTests.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/test/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacerTests.java
@@ -174,4 +174,24 @@ public class SnippetReplacerTests {
         assertNotNull(opResult);
         assertEquals(3, opResult.errorList.size());
     }
+
+    /**
+     * Tests that when a README has a code fence without a snippet declaration the code fence isn't mutated in any way.
+     */
+    @Test
+    public void readmeCodeFenceNoSnippet() throws Exception {
+        Path snippetSourceFile = getPathToResource("basic_src_snippet_parse.txt");
+        Path codeForReplacement = getPathToResource("readme_code_fence_no_snippet_before.txt");
+        Path expectedOutCome = getPathToResource("readme_code_fence_no_snippet_after.txt");
+        byte[] rawBytes = Files.readAllBytes(expectedOutCome);
+        String expectedString = new String(rawBytes, StandardCharsets.UTF_8);
+
+        Map<String, List<String>> foundSnippets = SnippetReplacer.getAllSnippets(
+            new ArrayList<>(Collections.singletonList(snippetSourceFile.toAbsolutePath())));
+        SnippetOperationResult<StringBuilder> opResult = SnippetReplacer.updateSnippets(codeForReplacement,
+            SnippetReplacer.SNIPPET_README_CALL_BEGIN, SnippetReplacer.SNIPPET_README_CALL_END, foundSnippets, "", "",
+            0, "", true);
+
+        assertEquals(opResult.result.toString(), expectedString);
+    }
 }

--- a/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/readme_code_fence_no_snippet_after.txt
+++ b/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/readme_code_fence_no_snippet_after.txt
@@ -1,0 +1,9 @@
+```bash
+This shouldn't be mutated as there is no codesnippet.
+```
+
+```java com.azure.data.applicationconfig.configurationclient.instantiation
+ConfigurationClient configurationClient = new ConfigurationClientBuilder()
+    .connectionString(connectionString)
+    .buildClient();
+```

--- a/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/readme_code_fence_no_snippet_before.txt
+++ b/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/readme_code_fence_no_snippet_before.txt
@@ -1,0 +1,7 @@
+```bash
+This shouldn't be mutated as there is no codesnippet.
+```
+
+```java com.azure.data.applicationconfig.configurationclient.instantiation
+This should be mutated as it is has a code snippet replacement tag.
+```


### PR DESCRIPTION
Fixes a bug where the codesnippet closing tag matched on README code fences that weren't meant for injection, such as XML code fences. This accidentally removed the code fence closing, resulting in broken READMEs.