### PR TITLE
[Python APIView] Fix issues with DocstringParser and TypehintParser. Add new test cases.

### DIFF
--- a/.azure-pipelines/apiview.yml
+++ b/.azure-pipelines/apiview.yml
@@ -171,7 +171,6 @@ stages:
               cd $(Build.SourcesDirectory)/$(PythonParserPackagePath)
               pip install tox
               tox
-              cd $(Build.SourcesDirectory)
             displayName: 'Test Python Package Parser'
 
           - task: PublishTestResults@2

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
+#build/
 develop-eggs/
 dist/
 downloads/
@@ -25,7 +25,6 @@ wheels/
 *.egg
 MANIFEST
 *.pyc
-*.whl
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -286,6 +285,20 @@ publish/
 # checkin your Azure Web App publish settings, but sensitive information contained
 # in these scripts will be unencrypted
 PublishScripts/
+
+# NuGet Packages
+#*.nupkg
+# The packages folder can be ignored because of Package Restore
+**/[Pp]ackages/*
+!packages/java-packages/
+!tools/sdk-testgen/packages/*
+# except build/, which is used as an MSBuild target.
+!**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+#*.nuget.props
+#*.nuget.targets
 
 # Microsoft Azure Build Output
 csx/

--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-#build/
+build/
 develop-eggs/
 dist/
 downloads/
@@ -25,6 +25,7 @@ wheels/
 *.egg
 MANIFEST
 *.pyc
+*.whl
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -285,20 +286,6 @@ publish/
 # checkin your Azure Web App publish settings, but sensitive information contained
 # in these scripts will be unencrypted
 PublishScripts/
-
-# NuGet Packages
-#*.nupkg
-# The packages folder can be ignored because of Package Restore
-**/[Pp]ackages/*
-!packages/java-packages/
-!tools/sdk-testgen/packages/*
-# except build/, which is used as an MSBuild target.
-!**/[Pp]ackages/build/
-# Uncomment if necessary however generally it will be regenerated when needed
-#!**/[Pp]ackages/repositories.config
-# NuGet v3's project.json files produces more ignorable files
-#*.nuget.props
-#*.nuget.targets
 
 # Microsoft Azure Build Output
 csx/

--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## Version 0.2.6 (Unreleased)
 Updated type parsing to properly handle cases in which type
-info wraps onto a second line.
+  info wraps onto a second line.
+Fixed issue where ivar type was not properly parsed from
+  the docstring.
 
 ## Version 0.2.5 (Unreleased)
 Fixed bug in which kwargs were duplicated in certain instances.

--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -5,6 +5,8 @@ Updated type parsing to properly handle cases in which type
   info wraps onto a second line.
 Fixed issue where ivar type was not properly parsed from
   the docstring.
+Fixed issue where typehint parsing was too strict and required
+  spaces.
 
 ## Version 0.2.5 (Unreleased)
 Fixed bug in which kwargs were duplicated in certain instances.

--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## Version 0.2.6 (Unreleased)
+Updated type parsing to properly handle cases in which type
+info wraps onto a second line.
+
 ## Version 0.2.5 (Unreleased)
 Fixed bug in which kwargs were duplicated in certain instances.
 Fix issue where non-async methods were erroneously marked async.

--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.2.5"
+VERSION = "0.2.6"

--- a/packages/python-packages/api-stub-generator/apistub/nodes/__init__.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/__init__.py
@@ -4,6 +4,7 @@ from ._argtype import ArgType
 from ._base_node import NodeEntityBase, get_qualified_name
 from ._class_node import ClassNode
 from ._docstring_parser import DocstringParser
+from ._typehint_parser import TypeHintParser
 from ._enum_node import EnumNode
 from ._function_node import FunctionNode
 from ._module_node import ModuleNode
@@ -17,6 +18,7 @@ __all__ = [
     "get_qualified_name",
     "ClassNode",
     "DocstringParser",
+    "TypeHintParser",
     "EnumNode",
     "FunctionNode",
     "ModuleNode",

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
@@ -1,8 +1,6 @@
 import logging
 import inspect
-import enum
 from enum import Enum
-import types
 import operator
 
 from ._base_node import NodeEntityBase

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
@@ -161,9 +161,9 @@ class ClassNode(NodeEntityBase):
         docstring = getattr(self.obj, "__doc__")
         if docstring:
             docstring_parser = DocstringParser(docstring)
-            for var in docstring_parser.find_args("ivar"):
+            for key, var in docstring_parser.ivars.items():
                 ivar_node = VariableNode(
-                    self.namespace, self, var.argname, var.argtype, None, True
+                    self.namespace, self, key, var.argtype, None, True
                 )
                 self.child_nodes.append(ivar_node)
 

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -6,19 +6,19 @@ from ._argtype import ArgType
 
 
 # REGEX to parse docstring
-find_arg_regex = "(?<!:):{}\s+([\w]*):(?!:)"
+find_arg_regex = "(?<!:):{}\\s+([\w]*):(?!:)"
 find_arg_and_type_regex = (
-    "(?<!:):{}\s+([~\w.]*[\[?[~\w.]*,?\s?[~\w.]*\]?]?)\s+([\w]*):(?!:)"
+    "(?<!:):{}\\s+([~\w.]*[\[?[~\w.]*,?\\s?[~\w.]*\]?]?)\\s+([\w]*):(?!:)"
 )
-find_single_type_regex = "(?<!:):{0}\s?{1}:[\s]*([\S]+)(?!:)"
+find_single_type_regex = "(?<!:):{0}\\s?{1}:[\\s]*([\S]+)(?!:)"
 find_union_type_regex = (
-    "(?<!:):{0}\s?{1}:[\s]*([\w.]*((\[[^\n]+\])|(\([^\n]+\))))(?!:)"
+    "(?<!:):{0}\\s?{1}:[\\s]*([\w.]*((\[[^\n]+\])|(\([^\n]+\))))(?!:)"
 )
-find_multi_type_regex = "(?<!:):({0})\s?{1}:([^:]+)(?!:)"
-find_docstring_return_type = "(?<!:):rtype\s?:\s+([^:]+)(?!:)"
+find_multi_type_regex = "(?<!:):({0})\\s?{1}:([^:]+)(?!:)"
+find_docstring_return_type = "(?<!:):rtype\\s?:\\s+([^:\n]+)(?!:)"
 
 # Regex to parse type hints
-find_type_hint_ret_type = "(?<!#)\s->\s+([^\n:]*)"
+find_type_hint_ret_type = "(?<!#)\\s->\\s+([^\n:]*)"
 
 docstring_types = ["param", "type", "paramtype", "keyword", "rtype"]
 

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -78,8 +78,7 @@ class DocstringParser:
 
 
     def _update_argtype(self, arg, text) -> ArgType:
-        # Need to parse type info
-        pass
+        arg.argtype = text
 
 
     def _process_arg_triple(self, tag):
@@ -122,11 +121,20 @@ class DocstringParser:
                 if len(split_tag) == 3:
                     self._process_arg_triple(split_tag)
                 elif len(split_tag) == 2:
-                    (arg, is_partial) = self._process_arg_tuple(split_tag, remainder)
+                    (arg, is_partial) = self._process_arg_tuple(split_tag, remainder.strip())
                     partial_arg = arg if is_partial else None
             elif partial_arg:
                 self._update_argtype(partial_arg, line)
                 partial_arg = None
+
+
+    def type_for(self, name):
+        arg = (
+            self.ivars.get(name, None) or
+            self.pos_args.get(name, None) or
+            self.kw_args.get(name, None)
+        )
+        return arg.argtype if arg else arg
 
 
     def find_type(self, type_name="type", var_name=""):

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -5,22 +5,7 @@ import logging
 from ._argtype import ArgType
 
 
-# REGEX to parse docstring
-find_arg_regex = "(?<!:):{}\\s+([\w]*):(?!:)"
-find_arg_and_type_regex = (
-    "(?<!:):{}\\s+([~\w.]*[\[?[~\w.]*,?\\s?[~\w.]*\]?]?)\\s+([\w]*):(?!:)"
-)
-find_single_type_regex = "(?<!:):{0}\\s?{1}:[\\s]*([\S]+)(?!:)"
-find_union_type_regex = (
-    "(?<!:):{0}\\s?{1}:[\\s]*([\w.]*((\[[^\n]+\])|(\([^\n]+\))))(?!:)"
-)
-find_multi_type_regex = "(?<!:):({0})\\s?{1}:([^:]+)(?!:)"
-find_docstring_return_type = "(?<!:):rtype\\s?:\\s+([^:\n]+)(?!:)"
-
-# Regex to parse type hints
 find_type_hint_ret_type = "(?<!#)\\s->\\s+([^\n:]*)"
-
-# New types
 
 line_tag_regex = re.compile(r"^\s*:([^:]+):(.*)")
 
@@ -44,7 +29,6 @@ class DocstringParser:
         self.ret_type = None
         self.docstring = docstring
         self._parse()
-
 
     def _process_arg_tuple(self, tag, line1, line2):
         # When two items are found, it is either the name
@@ -76,7 +60,6 @@ class DocstringParser:
                 # Assume both lines contain type info and concatenate
                 arg.argtype = " ".join([line1, line2])
 
-
     def _arg_for_type(self, name, keyword) -> ArgType:
         if keyword == "type":
             return self.pos_args[name]
@@ -88,7 +71,6 @@ class DocstringParser:
             logging.error(f"Unexpected keyword {keyword}.")
             return None
 
-
     def _process_arg_triple(self, tag):
         # When three items are found, all necessary info is found
         # and there can only be one simple type
@@ -97,6 +79,17 @@ class DocstringParser:
         arg = ArgType(name=name, argtype=typename)
         self._update_arg(arg, keyword)
 
+    def _process_return_type(self, line1, line2):
+        # If there's only useful text in the current or next line, we must
+        # assume that line contains the type info.
+        if line1 and not line2:
+            self.ret_type = line1
+        elif line2 and not line1:
+            self.ret_type = line2
+        else:
+            # TODO: When this assumption breaks down, you will need to revist...
+            # Assume both lines contain type info and concatenate
+            self.ret_type = " ".join([line1, line2])
 
     def _update_arg(self, arg, keyword):
         if keyword == "ivar":
@@ -108,32 +101,35 @@ class DocstringParser:
         else:
             logging.error(f"Unexpected keyword: {keyword}")
 
-
     def _parse(self):
         """Parses a docstring into an object."""
         if not self.docstring:
             logging.error("Unable to parse empty docstring.")
             return
 
-        lines = [x.replace("\n", "").strip() for x in self.docstring.splitlines()]
+        lines = [x.strip() for x in self.docstring.splitlines()]
         for line_no, line in enumerate(lines):
 
-            match = line_tag_regex.match(line)
-            if not match:
+            tag_match = line_tag_regex.match(line)
+            if not tag_match:
                 continue
 
-            (tag, line1) = match.groups()
+            (tag, line1) = tag_match.groups()
             split_tag = tag.split()
             if len(split_tag) == 3:
                 self._process_arg_triple(split_tag)
-            elif len(split_tag) == 2:
-                # retrieve next line, if available
-                try:
-                    line2 = lines[line_no + 1].strip()
-                except IndexError:
-                    line2 = None
-                self._process_arg_tuple(split_tag, line1.strip(), line2)
+                continue
 
+            # retrieve next line, if available
+            try:
+                line2 = lines[line_no + 1].strip()
+            except IndexError:
+                line2 = None
+
+            if len(split_tag) == 2:
+                self._process_arg_tuple(split_tag, line1.strip(), line2)
+            elif len(split_tag) == 1 and split_tag[0] == "rtype":
+                self._process_return_type(line1.strip(), line2)
 
     def type_for(self, name):
         arg = (
@@ -142,88 +138,6 @@ class DocstringParser:
             self.kw_args.get(name, None)
         )
         return arg.argtype if arg else arg
-
-
-# =========================== OLD STUFF ========================
-
-    def find_type(self, type_name="type", var_name=""):
-        # This method will find argument type or return type from docstring
-        # some params takes two types of params and some takes only one type
-        # search for type strings with multiple type like below e.g.
-        # :type <var_name>: <type1> or <type2>
-        multi_type_regex = re.compile(find_multi_type_regex.format(type_name, var_name))
-        type_groups = multi_type_regex.search(self.docstring)
-        if type_groups:
-            type_string = type_groups.groups()[2].replace("\n", "").strip()
-            logging.debug("variable name: {0}, type from docstring: {1}".format(var_name, type_string))
-            return type_string
-
-        # Check for Union type
-        union_type_regex = re.compile(find_union_type_regex.format(type_name, var_name))
-        type_groups = union_type_regex.search(self.docstring)
-        if type_groups:
-            return type_groups.groups()[1]
-
-        # Check for single type param
-        # type e.g. :type <var_name>: <type1>
-        single_type_regex = re.compile(
-            find_single_type_regex.format(type_name, var_name)
-        )
-        type_groups = single_type_regex.search(self.docstring)
-        if type_groups:
-            return type_groups.groups()[-1]
-
-        return None
-
-    def find_return_type(self):
-        # Find return type from docstring
-
-        ret_type = re.search(find_docstring_return_type, self.docstring)
-        if ret_type:
-            ret_type_val = ret_type.groups()[-1]
-            # clean up return types spread over multiple lines
-            ret_type_val = "".join([x.strip() for x in ret_type_val.splitlines()])
-            return ret_type_val.replace(",", ", ").replace("  ", " ")
-
-        return None
-
-    def find_args(self, arg_type="param"):
-        # This method will find positional or kw arguement
-        # find docstring that has both type and arg name in same docstring
-        arg_type_regex = re.compile(find_arg_and_type_regex.format(arg_type))
-        args = arg_type_regex.findall(self.docstring)
-        params = [
-            ArgType(x[1].strip(), x[0].strip())
-            if x[1].strip()
-            else ArgType(x[0].strip())
-            for x in args
-        ]
-
-        # fin param or keyword args that ddoesn't type in same docstring
-        arg_regex = re.compile(find_arg_regex.format(arg_type))
-        args = arg_regex.findall(self.docstring)
-        params.extend([ArgType(x.strip()) for x in args])
-
-        # Get type if it is missing
-        for p in params:
-            # Show kwarg is optional by setting default to "..."
-            if arg_type == "keyword":
-                p.default = "..."
-
-            if not p.argtype:
-                p.argtype = self.find_type("(type|keywordtype|paramtype|vartype)", p.argname)
-        return params
-
-    def parse(self):
-        """Returns a parsed docstring object
-        """
-        if not self.docstring:
-            logging.error("Docstring is empty to parse")
-            return
-
-        self.pos_args = { x.argname: x for x in self.find_args("param") }
-        self.kw_args = { x.argname: x for x in self.find_args("keyword") }
-        self.ret_type = self.find_return_type()
 
 
 class TypeHintParser:

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -30,8 +30,35 @@ class DocstringParser:
     def __init__(self, docstring):
         self.pos_args = OrderedDict()
         self.kw_args = OrderedDict()
+        self.ivars = OrderedDict()
         self.ret_type = None
         self.docstring = docstring
+        self._parse()
+
+    def _parse(self):
+        """Parses a docstring without regex."""
+        if not self.docstring:
+            logging.error("Docstring is empty to parse")
+            return
+
+        line_regex = re.compile(r"^\s*:([^:]+):(.*)")
+
+        for line_no, line in enumerate([x.replace("\n", "").strip() for x in self.docstring.splitlines()]):
+            match = line_regex.match(line)
+            if not match:
+                continue
+
+            (tag, remainder) = match.groups()
+            split_tag = tag.split()
+            if len(split_tag) == 2:
+                (keyword, name) = split_tag
+                test = "best"
+            elif len(split_tag) == 3:
+                (keyword, typename, name) = split_tag
+                test = "best"
+            else:
+                continue
+
 
     def find_type(self, type_name="type", var_name=""):
         # This method will find argument type or return type from docstring

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -87,8 +87,10 @@ class DocstringParser:
         elif line2 and not line1:
             self.ret_type = line2
         else:
-            # TODO: When this assumption breaks down, you will need to revist...
-            # Assume both lines contain type info and concatenate
+            # FIXME: How to distinguish between the case where
+            # the type info is fully contained on one line and followed
+            # by an irrelevant line from the case where the type info
+            # is split across two lines.
             self.ret_type = " ".join([line1, line2])
 
     def _update_arg(self, arg, keyword):

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -110,7 +110,7 @@ class DocstringParser:
 
 
     def _parse(self):
-        """Parses a docstring without regex."""
+        """Parses a docstring into an object."""
         if not self.docstring:
             logging.error("Unable to parse empty docstring.")
             return
@@ -143,6 +143,8 @@ class DocstringParser:
         )
         return arg.argtype if arg else arg
 
+
+# =========================== OLD STUFF ========================
 
     def find_type(self, type_name="type", var_name=""):
         # This method will find argument type or return type from docstring

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -1,11 +1,8 @@
 from collections import OrderedDict
 import re
-import inspect
 import logging
 from ._argtype import ArgType
 
-
-find_type_hint_ret_type = "(?<!#)\\s->\\s+([^\n:]*)"
 
 line_tag_regex = re.compile(r"^\s*:([^:]+):(.*)")
 
@@ -133,31 +130,3 @@ class DocstringParser:
             self.kw_args.get(name, None)
         )
         return arg.argtype if arg else arg
-
-
-class TypeHintParser:
-    """TypeHintParser helps to find return type from type hint is type hint is available
-    :param object: obj
-    """
-
-    def __init__(self, obj):
-        self.obj = obj
-        try:
-            self.code = inspect.getsource(obj)
-        except:
-            self.code = None
-            logging.error("Failed to get source of object {}".format(obj))
-
-    def find_return_type(self):
-        """Returns return type is type hint is available
-        """
-        if not self.code:
-            return None
-
-        # Find return type from type hint
-        ret_type = re.search(find_type_hint_ret_type, self.code)
-        # Don't return None as string literal
-        if ret_type and ret_type != "None":
-            return ret_type.groups()[-1]
-        else:
-            return None

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_docstring_parser.py
@@ -19,7 +19,9 @@ docstring_return_keywords = ["rtype"]
 
 
 class DocstringParser:
-    """This represents a parsed doc string which has list of positional and keyword arguements and return type
+    """This represents a parsed doc string which contain positional, instance, and keyword arguments
+       and return type. Arguments are represented as key-value pairs where the key is the argument
+       name and the value is the argument itself.
     """
 
     def __init__(self, docstring):

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -5,7 +5,8 @@ import astroid
 import operator
 import re
 from inspect import Parameter
-from ._docstring_parser import DocstringParser, TypeHintParser
+from ._docstring_parser import DocstringParser
+from ._typehint_parser import TypeHintParser
 from ._base_node import NodeEntityBase, get_qualified_name
 from ._argtype import ArgType
 
@@ -249,7 +250,7 @@ class FunctionNode(NodeEntityBase):
         # Parse type hint to get return type and types for positional args
         typehint_parser = TypeHintParser(self.obj)
         # Find return type from type hint if return type is not already set
-        type_hint_ret_type = typehint_parser.find_return_type()
+        type_hint_ret_type = typehint_parser.ret_type
         # Type hint must be present for all APIs. Flag it as an error if typehint is missing
         if  not type_hint_ret_type:
             if (is_typehint_mandatory(self.name)):

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -198,7 +198,7 @@ class FunctionNode(NodeEntityBase):
         if docstring:
             #  Parse doc string to find missing types, kwargs and return type
             parsed_docstring = DocstringParser(docstring)
-            parsed_docstring.parse()
+
             # Set return type if not already set
             if not self.return_type and parsed_docstring.ret_type:
                 logging.debug(

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -2,7 +2,6 @@ import logging
 import inspect
 from collections import OrderedDict
 import astroid
-import operator
 import re
 from inspect import Parameter
 from ._docstring_parser import DocstringParser

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_property_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_property_node.py
@@ -34,10 +34,10 @@ class PropertyNode(NodeEntityBase):
             if docstring:
                 docstring_parser = DocstringParser(getattr(self.obj, "__doc__"))
                 try:
-                    self.type = docstring_parser.find_type()
+                    self.type = docstring_parser.type_for(self.name)
                     # Check for rtype docstring
                     if not self.type:
-                        self.type = docstring_parser.find_return_type()
+                        self.type = docstring_parser.ret_type
                 except:
                     self.errors.append("Failed to find type of property {}".format(self.name))
                     

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_property_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_property_node.py
@@ -1,5 +1,6 @@
 from ._base_node import NodeEntityBase
-from ._docstring_parser import DocstringParser, TypeHintParser
+from ._docstring_parser import DocstringParser
+from ._typehint_parser import TypeHintParser
 
 
 class PropertyNode(NodeEntityBase):
@@ -26,7 +27,7 @@ class PropertyNode(NodeEntityBase):
         if hasattr(self.obj, "fget"):
             # Get property type if type hint 
             typehint_parser = TypeHintParser(getattr(self.obj, "fget"))
-            self.type = typehint_parser.find_return_type()
+            self.type = typehint_parser.ret_type
 
         # get type from docstring
         if hasattr(self.obj, "__doc__") and not self.type:

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_typehint_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_typehint_parser.py
@@ -1,0 +1,29 @@
+import re
+import inspect
+import logging
+
+
+find_type_hint_ret_type = "(?<!#)\\s?->\\s?([^\n:]*)"
+
+class TypeHintParser:
+    """TypeHintParser helps to find return type from type hint is type hint is available
+    :param object: obj
+    """
+
+    def __init__(self, obj):
+        self.obj = obj
+        try:
+            code = inspect.getsource(obj)
+            self.ret_type = self._parse_typehint(code)
+        except:
+            self.ret_type = None
+            logging.error("Failed to get source of object {}".format(obj))
+
+    def _parse_typehint(self, source):
+        # Find return type from type hint
+        ret_type = re.search(find_type_hint_ret_type, source)
+        # Don't return None as string literal
+        if ret_type and ret_type != "None":
+            return ret_type.groups()[-1]
+        else:
+            return None

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -17,7 +17,7 @@ Dummy docstring to verify standard return types and param types
 :rtype: Union[str, int]
 """
 
-docstring_Union_return_type2 = """
+docstring_union_return_type_followed_by_irrelevant_text = """
 Dummy docstring to verify standard return types and param types
 :rtype: Union(str, int)
 Dummy string at new line
@@ -65,6 +65,20 @@ docstring_param_nested_union = """
 :param dummyarg: Optional group to check if user exists in.
 :type dummyarg: typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]
 """
+
+docstring_param_multi_line_type_followed_by_irrelevant_text = """
+:param dummyarg: Optional group to check if user exists in.
+:type dummyarg: typing.Union[~azure.eventhub.EventDataBatch,
+    List[~azure.eventhub.EventData]]
+.. admonition:: Example:
+.. literalinclude:: ../samples/sample_detect_language.py
+    :start-after: [START batch_detect_language]
+    :end-before: [END batch_detect_language]
+    :language: python
+    :dedent: 8
+    :caption: Detecting language in a batch of documents.
+"""
+
 
 docstring_multi_complex_type = """
         :param documents: The set of documents to process as part of this batch.
@@ -129,8 +143,14 @@ class TestDocStringParser:
     def test_return_union_return_type(self):
         self._test_return_type(docstring_Union_return_type1, "Union[str, int]")
     
-    def test_return_union_return_type1(self):
-        self._test_return_type(docstring_Union_return_type2, "Union(str, int)")
+    def test_return_union_return_type_followed_by_irrelevant_text(self):
+        self._test_return_type(docstring_union_return_type_followed_by_irrelevant_text, "Union(str, int)")
+
+    def test_param_multi_line_type_followed_by_irrelevant_text(self):
+        self._test_variable_type(
+            docstring_param_multi_line_type_followed_by_irrelevant_text,
+            "dummyarg", "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]"
+        )
 
     def test_return_union_lower_case_return_type(self):
         self._test_return_type(docstring_union_return_type3, "union[str, int]")

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -170,70 +170,38 @@ class TestNewDocStringParser:
         })
 
 
-# class TestDocStringParser:
+class TestDocStringParser:
 
-#     def _test_return_type(self, docstring, expected):
-#         docstring_parser = DocstringParser(docstring)
-#         assert expected == docstring_parser.find_return_type()
+    def _test_return_type(self, docstring, expected):
+        docstring_parser = DocstringParser(docstring)
+        assert expected == docstring_parser.find_return_type()
 
-#     def _test_variable_type(self, docstring, varname, expected):
-#         docstring_parser = DocstringParser(docstring)
-#         assert expected == docstring_parser.find_type("(type|keywordtype|paramtype|vartype)", varname)
-
-#     def _test_find_args(self, docstring, expected_args, is_keyword = False):
-#         parser = DocstringParser(docstring)
-#         expected = {}
-#         for arg in expected_args:
-#             expected[arg.argname] = arg
-#         for arg in parser.find_args('keyword' if is_keyword else 'param'):
-#             assert arg.argname in expected and arg.argtype == expected[arg.argname].argtype
+    def _test_find_args(self, docstring, expected_args, is_keyword = False):
+        parser = DocstringParser(docstring)
+        expected = {}
+        for arg in expected_args:
+            expected[arg.argname] = arg
+        for arg in parser.find_args('keyword' if is_keyword else 'param'):
+            assert arg.argname in expected and arg.argtype == expected[arg.argname].argtype
             
-#     def test_return_builtin_return_type(self):
-#         self._test_return_type(docstring_standard_return_type, "str")
+    def test_return_builtin_return_type(self):
+        self._test_return_type(docstring_standard_return_type, "str")
 
-#     def test_return_union_return_type(self):
-#         self._test_return_type(docstring_Union_return_type1, "Union[str, int]")
+    def test_return_union_return_type(self):
+        self._test_return_type(docstring_Union_return_type1, "Union[str, int]")
     
-#     def test_return_union_return_type_followed_by_irrelevant_text(self):
-#         self._test_return_type(docstring_union_return_type_followed_by_irrelevant_text, "Union(str, int)")
+    def test_return_union_return_type_followed_by_irrelevant_text(self):
+        self._test_return_type(docstring_union_return_type_followed_by_irrelevant_text, "Union(str, int)")
 
-#     def test_param_multi_line_type_followed_by_irrelevant_text(self):
-#         self._test_variable_type(
-#             docstring_param_multi_line_type_followed_by_irrelevant_text,
-#             "dummyarg", "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]"
-#         )
+    def test_return_union_lower_case_return_type(self):
+        self._test_return_type(docstring_union_return_type3, "union[str, int]")
 
-#     def test_return_union_lower_case_return_type(self):
-#         self._test_return_type(docstring_union_return_type3, "union[str, int]")
+    def test_multi_return_type(self):
+        self._test_return_type(docstring_multi_ret_type, "str or ~azure.test.testclass or None")
 
-#     def test_multi_return_type(self):
-#         self._test_return_type(docstring_multi_ret_type, "str or ~azure.test.testclass or None")
+    def test_dict_return_type(self):
+        self._test_return_type(docstring_dict_ret_type, "dict[str, int]")
 
-#     def test_dict_return_type(self):
-#         self._test_return_type(docstring_dict_ret_type, "dict[str, int]")
-
-#     def test_param_type(self):
-#         self._test_variable_type(docstring_param_type, "val", "str")
-
-#     def test_param_type_private(self):
-#         self._test_variable_type(docstring_param_type_private, "client", "~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase")
-
-#     def test_params(self):
-#         args = [ArgType("name", "str"), ArgType("val", "str")]
-#         self._test_find_args(docstring_param_type, args)
-    
-#     def test_param_optional_type(self):
-#         self._test_variable_type(docstring_param_type_split, "pipe_id", "Union[str, int]")
-
-#     def test_param_or_type(self):
-#         self._test_variable_type(docstring_param_type_split, "data", "str or ~azure.dummy.datastream")
-#         self._test_variable_type(docstring_param_type_split, "pipeline", None)
-
-#     def test_type_typing_optional(self):
-#         self._test_variable_type(docstring_param_typing_optional, "group", "typing.Optional[str]")
-
-#     def test_nested_union_type(self):
-#         self._test_variable_type(docstring_param_nested_union, "dummyarg", "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]")
-
-#     def test_multi_text_analytics_type(self):
-#         self._test_variable_type(docstring_multi_complex_type, "documents", "list[str] or list[~azure.ai.textanalytics.DetectLanguageInput] or list[dict[str, str]]")
+    def test_params(self):
+        args = [ArgType("name", "str"), ArgType("val", "str")]
+        self._test_find_args(docstring_param_type, args)

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -6,6 +6,7 @@
 
 from apistub.nodes import DocstringParser
 
+
 docstring_standard_return_type = """
 Dummy docstring to verify standard return types and param types
 :rtype: str

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -173,10 +173,6 @@ class TestDocstringParser:
             "client": "~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase"
         })
 
-    # def test_docstring_intentional_fail(self):
-    #     # TODO: Verify this does (or at least should) fail the CI.
-    #     assert False
-
     def test_return_builtin_return_type(self):
         self._test_return_type(docstring_standard_return_type, "str")
 

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------
 
 from apistub.nodes import DocstringParser
-from apistub.nodes import ArgType
 
 docstring_standard_return_type = """
 Dummy docstring to verify standard return types and param types

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -169,6 +169,10 @@ class TestNewDocStringParser:
             "client": "~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase"
         })
 
+    def test_docstring_intentional_fail(self):
+        # TODO: Verify this does (or at least should) fail the CI.
+        assert False
+
 
 class TestDocStringParser:
 

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -44,7 +44,7 @@ docstring_param_type = """
 :type val: str
 """
 
-docstring_param_type1 = """
+docstring_param_type_split = """
 :param str name: Dummy name param
 :param val: Value type
 :type val: str
@@ -118,71 +118,122 @@ docstring_param_type_private = """
 :type client: ~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase
 """
 
+class TestNewDocStringParser:
 
-class TestDocStringParser:
-
-    def _test_return_type(self, docstring, expected):
-        docstring_parser = DocstringParser(docstring)
-        assert expected == docstring_parser.find_return_type()
-
-    def _test_variable_type(self, docstring, varname, expected):
-        docstring_parser = DocstringParser(docstring)
-        assert expected == docstring_parser.find_type("(type|keywordtype|paramtype|vartype)", varname)
-
-    def _test_find_args(self, docstring, expected_args, is_keyword = False):
+    def _test_variable_type(self, docstring, expected):
         parser = DocstringParser(docstring)
-        expected = {}
-        for arg in expected_args:
-            expected[arg.argname] = arg
-        for arg in parser.find_args('keyword' if is_keyword else 'param'):
-            assert arg.argname in expected and arg.argtype == expected[arg.argname].argtype
+        for varname, expect_val in expected.items():
+            assert expect_val == parser.type_for(varname)
+
+    def test_docstring_param_type(self):
+        self._test_variable_type(docstring_param_type, {
+            "name": "str",
+            "val": "str"
+        })
+
+    def test_docstring_param_type_split(self):
+        self._test_variable_type(docstring_param_type_split, {
+            "name": "str",
+            "val": "str",
+            "pipeline": "~azure.core.pipeline",
+            "pipe_id": "Union[str, int]",
+            "data": "str or ~azure.dummy.datastream"
+        })
+
+    def test_docstring_param_typing_optional(self):
+        self._test_variable_type(docstring_param_typing_optional, {
+            "group": "typing.Optional[str]"
+        })
+
+    def test_docstring_param_nested_union(self):
+        self._test_variable_type(docstring_param_nested_union, {
+            "dummyarg": "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]"
+        })
+
+    def test_docstring_param_multi_line_type_followed_by_irrelevant_text(self):
+        self._test_variable_type(docstring_param_multi_line_type_followed_by_irrelevant_text, {
+            "dummyarg": "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]"
+        })
+
+    def test_docstring_multi_complex_type(self):
+        self._test_variable_type(docstring_multi_complex_type, {
+            "documents": "list[str] or list[~azure.ai.textanalytics.DetectLanguageInput] or list[dict[str, str]]",
+            "country_hint": "str",
+            "model_version": "str",
+            "show_stats": "bool"
+        })
+
+    def test_docstring_param_type_private(self):
+        self._test_variable_type(docstring_param_type_private, {
+            "name": "str",
+            "client": "~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase"
+        })
+
+
+# class TestDocStringParser:
+
+#     def _test_return_type(self, docstring, expected):
+#         docstring_parser = DocstringParser(docstring)
+#         assert expected == docstring_parser.find_return_type()
+
+#     def _test_variable_type(self, docstring, varname, expected):
+#         docstring_parser = DocstringParser(docstring)
+#         assert expected == docstring_parser.find_type("(type|keywordtype|paramtype|vartype)", varname)
+
+#     def _test_find_args(self, docstring, expected_args, is_keyword = False):
+#         parser = DocstringParser(docstring)
+#         expected = {}
+#         for arg in expected_args:
+#             expected[arg.argname] = arg
+#         for arg in parser.find_args('keyword' if is_keyword else 'param'):
+#             assert arg.argname in expected and arg.argtype == expected[arg.argname].argtype
             
-    def test_return_builtin_return_type(self):
-        self._test_return_type(docstring_standard_return_type, "str")
+#     def test_return_builtin_return_type(self):
+#         self._test_return_type(docstring_standard_return_type, "str")
 
-    def test_return_union_return_type(self):
-        self._test_return_type(docstring_Union_return_type1, "Union[str, int]")
+#     def test_return_union_return_type(self):
+#         self._test_return_type(docstring_Union_return_type1, "Union[str, int]")
     
-    def test_return_union_return_type_followed_by_irrelevant_text(self):
-        self._test_return_type(docstring_union_return_type_followed_by_irrelevant_text, "Union(str, int)")
+#     def test_return_union_return_type_followed_by_irrelevant_text(self):
+#         self._test_return_type(docstring_union_return_type_followed_by_irrelevant_text, "Union(str, int)")
 
-    def test_param_multi_line_type_followed_by_irrelevant_text(self):
-        self._test_variable_type(
-            docstring_param_multi_line_type_followed_by_irrelevant_text,
-            "dummyarg", "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]"
-        )
+#     def test_param_multi_line_type_followed_by_irrelevant_text(self):
+#         self._test_variable_type(
+#             docstring_param_multi_line_type_followed_by_irrelevant_text,
+#             "dummyarg", "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]"
+#         )
 
-    def test_return_union_lower_case_return_type(self):
-        self._test_return_type(docstring_union_return_type3, "union[str, int]")
+#     def test_return_union_lower_case_return_type(self):
+#         self._test_return_type(docstring_union_return_type3, "union[str, int]")
 
-    def test_multi_return_type(self):
-        self._test_return_type(docstring_multi_ret_type, "str or ~azure.test.testclass or None")
+#     def test_multi_return_type(self):
+#         self._test_return_type(docstring_multi_ret_type, "str or ~azure.test.testclass or None")
 
-    def test_dict_return_type(self):
-        self._test_return_type(docstring_dict_ret_type, "dict[str, int]")
+#     def test_dict_return_type(self):
+#         self._test_return_type(docstring_dict_ret_type, "dict[str, int]")
 
-    def test_param_type(self):
-        self._test_variable_type(docstring_param_type, "val", "str")
+#     def test_param_type(self):
+#         self._test_variable_type(docstring_param_type, "val", "str")
 
-    def test_param_type_private(self):
-        self._test_variable_type(docstring_param_type_private, "client", "~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase")
+#     def test_param_type_private(self):
+#         self._test_variable_type(docstring_param_type_private, "client", "~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase")
 
-    def test_params(self):
-        args = [ArgType("name", "str"), ArgType("val", "str")]
-        self._test_find_args(docstring_param_type, args)
+#     def test_params(self):
+#         args = [ArgType("name", "str"), ArgType("val", "str")]
+#         self._test_find_args(docstring_param_type, args)
     
-    def test_param_optional_type(self):
-        self._test_variable_type(docstring_param_type1, "pipe_id", "Union[str, int]")
+#     def test_param_optional_type(self):
+#         self._test_variable_type(docstring_param_type_split, "pipe_id", "Union[str, int]")
 
-    def test_param_or_type(self):
-        self._test_variable_type(docstring_param_type1, "data", "str or ~azure.dummy.datastream")
-        self._test_variable_type(docstring_param_type1, "pipeline", None)
+#     def test_param_or_type(self):
+#         self._test_variable_type(docstring_param_type_split, "data", "str or ~azure.dummy.datastream")
+#         self._test_variable_type(docstring_param_type_split, "pipeline", None)
 
-    def test_type_typing_optional(self):
-        self._test_variable_type(docstring_param_typing_optional, "group", "typing.Optional[str]")
+#     def test_type_typing_optional(self):
+#         self._test_variable_type(docstring_param_typing_optional, "group", "typing.Optional[str]")
 
-    def test_nested_union_type(self):
-        self._test_variable_type(docstring_param_nested_union, "dummyarg", "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]")
+#     def test_nested_union_type(self):
+#         self._test_variable_type(docstring_param_nested_union, "dummyarg", "typing.Union[~azure.eventhub.EventDataBatch, List[~azure.eventhub.EventData]]")
 
-    def test_multi_text_analytics_type(self):
-        self._test_variable_type(docstring_multi_complex_type, "documents", "list[str] or list[~azure.ai.textanalytics.DetectLanguageInput] or list[dict[str, str]]")
+#     def test_multi_text_analytics_type(self):
+#         self._test_variable_type(docstring_multi_complex_type, "documents", "list[str] or list[~azure.ai.textanalytics.DetectLanguageInput] or list[dict[str, str]]")

--- a/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/docstring_parser_test.py
@@ -118,12 +118,16 @@ docstring_param_type_private = """
 :type client: ~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase
 """
 
-class TestNewDocStringParser:
+class TestDocstringParser:
 
     def _test_variable_type(self, docstring, expected):
         parser = DocstringParser(docstring)
         for varname, expect_val in expected.items():
             assert expect_val == parser.type_for(varname)
+
+    def _test_return_type(self, docstring, expected):
+        parser = DocstringParser(docstring)
+        assert expected == parser.ret_type
 
     def test_docstring_param_type(self):
         self._test_variable_type(docstring_param_type, {
@@ -169,25 +173,10 @@ class TestNewDocStringParser:
             "client": "~azure.search.documents._search_index_document_batching_client_base.SearchIndexDocumentBatchingClientBase"
         })
 
-    def test_docstring_intentional_fail(self):
-        # TODO: Verify this does (or at least should) fail the CI.
-        assert False
+    # def test_docstring_intentional_fail(self):
+    #     # TODO: Verify this does (or at least should) fail the CI.
+    #     assert False
 
-
-class TestDocStringParser:
-
-    def _test_return_type(self, docstring, expected):
-        docstring_parser = DocstringParser(docstring)
-        assert expected == docstring_parser.find_return_type()
-
-    def _test_find_args(self, docstring, expected_args, is_keyword = False):
-        parser = DocstringParser(docstring)
-        expected = {}
-        for arg in expected_args:
-            expected[arg.argname] = arg
-        for arg in parser.find_args('keyword' if is_keyword else 'param'):
-            assert arg.argname in expected and arg.argtype == expected[arg.argname].argtype
-            
     def test_return_builtin_return_type(self):
         self._test_return_type(docstring_standard_return_type, "str")
 
@@ -205,7 +194,3 @@ class TestDocStringParser:
 
     def test_dict_return_type(self):
         self._test_return_type(docstring_dict_ret_type, "dict[str, int]")
-
-    def test_params(self):
-        args = [ArgType("name", "str"), ArgType("val", "str")]
-        self._test_find_args(docstring_param_type, args)

--- a/packages/python-packages/api-stub-generator/tests/typehint_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/typehint_parser_test.py
@@ -1,0 +1,28 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+from apistub.nodes import TypeHintParser
+
+
+class TestTypeHintParser:
+
+    def test_typehint(self):
+        parser = TypeHintParser([])
+        code = """
+        # type: (str) -> str
+        return val
+        """
+        expected = "str"
+        assert parser._parse_typehint(code) == expected
+
+    def test_typehint_no_spaces(self):
+        parser = TypeHintParser([])
+        code = """
+        # type:(str)->str
+        return val
+        """
+        expected = "str"
+        assert parser._parse_typehint(code) == expected

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -14,7 +14,7 @@ namespace APIViewWeb
     {
         public override string Name { get; } = "Python";
         public override string Extension { get; } = ".whl";
-        public override string VersionString { get; } = "0.2.5";
+        public override string VersionString { get; } = "0.2.6";
 
         private readonly string _pythonExecutablePath;
         public override string ProcessName => _pythonExecutablePath;


### PR DESCRIPTION
Redesign of the docstring parser logic to minimize the number and complexity of regular expressions to address edge case scenarios. 

The parser uses a heuristic to determine whether type info continues onto a second line or is fully contained on the first line. If the first line ends with a comma or the word "or", it is assumed that the type info continues onto the second line.

Additional test cases have been added to ensure this logic works.

Refactors `TypehintParser` into its own file and adds test cases.

Fixes #1765. Fixes #1616.