### PR TITLE
Add additional blob exports to pipeline witness

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/BlobUploadProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/BlobUploadProcessor.cs
@@ -2,6 +2,8 @@
 {
     using System;
     using System.IO;
+    using System.Linq;
+    using System.Text;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
 
@@ -16,7 +18,9 @@
 
     public class BlobUploadProcessor
     {
+        private const string BuildsContainerName = "builds";
         private const string BuildLogLinesContainerName = "buildloglines";
+        private const string BuildTimelineRecordsContainerName = "buildtimelinerecords";
 
         private const string TimeFormat = @"yyyy-MM-dd\THH:mm:ss.fffffff\Z";
         private static readonly JsonSerializerSettings jsonSettings = new JsonSerializerSettings()
@@ -27,8 +31,10 @@
 
         private readonly ILogger<BlobUploadProcessor> logger;
         private readonly BuildLogProvider logProvider;
-        private readonly BlobContainerClient containerClient;
         private readonly BuildHttpClient buildClient;
+        private readonly BlobContainerClient buildLogLinesContainerClient;
+        private readonly BlobContainerClient buildsContainerClient;
+        private readonly BlobContainerClient buildTimelineRecordsContainerClient;
 
         public BlobUploadProcessor(ILogger<BlobUploadProcessor> logger, BuildLogProvider logProvider, BlobServiceClient blobServiceClient, BuildHttpClient buildClient)
         {
@@ -40,30 +46,185 @@
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.logProvider = logProvider ?? throw new ArgumentNullException(nameof(logProvider));
             this.buildClient = buildClient ?? throw new ArgumentNullException(nameof(buildClient));
-            this.containerClient = blobServiceClient.GetBlobContainerClient(BuildLogLinesContainerName);
+            this.buildsContainerClient = blobServiceClient.GetBlobContainerClient(BuildsContainerName);
+            this.buildTimelineRecordsContainerClient = blobServiceClient.GetBlobContainerClient(BuildTimelineRecordsContainerName);
+            this.buildLogLinesContainerClient = blobServiceClient.GetBlobContainerClient(BuildLogLinesContainerName);
         }
 
-        public async Task UploadLogBlobsAsync(Build build)
+        public async Task UploadBuildBlobsAsync(
+            string account,
+            Build build,
+            Timeline timeline)
         {
+            await UploadBuildBlobAsync(account, build);
+
+            await UploadTimelineBlobAsync(account, build, timeline);
+
             var logs = await buildClient.GetBuildLogsAsync(build.Project.Id, build.Id);
 
             foreach (var log in logs)
             {
-                var blobPath = $"{build.Project.Name}/{build.QueueTime:yyyy/MM/dd}/{build.Id}-{log.Id}.jsonl";
-                var blobClient = containerClient.GetBlobClient(blobPath);
-
-                if (await blobClient.ExistsAsync())
-                {
-                    this.logger.LogInformation("Skipping existing log {LogId} for build {BuildId}", log.Id, build.Id);
-                    continue;
-                }
-
-                await UploadLogBlobAsync(blobClient, build, log);
+                await UploadLogLinesBlobAsync(account, build, log);
             }
         }
 
-        private async Task UploadLogBlobAsync(BlobClient blobClient, Build build, BuildLog log)
+        private async Task UploadBuildBlobAsync(string account, Build build)
         {
+            try
+            {
+                var blobPath = $"{build.Project.Name}/{build.FinishTime:yyyy/MM/dd}/{build.Id}.jsonl";
+                var blobClient = this.buildsContainerClient.GetBlobClient(blobPath);
+
+                if (await blobClient.ExistsAsync())
+                {
+                    this.logger.LogInformation("Skipping existing build blob for build {BuildId}", build.Id);
+                    return;
+                }
+
+                var content = JsonConvert.SerializeObject(new
+                {
+                    OrganizationName = account,
+                    ProjectId = build.Project.Id,
+                    BuildId = build.Id,
+                    DefinitionId = build.Definition.Id,
+                    RepositoryId = build.Repository.Id,
+                    BuildNumber = build.BuildNumber,
+                    BuildNumberRevision = build.BuildNumberRevision,
+                    DefinitionName = build.Definition.Name,
+                    DefinitionPath = build.Definition.Path,
+                    DefinitionProjectId = build.Definition.Project.Id,
+                    DefinitionProjectName = build.Definition.Project.Name,
+                    DefinitionProjectRevision = build.Definition.Project.Revision,
+                    DefinitionProjectState = build.Definition.Project.State,
+                    DefinitionRevision = build.Definition.Revision,
+                    DefinitionType = build.Definition.Type,
+                    QueueTime = build.QueueTime,
+                    StartTime = build.StartTime,
+                    FinishTime = build.FinishTime,
+                    KeepForever = build.KeepForever,
+                    LastChangedByDisplayName = build.LastChangedBy?.DisplayName,
+                    LastChangedById = build.LastChangedBy?.Id,
+                    LastChangedByIsContainer = build.LastChangedBy?.IsContainer,
+                    LastChangedByUniqueName = build.LastChangedBy?.UniqueName,
+                    LastChangedDate = build.LastChangedDate,
+                    LogsId = build.Logs?.Id,
+                    LogsType = build.Logs?.Type,
+                    OrchestrationPlanId = build.OrchestrationPlan?.PlanId,
+                    Parameters = build.Parameters,
+                    PlanId = build.Plans.FirstOrDefault()?.PlanId,
+                    Priority = build.Priority,
+                    ProjectName = build.Project?.Name,
+                    ProjectRevision = build.Project?.Revision,
+                    ProjectState = build.Project?.State,
+                    QueueId = build.Queue?.Id,
+                    QueueName = build.Queue?.Name,
+                    QueuePoolId = build.Queue?.Pool?.Id,
+                    QueuePoolName = build.Queue?.Pool?.Name,
+                    Reason = build.Reason,
+                    RepositoryCheckoutSubmodules = build.Repository?.CheckoutSubmodules,
+                    RepositoryType = build.Repository?.Type,
+                    RequestedByDisplayName = build.RequestedBy?.DisplayName,
+                    RequestedById = build.RequestedBy?.Id,
+                    RequestedByIsContainer = build.RequestedBy?.IsContainer,
+                    RequestedByUniqueName = build.RequestedBy?.UniqueName,
+                    RequestedForDisplayName = build.RequestedFor?.DisplayName,
+                    RequestedForId = build.RequestedFor?.Id,
+                    RequestedForIsContainer = build.RequestedFor?.IsContainer,
+                    RequestedForUniqueName = build.RequestedFor?.UniqueName,
+                    Result = build.Result,
+                    RetainedByRelease = build.RetainedByRelease,
+                    SourceBranch = build.SourceBranch,
+                    SourceVersion = build.SourceVersion,
+                    Status = build.Status,
+                    Tags = build.Tags?.Any() == true ? JsonConvert.SerializeObject(build.Tags, jsonSettings) : null,
+                    Uri = build.Uri,
+                    ValidationResults = build.ValidationResults,
+                    Data = JsonConvert.SerializeObject(build, jsonSettings),
+                    EtlIngestDate = DateTime.UtcNow,
+                }, jsonSettings);
+
+                await blobClient.UploadAsync(new BinaryData(content));
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Error processing build blob for build {BuildId}", build.Id);
+                throw;
+            }
+        }
+
+        private async Task UploadTimelineBlobAsync(string account, Build build, Timeline timeline)
+        {
+            try
+            {
+                var blobPath = $"{build.Project.Name}/{build.FinishTime:yyyy/MM/dd}/{build.Id}-{timeline.ChangeId}.jsonl";
+                var blobClient = this.buildTimelineRecordsContainerClient.GetBlobClient(blobPath);
+
+                if (await blobClient.ExistsAsync())
+                {
+                    this.logger.LogInformation("Skipping existing timeline for build {BuildId}", build.Id);
+                    return;
+                }
+
+                var builder = new StringBuilder();
+                foreach(var record in timeline.Records)
+                {
+                    builder.AppendLine(JsonConvert.SerializeObject(new
+                    {
+                        OrganizationName = account,
+                        ProjectId = build.Project.Id,
+                        BuildId = build.Id,
+                        BuildTimelineId = timeline.Id,
+                        RepositoryId = build.Repository.Id,
+                        RecordId = record.Id,
+                        ParentId = record.ParentId,
+                        ChangeId = timeline.ChangeId,
+                        LastChangedBy = timeline.LastChangedBy,
+                        LastChangedOn = timeline.LastChangedOn,
+                        RecordChangeId = record.ChangeId,
+                        DetailsChangeId = record.Details?.ChangeId,
+                        DetailsId = record.Details?.Id,
+                        WorkerName = record.WorkerName,
+                        RecordName = record.Name,
+                        Order = record.Order,
+                        StartTime = record.StartTime,
+                        FinishTime = record.FinishTime,
+                        WarningCount = record.WarningCount,
+                        ErrorCount = record.ErrorCount,
+                        LogId = record.Log?.Id,
+                        LogType = record.Log?.Type,
+                        PercentComplete = record.PercentComplete,
+                        Result = record.Result,
+                        State = record.State,
+                        TaskId = record.Task?.Id,
+                        TaskName = record.Task?.Name,
+                        TaskVersion = record.Task?.Version,
+                        Type = record.RecordType,
+                        Issues = record.Issues?.Any() == true ? JsonConvert.SerializeObject(record.Issues, jsonSettings) : null,
+                        EtlIngestDate = DateTime.UtcNow,
+                    }, jsonSettings));
+                }
+
+                await blobClient.UploadAsync(new BinaryData(builder.ToString()));
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Error processing timeline for build {BuildId}", build.Id);
+                throw;
+            }
+        }
+
+        private async Task UploadLogLinesBlobAsync(string account, Build build, BuildLog log)
+        {
+            // we don't use FinishTime in the logs blob path to prevent duplicating logs when processing retries
+            var blobPath = $"{build.Project.Name}/{build.QueueTime:yyyy/MM/dd}/{build.Id}-{log.Id}.jsonl";
+            var blobClient = this.buildLogLinesContainerClient.GetBlobClient(blobPath);
+
+            if (await blobClient.ExistsAsync())
+            {
+                this.logger.LogInformation("Skipping existing log {LogId} for build {BuildId}", log.Id, build.Id);
+                return;
+            }
+
             var tempFile = Path.GetTempFileName();
 
             try
@@ -92,7 +253,7 @@
                         await messagesWriter.WriteLineAsync(JsonConvert.SerializeObject(
                             new
                             {
-                                OrganizationName = "azure-sdk",
+                                OrganizationName = account,
                                 ProjectId = build.Project.Id,
                                 BuildId = build.Id,
                                 BuildDefinitionId = build.Definition.Id,
@@ -117,7 +278,10 @@
             }
             finally
             {
-                File.Delete(tempFile);
+                if (File.Exists(tempFile))
+                {
+                    File.Delete(tempFile);
+                }
             }
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/RunProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/RunProcessor.cs
@@ -30,6 +30,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             this.vssConnection = vssConnection ?? throw new ArgumentNullException(nameof(vssConnection));
         }
 
+        private const string Account = "azure-sdk";
         private readonly IFailureAnalyzer failureAnalyzer;
         private readonly ILogger<RunProcessor> logger;
         private readonly CosmosClient cosmosClient;
@@ -41,7 +42,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             // We want to throw if we start getting messages from other Azure DevOps
             // organizations since currently Pipeline Witness is designed to only work
             // against our instance.
-            return uri.Host == "dev.azure.com" && uri.PathAndQuery.StartsWith("/azure-sdk/");
+            return uri.Host == "dev.azure.com" && uri.PathAndQuery.StartsWith($"/{Account}/");
         }
 
         public async Task ProcessRunAsync(Uri runUri)
@@ -141,7 +142,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             var container = await GetItemContainerAsync("azure-pipelines-runs");
             await container.UpsertItemAsync(run);
 
-            await this.blobUploadProcessor.UploadLogBlobsAsync(build);
+            await this.blobUploadProcessor.UploadBuildBlobsAsync(Account, build, timeline);
         }
 
         public async Task<Failure[]> GetFailureClassificationsAsync(Build build, Timeline timeline)

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogProvider.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogProvider.cs
@@ -2,7 +2,6 @@
 using System.Linq;
 using System.Threading.Tasks;
 
-using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.VisualStudio.Services.WebApi;
@@ -12,39 +11,24 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services
     public class BuildLogProvider
     {
         private readonly ILogger<BuildLogProvider> logger;
-        private readonly IMemoryCache cache;
         private readonly VssConnection vssConnection;
 
-        public BuildLogProvider(ILogger<BuildLogProvider> logger, IMemoryCache cache, VssConnection vssConnection)
+        public BuildLogProvider(ILogger<BuildLogProvider> logger, VssConnection vssConnection)
         {
             this.logger = logger;
-            this.cache = cache;
             this.vssConnection = vssConnection;
-        }
-
-        protected BuildLogProvider()
-        {
         }
 
         public virtual async Task<IReadOnlyList<string>> GetLogLinesAsync(Build build, int logId)
         {
-            var cacheKey = $"{build.Id}:{logId}";
+            logger.LogTrace("Getting logs for build {BuildId}, log {LogId} from rest api", build.Id, logId);
 
-            logger.LogTrace("Getting logs for {CacheKey} from cache", cacheKey);
-            var lines = await this.cache.GetOrCreateAsync(cacheKey, async entry =>
-            {
-                logger.LogTrace("Cache miss for {CacheKey}, falling back to rest api", cacheKey);
-                var buildHttpClient = vssConnection.GetClient<BuildHttpClient>();
-                var response = await buildHttpClient.GetBuildLogLinesAsync(build.Project.Id, build.Id, logId);
-                var characterCount = response.Sum(x => x.Length);
-                entry.Priority = CacheItemPriority.Low;
-                entry.Size =characterCount + 4;
+            var buildHttpClient = vssConnection.GetClient<BuildHttpClient>();
+            var response = await buildHttpClient.GetBuildLogLinesAsync(build.Project.Id, build.Id, logId);
 
-                logger.LogTrace("Caching {CharacterCount} characters in {LineCount} lines for {CacheKey}", characterCount, response.Count, cacheKey);
-                return response;
-            });
+            logger.LogTrace("Received {CharacterCount} characters in {LineCount} lines for build {BuildId}, log {LogId}", response.Sum(x => x.Length), response.Count, build.Id, logId);
 
-            return lines;
+            return response;
         }
     }
 }


### PR DESCRIPTION
Removes the cache from the log provider to reduce memory pressure.
Adds Build and BuildTimelineRecord exports to support additional tables in Kusto