### PR TITLE
Add yml definitons for managing nupkg releases

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -87,7 +87,7 @@ stages:
               mergeTestResults: true
 
   - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - template: pipelines/stages/net-release-to-feed.yml@azure-sdk-build-tools
+    - template: /eng/pipelines/templates/stages/net-release-to-devops.yml
       parameters:
         # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
         DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'

--- a/eng/pipelines/templates/stages/net-release-to-devops.yml
+++ b/eng/pipelines/templates/stages/net-release-to-devops.yml
@@ -29,7 +29,7 @@ stages:
       runOnce:
         deploy:
           steps:
-            - template: pipelines/steps/net-release-to-any.yml@azure-sdk-build-tools
+            - template: /eng/pipelines/steps/net-release-to-any.yml
               parameters:
                 ShouldDownloadArtifacts: ${{ parameters.ShouldDownloadArtifacts }}
                 ShouldCreateGitTag: ${{ parameters.ShouldCreateGitTag }}

--- a/eng/pipelines/templates/stages/net-release-to-devops.yml
+++ b/eng/pipelines/templates/stages/net-release-to-devops.yml
@@ -1,0 +1,42 @@
+parameters:
+  ShouldDownloadArtifacts: true
+  ShouldCreateGitTag: true
+  ShouldSignPackages: true
+  ShouldPublishSymbols: true
+  ShouldPublishToDevOpsFeed: true
+  ShouldPublishArtifact: true
+  # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
+  DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
+
+# Needs Github Release variable group linked.
+# Needs AzureSDK Nuget Release Pipelines Secrets variable group linked.
+
+stages:
+- stage: Release
+  jobs:
+  - deployment: Sign_And_Publish
+    environment: net-release
+    pool:
+      vmImage: windows-2019
+
+    variables:
+      ArtifactsPath: $(System.DefaultWorkingDirectory)\_artifacts\packages
+      BuildToolsRepoPath: $(System.DefaultWorkingDirectory)/_azure-sdk-build-tools
+      BuildToolsScriptsPath: $(BuildToolsRepoPath)/scripts
+      BuildToolsToolsPath: $(BuildToolsRepoPath)/tools
+
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+            - template: pipelines/steps/net-release-to-any.yml@azure-sdk-build-tools
+              parameters:
+                ShouldDownloadArtifacts: ${{ parameters.ShouldDownloadArtifacts }}
+                ShouldCreateGitTag: ${{ parameters.ShouldCreateGitTag }}
+                ShouldSignPackages: ${{ parameters.ShouldSignPackages }}
+                ShouldPublishSymbols: ${{ parameters.ShouldPublishSymbols }}
+                ShouldPublishToDevOpsFeed: ${{ parameters.ShouldPublishToDevOpsFeed }}
+                ShouldPublishArtifact: ${{ parameters.ShouldPublishArtifact }}
+                BuildToolsRepoPath: $(BuildToolsRepoPath)
+                ArtifactsPath: $(ArtifactsPath)
+                DevOpsFeedId: ${{ parameters.DevOpsFeedId }}

--- a/eng/pipelines/templates/steps/net-release-to-any.yml
+++ b/eng/pipelines/templates/steps/net-release-to-any.yml
@@ -1,0 +1,61 @@
+parameters:
+  ShouldDownloadArtifacts: false
+  ShouldCreateGitTag: false
+  ShouldSignPackages: false
+  ShouldPublishSymbols: false
+  ShouldPublishToDevOpsFeed: false
+  ShouldPublishArtifact: false
+  BuildToolsRepoPath: ''
+  ArtifactsPath: ''
+  DevOpsFeedId: ''
+
+steps:
+  - ${{ if ne(parameters.BuildToolsRepoPath, '') }}:
+    - template: tools/clone-buildtools/clone-buildtools.yml@azure-sdk-build-tools
+      parameters:
+        BuildToolsRepoPath: ${{ parameters.BuildToolsRepoPath }}
+
+  - ${{ if eq(parameters.ShouldDownloadArtifacts, 'true') }}:
+    - download: none # Disable the automatic downloading so that we can download ourselves to the location we want.
+    - task: DownloadPipelineArtifact@2
+      displayName: Download Packages
+      inputs:
+        artifact: packages
+        path: ${{ parameters.ArtifactsPath }}
+
+  - ${{ if eq(parameters.ShouldCreateGitTag, 'true') }}:
+    - task: PowerShell@2
+      displayName: 'Verify Package Tags and Create Git Releases'
+      inputs:
+        targetType: filePath
+        filePath: '/eng/common/scripts/create-tags-and-git-release.ps1'
+        arguments: '-artifactLocation ${{ parameters.ArtifactsPath }} -workingDirectory $(System.DefaultWorkingDirectory) -packageRepository Nuget -releaseSha $(Build.SourceVersion) -repoId $(Build.Repository.Id)'
+      env:
+        GH_TOKEN: $(azuresdk-github-pat)
+
+  - ${{ if eq(parameters.ShouldSignPackages, 'true') }}:
+    - template: pipelines/steps/net-signing.yml@azure-sdk-build-tools
+      parameters:
+        PackagesPath: ${{ parameters.ArtifactsPath }}
+        BuildToolsPath: ${{ parameters.BuildToolsRepoPath }}
+
+  - ${{ if eq(parameters.ShouldPublishSymbols, 'true') }}:
+    - task: MSBuild@1
+      displayName: 'Upload Symbols'
+      inputs:
+        solution: '${{ parameters.BuildToolsRepoPath }}/tools/symboltool/SymbolUploader.proj'
+        msbuildArguments: '/p:PackagesPath=${{ parameters.ArtifactsPath }} /p:MSPublicSymbolsPAT=$(azuresdk-microsoftpublicsymbols-devops-pat) /p:MSSymbolsPAT=$(azuresdk-microsoft-devops-pat) /p:AzureSDKSymbolsPAT=$(azuresdk-azure-sdk-devops-pat)'
+
+  - ${{ if eq(parameters.ShouldPublishToDevOpsFeed, 'true') }}:
+    - task: NuGetCommand@2
+      displayName: 'Publish to DevOps Feed'
+      inputs:
+        command: push
+        packagesToPush: '${{ parameters.ArtifactsPath }}/*.nupkg;!${{ parameters.ArtifactsPath }}/*.symbols.nupkg'
+        publishVstsFeed: ${{ parameters.DevOpsFeedID }}
+
+  - ${{ if eq(parameters.ShouldPublishArtifact, 'true') }}:
+    - publish: ${{ parameters.ArtifactsPath }}
+      displayName: 'Publish processed files'
+      artifact: processed-files
+      condition: always()

--- a/eng/pipelines/templates/steps/net-release-to-any.yml
+++ b/eng/pipelines/templates/steps/net-release-to-any.yml
@@ -1,13 +1,18 @@
 parameters:
   ShouldDownloadArtifacts: false
   ShouldCreateGitTag: false
+  ShouldCopyFromPartnerDrops: false
   ShouldSignPackages: false
   ShouldPublishSymbols: false
   ShouldPublishToDevOpsFeed: false
   ShouldPublishArtifact: false
+  ShouldPublishToNuget: false
+  ShouldPublishToBlobFeed: false
   BuildToolsRepoPath: ''
   ArtifactsPath: ''
   DevOpsFeedId: ''
+  PartnerDropsBlobPath: ''
+  NugetVersion: ''
 
 steps:
   - ${{ if ne(parameters.BuildToolsRepoPath, '') }}:
@@ -33,6 +38,14 @@ steps:
       env:
         GH_TOKEN: $(azuresdk-github-pat)
 
+  - ${{ if eq(parameters.ShouldCopyFromPartnerDrops, 'true') }}:
+    - task: PowerShell@2
+      displayName: 'Copy from AzureSdkPartnerDrops'
+      inputs:
+        targetType: filePath
+        filePath: '${{ parameters.BuildToolsRepoPath }}/scripts/copy-from-azuresdkpartnerdrops.ps1'
+        arguments: '-downloadDir ${{ parameters.ArtifactsPath }} -blobPath ${{ parameters.PartnerDropsBlobPath }} -blobKey $(azuresdkpartnerdrops-access-key)'
+
   - ${{ if eq(parameters.ShouldSignPackages, 'true') }}:
     - template: pipelines/steps/net-signing.yml@azure-sdk-build-tools
       parameters:
@@ -46,6 +59,24 @@ steps:
         solution: '${{ parameters.BuildToolsRepoPath }}/tools/symboltool/SymbolUploader.proj'
         msbuildArguments: '/p:PackagesPath=${{ parameters.ArtifactsPath }} /p:MSPublicSymbolsPAT=$(azuresdk-microsoftpublicsymbols-devops-pat) /p:MSSymbolsPAT=$(azuresdk-microsoft-devops-pat) /p:AzureSDKSymbolsPAT=$(azuresdk-azure-sdk-devops-pat)'
 
+  - ${{ if ne(parameters.NugetVersion, '') }}:
+    - task: NuGetToolInstaller@1
+      displayName: 'Use NuGet ${{ parameters.NugetVersion }}'
+      inputs:
+        versionSpec: ${{ parameters.NugetVersion }}
+
+  - ${{ if eq(parameters.ShouldPublishToNuget, 'true') }}:
+    - task: NuGetCommand@2
+      displayName: 'Publish to Nuget'
+      inputs:
+        command: push
+        packagesToPush: '${{ parameters.ArtifactsPath }}/**/*.nupkg;!${{ parameters.ArtifactsPath }}/**/*.symbols.nupkg'
+        nuGetFeedType: external
+        publishFeedCredentials: Nuget.org
+      condition: succeeded()
+  
+  - ${{ if eq(parameters.ShouldPublishToBlobFeed, 'true') }}:
+
   - ${{ if eq(parameters.ShouldPublishToDevOpsFeed, 'true') }}:
     - task: NuGetCommand@2
       displayName: 'Publish to DevOps Feed'
@@ -53,6 +84,7 @@ steps:
         command: push
         packagesToPush: '${{ parameters.ArtifactsPath }}/*.nupkg;!${{ parameters.ArtifactsPath }}/*.symbols.nupkg'
         publishVstsFeed: ${{ parameters.DevOpsFeedID }}
+
 
   - ${{ if eq(parameters.ShouldPublishArtifact, 'true') }}:
     - publish: ${{ parameters.ArtifactsPath }}

--- a/src/dotnet/Mgmt.CI.BuildTools/ci.yml
+++ b/src/dotnet/Mgmt.CI.BuildTools/ci.yml
@@ -45,7 +45,7 @@ stages:
             inputs:
               ArtifactName: packages
   - ${{ if ne(variables['System.TeamProject'], 'Public') }}:
-    - template: pipelines/stages/net-release-to-feed.yml@azure-sdk-build-tools
+    - template: /eng/pipelines/templates/stages/net-release-to-devops.yml
       parameters:
-        ShouldTag: false  # Disable tagging for now as github is rate limiting us
-        ShouldSign: false # Disable signing for now because the tools package contains a number files we cannot correctly sign
+        ShouldCreateGitTag: false  # Disable tagging for now as github is rate limiting us
+        ShouldSignPackages: false # Disable signing for now because the tools package contains a number files we cannot correctly sign


### PR DESCRIPTION
- Add a single definiotn for managing various type of nupkg releases.
- Make release steps opt in
- Depends on `https://dev.azure.com/azure-sdk/internal/_git/azure-sdk-build-tools/pullrequest/217`