### PR TITLE
Update list of cosmos containers to backup

### DIFF
--- a/scripts/python/apiview-syncdb/sync_cosmosdb.py
+++ b/scripts/python/apiview-syncdb/sync_cosmosdb.py
@@ -21,7 +21,7 @@ http_logger.setLevel(logging.WARNING)
 
 COSMOS_SELECT_ID_PARTITIONKEY_QUERY = "select c.id, c.{0} as partitionKey, c._ts from {1} c"
 
-COSMOS_CONTAINERS = ["Reviews", "Comments", ]
+COSMOS_CONTAINERS = ["Reviews", "Comments", "PullRequests"]
 BACKUP_CONTAINER = "backups"
 BLOB_NAME_PATTERN ="cosmos/{0}/{1}"
 


### PR DESCRIPTION
Azure data factory creates backup files in current date folder within storage container. Sync script needs update to restore Pull requests container to staging instance.