### PR TITLE
[Do not review] Implement the identity converter.

### DIFF
--- a/tools/identity-resolution/ci.yml
+++ b/tools/identity-resolution/ci.yml
@@ -43,8 +43,7 @@ extends:
           exit 1
         }
       displayName: Test on converting github to ms alias 
-      workingDirectory: tools/identity-resolution/identity-converter/  
-      continueOnError: true                                                                               
+      workingDirectory: tools/identity-resolution/identity-converter/                                                                         
     - pwsh: |
         $github = dotnet run `
           --aad-app-id-var $(notification-aad-app-id) `

--- a/tools/identity-resolution/ci.yml
+++ b/tools/identity-resolution/ci.yml
@@ -42,7 +42,7 @@ extends:
           Write-Host "Expect to get sizhu, but returned $msAlias"
           exit 1
         }
-      displayName: Test on converting github to ms alias command line   
+      displayName: Test on converting github to ms alias 
       workingDirectory: tools/identity-resolution/identity-converter/  
       continueOnError: true                                                                               
     - pwsh: |
@@ -59,5 +59,5 @@ extends:
           Write-Host "Expect to get sima-zhu, but returned $github"
           exit 1
         }
-      displayName: Test on converting ms alias to github command line     
+      displayName: Test on converting ms alias to github     
       workingDirectory: tools/identity-resolution/identity-converter/ 

--- a/tools/identity-resolution/ci.yml
+++ b/tools/identity-resolution/ci.yml
@@ -26,3 +26,38 @@ extends:
   parameters:
     ToolDirectory: tools/identity-resolution
     DotNetCoreVersion: 5.0.301
+    TestPostSteps:
+    - pwsh: |
+        $msAlias = dotnet run `
+          --aad-app-id-var $(notification-aad-app-id) `
+          --aad-app-secret-var $(notification-aad-secret) `
+          --aad-tenant-var $(notification-aad-tenant) `
+          --kusto-url-var $(notification-kusto-url) `
+          --kusto-database-var $(notification-kusto-db) `
+          --kusto-table-var $(notification-kusto-table) `
+          --input-format 'github' `
+          --input-value 'sima-zhu'
+        
+        if ($msAlias -ne "sizhu") {
+          Write-Host "Expect to get sizhu, but returned $msAlias"
+          exit 1
+        }
+      displayName: Test on converting github to ms alias command line   
+      workingDirectory: tools/identity-resolution/identity-converter/  
+      continueOnError: true                                                                               
+    - pwsh: |
+        $github = dotnet run `
+          --aad-app-id-var $(notification-aad-app-id) `
+          --aad-app-secret-var $(notification-aad-secret) `
+          --aad-tenant-var $(notification-aad-tenant) `
+          --kusto-url-var $(notification-kusto-url) `
+          --kusto-database-var $(notification-kusto-db) `
+          --kusto-table-var $(notification-kusto-table) `
+          --input-format 'msAlias' `
+          --input-value 'sizhu'
+        if ($github -ne "sima-zhu") {
+          Write-Host "Expect to get sima-zhu, but returned $github"
+          exit 1
+        }
+      displayName: Test on converting ms alias to github command line     
+      workingDirectory: tools/identity-resolution/identity-converter/ 

--- a/tools/identity-resolution/identity-converter/Azure.Sdk.Tools.IdentityConverter.csproj
+++ b/tools/identity-resolution/identity-converter/Azure.Sdk.Tools.IdentityConverter.csproj
@@ -10,8 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19317.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="CommandLine.Net" Version="2.3.0" />

--- a/tools/identity-resolution/identity-converter/Azure.Sdk.Tools.IdentityConverter.csproj
+++ b/tools/identity-resolution/identity-converter/Azure.Sdk.Tools.IdentityConverter.csproj
@@ -10,6 +10,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Moq" Version="4.16.1" />
+    <PackageReference Include="NUnit" Version="3.13.2" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19317.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="CommandLine.Net" Version="2.3.0" />

--- a/tools/identity-resolution/identity-converter/Program.cs
+++ b/tools/identity-resolution/identity-converter/Program.cs
@@ -1,18 +1,15 @@
 using Microsoft.Extensions.Logging;
-using Newtonsoft.Json;
 using Azure.Sdk.Tools.NotificationConfiguration.Helpers;
 using Azure.Sdk.Tools.NotificationConfiguration.Models;
 using System;
 using System.Threading.Tasks;
-using OutputColorizer;
 
 namespace Azure.Sdk.Tools.IdentityConverter
 {
     class Program
     {
-
         /// <summary>
-        /// Retrieves github-to-ms mapping information given the full name of an employee.
+        /// Github identity and ms alias conversion.
         /// </summary>
         /// <param name="aadAppIdVar">AAD App ID environment variable name (Kusto access)</param>
         /// <param name="aadAppSecretVar">AAD App Secret environment variable name (Kusto access)</param>
@@ -20,77 +17,72 @@ namespace Azure.Sdk.Tools.IdentityConverter
         /// <param name="kustoUrlVar">Kusto URL environment variable name</param>
         /// <param name="kustoDatabaseVar">Kusto DB environment variable name</param>
         /// <param name="kustoTableVar">Kusto Table environment variable name</param>
-        /// <param name="identityName">The full name of the employee</param>
-        /// <param name="identityEmail">The email of the employee like alias@microsoft.com</param>
-        /// <param name="targetvar">The name of DevOps output variable</param>
-        /// <returns></returns>
-        public static async Task Main(
+        /// <param name="inputFormat">The identity format to convert from. The value is case insensitive. Options: fullName, msAlias, github, addId, aadUpn</param>
+        /// <param name="inputValue">The input value to convert from. </param>
+        /// <returns>Exit code</returns>
+        public static async Task<int> Main(
             string aadAppIdVar,
             string aadAppSecretVar,
             string aadTenantVar,
             string kustoUrlVar,
             string kustoDatabaseVar,
             string kustoTableVar,
-            string identityName,
-            string identityEmail,
-            string targetvar
+            string inputFormat,
+            string inputValue
             )
         {
-
-#pragma warning disable CS0618 // Type or member is obsolete
+            
+            if (inputFormat == null || inputValue == null)
+            {
+                Console.Error.WriteLine("You must specify [Yellow!inputFormat] and [Yellow!inputValue].");
+                return 1;
+            }
+            #pragma warning disable CS0618 // Type or member is obsolete
             using (var loggerFactory = LoggerFactory.Create(builder => {
                 builder.AddConsole(config => { config.IncludeScopes = true; });
             }))
-#pragma warning restore CS0618 // Type or member is obsolete
+            try
             {
-                try
-                {
-                    var githubNameResolver = new GitHubNameResolver(
-                        Environment.GetEnvironmentVariable(aadAppIdVar),
-                        Environment.GetEnvironmentVariable(aadAppSecretVar),
-                        Environment.GetEnvironmentVariable(aadTenantVar),
-                        Environment.GetEnvironmentVariable(kustoUrlVar),
-                        Environment.GetEnvironmentVariable(kustoDatabaseVar),
-                        Environment.GetEnvironmentVariable(kustoTableVar),
+                
+                #pragma warning restore CS0618 // Type or member is obsolete
+                var githubNameResolver = new GitHubNameResolver(
+                        aadAppIdVar,
+                        aadAppSecretVar,
+                        aadTenantVar,
+                        kustoUrlVar,
+                        kustoDatabaseVar,
+                        kustoTableVar,
                         loggerFactory.CreateLogger<GitHubNameResolver>()
                     );
+                var result = default(IdentityDetail);
 
-                    if (identityName == null && identityEmail == null)
-                    {
-                        Colorizer.WriteLine("You must specify either [Yellow!identityName] or [Yellow!identityEmail].");
-                        return;
-                    }
-
-                    var result = default(IdentityDetail);
-
-                    if (identityName != null)
-                    {
-                        result = await githubNameResolver.GetMappingInformationFromAADName(identityName);
-                    }
-
-                    if (result == default(IdentityDetail) && identityEmail != null)
-                    {
-                        result = await githubNameResolver.GetMappingInformationFromAADUpn(identityEmail);
-                    }
-
-                    if (!String.IsNullOrEmpty(targetvar))
-                    {
-                        Console.WriteLine(String.Format("##vso[task.setvariable variable={0};]{1}", targetvar, result.GithubUserName));
-                    }
-                    if (result != default(IdentityDetail))
-                    {
-                        Colorizer.WriteLine("[Green!User resolved successfully.]");
-                        Console.WriteLine(JsonConvert.SerializeObject(result));
-                    }
-                }
-                catch (Exception)
+                if (String.Equals(inputFormat, "github", StringComparison.OrdinalIgnoreCase))
                 {
-                    if (!String.IsNullOrEmpty(targetvar))
+                    result = await githubNameResolver.GetMappingInformationFromGithubUserName(inputValue);
+                    if (result != null && result != default(IdentityDetail))
                     {
-                        Console.WriteLine(String.Format("##vso[task.setvariable variable={0};]{1}", targetvar, ""));
+                        Console.WriteLine(result.Alias);
+                        return 0;
                     }
-                    Colorizer.WriteLine("Ensure that a valid [Yellow!identityName] or [Yellow!identityEmail] has been specified.");
                 }
+
+                if (String.Equals(inputFormat, "msAlias", StringComparison.OrdinalIgnoreCase))
+                {
+                    result = await githubNameResolver.GetMappingInformationFromAlias(inputValue);
+                    if (result != null && result != default(IdentityDetail))
+                    {
+                        Console.WriteLine(result.GithubUserName);
+                        return 0;
+                    }
+                }
+
+                Console.Error.WriteLine("Did not retrieve any infomation for input ${inputFormat} and ${inputValue}. Acceptable input format is {'github', 'msAlias'}. ");
+                return 1;
+            }
+            catch (Exception)
+            {
+                Console.Error.WriteLine("Failed to connect with kusto table. Please check your inputs.");
+                return 1;
             }
         }
     }

--- a/tools/identity-resolution/identity-resolution/Helpers/GitHubNameResolver.cs
+++ b/tools/identity-resolution/identity-resolution/Helpers/GitHubNameResolver.cs
@@ -155,6 +155,63 @@ namespace Azure.Sdk.Tools.NotificationConfiguration.Helpers
                 return default;
             }
         }
+
+        /// <summary>
+        /// Queries Kusto for mapping information present in a target table. Assumes githubemployeelink. 
+        /// </summary>
+        /// <param name="alias">Employee email alias, e.g. 'username' in username@microsoft.com. </param>
+        /// <returns>Internal alias or null if no internal user found</returns>
+        public async Task<IdentityDetail> GetMappingInformationFromAlias(string alias)
+        {
+            var query = $"{kustoTable} | where aadAlias == '{alias}' | project githubUserName, aadId, aadName, aadAlias, aadUpn | limit 1;";
+
+            // TODO: Figure out how to make this async
+            using (var reader = client.ExecuteQuery(query))
+            {
+                if (reader.Read())
+                {
+                    return new IdentityDetail(){
+                        GithubUserName = reader.GetString(0),
+                        AadId = reader.GetString(1),
+                        Name = reader.GetString(2),
+                        Alias = reader.GetString(3),
+                        AadUpn = reader.GetString(4)
+                    };
+                }
+
+                logger.LogWarning("Could Not Resolve Identity of User = {0}", alias);
+                return default;
+            }
+        }
+
+        /// <summary>
+        /// Queries Kusto for mapping information present in a target table. Assumes githubemployeelink. 
+        /// </summary>
+        /// <param name="githubUserName">Employee github identity like sima-zhu.</param>
+        /// <returns>Internal alias or null if no internal user found</returns>
+        public async Task<IdentityDetail> GetMappingInformationFromGithubUserName(string githubUserName)
+        {
+            var query = $"{kustoTable} | where githubUserName == '{githubUserName}' | project githubUserName, aadId, aadName, aadAlias, aadUpn | limit 1;";
+
+            // TODO: Figure out how to make this async
+            using (var reader = client.ExecuteQuery(query))
+            {
+                if (reader.Read())
+                {
+                    return new IdentityDetail(){
+                        GithubUserName = reader.GetString(0),
+                        AadId = reader.GetString(1),
+                        Name = reader.GetString(2),
+                        Alias = reader.GetString(3),
+                        AadUpn = reader.GetString(4)
+                    };
+                }
+
+                logger.LogWarning("Could Not Resolve Identity of User = {0}", githubUserName);
+                return default;
+            }
+        }
+
 #pragma warning restore 1998
 
         /// <summary>


### PR DESCRIPTION
The PR is to use command line tool to do conversion between different user identities.
For example, provide github identity and return ms alias.

Tested the command locally. 

It is hard to test on local var. We have to mock the behavior of `githubNameResolver.GetInfofromGithubUserName`. However, it is hard to achieve from Program main class.

Testing the command line only. 