### PR TITLE
Downgrade snippet generator to 3.1

### DIFF
--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/Azure.Sdk.Tools.SnippetGenerator.Tests.csproj
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/Azure.Sdk.Tools.SnippetGenerator.Tests.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <IsPackable>false</IsPackable>
+        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Azure.Sdk.Tools.SnippetGenerator.csproj
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Azure.Sdk.Tools.SnippetGenerator.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>Generates code snippets for readmes in the azure-sdk-for-net repo.</Description>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>snippet-generator</ToolCommandName>
     <VersionPrefix>1.0.0</VersionPrefix>

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Azure.Sdk.Tools.SnippetGenerator.csproj
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Azure.Sdk.Tools.SnippetGenerator.csproj
@@ -7,6 +7,7 @@
     <ToolCommandName>snippet-generator</ToolCommandName>
     <VersionPrefix>1.0.0</VersionPrefix>
     <AssemblyName>Azure.Sdk.Tools.SnippetGenerator</AssemblyName>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
azure-sdk-for-net is moving to 3.1/6.0 testing. Downgrade the TFM to target a lower framework version