### PR TITLE
Adding updates and tests for Variable support

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Azure.Sdk.Tools.TestProxy.Tests.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Azure.Sdk.Tools.TestProxy.Tests.csproj
@@ -18,6 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="Test.RecordEntries\oauth_request_with_variables.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="Test.RecordEntries\oauth_request.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -3,7 +3,7 @@ using Azure.Sdk.Tools.TestProxy.Matchers;
 using Azure.Sdk.Tools.TestProxy.Sanitizers;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
-using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using Xunit;
@@ -193,6 +193,96 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await Assert.ThrowsAsync<FileNotFoundException>(
                async () => await recordingHandler.StartPlayback(pathToRecording, httpContext.Response)
             );
+        }
+
+        [Fact]
+        public async void TestStopRecordingWithVariables()
+        {
+            var tmpPath = Path.GetTempPath();
+            var startHttpContext = new DefaultHttpContext();
+            var pathToRecording = "recordings/oauth_request_new.json";
+            var recordingHandler = new RecordingHandler(tmpPath);
+            var dict = new Dictionary<string, string>{
+                { "key1","valueabc123" },
+                { "key2", "value123abc" }
+            };
+            var endHttpContext = new DefaultHttpContext();
+
+            recordingHandler.StartRecording(pathToRecording, startHttpContext.Response);
+            var sessionId = startHttpContext.Response.Headers["x-recording-id"].ToString();
+            
+            recordingHandler.StopRecording(sessionId, variables: new SortedDictionary<string, string>(dict));
+            var storedVariables = TestHelpers.LoadRecordSession(Path.Combine(tmpPath, pathToRecording)).Session.Variables;
+
+            Assert.Equal(dict.Count, storedVariables.Count);
+
+            foreach(var kvp in dict)
+            {
+                Assert.Equal(kvp.Value, storedVariables[kvp.Key]);
+            }
+        }
+
+        [Fact]
+        public void TestStopRecordingWithoutVariables()
+        {
+            var tmpPath = Path.GetTempPath();
+            var startHttpContext = new DefaultHttpContext();
+            var pathToRecording = "recordings/oauth_request_new.json";
+            var recordingHandler = new RecordingHandler(tmpPath);
+
+            recordingHandler.StartRecording(pathToRecording, startHttpContext.Response);
+            var sessionId = startHttpContext.Response.Headers["x-recording-id"].ToString();
+            recordingHandler.StopRecording(sessionId, variables: new SortedDictionary<string, string>());
+
+            var storedVariables = TestHelpers.LoadRecordSession(Path.Combine(tmpPath, pathToRecording)).Session.Variables;
+
+            Assert.Empty(storedVariables);
+        }
+
+        [Fact]
+        public void TestStopRecordingNullVariables()
+        {
+            var tmpPath = Path.GetTempPath();
+            var startHttpContext = new DefaultHttpContext();
+            var pathToRecording = "recordings/oauth_request_new.json";
+            var recordingHandler = new RecordingHandler(tmpPath);
+
+            recordingHandler.StartRecording(pathToRecording, startHttpContext.Response);
+            var sessionId = startHttpContext.Response.Headers["x-recording-id"].ToString();
+            recordingHandler.StopRecording(sessionId, variables: null);
+
+            var storedVariables = TestHelpers.LoadRecordSession(Path.Combine(tmpPath, pathToRecording)).Session.Variables;
+
+            Assert.Empty(storedVariables);
+        }
+
+        [Fact]
+        public async void TestStartPlaybackWithVariables()
+        {
+            var tmpPath = Path.GetTempPath();
+            var startHttpContext = new DefaultHttpContext();
+            var recordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+
+            await recordingHandler.StartPlayback("Test.RecordEntries/oauth_request_with_variables.json", startHttpContext.Response);
+            var sessionId = startHttpContext.Response.Headers["x-recording-id"].ToString();
+            var body = startHttpContext.Response.Body;
+
+            // TODO: figure out why body isn't set here
+        }
+
+        [Fact]
+        public async void TestStartPlaybackWithoutVariables()
+        {
+            var tmpPath = Path.GetTempPath();
+            var startHttpContext = new DefaultHttpContext();
+            var pathToRecording = "recordings/oauth_request_new.json";
+            var recordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+
+            recordingHandler.StartPlayback("Test.RecordEntries/oauth_request.json", startHttpContext.Response);
+            var sessionId = startHttpContext.Response.Headers["x-recording-id"].ToString();
+            var body = startHttpContext.Response.Body;
+            
+            // TODO: figure out why body isn't set here
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/oauth_request_with_variables.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/oauth_request_with_variables.json
@@ -1,0 +1,22 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/v2.0/token",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip,deflate",
+        "Connection": "keep-alive",
+        "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+        "User-Agent": "core-http/1.2.5 Node/v12.22.1 OS/ (x64-Linux-5.4.0-1043-azure)",
+        "x-ms-client-request-id": "a4d470c5-b830-11eb-9cc6-10e7c6392c5a"
+      },
+      "RequestBody": "scope=https%3A%2F%2Fvault.azure.net%2F.default%20openid%20profile%20offline_access&client_id=04b07795-8ddb-461a-bbee-02f9e1bf7b46&grant_type=device_code&device_code=DEVICE_CODE&client-request-id=client-request-id&client_info=1&x-client-SKU=msal.js.node&x-client-VER=1.0.3&x-client-OS=linux&x-client-CPU=x64&x-ms-lib-capability=retry-after, h429&x-client-current-telemetry=2|671,0|,&x-client-last-telemetry=2|0|||0,0",
+      "StatusCode": 201
+    }
+  ],
+  "Variables": {
+    "key1": "value1",
+    "key2": "value2"
+  }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
@@ -2,7 +2,11 @@
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
+using System.IO;
 using System.Net.Http;
 using System.Threading.Tasks;
 
@@ -34,12 +38,11 @@ namespace Azure.Sdk.Tools.TestProxy
         }
 
         [HttpPost]
-        public void Stop()
+        public void Stop([FromBody(EmptyBodyBehavior = EmptyBodyBehavior.Allow)] SortedDictionary<string, string> variables = null)
         {
             string id = RecordingHandler.GetHeader(Request, "x-recording-id");
 
-            _recordingHandler.StopRecording(id);
-
+            _recordingHandler.StopRecording(id, variables: variables);
         }
 
         public async Task HandleRequest()

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -3,6 +3,8 @@ using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http.Json;
+using Microsoft.Extensions.Options;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Concurrent;
@@ -63,7 +65,7 @@ namespace Azure.Sdk.Tools.TestProxy
         #endregion
 
         #region recording functionality
-        public void StopRecording(string sessionId)
+        public void StopRecording(string sessionId, SortedDictionary<string, string> variables = null)
         {
             if (!RecordingSessions.TryRemove(sessionId, out var fileAndSession))
             {
@@ -75,6 +77,14 @@ namespace Azure.Sdk.Tools.TestProxy
             foreach (RecordedTestSanitizer sanitizer in Sanitizers.Concat(session.AdditionalSanitizers))
             {
                 session.Session.Sanitize(sanitizer);
+            }
+
+            if(variables != null)
+            {
+                foreach(var kvp in variables)
+                {
+                    session.Session.Variables[kvp.Key] = kvp.Value;
+                }
             }
 
             if (String.IsNullOrEmpty(file))
@@ -280,6 +290,15 @@ namespace Azure.Sdk.Tools.TestProxy
             }
 
             outgoingResponse.Headers.Add("x-recording-id", id);
+
+            if(session.Session.Variables.Count > 0)
+            {
+                var json = JsonSerializer.Serialize(session.Session.Variables);
+                outgoingResponse.Headers.Add("Content-Type", "application/json");
+
+                // Write to the response
+                await outgoingResponse.WriteAsync(json);
+            }
         }
 
         public void StopPlayback(string recordingId, bool purgeMemoryStore = false)


### PR DESCRIPTION
Currently this is a breaking change. Specifically, when hitting `POST /Record/Stop`, one must always set `Content-Type: application/json`. The body itself is optional with the current configuration, but I couldn't figure out how to make it also accept empty content-type.

TODO:

- [ ] Talk with @mikeharder about above
- [ ] Figure out why `writeasync` to body actually works when run against a postman request, but is set to NullStream when evaluating in RecordingHandlerTests.
