### PR TITLE
Explicitly set vm image to avoid using ubuntu16

### DIFF
--- a/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
@@ -1,0 +1,27 @@
+parameters:
+  - name: Repository
+    type: string
+    default: $(Build.Repository.Name)
+  - name: Prefix
+    type: string
+  - name: CIConventionOptions
+    type: string
+    default: ''
+  - name: UPConventionOptions
+    type: string
+    default: ''
+  - name: TestsConventionOptions
+    type: string
+    default: ''
+jobs:
+- job: PreparePipelines
+  pool:
+    vmImage: 'windows-2019'
+  steps:
+    - template: /eng/common/pipelines/templates/steps/prepare-pipelines.yml
+      parameters:
+        Repository: {{parameters.Repository}}
+        Prefix: {{parameters.Prefix}}
+        CIConventionOptions: {{parameters.CIConventionOptions}}
+        UPConventionOptions: {{parameters.UPConventionOptions}}
+        TestsConventionOptions: {{parameters.TestsConventionOptions}}

--- a/eng/common/pipelines/templates/steps/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/steps/prepare-pipelines.yml
@@ -13,128 +13,125 @@ parameters:
   - name: TestsConventionOptions
     type: string
     default: ''
-jobs:
-- job: PreparePipelines
-  pool:
-    vmImage: 'windows-2019'
-  steps:
-    - template: install-pipeline-generation.yml
-    - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
-    # This covers our public repos.
-    - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-          --organization https://dev.azure.com/azure-sdk
-          --project public
-          --prefix ${{parameters.Prefix}}
-          --devopspath "\${{parameters.Prefix}}"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention ci
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --debug
-          ${{parameters.CIConventionOptions}}
-        displayName: Create CI pipelines for public repository
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-          --organization https://dev.azure.com/azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}
-          --devopspath "\${{parameters.Prefix}}"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention up
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --debug
-          ${{parameters.UPConventionOptions}}
-        displayName: Create UP pipelines for public repository
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-          --organization https://dev.azure.com/azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}
-          --devopspath "\${{parameters.Prefix}}"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention tests
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --debug
-          ${{parameters.TestsConventionOptions}}
-        displayName: Create Live Test pipelines for public repository
-        condition: ne('${{parameters.TestsConventionOptions}}','')
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 
-    # This covers our -pr repositories.
-    - ${{ if endsWith(parameters.Repository, '-pr')}}:
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-          --organization https://dev.azure.com/azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}-pr
-          --devopspath "\${{parameters.Prefix}}\pr"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention ci
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --debug
-          --no-schedule
-          ${{parameters.CIConventionOptions}}
-        displayName: Create CI pipelines for private repository
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-          --organization https://dev.azure.com/azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}-pr
-          --devopspath "\${{parameters.Prefix}}\pr"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention up
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --debug
-          --no-schedule
-          ${{parameters.UPConventionOptions}}
-        displayName: Create UP pipelines for private repository
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-          --organization https://dev.azure.com/azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}-pr
-          --devopspath "\${{parameters.Prefix}}\pr"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention tests
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --debug
-          --no-schedule
-          ${{parameters.TestsConventionOptions}}
-        displayName: Create Live Test pipelines for private repository
-        condition: ne('${{parameters.TestsConventionOptions}}','')
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+steps:
+  - template: install-pipeline-generation.yml
+  - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+  # This covers our public repos.
+  - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project public
+        --prefix ${{parameters.Prefix}}
+        --devopspath "\${{parameters.Prefix}}"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention ci
+        --agentpool Hosted
+        --branch refs/heads/$(DefaultBranch)
+        --patvar PATVAR
+        --debug
+        ${{parameters.CIConventionOptions}}
+      displayName: Create CI pipelines for public repository
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}
+        --devopspath "\${{parameters.Prefix}}"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention up
+        --agentpool Hosted
+        --branch refs/heads/$(DefaultBranch)
+        --patvar PATVAR
+        --debug
+        ${{parameters.UPConventionOptions}}
+      displayName: Create UP pipelines for public repository
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}
+        --devopspath "\${{parameters.Prefix}}"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention tests
+        --agentpool Hosted
+        --branch refs/heads/$(DefaultBranch)
+        --patvar PATVAR
+        --debug
+        ${{parameters.TestsConventionOptions}}
+      displayName: Create Live Test pipelines for public repository
+      condition: ne('${{parameters.TestsConventionOptions}}','')
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+
+  # This covers our -pr repositories.
+  - ${{ if endsWith(parameters.Repository, '-pr')}}:
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}-pr
+        --devopspath "\${{parameters.Prefix}}\pr"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention ci
+        --agentpool Hosted
+        --branch refs/heads/$(DefaultBranch)
+        --patvar PATVAR
+        --debug
+        --no-schedule
+        ${{parameters.CIConventionOptions}}
+      displayName: Create CI pipelines for private repository
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}-pr
+        --devopspath "\${{parameters.Prefix}}\pr"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention up
+        --agentpool Hosted
+        --branch refs/heads/$(DefaultBranch)
+        --patvar PATVAR
+        --debug
+        --no-schedule
+        ${{parameters.UPConventionOptions}}
+      displayName: Create UP pipelines for private repository
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}-pr
+        --devopspath "\${{parameters.Prefix}}\pr"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention tests
+        --agentpool Hosted
+        --branch refs/heads/$(DefaultBranch)
+        --patvar PATVAR
+        --debug
+        --no-schedule
+        ${{parameters.TestsConventionOptions}}
+      displayName: Create Live Test pipelines for private repository
+      condition: ne('${{parameters.TestsConventionOptions}}','')
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)

--- a/eng/common/pipelines/templates/steps/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/steps/prepare-pipelines.yml
@@ -13,125 +13,128 @@ parameters:
   - name: TestsConventionOptions
     type: string
     default: ''
+jobs:
+- job: PreparePipelines
+  pool:
+    vmImage: 'windows-2019'
+  steps:
+    - template: install-pipeline-generation.yml
+    - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+    # This covers our public repos.
+    - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project public
+          --prefix ${{parameters.Prefix}}
+          --devopspath "\${{parameters.Prefix}}"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention ci
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --debug
+          ${{parameters.CIConventionOptions}}
+        displayName: Create CI pipelines for public repository
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}
+          --devopspath "\${{parameters.Prefix}}"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention up
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --debug
+          ${{parameters.UPConventionOptions}}
+        displayName: Create UP pipelines for public repository
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}
+          --devopspath "\${{parameters.Prefix}}"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention tests
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --debug
+          ${{parameters.TestsConventionOptions}}
+        displayName: Create Live Test pipelines for public repository
+        condition: ne('${{parameters.TestsConventionOptions}}','')
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 
-steps:
-  - template: install-pipeline-generation.yml
-  - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
-  # This covers our public repos.
-  - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project public
-        --prefix ${{parameters.Prefix}}
-        --devopspath "\${{parameters.Prefix}}"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention ci
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --debug
-        ${{parameters.CIConventionOptions}}
-      displayName: Create CI pipelines for public repository
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}
-        --devopspath "\${{parameters.Prefix}}"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention up
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --debug
-        ${{parameters.UPConventionOptions}}
-      displayName: Create UP pipelines for public repository
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}
-        --devopspath "\${{parameters.Prefix}}"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention tests
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --debug
-        ${{parameters.TestsConventionOptions}}
-      displayName: Create Live Test pipelines for public repository
-      condition: ne('${{parameters.TestsConventionOptions}}','')
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-
-  # This covers our -pr repositories.
-  - ${{ if endsWith(parameters.Repository, '-pr')}}:
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}-pr
-        --devopspath "\${{parameters.Prefix}}\pr"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention ci
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --debug
-        --no-schedule
-        ${{parameters.CIConventionOptions}}
-      displayName: Create CI pipelines for private repository
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}-pr
-        --devopspath "\${{parameters.Prefix}}\pr"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention up
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --debug
-        --no-schedule
-        ${{parameters.UPConventionOptions}}
-      displayName: Create UP pipelines for private repository
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}-pr
-        --devopspath "\${{parameters.Prefix}}\pr"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention tests
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --debug
-        --no-schedule
-        ${{parameters.TestsConventionOptions}}
-      displayName: Create Live Test pipelines for private repository
-      condition: ne('${{parameters.TestsConventionOptions}}','')
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    # This covers our -pr repositories.
+    - ${{ if endsWith(parameters.Repository, '-pr')}}:
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}-pr
+          --devopspath "\${{parameters.Prefix}}\pr"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention ci
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --debug
+          --no-schedule
+          ${{parameters.CIConventionOptions}}
+        displayName: Create CI pipelines for private repository
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}-pr
+          --devopspath "\${{parameters.Prefix}}\pr"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention up
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --debug
+          --no-schedule
+          ${{parameters.UPConventionOptions}}
+        displayName: Create UP pipelines for private repository
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}-pr
+          --devopspath "\${{parameters.Prefix}}\pr"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention tests
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --debug
+          --no-schedule
+          ${{parameters.TestsConventionOptions}}
+        displayName: Create Live Test pipelines for private repository
+        condition: ne('${{parameters.TestsConventionOptions}}','')
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)


### PR DESCRIPTION
VM image is not set for prepare pipeline and devops uses implicit image name ubuntu16. Job is failing due to incorrect image name when ubuntu16 is used by pipeline. This PR is to set image name to windows 2019