### PR TITLE
[Test-Proxy] Don't match on `x-ms-useragent`

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
@@ -7,6 +7,7 @@
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>test-proxy</ToolCommandName>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.10.0" />

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -38,6 +38,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             "x-ms-date",
             "x-ms-client-request-id",
             "User-Agent",
+            "x-ms-useragent",
             "Request-Id",
             "traceparent"
         };
@@ -49,6 +50,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             "x-ms-date",
             "x-ms-client-request-id",
             "User-Agent",
+            "x-ms-useragent",
             "Request-Id",
             "If-Match",
             "If-None-Match",


### PR DESCRIPTION
We actually already treat the header `User-Agent` as volatile, so this isn't even a departure from what the test-proxy already does. Just an extension of it.

@HarshaNalluru 