### PR TITLE
[Test-Proxy] docker version updates

### DIFF
--- a/tools/test-proxy/docker/dockerfile-win
+++ b/tools/test-proxy/docker/dockerfile-win
@@ -30,11 +30,19 @@ ENV ProgramFiles="C:\Program Files" \
     # this override allows the tool server to listen to traffic over the docker bridge.
     # default URL of localhost:5000 or localhost:50001 are not usable from outside the container
     ASPNETCORE_URLS="http://0.0.0.0:5000;https://0.0.0.0:5001"
-    
+
 # while it may seem a bit strange to use "etc" on a windows container. We are mirroring
 # the methodology from the primary container, which is linux.
 RUN mkdir certwork & mkdir etc & cd etc & mkdir testproxy
 ADD docker_build/dotnet-devcert.pfx certwork
+
+# we still need to import this certificate to ensure it's available to all users. there is _something_ gnarly going on that purely having the cert 
+# available through the environment variables is causing some inconsistent weirdness.    
+COPY --from=build_env ["C:/Program Files/dotnet/sdk/5.0.401/DotnetTools/dotnet-dev-certs/5.0.10-servicing.21410.22/tools/net5.0/any/", "C:/dotnet-dev-certs/"]
+
+USER ContainerAdministrator
+RUN dotnet /dotnet-dev-certs/dotnet-dev-certs.dll https --clean --import /certwork/dotnet-devcert.pfx -p "password"
+USER ContainerUser
 
 WORKDIR /proxyserver
 


### PR DESCRIPTION
Essentially:
 - _sometimes_ the ASP.NET process just couldn't retrieve the certificate referenced in `KESTREL__DEFAULT__PATH`
 - In those cases, we'd see a really weird error that looked like 
![image](https://user-images.githubusercontent.com/45376673/136273559-c8144502-c636-4b01-9c02-fd687a6c017a.png)
 - all of my reading referenced re-importing the certificate. Given that we don't even _trust_ it (we just import it to the local machine store), I don't know why this has the affect it does. However, I won't argue with results.

Confirmed working in this [test build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1130049&view=logs&j=8befe419-3c43-5b79-8252-252cf2582e85).