### PR TITLE
Update test resources SP password creation to support Az >= 7.1.0

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -143,10 +143,10 @@ function NewServicePrincipalWrapper([string]$subscription, [string]$resourceGrou
         $spPassword = $servicePrincipal.Secret
         $appId = $servicePrincipal.ApplicationId
     } else {
-        if ((Get-Module Az).Version -eq "7.0.0") {
+        if ((Get-Module Az.Resources).Version -eq "5.1.0") {
             Write-Verbose "Creating password and credential for service principal via MS Graph API"
-            Write-Warning "Please update Az to >= 7.1.0 by running 'Update-Module Az'"
-            # Microsoft graph objects (Az version == 7.0.0) do not provision a secret on creation so it must be added separately.
+            Write-Warning "Please update Az.Resources to >= 5.2.0 by running 'Update-Module Az'"
+            # Microsoft graph objects (Az.Resources version == 5.1.0) do not provision a secret on creation so it must be added separately.
             # Submitting a password credential object without specifying a password will result in one being generated on the server side.
             $password = New-Object -TypeName "Microsoft.Azure.PowerShell.Cmdlets.Resources.MSGraph.Models.ApiV10.MicrosoftGraphPasswordCredential"
             $password.DisplayName = "Password for $displayName"


### PR DESCRIPTION
Az version 7.0.0 had an issue where new service principal credential creation would not automatically generate a password by default. To work around this, one had to pass in a password credential object with an empty password to get it to work.

With the update to 7.1.0, the behavior of creating a password automatically was restored, but it also appeared to change the parameter set such that the existing calls were broken (since we weren't passing a now required `ServicePrincipalId` parameter).

```
Cannot bind argument to parameter 'ServicePrincipalId' because it is an empty string.
```

This PR updates the script to handle 7.0.0 and >= 7.1.0 versions of Az. Eventually we can remove the special handling for 7.0.0 as no one should have it installed. For posterity in case anyone hits this, the error you get when running the 7.1.0 targeted code with 7.0.0 loaded is:

```
New-TestResources.ps1: Cannot bind argument to parameter 'String' because it is null.
```

Thanks to @kashifkhan for bringing this to my attention.