### PR TITLE
Handle type-aliased constants

### DIFF
--- a/src/go/cmd/content.go
+++ b/src/go/cmd/content.go
@@ -67,7 +67,6 @@ func (c *content) addConst(pkg pkg, g *ast.GenDecl) {
 }
 
 func getConstValue(pkg pkg, expr ast.Expr) string {
-	// get the type from the token type
 	if bl, ok := expr.(*ast.BasicLit); ok {
 		// const DefaultLinkCredit = 1
 		return bl.Value


### PR DESCRIPTION
Don't panic when failing to deduce a constant, print a warning so generation
can proceed as it might uncover other issues.