### PR TITLE
Reduce review update delay

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -498,7 +498,7 @@ namespace APIViewWeb.Respositories
                 var operation = _telemetryClient.StartOperation(requestTelemetry);
                 try
                 {
-                    await Task.Delay(5000);
+                    await Task.Delay(500);
                     await UpdateReviewAsync(review);
                 }
                 catch (Exception e)


### PR DESCRIPTION
Current delay is causing some reviews to be skipped if a new revision is created before existing review is updated. Reducing delay to 500ms as first solution.