### PR TITLE
Prefix matrix generation service directory sparse checkout with 'sdk'

### DIFF
--- a/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
+++ b/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
@@ -56,7 +56,7 @@ jobs:
             Paths: ${{ parameters.SparseCheckoutPaths }}
           ${{ if and(eq(length(parameters.SparseCheckoutPaths), 0), ne(parameters.AdditionalParameters.ServiceDirectory, '')) }}:
             Paths:
-              - ${{ parameters.AdditionalParameters.ServiceDirectory }}
+              - "sdk/${{ parameters.AdditionalParameters.ServiceDirectory }}"
 
     - ${{ each config in parameters.MatrixConfigs }}:
       - ${{ if eq(config.GenerateVMJobs, 'true') }}:


### PR DESCRIPTION
Currently the sparse checkout of the service directory happens to work because it will match on the directory name, e.g.
`git sparse-checkout add keyvault` will end up checking out `sdk/keyvault`. However, some service directories (such as
in azure-sdk-for-go) are now multiple directory segments, e.g. `keyvault/azkeys`. This breaks the git sparse checkout
matching, so to fix the service directory can be updated to an exact path `sdk/<service directory>`.
