### PR TITLE
Make lang ver explicit whild sdk ver is explicit

### DIFF
--- a/eng/Directory.Build.props
+++ b/eng/Directory.Build.props
@@ -4,7 +4,7 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>8.0</LangVersion>
     <SignAssembly>true</SignAssembly>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/BlobUploadProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/BlobUploadProcessor.cs
@@ -18,7 +18,7 @@
     public class BlobUploadProcessor
     {
         private const string TimeFormat = @"yyyy-MM-dd\THH:mm:ss.fffffff\Z";
-        private static readonly JsonSerializerSettings jsonSettings = new()
+        private static readonly JsonSerializerSettings jsonSettings = new JsonSerializerSettings()
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             Formatting = Formatting.None,


### PR DESCRIPTION
Currently, language version is "Latest", but the netcore sdk for ci builds is pinned at 3.1.   This is problematic on dev machines that have later sdk versions installed as it lets devs use language features that aren't supported in the ci builds.