### PR TITLE
Add disk metrics script and template

### DIFF
--- a/eng/common/pipelines/templates/steps/write-filesystemmetrics.yml
+++ b/eng/common/pipelines/templates/steps/write-filesystemmetrics.yml
@@ -1,0 +1,6 @@
+steps:
+    - task: Powershell@2
+      inputs:
+        filePath: $(Build.SourcesDirectory)/eng/common/scripts/Write-FileSystemMetrics.ps1
+        pwsh: true
+      displayName: Write filesystem metrics

--- a/eng/common/pipelines/templates/steps/write-filesystemmetrics.yml
+++ b/eng/common/pipelines/templates/steps/write-filesystemmetrics.yml
@@ -4,3 +4,4 @@ steps:
         filePath: $(Build.SourcesDirectory)/eng/common/scripts/Write-FileSystemMetrics.ps1
         pwsh: true
       displayName: Write filesystem metrics
+      continueOnError: true

--- a/eng/common/scripts/Write-FileSystemMetrics.ps1
+++ b/eng/common/scripts/Write-FileSystemMetrics.ps1
@@ -1,0 +1,29 @@
+foreach($volume in Get-Volume) {
+    if($null -ne $volume.DriveLetter) {
+       $entry = [ordered]@{
+        "name"= "agent_disk_size_bytes";
+        "value"= $volume.Size;
+        "timestamp"= [DateTimeOffset]::UtcNow;
+        "labels"= [ordered]@{
+          "driveLetter"= $volume.DriveLetter;
+          "fileSystemLabel"= $volume.FileSystemLabel;
+          "fileSystemType"= $volume.FileSystemType;
+        }
+      }
+
+      Write-Output "logmetric: $($entry | ConvertTo-Json -Compress)"
+
+      $entry = [ordered]@{
+        "name"= "agent_disk_remaining_bytes";
+        "value"= $volume.SizeRemaining;
+        "timestamp"= [DateTimeOffset]::UtcNow;
+        "labels"= [ordered]@{
+          "driveLetter"= $volume.DriveLetter;
+          "fileSystemLabel"= $volume.FileSystemLabel;
+          "fileSystemType"= $volume.FileSystemType;
+        }
+      }
+
+      Write-Output "logmetric: $($entry | ConvertTo-Json -Compress)"
+    }
+}

--- a/eng/common/scripts/Write-FileSystemMetrics.ps1
+++ b/eng/common/scripts/Write-FileSystemMetrics.ps1
@@ -1,29 +1,31 @@
-foreach($volume in Get-Volume) {
-    if($null -ne $volume.DriveLetter) {
-       $entry = [ordered]@{
-        "name"= "agent_disk_size_bytes";
-        "value"= $volume.Size;
-        "timestamp"= [DateTimeOffset]::UtcNow;
-        "labels"= [ordered]@{
-          "driveLetter"= $volume.DriveLetter;
-          "fileSystemLabel"= $volume.FileSystemLabel;
-          "fileSystemType"= $volume.FileSystemType;
-        }
+$drives = [IO.DriveInfo]::GetDrives() | Where-Object { $_.TotalSize -gt 0 -and $_.DriveType -eq 'Fixed' -and $null -ne $_.Name }
+
+foreach($drive in $drives) {
+    $entry = [ordered]@{
+      "name"= "agent_driveinfo_size_bytes";
+      "value"= $drive.TotalSize;
+      "timestamp"= [DateTimeOffset]::UtcNow;
+      "labels"= [ordered]@{
+        "name"= $drive.Name;
+        "volumeLabel"= $drive.VolumeLabel;
+        "driveType"= $drive.DriveType.ToString();
+        "driveFormat"= $drive.DriveFormat;
       }
-
-      Write-Output "logmetric: $($entry | ConvertTo-Json -Compress)"
-
-      $entry = [ordered]@{
-        "name"= "agent_disk_remaining_bytes";
-        "value"= $volume.SizeRemaining;
-        "timestamp"= [DateTimeOffset]::UtcNow;
-        "labels"= [ordered]@{
-          "driveLetter"= $volume.DriveLetter;
-          "fileSystemLabel"= $volume.FileSystemLabel;
-          "fileSystemType"= $volume.FileSystemType;
-        }
-      }
-
-      Write-Output "logmetric: $($entry | ConvertTo-Json -Compress)"
     }
+
+    Write-Output "logmetric: $($entry | ConvertTo-Json -Compress)"
+
+    $entry = [ordered]@{
+      "name"= "agent_driveinfo_available_bytes";
+      "value"= $drive.AvailableFreeSpace;
+      "timestamp"= [DateTimeOffset]::UtcNow;
+      "labels"= [ordered]@{
+        "name"= $drive.Name;
+        "volumeLabel"= $drive.VolumeLabel;
+        "driveType"= $drive.DriveType.ToString();
+        "driveFormat"= $drive.DriveFormat;
+      }
+    }
+
+    Write-Output "logmetric: $($entry | ConvertTo-Json -Compress)"
 }


### PR DESCRIPTION
emits metrics like:

```
logmetric: {"name":"agent_driveinfo_size_bytes","value":296559366144,"timestamp":"2021-12-07T00:10:39.783592+00:00","labels":{"name":"C:\\","volumeLabel":"System","driveType":"Fixed","driveFormat":"NTFS"}}
logmetric: {"name":"agent_driveinfo_available_bytes","value":176327012352,"timestamp":"2021-12-07T00:10:39.7865546+00:00","labels":{"name":"C:\\","volumeLabel":"System","driveType":"Fixed","driveFormat":"NTFS"}}
logmetric: {"name":"agent_driveinfo_size_bytes","value":214748360704,"timestamp":"2021-12-07T00:10:39.7888924+00:00","labels":{"name":"D:\\","volumeLabel":"Data","driveType":"Fixed","driveFormat":"NTFS"}}
logmetric: {"name":"agent_driveinfo_available_bytes","value":194948788224,"timestamp":"2021-12-07T00:10:39.7912437+00:00","labels":{"name":"D:\\","volumeLabel":"Data","driveType":"Fixed","driveFormat":"NTFS"}}
```

and on linux:
```
logmetric: {"name":"agent_driveinfo_size_bytes","value":34078720,"timestamp":"2021-12-07T00:14:38.5586226+00:00","labels":{"name":"/snap/snapd/13640","volumeLabel":"/snap/snapd/13640","driveType":"Fixed","driveFormat":"squashfs"}}
logmetric: {"name":"agent_driveinfo_available_bytes","value":0,"timestamp":"2021-12-07T00:14:38.5590331+00:00","labels":{"name":"/snap/snapd/13640","volumeLabel":"/snap/snapd/13640","driveType":"Fixed","driveFormat":"squashfs"}}
logmetric: {"name":"agent_driveinfo_size_bytes","value":157457793024,"timestamp":"2021-12-07T00:14:38.5594543+00:00","labels":{"name":"/mnt","volumeLabel":"/mnt","driveType":"Fixed","driveFormat":"lofs"}}
logmetric: {"name":"agent_driveinfo_available_bytes","value":144993136640,"timestamp":"2021-12-07T00:14:38.5598729+00:00","labels":{"name":"/mnt","volumeLabel":"/mnt","driveType":"Fixed","driveFormat":"lofs"}}
logmetric: {"name":"agent_driveinfo_size_bytes","value":44302336,"timestamp":"2021-12-07T00:14:38.5602935+00:00","labels":{"name":"/snap/snapd/14066","volumeLabel":"/snap/snapd/14066","driveType":"Fixed","driveFormat":"squashfs"}}
logmetric: {"name":"agent_driveinfo_available_bytes","value":0,"timestamp":"2021-12-07T00:14:38.5607022+00:00","labels":{"name":"/snap/snapd/14066","volumeLabel":"/snap/snapd/14066","driveType":"Fixed","driveFormat":"squashfs"}}
```