### PR TITLE
Added more fallback logic in code owner retriever

### DIFF
--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners/Program.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners/Program.cs
@@ -22,7 +22,7 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners
         {
             var target = targetDirectory.ToLower().Trim();
             var codeOwnersLocation = Path.Join(rootDirectory, ".github", "CODEOWNERS");
-            var owners = CodeOwnersFile.ParseAndFindClosestMatch(codeOwnersLocation, target);
+            var owners = CodeOwnersFile.ParseAndFindOwnersForClosestMatch(codeOwnersLocation, target);
             if (owners == null)
             {
                 Console.WriteLine(String.Format("We cannot find any closest code owners from the target path {0}", targetDirectory));

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners/Program.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners/Program.cs
@@ -1,144 +1,36 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text.Json;
-using System.Net.Http;
-using System.Net.Http.Headers;
-using System.Threading.Tasks;
 using Azure.Sdk.Tools.CodeOwnersParser;
 
 namespace Azure.Sdk.Tools.RetrieveCodeOwners
 {
     class Program
     {
-        private static readonly HttpClient client = new HttpClient();
         /// <summary>
         /// Retrieves codeowners information for specific section of the repo
         /// </summary>
         /// <param name="targetDirectory">The directory whose information is to be retrieved</param>
         /// <param name="rootDirectory">The root of the repo or $(Build.SourcesDirectory) on DevOps</param>
         /// <param name="vsoOwningUsers">Variable for setting user aliases</param>
-        /// <param name="vsoOwningTeams">Variable for setting user aliases</param>
-        /// <param name="vsoOwningLabels">Variable for setting user aliases</param>
         /// <returns></returns>
 
         public static void Main(
             string targetDirectory,
             string rootDirectory,
-            string vsoOwningUsers,
-            string vsoOwningTeams,
-            string vsoOwningLabels
+            string vsoOwningUsers
             )
         {
             var target = targetDirectory.ToLower().Trim();
             var codeOwnersLocation = Path.Join(rootDirectory, ".github", "CODEOWNERS");
-            var parsedEntries = CodeOwnersFile.ParseFile(codeOwnersLocation);
-            var filteredEntries = findClosestMatch(target, parsedEntries);
-
-            client.BaseAddress = new Uri("https://api.github.com/");
-            client.DefaultRequestHeaders.UserAgent.Add(new System.Net.Http.Headers.ProductInfoHeaderValue("CodeOwnerRetriever", "1.0"));
-            client.DefaultRequestHeaders.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("application/json"));
-            
-            List<string> users = new List<string>();
-            List<string> teams = new List<string>();
-            List<string> labels = new List<string>();
-            if (filteredEntries != null)
+            var owners = CodeOwnersFile.ParseAndFindClosestMatch(codeOwnersLocation, target);
+            if (owners == null)
             {
-                Console.WriteLine($"Found the closest code owners to match {target}:");
-                Console.WriteLine(String.Join(", ", filteredEntries.Owners));
-                foreach (var alias in filteredEntries.Owners)
-                {
-                    var userUriStub = $"users/{alias}";
-                    if (VerifyAlias(userUriStub))
-                    {
-                        users.Add(alias);
-                        continue;
-                    }
-                    else
-                    {
-                        // Assume its a team alias
-                        teams.Add(alias);
-                    }
-                }
-                labels.AddRange(filteredEntries.PRLabels);
-                labels.AddRange(filteredEntries.ServiceLabels);
+                Console.WriteLine(String.Format("We cannot find any closest code owners from the target path {0}", targetDirectory));
             }
-
-            if (vsoOwningUsers != null) {
-                var presentOwningUsers = Environment.GetEnvironmentVariable(vsoOwningUsers);
-                if (presentOwningUsers != null)
-                {
-                    foreach (var item in presentOwningUsers.Split(","))
-                    {
-                        users.Add(item.Trim());
-                    }
-                }
-                Console.WriteLine(String.Format("##vso[task.setvariable variable={0};]{1}", vsoOwningUsers, String.Join(",", users)));
-            }
-
-            if (vsoOwningTeams != null)
+            else
             {
-                var presentOwningTeams = Environment.GetEnvironmentVariable(vsoOwningTeams);
-                if (presentOwningTeams != null)
-                {
-                    foreach (var item in presentOwningTeams.Split(","))
-                    {
-                        teams.Add(item.Trim());
-                    }
-                }
-                Console.WriteLine(String.Format("##vso[task.setvariable variable={0};]{1}", vsoOwningTeams, (String.Join(",", teams))));
+                Console.WriteLine(String.Format("##vso[task.setvariable variable={0};]{1}", vsoOwningUsers, String.Join(",", owners)));
             }
-
-            if (vsoOwningLabels != null)
-            {
-                var presentOwningLabels = Environment.GetEnvironmentVariable(vsoOwningLabels);
-                if (presentOwningLabels != null)
-                {
-                    foreach (var item in presentOwningLabels.Split(","))
-                    {
-                        users.Add(item.Trim());
-                    }
-                }
-                Console.WriteLine(String.Format("##vso[task.setvariable variable={0};]{1}", vsoOwningLabels, (String.Join(",", labels))));
-            }
-        }
-
-        private static bool VerifyAlias(string uriStub)
-        {
-            try {
-                var response = client.GetAsync(uriStub);
-                if (response.Result.IsSuccessStatusCode)
-                {
-                    return true;
-                }
-                return false;
-            } catch 
-            {
-                Console.WriteLine($"Http call {uriStub} to failed.");
-                throw;
-            }
-        }
-
-        private static CodeOwnerEntry findClosestMatch(string filePath, List<CodeOwnerEntry> entries)
-        {
-            // Normalize the start and end of the paths by trimming slash
-            filePath = filePath.Trim('/');
-
-            // We want to find the match closest to the bottom of the codeowners file
-            for (int i = entries.Count - 1; i >= 0; i--)
-            {
-                string pathExpression = entries[i].PathExpression.Trim('/');
-
-                // Note that this only matches on paths without glob patterns which is good enough
-                // for our current scenarios but in the future might need to support globs
-                if (filePath.StartsWith(pathExpression, StringComparison.OrdinalIgnoreCase))
-                {
-                    return entries[i];
-                }
-            }
-
-            return null;
         }
     }
 }

--- a/tools/code-owners-parser/CodeOwnersParser/CodeOwnersFile.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/CodeOwnersFile.cs
@@ -79,24 +79,16 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
             // CODEOWNERS sorts the paths in order of 'RepoPath', 'ServicePath' and then 'PackagePath'.
             for (int i = codeOwnerEntries.Count - 1; i >= 0; i--)
             {
-                if (FindClosestMatch(targetPath, codeOwnerEntries[i].PathExpression)) {
+                string codeOwnerPath = codeOwnerEntries[i].PathExpression.Trim('/');
+                // Note that this only matches on paths without glob patterns which is good enough
+                // for our current scenarios but in the future might need to support globs
+                if (targetPath.StartsWith(codeOwnerPath, StringComparison.OrdinalIgnoreCase))
+                {
                     return codeOwnerEntries[i].Owners;
                 }
             }
 
             return null;
-        }
-
-        private static bool FindClosestMatch(string target, string codeOwnerPath)
-        {
-            codeOwnerPath = codeOwnerPath.Trim('/');
-            // Note that this only matches on paths without glob patterns which is good enough
-            // for our current scenarios but in the future might need to support globs
-            if (target.StartsWith(codeOwnerPath, StringComparison.OrdinalIgnoreCase))
-            {
-                return true;
-            }
-            return false;
         }
 
         private static string NormalizeLine(string line)

--- a/tools/code-owners-parser/CodeOwnersParser/CodeOwnersFile.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/CodeOwnersFile.cs
@@ -69,7 +69,7 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
             return entries;
         }
 
-        public static List<string> ParseAndFindClosestMatch(string filePathOrUrl, string targetPath)
+        public static List<string> ParseAndFindOwnersForClosestMatch(string codeOwnersFilePathOrUrl, string targetPath)
         {
             var codeOwnerEntries = ParseFile(filePathOrUrl);
             // Normalize the start and end of the paths by trimming slash

--- a/tools/code-owners-parser/CodeOwnersParser/CodeOwnersFile.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/CodeOwnersFile.cs
@@ -71,12 +71,12 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
 
         public static List<string> ParseAndFindOwnersForClosestMatch(string codeOwnersFilePathOrUrl, string targetPath)
         {
-            var codeOwnerEntries = ParseFile(filePathOrUrl);
+            var codeOwnerEntries = ParseFile(codeOwnersFilePathOrUrl);
             // Normalize the start and end of the paths by trimming slash
             targetPath = targetPath.Trim('/');
 
             // We want to find the match closest to the bottom of the codeowners file.
-            // CODEOWNERS sorts the paths in order of 'RepoPath', 'ServicePath' and 'PackagePath'.
+            // CODEOWNERS sorts the paths in order of 'RepoPath', 'ServicePath' and then 'PackagePath'.
             for (int i = codeOwnerEntries.Count - 1; i >= 0; i--)
             {
                 if (FindClosestMatch(targetPath, codeOwnerEntries[i].PathExpression)) {


### PR DESCRIPTION
**Summary**
Our current code is not able to fallback to upper level when there is mismatch.
**User story:**
In docs auto publish process, we expect to fetch code owner on package level. e.g. `core/core-amqp`
We are able to fetch CODEOWNERS in [here](https://github.com/Azure/azure-sdk-for-js/blob/main/.github/CODEOWNERS#L15)

However, for many package, we do not offer package level codeowners, which will return nothing based on our current code.

**Expectation**
We hope if we do not find any info from package level, we have the ability to fallback to service level. E.g `keyvault/keyvault-keys`
[CODEOWNERS](https://github.com/Azure/azure-sdk-for-js/blob/main/.github/CODEOWNERS#L66) only provide service level owners, so instead of return nothing back, we expect to have service level owners from above link.

The fallback logic is: package level-> service level -> sdk level

**Code tested in local using js repo CODEOWNERS**
input: /sdk/dd/
output: mayurid,lmazuel