### PR TITLE
Add group id into metadata for java use

### DIFF
--- a/eng/common/scripts/Update-DocsMsPackages.ps1
+++ b/eng/common/scripts/Update-DocsMsPackages.ps1
@@ -61,6 +61,7 @@ function GetDocsMetadataForMoniker($moniker) {
       RepoPath = $fileObject.ServiceDirectory;
       Type = $fileObject.SdkType;
       New = $fileObject.IsNewSdk;
+      GroupId = $fileObject.Gruop;
     }
   }
 


### PR DESCRIPTION
Java daily updates needs group id to download the required package. The group id is missing from azure-sdk-tool script Update-DocMsPackage.ps1. The PR is to add it back.
Test update in daily branch:
https://github.com/Azure/azure-docs-sdk-java/blob/daily/2021-10-14/package.json#L1762 