### PR TITLE
[APIView Python] Fix logic for determining if methods are async

### DIFF
--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.2.5 (Unreleased)
 Fixed bug in which kwargs were duplicated in certain instances.
+Fix issue where non-async methods were erroneously marked async.
 
 ## Version 0.2.2 (Unreleased)
 Bug fixes in type hint parser

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -69,9 +69,16 @@ class FunctionNode(NodeEntityBase):
     def _inspect(self):
         logging.debug("Processing function {0}".format(self.name))
         code = inspect.getsource(self.obj).strip()
-        # We cannot do "startswith" check here due to annotations or decorators present for functions
-        self.is_async = "async def" in code
-        self.def_key = "async def" if self.is_async else "def"
+        
+        for line in code.splitlines():
+            # skip decorators
+            if line.startswith("@"):
+                continue
+            # the first non-decorator line should be the function signature
+            self.is_async = line.startswith("async def")
+            self.def_key = "async def" if self.is_async else "def"
+            break
+
         # Update namespace ID to reflect async status. Otherwise ID will conflict between sync and async methods
         if self.is_async:
             self.namespace_id += ":async"
@@ -86,7 +93,7 @@ class FunctionNode(NodeEntityBase):
                     if hasattr(x, "name")
                 ]
         except:
-            # todo Update exception details in error
+            # TODO: Update exception details in error
             error_message = "Error in parsing decorators for function {}".format(
                 self.name
             )

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -72,10 +72,10 @@ class FunctionNode(NodeEntityBase):
         
         for line in code.splitlines():
             # skip decorators
-            if line.startswith("@"):
+            if line.strip().startswith("@"):
                 continue
             # the first non-decorator line should be the function signature
-            self.is_async = line.startswith("async def")
+            self.is_async = line.strip().startswith("async def")
             self.def_key = "async def" if self.is_async else "def"
             break
 


### PR DESCRIPTION
Fixes #1931

The prior logic would pick up if a method defined _inside_ another method was async and erroneously apply that to the containing method.

https://apiviewstaging.azurewebsites.net/Assemblies/Review/69e35769d0ad47f289f327cb400076ce?diffRevisionId=4a84ae61cb9e4c989c95c0ef3fd348c3&doc=False&diffOnly=True