### PR TITLE
Automate stress test eng-common-tools dockerfile release pipeline

### DIFF
--- a/eng/containers/ci.yml
+++ b/eng/containers/ci.yml
@@ -28,6 +28,13 @@ parameters:
     dockerFile: 'tools/stress-cluster/services/Stress.Watcher/Dockerfile'
     stableTags:
     - 'latest'
+  - name: stress_common_tools
+    pool: 'ubuntu-20.04'
+    dockerRepo: 'engsys/eng-common-tools'
+    prepareScript: tools/stress-cluster/prepare.ps1
+    dockerFile: 'tools/stress-cluster/Dockerfile'
+    stableTags:
+    - 'latest'
 
 trigger:
   branches:
@@ -39,6 +46,7 @@ trigger:
     - tools/test-proxy/docker/
     - tools/keyvault-mock-attestation/Dockerfile
     - tools/stress-cluster/services/Stress.Watcher/Dockerfile
+    - tools/stress-cluster/Dockerfile
 
 pr:
   branches:
@@ -50,6 +58,7 @@ pr:
     - tools/test-proxy/docker/
     - tools/keyvault-mock-attestation/Dockerfile
     - tools/stress-cluster/services/Stress.Watcher/Dockerfile
+    - tools/stress-cluster/Dockerfile
 
 variables:
   - name: containerRegistry

--- a/eng/containers/ci.yml
+++ b/eng/containers/ci.yml
@@ -28,11 +28,11 @@ parameters:
     dockerFile: 'tools/stress-cluster/services/Stress.Watcher/Dockerfile'
     stableTags:
     - 'latest'
-  - name: stress_common_tools
+  - name: stress_deploy_test_resources
     pool: 'ubuntu-20.04'
-    dockerRepo: 'engsys/eng-common-tools'
-    prepareScript: tools/stress-cluster/prepare.ps1
-    dockerFile: 'tools/stress-cluster/Dockerfile'
+    dockerRepo: 'stress/deploy-test-resources'
+    prepareScript: tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/prepare.ps1
+    dockerFile: 'tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/Dockerfile'
     stableTags:
     - 'latest'
 
@@ -46,7 +46,7 @@ trigger:
     - tools/test-proxy/docker/
     - tools/keyvault-mock-attestation/Dockerfile
     - tools/stress-cluster/services/Stress.Watcher/Dockerfile
-    - tools/stress-cluster/Dockerfile
+    - tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/Dockerfile
 
 pr:
   branches:
@@ -58,7 +58,7 @@ pr:
     - tools/test-proxy/docker/
     - tools/keyvault-mock-attestation/Dockerfile
     - tools/stress-cluster/services/Stress.Watcher/Dockerfile
-    - tools/stress-cluster/Dockerfile
+    - tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/Dockerfile
 
 variables:
   - name: containerRegistry


### PR DESCRIPTION
Updating the docker release pipeline to automatically publish the dockerfile for stress test deployment container