### PR TITLE
Add ci/publish and readme for stress test generator

### DIFF
--- a/tools/stress-cluster/chaos/README.md
+++ b/tools/stress-cluster/chaos/README.md
@@ -143,6 +143,8 @@ The usage of helm charts allows for two primary scenarios:
 - Stress tests can easily take dependencies on core configuration and templates required to interact with the cluster
 - Stress tests can easily be deployed and removed via the `helm` command line tool.
 
+**To quickly bootstrap a stress test package configuration, see the [stress test generator](https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/cluster/kubernetes/generator/README.md)**
+
 ### Layout
 
 The basic layout for a stress test is the following (see `examples/stress_deployment_example` for an example):

--- a/tools/stress-cluster/cluster/kubernetes/generator/README.md
+++ b/tools/stress-cluster/cluster/kubernetes/generator/README.md
@@ -1,0 +1,44 @@
+# Stress Test Generator
+
+This directory contains a CLI program for quickly generating a [stress test package](https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/chaos/README.md#creating-a-stress-test).
+
+## Usage
+
+*Dependencies*:
+
+- [.NET runtime](https://dotnet.microsoft.com/download)
+
+*To install the generator*:
+
+```
+dotnet tool install stress.generator --global --version '1.0.0-dev.*' --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
+```
+
+*To run the generator*:
+
+```
+mkdir <stress test package dir>
+stress-test-generator -d <stress test package dir>
+```
+
+The tool will ask a series of prompts to help generate the stress test package configuration and layout.
+
+After generation, see the docs on [Creating a Stress Test](https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/chaos/README.md#creating-a-stress-test) and [Deploying a Stress Test](https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/chaos/README.md#deploying-a-stress-test) to add and exercise your test code.
+
+## Development
+
+*Dev dependencies*:
+- [Dotnet SDK](https://dotnet.microsoft.com/download)
+
+*To build and run*:
+
+```
+# Omit the command line flags to generate in current working directory
+dotnet run -p ./Stress.Generator -- -d <output directory>
+```
+
+*To test*:
+
+```
+dotnet test
+```

--- a/tools/stress-cluster/cluster/kubernetes/generator/Stress.Generator/Program.cs
+++ b/tools/stress-cluster/cluster/kubernetes/generator/Stress.Generator/Program.cs
@@ -1,17 +1,44 @@
 using System;
+using System.IO;
+using CommandLine;
 
 namespace Stress.Generator
 {
     public class Program
     {
-        public static void Main()
+        public class Options
         {
-            Console.WriteLine("This program will help generate a stress test package.");
-            Console.WriteLine("CAUTION: This program may overwrite existing files.");
+            [Option('d', "directory", Required = false, HelpText = "Output directory for stress test.")]
+            public string OutputDirectory { get; set; } = Directory.GetCurrentDirectory();
+        }
 
-            var generator = new Generator();
-            var package = generator.GenerateResource<StressTestPackage>();
-            package.Write();
+        public static void Main(string[] args)
+        {
+            Parser.Default.ParseArguments<Options>(args).WithParsed<Options>(o =>
+            {
+                Console.WriteLine("This program will help generate a stress test package.");
+                Console.WriteLine("CAUTION: This program may overwrite existing files.");
+
+                var outdir = Path.GetFullPath(o.OutputDirectory);
+
+                var generator = new Generator();
+                var package = generator.GenerateResource<StressTestPackage>();
+
+                if (!Directory.Exists(outdir))
+                {
+                    Directory.CreateDirectory(outdir);
+                }
+                Directory.SetCurrentDirectory(outdir);
+
+                foreach (var f in Directory.GetFiles(outdir))
+                {
+                    Console.WriteLine(f);
+                }
+
+                package.Write();
+
+                Console.WriteLine($"Stress test created at {outdir}");
+            });
         }
     }
 }

--- a/tools/stress-cluster/cluster/kubernetes/generator/Stress.Generator/Stress.Generator.csproj
+++ b/tools/stress-cluster/cluster/kubernetes/generator/Stress.Generator/Stress.Generator.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net5.0</TargetFramework>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>stress-test-generator</ToolCommandName>
     <RootNamespace>Stress.Generator</RootNamespace>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>

--- a/tools/stress-cluster/cluster/kubernetes/generator/Stress.Generator/Stress.Generator.csproj
+++ b/tools/stress-cluster/cluster/kubernetes/generator/Stress.Generator/Stress.Generator.csproj
@@ -8,4 +8,8 @@
     <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser" Version="2.8.0" />
+  </ItemGroup>
+
 </Project>

--- a/tools/stress-cluster/cluster/kubernetes/generator/ci.yml
+++ b/tools/stress-cluster/cluster/kubernetes/generator/ci.yml
@@ -1,0 +1,22 @@
+# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+trigger:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - tools/stress-cluster/cluster/kubernetes/generator
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - tools/stress-cluster/cluster/kubernetes/generator
+
+extends:
+  template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+  parameters:
+    ToolDirectory: tools/stress-cluster/cluster/kubernetes/generator
+    DotNetCoreVersion: 5.0.301


### PR DESCRIPTION
This PR adds documentation and dotnet tool publishing for the stress test generator.

- Add output directory flag to stress test generator
- [stress test generator] Add pipeline and readme
