### PR TITLE
[Test-Proxy] Change storage directory from `/etc/testproxy` -> `/srv/testproxy`

### DIFF
--- a/eng/common/testproxy/docker-start-proxy.ps1
+++ b/eng/common/testproxy/docker-start-proxy.ps1
@@ -77,9 +77,9 @@ if ($Mode -eq "start"){
     else {
         $attempts = 0
         Write-Host "Attempting creation of Docker host $CONTAINER_NAME"
-        Write-Host "docker container create -v `"${root}:${Initial}/etc/testproxy`" $LinuxContainerArgs -p 5001:5001 -p 5000:5000 --name $CONTAINER_NAME $SelectedImage"
+        Write-Host "docker container create -v `"${root}:${Initial}/srv/testproxy`" $LinuxContainerArgs -p 5001:5001 -p 5000:5000 --name $CONTAINER_NAME $SelectedImage"
         while($attempts -lt 3){
-            docker container create -v "${root}:${Initial}/etc/testproxy" $LinuxContainerArgs -p 5001:5001 -p 5000:5000 --name $CONTAINER_NAME $SelectedImage
+            docker container create -v "${root}:${Initial}/srv/testproxy" $LinuxContainerArgs -p 5001:5001 -p 5000:5000 --name $CONTAINER_NAME $SelectedImage
 
             if($LASTEXITCODE -ne 0){
                 $attempts += 1

--- a/eng/common/testproxy/docker-start-proxy.ps1
+++ b/eng/common/testproxy/docker-start-proxy.ps1
@@ -31,7 +31,7 @@ catch {
     Write-Error "Please check your docker invocation and try running the script again."
 }
 
-$SELECTED_IMAGE_TAG = "1203416"
+$SELECTED_IMAGE_TAG = "1209124"
 $CONTAINER_NAME = "ambitious_azsdk_test_proxy"
 $LINUX_IMAGE_SOURCE = "azsdkengsys.azurecr.io/engsys/testproxy-lin:${SELECTED_IMAGE_TAG}"
 $WINDOWS_IMAGE_SOURCE = "azsdkengsys.azurecr.io/engsys/testproxy-win:${SELECTED_IMAGE_TAG}"

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -44,18 +44,18 @@ If you've already installed the tool, you can always check the installed version
 The Azure SDK Team maintains a public Azure Container Registry.
 
 ```powershell
-> docker run -v <your-volume-name-or-location>:/etc/testproxy -p 5001:5001 -p 5000:5000 azsdkengsys.azurecr.io/engsys/testproxy-lin:latest
+> docker run -v <your-volume-name-or-location>:/srv/testproxy/ -p 5001:5001 -p 5000:5000 azsdkengsys.azurecr.io/engsys/testproxy-lin:latest
 ```
 
 For example, to save test recordings to disk in your repo's `/sdk/<service>/tests/recordings` directory, provide the path to the root of the repo:
 
 ```powershell
-> docker run -v C:\\repo\\azure-sdk-for-<language>:/etc/testproxy -p 5001:5001 -p 5000:5000 azsdkengsys.azurecr.io/engsys/testproxy-lin:latest
+> docker run -v C:\\repo\\azure-sdk-for-<language>:/srv/testproxy/ -p 5001:5001 -p 5000:5000 azsdkengsys.azurecr.io/engsys/testproxy-lin:latest
 ```
 
 Note the **port and volume mapping** as arguments! Any files that exist in this volume locally will only be appended to/updated in place. It is a non-destructive initialize.
 
-Within the container, recording outputs are written within the directory `/etc/testproxy`.
+Within the container, recording outputs are written within the directory `/srv/testproxy/`.
 
 #### A note about docker caching
 

--- a/tools/test-proxy/docker/README.md
+++ b/tools/test-proxy/docker/README.md
@@ -24,15 +24,15 @@ docker build . -t test-proxy
 Start locally using:
 
 ```docker
-docker run -p 5000:5000 -p 5001:5001 -v <yourvolume>:/etc/testproxy -t test-proxy 
+docker run -p 5000:5000 -p 5001:5001 -v <yourvolume>:/srv/testproxy/ -t test-proxy
 ```
 
-Generated files will be within `/etc/testproxy/` inside the docker image. Providing a volume as shown above is necessary if you want to propogate these recordings onto your local file system.
+Generated files will be within `/srv/testproxy/` inside the docker image. Providing a volume as shown above is necessary if you want to propogate these recordings onto your local file system.
 
-If you _don't_ provide a volume bound to `/etc/testproxy`, it's not actually the end of the world. Use `docker cp` to grab those files into your host system.
+If you _don't_ provide a volume bound to `/srv/testproxy/`, it's not actually the end of the world. Use `docker cp` to grab those files into your host system.
 
 ```docker
-docker cp <containerid>:/etc/testproxy/ <target local path local path>
+docker cp <containerid>:/srv/testproxy/ <target local path local path>
 ```
 
 ### Windows Container

--- a/tools/test-proxy/docker/dockerfile
+++ b/tools/test-proxy/docker/dockerfile
@@ -34,7 +34,8 @@ RUN \
     # Run script to import certificate
     && chmod +x $CERT_FOLDER/$CERT_IMPORT_SH \
     && $CERT_FOLDER/$CERT_IMPORT_SH \
-    && rm $CERT_FOLDER/$CERT_IMPORT_SH
+    && rm $CERT_FOLDER/$CERT_IMPORT_SH \
+    && mkdir -p /srv/testproxy
 
 EXPOSE 5000 5001
 
@@ -42,4 +43,4 @@ WORKDIR /proxyserver
 
 COPY --from=build /proxyserver .
 
-ENTRYPOINT ["dotnet", "Azure.Sdk.Tools.TestProxy.dll", "--storage-location", "/etc/testproxy"]
+ENTRYPOINT ["dotnet", "Azure.Sdk.Tools.TestProxy.dll", "--storage-location", "/srv/testproxy"]

--- a/tools/test-proxy/docker/dockerfile-win
+++ b/tools/test-proxy/docker/dockerfile-win
@@ -34,7 +34,7 @@ USER ContainerAdministrator
 
 # while it may seem a bit strange to use "etc" on a windows container. We are mirroring
 # the methodology from the primary container, which is linux.
-RUN mkdir certwork & mkdir etc & cd etc & mkdir testproxy
+RUN mkdir certwork & mkdir srv & cd srv & mkdir testproxy
 ADD docker_build/dotnet-devcert.pfx certwork
 
 # we still need to import this certificate to ensure it's available to all users. there is _something_ gnarly going on that purely having the cert 
@@ -51,4 +51,4 @@ COPY --from=build_env /proxyserver .
 EXPOSE 5001
 EXPOSE 5000
 
-ENTRYPOINT ["host-patcher.cmd", "&",  "dotnet", "Azure.Sdk.Tools.TestProxy.dll", "--storage-location", "/etc/testproxy"]
+ENTRYPOINT ["host-patcher.cmd", "&",  "dotnet", "Azure.Sdk.Tools.TestProxy.dll", "--storage-location", "/srv/testproxy/"]

--- a/tools/test-proxy/startup-scripts/start-server.js
+++ b/tools/test-proxy/startup-scripts/start-server.js
@@ -55,8 +55,8 @@ function dockerInteract(mode, root){
         // else we need to create it
         else {
             console.log("Attempting creation of Docker host " + CONTAINER_NAME);
-            console.log('docker container create -v ' + resolvedPath + ':/etc/testproxy -p 5001:5001 -p 5000:5000 --name ' + CONTAINER_NAME + ' ' + IMAGE_SOURCE);
-            execSync('docker container create -v ' + resolvedPath + ':/etc/testproxy -p 5001:5001 -p 5000:5000 --name ' + CONTAINER_NAME + ' ' + IMAGE_SOURCE, (error, stdout, stderr) => {
+            console.log('docker container create -v ' + resolvedPath + ':/srv/testproxy/ -p 5001:5001 -p 5000:5000 --name ' + CONTAINER_NAME + ' ' + IMAGE_SOURCE);
+            execSync('docker container create -v ' + resolvedPath + ':/srv/testproxy/ -p 5001:5001 -p 5000:5000 --name ' + CONTAINER_NAME + ' ' + IMAGE_SOURCE, (error, stdout, stderr) => {
                 if (error) {
                     console.error('Creation of the test-proxy failed with docker error.');
                     console.error(error)

--- a/tools/test-proxy/startup-scripts/start-server.ps1
+++ b/tools/test-proxy/startup-scripts/start-server.ps1
@@ -40,7 +40,7 @@ if ($mode -eq "start"){
     # else we need to create it
     else {
         Write-Host "Attempting creation of Docker host $CONTAINER_NAME"
-        docker container create -v ${repoRoot}:/etc/testproxy -p 5001:5001 -p 5000:5000 --name $CONTAINER_NAME $IMAGE_SOURCE
+        docker container create -v ${repoRoot}:/srv/testproxy/ -p 5001:5001 -p 5000:5000 --name $CONTAINER_NAME $IMAGE_SOURCE
     }
 
     Write-Host "Attempting start of Docker host $CONTAINER_NAME"

--- a/tools/test-proxy/startup-scripts/start-server.py
+++ b/tools/test-proxy/startup-scripts/start-server.py
@@ -41,7 +41,7 @@ def docker_interact(mode, root):
         # else we need to create it
         else:
             print("Attempting creation of Docker host {}".format(CONTAINER_NAME))
-            subprocess.check_call(["docker", "container", "create", "-v", "{}:/etc/testproxy".format(resolved_root), "-p", "5001:5001", "-p", "5000:5000", "--name", CONTAINER_NAME, IMAGE_SOURCE ])
+            subprocess.check_call(["docker", "container", "create", "-v", "{}:/srv/testproxy/".format(resolved_root), "-p", "5001:5001", "-p", "5000:5000", "--name", CONTAINER_NAME, IMAGE_SOURCE ])
 
         print("Attempting start of Docker host {}".format(CONTAINER_NAME))
         subprocess.check_call(["docker", "container", "start", CONTAINER_NAME])


### PR DESCRIPTION
`/etc` really is for configuration. In the interests of consistency, we're adjusting this so that we don't go against people's regular expectations.

I'm running a `docker-containers-publish` manually off this branch so that I can also update the the targeted docker tag _in this PR_ all in one shot.

