### PR TITLE
[Test-Proxy] Address Empty-Body-Stream Error

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -145,7 +145,7 @@ namespace Azure.Sdk.Tools.TestProxy
             byte[] body = new byte[]{};
 
             // HEAD requests do NOT have a body regardless of the value of the Content-Length header
-            if (incomingRequest.Method.ToUpperInvariant() == "HEAD") {
+            if (!incomingRequest.Method.ToUpperInvariant() == "HEAD") {
                 body = DecompressBody((MemoryStream)await upstreamResponse.Content.ReadAsStreamAsync().ConfigureAwait(false), upstreamResponse.Content.Headers);
             }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -141,7 +141,13 @@ namespace Azure.Sdk.Tools.TestProxy
             var headerListOrig = incomingRequest.Headers.Select(x => String.Format("{0}: {1}", x.Key, x.Value.First())).ToList();
             var headerList = upstreamRequest.Headers.Select(x => String.Format("{0}: {1}", x.Key, x.Value.First())).ToList();
 
-            var body = DecompressBody((MemoryStream) await upstreamResponse.Content.ReadAsStreamAsync().ConfigureAwait(false), upstreamResponse.Content.Headers);
+
+            byte[] body = new byte[]{};
+
+            // HEAD requests do NOT have a body regardless of the value of the Content-Length header
+            if (incomingRequest.Method.ToUpperInvariant() == "HEAD") {
+                body = DecompressBody((MemoryStream)await upstreamResponse.Content.ReadAsStreamAsync().ConfigureAwait(false), upstreamResponse.Content.Headers);
+            }
 
             entry.Response.Body = body.Length == 0 ? null : body;
             entry.StatusCode = (int)upstreamResponse.StatusCode;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -145,7 +145,7 @@ namespace Azure.Sdk.Tools.TestProxy
             byte[] body = new byte[]{};
 
             // HEAD requests do NOT have a body regardless of the value of the Content-Length header
-            if (!incomingRequest.Method.ToUpperInvariant() == "HEAD") {
+            if (incomingRequest.Method.ToUpperInvariant() != "HEAD") {
                 body = DecompressBody((MemoryStream)await upstreamResponse.Content.ReadAsStreamAsync().ConfigureAwait(false), upstreamResponse.Content.Headers);
             }
 


### PR DESCRIPTION
@seankane-msft this was super duper interesting.

Turns out, if it's a `HEAD` request, no matter WHAT the `Content-Length`  is, the spec says ignore the body. 

Easy fix once we understood. 👍 