### PR TITLE
Add header transform

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -511,7 +511,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderTransform";
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(
-                "{ \"key\": \"Location\", \"replacement\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\", \"condition\": { \"uriRegex\": \".*/token\", \"responseHeaderCondition\": { \"key\": \"Location\", \"valueRegex\": \".*/value\" } }}");
+                "{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\", \"condition\": { \"uriRegex\": \".*/token\", \"responseHeader\": { \"key\": \"Location\", \"valueRegex\": \".*/value\" } }}");
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
 
             var controller = new Admin(testRecordingHandler)
@@ -528,8 +528,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             Assert.True(result is HeaderTransform);
             var key = (string) typeof(HeaderTransform).GetField("_key", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(result);
-            var replacement = (string) typeof(HeaderTransform).GetField("_replacement", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(result);
-            var regex = result.Condition.ResponseHeaderCondition.ValueRegex;
+            var replacement = (string) typeof(HeaderTransform).GetField("_value", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(result);
+            var regex = result.Condition.ResponseHeader.ValueRegex;
             Assert.Equal("Location", key);
             Assert.Equal("https://fakeazsdktestaccount.table.core.windows.net/Tables", replacement);
             Assert.Equal(".*/value", regex);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -511,7 +511,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderTransform";
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(
-                "{ \"key\": \"Location\", \"replacement\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\", \"valueRegex\": \".*/value\", \"condition\": { \"uriRegex\": \".*/token\" } }");
+                "{ \"key\": \"Location\", \"replacement\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\", \"condition\": { \"uriRegex\": \".*/token\", \"responseHeaderCondition\": { \"key\": \"Location\", \"valueRegex\": \".*/value\" } }}");
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
 
             var controller = new Admin(testRecordingHandler)
@@ -529,7 +529,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             Assert.True(result is HeaderTransform);
             var key = (string) typeof(HeaderTransform).GetField("_key", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(result);
             var replacement = (string) typeof(HeaderTransform).GetField("_replacement", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(result);
-            var regex = (string) typeof(HeaderTransform).GetField("_valueRegex", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(result);
+            var regex = result.Condition.ResponseHeaderCondition.ValueRegex;
             Assert.Equal("Location", key);
             Assert.Equal("https://fakeazsdktestaccount.table.core.windows.net/Tables", replacement);
             Assert.Equal(".*/value", regex);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -532,9 +532,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var key = (string) typeof(HeaderTransform).GetField("_key", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(result);
             var replacement = (string) typeof(HeaderTransform).GetField("_replacement", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(result);
             var regex = (string) typeof(HeaderTransform).GetField("_valueRegex", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(result);
-            Assert.Equal(key, "Location");
-            Assert.Equal(replacement, "https://fakeazsdktestaccount.table.core.windows.net/Tables");
-            Assert.Equal(regex, ".*/value");
+            Assert.Equal("Location", key);
+            Assert.Equal("https://fakeazsdktestaccount.table.core.windows.net/Tables", replacement);
+            Assert.Equal(".*/value", regex);
             Assert.Equal(".*/token", result.Condition.UriRegex);
 
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -509,8 +509,6 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
-            var apiVersion = "2016-03-21";
-            httpContext.Request.Headers["x-api-version"] = apiVersion;
             httpContext.Request.Headers["x-abstraction-identifier"] = "HeaderTransform";
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(
                 "{ \"key\": \"Location\", \"replacement\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\", \"valueRegex\": \".*/value\", \"condition\": { \"uriRegex\": \".*/token\" } }");

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -202,6 +202,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             HttpResponse response = new DefaultHttpContext().Response;
             await testRecordingHandler.HandlePlaybackRequest(recordingId, request, response);
             Assert.Equal("0", response.Headers["Retry-After"]);
+
+            // this response did not have the retry-after header initially, so it should not have been added.
+            entry = testRecordingHandler.PlaybackSessions[recordingId].Session.Entries[0];
+            request = TestHelpers.CreateRequestFromEntry(entry);
+            response = new DefaultHttpContext().Response;
+            await testRecordingHandler.HandlePlaybackRequest(recordingId, request, response);
+            Assert.False(response.Headers.ContainsKey("Retry-After"));
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -31,9 +31,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         {
             if (skipsToCheck.HasFlag(CheckSkips.IncludeTransforms))
             {
-                Assert.Equal(2, handlerForTest.Transforms.Count);
+                Assert.Equal(3, handlerForTest.Transforms.Count);
                 Assert.IsType<StorageRequestIdTransform>(handlerForTest.Transforms[0]);
                 Assert.IsType<ClientIdTransform>(handlerForTest.Transforms[1]);
+                Assert.IsType<HeaderTransform>(handlerForTest.Transforms[2]);
             }
 
             if (skipsToCheck.HasFlag(CheckSkips.IncludeMatcher))

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/response_with_header_to_transform.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/response_with_header_to_transform.json
@@ -1,0 +1,87 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeazsdktestaccount.table.core.windows.net/Tables",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "34",
+        "Content-Type": "application/json;odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "Date": "Tue, 18 May 2021 23:27:42 GMT",
+        "User-Agent": "azsdk-python-data-tables/12.0.0b7 Python/3.8.6 (Windows-10-10.0.19041-SP0)",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-date": "Tue, 18 May 2021 23:27:42 GMT",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "{\u0022TableName\u0022:    \u0022listtable09bf2a3d\u0022}",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Tue, 18 May 2021 23:27:43 GMT",
+        "Retry-After": "10",
+        "Location": "https://fakeazsdktestaccount.table.core.windows.net/Tables(\u0027listtable09bf2a3d\u0027)",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-request-id": "d2270777-c002-0072-313d-4ce19f000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeazsdktestaccount.table.core.windows.net/$metadata#Tables/@Element",
+        "TableName": "listtable09bf2a3d",
+        "connectionString":  null
+      }
+    },
+    {
+      "RequestUri": "https://fakeazsdktestaccount.table.core.windows.net/Tables",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "34",
+        "Content-Type": "application/json;odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "Date": "Tue, 18 May 2021 23:27:42 GMT",
+        "User-Agent": "azsdk-python-data-tables/12.0.0b7 Python/3.8.6 (Windows-10-10.0.19041-SP0)",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-date": "Tue, 18 May 2021 23:27:42 GMT",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "{\u0022TableName\u0022:    \u0022listtable09bf2a3d\u0022}",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Tue, 18 May 2021 23:27:43 GMT",
+        "Retry-After": "10",
+        "Location": "https://fakeazsdktestaccount.table.core.windows.net/Tables1(\u0027listtable09bf2a3d\u0027)",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-request-id": "d2270777-c002-0072-313d-4ce19f000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeazsdktestaccount.table.core.windows.net/$metadata#Tables/@Element",
+        "TableName": "listtable09bf2a3d",
+        "connectionString":  null
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/response_with_header_to_transform.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/response_with_header_to_transform.json
@@ -24,7 +24,7 @@
         "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
         "Date": "Tue, 18 May 2021 23:27:43 GMT",
         "Retry-After": "10",
-        "Location": "https://fakeazsdktestaccount.table.core.windows.net/Tables(\u0027listtable09bf2a3d\u0027)",
+        "Location": ["https://fakeazsdktestaccount.table.core.windows.net/Tables(\u0027listtable09bf2a3d\u0027)", "nomatch"],
         "Server": [
           "Windows-Azure-Table/1.0",
           "Microsoft-HTTPAPI/2.0"

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/response_with_retry_after.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/response_with_retry_after.json
@@ -40,6 +40,46 @@
         "TableName": "listtable09bf2a3d",
         "connectionString":  null
       }
+    },
+    {
+      "RequestUri": "https://fakeazsdktestaccount.table.core.windows.net/Tables/value",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "34",
+        "Content-Type": "application/json;odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "Date": "Tue, 18 May 2021 23:27:42 GMT",
+        "User-Agent": "azsdk-python-data-tables/12.0.0b7 Python/3.8.6 (Windows-10-10.0.19041-SP0)",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-date": "Tue, 18 May 2021 23:27:42 GMT",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "{\u0022TableName\u0022:    \u0022listtable09bf2a3d\u0022}",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Tue, 18 May 2021 23:27:43 GMT",
+        "Location": "https://fakeazsdktestaccount.table.core.windows.net/Tables(\u0027listtable09bf2a3d\u0027)",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-request-id": "d2270777-c002-0072-313d-4ce19f000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeazsdktestaccount.table.core.windows.net/$metadata#Tables/@Element",
+        "TableName": "listtable09bf2a3d",
+        "connectionString":  null
+      }
     }
   ],
   "Variables": {}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/response_with_xml_body.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/response_with_xml_body.json
@@ -30,7 +30,6 @@
         ],
         "Transfer-Encoding": "chunked",
         "X-Content-Type-Options": "nosniff",
-        "x-ms-client-request-id": "b24f75a9-b830-11eb-b949-10e7c6392c5a",
         "x-ms-request-id": "d2271628-c002-0072-5e3d-4ce19f000000",
         "x-ms-version": "2019-02-02"
       },
@@ -63,7 +62,6 @@
           "Microsoft-HTTPAPI/2.0"
         ],
         "Transfer-Encoding": "chunked",
-        "x-ms-client-request-id": "b25bf92a-b830-11eb-947a-10e7c6392c5a",
         "x-ms-request-id": "d2271635-c002-0072-6a3d-4ce19f000000",
         "x-ms-version": "2019-02-02"
       },

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TransformTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TransformTests.cs
@@ -19,14 +19,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             testRecordingHandler.Transforms.Add(clientIdTransform);
 
             var playbackContext = new DefaultHttpContext();
-            var transformedContent = "This should still show up.";
             var targetHeaderKey = "x-ms-client-request-id";
             var targetFile = "Test.RecordEntries/response_with_xml_body.json";
+
             var transformedEntry = TestHelpers.LoadRecordSession(targetFile).Session.Entries[0];
-            transformedEntry.Request.Headers[targetHeaderKey] = new string[] { transformedContent };
+            var clientId = transformedEntry.Request.Headers[targetHeaderKey][0];
             var untransformedEntry = TestHelpers.LoadRecordSession(targetFile).Session.Entries[1];
-            var originalRequestHeader = untransformedEntry.Request.Headers[targetHeaderKey][0].ToString();
-            untransformedEntry.Request.Headers[targetHeaderKey] = new string[] { "This shouldn't show up on response. The transform shouldn't apply." };
 
             // start playback
             playbackContext.Request.Headers["x-recording-file"] = targetFile;
@@ -44,14 +42,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             HttpRequest transformedRequest = TestHelpers.CreateRequestFromEntry(transformedEntry);
             HttpResponse transformedResponse = new DefaultHttpContext().Response;
             await testRecordingHandler.HandlePlaybackRequest(recordingId, transformedRequest, transformedResponse);
-            Assert.Contains(transformedContent, transformedResponse.Headers["x-ms-client-request-id"].ToString());
+            Assert.Contains(clientId, transformedResponse.Headers["x-ms-client-request-id"].ToString());
 
-            // this one should keep the x-ms-client-request-id that was in the recording, the transform should NOT apply
+            // this one should not add the x-ms-client-request-id to the response, the transform should NOT apply
             HttpRequest nonTransformedRequest = TestHelpers.CreateRequestFromEntry(untransformedEntry);
             HttpResponse nonTransformedresponse = new DefaultHttpContext().Response;
             await testRecordingHandler.HandlePlaybackRequest(recordingId, nonTransformedRequest, nonTransformedresponse);
 
-            Assert.Equal(originalRequestHeader, nonTransformedresponse.Headers["x-ms-client-request-id"].ToString());
+            Assert.False(nonTransformedresponse.Headers.ContainsKey(targetHeaderKey));
         }
 
         [Fact]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TransformTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TransformTests.cs
@@ -55,7 +55,16 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [Fact]
         public async Task CanApplyHeaderTransform()
         {
-            var headerTransform = new HeaderTransform("Location", "http://localhost", valueRegex: @".*/Tables\(.*");
+            var headerTransform = new HeaderTransform(
+                "Location",
+                "http://localhost",
+                condition: new ApplyCondition
+                {
+                    ResponseHeaderCondition = new HeaderCondition
+                    {
+                        Key = "Location", ValueRegex = @".*/Tables\(.*"
+                    }
+                });
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             testRecordingHandler.Transforms.Clear();
             testRecordingHandler.Transforms.Add(headerTransform);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TransformTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TransformTests.cs
@@ -60,9 +60,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 "http://localhost",
                 condition: new ApplyCondition
                 {
-                    ResponseHeaderCondition = new HeaderCondition
+                    ResponseHeader = new HeaderCondition
                     {
-                        Key = "Location", ValueRegex = @".*/Tables\(.*"
+                        Key = "Location",
+                        ValueRegex = @".*/Tables\(.*"
                     }
                 });
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
@@ -24,7 +24,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
         private string _uriRegex;
 
-        public HeaderCondition ResponseHeaderCondition { get; set; }
+        public HeaderCondition ResponseHeader { get; set; }
 
         private JsonProperty GetProp(string name, JsonElement jsonElement)
         {
@@ -47,7 +47,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             try
             {
                 // URI condition
-                var uriProp = GetProp("UriRegex", jsonElement);
+                var uriProp = GetProp(nameof(UriRegex), jsonElement);
 
                 if(uriProp.Value.ValueKind != JsonValueKind.Undefined)
                 {
@@ -56,11 +56,11 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 }
 
                 // Response header condition
-                var headerProp = GetProp("ResponseHeaderCondition", jsonElement);
+                var headerProp = GetProp(nameof(ResponseHeader), jsonElement);
                 if(headerProp.Value.ValueKind != JsonValueKind.Undefined)
                 {
-                    ResponseHeaderCondition = JsonSerializer.Deserialize<HeaderCondition>(headerProp.Value, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                    if (ResponseHeaderCondition.Key == null)
+                    ResponseHeader = JsonSerializer.Deserialize<HeaderCondition>(headerProp.Value, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    if (ResponseHeader.Key == null)
                     {
                         throw new ArgumentException("Key is required for response header conditions.");
                     }
@@ -97,19 +97,19 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 }
             }
 
-            if (ResponseHeaderCondition != null)
+            if (ResponseHeader != null)
             {
-                if (!entry.Response.Headers.ContainsKey(ResponseHeaderCondition.Key))
+                if (!entry.Response.Headers.ContainsKey(ResponseHeader.Key))
                 {
                     return false;
                 }
 
-                if (ResponseHeaderCondition.ValueRegex != null)
+                if (ResponseHeader.ValueRegex != null)
                 {
-                    foreach (string header in entry.Response.Headers[ResponseHeaderCondition.Key])
+                    foreach (string header in entry.Response.Headers[ResponseHeader.Key])
                     {
                         // if at least one header value matches, then the condition passes
-                        if (Regex.IsMatch(header, ResponseHeaderCondition.ValueRegex))
+                        if (Regex.IsMatch(header, ResponseHeader.ValueRegex))
                         {
                             return true;
                         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
@@ -89,8 +89,13 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 }
             }
 
-            if (ResponseHeaderCondition != null && entry.Response.Headers.ContainsKey(ResponseHeaderCondition.Key))
+            if (ResponseHeaderCondition != null)
             {
+                if (!entry.Response.Headers.ContainsKey(ResponseHeaderCondition.Key))
+                {
+                    return false;
+                }
+
                 if (ResponseHeaderCondition.ValueRegex != null)
                 {
                     if (!Regex.IsMatch(entry.Response.Headers[ResponseHeaderCondition.Key].First(), ResponseHeaderCondition.ValueRegex))

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
@@ -98,10 +98,16 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
                 if (ResponseHeaderCondition.ValueRegex != null)
                 {
-                    if (!Regex.IsMatch(entry.Response.Headers[ResponseHeaderCondition.Key].First(), ResponseHeaderCondition.ValueRegex))
+                    foreach (string header in entry.Response.Headers[ResponseHeaderCondition.Key])
                     {
-                        return false;
+                        // if at least one header value matches, then the condition passes
+                        if (Regex.IsMatch(header, ResponseHeaderCondition.ValueRegex))
+                        {
+                            return true;
+                        }
                     }
+
+                    return false;
                 }
             }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
@@ -12,7 +12,17 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 {
     public class ApplyCondition
     {
-        public string UriRegex { get; set; }
+        public string UriRegex
+        {
+            get => _uriRegex;
+            set
+            {
+                StringSanitizer.ConfirmValidRegex(value);
+                _uriRegex = value;
+            }
+        }
+
+        private string _uriRegex;
 
         public HeaderCondition ResponseHeaderCondition { get; set; }
 
@@ -42,7 +52,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 if(uriProp.Value.ValueKind != JsonValueKind.Undefined)
                 {
                     UriRegex = uriProp.Value.GetString();
-                    StringSanitizer.ConfirmValidRegex(UriRegex);
                     conditionDefined = true;
                 }
 
@@ -51,7 +60,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 if(headerProp.Value.ValueKind != JsonValueKind.Undefined)
                 {
                     ResponseHeaderCondition = JsonSerializer.Deserialize<HeaderCondition>(headerProp.Value, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                    StringSanitizer.ConfirmValidRegex(ResponseHeaderCondition.ValueRegex);
                     if (ResponseHeaderCondition.Key == null)
                     {
                         throw new ArgumentException("Key is required for response header conditions.");

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
@@ -60,7 +60,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 if(headerProp.Value.ValueKind != JsonValueKind.Undefined)
                 {
                     ResponseHeader = JsonSerializer.Deserialize<HeaderCondition>(headerProp.Value, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-                    if (ResponseHeader.Key == null)
+                    if (string.IsNullOrWhiteSpace(ResponseHeader.Key))
                     {
                         throw new ArgumentException("Key is required for response header conditions.");
                     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HeaderCondition.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HeaderCondition.cs
@@ -1,9 +1,20 @@
 ﻿namespace Azure.Sdk.Tools.TestProxy.Common
 {
+    /// <summary>
+    /// A condition that can be used to apply an action based on the presence of a header.
+    /// </summary>
     public class HeaderCondition
     {
+        /// <summary>
+        /// The header key that must be present for the condition to pass.
+        /// </summary>
         public string Key { get; set; }
 
+        /// <summary>
+        /// An optional regex that can be applied to the value of the header.
+        /// If the header contains multiple values, at least one of the value must match
+        /// the regex for the condition to pass.
+        /// </summary>
         public string ValueRegex
         {
             get => _valueRegex;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HeaderCondition.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HeaderCondition.cs
@@ -4,6 +4,16 @@
     {
         public string Key { get; set; }
 
-        public string ValueRegex { get; set; }
+        public string ValueRegex
+        {
+            get => _valueRegex;
+            set
+            {
+                StringSanitizer.ConfirmValidRegex(value);
+                _valueRegex = value;
+            }
+        }
+
+        private string _valueRegex;
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HeaderCondition.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HeaderCondition.cs
@@ -1,0 +1,9 @@
+﻿namespace Azure.Sdk.Tools.TestProxy.Common
+{
+    public class HeaderCondition
+    {
+        public string Key { get; set; }
+
+        public string ValueRegex { get; set; }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ResponseTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ResponseTransform.cs
@@ -22,8 +22,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// Base class used to describe transforming a played back response with necessary 
         /// changes directly from a request.
         /// </summary>
-        /// <param name="request"></param>
-        /// <param name="response"></param>
+        /// <param name="entry">The entry to transform.</param>
         public abstract void ApplyTransform(RecordEntry entry);
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ResponseTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ResponseTransform.cs
@@ -10,11 +10,11 @@ namespace Azure.Sdk.Tools.TestProxy.Common
     {
         public ApplyCondition Condition = null;
 
-        public void Transform(HttpRequest request, HttpResponse response)
+        public void Transform(RecordEntry entry)
         {
-            if (Condition == null || Condition.IsApplicable(request))
+            if (Condition == null || Condition.IsApplicable(entry))
             {
-                ApplyTransform(request, response);
+                ApplyTransform(entry);
             }
         }
 
@@ -24,6 +24,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// </summary>
         /// <param name="request"></param>
         /// <param name="response"></param>
-        public abstract void ApplyTransform(HttpRequest request, HttpResponse response);
+        public abstract void ApplyTransform(RecordEntry entry);
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -462,7 +462,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 {
                     new StorageRequestIdTransform(),
                     new ClientIdTransform(),
-                    new HeaderTransform("retry-after", "0")
+                    new HeaderTransform("Retry-After", "0")
                 };
 
                 Matcher = new RecordMatcher();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -463,6 +463,15 @@ namespace Azure.Sdk.Tools.TestProxy
                     new StorageRequestIdTransform(),
                     new ClientIdTransform(),
                     new HeaderTransform("Retry-After", "0")
+                    {
+                        Condition = new ApplyCondition
+                        {
+                            ResponseHeader = new HeaderCondition
+                            {
+                                Key = "Retry-After"
+                            }
+                        }
+                    }
                 };
 
                 Matcher = new RecordMatcher();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -349,15 +349,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             foreach (var header in match.Response.Headers)
             {
-                if (header.Key == "Retry-After")
-                {
-                    // in Playback, we change Retry-After header to 0 to prevent unnecessary waiting
-                    outgoingResponse.Headers.Add(header.Key, "0");
-                }
-                else
-                {
-                    outgoingResponse.Headers.Add(header.Key, header.Value.ToArray());
-                }
+                outgoingResponse.Headers.Add(header.Key, header.Value.ToArray());
             }
 
             foreach (ResponseTransform transform in session.AdditionalTransforms.Count > 0 ? Transforms.Concat(session.AdditionalTransforms) : Transforms)
@@ -469,7 +461,8 @@ namespace Azure.Sdk.Tools.TestProxy
                 Transforms = new List<ResponseTransform>
                 {
                     new StorageRequestIdTransform(),
-                    new ClientIdTransform()
+                    new ClientIdTransform(),
+                    new HeaderTransform("retry-after", "0")
                 };
 
                 Matcher = new RecordMatcher();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -343,7 +343,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             var match = session.Session.Lookup(entry, session.CustomMatcher ?? Matcher, session.AdditionalSanitizers.Count > 0 ? Sanitizers.Concat(session.AdditionalSanitizers) : Sanitizers, remove);
 
-            foreach (ResponseTransform transform in session.AdditionalTransforms.Count > 0 ? Transforms.Concat(session.AdditionalTransforms) : Transforms)
+            foreach (ResponseTransform transform in Transforms.Concat(session.AdditionalTransforms))
             {
                 transform.Transform(match);
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -343,6 +343,11 @@ namespace Azure.Sdk.Tools.TestProxy
 
             var match = session.Session.Lookup(entry, session.CustomMatcher ?? Matcher, session.AdditionalSanitizers.Count > 0 ? Sanitizers.Concat(session.AdditionalSanitizers) : Sanitizers, remove);
 
+            foreach (ResponseTransform transform in session.AdditionalTransforms.Count > 0 ? Transforms.Concat(session.AdditionalTransforms) : Transforms)
+            {
+                transform.Transform(match);
+            }
+
             Interlocked.Increment(ref Startup.RequestsPlayedBack);
 
             outgoingResponse.StatusCode = match.StatusCode;
@@ -350,11 +355,6 @@ namespace Azure.Sdk.Tools.TestProxy
             foreach (var header in match.Response.Headers)
             {
                 outgoingResponse.Headers.Add(header.Key, header.Value.ToArray());
-            }
-
-            foreach (ResponseTransform transform in session.AdditionalTransforms.Count > 0 ? Transforms.Concat(session.AdditionalTransforms) : Transforms)
-            {
-                transform.Transform(incomingRequest, outgoingResponse);
             }
 
             outgoingResponse.Headers.Remove("Transfer-Encoding");

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/ApiVersionTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/ApiVersionTransform.cs
@@ -20,11 +20,11 @@ namespace Azure.Sdk.Tools.TestProxy.Transforms
         /// </summary>
         /// <param name="request"></param>
         /// <param name="response"></param>
-        public override void ApplyTransform(HttpRequest request, HttpResponse response)
+        public override void ApplyTransform(RecordEntry entry)
         {
-            if (request.Headers.TryGetValue("api-version", out var clientId))
+            if (entry.Request.Headers.TryGetValue("api-version", out var clientId))
             {
-                response.Headers.Add("api-version", clientId);
+                entry.Response.Headers.Add("api-version", clientId);
             }
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/ApiVersionTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/ApiVersionTransform.cs
@@ -18,8 +18,7 @@ namespace Azure.Sdk.Tools.TestProxy.Transforms
         /// This transform applies during playback mode. It copies the header "api-version" of the request
         /// onto the response before sending the response back to the client.
         /// </summary>
-        /// <param name="request"></param>
-        /// <param name="response"></param>
+        /// <param name="entry">The entry to transform.</param>
         public override void ApplyTransform(RecordEntry entry)
         {
             if (entry.Request.Headers.TryGetValue("api-version", out var clientId))

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/ClientIdTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/ClientIdTransform.cs
@@ -18,11 +18,11 @@ namespace Azure.Sdk.Tools.TestProxy.Transforms
             Condition = condition;
         }
 
-        public override void ApplyTransform(HttpRequest request, HttpResponse response)
+        public override void ApplyTransform(RecordEntry entry)
         {
-            if (request.Headers.TryGetValue("x-ms-client-id", out var clientId))
+            if (entry.Request.Headers.TryGetValue("x-ms-client-id", out var clientId))
             {
-                response.Headers.Add("x-ms-client-id", clientId);
+                entry.Request.Headers.Add("x-ms-client-id", clientId);
             }
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/ClientIdTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/ClientIdTransform.cs
@@ -22,7 +22,7 @@ namespace Azure.Sdk.Tools.TestProxy.Transforms
         {
             if (entry.Request.Headers.TryGetValue("x-ms-client-id", out var clientId))
             {
-                entry.Request.Headers.Add("x-ms-client-id", clientId);
+                entry.Response.Headers.Add("x-ms-client-id", clientId);
             }
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
@@ -1,41 +1,36 @@
-﻿using System.Linq;
-using System.Text.RegularExpressions;
-using Azure.Sdk.Tools.TestProxy.Common;
-using Microsoft.AspNetCore.Http;
+﻿using Azure.Sdk.Tools.TestProxy.Common;
 
 namespace Azure.Sdk.Tools.TestProxy.Transforms
 {
     /// <summary>
-    /// Transforms an existing header value in a response header.
+    /// Sets a header in a response.
     /// </summary>
     public class HeaderTransform : ResponseTransform
     {
         private readonly string _key;
-        private readonly string _replacement;
+        private readonly string _value;
 
         /// <summary>
-        /// Constructs a new HeaderTransform instance.
+        /// Constructs a new HeaderTransform instance. If the header should only be overwritten if already
+        /// present in the response, use a Condition populated with a ResponseHeader.
         /// </summary>
-        /// <param name="key">The header key for the header to transform.</param>
-        /// <param name="replacement">The replacement value for the header.</param>
+        /// <param name="key">The header key for the header.</param>
+        /// <param name="value">The value for the header.</param>
         /// <param name="condition">
         /// A condition that dictates when this transform applies to a request/response pair. The content of this key should be a JSON object that contains configuration keys.
         /// Currently, that only includes the key "uriRegex". This translates to an object that looks like '{ "uriRegex": "when this regex matches, apply the sanitizer" }'.
         /// Defaults to "apply always."
         /// </param>
-        public HeaderTransform(string key, string replacement, ApplyCondition condition = null)
+        public HeaderTransform(string key, string value, ApplyCondition condition = null)
         {
             _key = key;
-            _replacement = replacement;
+            _value = value;
             Condition = condition;
         }
 
         public override void ApplyTransform(RecordEntry entry)
         {
-            if (entry.Response.Headers.ContainsKey(_key))
-            {
-                entry.Response.Headers[_key] = new string[] { _replacement };
-            }
+            entry.Response.Headers[_key] = new string[] { _value };
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
@@ -3,7 +3,8 @@
 namespace Azure.Sdk.Tools.TestProxy.Transforms
 {
     /// <summary>
-    /// Sets a header in a response.
+    /// Sets a header in a response. If the header should only be set if the key is already
+    /// present in the response, use a Condition populated with a ResponseHeader.
     /// </summary>
     public class HeaderTransform : ResponseTransform
     {
@@ -11,8 +12,7 @@ namespace Azure.Sdk.Tools.TestProxy.Transforms
         private readonly string _value;
 
         /// <summary>
-        /// Constructs a new HeaderTransform instance. If the header should only be overwritten if already
-        /// present in the response, use a Condition populated with a ResponseHeader.
+        /// Constructs a new HeaderTransform instance.
         /// </summary>
         /// <param name="key">The header key for the header.</param>
         /// <param name="value">The value for the header.</param>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
@@ -3,8 +3,7 @@
 namespace Azure.Sdk.Tools.TestProxy.Transforms
 {
     /// <summary>
-    /// Sets a header in a response. If the header should only be set if the key is already
-    /// present in the response, use a Condition populated with a ResponseHeader.
+    /// Sets a header in a response.
     /// </summary>
     public class HeaderTransform : ResponseTransform
     {
@@ -21,6 +20,12 @@ namespace Azure.Sdk.Tools.TestProxy.Transforms
         /// Currently, that only includes the key "uriRegex". This translates to an object that looks like '{ "uriRegex": "when this regex matches, apply the sanitizer" }'.
         /// Defaults to "apply always."
         /// </param>
+        /// <remarks>
+        /// By default, the header will be set in the response whether or not the header key is already
+        /// present.
+        /// If the header should only be set if the header key is already present in the response,
+        /// include a Condition populated with a ResponseHeader in the HeaderTransform JSON.
+        /// </remarks>
         public HeaderTransform(string key, string value, ApplyCondition condition = null)
         {
             _key = key;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
@@ -1,0 +1,38 @@
+﻿using System.Text.RegularExpressions;
+using Azure.Sdk.Tools.TestProxy.Common;
+using Microsoft.AspNetCore.Http;
+
+namespace Azure.Sdk.Tools.TestProxy.Transforms
+{
+    public class HeaderTransform : ResponseTransform
+    {
+        private readonly string _key;
+        private readonly string _replacement;
+        private readonly string _valueRegex;
+
+        public HeaderTransform(string key, string replacement, string valueRegex = null, ApplyCondition condition = null)
+        {
+            _key = key;
+            _replacement = replacement;
+            _valueRegex = valueRegex;
+            Condition = condition;
+        }
+
+        public override void ApplyTransform(HttpRequest request, HttpResponse response)
+        {
+            if (response.Headers.ContainsKey(_key))
+            {
+                if (_valueRegex != null)
+                {
+                    var regex = new Regex(_valueRegex);
+                    if (!regex.Match(response.Headers[_key]).Success)
+                    {
+                        return;
+                    }
+                }
+
+                response.Headers[_key] = _replacement;
+            }
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
@@ -4,12 +4,27 @@ using Microsoft.AspNetCore.Http;
 
 namespace Azure.Sdk.Tools.TestProxy.Transforms
 {
+    /// <summary>
+    /// Transforms an existing header value in a response header.
+    /// </summary>
     public class HeaderTransform : ResponseTransform
     {
         private readonly string _key;
         private readonly string _replacement;
         private readonly string _valueRegex;
 
+        /// <summary>
+        /// Constructs a new HeaderTransform instance.
+        /// </summary>
+        /// <param name="key">The header key for the header to transform.</param>
+        /// <param name="replacement">The replacement value for the header.</param>
+        /// <param name="valueRegex">An optional regex. If specified, the value for the header will be replaced only if
+        /// the regex matches the existing value.</param>
+        /// <param name="condition">
+        /// A condition that dictates when this transform applies to a request/response pair. The content of this key should be a JSON object that contains configuration keys.
+        /// Currently, that only includes the key "uriRegex". This translates to an object that looks like '{ "uriRegex": "when this regex matches, apply the sanitizer" }'.
+        /// Defaults to "apply always."
+        /// </param>
         public HeaderTransform(string key, string replacement, string valueRegex = null, ApplyCondition condition = null)
         {
             _key = key;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
@@ -12,26 +12,21 @@ namespace Azure.Sdk.Tools.TestProxy.Transforms
     {
         private readonly string _key;
         private readonly string _replacement;
-        private readonly string _valueRegex;
 
         /// <summary>
         /// Constructs a new HeaderTransform instance.
         /// </summary>
         /// <param name="key">The header key for the header to transform.</param>
         /// <param name="replacement">The replacement value for the header.</param>
-        /// <param name="valueRegex">An optional regex. If specified, the value for the header will be replaced only if
-        /// the regex matches the existing value.</param>
         /// <param name="condition">
         /// A condition that dictates when this transform applies to a request/response pair. The content of this key should be a JSON object that contains configuration keys.
         /// Currently, that only includes the key "uriRegex". This translates to an object that looks like '{ "uriRegex": "when this regex matches, apply the sanitizer" }'.
         /// Defaults to "apply always."
         /// </param>
-        public HeaderTransform(string key, string replacement, string valueRegex = null, ApplyCondition condition = null)
+        public HeaderTransform(string key, string replacement, ApplyCondition condition = null)
         {
             _key = key;
             _replacement = replacement;
-            // consider moving this into ApplyCondition if we have another use case where we need to filter based on a header key
-            _valueRegex = valueRegex;
             Condition = condition;
         }
 
@@ -39,15 +34,6 @@ namespace Azure.Sdk.Tools.TestProxy.Transforms
         {
             if (entry.Response.Headers.ContainsKey(_key))
             {
-                if (_valueRegex != null)
-                {
-                    var regex = new Regex(_valueRegex);
-                    if (!regex.Match(entry.Response.Headers[_key].First()).Success)
-                    {
-                        return;
-                    }
-                }
-
                 entry.Response.Headers[_key] = new string[] { _replacement };
             }
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/HeaderTransform.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Linq;
+using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.TestProxy.Common;
 using Microsoft.AspNetCore.Http;
 
@@ -29,24 +30,25 @@ namespace Azure.Sdk.Tools.TestProxy.Transforms
         {
             _key = key;
             _replacement = replacement;
+            // consider moving this into ApplyCondition if we have another use case where we need to filter based on a header key
             _valueRegex = valueRegex;
             Condition = condition;
         }
 
-        public override void ApplyTransform(HttpRequest request, HttpResponse response)
+        public override void ApplyTransform(RecordEntry entry)
         {
-            if (response.Headers.ContainsKey(_key))
+            if (entry.Response.Headers.ContainsKey(_key))
             {
                 if (_valueRegex != null)
                 {
                     var regex = new Regex(_valueRegex);
-                    if (!regex.Match(response.Headers[_key]).Success)
+                    if (!regex.Match(entry.Response.Headers[_key].First()).Success)
                     {
                         return;
                     }
                 }
 
-                response.Headers[_key] = _replacement;
+                entry.Response.Headers[_key] = new string[] { _replacement };
             }
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/StorageRequestIdTransform.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Transforms/StorageRequestIdTransform.cs
@@ -15,12 +15,12 @@ namespace Azure.Sdk.Tools.TestProxy.Transforms
             Condition = condition;
         }
 
-        public override void ApplyTransform(HttpRequest request, HttpResponse response)
+        public override void ApplyTransform(RecordEntry entry)
         {
             // Storage Blobs requires "x-ms-client-request-id" header in request and response to match
-            if (request.Headers.TryGetValue("x-ms-client-request-id", out var clientRequestId))
+            if (entry.Request.Headers.TryGetValue("x-ms-client-request-id", out var clientRequestId))
             {
-                response.Headers["x-ms-client-request-id"] = clientRequestId;
+                entry.Response.Headers["x-ms-client-request-id"] = clientRequestId;
             }
         }
     }


### PR DESCRIPTION
Addresses https://github.com/Azure/azure-sdk-tools/issues/2482

Also, reworks Transforms to be applied on RecordEntry rather than HttpRequest/Response. This helps avoid duplicating the condition logic for sanitizers and transforms.