### PR TITLE
[Test-Proxy] Update Exception Handling For Error Propogation, Allow No-Op BodyKeySanitizer

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminFunctionalityTests.cs
@@ -1,3 +1,4 @@
+using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Matchers;
 using Azure.Sdk.Tools.TestProxy.Sanitizers;
 using Azure.Sdk.Tools.TestProxy.Transforms;
@@ -5,6 +6,7 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -84,9 +86,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            await Assert.ThrowsAsync<BadHttpRequestException>(
+            var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.SetMatcher()
             );
+            assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
 
         [Fact]
@@ -131,9 +134,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             testRecordingHandler.Sanitizers.Clear();
             
-            await Assert.ThrowsAsync<BadHttpRequestException>(
+            var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.AddSanitizer()
             );
+            assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
 
         [Fact]
@@ -202,9 +206,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            await Assert.ThrowsAsync<BadHttpRequestException>(
+            var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.AddSanitizer()
             );
+            assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
 
         [Fact]
@@ -274,9 +279,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            await Assert.ThrowsAsync<BadHttpRequestException>(
+            var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.AddTransform()
             );
+            assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/SanitizerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/SanitizerTests.cs
@@ -323,9 +323,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var replacementValue = "BodyIsSanitized";
 
             var bodyKeySanitizer = new BodyKeySanitizer(jsonPath: "$.Location", value: replacementValue);
+            var originalValue = Encoding.UTF8.GetString(targetEntry.Request.Body);
             session.Session.Sanitize(bodyKeySanitizer);
+            var newValue = Encoding.UTF8.GetString(targetEntry.Request.Body);
 
-            Assert.DoesNotContain(replacementValue, Encoding.UTF8.GetString(targetEntry.Request.Body));
+            Assert.DoesNotContain(replacementValue, newValue);
+            Assert.Equal(originalValue, newValue);
         }
 
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/post_delete_get_content.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/post_delete_get_content.json
@@ -17,7 +17,7 @@
         "x-ms-date": "Tue, 18 May 2021 23:27:42 GMT",
         "x-ms-version": "2019-02-02"
       },
-      "RequestBody": "{\u0022TableName\u0022: \u0022listtable09bf2a3d\u0022}",
+      "RequestBody": "{\u0022TableName\u0022:    \u0022listtable09bf2a3d\u0022}",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -153,7 +153,6 @@ namespace Azure.Sdk.Tools.TestProxy
                         }
                         else
                         {
-                            // TODO: make this a specific argument not found exception
                             throw new HttpException(HttpStatusCode.BadRequest, $"Required parameter key {param} was not found in the request body.");
                         }
                     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Text.Json;
 using System.Threading.Tasks;
 
@@ -138,7 +139,7 @@ namespace Azure.Sdk.Tools.TestProxy
                         {
                             if (!acceptableEmptyArgs.Contains(param.Name))
                             {
-                                throw new BadHttpRequestException($"Parameter {param.Name} was passed with no value. Please check the request body and try again.");
+                                throw new HttpException(HttpStatusCode.BadRequest, $"Parameter {param.Name} was passed with no value. Please check the request body and try again.");
                             }
                         }
                         
@@ -153,7 +154,7 @@ namespace Azure.Sdk.Tools.TestProxy
                         else
                         {
                             // TODO: make this a specific argument not found exception
-                            throw new BadHttpRequestException($"Required parameter key {param} was not found in the request body.");
+                            throw new HttpException(HttpStatusCode.BadRequest, $"Required parameter key {param} was not found in the request body.");
                         }
                     }
                 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
@@ -24,7 +24,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         public HttpException(int httpStatusCode)
             : this((HttpStatusCode)httpStatusCode)
         {
-            this.StatusCode = httpStatusCode;        
+            this.StatusCode = (HttpStatusCode)httpStatusCode;        
         }
 
         public HttpException(HttpStatusCode statusCode, string message)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
@@ -24,6 +24,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         public HttpException(int httpStatusCode)
             : this((HttpStatusCode)httpStatusCode)
         {
+            this.StatusCode = statusCode;        
         }
 
         public HttpException(HttpStatusCode statusCode, string message)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
@@ -24,7 +24,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         public HttpException(int httpStatusCode)
             : this((HttpStatusCode)httpStatusCode)
         {
-            this.StatusCode = statusCode;        
+            this.StatusCode = httpStatusCode;        
         }
 
         public HttpException(HttpStatusCode statusCode, string message)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
@@ -24,7 +24,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         public HttpException(int httpStatusCode)
             : this((HttpStatusCode)httpStatusCode)
         {
-            this.StatusCode = (HttpStatusCode)httpStatusCode;        
         }
 
         public HttpException(HttpStatusCode statusCode, string message)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.TestProxy.Common
+{
+    public class HttpException : Exception
+    {
+        public HttpStatusCode StatusCode { get; }
+
+        public HttpException(HttpStatusCode statusCode)
+        {
+            this.StatusCode = statusCode;
+        }
+
+        public HttpException(int httpStatusCode)
+            : this((HttpStatusCode)httpStatusCode)
+        {
+        }
+
+        public HttpException(HttpStatusCode statusCode, string message)
+            : base(message)
+        {
+            this.StatusCode = statusCode;
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpException.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
+using System.Runtime.Serialization;
 using System.Threading.Tasks;
 
 namespace Azure.Sdk.Tools.TestProxy.Common
@@ -9,6 +10,11 @@ namespace Azure.Sdk.Tools.TestProxy.Common
     public class HttpException : Exception
     {
         public HttpStatusCode StatusCode { get; }
+
+        public HttpException()
+        {
+            this.StatusCode = HttpStatusCode.InternalServerError;
+        }
 
         public HttpException(HttpStatusCode statusCode)
         {
@@ -25,5 +31,16 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         {
             this.StatusCode = statusCode;
         }
+
+        public HttpException(HttpStatusCode statusCode, string message, Exception innerException) : base(message, innerException)
+        {
+            this.StatusCode = statusCode;
+        }
+
+        protected HttpException(HttpStatusCode statusCode, SerializationInfo info, StreamingContext context) : base(info, context)
+        {
+            this.StatusCode = statusCode;
+        }
+
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace Azure.Sdk.Tools.TestProxy.Common
+{
+    public class HttpExceptionMiddleware
+    {
+        private readonly RequestDelegate next;
+
+        public HttpExceptionMiddleware(RequestDelegate next)
+        {
+            this.next = next;
+        }
+
+        public async Task Invoke(HttpContext context)
+        {
+            try
+            {
+                await this.next.Invoke(context);
+            }
+            catch (HttpException e)
+            {
+                var response = context.Response;
+                if (response.HasStarted)
+                {
+                    throw;
+                }
+
+                int statusCode = (int)e.StatusCode;
+                if (statusCode >= 500 && statusCode <= 599)
+                {
+                    throw;
+                }
+
+                response.Clear();
+                response.StatusCode = statusCode;
+                response.ContentType = "application/json;";
+
+                var bodyObj = new
+                {
+                    Message = e.Message,
+                    Status = e.StatusCode.ToString()
+                };
+
+                var body = JsonSerializer.Serialize(bodyObj);
+                await context.Response.WriteAsync(body);
+            }
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/TestRecordingMismatchException.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/TestRecordingMismatchException.cs
@@ -2,26 +2,27 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Net;
 using System.Runtime.Serialization;
 
 namespace Azure.Sdk.Tools.TestProxy.Common
 {
     [Serializable]
-    public class TestRecordingMismatchException : Exception
+    public class TestRecordingMismatchException : HttpException
     {
-        public TestRecordingMismatchException()
+        public TestRecordingMismatchException() : base(HttpStatusCode.NotFound)
         {
         }
 
-        public TestRecordingMismatchException(string message) : base(message)
+        public TestRecordingMismatchException(string message) : base(HttpStatusCode.NotFound, message)
         {
         }
 
-        public TestRecordingMismatchException(string message, Exception innerException) : base(message, innerException)
+        public TestRecordingMismatchException(string message, Exception innerException) : base(HttpStatusCode.NotFound, message, innerException)
         {
         }
 
-        protected TestRecordingMismatchException(SerializationInfo info, StreamingContext context) : base(info, context)
+        protected TestRecordingMismatchException(SerializationInfo info, StreamingContext context) : base(HttpStatusCode.NotFound, info, context)
         {
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -12,6 +12,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -401,7 +402,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (inMemSession == null && recordingSession == (null, null) && playbackSession == null)
             {
-                throw new BadHttpRequestException($"{recordingId} is not an active session for either record or playback. Check the value being passed and try again.");
+                throw new HttpException(HttpStatusCode.BadRequest, $"{recordingId} is not an active session for either record or playback. Check the value being passed and try again.");
             }
         }
 
@@ -409,7 +410,7 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             if (!PlaybackSessions.TryGetValue(recordingId, out var session))
             {
-                throw new BadHttpRequestException($"{recordingId} is not an active playback session. Check the value being passed and try again.");
+                throw new HttpException(HttpStatusCode.BadRequest, $"{recordingId} is not an active playback session. Check the value being passed and try again.");
             }
 
             session.AdditionalTransforms.Add(transform);
@@ -420,7 +421,7 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             if (!PlaybackSessions.TryGetValue(recordingId, out var session))
             {
-                throw new BadHttpRequestException($"{recordingId} is not an active playback session. Check the value being passed and try again.");
+                throw new HttpException(HttpStatusCode.BadRequest, $"{recordingId} is not an active playback session. Check the value being passed and try again.");
             }
 
             session.CustomMatcher = matcher;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -92,7 +92,6 @@ namespace Azure.Sdk.Tools.TestProxy
                     });
             });
 
-
             services.AddControllers(options =>
             {
                 options.InputFormatters.Add(new EmptyBodyFormatter());
@@ -109,6 +108,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 app.UseDeveloperExceptionPage();
             }
             app.UseCors("DefaultPolicy");
+            app.UseMiddleware<HttpExceptionMiddleware>();
 
             MapRecording(app);
             app.UseRouting();


### PR DESCRIPTION
@JoshLove-msft I will use this basis to propogate the TestMismatchExceptions back.
