### PR TITLE
[Test-Proxy] Fix default startup location in `docker-start-proxy.ps1`, Update `windows` tool initialize

### DIFF
--- a/eng/common/testproxy/docker-start-proxy.ps1
+++ b/eng/common/testproxy/docker-start-proxy.ps1
@@ -1,12 +1,18 @@
  #!/usr/bin/env pwsh -c
 
 <#
+.SYNOPSIS
+Easy start/stop of docker proxy.
+
 .DESCRIPTION
 Start the docker proxy container. If it is already running, quietly exit. Any other error should fail.
+
 .PARAMETER Mode
-"start" or "stop" to start up or stop the test-proxy instance.
+Pass value "start" or "stop" to start up or stop the test-proxy instance.
+
 .PARAMETER TargetFolder
 The folder in which context the test proxy will be started. Defaults to current working directory.
+
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
@@ -14,7 +20,7 @@ param(
     [String]
     $Mode,
     [String]
-    $TargetFolder = "."
+    $TargetFolder = ""
 )
 
 try {
@@ -29,6 +35,11 @@ $SELECTED_IMAGE_TAG = "1147815"
 $CONTAINER_NAME = "ambitious_azsdk_test_proxy"
 $LINUX_IMAGE_SOURCE = "azsdkengsys.azurecr.io/engsys/testproxy-lin:${SELECTED_IMAGE_TAG}"
 $WINDOWS_IMAGE_SOURCE = "azsdkengsys.azurecr.io/engsys/testproxy-win:${SELECTED_IMAGE_TAG}"
+
+if (-not $TargetFolder){
+    $TargetFolder = Join-Path -Path $PSScriptRoot -ChildPath "../../../"
+}
+
 $root = (Resolve-Path $TargetFolder).Path.Replace("`\", "/")
 
 function Get-Proxy-Container(){

--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -21,7 +21,7 @@ steps:
 
   - pwsh: |
       Start-Process $(Build.BinariesDirectory)/test-proxy/test-proxy.exe `
-        -ArgumentList "--storage-location '${{ parameters.rootFolder }}'" `
+        -ArgumentList "--storage-location ${{ parameters.rootFolder }}" `
         -NoNewWindow -PassThru -RedirectStandardOutput $(Build.SourcesDirectory)/test-proxy.log
     displayName: 'Run the testproxy - windows'
     condition: and(succeeded(), eq(variables['Agent.OS'],'Windows_NT'))


### PR DESCRIPTION
One can use script located at `eng/common/testproxy/docker-start-proxy.ps1` to start and stop a default docker configuration.

There is a second argument, `TargetFolder`, that is used to change the folder  will be bound to the volume of the new docker container.

The default used to be `"."`, so that the current folder would bind to the volume.

This PR changes the behavior so that if no target folder is provided, it will instead default to root of the containing repository. The ability to provide this context is unchanged.

