### PR TITLE
Make changes on docker validation

### DIFF
--- a/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+++ b/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
@@ -26,7 +26,12 @@ parameters:
     type: object
     default:
       - '**'
-
+  - name: PackageSourceOverride
+    type: string
+    default: ''
+  - name: DocValidationImageId
+    type: string
+    default: ''
 steps:
 - template: /eng/common/pipelines/templates/steps/enable-long-path-support.yml
 
@@ -73,7 +78,13 @@ steps:
     parameters:
       WorkingDirectory: $(DocRepoLocation)
       DefaultBranchVariableName: TargetBranchName
-
+# Pull and build the docker image.
+- ${{ if ne(parameters.DocValidationImageId, '') }}:
+- template: /eng/common/pipelines/templates/steps/docker-pull-image.yml
+  parameters:
+    ContainerRegistryClientId: $(azuresdkimages-cr-clientid)
+    ContainerRegistryClientSecret: $(azuresdkimages-cr-clientsecret)
+    ImageId: '${{ parameters.DocValidationImageId }}'
 - pwsh: |
     $packageInfoJson = '${{ convertToJson(parameters.PackageInfoLocations) }}'.Trim('"').Replace("\\", "/")
     $packageInfoLocations = ConvertFrom-Json $packageInfoJson
@@ -81,7 +92,9 @@ steps:
       -PackageInfoJsonLocations $packageInfoLocations `
       -DocRepoLocation "$(DocRepoLocation)" `
       -Language '${{parameters.Language}}' `
-      -RepoId '${{ parameters.RepoId }}'
+      -RepoId '${{ parameters.RepoId }}' `
+      -DocValidationImageId '${{ parameters.DocValidationImageId }}' `
+      -PackageSourceOverride '${{ parameters.PackageSourceOverride }}'
   displayName: Apply Documentation Updates
 
 - template: /eng/common/pipelines/templates/steps/git-push-changes.yml

--- a/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+++ b/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
@@ -80,11 +80,11 @@ steps:
       DefaultBranchVariableName: TargetBranchName
 # Pull and build the docker image.
 - ${{ if ne(parameters.DocValidationImageId, '') }}:
-- template: /eng/common/pipelines/templates/steps/docker-pull-image.yml
-  parameters:
-    ContainerRegistryClientId: $(azuresdkimages-cr-clientid)
-    ContainerRegistryClientSecret: $(azuresdkimages-cr-clientsecret)
-    ImageId: '${{ parameters.DocValidationImageId }}'
+  - template: /eng/common/pipelines/templates/steps/docker-pull-image.yml
+    parameters:
+      ContainerRegistryClientId: $(azuresdkimages-cr-clientid)
+      ContainerRegistryClientSecret: $(azuresdkimages-cr-clientsecret)
+      ImageId: '${{ parameters.DocValidationImageId }}'
 - pwsh: |
     $packageInfoJson = '${{ convertToJson(parameters.PackageInfoLocations) }}'.Trim('"').Replace("\\", "/")
     $packageInfoLocations = ConvertFrom-Json $packageInfoJson

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -202,9 +202,9 @@ foreach ($packageInfoLocation in $PackageInfoJsonLocations) {
   # Add validation step for daily update and release
   if ($ValidateDocsMsPackagesFn -and (Test-Path "Function:$ValidateDocsMsPackagesFn")) {
     &$ValidateDocsMsPackagesFn -PackageInfo $packageInfo -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $DocValidationImageId
-    if ($LASTEXITCODE -ne 0) {
+    if ($LASTEXITCODE) {
       LogError "The package failed Doc.Ms validation. Check https://aka.ms/azsdk/docs/docker for more details on how to diagnose this issue."
-      exit 1
+      exit $LASTEXITCODE
     }
   }
   UpdateDocsMsMetadataForPackage $packageInfoLocation $packageInfo

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -26,14 +26,23 @@ path information is provided by $GetDocsMsMetadataForPackageFn
 Programming language to supply to metadata
 
 .PARAMETER RepoId
-GitHub repository ID of the SDK. Typically of the form: 'Azure/azure-sdk-for-js'
+GitHub repository ID of the SDK. Typically of the form: 'Azure/azure-sdk-for-js' 
 
+.PARAMETER DocValidationImageId
+The docker image id in format of '$containerRegistry/$imageName:$tag'
+e.g. azuresdkimages.azurecr.io/jsrefautocr:latest
+
+.PARAMETER PackageSourceOverride
+Optional parameter to supply a different package source (useful for daily dev
+docs generation from pacakges which are not published to the default feed). This
+variable is meant to be used in the domain-specific business logic in
+&$ValidateDocsMsPackagesFn
 #>
 
 param(
   [Parameter(Mandatory = $true)]
   [array]$PackageInfoJsonLocations,
-
+  
   [Parameter(Mandatory = $true)]
   [string]$DocRepoLocation, 
 
@@ -41,7 +50,13 @@ param(
   [string]$Language,
 
   [Parameter(Mandatory = $true)]
-  [string]$RepoId
+  [string]$RepoId,
+
+  [Parameter(Mandatory = $false)]
+  [string]$DocValidationImageId,
+
+  [Parameter(Mandatory = $false)]
+  [string]$PackageSourceOverride
 )
 
 . (Join-Path $PSScriptRoot common.ps1)
@@ -104,13 +119,12 @@ ms.technology: azure
 ms.devlang: $Language
 ms.service: $service
 ---
-
 "@
 
   return "$header`n$ReadmeContent"
 }
 
-function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation) { 
+function GetPackageInfoJson ($packageInfoJsonLocation) {
   if (!(Test-Path $packageInfoJsonLocation)) {
     LogWarning "Package metadata not found for $packageInfoJsonLocation"
     return
@@ -118,7 +132,6 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation) {
   
   $packageInfoJson = Get-Content $packageInfoJsonLocation -Raw
   $packageInfo = ConvertFrom-Json $packageInfoJson
-  $originalVersion = [AzureEngSemanticVersion]::ParseVersionString($packageInfo.Version)
   if ($packageInfo.DevVersion) {
     # If the package is of a dev version there may be language-specific needs to 
     # specify the appropriate version. For example, in the case of JS, the dev 
@@ -131,6 +144,11 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation) {
       $packageInfo.Version = $packageInfo.DevVersion
     }
   }
+  return $packageInfo
+}
+
+function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation, $packageInfo) { 
+  $originalVersion = [AzureEngSemanticVersion]::ParseVersionString($packageInfo.Version)
 
   $packageMetadataArray = (Get-CSVMetadata).Where({ $_.Package -eq $packageInfo.Name -and $_.GroupId -eq $packageInfo.Group -and $_.Hide -ne 'true' -and $_.New -eq 'true' })
   if ($packageMetadataArray.Count -eq 0) { 
@@ -176,7 +194,18 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation) {
     -Value $packageInfoJson
 }
 
-foreach ($packageInfo in $PackageInfoJsonLocations) {
+foreach ($packageInfoLocation in $PackageInfoJsonLocations) {
   Write-Host "Updating metadata for package: $packageInfo"
-  UpdateDocsMsMetadataForPackage $packageInfo
+
+  # Convert package metadata json file to metadata json property.
+  $packageInfo = GetPackageInfoJson $packageInfoLocation
+  # Add validation step for daily update and release
+  if ($ValidateDocsMsPackagesFn -and (Test-Path "Function:$ValidateDocsMsPackagesFn")) {
+    &$ValidateDocsMsPackagesFn -PackageInfo $packageInfo $PackageSourceOverride $DocValidationImageId
+    if ($LASTEXITCODE -ne 0) {
+      LogError "The package failed Doc.Ms validation. Please fixed the doc and republish to Doc.Ms."
+      exit 1
+    }
+  }
+  UpdateDocsMsMetadataForPackage $packageInfoLocation $packageInfo
 }

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -26,7 +26,7 @@ path information is provided by $GetDocsMsMetadataForPackageFn
 Programming language to supply to metadata
 
 .PARAMETER RepoId
-GitHub repository ID of the SDK. Typically of the form: 'Azure/azure-sdk-for-js' 
+GitHub repository ID of the SDK. Typically of the form: 'Azure/azure-sdk-for-js'
 
 .PARAMETER DocValidationImageId
 The docker image id in format of '$containerRegistry/$imageName:$tag'

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -42,7 +42,7 @@ variable is meant to be used in the domain-specific business logic in
 param(
   [Parameter(Mandatory = $true)]
   [array]$PackageInfoJsonLocations,
-  
+
   [Parameter(Mandatory = $true)]
   [string]$DocRepoLocation, 
 

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -203,7 +203,7 @@ foreach ($packageInfoLocation in $PackageInfoJsonLocations) {
   if ($ValidateDocsMsPackagesFn -and (Test-Path "Function:$ValidateDocsMsPackagesFn")) {
     &$ValidateDocsMsPackagesFn -PackageInfo $packageInfo -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $DocValidationImageId
     if ($LASTEXITCODE -ne 0) {
-      LogError "The package failed Doc.Ms validation. Check https://aka.ms/azsdk/docs/docker for how to reproduce the errors"
+      LogError "The package failed Doc.Ms validation. Check https://aka.ms/azsdk/docs/docker for more details on how to diagnose this issue."
       exit 1
     }
   }

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -201,7 +201,7 @@ foreach ($packageInfoLocation in $PackageInfoJsonLocations) {
   $packageInfo = GetPackageInfoJson $packageInfoLocation
   # Add validation step for daily update and release
   if ($ValidateDocsMsPackagesFn -and (Test-Path "Function:$ValidateDocsMsPackagesFn")) {
-    &$ValidateDocsMsPackagesFn -PackageInfo $packageInfo $PackageSourceOverride $DocValidationImageId
+    &$ValidateDocsMsPackagesFn -PackageInfo $packageInfo -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $DocValidationImageId
     if ($LASTEXITCODE -ne 0) {
       LogError "The package failed Doc.Ms validation. Check https://aka.ms/azsdk/docs/docker for how to reproduce the errors"
       exit 1

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -203,7 +203,7 @@ foreach ($packageInfoLocation in $PackageInfoJsonLocations) {
   if ($ValidateDocsMsPackagesFn -and (Test-Path "Function:$ValidateDocsMsPackagesFn")) {
     &$ValidateDocsMsPackagesFn -PackageInfo $packageInfo $PackageSourceOverride $DocValidationImageId
     if ($LASTEXITCODE -ne 0) {
-      LogError "The package failed Doc.Ms validation. Please fixed the doc and republish to Doc.Ms."
+      LogError "The package failed Doc.Ms validation. Check https://aka.ms/azsdk/docs/docker for how to reproduce the errors"
       exit 1
     }
   }

--- a/eng/common/scripts/common.ps1
+++ b/eng/common/scripts/common.ps1
@@ -45,3 +45,4 @@ $GetDocsMsDevLanguageSpecificPackageInfoFn = "Get-${Language}-DocsMsDevLanguageS
 $GetGithubIoDocIndexFn = "Get-${Language}-GithubIoDocIndex"
 $FindArtifactForApiReviewFn = "Find-${Language}-Artifacts-For-Apireview"
 $TestProxyTrustCertFn = "Import-Dev-Cert-${Language}"
+$ValidateDocsMsPackagesFn = "Validate-${Language}-DocMsPackages"


### PR DESCRIPTION
The PR is to validate whether packages are good for the Doc.MS before updating docs.
Currently, we have workaround which add docker id+secret to pipeline existing variable group: Release to Github IO secrets.
Create an issue for long term fix: https://github.com/Azure/azure-sdk-tools/issues/2373

Test pipeline on release pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1225620&view=results
Test pipeline on unified pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1225618&view=results
Test on no docker id: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1225295&view=results