### PR TITLE
Support AAD graph and Microsoft Graph service principal APIs

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -127,6 +127,38 @@ function Retry([scriptblock] $Action, [int] $Attempts = 5)
     }
 }
 
+# NewServicePrincipalWrapper creates an object from an AAD graph or Microsoft Graph service principal object type.
+# This is necessary to work around breaking changes introduced in Az version 7.0.0:
+# https://azure.microsoft.com/en-us/updates/update-your-apps-to-use-microsoft-graph-before-30-june-2022/
+function NewServicePrincipalWrapper($servicePrincipal)
+{
+    $spPassword = ""
+    if ($servicePrincipal.GetType().Name -eq 'MicrosoftGraphServicePrincipal') {
+        Write-Host "Creating password for service principal via MS Graph API"
+        # Microsoft graph objects (Az version >= 7.0.0) do not provision a secret # on creation so it must be added separately.
+        # Submitting a password credential object without specifying a password will result in one being generated on the server side.
+        $password = New-Object -TypeName "Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphPasswordCredential"
+        $password.DisplayName = "Password for $displayName"
+        $credential = Retry { New-AzADSpCredential -PasswordCredentials $password -ServicePrincipalObject $servicePrincipal }
+        $spPassword = ConvertTo-SecureString $credential.SecretText -AsPlainText -Force
+    } else {
+        # Secret property exists on PSADServicePrincipal type from AAD graph in Az # module versions < 7.0.0
+        $spPassword = $servicePrincipal.Secret
+    }
+
+    # MicrosoftGraphServicePrincipal objects have AppId, AAD graph objects have ApplicationId
+    $appId = $servicePrincipal.AppId ? $servicePrincipal.AppId : $servicePrincipal.ApplicationId
+
+    return @{
+        AppId = $appId
+        ApplicationId = $appId
+        # This is the ObjectId/OID but most return objects use .Id so keep it consistent to prevent confusion
+        Id = $servicePrincipal.Id
+        DisplayName = $servicePrincipal.DisplayName
+        Secret = $spPassword
+    }
+}
+
 function LoadCloudConfig([string] $env)
 {
     $configPath = "$PSScriptRoot/clouds/$env.json"
@@ -522,8 +554,8 @@ try {
     # If no test application ID was specified during an interactive session, create a new service principal.
     if (!$CI -and !$TestApplicationId) {
         # Cache the created service principal in this session for frequent reuse.
-        $servicePrincipal = if ($AzureTestPrincipal -and (Get-AzADServicePrincipal -ApplicationId $AzureTestPrincipal.ApplicationId) -and $AzureTestSubscription -eq $SubscriptionId) {
-            Log "TestApplicationId was not specified; loading cached service principal '$($AzureTestPrincipal.ApplicationId)'"
+        $servicePrincipal = if ($AzureTestPrincipal -and (Get-AzADServicePrincipal -ApplicationId $AzureTestPrincipal.AppId) -and $AzureTestSubscription -eq $SubscriptionId) {
+            Log "TestApplicationId was not specified; loading cached service principal '$($AzureTestPrincipal.AppId)'"
             $AzureTestPrincipal
         } else {
             Log "TestApplicationId was not specified; creating a new service principal in subscription '$SubscriptionId'"
@@ -537,19 +569,21 @@ try {
                 $displayName = "$($baseName)$suffix.test-resources.azure.sdk"
             }
 
+
             $servicePrincipal = Retry {
                 New-AzADServicePrincipal -Role "Owner" -Scope "/subscriptions/$SubscriptionId/resourceGroups/$ResourceGroupName" -DisplayName $displayName
             }
+            $servicePrincipalWrapper = NewServicePrincipalWrapper $servicePrincipal
 
-            $global:AzureTestPrincipal = $servicePrincipal
+            $global:AzureTestPrincipal = $servicePrincipalWrapper
             $global:AzureTestSubscription = $SubscriptionId
 
-            Log "Created service principal '$($AzureTestPrincipal.ApplicationId)'"
-            $AzureTestPrincipal
+            Log "Created service principal. AppId: '$($AzureTestPrincipal.AppId)' ObjectId: '$($AzureTestPrincipal.Id)'"
+            $servicePrincipalWrapper
             $resourceGroupRoleAssigned = $true
         }
 
-        $TestApplicationId = $servicePrincipal.ApplicationId
+        $TestApplicationId = $servicePrincipal.AppId
         $TestApplicationOid = $servicePrincipal.Id
         $TestApplicationSecret = (ConvertFrom-SecureString $servicePrincipal.Secret -AsPlainText)
     }
@@ -886,7 +920,7 @@ Bicep templates, test-resources.bicep.env.
 
 .PARAMETER SuppressVsoCommands
 By default, the -CI parameter will print out secrets to logs with Azure Pipelines log
-commands that cause them to be redacted. For CI environments that don't support this (like 
+commands that cause them to be redacted. For CI environments that don't support this (like
 stress test clusters), this flag can be set to $false to avoid printing out these secrets to the logs.
 
 .EXAMPLE


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-tools/issues/2413

Until the AAD graph API is fully retired and we force local users to update to Az module 7.0.0, we need to support the breaking changes that come with Az 7.0.0 (detailed in the above issue).

Instead of trying to figure out which Az module is loaded and/or force a specific module version, this change creates a simple wrapper object for service principal creation that can handle the breaking changes between the AAD graph and MS graph objects. The two primary differences are:

1. The `ApplicationId` property becomes `AppId`
2. The service principal password is not created and returned on service principal create via the `Secret` property. Instead, you have to do a subsequent call to the `addPassword` MS Graph API. The best way I've found to do this so far (given the lack of docs) is by looking at the [service principal cmdlet](https://github.com/Azure/azure-powershell/blob/main/src/Resources/MSGraph.Autorest/custom/New-AzADSpCredential.ps1#L164). It seems like it should do this by default, but I think the parameter set requirements restrict hitting that code path?

I've tested this with Az 7.0.0 and 6.4.0 loaded, with both CI true/false and with/without cached credentials and it seems to work fine.