### PR TITLE
Skip unnecessary and misleading role assignment warnings in local test resource deployment

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -463,7 +463,10 @@ try {
     # service principal without permissions to grant RBAC roles to other service principals. That should not be
     # considered a critical failure, as the test application may have subscription-level permissions and not require
     # the explicit grant.
-    if (!$resourceGroupRoleAssigned) {
+    #
+    # Ignore this check if $AzureTestPrincipal is specified as role assignment will already have been attempted on a
+    # previous run, and these error messages can be misleading for local runs.
+    if (!$resourceGroupRoleAssigned -and !$AzureTestPrincipal) {
         Log "Attempting to assigning the 'Owner' role for '$ResourceGroupName' to the Test Application '$TestApplicationId'"
         $principalOwnerAssignment = New-AzRoleAssignment -RoleDefinitionName "Owner" -ApplicationId "$TestApplicationId" -ResourceGroupName "$ResourceGroupName" -ErrorAction SilentlyContinue
 


### PR DESCRIPTION
The "cannot assign owner" warning message will print on repeated local runs for the script when people don't have owner, and is somewhat of a red herring (as explained in the code comments). I don't think it's actually necessary to warn here since we already skip this section on first run of the script.