### PR TITLE
Add flag to force relaxed JSON encoding

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/request_with_double_encoded_characters.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/request_with_double_encoded_characters.json
@@ -1,0 +1,45 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeazsdktestaccount.table.core.windows.net/Tables",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "34",
+        "Content-Type": "application/json;odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "Date": "Tue, 18 May 2021 23:27:42 GMT",
+        "User-Agent": "azsdk-python-data-tables/12.0.0b7 Python/3.8.6 (Windows-10-10.0.19041-SP0)",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-date": "Tue, 18 May 2021 23:27:42 GMT",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "{\u0022Category\u0022:    \u0022Travel \\u0026 Leisure\u0022}",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Tue, 18 May 2021 23:27:43 GMT",
+        "Location": "https://fakeazsdktestaccount.table.core.windows.net/Tables(\u0027listtable09bf2a3d\u0027)",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-request-id": "d2270777-c002-0072-313d-4ce19f000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeazsdktestaccount.table.core.windows.net/$metadata#Tables/@Element",
+        "TableName": "listtable09bf2a3d",
+        "connectionString": null
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/BodyKeySanitizer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/BodyKeySanitizer.cs
@@ -15,6 +15,7 @@ namespace Azure.Sdk.Tools.TestProxy.Sanitizers
         private string _newValue;
         private string _regexValue = null;
         private string _groupForReplace = null;
+        private bool _forceRelaxedJsonEncoding;
 
         /// <summary>
         /// This sanitizer offers regex update of a specific JTokenPath. EG: "TableName" within a json response body having its value replaced by
@@ -26,12 +27,15 @@ namespace Azure.Sdk.Tools.TestProxy.Sanitizers
         /// <param name="value">The substitution value.</param>
         /// <param name="regex">A regex. Can be defined as a simple regex replace OR if groupForReplace is set, a subsitution operation. Defaults to replacing the entire string.</param>
         /// <param name="groupForReplace">The regex capture group that needs to be operated upon. Do not set if you're invoking a simple replacement operation.</param>
-        public BodyKeySanitizer(string jsonPath, string value = "Sanitized", string regex = ".+", string groupForReplace = null)
+        /// <param name="forceRelaxedJsonEncoding">If true, the entire body will be reserialized using relaxed JSON encoding, regardless of whether a match occurred or not.
+        /// By default, the relaxed JSON encoding only happends when there is a match.</param>
+        public BodyKeySanitizer(string jsonPath, string value = "Sanitized", string regex = ".+", string groupForReplace = null, bool forceRelaxedJsonEncoding = false)
         {
             _jsonPath = jsonPath;
             _newValue = value;
             _regexValue = regex;
             _groupForReplace = groupForReplace;
+            _forceRelaxedJsonEncoding = forceRelaxedJsonEncoding;
 
             StringSanitizer.ConfirmValidRegex(regex);
         }
@@ -86,7 +90,7 @@ namespace Azure.Sdk.Tools.TestProxy.Sanitizers
                 }
             }
 
-            return sanitized ? JsonConvert.SerializeObject(jsonO, SerializerSettings) : body;
+            return sanitized || _forceRelaxedJsonEncoding ? JsonConvert.SerializeObject(jsonO, SerializerSettings) : body;
         }
 
 


### PR DESCRIPTION
This is a feature that at least one library depends on for .NET. The issue is that System.Text.Json uses strict encoding by default which causes something like an ampersand to get escaped. This means that JSON containing an ampersand cannot be round-tripped. This isn't an issue if we end up re-serializing during sanitization with NewtonSoft as that does not have the same encoding behavior. We only re-serialize with JSON if something was actually changed - actually @scbedd made this fix in a previous PR. However, we can't just always reserialize as some other libraries rely on the body not being reserialized. 

It is a bit weird that this is exposed on BodyKeySanitizer as when using this setting you would probably not really care about what JsonPath to sanitize, but since this is such a niche feature, I didn't think it was worth creating its own Sanitizer type.