### PR TITLE
Create virtual env and run package parser inside virtual env

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -2,7 +2,10 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.Threading.Tasks;
+using ApiView;
 using Microsoft.Extensions.Configuration;
 
 namespace APIViewWeb
@@ -13,19 +16,93 @@ namespace APIViewWeb
         public override string Extension { get; } = ".whl";
         public override string VersionString { get; } = "0.2.4";
 
-        private readonly string _apiViewPythonProcessor;
-        public override string ProcessName => _apiViewPythonProcessor;
+        private readonly string _pythonExecutablePath;
+        public override string ProcessName => _pythonExecutablePath;
+        private readonly string _apiStubWheelPath;
 
         public PythonLanguageService(IConfiguration configuration)
         {
-            // apistubgen is located in python's scripts path e.g. <Pythonhome>/Scripts/apistubgen
-            // Env variable PYTHONPROCESSORPATH is set to <pythonhome>/Scripts/apistubgen where parser is located
-            _apiViewPythonProcessor = configuration["PYTHONPROCESSORPATH"] ?? string.Empty;
+            _pythonExecutablePath = configuration["PYTHONEXECUTABLEPATH"] ?? "python";
+            _apiStubWheelPath = Path.Combine(Path.GetDirectoryName(typeof(PythonLanguageService).Assembly.Location), "api-stub-generator");
         }
         public override string GetProcessorArguments(string originalName, string tempDirectory, string jsonPath)
         {
             return $"--pkg-path {originalName} --temp-path {tempDirectory}" +
                 $" --out-path {jsonPath} --hide-report";
+        }
+
+        private string GetPythonVirtualEnv(string tempDirectory)
+        {
+            // Create virtual instance
+            RunProcess(tempDirectory, ProcessName, $" -m virtualenv {tempDirectory} --system-site-packages");
+            string venvPath = Path.Combine(tempDirectory, "Scripts", "python.exe");
+            if (File.Exists(venvPath))
+            {
+                RunProcess(tempDirectory, venvPath, $" -m pip install {_apiStubWheelPath}");
+            }
+            else
+            {
+                throw new InvalidOperationException("Failed to create virtualenv for python package parser");
+            }
+
+            return Path.Combine(tempDirectory, "Scripts", "apistubgen");
+        }
+
+        public override async Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis)
+        {
+            var tempPath = Path.GetTempPath();
+            var randomSegment = Guid.NewGuid().ToString("N");
+            var tempDirectory = Path.Combine(tempPath, "ApiView", randomSegment);
+            Directory.CreateDirectory(tempDirectory);
+            var originalFilePath = Path.Combine(tempDirectory, originalName);
+
+            var jsonFilePath = Path.ChangeExtension(originalFilePath, ".json");
+
+            using (var file = File.Create(originalFilePath))
+            {
+                await stream.CopyToAsync(file);
+            }
+
+            try
+            {
+                var apiStubGenPath = GetPythonVirtualEnv(tempDirectory);
+                var arguments = GetProcessorArguments(originalName, tempDirectory, jsonFilePath);
+                RunProcess(tempDirectory, apiStubGenPath, arguments);
+                using (var codeFileStream = File.OpenRead(jsonFilePath))
+                {
+                    var codeFile = await CodeFile.DeserializeAsync(codeFileStream);
+                    codeFile.VersionString = VersionString;
+                    codeFile.Language = Name;
+                    return codeFile;
+                }
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+
+        private void RunProcess(string workingDirectory, string processName, string args)
+        {
+            var processStartInfo = new ProcessStartInfo(processName, args)
+            {
+                WorkingDirectory = workingDirectory,
+                RedirectStandardError = true,
+                RedirectStandardOutput = true
+            };
+            using (var process = Process.Start(processStartInfo))
+            {
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    throw new InvalidOperationException(
+                        "Processor failed: " + Environment.NewLine +
+                        "stdout: " + Environment.NewLine +
+                        process.StandardOutput.ReadToEnd() + Environment.NewLine +
+                        "stderr: " + Environment.NewLine +
+                        process.StandardError.ReadToEnd() + Environment.NewLine);
+                }
+            }
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
@@ -22,7 +22,8 @@ namespace APIViewWeb
         public async Task<PullRequestModel> GetPullRequestAsync(int pullRequestNumber, string repoName, string packageName)
         {
             var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.RepoName = '{repoName}' and c.PackageName = '{packageName}'";
-            return await GetPullRequestFromQueryAsync(query);
+            var requests = await GetPullRequestFromQueryAsync(query);
+            return requests.Count > 0 ? requests[0] : null;
         }
 
         public async Task UpsertPullRequestAsync(PullRequestModel pullRequestModel)
@@ -32,32 +33,20 @@ namespace APIViewWeb
 
         public async Task<IEnumerable<PullRequestModel>> GetPullRequestsAsync(bool isOpen)
         {
-            var pullRequests = new List<PullRequestModel>();
-            var queryDefinition = new QueryDefinition("SELECT * FROM PullRequests c WHERE c.IsOpen = @isOpen").WithParameter("@isClosed", isOpen);
-            var itemQueryIterator = _pullRequestsContainer.GetItemQueryIterator<PullRequestModel>(queryDefinition);
+            var query = $"SELECT * FROM PullRequests c WHERE c.IsOpen = {(isOpen? "true": "false")}";
+            return await GetPullRequestFromQueryAsync(query);
+        }
+
+        private async Task<List<PullRequestModel>> GetPullRequestFromQueryAsync(string query)
+        {
+            var allRequests = new List<PullRequestModel>();
+            var itemQueryIterator = _pullRequestsContainer.GetItemQueryIterator<PullRequestModel>(query);
             while (itemQueryIterator.HasMoreResults)
             {
                 var result = await itemQueryIterator.ReadNextAsync();
-                pullRequests.AddRange(result.Resource);
-            }
-            return pullRequests;
-        }
-
-        private async Task<PullRequestModel> GetPullRequestFromQueryAsync(string query)
-        {
-            var itemQueryIterator = _pullRequestsContainer.GetItemQueryIterator<PullRequestModel>(query);
-            if (itemQueryIterator.HasMoreResults)
-            {
-                var allRequests = new List<PullRequestModel>();
-                var result = await itemQueryIterator.ReadNextAsync();
                 allRequests.AddRange(result.Resource);
-                if (allRequests.Count > 0)
-                {
-                   return allRequests[0];
-                }
             }
-
-            return null;
+            return allRequests;
         }
     }
 }


### PR DESCRIPTION
Python package are installed in same env that corrupts installed module when two requests are processed in parallel. This change is to create a virtual env for python package parser request inside temp directory.