### PR TITLE
mock-service-host: configurable excludedValidationPath

### DIFF
--- a/tools/mock-service-host/script/renew-ssh.ps1
+++ b/tools/mock-service-host/script/renew-ssh.ps1
@@ -1,4 +1,4 @@
 
 openssl rand -writerand .rnd
 openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/CN=127.0.0.1/ST=Shanghai/L=Shanghai/O=ame" -keyout $PSScriptRoot\..\.ssh\127-0-0-1-ca.pem -out $PSScriptRoot\..\.ssh\127-0-0-1-ca.crt
-openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/CN=localhost/ST=Shanghai/L=Shanghai/O=ame" -keyout $PSScriptRoot..\.ssh\localhost-ca.pem -out $PSScriptRoot..\.ssh\localhost-ca.crt
+openssl req -new -newkey rsa:4096 -days 3650 -nodes -x509 -subj "/CN=localhost/ST=Shanghai/L=Shanghai/O=ame" -keyout $PSScriptRoot\..\.ssh\localhost-ca.pem -out $PSScriptRoot\..\.ssh\localhost-ca.crt

--- a/tools/mock-service-host/src/common/config.ts
+++ b/tools/mock-service-host/src/common/config.ts
@@ -16,6 +16,7 @@ export interface Config {
     specRetrievalGitAuthToken: string
     specRetrievalRefreshIntervalMilliseconds: number
     validationPathsPattern: string[]
+    excludedValidationPathsPattern: string[]
     enableExampleGeneration: boolean
     exampleGenerationFolder: string
     cascadeEnabled: boolean

--- a/tools/mock-service-host/src/common/configSchema.ts
+++ b/tools/mock-service-host/src/common/configSchema.ts
@@ -113,6 +113,12 @@ export const configSchema = convict<Config>({
         default: ['/specification/**/resource-manager/**/*.json'],
         env: 'validationPathsPattern'
     },
+    excludedValidationPathsPattern: {
+        doc: 'The pattern which excluded from the validationPathsPattern',
+        format: Array,
+        default: [],
+        env: 'excludedValidationPathsPattern'
+    },
     enableExampleGeneration: {
         doc: 'If true example files will not be generated along with each REST calling.',
         format: Boolean,

--- a/tools/mock-service-host/src/mid/coordinator.ts
+++ b/tools/mock-service-host/src/mid/coordinator.ts
@@ -127,6 +127,7 @@ export class Coordinator {
                 shouldClone: false
             },
             swaggerPathsPattern: this.config.validationPathsPattern,
+            excludedSwaggerPathsPattern: this.config.excludedValidationPathsPattern,
             directory: path.resolve(this.config.specRetrievalLocalRelativePath),
             isPathCaseSensitive: false
         }


### PR DESCRIPTION
The oav exclude azurestack and dataplan path by default.
This PR make the excluded pattern as configurable and default as empty.