### PR TITLE
Add Root Directory and Glob for Injecting Snippets into READMEs

### DIFF
--- a/packages/java-packages/codesnippet-maven-plugin/pom.xml
+++ b/packages/java-packages/codesnippet-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.azure.tools</groupId>
   <artifactId>codesnippet-maven-plugin</artifactId>
-  <version>1.0.0-beta.3</version>
+  <version>1.0.0-beta.4</version>
   <packaging>maven-plugin</packaging>
 
   <name>Codesnippet Maven Plugin</name>

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/SnippetBaseMojo.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/SnippetBaseMojo.java
@@ -32,6 +32,11 @@ public abstract class SnippetBaseMojo extends AbstractMojo {
     public static final String DEFAULT_SOURCE_GLOB = "**/src/main/java/**/*.java";
 
     /**
+    * Default glob to match README files.
+    */
+    public static final String DEFAULT_README_GLOB = "**/README.md";
+
+    /**
      * Glob for the files that contain codesnippet definitions.
      * <p>
      * Default value is {@link #DEFAULT_CODESNIPPET_GLOB}.
@@ -73,12 +78,20 @@ public abstract class SnippetBaseMojo extends AbstractMojo {
     private boolean includeSource;
 
     /**
-     * Path of the README file.
-     * <p>
-     * Default value is {@code ${project.basedir}/README.md}.
-     */
-    @Parameter(property = PROPERTY_PREFIX + "readmePath", defaultValue = "${project.basedir}/README.md")
-    private File readmePath;
+    * Glob for the README files to inject codesnippets.
+    * <p>
+    * Default value is {@link #DEFAULT_README_GLOB}.
+    */
+    @Parameter(property = PROPERTY_PREFIX + "readmeGlob", defaultValue = DEFAULT_README_GLOB)
+    private String readmeGlob;
+
+    /**
+    * Root directory to begin searching for README files.
+    * <p>
+    * Default value is {@code ${project.basedir}}.
+    */
+    @Parameter(property = PROPERTY_PREFIX + "readmeRootDirectory", defaultValue = "${project.basedir}")
+    private File readmeRootDirectory;
 
     /**
      * Flag indicating if README files should be targeted for codesnippet injection or validation.
@@ -158,12 +171,21 @@ public abstract class SnippetBaseMojo extends AbstractMojo {
     }
 
     /**
-     * Gets the path of the README file.
+     * Gets the glob for the README files to inject codesnippets.
      *
-     * @return The path of the README file.
+     * @return The glob for the README files to inject codesnippets.
      */
-    protected File getReadmePath() {
-        return readmePath;
+    protected String getReadmeGlob() {
+        return readmeGlob;
+    }
+
+    /**
+     * Gets the root directory to begin searching for README files.
+     *
+     * @return The root directory to begin searching for README files.
+     */
+    protected File getReadmeRootDirectory() {
+        return readmeRootDirectory;
     }
 
     /**
@@ -227,7 +249,9 @@ public abstract class SnippetBaseMojo extends AbstractMojo {
 
         boolean includeSource = getAndLogConfiguration("Is source included? %b", this::isIncludeSource, log);
 
-        Path readmePath = getAndLogConfiguration("Using README path: %s", () -> getReadmePath().toPath(), log);
+        Path readmeRootDirectory = getAndLogConfiguration("Using README root directory: %s",
+            () -> getReadmeRootDirectory().toPath(), log);
+        String readmeGlob = getAndLogConfiguration("Using README glob: %s", this::getReadmeGlob, log);
         boolean includeReadme = getAndLogConfiguration("Is README included? %b", this::isIncludeReadme, log);
 
         int maxLineLength = getAndLogConfiguration("Using max line length: %d", this::getMaxLineLength, log);
@@ -237,7 +261,8 @@ public abstract class SnippetBaseMojo extends AbstractMojo {
             try {
                 log.debug("Beginning codesnippet update execution.");
                 SnippetReplacer.updateCodesnippets(codesnippetRootDirectory, codesnippetGlob, sourcesRootDirectory,
-                    sourcesGlob, includeSource, readmePath, includeReadme, maxLineLength, failOnError, log);
+                    sourcesGlob, includeSource, readmeRootDirectory, readmeGlob, includeReadme, maxLineLength,
+                    failOnError, log);
                 log.debug("Completed codesnippet update execution.");
             } catch (IOException ex) {
                 log.error(ex);
@@ -249,7 +274,8 @@ public abstract class SnippetBaseMojo extends AbstractMojo {
             try {
                 log.debug("Beginning codesnippet verification execution.");
                 SnippetReplacer.verifyCodesnippets(codesnippetRootDirectory, codesnippetGlob, sourcesRootDirectory,
-                    sourcesGlob, includeSource, readmePath, includeReadme, maxLineLength, failOnError, log);
+                    sourcesGlob, includeSource, readmeRootDirectory, readmeGlob, includeReadme, maxLineLength,
+                    failOnError, log);
                 log.debug("Completed codesnippet verification execution.");
             } catch (IOException ex) {
                 log.error(ex);

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
@@ -67,15 +67,15 @@ public final class SnippetReplacer {
      *
      * A "bad snippet call" is simply calling for a snippet whose Id has no definition.
      *
-     * See {@link #updateCodesnippets(Path, String, Path, String, boolean, Path, boolean, int, boolean, Log)} for
-     * details on actually defining and calling snippets.
+     * See {@link #updateCodesnippets(Path, String, Path, String, boolean, Path, String, boolean, int, boolean, Log)}
+     * for details on actually defining and calling snippets.
      */
     public static void verifyCodesnippets(Path codesnippetRootDirectory, String codesnippetGlob,
-        Path sourcesRootDirectory, String sourcesGlob, boolean includeSources, Path readmePath, boolean includeReadme,
-        int maxLineLength, boolean failOnError, Log logger)
+        Path sourcesRootDirectory, String sourcesGlob, boolean includeSources, Path readmeRootDirectory,
+        String readmeGlob, boolean includeReadme, int maxLineLength, boolean failOnError, Log logger)
         throws IOException, MojoExecutionException, MojoFailureException {
         runCodesnippets(codesnippetRootDirectory, codesnippetGlob, sourcesRootDirectory, sourcesGlob, includeSources,
-            readmePath, includeReadme, maxLineLength, failOnError, ExecutionMode.VERIFY, logger);
+            readmeRootDirectory, readmeGlob, includeReadme, maxLineLength, failOnError, ExecutionMode.VERIFY, logger);
     }
 
     static List<CodesnippetError> verifyReadmeCodesnippets(Path file, Map<String, Codesnippet> snippetMap)
@@ -120,17 +120,18 @@ public final class SnippetReplacer {
      * After finishing update operations, this function will throw a MojoExecutionException after reporting all snippet
      * CALLS that have no DEFINITION.
      */
-    public static void updateCodesnippets(Path codesnippetRootDirectory, String codesnippetGlob, Path sourcesRootDirectory,
-        String sourcesGlob, boolean includeSources, Path readmePath, boolean includeReadme, int maxLineLength,
-        boolean failOnError, Log logger) throws IOException, MojoExecutionException, MojoFailureException {
+    public static void updateCodesnippets(Path codesnippetRootDirectory, String codesnippetGlob,
+        Path sourcesRootDirectory, String sourcesGlob, boolean includeSources, Path readmeRootDirectory,
+        String readmeGlob, boolean includeReadme, int maxLineLength, boolean failOnError, Log logger)
+            throws IOException, MojoExecutionException, MojoFailureException {
         runCodesnippets(codesnippetRootDirectory, codesnippetGlob, sourcesRootDirectory, sourcesGlob, includeSources,
-            readmePath, includeReadme, maxLineLength, failOnError, ExecutionMode.UPDATE, logger);
+            readmeRootDirectory, readmeGlob, includeReadme, maxLineLength, failOnError, ExecutionMode.UPDATE, logger);
     }
 
     private static void runCodesnippets(Path codesnippetRootDirectory, String codesnippetGlob,
-        Path sourcesRootDirectory, String sourcesGlob, boolean includeSources, Path readmePath, boolean includeReadme,
-        int maxLineLength, boolean failOnError, ExecutionMode mode, Log logger)
-        throws IOException, MojoExecutionException, MojoFailureException {
+        Path sourcesRootDirectory, String sourcesGlob, boolean includeSources, Path readmeRootDirectory,
+        String readmeGlob, boolean includeReadme, int maxLineLength, boolean failOnError, ExecutionMode mode,
+        Log logger) throws IOException, MojoExecutionException, MojoFailureException {
         // Neither sources nor README is included in the update, there is no work to be done.
         if (!includeSources && !includeReadme) {
             logger.debug("Neither sources or README were included. No codesnippet updating will be done.");
@@ -166,10 +167,12 @@ public final class SnippetReplacer {
         // now find folderToVerify/README.md
         // run Update ReadmeSnippets on that
         if (includeReadme) {
-            if (mode == ExecutionMode.UPDATE) {
-                errors.addAll(updateReadmeCodesnippets(readmePath, foundSnippets));
-            } else {
-                errors.addAll(verifyReadmeCodesnippets(readmePath, foundSnippets));
+            for (Path readmeFile : globFiles(readmeRootDirectory, readmeGlob, true)) {
+                if (mode == ExecutionMode.UPDATE) {
+                    errors.addAll(updateReadmeCodesnippets(readmeFile, foundSnippets));
+                } else {
+                    errors.addAll(verifyReadmeCodesnippets(readmeFile, foundSnippets));
+                }
             }
         }
 

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
@@ -460,8 +460,9 @@ public final class SnippetReplacer {
         }
 
         if (minWhitespace != null) {
+            Pattern minWhitespacePattern = Pattern.compile(minWhitespace);
             for (String snippetLine : snippetText) {
-                modifiedStrings.add(snippetLine.replaceFirst(minWhitespace, ""));
+                modifiedStrings.add(minWhitespacePattern.matcher(snippetLine).replaceFirst(""));
             }
         }
 


### PR DESCRIPTION
This PR updates `codesnippet-maven-plugin` to use a root directory and glob for finding README files to inject codesnippets. This follows the pattern currently being used by source files and allows for multiple READMEs to be injected.