### PR TITLE
mock-service-host: use localPort

### DIFF
--- a/tools/mock-service-host/src/mid/coordinator.ts
+++ b/tools/mock-service-host/src/mid/coordinator.ts
@@ -15,6 +15,7 @@ import {
     ValidationFail
 } from '../common/errors'
 import { InjectableTypes } from '../lib/injectableTypes'
+import { LiveValidationError } from 'oav/dist/lib/models'
 import { OperationMatch, OperationSearcher } from 'oav/dist/lib/liveValidation/operationSearcher'
 import { ResourcePool } from './resource'
 import { ResponseGenerator } from './responser'
@@ -320,9 +321,11 @@ export class Coordinator {
         let firstloop = true
         while (uriPath.length > 0) {
             if (firstloop || uriPath.length % 2 === 1) {
-                const testingUrl = `${req.protocol}://${req.headers?.host}${uriPath.join(
-                    '/'
-                )}?${query}`
+                let hostAndPort = req.headers?.host as string
+                if (hostAndPort.split(':').length > 0) {
+                    hostAndPort = `${hostAndPort}:${req.localPort}`
+                }
+                const testingUrl = `${req.protocol}://${hostAndPort}${uriPath.join('/')}?${query}`
                 try {
                     const validationRequest = this.liveValidator.parseValidationRequest(
                         testingUrl,
@@ -332,7 +335,13 @@ export class Coordinator {
                     this.liveValidator.operationSearcher.search(validationRequest)
                     return testingUrl
                 } catch (error) {
-                    // don't has 'GET' verb for this url
+                    if (
+                        error instanceof LiveValidationError &&
+                        error?.code === Constants.ErrorCodes.MultipleOperationsFound.name
+                    ) {
+                        return testingUrl
+                    }
+                    console.info(error) // don't has 'GET' verb for this url
                 }
             }
             uriPath.splice(-1)

--- a/tools/mock-service-host/src/mid/coordinator.ts
+++ b/tools/mock-service-host/src/mid/coordinator.ts
@@ -322,7 +322,7 @@ export class Coordinator {
         while (uriPath.length > 0) {
             if (firstloop || uriPath.length % 2 === 1) {
                 let hostAndPort = req.headers?.host as string
-                if (hostAndPort.split(':').length > 0) {
+                if (hostAndPort.indexOf(':') < 0) {
                     hostAndPort = `${hostAndPort}:${req.localPort}`
                 }
                 const testingUrl = `${req.protocol}://${hostAndPort}${uriPath.join('/')}?${query}`

--- a/tools/mock-service-host/src/mid/models.ts
+++ b/tools/mock-service-host/src/mid/models.ts
@@ -3,6 +3,7 @@ import { StringMap } from '@azure-tools/openapi-tools-common'
 
 export interface VirtualServerRequest extends LiveRequest {
     protocol: string
+    localPort: number
 }
 
 export class VirtualServerResponse implements LiveResponse {

--- a/tools/mock-service-host/test/unittest/testcoordinator.ts
+++ b/tools/mock-service-host/test/unittest/testcoordinator.ts
@@ -201,7 +201,8 @@ describe('generateResponse()', () => {
             method: 'POST',
             headers: {
                 host: 'localhost'
-            }
+            },
+            localPort: 8443
         }
         assert.strictEqual(
             await coordinator.findLROGet(liveRequest),

--- a/tools/mock-service-host/test/unittest/testcoordinator.ts
+++ b/tools/mock-service-host/test/unittest/testcoordinator.ts
@@ -163,12 +163,12 @@ describe('generateResponse()', () => {
                 correlationId: string
             ) => {
                 const getUrls = [
-                    'https://localhost/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type',
-                    'https://localhost/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType',
-                    'https://localhost/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2',
-                    'https://localhost/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2',
-                    'https://localhost/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2/start',
-                    'https://localhost/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2/Type3'
+                    'https://localhost:8443/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type',
+                    'https://localhost:8443/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType',
+                    'https://localhost:8443/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2',
+                    'https://localhost:8443/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2',
+                    'https://localhost:8443/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2/start',
+                    'https://localhost:8443/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2/Type3'
                 ]
                 if (getUrls.indexOf(requestUrl.split('?')[0]) < 0) {
                     throw new Error('No operation')
@@ -200,7 +200,7 @@ describe('generateResponse()', () => {
                 '/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2/Type3/myType3/start?api-version=20210701',
             method: 'POST',
             headers: {
-                host: 'localhost'
+                host: 'localhost:8443'
             },
             localPort: 8443
         }

--- a/tools/mock-service-host/test/unittest/testcoordinator.ts
+++ b/tools/mock-service-host/test/unittest/testcoordinator.ts
@@ -206,28 +206,28 @@ describe('generateResponse()', () => {
         }
         assert.strictEqual(
             await coordinator.findLROGet(liveRequest),
-            'https://localhost/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2?api-version=20210701&lro-callback=true'
+            'https://localhost:8443/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2?api-version=20210701&lro-callback=true'
         )
 
         liveRequest.url =
             '/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2?api-version=20210701'
         assert.strictEqual(
             await coordinator.findLROGet(liveRequest),
-            'https://localhost/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2?api-version=20210701&lro-callback=true'
+            'https://localhost:8443/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2?api-version=20210701&lro-callback=true'
         )
 
         liveRequest.url =
             '/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2/stop?api-version=20210701'
         assert.strictEqual(
             await coordinator.findLROGet(liveRequest),
-            'https://localhost/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2?api-version=20210701&lro-callback=true'
+            'https://localhost:8443/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/Type2/myType2?api-version=20210701&lro-callback=true'
         )
 
         liveRequest.url =
             '/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType/new?api-version=20210701'
         assert.strictEqual(
             await coordinator.findLROGet(liveRequest),
-            'https://localhost/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType?api-version=20210701&lro-callback=true'
+            'https://localhost:8443/subscriptions/xxx/resourceGroups/xx/providers/Microsoft.Mock/Type/myType?api-version=20210701&lro-callback=true'
         )
 
         liveRequest.url =


### PR DESCRIPTION
.Net SDK don't send port in http header, so to use port in the request.socket.