### PR TITLE
fix bug in prepare relaease 

### DIFF
--- a/eng/common/scripts/Prepare-Release.ps1
+++ b/eng/common/scripts/Prepare-Release.ps1
@@ -113,8 +113,11 @@ Write-Host "Assuming release is in $month with release date $releaseDateString" 
 if (Test-Path "Function:GetExistingPackageVersions")
 {
     $releasedVersions = GetExistingPackageVersions -PackageName $packageProperties.Name -GroupId $packageProperties.Group
-    $latestReleasedVersion = $releasedVersions[$releasedVersions.Count - 1]
-    Write-Host "Latest released version: ${latestReleasedVersion}" -ForegroundColor Green
+    if ($null -ne $releasedVersions -and $releasedVersions.Count -gt 0)
+    {
+      $latestReleasedVersion = $releasedVersions[$releasedVersions.Count - 1]
+      Write-Host "Latest released version: ${latestReleasedVersion}" -ForegroundColor Green
+    }
 }
 
 $currentProjectVersion = $packageProperties.Version


### PR DESCRIPTION
This handles cases where the package is beign released for the first time. i.e there is no previously existing versions.