### PR TITLE
Use arm template parameters as sole input for live test environment variables

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -84,11 +84,13 @@ if (!$PSBoundParameters.ContainsKey('ErrorAction')) {
     $ErrorActionPreference = 'Stop'
 }
 
-function Log($Message) {
+function Log($Message)
+{
     Write-Host ('{0} - {1}' -f [DateTime]::Now.ToLongTimeString(), $Message)
 }
 
-function Retry([scriptblock] $Action, [int] $Attempts = 5) {
+function Retry([scriptblock] $Action, [int] $Attempts = 5)
+{
     $attempt = 0
     $sleep = 5
 
@@ -109,7 +111,20 @@ function Retry([scriptblock] $Action, [int] $Attempts = 5) {
     }
 }
 
-function MergeHashes([hashtable] $source, [psvariable] $dest) {
+function LoadCloudConfig([string] $env)
+{
+    $configPath = "$PSScriptRoot/clouds/$env.json"
+    if (!(Test-Path $configPath)) {
+        Write-Warning "Could not find cloud configuration for environment '$env'"
+        return @{}
+    }
+
+    $config = Get-Content $configPath | ConvertFrom-Json -AsHashtable
+    return $config
+}
+
+function MergeHashes([hashtable] $source, [psvariable] $dest)
+{
     foreach ($key in $source.Keys) {
         if ($dest.Value.ContainsKey($key) -and $dest.Value[$key] -ne $source[$key]) {
             Write-Warning ("Overwriting '$($dest.Name).$($key)' with value '$($dest.Value[$key])' " +
@@ -119,7 +134,8 @@ function MergeHashes([hashtable] $source, [psvariable] $dest) {
     }
 }
 
-function BuildBicepFile([System.IO.FileSystemInfo] $file) {
+function BuildBicepFile([System.IO.FileSystemInfo] $file)
+{
     if (!(Get-Command bicep -ErrorAction Ignore)) {
         Write-Error "A bicep file was found at '$($file.FullName)' but the Azure Bicep CLI is not installed. See https://aka.ms/install-bicep-pwsh"
         throw
@@ -492,6 +508,8 @@ try {
         $templateParameters.Add('testApplicationSecret', $TestApplicationSecret)
     }
 
+    $defaultCloudParameters = LoadCloudConfig $Environment
+    MergeHashes $defaultCloudParameters $(Get-Variable templateParameters)
     MergeHashes $ArmTemplateParameters $(Get-Variable templateParameters)
     MergeHashes $AdditionalParameters $(Get-Variable templateParameters)
 

--- a/eng/common/TestResources/clouds/AzureChinaCloud.json
+++ b/eng/common/TestResources/clouds/AzureChinaCloud.json
@@ -1,0 +1,15 @@
+{
+    "azConfigEndpointSuffix": ".azconfig.azure.cn",
+    "azureAuthorityHost": "https://login.chinacloudapi.cn/",
+    "cognitiveServicesEndpointSuffix": ".cognitiveservices.azure.cn",
+    "containerRegistryEndpointSuffix": ".azurecr.cn",
+    "cosmosEndpointSuffix": "cosmos.azure.cn",
+    "enableStorageVersioning": false,
+    "keyVaultDomainSuffix": ".vault.azure.cn",
+    "keyVaultEndpointSuffix": ".vault.azure.cn",
+    "keyVaultSku": "standard",
+    "searchEndpointSuffix": "search.azure.cn",
+    "serviceBusEndpointSuffix": ".servicebus.chinacloudapi.cn",
+    "storageEndpointSuffix": "core.chinacloudapi.cn",
+    "textAnalyticsSku": "S"
+}

--- a/eng/common/TestResources/clouds/AzureCloud.json
+++ b/eng/common/TestResources/clouds/AzureCloud.json
@@ -1,0 +1,8 @@
+{
+    "azureAuthorityHost": "https://login.microsoftonline.com/",
+    "cognitiveServicesEndpointSuffix": ".cognitiveservices.azure.com",
+    "communicationServicesEndpointSuffix": ".communication.azure.com",
+    "keyVaultDomainSuffix": ".vault.azure.net",
+    "keyVaultEndpointSuffix": ".vault.azure.net",
+    "storageEndpointSuffix": "core.windows.net"
+}

--- a/eng/common/TestResources/clouds/AzureUSGovernment.json
+++ b/eng/common/TestResources/clouds/AzureUSGovernment.json
@@ -1,0 +1,15 @@
+{
+    "azConfigEndpointSuffix": ".azconfig.azure.us",
+    "azureAuthorityHost": "https://login.microsoftonline.us/",
+    "cognitiveServicesEndpointSuffix": ".cognitiveservices.azure.us",
+    "containerRegistryEndpointSuffix": ".azurecr.us",
+    "cosmosEndpointSuffix": "cosmos.azure.us",
+    "enableStorageVersioning": false,
+    "formRecognizerLocation": "usgovvirginia",
+    "keyVaultDomainSuffix": ".vault.usgovcloudapi.net",
+    "keyVaultEndpointSuffix": ".vault.usgovcloudapi.net",
+    "keyVaultSku": "premium",
+    "searchEndpointSuffix": "search.azure.us",
+    "serviceBusEndpointSuffix": ".servicebus.usgovcloudapi.net",
+    "storageEndpointSuffix": "core.usgovcloudapi.net"
+}


### PR DESCRIPTION
For sovereign cloud testing, many cloud-specific arm template parameters and environment variables get passed in from an external keyvault source. This makes them hard to manage and track. This PR moves some common live testing values into source control for easier management. Some values are service-specific (like formRecognizerLocation), so perhaps we could consider a service-specific location for them, but I don't want the config layering to get too complex either.

Related:
https://github.com/Azure/azure-sdk-for-java/pull/25301
https://github.com/Azure/azure-sdk-for-net/pull/25250
https://github.com/Azure/azure-sdk-for-python/pull/21693