### PR TITLE
[APIView] Remove trailing cd that is turning the step green

### DIFF
--- a/.azure-pipelines/apiview.yml
+++ b/.azure-pipelines/apiview.yml
@@ -171,7 +171,6 @@ stages:
               cd $(Build.SourcesDirectory)/$(PythonParserPackagePath)
               pip install tox
               tox
-              cd $(Build.SourcesDirectory)
             displayName: 'Test Python Package Parser'
 
           - task: PublishTestResults@2


### PR DESCRIPTION
The step where the `cd` is removed is _always_ green. My hunch is that the step only exits with code 1 if the very last command within it exited with code 1. That's why `tox` is failing but the step was green.