### PR TITLE
Adding Redirection of nohup-ed tool runs so we can dump the log later

### DIFF
--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -22,13 +22,13 @@ steps:
   - pwsh: |
       Start-Process $(Build.BinariesDirectory)/test-proxy/test-proxy.exe `
         -ArgumentList "--storage-location '${{ parameters.rootFolder }}'" `
-        -NoNewWindow -PassThru
+        -NoNewWindow -PassThru -RedirectStandardOutput $(Build.SourcesDirectory)/test-proxy.log
     displayName: 'Run the testproxy - windows'
     condition: and(succeeded(), eq(variables['Agent.OS'],'Windows_NT'))
 
   # nohup does NOT continue beyond the current session if you use it within powershell
   - bash: |
-      nohup $(Build.BinariesDirectory)/test-proxy/test-proxy &
+      nohup $(Build.BinariesDirectory)/test-proxy/test-proxy > $(Build.SourcesDirectory)/test-proxy.log &
     displayName: "Run the testproxy - linux/mac"
     condition: and(succeeded(), ne(variables['Agent.OS'],'Windows_NT'))
     workingDirectory: "${{ parameters.rootFolder }}"


### PR DESCRIPTION
This is attempt #2. Failure to patch is blocking the other PR. If I can just simplify the commits and have it work, that's definitely the easiest way.