### PR TITLE
Use stress test environment defaults for group and subscription

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -79,7 +79,7 @@ param (
     [switch] $OutFile,
 
     [Parameter()]
-    [switch] $RedactLogs
+    [boolean] $DevopsLogging = ($null -ne $env:SYSTEM_TEAMPROJECTID)
 )
 
 . $PSScriptRoot/SubConfig-Helpers.ps1
@@ -227,7 +227,7 @@ function SetDeploymentOutputs([string]$serviceName, [object]$azContext, [object]
                 if (ShouldMarkValueAsSecret $serviceDirectoryPrefix $key $value $notSecretValues) {
                     # Treat all ARM template output variables as secrets since "SecureString" variables do not set values.
                     # In order to mask secrets but set environment variables for any given ARM template, we set variables twice as shown below.
-                    if (!$RedactLogs) {
+                    if ($DevopsLogging) {
                         Write-Host "##vso[task.setvariable variable=_$key;issecret=true;]$value"
                         Write-Host "Setting variable as secret '$key': $value"
                     } else {
@@ -237,7 +237,7 @@ function SetDeploymentOutputs([string]$serviceName, [object]$azContext, [object]
                     Write-Host "Setting variable '$key': $value"
                     $notSecretValues += $value
                 }
-                if (!$RedactLogs) {
+                if ($DevopsLogging) {
                     Write-Host "##vso[task.setvariable variable=$key;]$value"
                 }
             } else {
@@ -875,10 +875,10 @@ The environment file will be named for the test resources template that it was
 generated for. For ARM templates, it will be test-resources.json.env. For
 Bicep templates, test-resources.bicep.env.
 
-.PARAMETER RedactLogs
+.PARAMETER DevopsLogging
 By default, the -CI parameter will print out secrets to logs with Azure Pipelines log
 commands that cause them to be redacted. For CI environments that don't support this (like 
-stress test clusters), this flag avoids printing out these secrets to the logs.
+stress test clusters), this flag can be set to $false to avoid printing out these secrets to the logs.
 
 .EXAMPLE
 Connect-AzAccount -Subscription 'REPLACE_WITH_SUBSCRIPTION_ID'

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -79,7 +79,7 @@ param (
     [switch] $OutFile,
 
     [Parameter()]
-    [boolean] $DevopsLogging = ($null -ne $env:SYSTEM_TEAMPROJECTID)
+    [switch] $DevopsLogging = ($null -ne $env:SYSTEM_TEAMPROJECTID)
 )
 
 . $PSScriptRoot/SubConfig-Helpers.ps1

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -79,7 +79,7 @@ param (
     [switch] $OutFile,
 
     [Parameter()]
-    [switch] $DevopsLogging = ($null -ne $env:SYSTEM_TEAMPROJECTID)
+    [switch] $SuppressVsoCommands = ($null -ne $env:SYSTEM_TEAMPROJECTID)
 )
 
 . $PSScriptRoot/SubConfig-Helpers.ps1
@@ -92,6 +92,17 @@ if (!$PSBoundParameters.ContainsKey('ErrorAction')) {
 function Log($Message)
 {
     Write-Host ('{0} - {1}' -f [DateTime]::Now.ToLongTimeString(), $Message)
+}
+
+# vso commands are specially formatted log lines that are parsed by Azure Pipelines
+# to perform additional actions, most commonly marking values as secrets.
+# https://docs.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands
+function LogVsoCommand([string]$message)
+{
+    if (!$CI -or $SuppressVsoCommands) {
+        return
+    }
+    Write-Host $message
 }
 
 function Retry([scriptblock] $Action, [int] $Attempts = 5)
@@ -227,19 +238,13 @@ function SetDeploymentOutputs([string]$serviceName, [object]$azContext, [object]
                 if (ShouldMarkValueAsSecret $serviceDirectoryPrefix $key $value $notSecretValues) {
                     # Treat all ARM template output variables as secrets since "SecureString" variables do not set values.
                     # In order to mask secrets but set environment variables for any given ARM template, we set variables twice as shown below.
-                    if ($DevopsLogging) {
-                        Write-Host "##vso[task.setvariable variable=_$key;issecret=true;]$value"
-                        Write-Host "Setting variable as secret '$key': $value"
-                    } else {
-                        Write-Host "Setting variable as secret '$key': REDACTED"
-                    }
+                    LogVsoCommand "##vso[task.setvariable variable=_$key;issecret=true;]$value"
+                    Write-Host "Setting variable as secret '$key'"
                 } else {
                     Write-Host "Setting variable '$key': $value"
                     $notSecretValues += $value
                 }
-                if ($DevopsLogging) {
-                    Write-Host "##vso[task.setvariable variable=$key;]$value"
-                }
+                LogVsoCommand "##vso[task.setvariable variable=$key;]$value"
             } else {
                 Write-Host ($shellExportFormat -f $key, $value)
             }
@@ -483,7 +488,7 @@ try {
 
         # Set the resource group name variable.
         Write-Host "Setting variable 'AZURE_RESOURCEGROUP_NAME': $ResourceGroupName"
-        Write-Host "##vso[task.setvariable variable=AZURE_RESOURCEGROUP_NAME;]$ResourceGroupName"
+        LogVsoCommand "##vso[task.setvariable variable=AZURE_RESOURCEGROUP_NAME;]$ResourceGroupName"
         if ($EnvironmentVariables.ContainsKey('AZURE_RESOURCEGROUP_NAME') -and `
             $EnvironmentVariables['AZURE_RESOURCEGROUP_NAME'] -ne $ResourceGroupName)
         {
@@ -875,7 +880,7 @@ The environment file will be named for the test resources template that it was
 generated for. For ARM templates, it will be test-resources.json.env. For
 Bicep templates, test-resources.bicep.env.
 
-.PARAMETER DevopsLogging
+.PARAMETER SuppressVsoCommands
 By default, the -CI parameter will print out secrets to logs with Azure Pipelines log
 commands that cause them to be redacted. For CI environments that don't support this (like 
 stress test clusters), this flag can be set to $false to avoid printing out these secrets to the logs.

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -79,7 +79,7 @@ param (
     [switch] $OutFile,
 
     [Parameter()]
-    [switch] $SuppressVsoCommands = ($null -ne $env:SYSTEM_TEAMPROJECTID)
+    [switch] $SuppressVsoCommands = ($null -eq $env:SYSTEM_TEAMPROJECTID)
 )
 
 . $PSScriptRoot/SubConfig-Helpers.ps1

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -571,7 +571,7 @@ Aliases:
 
 Required: False
 Position: Named
-Default value: ($null -ne $env:SYSTEM_TEAMPROJECTID)
+Default value: ($null -eq $env:SYSTEM_TEAMPROJECTID)
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -18,7 +18,7 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
  [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
  [-SubscriptionId <String>] [-DeleteAfterHours <Int32>] [-Location <String>] [-Environment <String>]
  [-ArmTemplateParameters <Hashtable>] [-AdditionalParameters <Hashtable>] [-EnvironmentVariables <Hashtable>]
- [-CI] [-Force] [-OutFile] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-CI] [-Force] [-OutFile] [-RedactLogs] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Provisioner
@@ -28,7 +28,8 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
  -TenantId <String> [-SubscriptionId <String>] -ProvisionerApplicationId <String>
  -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>] [-Location <String>]
  [-Environment <String>] [-ArmTemplateParameters <Hashtable>] [-AdditionalParameters <Hashtable>]
- [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile] [-RedactLogs] [-WhatIf] [-Confirm]
+ [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -544,6 +545,24 @@ generated for.
 For ARM templates, it will be test-resources.json.env.
 For
 Bicep templates, test-resources.bicep.env.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RedactLogs
+By default, the -CI parameter will print out secrets to logs with Azure Pipelines log
+commands that cause them to be redacted.
+For CI environments that don't support this (like 
+stress test clusters), this flag avoids printing out these secrets to the logs.
 
 ```yaml
 Type: SwitchParameter

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -18,7 +18,7 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
  [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
  [-SubscriptionId <String>] [-DeleteAfterHours <Int32>] [-Location <String>] [-Environment <String>]
  [-ArmTemplateParameters <Hashtable>] [-AdditionalParameters <Hashtable>] [-EnvironmentVariables <Hashtable>]
- [-CI] [-Force] [-OutFile] [-RedactLogs] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-CI] [-Force] [-OutFile] [-DevopsLogging <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Provisioner
@@ -28,7 +28,7 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
  -TenantId <String> [-SubscriptionId <String>] -ProvisionerApplicationId <String>
  -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>] [-Location <String>]
  [-Environment <String>] [-ArmTemplateParameters <Hashtable>] [-AdditionalParameters <Hashtable>]
- [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile] [-RedactLogs] [-WhatIf] [-Confirm]
+ [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile] [-DevopsLogging <Boolean>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -558,20 +558,20 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -RedactLogs
+### -DevopsLogging
 By default, the -CI parameter will print out secrets to logs with Azure Pipelines log
 commands that cause them to be redacted.
 For CI environments that don't support this (like 
-stress test clusters), this flag avoids printing out these secrets to the logs.
+stress test clusters), this flag can be set to $false to avoid printing out these secrets to the logs.
 
 ```yaml
-Type: SwitchParameter
+Type: Boolean
 Parameter Sets: (All)
 Aliases:
 
 Required: False
 Position: Named
-Default value: False
+Default value: ($null -ne $env:SYSTEM_TEAMPROJECTID)
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -18,7 +18,7 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
  [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
  [-SubscriptionId <String>] [-DeleteAfterHours <Int32>] [-Location <String>] [-Environment <String>]
  [-ArmTemplateParameters <Hashtable>] [-AdditionalParameters <Hashtable>] [-EnvironmentVariables <Hashtable>]
- [-CI] [-Force] [-OutFile] [-DevopsLogging <Boolean>] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-CI] [-Force] [-OutFile] [-SuppressVsoCommands] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Provisioner
@@ -28,7 +28,7 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
  -TenantId <String> [-SubscriptionId <String>] -ProvisionerApplicationId <String>
  -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>] [-Location <String>]
  [-Environment <String>] [-ArmTemplateParameters <Hashtable>] [-AdditionalParameters <Hashtable>]
- [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile] [-DevopsLogging <Boolean>] [-WhatIf] [-Confirm]
+ [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile] [-SuppressVsoCommands] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -558,14 +558,14 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -DevopsLogging
+### -SuppressVsoCommands
 By default, the -CI parameter will print out secrets to logs with Azure Pipelines log
 commands that cause them to be redacted.
 For CI environments that don't support this (like 
 stress test clusters), this flag can be set to $false to avoid printing out these secrets to the logs.
 
 ```yaml
-Type: Boolean
+Type: SwitchParameter
 Parameter Sets: (All)
 Aliases:
 

--- a/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
+++ b/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
@@ -1,3 +1,4 @@
+[CmdletBinding(DefaultParameterSetName = 'Default')]
 param(
     [string]$SearchDirectory,
     [hashtable]$Filters,

--- a/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
+++ b/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
@@ -1,3 +1,6 @@
+# Set a default parameter set here so we can call this script without requiring -Login and -Subscription,
+# but if it IS called with either of those, then both parameters need to be required. Not defining a
+# default parameter set makes Login/Subscription required all the time.
 [CmdletBinding(DefaultParameterSetName = 'Default')]
 param(
     [string]$SearchDirectory,

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -86,6 +86,9 @@ function DeployStressTests(
     }
 
     if ($login) {
+        if (!$clusterGroup -or !$subscription) {
+            throw "clusterGroup and subscription parameters must be specified when logging into an environment that is not test or prod."
+        }
         Login $subscription $clusterGroup $pushImages
     }
 

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -27,7 +27,7 @@ function RunOrExitOnFailure()
     }
 }
 
-function Login([string]$subscription, [string]$clusterGroup, [boolean]$pushImages)
+function Login([string]$subscription, [string]$clusterGroup, [switch]$pushImages)
 {
     Write-Host "Logging in to subscription, cluster and container registry"
     az account show *> $null
@@ -58,12 +58,12 @@ function DeployStressTests(
     [hashtable]$filters = @{},
     [string]$environment = 'test',
     [string]$repository = '',
-    [boolean]$pushImages = $false,
+    [switch]$pushImages,
     [string]$clusterGroup = '',
     [string]$deployId = 'local',
-    [boolean]$login = $false,
+    [switch]$login,
     [string]$subscription = '',
-    [boolean]$ci = $false
+    [switch]$ci
 ) {
     if ($environment -eq 'test') {
         if ($clusterGroup -or $subscription) {
@@ -120,8 +120,8 @@ function DeployStressPackage(
     [string]$deployId,
     [string]$environment,
     [string]$repositoryBase,
-    [boolean]$pushImages,
-    [boolean]$login
+    [switch]$pushImages,
+    [switch]$login
 ) {
     $registry = RunOrExitOnFailure az acr list -g $clusterGroup --subscription $subscription -o json
     $registryName = ($registry | ConvertFrom-Json).name

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -79,10 +79,24 @@ function DeployStressTests(
     [string]$environment = 'test',
     [string]$repository = 'images',
     [boolean]$pushImages = $false,
-    [string]$clusterGroup = 'rg-stress-cluster-test',
+    [string]$clusterGroup = '',
     [string]$deployId = 'local',
-    [string]$subscription = 'Azure SDK Developer Playground'
+    [string]$subscription = ''
 ) {
+    if ($environment -eq 'test') {
+        if ($clusterGroup -or $subscription) {
+            Write-Warning "Overriding cluster group and subscription with defaults for 'test' environment."
+        }
+        $clusterGroup = 'rg-stress-cluster-test'
+        $subscription = 'Azure SDK Developer Playground'
+    } elseif ($environment -eq 'prod') {
+        if ($clusterGroup -or $subscription) {
+            Write-Warning "Overriding cluster group and subscription with defaults for 'prod' environment."
+        }
+        $clusterGroup = 'rg-stress-cluster-prod'
+        $subscription = 'Azure SDK Test Resources'
+    }
+
     if ($PSCmdlet.ParameterSetName -eq 'DoLogin') {
         Login $subscription $clusterGroup $pushImages
     }

--- a/eng/pipelines/stress-test-release.yml
+++ b/eng/pipelines/stress-test-release.yml
@@ -3,15 +3,15 @@ pr: none
 trigger: none
 
 parameters:
-  - name: Subscription
-    type: string
-    default: 'Azure SDK Test Resources'
   - name: Environment
     type: string
     default: prod
-  - name: ClusterGroup
+  - name: SubscriptionOverride
     type: string
-    default: rg-stress-cluster-prod
+    default: ''
+  - name: ClusterGroupOverride
+    type: string
+    default: ''
   - name: TestRepository
     displayName: Stress Test Repository
     type: string
@@ -85,8 +85,8 @@ jobs:
           -Environment '${{ parameters.Environment }}'
           -Repository '$(Agent.JobName)'
           -PushImages
-          -ClusterGroup '${{ parameters.ClusterGroup }}'
+          -ClusterGroup '${{ parameters.ClusterGroupOverride }}'
           -Login
-          -Subscription '${{ parameters.Subscription }}'
+          -Subscription '${{ parameters.SubscriptionOverride }}'
           -DeployId '$(Build.BuildNumber)'
           -CI

--- a/tools/stress-cluster/chaos/examples/network-stress-example/templates/testjob.yaml
+++ b/tools/stress-cluster/chaos/examples/network-stress-example/templates/testjob.yaml
@@ -11,6 +11,6 @@ spec:
   containers:
     - name: network-example
       command: ["bash", "poll.sh"]
-      image: {{ default "" .Values.repository }}/network-stress-example:{{ default "v1" .Values.tag }}
+      image: {{ .Values.image }}
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: stress-test-addons
 description: Baseline resources and templates for stress testing clusters
 
-version: 0.1.12
+version: 0.1.13
 appVersion: v0.1

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/Dockerfile
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/Dockerfile
@@ -7,4 +7,4 @@ COPY ./docker_build/common /common
 COPY test-resources-post.ps1 /scripts/stress-test/
 COPY deploy-stress-test-resources.ps1 /scripts/stress-test/
 
-CMD pwsh -c ./common/TestResources/deploy-stress-test.ps1
+CMD pwsh -c /scripts/stress-test/deploy-stress-test-resources.ps1

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/deploy-stress-test-resources.ps1
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/deploy-stress-test-resources.ps1
@@ -29,7 +29,7 @@ $env = & /common/TestResources/New-TestResources.ps1 `
     -Location 'westus2' `
     -DeleteAfterHours 168 `
     -ServiceDirectory '/azure/' `
-    -DevopsLogging:$false `
+    -SuppressVsoCommands:$true `
     -CI `
     -Force
 

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/deploy-stress-test-resources.ps1
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/deploy-stress-test-resources.ps1
@@ -29,8 +29,8 @@ $env = & /common/TestResources/New-TestResources.ps1 `
     -Location 'westus2' `
     -DeleteAfterHours 168 `
     -ServiceDirectory '/azure/' `
+    -DevopsLogging = $false `
     -CI `
-    -RedactLogs `
     -Force
 
 #>

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/deploy-stress-test-resources.ps1
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/deploy-stress-test-resources.ps1
@@ -29,7 +29,7 @@ $env = & /common/TestResources/New-TestResources.ps1 `
     -Location 'westus2' `
     -DeleteAfterHours 168 `
     -ServiceDirectory '/azure/' `
-    -DevopsLogging = $false `
+    -DevopsLogging:$false `
     -CI `
     -Force
 

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/deploy-stress-test-resources.ps1
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/deploy-stress-test-resources.ps1
@@ -15,7 +15,8 @@ mkdir /azure
 Copy-Item "/scripts/stress-test/test-resources-post.ps1" -Destination "/azure/"
 Copy-Item "/mnt/testresources/*" -Destination "/azure/"
 
-& /common/TestResources/New-TestResources.ps1 `
+# Capture output so we don't print environment variable secrets
+$env = & /common/TestResources/New-TestResources.ps1 `
     -BaseName $env:RESOURCE_GROUP_NAME `
     -ResourceGroupName $env:RESOURCE_GROUP_NAME `
     -SubscriptionId $secrets.AZURE_SUBSCRIPTION_ID `
@@ -29,6 +30,7 @@ Copy-Item "/mnt/testresources/*" -Destination "/azure/"
     -DeleteAfterHours 168 `
     -ServiceDirectory '/azure/' `
     -CI `
-    -Force 
+    -RedactLogs `
+    -Force
 
 #>

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/test-resources-post.ps1
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/test-resources-post.ps1
@@ -12,7 +12,14 @@ if ([string]::IsNullOrEmpty($outputFile)) {
 }
 
 $environmentText = ''
-foreach($entry in $DeploymentOutputs.GetEnumerator()) {
+
+try {
+    foreach ($line in (Get-Content $outputFile)) {
+        $environmentText += ($line + "`n")
+    }
+} catch {}
+
+foreach ($entry in $DeploymentOutputs.GetEnumerator()) {
     $environmentText += "$($entry.name)=$($entry.value)`n"
 }
 

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
@@ -3,6 +3,15 @@ entries:
   stress-test-addons:
   - apiVersion: v2
     appVersion: v0.1
+    created: "2021-12-02T17:54:52.7194418-05:00"
+    description: Baseline resources and templates for stress testing clusters
+    digest: 1e944bd23f2a7697d539d06abdc6216ac1549e2a29d65752442aef3e4286f38a
+    name: stress-test-addons
+    urls:
+    - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.13.tgz
+    version: 0.1.13
+  - apiVersion: v2
+    appVersion: v0.1
     created: "2021-11-16T19:21:18.4750036-05:00"
     description: Baseline resources and templates for stress testing clusters
     digest: e83aa9490e2afa1c3917fb31b4cf4594414ee52d2b7182104bd84d9e1b7b860f
@@ -91,4 +100,4 @@ entries:
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.2.tgz
     version: 0.1.2
-generated: "2021-11-16T19:21:18.4744262-05:00"
+generated: "2021-12-02T17:54:52.7127566-05:00"

--- a/tools/stress-cluster/cluster/provision.ps1
+++ b/tools/stress-cluster/cluster/provision.ps1
@@ -45,7 +45,7 @@ function DeployStaticResources([hashtable]$params) {
     $sp = RunOrExitOnFailure az ad sp create-for-rbac `
         -o json `
         -n "stress-provisioner-$($params.groupSuffix)" `
-        --role Contributor `
+        --role Owner `
         --scopes "/subscriptions/$($params.subscriptionId)"
     $spInfo = $sp | ConvertFrom-Json
     $oid = (RunOrExitOnFailure az ad sp show -o json --id $spInfo.appId | ConvertFrom-Json).objectId


### PR DESCRIPTION
- There's no need to have to specify the cluster resource group and subscription when we already know these values ahead of time. We still need to keep them as parameters to enable people to deploy to dev environments they've provisioned themselves.
- Fix secret logging in CI mode from New-TestResources
- Fix the stress deployment script overwriting pre-existing env variables
- Simplify stress chart image handling
- Bump addons chart to 0.1.13