### PR TITLE
Mitigate relative path calculation error on multiple iterations

### DIFF
--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -73,6 +73,14 @@ function GetRelativePath($path) {
   if (!$path) {
     return ''
   }
+
+  # If the path is already relative return the path. Calling `GetRelativePath`
+  # on a relative path converts the relative path to an absolute path based on
+  # the current working directory which can result in unexpected outputs.
+  if (![IO.Path]::IsPathRooted($path)) {
+    return $path
+  }
+
   $relativeTo = Resolve-Path $PSScriptRoot/../../../
   # Replace "\" with "/" so the path is valid across other platforms and tools
   $relativePath = [IO.Path]::GetRelativePath($relativeTo, $path) -replace "\\", '/'

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -48,8 +48,15 @@ function SetOutput($outputPath, $incomingPackageSpec) {
   else
   {
     $outputObject = $incomingPackageSpec
+
+    # Set file paths to relative paths. Only do this if there is no existing
+    # package info json file as running this multiple times can create
+    # unexpected relative paths in some scenarios.
+    $outputObject.DirectoryPath = GetRelativePath $outputObject.DirectoryPath
+    $outputObject.ReadMePath = GetRelativePath $outputObject.ReadMePath
+    $outputObject.ChangeLogPath = GetRelativePath $outputObject.ChangeLogPath
   }
-  
+
 
   if ($addDevVersion)
   {
@@ -57,11 +64,6 @@ function SetOutput($outputPath, $incomingPackageSpec) {
     # as the DevVersion. This may be overridden later.
     $outputObject.DevVersion = $incomingPackageSpec.Version
   }
-
-  # Set file paths to relative paths
-  $outputObject.DirectoryPath = GetRelativePath $outputObject.DirectoryPath
-  $outputObject.ReadMePath = GetRelativePath $outputObject.ReadMePath
-  $outputObject.ChangeLogPath = GetRelativePath $outputObject.ChangeLogPath
 
   Set-Content `
     -Path $outputPath `

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -48,15 +48,8 @@ function SetOutput($outputPath, $incomingPackageSpec) {
   else
   {
     $outputObject = $incomingPackageSpec
-
-    # Set file paths to relative paths. Only do this if there is no existing
-    # package info json file as running this multiple times can create
-    # unexpected relative paths in some scenarios.
-    $outputObject.DirectoryPath = GetRelativePath $outputObject.DirectoryPath
-    $outputObject.ReadMePath = GetRelativePath $outputObject.ReadMePath
-    $outputObject.ChangeLogPath = GetRelativePath $outputObject.ChangeLogPath
   }
-
+  
 
   if ($addDevVersion)
   {
@@ -64,6 +57,11 @@ function SetOutput($outputPath, $incomingPackageSpec) {
     # as the DevVersion. This may be overridden later.
     $outputObject.DevVersion = $incomingPackageSpec.Version
   }
+
+  # Set file paths to relative paths
+  $outputObject.DirectoryPath = GetRelativePath $outputObject.DirectoryPath
+  $outputObject.ReadMePath = GetRelativePath $outputObject.ReadMePath
+  $outputObject.ChangeLogPath = GetRelativePath $outputObject.ChangeLogPath
 
   Set-Content `
     -Path $outputPath `


### PR DESCRIPTION
@praveenkuttappan @weshaggard 

This change mitigates an obscure issue we ran into after the change to `Save-Package-Properties.ps1` merged. It would seem that the relative path computation will, on DevOps machines, generate relative paths with an extra `../` prepended unnecessarily. 

Mitigates https://github.com/Azure/azure-sdk-tools/issues/2094 