### PR TITLE
[Test Proxy] Update Python dev cert setup instructions

### DIFF
--- a/tools/test-proxy/documentation/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/trusting-cert-per-language.md
@@ -38,8 +38,8 @@ After doing any setup described in the [general section](#generally), run the
 ~/azure-sdk-for-python> python scripts\devops_tasks\trust_proxy_cert.py
 ```
 
-This will download the [test proxy certificate](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/common/testproxy/dotnet-devcert.crt) and place it under
-`azure-sdk-for-python/.certificate` as a `pem` file.
+This will copy the [test proxy certificate](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/common/testproxy/dotnet-devcert.crt) and place the copy
+under `azure-sdk-for-python/.certificate` as a `pem` file.
 
 The only remaining step is to set two environment variables to point to this certificate. The script will output the environment variables and values that you'll
 need to set once it finishes running. For example:

--- a/tools/test-proxy/documentation/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/trusting-cert-per-language.md
@@ -32,16 +32,31 @@ Also note that taken to trust this cert will _also apply to installing the dotne
 
 As always, [stack overflow comes through](https://stackoverflow.com/a/39358282). Unlike `go`, there is nothing specific that needs to happen in the test code itself.
 
-As a pre-req, ensure that the certificate file present [here](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/common/testproxy/dotnet-devcert.crt) is downloaded and renamed to the `pem` file format. Normally a `.crt` file would be binary encoded in DER format, but the ASP.NET dev certs are not encoded that way when they are created, so we don't need to worry about re-encoding anything!
+After doing any setup described in the [general section](#generally), run the
+[trust_proxy_cert.py](https://github.com/Azure/azure-sdk-for-python/blob/main/scripts/devops_tasks/trust_proxy_cert.py) script:
+```cmd
+~/azure-sdk-for-python> python scripts\devops_tasks\trust_proxy_cert.py
+```
 
-To trust this certificate...
+This will download the [test proxy certificate](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/common/testproxy/dotnet-devcert.crt) and place it under
+`azure-sdk-for-python/.certificate` as a `pem` file.
 
-1. Ensure that `SSL_CERTS_DIR` points to the directory containing your newly downloaded PEM file.
-2. The `requests` library does NOT honor the `SSL_CERTS_DIR` environment variable. They have no intention of doing so. Instead, you'll need to...
-   1. Find your `certifi` certificate bundle using `requests.certs.where()`. Once located, **combine it** with the newly downloaded pemfile mentioned above.
-   2. [Here is scripted example of combining](https://github.com/Azure/azure-sdk-for-python/commit/3f4ef4d64382edd74a830bfb71622c6fd8edb5c1)
-   3. Set `REQUESTS_CA_BUNDLE` to the location of the newly combined pemfile.
-3. Ensure SSL verification is enabled still, notice that your requests to the test proxy still succeed!
+The only remaining step is to set two environment variables to point to this certificate. The script will output the environment variables and values that you'll
+need to set once it finishes running. For example:
+```
+Set the following certificate paths:
+        SSL_CERT_DIR=C:\azure-sdk-for-python\.certificate
+        REQUESTS_CA_BUNDLE=C:\azure-sdk-for-python\.certificate\dotnet-devcert.pem
+```
+
+Persistently set these environment variables. For example, in a Windows command prompt, use the `SETX` command (not the `SET` command) to set these variables.
+Using the example above, you would run:
+```cmd
+SETX SSL_CERT_DIR "C:\azure-sdk-for-python\.certificate"
+SETX REQUESTS_CA_BUNDLE "C:\azure-sdk-for-python\.certificate\dotnet-devcert.pem"
+```
+
+A new process should be started up to make these variables available. In a new terminal, running tests with the test proxy should now work with HTTPS requests.
 
 ## Java
 


### PR DESCRIPTION
@scbedd Resolves https://github.com/Azure/azure-sdk-for-python/issues/20932. This makes it more clear that the (fantastic) `trust_proxy_cert.py` script does almost all the work for you, and makes it more clear that the outputted environment variables need to be _persistently_ set.