### PR TITLE
Package Python 3.9 in apiview deployment

### DIFF
--- a/.azure-pipelines/apiview.yml
+++ b/.azure-pipelines/apiview.yml
@@ -95,10 +95,16 @@ stages:
               mavenPomFile: 'src/java/apiview-java-processor/pom.xml'
               goals: 'clean package'
 
+          # Below 3 steps to package Python 3.9 is temporary work around until we have sandboxing ready
           - task: UsePythonVersion@0
             displayName: 'Use Python 3.9'
             inputs:
               versionSpec: 3.9
+
+          - script: |
+              pip install $(PythonParserPackagePath) $(ProtocolParserPackagePath)
+              pip install virtualenv aiohttp chardet trio
+            displayName: 'Setup Python Environment'
 
           - pwsh: |
               $pythonPath = split-path (get-command python).Path -Parent

--- a/.azure-pipelines/apiview.yml
+++ b/.azure-pipelines/apiview.yml
@@ -97,9 +97,6 @@ stages:
 
           # Below 3 steps to package Python 3.9 is temporary work around until we have sandboxing ready
           - task: UsePythonVersion@0
-            displayName: 'Use Python 3.9'
-            inputs:
-              versionSpec: 3.9
 
           - script: |
               pip install $(PythonParserPackagePath) $(ProtocolParserPackagePath)
@@ -110,8 +107,8 @@ stages:
               $pythonPath = split-path (get-command python).Path -Parent
               Write-Host "Python home path $($pythonPath)"
               copy-item -Path "$pythonPath" -Destination "$(Build.ArtifactStagingDirectory)/APIViewWeb/Python" -Recurse -Force
-              Write-Host "Packaged Python 3.9"
-            displayName: 'Package Python 3.9'
+              Write-Host "Packaged Python"
+            displayName: 'Package Python'
 
           - pwsh: |
               copy-item -Path $(PythonParserPackagePath) -Destination $(Build.ArtifactStagingDirectory)/APIViewWeb/api-stub-generator -Recurse -Force

--- a/.azure-pipelines/apiview.yml
+++ b/.azure-pipelines/apiview.yml
@@ -101,9 +101,9 @@ stages:
               versionSpec: 3.9
 
           - pwsh: |
-              $path = split-path (get-command python).Path -Parent
-              Write-Host "Python home path $($path)"
-              copy-item -Path $(path) -Destination $(Build.ArtifactStagingDirectory)/APIViewWeb/Python -Recurse -Force
+              $pythonPath = split-path (get-command python).Path -Parent
+              Write-Host "Python home path $($pythonPath)"
+              copy-item -Path "$pythonPath" -Destination "$(Build.ArtifactStagingDirectory)/APIViewWeb/Python" -Recurse -Force
               Write-Host "Packaged Python 3.9"
             displayName: 'Package Python 3.9'
 

--- a/.azure-pipelines/apiview.yml
+++ b/.azure-pipelines/apiview.yml
@@ -95,6 +95,18 @@ stages:
               mavenPomFile: 'src/java/apiview-java-processor/pom.xml'
               goals: 'clean package'
 
+          - task: UsePythonVersion@0
+            displayName: 'Use Python 3.9'
+            inputs:
+              versionSpec: 3.9
+
+          - pwsh: |
+              $path = split-path (get-command python).Path -Parent
+              Write-Host "Python home path $($path)"
+              copy-item -Path $(path) -Destination $(Build.ArtifactStagingDirectory)/APIViewWeb/Python -Recurse -Force
+              Write-Host "Packaged Python 3.9"
+            displayName: 'Package Python 3.9'
+
           - pwsh: |
               copy-item -Path $(PythonParserPackagePath) -Destination $(Build.ArtifactStagingDirectory)/APIViewWeb/api-stub-generator -Recurse -Force
               copy-item -Path $(ProtocolParserPackagePath) -Destination $(Build.ArtifactStagingDirectory)/APIViewWeb/protocol-stub-generator -Recurse -Force

--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## Version 0.2.7 (Unreleased)
+Updated version to regenerate all reviews using Python 3.9
+
 ## Version 0.2.6 (Unreleased)
 Updated type parsing to properly handle cases in which type
   info wraps onto a second line.

--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -4,15 +4,16 @@ import logging
 import re
 import importlib
 import inspect
+import platform
 
 from ._token import Token
 from ._token_kind import TokenKind
 from ._version import VERSION
 from ._diagnostic import Diagnostic
 
-JSON_FIELDS = ["Name", "Version", "VersionString", "Navigation", "Tokens", "Diagnostics", "PackageName"]
+JSON_FIELDS = ["Name", "Version", "VersionString", "Navigation", "Tokens", "Diagnostics", "PackageName", "Language"]
 
-HEADER_TEXT = "# Package is parsed using api-stub-generator(version:{})".format(VERSION)
+HEADER_TEXT = "# Package is parsed using api-stub-generator(version:{0}), Python version: {1}".format(VERSION, platform.python_version())
 TYPE_NAME_REGEX = re.compile("(~?[a-zA-Z\d._]+)")
 TYPE_OR_SEPERATOR = " or "
 

--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.2.6"
+VERSION = "0.2.7"


### PR DESCRIPTION
Python 3.6 is the latest version available as an extension for Azure web app. It seems Azure web app is not supporting new versions of Python as an extension. This change is to package Python 3.9 as part of deployment and APIView will use this integrated python version to generate review. This will be required only until we have sandboxing changes to offload review generation to pipeline. But Python 3.6 support needs to be dropped before 2022