### PR TITLE
Pin maximum az versions temporarily due to breaking api changes in graph

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -5,8 +5,9 @@
 
 #Requires -Version 6.0
 #Requires -PSEdition Core
-#Requires -Modules @{ModuleName='Az.Accounts'; ModuleVersion='1.6.4'}
-#Requires -Modules @{ModuleName='Az.Resources'; ModuleVersion='1.8.0'}
+#Requires -Modules @{ModuleName='Az.Accounts'; ModuleVersion='1.6.4'; MaximumVersion='2.7.0'}
+#Requires -Modules @{ModuleName='Az.Resources'; ModuleVersion='1.8.0'; MaximumVersion='4.3.1'}
+#Requires -Modules @{ModuleName='Az'; MaximumVersion='6.4.0'}
 
 [CmdletBinding(DefaultParameterSetName = 'Default', SupportsShouldProcess = $true, ConfirmImpact = 'Medium')]
 param (


### PR DESCRIPTION
Due to breaking API changes in the latest azure powershell module versions (see https://github.com/Azure/azure-sdk-tools/issues/2413), local users may see odd errors around parsing graph objects, empty service principals, etc. To make it easier to understand what these errors mean and also enable users with multiple versions installed to use working ones, pin a maximum version of the Az modules.

Based on my local versions, I have Az.Resources pinned at 4.3.1, but 4.4.1 may be ok. I will test.

CC @jsquire @weshaggard @mikeharder 
