### PR TITLE
[Test-Proxy] Match any URI Order

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -209,7 +209,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["x-abstraction-identifier"] = "CustomDefaultMatcher";
-            httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"ignoreQueryOrdering\": \"true\" }");
+            httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"ignoreQueryOrdering\": true }");
 
             // content length must be set for the body to be parsed in SetMatcher
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
@@ -225,7 +225,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var matcher = testRecordingHandler.Matcher;
             Assert.True(matcher is CustomDefaultMatcher);
 
-            var queryOrderingValue = (bool)typeof(RecordMatcher).GetField("ignoreQueryOrdering", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(matcher);
+            var queryOrderingValue = (bool)typeof(RecordMatcher).GetField("_ignoreQueryOrdering", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(matcher);
             Assert.True(queryOrderingValue);
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -203,6 +203,33 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
+        public async Task TestSetCustomMatcherWithQueryOrdering()
+        {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Headers["x-abstraction-identifier"] = "CustomDefaultMatcher";
+            httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"ignoreQueryOrdering\": \"true\" }");
+
+            // content length must be set for the body to be parsed in SetMatcher
+            httpContext.Request.ContentLength = httpContext.Request.Body.Length;
+
+            var controller = new Admin(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = httpContext
+                }
+            };
+            await controller.SetMatcher();
+            var matcher = testRecordingHandler.Matcher;
+            Assert.True(matcher is CustomDefaultMatcher);
+
+            var queryOrderingValue = (bool)typeof(RecordMatcher).GetField("ignoreQueryOrdering", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(matcher);
+            Assert.True(queryOrderingValue);
+        }
+
+
+        [Fact]
         public async void TestSetMatcherIndividualRecording()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/MatcherTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/MatcherTests.cs
@@ -1,12 +1,12 @@
-﻿using Azure.Core;
-using Azure.Sdk.Tools.TestProxy.Common;
+﻿using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Matchers;
-using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Mvc;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
-using System.Text.Json;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -178,6 +178,54 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             Assert.Throws<TestRecordingMismatchException>(() => {
                 sessionForRetrieval.Session.Lookup(differentRequest, HeaderlessMatcher, sanitizers: new List<RecordedTestSanitizer>(), remove: false);
             });
+        }
+
+        [Fact]
+        public async Task CustomMatcherMatchesDifferentUriOrder()
+        {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            testRecordingHandler.Matcher = new CustomDefaultMatcher(ignoreQueryOrder: true);
+            var playbackContext = new DefaultHttpContext();
+            var targetFile = "Test.RecordEntries/request_with_subscriptionid.json";
+            playbackContext.Request.Headers["x-recording-file"] = targetFile;
+
+            var controller = new Playback(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = playbackContext
+                }
+            };
+            await controller.Start();
+            var recordingId = playbackContext.Response.Headers["x-recording-id"].ToString();
+
+            // prepare recording context
+            playbackContext.Request.Headers.Clear();
+            playbackContext.Response.Headers.Clear();
+            var requestHeaders = new Dictionary<string, string>(){
+                { ":authority", "localhost:5001" },
+                { ":method", "POST" },
+                { ":path", "/" },
+                { ":scheme", "https" },
+                { "Accept-Encoding", "gzip" },
+                { "Content-Length", "0" },
+                { "User-Agent", "Go-http-client/2.0" },
+                { "x-recording-id", recordingId },
+                { "x-recording-upstream-base-uri", "https://management.azure.com/" }
+            };
+            foreach (var kvp in requestHeaders)
+            {
+                playbackContext.Request.Headers.Add(kvp.Key, kvp.Value);
+            }
+            playbackContext.Request.Method = "POST";
+
+            // the query parameters are in reversed order from the recording deliberately.
+            var queryString = "?uselessUriAddition=hellothere&api-version=2019-05-01";
+            var path = "/subscriptions/12345678-1234-1234-5678-123456789010/providers/Microsoft.ContainerRegistry/checkNameAvailability";
+            playbackContext.Request.Host = new HostString("https://localhost:5001");
+            playbackContext.Features.Get<IHttpRequestFeature>().RawTarget = path + queryString;
+            await testRecordingHandler.HandlePlaybackRequest(recordingId, playbackContext.Request, playbackContext.Response);
+            Assert.Equal("WESTUS:20210909T204819Z:f9a33867-6efc-4748-b322-303b2b933466", playbackContext.Response.Headers["x-ms-routing-request-id"].ToString());
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/MatcherTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/MatcherTests.cs
@@ -184,7 +184,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         public async Task CustomMatcherMatchesDifferentUriOrder()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            testRecordingHandler.Matcher = new CustomDefaultMatcher(ignoreQueryOrder: true);
+            testRecordingHandler.Matcher = new CustomDefaultMatcher(ignoreQueryOrdering: true);
             var playbackContext = new DefaultHttpContext();
             var targetFile = "Test.RecordEntries/request_with_subscriptionid.json";
             playbackContext.Request.Headers["x-recording-file"] = targetFile;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -145,10 +145,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             }
             playbackContext.Request.Method = "POST";
 
+            // the query parameters are in reversed order from the recording deliberately.
             var queryString = "?uselessUriAddition=hellothere&api-version=2019-05-01";
             var path = "/subscriptions/12345678-1234-1234-5678-123456789010/providers/Microsoft.ContainerRegistry/checkNameAvailability";
-
-            // set URI for the request, deliberately out of order
             playbackContext.Request.Host = new HostString("https://localhost:5001");
             playbackContext.Features.Get<IHttpRequestFeature>().RawTarget = path + queryString;
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -108,7 +108,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public async Task TestRecordAndMatchDifferentUriOrder()
+        public async Task TestPlaybackThrowsOnDifferentUriOrder()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var playbackContext = new DefaultHttpContext();
@@ -151,8 +151,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             playbackContext.Request.Host = new HostString("https://localhost:5001");
             playbackContext.Features.Get<IHttpRequestFeature>().RawTarget = path + queryString;
 
-            await testRecordingHandler.HandlePlaybackRequest(recordingId, playbackContext.Request, playbackContext.Response);
-            Assert.Equal("WESTUS:20210909T204819Z:f9a33867-6efc-4748-b322-303b2b933466", playbackContext.Response.Headers["x-ms-routing-request-id"].ToString());
+
+            var resultingException = await Assert.ThrowsAsync<TestRecordingMismatchException>(
+               async () => await testRecordingHandler.HandlePlaybackRequest(recordingId, playbackContext.Request, playbackContext.Response)
+            );
+
+            Assert.Contains("Uri doesn't match:", resultingException.Message);
         }
 
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -3,10 +3,13 @@ using Azure.Sdk.Tools.TestProxy.Matchers;
 using Azure.Sdk.Tools.TestProxy.Sanitizers;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
+using System.Text;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -103,5 +106,55 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             Assert.True(testRecordingHandler.InMemorySessions.Count() == 1);
             Assert.NotNull(testRecordingHandler.InMemorySessions[inMemId]);
         }
+
+        [Fact]
+        public async Task TestRecordAndMatchDifferentUriOrder()
+        {
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var playbackContext = new DefaultHttpContext();
+            var targetFile = "Test.RecordEntries/request_with_subscriptionid.json";
+            playbackContext.Request.Headers["x-recording-file"] = targetFile;
+
+            var controller = new Playback(testRecordingHandler)
+            {
+                ControllerContext = new ControllerContext()
+                {
+                    HttpContext = playbackContext
+                }
+            };
+            await controller.Start();
+            var recordingId = playbackContext.Response.Headers["x-recording-id"].ToString();
+
+            // prepare recording context
+            playbackContext.Request.Headers.Clear();
+            playbackContext.Response.Headers.Clear();
+            var requestHeaders = new Dictionary<string, string>(){
+                { ":authority", "localhost:5001" },
+                { ":method", "POST" },
+                { ":path", "/" },
+                { ":scheme", "https" },
+                { "Accept-Encoding", "gzip" },
+                { "Content-Length", "0" },
+                { "User-Agent", "Go-http-client/2.0" },
+                { "x-recording-id", recordingId },
+                { "x-recording-upstream-base-uri", "https://management.azure.com/" }
+            };
+            foreach (var kvp in requestHeaders)
+            {
+                playbackContext.Request.Headers.Add(kvp.Key, kvp.Value);
+            }
+            playbackContext.Request.Method = "POST";
+
+            var queryString = "?uselessUriAddition=hellothere&api-version=2019-05-01";
+            var path = "/subscriptions/12345678-1234-1234-5678-123456789010/providers/Microsoft.ContainerRegistry/checkNameAvailability";
+
+            // set URI for the request, deliberately out of order
+            playbackContext.Request.Host = new HostString("https://localhost:5001");
+            playbackContext.Features.Get<IHttpRequestFeature>().RawTarget = path + queryString;
+
+            await testRecordingHandler.HandlePlaybackRequest(recordingId, playbackContext.Request, playbackContext.Response);
+            Assert.Equal("WESTUS:20210909T204819Z:f9a33867-6efc-4748-b322-303b2b933466", playbackContext.Response.Headers["x-ms-routing-request-id"].ToString());
+        }
+
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/request_with_subscriptionid.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/request_with_subscriptionid.json
@@ -1,7 +1,7 @@
 ﻿{
   "Entries": [
     {
-      "RequestUri": "https://management.azure.com/subscriptions/12345678-1234-1234-5678-123456789010/providers/Microsoft.ContainerRegistry/checkNameAvailability?api-version=2019-05-01",
+      "RequestUri": "https://management.azure.com/subscriptions/12345678-1234-1234-5678-123456789010/providers/Microsoft.ContainerRegistry/checkNameAvailability?api-version=2019-05-01&uselessUriAddition=hellothere",
       "RequestMethod": "POST",
       "RequestHeaders": {
         ":authority": "localhost:5001",

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -198,8 +198,14 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             IsEquivalentUri(entry.RequestUri, otherEntry.RequestUri) &&
             CompareHeaderDictionaries(entry.Request.Headers, otherEntry.Request.Headers, VolatileHeaders) == 0;
 
-        private bool AreUrisSame(string entryUri, string otherEntryUri) =>
-            NormalizeUri(entryUri) == NormalizeUri(otherEntryUri);
+        private bool AreUrisSame(string entryUri, string otherEntryUri)
+        {
+            // a = from entries list
+            // b = incoming uri we're matching against
+            var a = NormalizeUri(entryUri);
+            var b = NormalizeUri(otherEntryUri);
+            return a == b;
+        }
 
         private string NormalizeUri(string uriToNormalize)
         {
@@ -208,7 +214,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             req.Reset(uri);
             req.Query = "";
             NameValueCollection queryParams = HttpUtility.ParseQueryString(uri.Query);
-            foreach (string param in queryParams)
+            foreach (string param in queryParams.AllKeys.OrderBy(x => x))
             {
                 req.AppendQuery(
                     param,

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -198,14 +198,8 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             IsEquivalentUri(entry.RequestUri, otherEntry.RequestUri) &&
             CompareHeaderDictionaries(entry.Request.Headers, otherEntry.Request.Headers, VolatileHeaders) == 0;
 
-        private bool AreUrisSame(string entryUri, string otherEntryUri)
-        {
-            // a = from entries list
-            // b = incoming uri we're matching against
-            var a = NormalizeUri(entryUri);
-            var b = NormalizeUri(otherEntryUri);
-            return a == b;
-        }
+        private bool AreUrisSame(string entryUri, string otherEntryUri) =>
+                    NormalizeUri(entryUri) == NormalizeUri(otherEntryUri);
 
         private string NormalizeUri(string uriToNormalize)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -26,10 +26,12 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         };
 
         private bool _compareBodies;
+        private bool _ignoreQueryOrdering;
 
-        public RecordMatcher(bool compareBodies = true)
+        public RecordMatcher(bool compareBodies = true, bool ignoreQueryOrdering = false)
         {
             _compareBodies = compareBodies;
+            _ignoreQueryOrdering = ignoreQueryOrdering;
         }
 
         public HashSet<string> ExcludeHeaders = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -201,6 +203,16 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         private bool AreUrisSame(string entryUri, string otherEntryUri) =>
             NormalizeUri(entryUri) == NormalizeUri(otherEntryUri);
 
+        private void AddQueriesToUri(RequestUriBuilder req, IEnumerable<string> accessKeySet, NameValueCollection queryParams)
+        {
+            foreach (string param in accessKeySet)
+            {
+                req.AppendQuery(
+                    param,
+                    VolatileQueryParameters.Contains(param) ? VolatileValue : queryParams[param]);
+            }
+        }
+
         private string NormalizeUri(string uriToNormalize)
         {
             var req = new RequestUriBuilder();
@@ -208,12 +220,16 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             req.Reset(uri);
             req.Query = "";
             NameValueCollection queryParams = HttpUtility.ParseQueryString(uri.Query);
-            foreach (string param in queryParams.AllKeys.OrderBy(x => x))
+
+            if (_ignoreQueryOrdering)
             {
-                req.AppendQuery(
-                    param,
-                    VolatileQueryParameters.Contains(param) ? VolatileValue : queryParams[param]);
+                AddQueriesToUri(req, queryParams.AllKeys.OrderBy(x => x), queryParams);
             }
+            else
+            {
+                AddQueriesToUri(req, queryParams.AllKeys, queryParams);
+            }
+
             return req.ToUri().ToString();
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -199,7 +199,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             CompareHeaderDictionaries(entry.Request.Headers, otherEntry.Request.Headers, VolatileHeaders) == 0;
 
         private bool AreUrisSame(string entryUri, string otherEntryUri) =>
-                    NormalizeUri(entryUri) == NormalizeUri(otherEntryUri);
+            NormalizeUri(entryUri) == NormalizeUri(otherEntryUri);
 
         private string NormalizeUri(string uriToNormalize)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Matchers/CustomDefaultMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Matchers/CustomDefaultMatcher.cs
@@ -16,7 +16,8 @@ namespace Azure.Sdk.Tools.TestProxy.Matchers
         /// </summary>
         /// <param name="compareBodies">Should the body value be compared during lookup operations?</param>
         /// <param name="nonDefaultHeaderExclusions">A comma separated list of additional headers that should be excluded during matching.</param>
-        public CustomDefaultMatcher(bool compareBodies = true, string nonDefaultHeaderExclusions = "") : base(compareBodies: compareBodies)
+        /// <param name="ignoreQueryOrder">By default, the test-proxy does not sort query params before matching. Setting true will sort query params alphabetically before comparing URI.</param>
+        public CustomDefaultMatcher(bool compareBodies = true, string nonDefaultHeaderExclusions = "", bool ignoreQueryOrder = false) : base(compareBodies: compareBodies, ignoreQueryOrdering: ignoreQueryOrder)
         {
             foreach(var exclusion in nonDefaultHeaderExclusions.Split(",").Where(x => !string.IsNullOrEmpty(x.Trim())))
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Matchers/CustomDefaultMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Matchers/CustomDefaultMatcher.cs
@@ -16,8 +16,8 @@ namespace Azure.Sdk.Tools.TestProxy.Matchers
         /// </summary>
         /// <param name="compareBodies">Should the body value be compared during lookup operations?</param>
         /// <param name="nonDefaultHeaderExclusions">A comma separated list of additional headers that should be excluded during matching.</param>
-        /// <param name="ignoreQueryOrder">By default, the test-proxy does not sort query params before matching. Setting true will sort query params alphabetically before comparing URI.</param>
-        public CustomDefaultMatcher(bool compareBodies = true, string nonDefaultHeaderExclusions = "", bool ignoreQueryOrder = false) : base(compareBodies: compareBodies, ignoreQueryOrdering: ignoreQueryOrder)
+        /// <param name="ignoreQueryOrdering">By default, the test-proxy does not sort query params before matching. Setting true will sort query params alphabetically before comparing URI.</param>
+        public CustomDefaultMatcher(bool compareBodies = true, string nonDefaultHeaderExclusions = "", bool ignoreQueryOrdering = false) : base(compareBodies: compareBodies, ignoreQueryOrdering: ignoreQueryOrdering)
         {
             foreach(var exclusion in nonDefaultHeaderExclusions.Split(",").Where(x => !string.IsNullOrEmpty(x.Trim())))
             {


### PR DESCRIPTION
@mccoyp @YalinLi0312  this will account for the different query _ordering_ between py2 and py3.

@JoshLove-msft , @seankane-msft , @HarshaNalluru I can't _think_ of any cases where this would negatively impact us (short of perf testing). You see any problems with this?
