### PR TITLE
[Swift APIView] Fix non-unique line IDs and add Package Version support

### DIFF
--- a/.azure-pipelines/apiview.yml
+++ b/.azure-pipelines/apiview.yml
@@ -10,6 +10,7 @@ trigger:
       - .azure-pipelines/apiview.yml
       - src/dotnet/APIView
       - src/java/apiview-java-processor
+      - src/swift
       - src/ts/ts-genapi
       - packages/python-packages/api-stub-generator
       - packages/python-packages/protocol-stub-generator
@@ -26,6 +27,7 @@ pr:
       - .azure-pipelines/apiview.yml
       - src/dotnet/APIView
       - src/java/apiview-java-processor
+      - src/swift
       - src/ts/ts-genapi
       - packages/python-packages/api-stub-generator
       - packages/python-packages/protocol-stub-generator

--- a/src/swift/README.md
+++ b/src/swift/README.md
@@ -21,7 +21,8 @@ You may run the tool directly in Xcode or from the command line.
 Parameters:
   `--source`: May target a folder, which will collect and process all `*.swift`, `*.h` and `*.swiftinterace` files in the folder and its subfolders. Can also target a single file.
   `--dest`:  (Optional) The path and desired JSON filename. If not provided, it will output as `SwiftAPIView.json` inside your Documents directory.
-  `--package-name`: (Optional) The top-level package name to use. If not provided, Swift APIView will attempt to determine the package name. If unsuccessful, supply the value or it will use "Default".
+  `--package-name`: (Optional) The top-level package name to use. If not provided, Swift APIView will attempt to determine the package name. If unsuccessful, you must supply the value.
+  `--package-version`: (Optional) The package version the APIView is being created for. This will affect how the review is listed in APIView (ex: "AzureFoo (version 1.0.0)"). If not provided, Swift APIView will attempt to determine the package version. If unsuccessful, you must supply the value. 
 
 #### Xcode
 
@@ -31,5 +32,5 @@ Edit `SwiftAPIView`'s "Run" scheme. This will allow you to pass command line arg
 
 Navigate to the build artifacts folder from Xcode and then run:
 ```
-./SwiftAPIView --source=<PATH_TO_SOURCE> [--dest=<PATH_TO_DESTINATION_FILE>] [--package-name=<NAME>]`
+./SwiftAPIView --source=<PATH_TO_SOURCE> [--dest=<PATH_TO_DESTINATION_FILE>] [--package-name=<NAME>] [--package-version=<VERSION>]`
 ```

--- a/src/swift/Sources/CommandLineArguments.swift
+++ b/src/swift/Sources/CommandLineArguments.swift
@@ -34,6 +34,7 @@ class CommandLineArguments: Encodable {
         "source",
         "dest",
         "package-name",
+        "package-version"
     ]
 
     // MARK: Computed properties
@@ -50,6 +51,10 @@ class CommandLineArguments: Encodable {
 
     var packageName: String? {
         return rawArgs["package-name"]
+    }
+
+    var packageVersion: String? {
+        return rawArgs["package-version"]
     }
 
     // MARK: Initializers

--- a/src/swift/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
+++ b/src/swift/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
@@ -61,7 +61,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--source=/Users/travisprescott/repos/MixedCodeDemo/Sources"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--source=/Users/travisprescott/repos/SpeechSDK/source/bindings/objective-c/public"
@@ -69,7 +69,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--source=/Users/travisprescott/Documents/AzureCommunicationCalling.framework"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--source=/Users/travisprescott/repos/azure-sdk-tools/src/swift/Tests/TestSwiftFile.swift"


### PR DESCRIPTION
https://apiviewstaging.azurewebsites.net/Assemblies/Review/94ee72d4b18845b09fe75a270d93077f

APIView now correctly allows you to put a comment on any line and does not duplicate comments.
Additionally, it will extract the package version (or allow you to specify with `--package-version`) so that the listing in APIView will include the version (Example: "AzureCommunicationCalling (version 2.0.0)")

Fixes #2254.
Fixes #2362.

Also, adds swift to the CI path so that it will run and I don't have to override check-enforcer. There aren't any Swift-specific checks at this time. 