### PR TITLE
Upgrade to 6.0

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Azure.Sdk.Tools.TestProxy.Tests.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Azure.Sdk.Tools.TestProxy.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <!--Use netcoreapp3.1 as it is the oldest LTS version that the .NET repo targets-->
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <NoWarn>$(NoWarn);1591;AZC0001;AZC0012;CA1724;CA1801;CA1812;CA1822;SA1028</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
@@ -11,8 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.10.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.5" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
   </ItemGroup>
 </Project>

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -25,4 +25,4 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/test-proxy
-    DotNetCoreVersion: "3.x"
+    DotNetCoreVersion: "6.x"

--- a/tools/test-proxy/docker/dockerfile
+++ b/tools/test-proxy/docker/dockerfile
@@ -1,17 +1,12 @@
-# we need access to dotnet dev certs tool to properly import the certificate
-# only .NET 5.0 and higher actually has access to --import a specific target certificate
-FROM mcr.microsoft.com/dotnet/sdk:5.0.400-alpine3.13 AS dotnet_build_cache
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.9-alpine3.13 AS dotnet_runtime_cache
-
-FROM mcr.microsoft.com/dotnet/sdk:3.1-alpine3.14 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-alpine3.14 AS build
 
 # copy the code
 COPY docker_build/Azure.Sdk.Tools.TestProxy/ /proxyservercode
 
 # publish the package
-RUN cd /proxyservercode && dotnet publish -c Release -o /proxyserver -f netcoreapp3.1
+RUN cd /proxyservercode && dotnet publish -c Release -o /proxyserver -f net6.0
 
-FROM mcr.microsoft.com/dotnet/aspnet:3.1-alpine3.14
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine3.14
 
 ENV \
     NO_AT_BRIDGE=1 \
@@ -22,9 +17,8 @@ ENV \
     # default URL of localhost:5000 or localhost:50001 are not usable from outside the container
     ASPNETCORE_URLS="http://0.0.0.0:5000;https://0.0.0.0:5001"
 
-# dotnet-dev-certs tool is not included in aspnet image, so manually copy from sdk image (along with the .NET runtime associated)
-COPY --from=dotnet_build_cache /usr/share/dotnet/sdk/5.0.400/DotnetTools/dotnet-dev-certs/5.0.9-servicing.21365.3/tools/net5.0/any/ /dotnet-dev-certs
-COPY --from=dotnet_runtime_cache ["/usr/share/dotnet/shared/Microsoft.NETCore.App/", "/usr/share/dotnet/shared/Microsoft.NETCore.App/"]
+# dotnet-dev-certs tool is not included in aspnet image, so manually copy from sdk image
+COPY --from=build /usr/share/dotnet/sdk/6.0.101/DotnetTools/dotnet-dev-certs/6.0.1-servicing.21567.14/tools/net6.0/any/ /dotnet-dev-certs
 
 # prep the machine dev certificate
 COPY docker_build/$CERT_IMPORT_SH docker_build/dotnet-devcert.pfx docker_build/dotnet-devcert.crt $CERT_FOLDER/
@@ -40,9 +34,7 @@ RUN \
     && chmod +x $CERT_FOLDER/$CERT_IMPORT_SH \
     && $CERT_FOLDER/$CERT_IMPORT_SH \
     && rm $CERT_FOLDER/$CERT_IMPORT_SH \
-    && mkdir -p /srv/testproxy \
-    && rm -rf /usr/share/dotnet/shared/Microsoft.NETCore.App/5.0.9 \
-    && rm -rf /dotnet-dev-certs
+    && mkdir -p /srv/testproxy
 
 EXPOSE 5000 5001
 

--- a/tools/test-proxy/docker/dockerfile-win
+++ b/tools/test-proxy/docker/dockerfile-win
@@ -1,17 +1,13 @@
-# we need access to dotnet dev certs tool to properly import the certificate
-# only .NET 5.0 and higher actually has access to --import a specific target certificate
-FROM mcr.microsoft.com/dotnet/sdk:5.0.401-nanoserver-1809 AS dotnet_build_cache
-FROM mcr.microsoft.com/dotnet/aspnet:5.0.10-nanoserver-1809 AS dotnet_runtime_cache
-
-FROM mcr.microsoft.com/dotnet/sdk:3.1-nanoserver-1809 AS build_env
+FROM mcr.microsoft.com/dotnet/sdk:6.0.101-nanoserver-1809 AS build_env
 
 # copy the code
 COPY docker_build/Azure.Sdk.Tools.TestProxy/ /proxyservercode
 
 # publish the package
-RUN cd /proxyservercode && dotnet publish -c Release -o /proxyserver -f netcoreapp3.1
+RUN cd /proxyservercode && dotnet publish -c Release -o /proxyserver -f net6.0
 
-FROM mcr.microsoft.com/dotnet/aspnet:3.1-nanoserver-1809 AS build
+FROM mcr.microsoft.com/dotnet/aspnet:6.0.1-nanoserver-1809 AS build
+
 ENV ProgramFiles="C:\Program Files" \
     # set a fixed location for the Module analysis cache
     PSModuleAnalysisCachePath="C:\Users\Public\AppData\Local\Microsoft\Windows\PowerShell\docker\ModuleAnalysisCache" \
@@ -43,12 +39,9 @@ ADD docker_build/dotnet-devcert.pfx certwork
 
 # we still need to import this certificate to ensure it's available to all users. there is _something_ gnarly going on that purely having the cert 
 # available through the environment variables is causing some inconsistent weirdness.    
-COPY --from=dotnet_build_cache ["C:/Program Files/dotnet/sdk/5.0.401/DotnetTools/dotnet-dev-certs/5.0.10-servicing.21410.22/tools/net5.0/any/", "C:/dotnet-dev-certs/"]
-COPY --from=dotnet_runtime_cache ["C:/Program Files/dotnet/shared/Microsoft.NETCore.App/", "C:/Program Files/dotnet/shared/Microsoft.NETCore.App/"]
+COPY --from=build_env ["C:/Program Files/dotnet/sdk/6.0.101/DotnetTools/dotnet-dev-certs/6.0.1-servicing.21567.14/tools/net6.0/any/", "C:/dotnet-dev-certs/"]
 
-RUN dotnet /dotnet-dev-certs/dotnet-dev-certs.dll https --clean --import /certwork/dotnet-devcert.pfx -p "password" \
-    && rmdir "C:/dotnet-dev-certs/" /s /q \
-    && rmdir "C:/Program Files/dotnet/shared/Microsoft.NETCore.App/5.0.10" /s /q
+RUN dotnet /dotnet-dev-certs/dotnet-dev-certs.dll https --clean --import /certwork/dotnet-devcert.pfx -p "password"
 
 WORKDIR /proxyserver
 ADD host-patcher.cmd .


### PR DESCRIPTION
There are TLS issues when trying to communicate from .NET 6.0 to Test-Proxy compiled on 3.1.
Rather than try to workaround those issues, we agreed to just upgrade to 6.0.