### PR TITLE
[Test-Proxy] `/Playback/Start/` should always populate a json response body

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -282,14 +282,12 @@ namespace Azure.Sdk.Tools.TestProxy
 
             outgoingResponse.Headers.Add("x-recording-id", id);
 
-            if(session.Session.Variables.Count > 0)
-            {
-                var json = JsonSerializer.Serialize(session.Session.Variables);
-                outgoingResponse.Headers.Add("Content-Type", "application/json");
 
-                // Write to the response
-                await outgoingResponse.WriteAsync(json);
-            }
+            var json = JsonSerializer.Serialize(session.Session.Variables);
+            outgoingResponse.Headers.Add("Content-Type", "application/json");
+
+            // Write to the response
+            await outgoingResponse.WriteAsync(json);
         }
 
         public void StopPlayback(string recordingId, bool purgeMemoryStore = false)


### PR DESCRIPTION
Even if it's empty.

@JoshLove-msft 