### PR TITLE
Enable Scoping of Doc-Warden Run.

### DIFF
--- a/packages/python-packages/doc-warden/README.md
+++ b/packages/python-packages/doc-warden/README.md
@@ -72,8 +72,11 @@ Currently supports 3 commands. Values: `['scan', 'presence', 'content', `index`]
 `--scan-directory`
 The target directory `warden` should be scanning. **Required.**
 
+`--repo-root`
+The root of the repo. Entries in the config-file should be relative to this directory. **Optional.**
+
 `--scan-language`
-`warden` checks for packages by _convention_, so it needs to understand what language it is looking at. This must be populated either in `.docsettings file` or by parameter. **Required.**
+`warden` checks for packages by _convention_, so it needs to understand what language it is looking at. This must be populated either in `.docsettings file` or by parameter. **Optional.**
 
 `--config-location`
 By default, `warden` looks for the `.docsettings` file in the root of the repository. However, populating this location will override this behavior and instead pull the file from the location in this parameter. **Optional.**

--- a/packages/python-packages/doc-warden/changelog.md
+++ b/packages/python-packages/doc-warden/changelog.md
@@ -1,4 +1,6 @@
 # Release History
+## 0.7.2
+- Add and `--repo-root` argument. This allows scoping of the run to any directory in the repo as long as all entries in the config file are relative to this directory.
 
 ## 0.7.1
 - Fixed an issue where `doc-warden` was handling the code fence blocks improperly. This issue caused verson `0.7.0` to throw errors when it SHOULDN'T have been.

--- a/packages/python-packages/doc-warden/warden/WardenConfiguration.py
+++ b/packages/python-packages/doc-warden/warden/WardenConfiguration.py
@@ -42,8 +42,14 @@ class WardenConfiguration():
             '-d',
             '--scan-directory',
             dest = 'scan_directory',
-            help = 'The repo directory that this tool should be scanning.',
+            help = 'The directory on a repo that this tool should be scanning.',
             required = True)
+        parser.add_argument(
+            '-u',
+            '--repo-root',
+            dest = 'repo_root',
+            help = 'The root of the repo',
+            required = False)
         parser.add_argument(
             '-c',
             '--config-location',
@@ -103,8 +109,9 @@ class WardenConfiguration():
 
         self.command = args.command
         self.target_directory = args.scan_directory
-        self.yml_location = args.config_location or os.path.join(self.target_directory, '.docsettings.yml')
-        self.package_index_output_location = args.package_output_location or os.path.join(self.target_directory, 'packages.md')
+        self.repo_root = args.repo_root or self.target_directory
+        self.yml_location = args.config_location or os.path.join(self.repo_root, '.docsettings.yml')
+        self.package_index_output_location = args.package_output_location or os.path.join(self.repo_root, 'packages.md')
         self.target = args.target or 'default'
         self.target_files = []
 
@@ -172,26 +179,26 @@ class WardenConfiguration():
     # strips the directory up till the repo root. Allows us to easily think about 
     # relative paths instead of absolute on disk
     def get_output_path(self, input_path):
-        return input_path.replace(os.path.normpath(self.target_directory), '')
+        return input_path.replace(os.path.normpath(self.repo_root), '')
 
     def get_known_presence_issues(self):
         known_issue_paths = []
         for exception_tuple in self.known_presence_issues:
             if any(exception_tuple[0].lower().endswith(target_file) for target_file in self.target_files):
-                known_issue_paths.append(os.path.normpath(os.path.join(self.target_directory, os.path.dirname(exception_tuple[0]))))
+                known_issue_paths.append(os.path.normpath(os.path.join(self.repo_root, os.path.dirname(exception_tuple[0]))))
             elif any(target_file.startswith('readme') for target_file in self.target_files):
-                known_issue_paths.append(os.path.normpath(os.path.join(self.target_directory, exception_tuple[0])))
+                known_issue_paths.append(os.path.normpath(os.path.join(self.repo_root, exception_tuple[0])))
         return known_issue_paths
 
     def get_known_content_issues(self):
         known_issue_paths = []
         for exception_tuple in self.known_content_issues:
             if any(exception_tuple[0].lower().endswith(target_file) for target_file in self.target_files):
-                known_issue_paths.append(os.path.normpath(os.path.join(self.target_directory, exception_tuple[0])))
+                known_issue_paths.append(os.path.normpath(os.path.join(self.repo_root, exception_tuple[0])))
         return known_issue_paths
 
     def get_package_indexing_traversal_stops(self):
-        return [os.path.normpath(os.path.join(self.target_directory, traversal_stop)) for traversal_stop in self.package_indexing_traversal_stops]
+        return [os.path.normpath(os.path.join(self.repo_root, traversal_stop)) for traversal_stop in self.package_indexing_traversal_stops]
 
     def get_repository_details(self):
         return WardenConfiguration.REPOSITORY_SETS[self.scan_language]
@@ -200,6 +207,7 @@ class WardenConfiguration():
         current_config = {
             'command': self.command,
             'target_directory': self.target_directory,
+            'repo_root': self.repo_root,
             'yml_location': self.yml_location,
             'omitted_paths': self.omitted_paths,
             'package_indexing_exclusion_list': self.package_indexing_exclusion_list,

--- a/packages/python-packages/doc-warden/warden/warden_common.py
+++ b/packages/python-packages/doc-warden/warden/warden_common.py
@@ -120,18 +120,18 @@ def get_file_sets(configuration, target_pattern, lambda_check=None):
 
 # gets the set of files in the target directory that have explicitly been omitted in the config settings
 def get_omitted_files(configuration):
-    target_directory = configuration.target_directory
+    repo_root = configuration.repo_root
     omitted_paths = []
     dirs = configuration.omitted_paths or []
 
     # single special case here. if wildcard match at the beginning, do not join, use the pattern as is
     adjusted_dirs = [
-        pattern if pattern.startswith("*") else os.path.join(target_directory, pattern)
+        pattern if pattern.startswith("*") else os.path.join(repo_root, pattern)
         for pattern in dirs
     ]
     omitted_paths.extend(
         walk_directory_for_pattern(
-            target_directory, adjusted_dirs, configuration, None, True
+            repo_root, adjusted_dirs, configuration, None, True
         )
     )
 


### PR DESCRIPTION
- Add `--repo_root` argument to docwarden to enable scoping of docwarden to service directory.