### PR TITLE
[Test-Proxy] More explicit error handling around `Admin/Add<Sanitizer/Matcher/Transform>`

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
@@ -1,3 +1,4 @@
+using Azure.Sdk.Tools.TestProxy.Matchers;
 using Azure.Sdk.Tools.TestProxy.Sanitizers;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
@@ -19,22 +20,198 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
     /// </summary>
     public class AdminFunctionalityTests
     {
-
-
         [Fact]
-        public void TestSetMatcher()
+        public async void TestSetMatcher()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-abstraction-identifier"] = "BodilessMatcher";
+            httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{}");
 
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            testRecordingHandler.Sanitizers.Clear();
+            await controller.SetMatcher();
+
+            var result = testRecordingHandler.Matcher;
+            Assert.True(result is BodilessMatcher);
         }
 
         [Fact]
-        public void TestAddSanitizer()
+        public async void TestSetMatcherIndividualRecording()
+        {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            await testRecordingHandler.StartPlayback("Test.RecordEntries/oauth_request_with_variables.json", httpContext.Response);
+            var recordingId = httpContext.Response.Headers["x-recording-id"];
+            httpContext.Request.Headers["x-recording-id"] = recordingId;
+            httpContext.Request.Headers["x-abstraction-identifier"] = "BodilessMatcher";
+            httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{}");
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            await controller.SetMatcher();
+
+            var result = testRecordingHandler.PlaybackSessions[recordingId].CustomMatcher;
+            Assert.True(result is BodilessMatcher);
+        }
+
+        [Fact]
+        public async void TestSetMatcherThrowsOnBadRecordingId()
+        {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-recording-id"] = "bad-recording-id";
+            httpContext.Request.Headers["x-abstraction-identifier"] = "BodilessMatcher";
+            httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{}");
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+
+            await Assert.ThrowsAsync<BadHttpRequestException>(
+               async () => await controller.SetMatcher()
+            );
+        }
+
+        [Fact]
+        public async void TestAddSanitizer()
         {
             // arrange
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
-            var apiVersion = "2016-03-21";
-            httpContext.Request.Headers["x-api-version"] = apiVersion;
+            httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
+            httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
+            httpContext.Request.ContentLength = 92;
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            testRecordingHandler.Sanitizers.Clear();
+            await controller.AddSanitizer();
+
+            var result = testRecordingHandler.Sanitizers.First();
+            Assert.True(result is HeaderRegexSanitizer);
+        }
+
+        [Fact]
+        public async void TestAddSanitizerWrongEmptyValue()
+        {
+            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            //var httpContext = new DefaultHttpContext();
+            //httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
+            //httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
+            //httpContext.Request.ContentLength = 92;
+
+            //var controller = new Admin(testRecordingHandler)
+            //{
+            //    ControllerContext = new ControllerContext()
+            //    {
+            //        HttpContext = httpContext
+            //    }
+            //};
+            //testRecordingHandler.Sanitizers.Clear();
+            //await controller.AddSanitizer();
+
+            //var result = testRecordingHandler.Sanitizers.First();
+            //Assert.True(result is HeaderRegexSanitizer);
+        }
+
+        [Fact]
+        public async void TestAddSanitizerAcceptableEmptyValue()
+        {
+            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            //var httpContext = new DefaultHttpContext();
+            //httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
+            //httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
+            //httpContext.Request.ContentLength = 92;
+
+            //var controller = new Admin(testRecordingHandler)
+            //{
+            //    ControllerContext = new ControllerContext()
+            //    {
+            //        HttpContext = httpContext
+            //    }
+            //};
+            //testRecordingHandler.Sanitizers.Clear();
+            //await controller.AddSanitizer();
+
+            //var result = testRecordingHandler.Sanitizers.First();
+            //Assert.True(result is HeaderRegexSanitizer);
+        }
+
+        [Fact]
+        public async void TestAddSanitizerUnsetResolvesNull()
+        {
+            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            //var httpContext = new DefaultHttpContext();
+            //httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
+            //httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
+            //httpContext.Request.ContentLength = 92;
+
+            //var controller = new Admin(testRecordingHandler)
+            //{
+            //    ControllerContext = new ControllerContext()
+            //    {
+            //        HttpContext = httpContext
+            //    }
+            //};
+            //testRecordingHandler.Sanitizers.Clear();
+            //await controller.AddSanitizer();
+
+            //var result = testRecordingHandler.Sanitizers.First();
+            //Assert.True(result is HeaderRegexSanitizer);
+        }
+
+        [Fact]
+        public async void TestAddSanitizerIndividualRecording()
+        {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            await testRecordingHandler.StartPlayback("Test.RecordEntries/oauth_request_with_variables.json", httpContext.Response);
+            var recordingId = httpContext.Response.Headers["x-recording-id"];
+            httpContext.Request.Headers["x-recording-id"] = recordingId;
+            httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
+            httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
+            httpContext.Request.ContentLength = 92;
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            await controller .AddSanitizer();
+
+            var result = testRecordingHandler.PlaybackSessions[recordingId].AdditionalSanitizers.First();
+            Assert.True(result is HeaderRegexSanitizer);
+        }
+
+        [Fact]
+        public async void TestAddSanitizerThrowsOnBadRecordingId()
+        {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-recording-id"] = "bad-recording-id";
             httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
             httpContext.Request.ContentLength = 92;
@@ -47,18 +224,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            testRecordingHandler.Sanitizers.Clear();
-
-            controller.AddSanitizer();
-
-            var result = testRecordingHandler.Sanitizers.First();
-            Assert.True(result is HeaderRegexSanitizer);
+            await Assert.ThrowsAsync<BadHttpRequestException>(
+               async () => await controller.AddSanitizer()
+            );
         }
 
         [Fact]
-        public void TestAddTransform()
+        public async void TestAddTransform()
         {
-            // arrange
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
             var apiVersion = "2016-03-21";
@@ -74,33 +247,58 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
 
             testRecordingHandler.Transforms.Clear();
-
-            // act
-            controller.AddTransform();
-
+            await controller .AddTransform();
             var result = testRecordingHandler.Transforms.First();
 
-            // assert
             Assert.True(result is ApiVersionTransform);
         }
 
         [Fact]
-        public void TestAddTransformIndividualRecording()
+        public async void TestAddTransformIndividualRecording()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            await testRecordingHandler.StartPlayback("Test.RecordEntries/oauth_request_with_variables.json", httpContext.Response);
+            var recordingId = httpContext.Response.Headers["x-recording-id"];
+            var apiVersion = "2016-03-21";
+            httpContext.Request.Headers["x-api-version"] = apiVersion;
+            httpContext.Request.Headers["x-abstraction-identifier"] = "ApiVersionTransform";
+            httpContext.Request.Headers["x-recording-id"] = recordingId;
 
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            await controller .AddTransform();
+
+            var result = testRecordingHandler.PlaybackSessions[recordingId].AdditionalTransforms.First();
+            Assert.True(result is ApiVersionTransform);
         }
 
-
         [Fact]
-        public void TestAddSanitizerIndividualRecording()
+        public async void TestAddTransformThrowsOnBadRecordingId()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            var apiVersion = "2016-03-21";
+            httpContext.Request.Headers["x-api-version"] = apiVersion;
+            httpContext.Request.Headers["x-abstraction-identifier"] = "ApiVersionTransform";
+            httpContext.Request.Headers["x-recording-id"] = "bad-recording-id";
 
-        }
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
 
-        [Fact]
-        public void TestSetMatcherIndividualRecording()
-        {
-
+            await Assert.ThrowsAsync<BadHttpRequestException>(
+               async () => await controller.AddTransform()
+            );
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
     public class AdminFunctionalityTests
     {
         [Fact]
-        public async void TestSetMatcher()
+        public async Task TestSetMatcher()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.IO;
 using System.Linq;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Azure.Sdk.Tools.TestProxy.Tests

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
@@ -207,7 +207,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public async void TestAddTransform()
+        public async Task TestAddTransform()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
@@ -115,70 +115,47 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [Fact]
         public async void TestAddSanitizerWrongEmptyValue()
         {
-            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            //var httpContext = new DefaultHttpContext();
-            //httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
-            //httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
-            //httpContext.Request.ContentLength = 92;
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
+            httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
+            httpContext.Request.ContentLength = 92;
 
-            //var controller = new Admin(testRecordingHandler)
-            //{
-            //    ControllerContext = new ControllerContext()
-            //    {
-            //        HttpContext = httpContext
-            //    }
-            //};
-            //testRecordingHandler.Sanitizers.Clear();
-            //await controller.AddSanitizer();
-
-            //var result = testRecordingHandler.Sanitizers.First();
-            //Assert.True(result is HeaderRegexSanitizer);
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            testRecordingHandler.Sanitizers.Clear();
+            
+            await Assert.ThrowsAsync<BadHttpRequestException>(
+               async () => await controller.AddSanitizer()
+            );
         }
 
         [Fact]
         public async void TestAddSanitizerAcceptableEmptyValue()
         {
-            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            //var httpContext = new DefaultHttpContext();
-            //httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
-            //httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
-            //httpContext.Request.ContentLength = 92;
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
+            httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"\" }");
+            httpContext.Request.ContentLength = 92;
 
-            //var controller = new Admin(testRecordingHandler)
-            //{
-            //    ControllerContext = new ControllerContext()
-            //    {
-            //        HttpContext = httpContext
-            //    }
-            //};
-            //testRecordingHandler.Sanitizers.Clear();
-            //await controller.AddSanitizer();
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            testRecordingHandler.Sanitizers.Clear();
+            await controller.AddSanitizer();
 
-            //var result = testRecordingHandler.Sanitizers.First();
-            //Assert.True(result is HeaderRegexSanitizer);
-        }
-
-        [Fact]
-        public async void TestAddSanitizerUnsetResolvesNull()
-        {
-            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            //var httpContext = new DefaultHttpContext();
-            //httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
-            //httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
-            //httpContext.Request.ContentLength = 92;
-
-            //var controller = new Admin(testRecordingHandler)
-            //{
-            //    ControllerContext = new ControllerContext()
-            //    {
-            //        HttpContext = httpContext
-            //    }
-            //};
-            //testRecordingHandler.Sanitizers.Clear();
-            //await controller.AddSanitizer();
-
-            //var result = testRecordingHandler.Sanitizers.First();
-            //Assert.True(result is HeaderRegexSanitizer);
+            var result = testRecordingHandler.Sanitizers.First();
+            Assert.True(result is HeaderRegexSanitizer);
         }
 
         [Fact]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -91,7 +91,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             testRecordingHandler.Sanitizers.Clear();
             testRecordingHandler.Sanitizers.Add(new BodyRegexSanitizer("sanitized", ".*"));
-            testRecordingHandler.AddRecordSanitizer(recordingId, new GeneralRegexSanitizer("sanitized", ".*"));
+            testRecordingHandler.AddSanitizerToRecording(recordingId, new GeneralRegexSanitizer("sanitized", ".*"));
             testRecordingHandler.SetDefaultExtensions(recordingId);
             var session = testRecordingHandler.RecordingSessions.First().Value;
 
@@ -115,7 +115,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             testRecordingHandler.Sanitizers.Clear();
             testRecordingHandler.Sanitizers.Add(new BodyRegexSanitizer("sanitized", ".*"));
             testRecordingHandler.Transforms.Clear();
-            testRecordingHandler.AddRecordSanitizer(recordingId, new GeneralRegexSanitizer("sanitized", ".*"));
+            testRecordingHandler.AddSanitizerToRecording(recordingId, new GeneralRegexSanitizer("sanitized", ".*"));
             testRecordingHandler.SetDefaultExtensions();
             var session = testRecordingHandler.RecordingSessions.First().Value;
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -47,7 +47,7 @@ namespace Azure.Sdk.Tools.TestProxy
         }
 
         [HttpPost]
-        public async void AddTransform()
+        public async Task AddTransform()
         {
             var tName = RecordingHandler.GetHeader(Request, "x-abstraction-identifier");
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
@@ -56,7 +56,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (recordingId != null)
             {
-                _recordingHandler.AddPlaybackTransform(recordingId, t);
+                _recordingHandler.AddTransformToRecording(recordingId, t);
             }
             else
             {
@@ -65,7 +65,7 @@ namespace Azure.Sdk.Tools.TestProxy
         }
 
         [HttpPost]
-        public async void AddSanitizer()
+        public async Task AddSanitizer()
         {
             var sName = RecordingHandler.GetHeader(Request, "x-abstraction-identifier");
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
@@ -74,7 +74,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (recordingId != null)
             {
-                _recordingHandler.AddRecordSanitizer(recordingId, s);
+                _recordingHandler.AddSanitizerToRecording(recordingId, s);
             }
             else
             {
@@ -83,7 +83,7 @@ namespace Azure.Sdk.Tools.TestProxy
         }
 
         [HttpPost]
-        public async void SetMatcher()
+        public async Task SetMatcher()
         {
             var mName = RecordingHandler.GetHeader(Request, "x-abstraction-identifier");
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
@@ -92,7 +92,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (recordingId != null)
             {
-                _recordingHandler.SetPlaybackMatcher(recordingId, m);
+                _recordingHandler.SetMatcherForRecording(recordingId, m);
             }
             else
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -115,7 +115,7 @@ namespace Azure.Sdk.Tools.TestProxy
             return GenerateInstance("Azure.Sdk.Tools.TestProxy.Matchers.", name, new string[]{}, documentBody:body);
         }
 
-        public object GenerateInstance(string typePrefix, string name, string[] acceptableEmptyArgs, JsonDocument documentBody = null)
+        private object GenerateInstance(string typePrefix, string name, string[] acceptableEmptyArgs, JsonDocument documentBody = null)
         {
             try
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -102,20 +102,20 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public object GetSanitizer(string name, JsonDocument body)
         {
-            return GenerateInstance("Azure.Sdk.Tools.TestProxy.Sanitizers.", name, new string[] { "value" }, documentBody: body);
+            return GenerateInstance("Azure.Sdk.Tools.TestProxy.Sanitizers.", name, new HashSet<string>() { "value" }, documentBody: body);
         }
 
         public object GetTransform(string name, JsonDocument body)
         {
-            return GenerateInstance("Azure.Sdk.Tools.TestProxy.Transforms.", name, new string[]{}, documentBody: body);
+            return GenerateInstance("Azure.Sdk.Tools.TestProxy.Transforms.", name, new HashSet<string>() { }, documentBody: body);
         }
 
         public object GetMatcher(string name, JsonDocument body)
         {
-            return GenerateInstance("Azure.Sdk.Tools.TestProxy.Matchers.", name, new string[]{}, documentBody:body);
+            return GenerateInstance("Azure.Sdk.Tools.TestProxy.Matchers.", name, new HashSet<string>() { }, documentBody:body);
         }
 
-        private object GenerateInstance(string typePrefix, string name, string[] acceptableEmptyArgs, JsonDocument documentBody = null)
+        private object GenerateInstance(string typePrefix, string name, HashSet<string> acceptableEmptyArgs, JsonDocument documentBody = null)
         {
             try
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -134,7 +134,7 @@ namespace Azure.Sdk.Tools.TestProxy
                     {
                         var valueResult = jsonElement.GetString();
 
-                        if(String.IsNullOrEmpty(valueResult))
+                        if(string.IsNullOrEmpty(valueResult))
                         {
                             if (!acceptableEmptyArgs.Contains(param.Name))
                             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -382,9 +382,6 @@ namespace Azure.Sdk.Tools.TestProxy
         #endregion
 
         #region common functions
-
-
-
         public void AddSanitizerToRecording(string recordingId, RecordedTestSanitizer sanitizer)
         {
             if (PlaybackSessions.TryGetValue(recordingId, out var playbackSession))

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -250,16 +250,6 @@ namespace Azure.Sdk.Tools.TestProxy
             return upstreamRequest;
         }
 
-        public void AddRecordSanitizer(string recordingId, RecordedTestSanitizer sanitizer)
-        {
-            if (!RecordingSessions.TryGetValue(recordingId, out var session))
-            {
-                throw new InvalidOperationException("No recording loaded with that ID.");
-            }
-
-            session.ModifiableSession.AdditionalSanitizers.Add(sanitizer);
-        }
-
         #endregion
 
         #region playback functionality
@@ -389,39 +379,55 @@ namespace Azure.Sdk.Tools.TestProxy
             return entry;
         }
 
-        public void AddPlaybackSanitizer(string recordingId, RecordedTestSanitizer sanitizer)
+        #endregion
+
+        #region common functions
+
+
+
+        public void AddSanitizerToRecording(string recordingId, RecordedTestSanitizer sanitizer)
         {
-            if (!PlaybackSessions.TryGetValue(recordingId, out var session))
+            if (PlaybackSessions.TryGetValue(recordingId, out var playbackSession))
             {
-                throw new InvalidOperationException("No recording loaded with that ID.");
+                playbackSession.AdditionalSanitizers.Add(sanitizer);
             }
 
-            session.AdditionalSanitizers.Add(sanitizer);
-        }
-
-        public void SetPlaybackMatcher(string recordingId, RecordMatcher matcher)
-        {
-            if (!PlaybackSessions.TryGetValue(recordingId, out var session))
+            if (RecordingSessions.TryGetValue(recordingId, out var recordingSession))
             {
-                throw new InvalidOperationException("No recording loaded with that ID.");
+                recordingSession.ModifiableSession.AdditionalSanitizers.Add(sanitizer);
             }
 
-            session.CustomMatcher = matcher;
+            if (InMemorySessions.TryGetValue(recordingId, out var inMemSession))
+            {
+                inMemSession.AdditionalSanitizers.Add(sanitizer);
+            }
+
+            if (inMemSession == null && recordingSession == (null, null) && playbackSession == null)
+            {
+                throw new BadHttpRequestException($"{recordingId} is not an active session for either record or playback. Check the value being passed and try again.");
+            }
         }
 
-        public void AddPlaybackTransform(string recordingId, ResponseTransform transform)
+        public void AddTransformToRecording(string recordingId, ResponseTransform transform)
         {
             if (!PlaybackSessions.TryGetValue(recordingId, out var session))
             {
-                throw new InvalidOperationException("No recording loaded with that ID.");
+                throw new BadHttpRequestException($"{recordingId} is not an active playback session. Check the value being passed and try again.");
             }
 
             session.AdditionalTransforms.Add(transform);
         }
 
-        #endregion
 
-        #region common functions
+        public void SetMatcherForRecording(string recordingId, RecordMatcher matcher)
+        {
+            if (!PlaybackSessions.TryGetValue(recordingId, out var session))
+            {
+                throw new BadHttpRequestException($"{recordingId} is not an active playback session. Check the value being passed and try again.");
+            }
+
+            session.CustomMatcher = matcher;
+        }
 
         public void SetDefaultExtensions(string recordingId = null)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/UriRegexSanitizer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/UriRegexSanitizer.cs
@@ -18,7 +18,7 @@ namespace Azure.Sdk.Tools.TestProxy.Sanitizers
         /// <param name="value">The substitution value.</param>
         /// <param name="regex">A regex. Can be defined as a simple regex replace OR if groupForReplace is set, a subsitution operation.</param>
         /// <param name="groupForReplace">The capture group that needs to be operated upon. Do not set if you're invoking a simple replacement operation.</param>
-        public UriRegexSanitizer(string value = "Sanitized", string regex = ".*", string groupForReplace = null)
+        public UriRegexSanitizer(string value = "Sanitized", string regex = null, string groupForReplace = null)
         {
             _regexValue = regex;
             _newValue = value;


### PR DESCRIPTION
@seankane-msft I ended up spending a bunch of time in the tests. There should be _no_ visible change to the API surface with this PR, but we get a lot more explicit about a specific class of errors.