### PR TITLE
Increase GitHub get issues fetch limit

### DIFF
--- a/eng/common/scripts/Invoke-GitHubAPI.ps1
+++ b/eng/common/scripts/Invoke-GitHubAPI.ps1
@@ -201,7 +201,7 @@ function Get-GitHubIssues {
     $AuthToken
   )
 
-  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/issues?labels=$Labels"
+  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/issues?labels=$Labels&per_page=100"
 
   if ($CreatedBy) {
     $uri += "&creator=$CreatedBy"


### PR DESCRIPTION
Github issues get AI returns max of 30 issues. Long term fix is to add a new API to search for an GH issue with a given label. Work around is to increase the limit to avoid creating duplicate issues.