### PR TITLE
[Test-Proxy] Patch dockerfile-win to allow access of localhost through `host.docker.internal` hostname

### DIFF
--- a/eng/common/testproxy/docker-start-proxy.ps1
+++ b/eng/common/testproxy/docker-start-proxy.ps1
@@ -40,6 +40,7 @@ function Get-Proxy-Container(){
 
 $SelectedImage = $LINUX_IMAGE_SOURCE
 $Initial = ""
+$LinuxContainerArgs = "--add-host=host.docker.internal:host-gateway"
 
 # most of the time, running this script on a windows machine will work just fine, as docker defaults to linux containers
 # however, in CI, windows images default to _windows_ containers. We cannot swap them. We can tell if we're in a CI build by
@@ -47,6 +48,7 @@ $Initial = ""
 if ($IsWindows -and $env:TF_BUILD){
     $SelectedImage = $WINDOWS_IMAGE_SOURCE
     $Initial = "C:"
+    $LinuxContainerArgs = ""
 }
 
 if ($Mode -eq "start"){
@@ -63,8 +65,8 @@ if ($Mode -eq "start"){
     # else we need to create it
     else {
         Write-Host "Attempting creation of Docker host $CONTAINER_NAME"
-        Write-Host "docker container create -v `"${root}:${Initial}/etc/testproxy`" -p 5001:5001 -p 5000:5000 --name $CONTAINER_NAME $SelectedImage"
-        docker container create -v "${root}:${Initial}/etc/testproxy" -p 5001:5001 -p 5000:5000 --name $CONTAINER_NAME $SelectedImage
+        Write-Host "docker container create -v `"${root}:${Initial}/etc/testproxy`" $LinuxContainerArgs -p 5001:5001 -p 5000:5000 --name $CONTAINER_NAME $SelectedImage"
+        docker container create -v "${root}:${Initial}/etc/testproxy" $LinuxContainerArgs -p 5001:5001 -p 5000:5000 --name $CONTAINER_NAME $SelectedImage
     }
 
     Write-Host "Attempting start of Docker host $CONTAINER_NAME"

--- a/tools/test-proxy/docker/dockerfile-win
+++ b/tools/test-proxy/docker/dockerfile-win
@@ -8,7 +8,6 @@ RUN cd /proxyservercode && dotnet publish -c Release -o /proxyserver -f net5.0
 
 FROM mcr.microsoft.com/dotnet/aspnet:5.0.10-nanoserver-1809 AS build
 
-# Copy PowerShell Core from the installer container
 ENV ProgramFiles="C:\Program Files" \
     # set a fixed location for the Module analysis cache
     PSModuleAnalysisCachePath="C:\Users\Public\AppData\Local\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" \
@@ -31,6 +30,8 @@ ENV ProgramFiles="C:\Program Files" \
     # default URL of localhost:5000 or localhost:50001 are not usable from outside the container
     ASPNETCORE_URLS="http://0.0.0.0:5000;https://0.0.0.0:5001"
 
+USER ContainerAdministrator
+
 # while it may seem a bit strange to use "etc" on a windows container. We are mirroring
 # the methodology from the primary container, which is linux.
 RUN mkdir certwork & mkdir etc & cd etc & mkdir testproxy
@@ -40,15 +41,14 @@ ADD docker_build/dotnet-devcert.pfx certwork
 # available through the environment variables is causing some inconsistent weirdness.    
 COPY --from=build_env ["C:/Program Files/dotnet/sdk/5.0.401/DotnetTools/dotnet-dev-certs/5.0.10-servicing.21410.22/tools/net5.0/any/", "C:/dotnet-dev-certs/"]
 
-USER ContainerAdministrator
 RUN dotnet /dotnet-dev-certs/dotnet-dev-certs.dll https --clean --import /certwork/dotnet-devcert.pfx -p "password"
-USER ContainerUser
 
 WORKDIR /proxyserver
+ADD host-patcher.cmd .
 
 COPY --from=build_env /proxyserver .
 
 EXPOSE 5001
 EXPOSE 5000
 
-ENTRYPOINT ["dotnet", "Azure.Sdk.Tools.TestProxy.dll", "--storage-location", "/etc/testproxy"]
+ENTRYPOINT ["host-patcher.cmd", "&",  "dotnet", "Azure.Sdk.Tools.TestProxy.dll", "--storage-location", "/etc/testproxy"]

--- a/tools/test-proxy/docker/host-patcher.cmd
+++ b/tools/test-proxy/docker/host-patcher.cmd
@@ -1,0 +1,16 @@
+@echo OFF
+REM ipconfig output looks like this:
+REM Windows IP Configuration
+REM Ethernet adapter Ethernet:
+REM    Connection-specific DNS Suffix  . : corp.microsoft.com
+REM    Link-local IPv6 Address . . . . . : fe80::20f0:fead:af44:9e18%4
+REM    IPv4 Address. . . . . . . . . . . : 172.28.25.93
+REM    Subnet Mask . . . . . . . . . . . : 255.255.240.0
+REM    Default Gateway . . . . . . . . . : 172.28.16.1
+
+for /f "tokens=1-2,14" %%i in ('ipconfig') do ^
+if "%%i %%j"=="IPv4 Address." set IPADDR=%%k
+
+del "C:\Windows\System32\drivers\etc\hosts"
+echo %IPADDR%    host.docker.internal >> "C:\Windows\System32\drivers\etc\hosts"
+


### PR DESCRIPTION
This was a barrel of fun. @HarshaNalluru thanks very much for bringing this one up. 

