### PR TITLE
Skip caching reviews access by backend services

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -179,7 +179,7 @@ namespace APIViewWeb.Repositories
 
         private async Task GetFormattedDiff(RenderedCodeFile renderedCodeFile, ReviewRevisionModel lastRevision, StringBuilder stringBuilder)
         {
-            RenderedCodeFile autoReview = await _codeFileRepository.GetCodeFileAsync(lastRevision);
+            RenderedCodeFile autoReview = await _codeFileRepository.GetCodeFileAsync(lastRevision, false);
             var autoReviewTextFile = autoReview.RenderText(showDocumentation: false, skipDiff: true);
             var prCodeTextFile = renderedCodeFile.RenderText(showDocumentation: false, skipDiff: true);
             var diffLines = InlineDiff.Compute(autoReviewTextFile, prCodeTextFile, autoReviewTextFile, prCodeTextFile);

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -360,7 +360,7 @@ namespace APIViewWeb.Respositories
         public async Task<bool> IsReviewSame(ReviewRevisionModel revision, RenderedCodeFile renderedCodeFile)
         {
             //This will compare and check if new code file content is same as revision in parameter
-            var lastRevisionFile = await _codeFileRepository.GetCodeFileAsync(revision);
+            var lastRevisionFile = await _codeFileRepository.GetCodeFileAsync(revision, false);
             var lastRevisionTextLines = lastRevisionFile.RenderText(showDocumentation: false, skipDiff: true);
             var fileTextLines = renderedCodeFile.RenderText(showDocumentation: false, skipDiff: true);
             return lastRevisionTextLines.SequenceEqual(fileTextLines);


### PR DESCRIPTION
Avoid caching when reviews are created  or compared by PR or CI pipeline