### PR TITLE
Fixing nested copy items in prepare.ps1 for stress test

### DIFF
--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/prepare.ps1
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/prepare.ps1
@@ -2,4 +2,5 @@ $repositoryRoot = Resolve-Path (Join-Path -Path $PSScriptRoot -ChildPath "../../
 $copyDirectory = Resolve-Path (Join-Path -Path $repositoryRoot -ChildPath "eng/common/")
 $targetDirectory = "$PsScriptRoot/docker_build/common"
 
-Copy-Item -Path $copyDirectory -Destination $targetDirectory -Force -Recurse
+New-Item -Force -Type Directory $targetDirectory
+Copy-Item -Path "$copyDirectory/*" -Destination $targetDirectory -Force -Recurse


### PR DESCRIPTION
The prepare.ps1 script will copy the items and create a nested /common directory if the /common directory already exist