### PR TITLE
Add Diagnostics for Maven Name and Description

### DIFF
--- a/src/java/apiview-java-processor/pom.xml
+++ b/src/java/apiview-java-processor/pom.xml
@@ -2,71 +2,101 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+  <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.azure</groupId>
-    <artifactId>apiview-java-processor</artifactId>
-    <version>1.25.0</version>
+  <groupId>com.azure</groupId>
+  <artifactId>apiview-java-processor</artifactId>
+  <version>1.25.0</version>
 
-    <properties>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 
-    <dependencies>
-        <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>2.11.2</version>
-        </dependency>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.11.2</version>
+    </dependency>
 
-        <dependency>
-            <groupId>com.github.javaparser</groupId>
-            <artifactId>javaparser-symbol-solver-core</artifactId>
-            <version>3.16.1</version>
-        </dependency>
-    </dependencies>
+    <dependency>
+      <groupId>com.github.javaparser</groupId>
+      <artifactId>javaparser-symbol-solver-core</artifactId>
+      <version>3.16.1</version>
+    </dependency>
 
-    <build>
-        <plugins>
-            <!-- Set a compiler level -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.8.1</version>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <version>5.8.1</version> <!-- {x-version-update;org.junit.jupiter:junit-jupiter-api;external_dependency} -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-engine</artifactId>
+      <version>5.8.1</version> <!-- {x-version-update;org.junit.jupiter:junit-jupiter-engine;external_dependency} -->
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
+      <version>5.8.1</version> <!-- {x-version-update;org.junit.jupiter:junit-jupiter-params;external_dependency} -->
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
 
-            <!-- Maven Assembly Plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-assembly-plugin</artifactId>
-                <version>3.1.1</version>
-                <configuration>
-                    <descriptorRefs>
-                        <descriptorRef>jar-with-dependencies</descriptorRef>
-                    </descriptorRefs>
-                    <archive>
-                        <manifest>
-                            <mainClass>com.azure.tools.apiview.processor.Main</mainClass>
-                        </manifest>
-                    </archive>
-                    <appendAssemblyId>false</appendAssemblyId>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>make-assembly</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>single</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+  <build>
+    <plugins>
+      <!-- Set a compiler level -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <source>1.8</source>
+          <target>1.8</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.0.0-M5</version>
+        <configuration>
+          <argLine>
+            --add-opens com.azure.tools.apiview.processor.diagnostics.rules=ALL_UNNAMED
+          </argLine>
+        </configuration>
+      </plugin>
+
+      <!-- Maven Assembly Plugin -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.1.1</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+          <archive>
+            <manifest>
+              <mainClass>com.azure.tools.apiview.processor.Main</mainClass>
+            </manifest>
+          </archive>
+          <appendAssemblyId>false</appendAssemblyId>
+        </configuration>
+        <executions>
+          <execution>
+            <id>make-assembly</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/MiscUtils.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/MiscUtils.java
@@ -5,6 +5,7 @@ import java.util.regex.Pattern;
 public class MiscUtils {
 
     public static final String LINEBREAK = "\n"; // or "\r\n";
+    private static final Pattern QUOTED_LINEBREAK = Pattern.compile(Pattern.quote(LINEBREAK));
 
     public static String escapeHTML(final String s) {
         final StringBuilder out = new StringBuilder(Math.max(16, s.length()));
@@ -23,7 +24,7 @@ public class MiscUtils {
 
     public static String wrap(final String string, final int lineLength) {
         final StringBuilder b = new StringBuilder();
-        for (final String line : string.split(Pattern.quote(LINEBREAK))) {
+        for (final String line : QUOTED_LINEBREAK.split(string)) {
             b.append(wrapLine(line, lineLength));
         }
         return b.toString();

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/APIListing.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/APIListing.java
@@ -1,11 +1,11 @@
 package com.azure.tools.apiview.processor.model;
 
-import com.azure.tools.apiview.processor.Main;
 import com.azure.tools.apiview.processor.model.maven.Pom;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -77,6 +77,10 @@ public class APIListing {
 
     public void addDiagnostic(Diagnostic diagnostic) {
         this.diagnostics.add(diagnostic);
+    }
+
+    public List<Diagnostic> getDiagnostics() {
+        return Collections.unmodifiableList(diagnostics);
     }
 
     public String getLanguage() {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/Diagnostic.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/Diagnostic.java
@@ -31,4 +31,8 @@ public class Diagnostic {
         this.level = level;
         this.helpLinkUri = helpLinkUri;
     }
+
+    public String getText() {
+        return text;
+    }
 }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/maven/Pom.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/maven/Pom.java
@@ -21,6 +21,10 @@ import java.util.List;
 public class Pom implements MavenGAV {
     private Gav gav;
     private Gav parent;
+
+    private String name;
+    private String description;
+
     private List<Dependency> dependencies;
 
     private Float jacocoMinLineCoverage;
@@ -69,6 +73,14 @@ public class Pom implements MavenGAV {
             n = (Node) xPath.evaluate("/project/build/plugins/plugin/artifactId[text()='maven-checkstyle-plugin']/../configuration/excludes", xmlDocument, XPathConstants.NODE);
             this.checkstyleExcludes = n == null ? null : n.getTextContent();
 
+            // Maven name
+            n = (Node) xPath.evaluate("/project/name", xmlDocument, XPathConstants.NODE);
+            this.name = (n == null) ? null : n.getTextContent();
+
+            // Maven description
+            n = (Node) xPath.evaluate("/project/description", xmlDocument, XPathConstants.NODE);
+            this.description = (n == null) ? null : n.getTextContent();
+
             // actual dependencies
             final String dependencyExpression = "/project/dependencies/dependency";
             NodeList dependenciesNodeList = (NodeList) xPath.evaluate(dependencyExpression, xmlDocument, XPathConstants.NODESET);
@@ -106,6 +118,14 @@ public class Pom implements MavenGAV {
 
     public Gav getParent() {
         return parent;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getDescription() {
+        return description;
     }
 
     public List<Dependency> getDependencies() {

--- a/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/diagnostics/rules/NoLocalesInJavadocUrlDiagnosticRuleTests.java
+++ b/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/diagnostics/rules/NoLocalesInJavadocUrlDiagnosticRuleTests.java
@@ -1,0 +1,77 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.tools.apiview.processor.diagnostics.rules;
+
+import com.azure.tools.apiview.processor.model.APIListing;
+import com.github.javaparser.ast.Node;
+import com.github.javaparser.ast.comments.Comment;
+import com.github.javaparser.ast.comments.JavadocComment;
+import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests {@link NoLocalesInJavadocUrlDiagnosticRule}.
+ */
+public class NoLocalesInJavadocUrlDiagnosticRuleTests {
+    @Test
+    public void matchesSingleLocaleInJavadocLine() {
+        final String javadoc = "A Javadoc line with a/url/with/en-us/locale";
+
+        NoLocalesInJavadocUrlDiagnosticRule rule = new NoLocalesInJavadocUrlDiagnosticRule();
+        NodeWithJavadoc<?> javadocNode = createJavadocNode(javadoc);
+        APIListing apiListing = new APIListing();
+
+        rule.checkJavaDoc(javadocNode, "matchesSingleLocaleInJavadocLine", apiListing);
+
+        assertEquals(1, apiListing.getDiagnostics().size());
+        assertTrue(apiListing.getDiagnostics().get(0).getText().contains("/en-us/"));
+    }
+
+    @Test
+    public void matchesAllLocalesInJavadocLine() {
+        final String javadoc = "A Javadoc line with a/url/with/en-us/local and another/url/with/fr-fr/locale";
+
+        NoLocalesInJavadocUrlDiagnosticRule rule = new NoLocalesInJavadocUrlDiagnosticRule();
+        NodeWithJavadoc<?> javadocNode = createJavadocNode(javadoc);
+        APIListing apiListing = new APIListing();
+
+        rule.checkJavaDoc(javadocNode, "matchesAllLocalesInJavadocLine", apiListing);
+
+        assertEquals(2, apiListing.getDiagnostics().size());
+        assertTrue(apiListing.getDiagnostics().get(0).getText().contains("/en-us/"));
+        assertTrue(apiListing.getDiagnostics().get(1).getText().contains("/fr-fr/"));
+    }
+
+    @Test
+    public void doesNotMatchLocaleNotInUrl() {
+        final String javadoc = "A Javadoc line with a non-URL en-us locale";
+
+        NoLocalesInJavadocUrlDiagnosticRule rule = new NoLocalesInJavadocUrlDiagnosticRule();
+        NodeWithJavadoc<?> javadocNode = createJavadocNode(javadoc);
+        APIListing apiListing = new APIListing();
+
+        rule.checkJavaDoc(javadocNode, "doesNotMatchLocaleNotInUrl", apiListing);
+
+        assertEquals(0, apiListing.getDiagnostics().size());
+    }
+
+    private static NodeWithJavadoc<?> createJavadocNode(String javadoc) {
+        return new NodeWithJavadoc<Node>() {
+            @Override
+            public Optional<Comment> getComment() {
+                return Optional.of(new JavadocComment(javadoc));
+            }
+
+            @Override
+            public Node setComment(Comment comment) {
+                return null;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Adds diagnostics to Java's ApiView for the Maven package name and description. Additionally, makes minor changes to the `NoLocalesInJavadocUrlDiagnosticRule` to use a single pass `Pattern` instead of looping on containing each individual locale tested.