### PR TITLE
[pipeline generator] Build out weekly test pipelines for all services and fix scheduling

### DIFF
--- a/eng/common/pipelines/templates/steps/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/steps/prepare-pipelines.yml
@@ -74,6 +74,25 @@ steps:
       condition: ne('${{parameters.TestsConventionOptions}}','')
       env:
         PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    - script: >
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+        --organization https://dev.azure.com/azure-sdk
+        --project internal
+        --prefix ${{parameters.Prefix}}
+        --devopspath "\${{parameters.Prefix}}"
+        --path $(System.DefaultWorkingDirectory)/sdk
+        --endpoint Azure
+        --repository ${{parameters.Repository}}
+        --convention weekly
+        --agentpool Hosted
+        --branch refs/heads/$(DefaultBranch)
+        --patvar PATVAR
+        --debug
+        ${{parameters.TestsConventionOptions}}
+      displayName: Create Weekly (Multi-Cloud) Live Test pipelines for public repository
+      condition: ne('${{parameters.TestsConventionOptions}}','')
+      env:
+        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 
   # This covers our -pr repositories.
   - ${{ if endsWith(parameters.Repository, '-pr')}}:

--- a/eng/common/pipelines/templates/steps/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/steps/prepare-pipelines.yml
@@ -71,7 +71,7 @@ steps:
         --debug
         ${{parameters.TestsConventionOptions}}
       displayName: Create Live Test pipelines for public repository
-      condition: ne('${{parameters.TestsConventionOptions}}','')
+      condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
       env:
         PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
     - script: >
@@ -90,7 +90,7 @@ steps:
         --debug
         ${{parameters.TestsConventionOptions}}
       displayName: Create Weekly (Multi-Cloud) Live Test pipelines for public repository
-      condition: ne('${{parameters.TestsConventionOptions}}','')
+      condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
       env:
         PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 
@@ -151,6 +151,6 @@ steps:
         --no-schedule
         ${{parameters.TestsConventionOptions}}
       displayName: Create Live Test pipelines for private repository
-      condition: ne('${{parameters.TestsConventionOptions}}','')
+      condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
       env:
         PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -145,6 +145,12 @@ jobs:
     condition: ne(variables['TestOptions'],'')
     env:
       PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+  - script: |
+      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator --organization https://dev.azure.com/azure-sdk --project internal --prefix $(Prefix) --path $(Pipeline.Workspace)/$(RepositoryName)/sdk --endpoint Azure --repository Azure/$(RepositoryName) --convention weekly --agentpool Hosted --branch refs/heads/$(DefaultBranch) --patvar PATVAR --debug $(TestOptions)
+    displayName: 'Generate weekly test pipelines (multi-cloud) for: $(RepositoryName)'
+    condition: ne(variables['TestOptions'],'')
+    env:
+      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 
   # - script: |
   #     pipeline-generator --organization https://dev.azure.com/azure-sdk --project internal --prefix $(Prefix)-pr --devopspath "\$(Prefix)\pr" --path $(Pipeline.Workspace)/$(RepositoryName)/sdk --endpoint Azure --repository Azure/$(RepositoryName)-pr --convention ci --agentpool Hosted --branch refs/heads/ $(DefaultBranch) --patvar PATVAR --debug

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -142,13 +142,13 @@ jobs:
   - script: |
       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator --organization https://dev.azure.com/azure-sdk --project internal --prefix $(Prefix) --path $(Pipeline.Workspace)/$(RepositoryName)/sdk --endpoint Azure --repository Azure/$(RepositoryName) --convention tests --agentpool Hosted --branch refs/heads/$(DefaultBranch) --patvar PATVAR --debug $(TestOptions)
     displayName: 'Generate test pipelines for: $(RepositoryName)'
-    condition: ne(variables['TestOptions'],'')
+    condition: and(succeeded(), ne(variables['TestOptions'],''))
     env:
       PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
   - script: |
       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator --organization https://dev.azure.com/azure-sdk --project internal --prefix $(Prefix) --path $(Pipeline.Workspace)/$(RepositoryName)/sdk --endpoint Azure --repository Azure/$(RepositoryName) --convention weekly --agentpool Hosted --branch refs/heads/$(DefaultBranch) --patvar PATVAR --debug $(TestOptions)
     displayName: 'Generate weekly test pipelines (multi-cloud) for: $(RepositoryName)'
-    condition: ne(variables['TestOptions'],'')
+    condition: and(succeeded(), ne(variables['TestOptions'],''))
     env:
       PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pipeline-generator</ToolCommandName>

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
@@ -25,7 +25,7 @@ namespace PipelineGenerator.Conventions
         {
             var hasChanges = await base.ApplyConventionAsync(definition, component);
 
-            if (EnsureDefautPullRequestTrigger(definition, overrideYaml: true, securePipeline: true))
+            if (EnsureDefaultPullRequestTrigger(definition, overrideYaml: true, securePipeline: true))
             {
                 hasChanges = true;
             }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
@@ -16,7 +16,7 @@ namespace PipelineGenerator.Conventions
         {
         }
 
-        protected override string GetDefinitionName(SdkComponent component)
+        public override string GetDefinitionName(SdkComponent component)
         {
             return component.Variant == null ? $"{Context.Prefix} - {component.Name} - tests" : $"{Context.Prefix} - {component.Name} - tests.{component.Variant}";
         }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -349,23 +349,19 @@ namespace PipelineGenerator.Conventions
                 {
                     if (overrideYaml)
                     {
-                        if (trigger.SettingsSourceType != 1 ||
-                            trigger.BranchFilters.Contains("+*"))
+                        // Override what is in the yaml file and use what is in the pipeline definition
+                        trigger.SettingsSourceType = 1;
+
+                        if (!trigger.BranchFilters.Contains("+*"))
                         {
-                            // Override what is in the yaml file and use what is in the pipeline definition
-                            trigger.SettingsSourceType = 1;
                             trigger.BranchFilters.Add("+*");
                         }
                     }
-                    else
+                    else if (trigger.SettingsSourceType != 2)
                     {
-                        if (trigger.SettingsSourceType != 2)
-                        {
-                            // Pull settings from yaml
-                            trigger.SettingsSourceType = 2;
-                            hasChanges = true;
-                        }
-
+                        // Pull settings from yaml
+                        trigger.SettingsSourceType = 2;
+                        hasChanges = true;
                     }
                     if (trigger.RequireCommentsForNonTeamMembersOnly != false ||
                        trigger.Forks.AllowSecrets != securePipeline ||

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -26,7 +26,7 @@ namespace PipelineGenerator.Conventions
 
         public abstract string SearchPattern { get; }
 
-        protected abstract string GetDefinitionName(SdkComponent component);
+        public abstract string GetDefinitionName(SdkComponent component);
 
         public async Task<BuildDefinition> DeleteDefinitionAsync(SdkComponent component, CancellationToken cancellationToken)
         {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -313,7 +313,7 @@ namespace PipelineGenerator.Conventions
             return Task.FromResult(hasChanges);
         }
 
-        protected bool EnsureDefautPullRequestTrigger(BuildDefinition definition, bool overrideYaml = true, bool securePipeline = true)
+        protected bool EnsureDefaultPullRequestTrigger(BuildDefinition definition, bool overrideYaml = true, bool securePipeline = true)
         {
             bool hasChanges = false;
             var prTriggers = definition.Triggers.OfType<PullRequestTrigger>();
@@ -377,7 +377,7 @@ namespace PipelineGenerator.Conventions
                         trigger.Forks.Enabled = true;
                         trigger.RequireCommentsForNonTeamMembersOnly = false;
                         trigger.IsCommentRequiredForPullRequest = securePipeline;
-   
+
                         hasChanges = true;
                     }
                 }
@@ -390,7 +390,7 @@ namespace PipelineGenerator.Conventions
             bool hasChanges = false;
             var scheduleTriggers = definition.Triggers.OfType<ScheduleTrigger>();
 
-            // Only add the schedule trigger if one doesn't exist. 
+            // Only add the schedule trigger if one doesn't exist.
             if (scheduleTriggers == default || !scheduleTriggers.Any())
             {
                 var computedSchedule = CreateScheduleFromDefinition(definition);

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -350,11 +350,16 @@ namespace PipelineGenerator.Conventions
                     if (overrideYaml)
                     {
                         // Override what is in the yaml file and use what is in the pipeline definition
-                        trigger.SettingsSourceType = 1;
+                        if (trigger.SettingsSourceType != 1)
+                        {
+                            trigger.SettingsSourceType = 1;
+                            hasChanges = true;
+                        }
 
                         if (!trigger.BranchFilters.Contains("+*"))
                         {
                             trigger.BranchFilters.Add("+*");
+                            hasChanges = true;
                         }
                     }
                     else if (trigger.SettingsSourceType != 2)

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
@@ -25,7 +25,7 @@ namespace PipelineGenerator.Conventions
         {
             var hasChanges = await base.ApplyConventionAsync(definition, component);
 
-            if (EnsureDefautPullRequestTrigger(definition, overrideYaml: false, securePipeline: false))
+            if (EnsureDefaultPullRequestTrigger(definition, overrideYaml: false, securePipeline: false))
             {
                 hasChanges = true;
             }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
@@ -14,7 +14,7 @@ namespace PipelineGenerator.Conventions
         {
         }
 
-        protected override string GetDefinitionName(SdkComponent component)
+        public override string GetDefinitionName(SdkComponent component)
         {
             return component.Variant == null ? $"{Context.Prefix} - {component.Name} - ci" : $"{Context.Prefix} - {component.Name} - ci.{component.Variant}";
         }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -14,7 +14,7 @@ namespace PipelineGenerator.Conventions
         {
         }
 
-        protected override string GetDefinitionName(SdkComponent component)
+        public override string GetDefinitionName(SdkComponent component)
         {
             return component.Variant == null ? $"{Context.Prefix} - {component.Name}" : $"{Context.Prefix} - {component.Name} - {component.Variant}";
         }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -25,7 +25,7 @@ namespace PipelineGenerator.Conventions
         {
             var hasChanges = await base.ApplyConventionAsync(definition, component);
 
-            if (EnsureDefautPullRequestTrigger(definition, overrideYaml: true, securePipeline: true))
+            if (EnsureDefaultPullRequestTrigger(definition, overrideYaml: true, securePipeline: true))
             {
                 hasChanges = true;
             }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
@@ -23,10 +23,12 @@ namespace PipelineGenerator.Conventions
             var bucket = definition.Id % TotalBuckets;
             var startHours = bucket / BucketsPerHour;
             var startMinutes = bucket % BucketsPerHour;
+            var daysToBuild = new ScheduleDays[]{ ScheduleDays.Saturday, ScheduleDays.Sunday };
+            var dayBucket = definition.Id % daysToBuild.Length;
 
             var schedule = new Schedule
             {
-                DaysToBuild = ScheduleDays.Saturday | ScheduleDays.Sunday,
+                DaysToBuild = daysToBuild[dayBucket],
                 ScheduleOnlyWithChanges = true,
                 StartHours = FirstSchedulingHour + startHours,
                 StartMinutes = startMinutes * BucketSizeInMinutes,

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
@@ -9,7 +9,7 @@ namespace PipelineGenerator.Conventions
         {
         }
 
-        protected override string GetDefinitionName(SdkComponent component)
+        public override string GetDefinitionName(SdkComponent component)
         {
             var definitionName = $"{Context.Prefix} - {component.Name} - tests-weekly";
             if (component.Variant != null) {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/ExitCondition.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/ExitCondition.cs
@@ -7,6 +7,7 @@ namespace PipelineGenerator
         Success = 0,
         Exception = 1,
         InvalidArguments = 2,
-        NoComponentsFound = 3
+        NoComponentsFound = 3,
+        DuplicateComponentsFound = 4
     }
 }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
@@ -26,18 +26,19 @@ namespace PipelineGenerator
         private string devOpsPath;
 
         public PipelineGenerationContext(
-            string organization, 
-            string project, 
-            string patvar, 
-            string endpoint, 
-            string repository, 
-            string branch, 
-            string agentPool, 
+            string organization,
+            string project,
+            string patvar,
+            string endpoint,
+            string repository,
+            string branch,
+            string agentPool,
             string[] variableGroups,
             string devOpsPath,
-            string prefix, 
+            string prefix,
             bool whatIf,
-            bool noSchedule)
+            bool noSchedule,
+            bool overwriteTriggers)
         {
             this.organization = organization;
             this.project = project;
@@ -51,16 +52,18 @@ namespace PipelineGenerator
             this.Prefix = prefix;
             this.WhatIf = whatIf;
             this.NoSchedule = noSchedule;
+            this.OverwriteTriggers = overwriteTriggers;
         }
 
         public string Branch { get; }
         public string Prefix { get; }
         public bool WhatIf { get; }
         public bool NoSchedule { get; }
+        public bool OverwriteTriggers { get; }
         public int[] VariableGroups => this.variableGroups;
         public string DevOpsPath => string.IsNullOrEmpty(this.devOpsPath) ? Prefix : this.devOpsPath;
 
-        private int[] ParseIntArray(string[] strs) 
+        private int[] ParseIntArray(string[] strs)
             => strs.Select(str => int.Parse(str)).ToArray();
 
         private VssConnection cachedConnection;
@@ -91,7 +94,7 @@ namespace PipelineGenerator
         }
 
         private TeamProjectReference cachedProjectReference;
-       
+
         public async Task<TeamProjectReference> GetProjectReferenceAsync(CancellationToken cancellationToken)
         {
             if (cachedProjectReference == null)

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
@@ -61,6 +61,7 @@ namespace PipelineGenerator
             var destroyOption = app.Option("--destroy", "Use this switch to delete the pipelines instead (DANGER!)", CommandOptionType.NoValue);
             var debugOption = app.Option("--debug", "Turn on debug level logging.", CommandOptionType.NoValue);
             var noScheduleOption = app.Option("--no-schedule", "Don't create any scheduled triggers.", CommandOptionType.NoValue);
+            var overwriteTriggersOption = app.Option("--overwrite-triggers", "Overwrite existing pipeline triggers (triggers may be manually modified, use with caution).", CommandOptionType.NoValue);
 
             app.OnExecute(() =>
             {
@@ -83,6 +84,7 @@ namespace PipelineGenerator
                     openOption.HasValue(),
                     destroyOption.HasValue(),
                     noScheduleOption.HasValue(),
+                    overwriteTriggersOption.HasValue(),
                     cancellationTokenSource.Token
                     ).Result;
 
@@ -146,6 +148,7 @@ namespace PipelineGenerator
             bool open,
             bool destroy,
             bool noSchedule,
+            bool overwriteTriggers,
             CancellationToken cancellationToken)
         {
             try
@@ -167,7 +170,8 @@ namespace PipelineGenerator
                     devOpsPathValue,
                     prefix,
                     whatIf,
-                    noSchedule
+                    noSchedule,
+                    overwriteTriggers
                     );
 
                 var pipelineConvention = GetPipelineConvention(convention, context);


### PR DESCRIPTION
This PR updates the weekly test pipeline to run by default for all services (which will behave like our weekday live tests). It also fixes a scheduling/bucketing problem where the weekly tests were running on both Saturday and Sunday.

Update: this PR also adds name collision detection for pipeline definitions, with a helpful log message for a workaround. Resolves https://github.com/Azure/azure-sdk-tools/issues/2474
Resolves https://github.com/Azure/azure-sdk-tools/issues/2377