### PR TITLE
Resolve mac agent failure

### DIFF
--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -15,17 +15,11 @@ steps:
       Write-Host "##vso[task.setvariable variable=ASPNETCORE_Kestrel__Certificates__Default__Password]password"
     displayName: 'Configure Kestrel Environment Variables'
 
-  - task: UseDotNet@2
-    displayName: "Use .NET Core SDK"
-    inputs:
-      packageType: sdk
-      version: 5.0.205
-
   - pwsh: |
       dotnet tool install azure.sdk.tools.testproxy `
         --tool-path $(Build.BinariesDirectory)/test-proxy `
         --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json `
-        --version 1.0.0-dev.20210811.2
+        --version 1.0.0-dev.20211104.2
     displayName: "Install test-proxy"
 
   - pwsh: |
@@ -37,11 +31,7 @@ steps:
 
   # nohup does NOT continue beyond the current session if you use it within powershell
   - bash: |
-      sudo nohup $(Build.BinariesDirectory)/test-proxy/test-proxy &
+      nohup $(Build.BinariesDirectory)/test-proxy/test-proxy &
     displayName: "Run the testproxy - linux/mac"
     condition: and(succeeded(), ne(variables['Agent.OS'],'Windows_NT'))
     workingDirectory: "${{ parameters.rootFolder }}"
-
-  - pwsh: |
-      Write-Host "##vso[task.setvariable variable=PATH]$(OriginalPath)"
-    displayName: 'Restore .NET version by resetting path'


### PR DESCRIPTION
1. `sudo` on the mac agents is having the effect of killing the environment variables that are set. That is the origin of being unable to find the `.dylib`
2. `nohup` is no longer  necessary to invoke with `sudo` on linux
3. Removing the `use .net version`, .NET 5.0 is preloaded on the agents.

A follow-up PR is coming that installs dev certificates in a per-platform methodology.

@HarshaNalluru this unblocks you to add to CI. I just gotta push this out for you. Sorry for the delay, this PR seems simple (and it is), but it's pretty much the very last thing I checked.