### PR TITLE
Use namespaced cluster role and binding for stress watcher

### DIFF
--- a/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/templates/stresswatcher.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/templates/stresswatcher.yaml
@@ -24,7 +24,7 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: stress-writer
+  name: stress-resource-patcher-{{ .Release.Namespace }}
 rules:
 - apiGroups:
   - '*'
@@ -40,7 +40,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: stress-watcher-cluster-role-binding
+  name: stress-resource-patcher-{{ .Release.Namespace }}
 subjects:
 - namespace: {{ .Release.Namespace }}
   kind: ServiceAccount
@@ -48,4 +48,4 @@ subjects:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: stress-writer
+  name: stress-resource-patcher-{{ .Release.Namespace }}


### PR DESCRIPTION
For cases where the stress-watcher is deployed to multiple namespaces (e.g. during development), updates to the target namespace service account of the cluster role binding would break authorization for previous deployments in other namespaces. This updates the role binding to be unique to the namespace of the helm release