### PR TITLE
[Swift] APIView: Support async keyword

### DIFF
--- a/src/swift/Sources/Models/TokenFile.swift
+++ b/src/swift/Sources/Models/TokenFile.swift
@@ -587,6 +587,16 @@ class TokenFile: Codable {
         }
     }
 
+    private func handle(async: AsyncKind) {
+        switch `async` {
+        case .async:
+            keyword(value: `async`.textDescription)
+            whitespace()
+        default:
+            return
+        }
+    }
+
     private func handle(throws: ThrowsKind) {
         switch `throws` {
         case .throwing, .rethrowing:
@@ -645,6 +655,7 @@ class TokenFile: Codable {
         }
         punctuation(")")
         whitespace()
+        handle(async: signature.asyncKind)
         handle(throws: signature.throwsKind)
         handle(result: signature.result?.type)
         whitespace()


### PR DESCRIPTION
Fixes #2129.

Note: Other fixes were required in a branch of `swift-ast` which SwiftAPIView relies on. 