### PR TITLE
Added more parameter for JS use

### DIFF
--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -195,13 +195,13 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation, $packageInfo) 
 }
 
 foreach ($packageInfoLocation in $PackageInfoJsonLocations) {
-  Write-Host "Updating metadata for package: $packageInfo"
+  Write-Host "Updating metadata for package: $packageInfoLocation"
 
   # Convert package metadata json file to metadata json property.
   $packageInfo = GetPackageInfoJson $packageInfoLocation
   # Add validation step for daily update and release
   if ($ValidateDocsMsPackagesFn -and (Test-Path "Function:$ValidateDocsMsPackagesFn")) {
-    &$ValidateDocsMsPackagesFn -PackageInfo $packageInfo -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $DocValidationImageId
+    &$ValidateDocsMsPackagesFn -PackageInfo $packageInfo -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $DocValidationImageId -DocRepoLocation $DocRepoLocation
     if ($LASTEXITCODE) {
       LogError "The package failed Doc.Ms validation. Check https://aka.ms/azsdk/docs/docker for more details on how to diagnose this issue."
       exit $LASTEXITCODE


### PR DESCRIPTION
For JS validation, we have to read package config from docs repo `ci-config` which needs to pass the docs repo location.
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1239913&view=results