### PR TITLE
Some compatible workaround for mock server

### DIFF
--- a/tools/mock-service-host/src/common/utils.ts
+++ b/tools/mock-service-host/src/common/utils.ts
@@ -47,6 +47,22 @@ export function replacePropertyValue(
     return newObject
 }
 
+export function removeNullValueKey(object: any): any {
+    if (typeof object !== 'object') return object
+
+    const newObject = lodash.clone(object)
+
+    lodash.each(object, (val, key) => {
+        if (val === null) {
+            delete newObject[key]
+        } else if (typeof val === 'object') {
+            newObject[key] = removeNullValueKey(val)
+        }
+    })
+
+    return newObject
+}
+
 export function getPureUrl(url: string): string {
     return url?.split('?')[0]
 }

--- a/tools/mock-service-host/src/mid/coordinator.ts
+++ b/tools/mock-service-host/src/mid/coordinator.ts
@@ -66,13 +66,7 @@ export class Coordinator {
                 nearest = parseInt(code)
             }
         }
-        if (nearest)
-            return [
-                nearest,
-                responses[nearest.toString()].body === undefined
-                    ? {}
-                    : responses[nearest.toString()].body
-            ]
+        if (nearest) return [nearest, responses[nearest.toString()].body]
         throw new NoResponse(status.toString())
     }
 

--- a/tools/mock-service-host/src/mid/coordinator.ts
+++ b/tools/mock-service-host/src/mid/coordinator.ts
@@ -66,7 +66,13 @@ export class Coordinator {
                 nearest = parseInt(code)
             }
         }
-        if (nearest) return [nearest, responses[nearest.toString()].body]
+        if (nearest)
+            return [
+                nearest,
+                responses[nearest.toString()].body === undefined
+                    ? {}
+                    : responses[nearest.toString()].body
+            ]
         throw new NoResponse(status.toString())
     }
 


### PR DESCRIPTION
<s>1. Return {} when body is empty</s>
2. Escape query param
3. Remove null value before compare
4. Trim for example name