### PR TITLE
adding simple wrapper exposing the default matcher to for customization

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Matchers/CustomDefaultMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Matchers/CustomDefaultMatcher.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Azure.Sdk.Tools.TestProxy.Common;
+
+namespace Azure.Sdk.Tools.TestProxy.Matchers
+{
+    /// <summary>
+    /// This matcher exposes the default matcher in a customizable way. Currently this merely includes enabling/disabling body match and adding additional excluded headers. The range of customizability will extend past these initial two.
+    /// </summary>
+    public class CustomDefaultMatcher : RecordMatcher
+    {
+        /// <summary>
+        /// Both compareBodies and nonDefaultHeaderExclusions are safely defaulted for this constructor. This means that providing neither of them will produce a matcher that is functionally identical to the default.
+        /// </summary>
+        /// <param name="compareBodies">Should the body value be compared during lookup operations?</param>
+        /// <param name="nonDefaultHeaderExclusions">A comma separated list of additional headers that should be excluded during matching.</param>
+        public CustomDefaultMatcher(bool compareBodies = true, string nonDefaultHeaderExclusions = "") : base(compareBodies: compareBodies)
+        {
+            foreach(var exclusion in nonDefaultHeaderExclusions.Split(",").Where(x => !String.IsNullOrEmpty(x.Trim())))
+            {
+                if (!ExcludeHeaders.TryGetValue(exclusion, out var _)){
+                    ExcludeHeaders.Add(exclusion);
+                }
+            }
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Matchers/CustomDefaultMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Matchers/CustomDefaultMatcher.cs
@@ -18,9 +18,9 @@ namespace Azure.Sdk.Tools.TestProxy.Matchers
         /// <param name="nonDefaultHeaderExclusions">A comma separated list of additional headers that should be excluded during matching.</param>
         public CustomDefaultMatcher(bool compareBodies = true, string nonDefaultHeaderExclusions = "") : base(compareBodies: compareBodies)
         {
-            foreach(var exclusion in nonDefaultHeaderExclusions.Split(",").Where(x => !String.IsNullOrEmpty(x.Trim())))
+            foreach(var exclusion in nonDefaultHeaderExclusions.Split(",").Where(x => !string.IsNullOrEmpty(x.Trim())))
             {
-                if (!ExcludeHeaders.TryGetValue(exclusion, out var _)){
+                if (!ExcludeHeaders.Contains(exclusion)){
                     ExcludeHeaders.Add(exclusion);
                 }
             }


### PR DESCRIPTION
@JoshLove-msft This is a basic

> add these additional headers with exclude

I think that what I'll do here is add another argument, something like `extendDefaults` that defaults to `true`. If that element is `true`, then we will start you from a blank slate of excluded headers. What do you think?

@HarshaNalluru this same matcher will be extended for the `matching conditions` that you asked about last week. I need to figure out how to pull in non-string-only inputs from the sanitizer/matcher/transform Admin API, but I'll get there.

