### PR TITLE
Remove cluster group and subscription overrides for stress test release

### DIFF
--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -149,9 +149,10 @@ function DeployStressPackage(
     }
     $imageTag += "/$($pkg.Namespace)/$($pkg.ReleaseName):${deployId}"
 
-    if ($pushImages) {
+    $dockerFilePath = "$($pkg.Directory)/Dockerfile"
+    if ($pushImages -and (Test-Path $dockerFilePath)) {
         Write-Host "Building and pushing stress test docker image '$imageTag'"
-        $dockerFile = Get-ChildItem "$($pkg.Directory)/Dockerfile"
+        $dockerFile = Get-ChildItem $dockerFilePath
         Run docker build -t $imageTag -f $dockerFile.FullName $dockerFile.DirectoryName
         if ($LASTEXITCODE) { return }
         Run docker push $imageTag

--- a/eng/pipelines/stress-test-release.yml
+++ b/eng/pipelines/stress-test-release.yml
@@ -73,7 +73,10 @@ jobs:
     - task: AzureCLI@2
       displayName: Build and Deploy Stress Tests
       inputs:
-        azureSubscription: ${{ parameters.Subscription }}
+        ${{ if eq(parameters.Environment, 'prod') }}:
+          azureSubscription: Azure SDK Test Resources
+        ${{ if eq(parameters.Environment, 'test') }}:
+          azureSubscription: Azure SDK Developer Playground
         scriptType: pscore
         scriptPath: $(System.DefaultWorkingDirectory)/$(Repository)/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
         arguments:

--- a/eng/pipelines/stress-test-release.yml
+++ b/eng/pipelines/stress-test-release.yml
@@ -6,12 +6,9 @@ parameters:
   - name: Environment
     type: string
     default: prod
-  - name: SubscriptionOverride
-    type: string
-    default: ''
-  - name: ClusterGroupOverride
-    type: string
-    default: ''
+    values:
+    - prod
+    - test
   - name: TestRepository
     displayName: Stress Test Repository
     type: string
@@ -85,8 +82,6 @@ jobs:
           -Environment '${{ parameters.Environment }}'
           -Repository '$(Agent.JobName)'
           -PushImages
-          -ClusterGroup '${{ parameters.ClusterGroupOverride }}'
           -Login
-          -Subscription '${{ parameters.SubscriptionOverride }}'
           -DeployId '$(Build.BuildNumber)'
           -CI


### PR DESCRIPTION
The Azure Pipelines UI marks parameters that default to an empty string as "Required" which defeats the whole purpose of
having empty defaults. The overrides are only there as an option for people to use the pipeline for custom dev
environments. Since I think this scenario is pretty rare, I'm just going to remove support for it (you can still
deploy to custom dev environments via the same underlying scripts). Instead, this change simplifies the parameters
to have an environment drop-down that shows you all options to pick from.

![image](https://user-images.githubusercontent.com/1020379/145469943-3fc7e8c5-bf60-4508-a9b0-1f70a0d63099.png)
