### PR TITLE
[Test-Proxy] Ensure that double leading `/` in PATH won't result in host-less target URIs

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -497,6 +497,12 @@ namespace Azure.Sdk.Tools.TestProxy
             // to give us some amount of safety, but note that we explicitly disable escaping in that combination.
             var rawTarget = request.HttpContext.Features.Get<IHttpRequestFeature>().RawTarget;
             var host = new Uri(GetHeader(request, "x-recording-upstream-base-uri"));
+
+            if (rawTarget.StartsWith("//"))
+            {
+                rawTarget = "/" + rawTarget.Substring(2);
+            }
+
             return new Uri(host, rawTarget);
         }
 


### PR DESCRIPTION
[Comment discussing why this PR exists](https://github.com/Azure/azure-sdk-tools/issues/2262#issuecomment-971071499)

@mikeharder what do you think here? I'm thinking that this is an issue client side.