### PR TITLE
Remove the new sdk check and populate json for track 1 package

### DIFF
--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -107,6 +107,7 @@ if ($allPackageProperties)
           $configFilePrefix = $pkg.ArtifactName
         }
         $outputPath = Join-Path -Path $outDirectory "$configFilePrefix.json"
+        Write-Host "Output path of json file: $outputPath"
         SetOutput $outputPath $pkg
     }
 


### PR DESCRIPTION
We currently do not populate {package}.json file for track 1 packages which is used to release step to read package properties.

However, we expect to support all packages which utilize our pipeline to release. 

The PR is to remove the `new_sdk` check so that we generate and publish json file whenever they go through our pipelines.

The change failed at reading line from `msbuild` command. We are lack of ability to tell which line is "introduction message" , which line actually reading the package info.

Here is fix: https://github.com/Azure/azure-sdk-for-net/pull/24950