### PR TITLE
[Test-Proxy] Adding some additional error handling, updating all explicit exceptions to surface with coherent errors

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -23,6 +23,49 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
     /// </summary>
     public class AdminFunctionalityTests
     {
+        public async void TestAddSanitizerThrowsOnInvalidAbstractionId()
+        {
+            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            //var httpContext = new DefaultHttpContext();
+            //httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
+            //httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
+            //httpContext.Request.ContentLength = 92;
+
+            //var controller = new Admin(testRecordingHandler)
+            //{
+            //    ControllerContext = new ControllerContext()
+            //    {
+            //        HttpContext = httpContext
+            //    }
+            //};
+            //testRecordingHandler.Sanitizers.Clear();
+
+            //var assertion = await Assert.ThrowsAsync<HttpException>(
+            //   async () => await controller.AddSanitizer()
+            //);
+            //assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
+        }
+
+        public async void TestAddSanitizerThrowsOnEmptyAbstractionId()
+        {
+        }
+
+        public async void TestAddTransformThrowsOnInvalidAbstractionId()
+        {
+        }
+
+        public async void TestAddTransformThrowsOnEmptyAbstractionId()
+        {
+        }
+
+        public async void TestSetMatcherThrowsOnInvalidAbstractionId()
+        {
+        }
+
+        public async void TestSetMatcherThrowsOnEmptyAbstractionId()
+        {
+        }
+
         [Fact]
         public async Task TestSetMatcher()
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -21,7 +21,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
     /// 
     /// The testing of the actual functionality of each of these concepts should take place in SanitizerTests, TransformTests, etc.
     /// </summary>
-    public class AdminFunctionalityTests
+    public class AdminTests
     {
         public async void TestAddSanitizerThrowsOnInvalidAbstractionId()
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -23,47 +23,131 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
     /// </summary>
     public class AdminTests
     {
+        [Fact]
         public async void TestAddSanitizerThrowsOnInvalidAbstractionId()
         {
-            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            //var httpContext = new DefaultHttpContext();
-            //httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
-            //httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
-            //httpContext.Request.ContentLength = 92;
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-abstraction-identifier"] = "AnInvalidSanitizer";
 
-            //var controller = new Admin(testRecordingHandler)
-            //{
-            //    ControllerContext = new ControllerContext()
-            //    {
-            //        HttpContext = httpContext
-            //    }
-            //};
-            //testRecordingHandler.Sanitizers.Clear();
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            testRecordingHandler.Sanitizers.Clear();
 
-            //var assertion = await Assert.ThrowsAsync<HttpException>(
-            //   async () => await controller.AddSanitizer()
-            //);
-            //assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
+            var assertion = await Assert.ThrowsAsync<HttpException>(
+               async () => await controller.AddSanitizer()
+            );
+            assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
 
+        [Fact]
         public async void TestAddSanitizerThrowsOnEmptyAbstractionId()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            testRecordingHandler.Sanitizers.Clear();
+
+            var assertion = await Assert.ThrowsAsync<HttpException>(
+               async () => await controller.AddSanitizer()
+            );
+            assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
 
+        [Fact]
         public async void TestAddTransformThrowsOnInvalidAbstractionId()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-abstraction-identifier"] = "AnInvalidTransform";
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            testRecordingHandler.Transforms.Clear();
+
+            var assertion = await Assert.ThrowsAsync<HttpException>(
+               async () => await controller.AddTransform()
+            );
+            assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
 
+        [Fact]
         public async void TestAddTransformThrowsOnEmptyAbstractionId()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            testRecordingHandler.Transforms.Clear();
+
+            var assertion = await Assert.ThrowsAsync<HttpException>(
+               async () => await controller.AddTransform()
+            );
+            assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
 
+        [Fact]
         public async void TestSetMatcherThrowsOnInvalidAbstractionId()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-abstraction-identifier"] = "AnInvalidMatcher";
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+
+            var assertion = await Assert.ThrowsAsync<HttpException>(
+               async () => await controller.SetMatcher()
+            );
+            assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
 
+        [Fact]
         public async void TestSetMatcherThrowsOnEmptyAbstractionId()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+
+            var assertion = await Assert.ThrowsAsync<HttpException>(
+               async () => await controller.SetMatcher()
+            );
+            assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
 
         [Fact]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -1,0 +1,39 @@
+using Azure.Sdk.Tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Matchers;
+using Azure.Sdk.Tools.TestProxy.Sanitizers;
+using Azure.Sdk.Tools.TestProxy.Transforms;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.Sdk.Tools.TestProxy.Tests
+{
+    public class PlaybackTests
+    {
+        public async void TestStartPlaybackSimple()
+        {
+        }
+
+        public async void TestStartPlaybackInMemory()
+        {
+        }
+
+        public async void TestStartPlaybackThrowsOnInvalidInput()
+        {
+        }
+
+        public async void TestStopPlaybackSimple()
+        {
+
+        }
+
+        public async void TestStopPlaybackInMemory()
+        {
+
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -33,6 +33,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             var value = httpContext.Response.Headers["x-recording-id"].ToString();
             Assert.NotNull(value);
+            Assert.True(testRecordingHandler.PlaybackSessions.ContainsKey(value));
         }
 
         [Fact]
@@ -54,6 +55,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             recordContext.Request.Headers["x-recording-id"] = new string[] { inMemId };
             recordController.Stop();
 
+            // apply same recordingId when starting in-memory session
             var playbackContext = new DefaultHttpContext();
             playbackContext.Request.Headers["x-recording-id"] = inMemId;
             var playbackController = new Playback(testRecordingHandler)
@@ -67,6 +69,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             var value = playbackContext.Response.Headers["x-recording-id"].ToString();
             Assert.NotNull(value);
+            Assert.True(testRecordingHandler.PlaybackSessions.ContainsKey(value));
+            Assert.True(testRecordingHandler.InMemorySessions.Count() == 1);
         }
 
         [Fact]
@@ -130,11 +134,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
             await controller.Start();
-
             var targetRecordingId = httpContext.Response.Headers["x-recording-id"].ToString();
+            
             httpContext.Request.Headers["x-recording-id"] = new string[] { targetRecordingId };
-
             controller.Stop();
+
+            Assert.False(testRecordingHandler.PlaybackSessions.ContainsKey(targetRecordingId));
         }
 
         [Fact]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -4,6 +4,7 @@ using Azure.Sdk.Tools.TestProxy.Sanitizers;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using System;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -14,26 +15,162 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 {
     public class PlaybackTests
     {
+        [Fact]
         public async void TestStartPlaybackSimple()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-recording-file"] = "Test.RecordEntries/requests_with_continuation.json";
+
+            var controller = new Playback(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            await controller.Start();
+
+            var value = httpContext.Response.Headers["x-recording-id"].ToString();
+            Assert.NotNull(value);
         }
 
+        [Fact]
         public async void TestStartPlaybackInMemory()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+
+            // get a recordingId that can be used for in-mem
+            var recordContext = new DefaultHttpContext();
+            var recordController = new Record(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = recordContext
+                }
+            };
+            recordController.Start();
+            var inMemId = recordContext.Response.Headers["x-recording-id"].ToString();
+            recordContext.Request.Headers["x-recording-id"] = new string[] { inMemId };
+            recordController.Stop();
+
+            var playbackContext = new DefaultHttpContext();
+            playbackContext.Request.Headers["x-recording-id"] = inMemId;
+            var playbackController = new Playback(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = playbackContext
+                }
+            };
+            await playbackController.Start();
+
+            var value = playbackContext.Response.Headers["x-recording-id"].ToString();
+            Assert.NotNull(value);
         }
 
+        [Fact]
+        public async void TestStartPlaybackInMemoryThrowsInInvalidRecordingId()
+        {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+
+            var playbackContext = new DefaultHttpContext();
+            var recordingId = Guid.NewGuid().ToString();
+            playbackContext.Request.Headers["x-recording-id"] = recordingId;
+            var playbackController = new Playback(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = playbackContext
+                }
+            };
+
+            var assertion = await Assert.ThrowsAsync<HttpException>(
+                async () => await playbackController.Start()
+            );
+
+            Assert.Equal($"There is no in-memory session with id {recordingId} available for playback retrieval.", assertion.Message);
+        }
+
+        [Fact]
         public async void TestStartPlaybackThrowsOnInvalidInput()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+
+            var playbackContext = new DefaultHttpContext();
+            var recordingId = Guid.NewGuid().ToString();
+            playbackContext.Request.Headers["x-recording-id"] = recordingId;
+            var playbackController = new Playback(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = playbackContext
+                }
+            };
+
+            var assertion = await Assert.ThrowsAsync<HttpException>(
+                async () => await playbackController.Start()
+            );
+
+            Assert.Equal($"There is no in-memory session with id {recordingId} available for playback retrieval.", assertion.Message);
         }
 
+        [Fact]
         public async void TestStopPlaybackSimple()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-recording-file"] = "Test.RecordEntries/requests_with_continuation.json";
 
+            var controller = new Playback(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            await controller.Start();
+
+            var targetRecordingId = httpContext.Response.Headers["x-recording-id"].ToString();
+            httpContext.Request.Headers["x-recording-id"] = new string[] { targetRecordingId };
+
+            controller.Stop();
         }
 
+        [Fact]
         public async void TestStopPlaybackInMemory()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
 
+            // get a recordingId that can be used for in-mem
+            var recordContext = new DefaultHttpContext();
+            var recordController = new Record(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = recordContext
+                }
+            };
+            recordController.Start();
+            var inMemId = recordContext.Response.Headers["x-recording-id"].ToString();
+            recordContext.Request.Headers["x-recording-id"] = new string[] { inMemId };
+            recordController.Stop();
+
+            var playbackContext = new DefaultHttpContext();
+            playbackContext.Request.Headers["x-recording-id"] = inMemId;
+            var playbackController = new Playback(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = playbackContext
+                }
+            };
+            await playbackController.Start();
+            var targetRecordingId = playbackContext.Response.Headers["x-recording-id"].ToString();
+            playbackContext.Request.Headers["x-recording-id"] = new string[] { targetRecordingId };
+            playbackController.Stop();
+
+            testRecordingHandler.InMemorySessions.ContainsKey(targetRecordingId);
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -14,6 +14,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 {
     public class RecordTests
     {
+        [Fact]
         public async void TestStartRecordSimple()
         {
             //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
@@ -37,18 +38,22 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             //assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
         }
 
+        [Fact]
         public async void TestStartRecordInMemory()
         {
         }
 
+        [Fact]
         public async void TestStartRecord()
         {
         }
 
+        [Fact]
         public async void TestStopRecordingSimple()
         {
         }
 
+        [Fact]
         public async void TestStopRecordingInMemory()
         {
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -1,0 +1,56 @@
+using Azure.Sdk.Tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Matchers;
+using Azure.Sdk.Tools.TestProxy.Sanitizers;
+using Azure.Sdk.Tools.TestProxy.Transforms;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.Sdk.Tools.TestProxy.Tests
+{
+    public class RecordTests
+    {
+        public async void TestStartRecordSimple()
+        {
+            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            //var httpContext = new DefaultHttpContext();
+            //httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderRegexSanitizer";
+            //httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
+            //httpContext.Request.ContentLength = 92;
+
+            //var controller = new Admin(testRecordingHandler)
+            //{
+            //    ControllerContext = new ControllerContext()
+            //    {
+            //        HttpContext = httpContext
+            //    }
+            //};
+            //testRecordingHandler.Sanitizers.Clear();
+
+            //var assertion = await Assert.ThrowsAsync<HttpException>(
+            //   async () => await controller.AddSanitizer()
+            //);
+            //assertion.StatusCode.Equals(HttpStatusCode.BadRequest);
+        }
+
+        public async void TestStartRecordInMemory()
+        {
+        }
+
+        public async void TestStartRecord()
+        {
+        }
+
+        public async void TestStopRecordingSimple()
+        {
+        }
+
+        public async void TestStopRecordingInMemory()
+        {
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -251,13 +251,15 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var tmpPath = Path.GetTempPath();
             var currentPath = Directory.GetCurrentDirectory();
             var httpContext = new DefaultHttpContext();
-            var pathToRecording = Path.Combine(currentPath, "Test.RecordEntries/oauth_request_wrong.json");
+            var recordingPath = "Test.RecordEntries/oauth_request_wrong.json";
+            var pathToRecording = Path.Combine(currentPath, recordingPath);
 
             var recordingHandler = new RecordingHandler(tmpPath);
 
-            await Assert.ThrowsAsync<FileNotFoundException>(
+            var resultingException = await Assert.ThrowsAsync<HttpException>(
                async () => await recordingHandler.StartPlayback(pathToRecording, httpContext.Response)
             );
+            Assert.Contains($"{recordingPath} does not exist", resultingException.Message);
         }
 
         [Fact]
@@ -269,9 +271,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             var recordingHandler = new RecordingHandler(currentPath);
 
-            await Assert.ThrowsAsync<FileNotFoundException>(
+            var resultingException = await Assert.ThrowsAsync<HttpException>(
                async () => await recordingHandler.StartPlayback(pathToRecording, httpContext.Response)
             );
+            Assert.Contains($"{pathToRecording} does not exist", resultingException.Message);
         }
 
         [Fact]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -301,7 +301,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             var recordingHandler = new RecordingHandler(tmpPath);
 
-            var resultingException = await Assert.ThrowsAsync<HttpException>(
+            var resultingException = await Assert.ThrowsAsync<TestRecordingMismatchException>(
                async () => await recordingHandler.StartPlayback(pathToRecording, httpContext.Response)
             );
             Assert.Contains($"{recordingPath} does not exist", resultingException.Message);
@@ -316,7 +316,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             var recordingHandler = new RecordingHandler(currentPath);
 
-            var resultingException = await Assert.ThrowsAsync<HttpException>(
+            var resultingException = await Assert.ThrowsAsync<TestRecordingMismatchException>(
                async () => await recordingHandler.StartPlayback(pathToRecording, httpContext.Response)
             );
             Assert.Contains($"{pathToRecording} does not exist", resultingException.Message);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -3,6 +3,7 @@ using Azure.Sdk.Tools.TestProxy.Matchers;
 using Azure.Sdk.Tools.TestProxy.Sanitizers;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -51,12 +52,56 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [Fact]
         public void TestGetHeader()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-test-presence"] = "This header has a value";
 
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+
+            RecordingHandler.GetHeader(httpContext.Request, "x-test-presence");
         }
 
+        [Fact]
         public void TestGetHeaderThrowsOnMissingHeader()
         {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
 
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+
+            var assertion = Assert.Throws<HttpException>(
+               () => RecordingHandler.GetHeader(httpContext.Request, "x-test-presence")
+            );
+        }
+
+        [Fact]
+        public void TestGetHeaderSilentOnAcceptableHeaderMiss()
+        {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+
+            var value = RecordingHandler.GetHeader(httpContext.Request, "x-test-presence", allowNulls: true);
+            Assert.Null(value);
         }
 
         [Fact]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -49,6 +49,17 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
+        public void TestGetHeader()
+        {
+
+        }
+
+        public void TestGetHeaderThrowsOnMissingHeader()
+        {
+
+        }
+
+        [Fact]
         public void TestResetAfterAddition()
         {
             // arrange

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -22,18 +22,6 @@ namespace Azure.Sdk.Tools.TestProxy
         public Admin(RecordingHandler recordingHandler) => _recordingHandler = recordingHandler;
 
         [HttpPost]
-        public void StartSession()
-        {
-            // so far, nothing necessary here
-        }
-
-        [HttpPost]
-        public void StopSession()
-        {
-            // so far, nothing necessary here
-        }
-
-        [HttpPost]
         public void Reset()
         {
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
@@ -160,11 +148,9 @@ namespace Azure.Sdk.Tools.TestProxy
 
                 return Activator.CreateInstance(t, arg_list.ToArray());
             }
-            catch(Exception e)
+            catch
             {
-                e.Data.Add("Attempted Type", String.Format("Requested type {0} is not not recognized.", typePrefix + name));
-
-                throw;
+                throw new HttpException(HttpStatusCode.BadRequest, String.Format("Requested type {0} is not not recognized.", typePrefix + name));
             }
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
@@ -4,6 +4,7 @@
 using Azure.Sdk.Tools.TestProxy.Common;
 using Microsoft.AspNetCore.Mvc;
 using System;
+using System.Net;
 using System.Threading.Tasks;
 
 namespace Azure.Sdk.Tools.TestProxy
@@ -31,7 +32,7 @@ namespace Azure.Sdk.Tools.TestProxy
             }
             else
             {
-                throw new InvalidOperationException("Either header 'x-recording-file' or 'x-recording-id' must be set when starting playback.");
+                throw new HttpException(HttpStatusCode.BadRequest, "At least one of two headers 'x-recording-file' or 'x-recording-id' must be set when starting playback.");
             }
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -271,7 +271,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
                 if (!File.Exists(path))
                 {
-                    throw new HttpException(HttpStatusCode.BadRequest, $"Recording file path {path} does not exist.");
+                    throw new TestRecordingMismatchException($"Recording file path {path} does not exist.");
                 }
 
                 using var stream = System.IO.File.OpenRead(path);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -261,7 +261,7 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 if (!InMemorySessions.TryGetValue(sessionId, out session))
                 {
-                    throw new HttpException(HttpStatusCode.BadRequest, $"There is no in-memory session with id {id} available for playback retrieval.");
+                    throw new HttpException(HttpStatusCode.BadRequest, $"There is no in-memory session with id {sessionId} available for playback retrieval.");
                 }
                 session.SourceRecordingId = sessionId;
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -92,8 +92,7 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 if (!InMemorySessions.TryAdd(sessionId, session))
                 {
-                    // This should not happen as the key is a new GUID.
-                    throw new InvalidOperationException("Failed to save in-memory session.");
+                    throw new HttpException(HttpStatusCode.InternalServerError, $"Unexpectedly failed to add new in-memory session under id {sessionId}.");
                 }
             }
             else
@@ -123,8 +122,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (!RecordingSessions.TryAdd(id, session))
             {
-                // This should not happen as the key is a new GUID.
-                throw new InvalidOperationException("Failed to add new session.");
+                throw new HttpException(HttpStatusCode.InternalServerError, $"Unexpectedly failed to add new recording session under id {id}.");
             }
 
             outgoingResponse.Headers.Add("x-recording-id", id);
@@ -134,7 +132,7 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             if (!RecordingSessions.TryGetValue(recordingId, out var session))
             {
-                throw new InvalidOperationException("No recording loaded with that ID.");
+                throw new HttpException(HttpStatusCode.BadRequest, $"There is no active recording session under id {recordingId}.");
             }
 
             var entry = await CreateEntryAsync(incomingRequest).ConfigureAwait(false);
@@ -263,21 +261,27 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 if (!InMemorySessions.TryGetValue(sessionId, out session))
                 {
-                    throw new InvalidOperationException("Failed to retrieve in-memory session.");
+                    throw new HttpException(HttpStatusCode.BadRequest, $"There is no in-memory session with id {id} available for playback retrieval.");
                 }
                 session.SourceRecordingId = sessionId;
             }
             else
             {
-                using var stream = System.IO.File.OpenRead(GetRecordingPath(sessionId));
+                var path = GetRecordingPath(sessionId);
+
+                if (!File.Exists(path))
+                {
+                    throw new HttpException(HttpStatusCode.BadRequest, $"Recording file path {path} does not exist.");
+                }
+
+                using var stream = System.IO.File.OpenRead(path);
                 using var doc = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
                 session = new ModifiableRecordSession(RecordSession.Deserialize(doc.RootElement));
             }
 
             if (!PlaybackSessions.TryAdd(id, session))
             {
-                // This should not happen as the key is a new GUID.
-                throw new InvalidOperationException("Failed to add new session.");
+                throw new HttpException(HttpStatusCode.InternalServerError, $"Unexpectedly failed to add new playback session under id {id}.");
             }
 
             outgoingResponse.Headers.Add("x-recording-id", id);
@@ -294,21 +298,21 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             if (!PlaybackSessions.TryRemove(recordingId, out var session))
             {
-                throw new InvalidOperationException("Unexpected failure to retrieve playback session.");
+                throw new HttpException(HttpStatusCode.BadRequest, $"There is no active playback session under recording id {recordingId}.");
             }
 
             if (!String.IsNullOrEmpty(session.SourceRecordingId) && purgeMemoryStore)
             {
                 if (!InMemorySessions.TryGetValue(session.SourceRecordingId, out var inMemorySession))
                 {
-                    throw new InvalidOperationException("Unexpected failure to retrieve in-memory session.");
+                    throw new HttpException(HttpStatusCode.InternalServerError, $"Unexpectedly failed to retrieve in-memory session {session.SourceRecordingId}.");
                 }
 
                 Interlocked.Add(ref Startup.RequestsRecorded, -1 * inMemorySession.Session.Entries.Count);                
 
                 if (!InMemorySessions.TryRemove(session.SourceRecordingId, out _))
                 {
-                    throw new InvalidOperationException("Unexpected failure to remove in-memory session.");
+                    throw new HttpException(HttpStatusCode.InternalServerError, $"Unexpectedly failed to remove in-memory session {session.SourceRecordingId}.");
                 }
 
                 GC.Collect();
@@ -319,7 +323,7 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             if (!PlaybackSessions.TryGetValue(recordingId, out var session))
             {
-                throw new InvalidOperationException("No recording loaded with that ID.");
+                throw new HttpException(HttpStatusCode.BadRequest, $"There is no active playback session under recording id {recordingId}.");
             }
 
             var entry = await CreateEntryAsync(incomingRequest).ConfigureAwait(false);
@@ -463,6 +467,11 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public string GetRecordingPath(string file)
         {
+            if (String.IsNullOrWhiteSpace(file))
+            {
+                throw new HttpException(HttpStatusCode.BadRequest, $"Recording file value of {file} is invalid. Try again with a populated filename.");
+            }
+
             var path = file;
 
             if (!Path.IsPathFullyQualified(file))
@@ -481,7 +490,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 {
                     return null;
                 }
-                throw new InvalidOperationException("Missing header: " + name);
+                throw new HttpException(HttpStatusCode.BadRequest, $"Expected header {name} is not populated in request.");
             }
 
             return value;
@@ -495,7 +504,22 @@ namespace Azure.Sdk.Tools.TestProxy
             // Using the RawTarget PREVENTS this automatic decode. We still lean on the URI constructors
             // to give us some amount of safety, but note that we explicitly disable escaping in that combination.
             var rawTarget = request.HttpContext.Features.Get<IHttpRequestFeature>().RawTarget;
-            var host = new Uri(GetHeader(request, "x-recording-upstream-base-uri"));
+            var hostValue = GetHeader(request, "x-recording-upstream-base-uri");
+            
+            // There is an ongoing issue where some libraries send a URL with two leading // after the hostname.
+            // This will just handle the error explicitly rather than letting it slip through and cause random issues during record/playback sessions.
+            if (rawTarget.StartsWith("//"))
+            {
+                throw new HttpException(HttpStatusCode.BadRequest, $"The URI being passed has two leading '/' in the Target, which will break URI combine with the hostname. Visible URI target: {rawTarget}.");
+            }
+
+            // it is easy to forget the x-recording-upstream-base-uri value
+            if (string.IsNullOrWhiteSpace(hostValue))
+            {
+                throw new HttpException(HttpStatusCode.BadRequest, $"The value present in header 'x-recording-upstream-base-uri' is not a valid hostname: {hostValue}.");
+            }
+
+            var host = new Uri(hostValue);
             return new Uri(host, rawTarget);
         }
 


### PR DESCRIPTION
- Adding explicit error handling for missing/improperly set hostname in a record request
- No more `InvalidOperationException` that doesn't get propogated back to the caller in a coherent fashion
