### PR TITLE
Remove update review option and update review automatically

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -5,16 +5,6 @@
     ViewData["Title"] = Model.Review.DisplayName;
 }
 
-@if (Model.Review.UpdateAvailable)
-{
-    <div class="alert alert-warning" role="alert" asp-resource="@Model.Review" asp-requirement="@ReviewOwnerRequirement.Instance">
-        <form asp-page-handler="RefreshModel" class=".form-inline" method="post" asp-route-id="@Model.Review.ReviewId">
-            Your code review uses older format and can be updated
-            <button type="submit" class="btn btn-link">Update model</button>
-        </form>
-    </div>
-}
-
 <div class="row">
     <div class="col my-2">
         <div class="dropdown float-left mr-2">

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
@@ -42,12 +42,15 @@ namespace APIViewWeb
             return reviews.FirstOrDefault();
         }
 
-        public async Task<IEnumerable<ReviewModel>> GetReviewsAsync(bool isClosed, string language, string packageName = null, ReviewType filterType = ReviewType.Manual)
+        public async Task<IEnumerable<ReviewModel>> GetReviewsAsync(bool isClosed, string language, string packageName = null, ReviewType? filterType = null)
         {
             var queryStringBuilder = new StringBuilder("SELECT * FROM Reviews r WHERE (IS_DEFINED(r.IsClosed) ? r.IsClosed : false) = @isClosed ");
 
             //Add filter if looking for automatic, manual or PR reviews
-            queryStringBuilder.Append("AND (IS_DEFINED(r.FilterType) ? r.FilterType : 0) = @filterType ");
+            if (filterType != null)
+            {
+               queryStringBuilder.Append("AND (IS_DEFINED(r.FilterType) ? r.FilterType : 0) = @filterType ");
+            }
 
             // Add language and package name clause
             // Currently we don't have any use case of searching for a package name across languages

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -492,11 +492,8 @@ namespace APIViewWeb.Respositories
 
         public async void UpdateReviewBackground()
         {
-            // Enabling this only for manual reviews in the beginning to check impact on system performance
-            // We will enable it for all reviews based on the perf details
-            // Automatic reviews are already updated as part of scheduled upload daily
-            var reviews = await _reviewsRepository.GetReviewsAsync(false, "All", filterType: ReviewType.Manual);
-            foreach(var review in reviews.Where(r => IsUpdateAvailable(r)))
+            var reviews = await _reviewsRepository.GetReviewsAsync(false, "All");
+            foreach (var review in reviews.Where(r => IsUpdateAvailable(r)))
             {
                 var requestTelemetry = new RequestTelemetry { Name = "Updating Review " + review.ReviewId };
                 var operation = _telemetryClient.StartOperation(requestTelemetry);


### PR DESCRIPTION
We have added automated review update when new parser version is present and currently this is only done for manual reviews. This change is to update automatic as well as pull request reviews. This change will also remove UI review update option.