### PR TITLE
Added support for RequestContext

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
@@ -125,6 +125,7 @@ namespace RandomNamespace
         public async Task AZC0002DoesntFireIfThereIsAnOverloadWithRequestContext()
         {
             const string code = @"
+using Azure;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -221,6 +222,7 @@ namespace RandomNamespace
         public async Task AZC0002NotProducedForMethodsWithRequestContext()
         {
             const string code = @"
+using Azure;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
@@ -87,6 +87,33 @@ namespace RandomNamespace
         }
 
         [Fact]
+        public async Task AZC0002ProducedForMethodsWhereRequestContextIsNotLast()
+        {
+            const string code = @"
+using Azure;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public virtual Task {|AZC0002:GetAsync|}(RequestContext context = default, string text = default)
+        {
+            return null;
+        }
+
+        public virtual void {|AZC0002:Get|}(RequestContext context = default, string text = default)
+        {
+        }
+    }
+}";
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
+        }
+
+        [Fact]
         public async Task AZC0002DoesntFireIfThereIsAnOverloadWithCancellationToken()
         {
             const string code = @"

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
@@ -121,6 +121,40 @@ namespace RandomNamespace
                 .RunAsync();
         }
 
+        [Fact]
+        public async Task AZC0002DoesntFireIfThereIsAnOverloadWithRequestContext()
+        {
+            const string code = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public virtual Task GetAsync(string s)
+        {
+            return null;
+        }
+
+        public virtual void Get(string s)
+        {
+        }
+
+        public virtual Task GetAsync(string s, RequestContext context = default)
+        {
+            return null;
+        }
+
+        public virtual void Get(string s, RequestContext context = default)
+        {
+        }
+    }
+}";
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
+        }
 
         [Fact]
         public async Task AZC0002ProducedWhenCancellationTokenOverloadsDontMatch()
@@ -174,6 +208,32 @@ namespace RandomNamespace
         }
 
         public virtual void Get(CancellationToken cancellationToken = default)
+        {
+        }
+    }
+}";
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task AZC0002NotProducedForMethodsWithRequestContext()
+        {
+            const string code = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public virtual Task GetAsync(RequestContext context = default)
+        {
+            return null;
+        }
+
+        public virtual void Get(RequestContext context = default)
         {
         }
     }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
@@ -16,7 +16,7 @@ namespace Azure.ClientSdk.Analyzers.Tests
     {
         private static readonly ReferenceAssemblies DefaultReferenceAssemblies =
             ReferenceAssemblies.Default.AddPackages(ImmutableArray.Create(
-                new PackageIdentity("Azure.Core", "1.0.0"),
+                new PackageIdentity("Azure.Core", "1.21.0"),
                 new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "1.1.0"),
                 new PackageIdentity("System.Text.Json", "4.6.0"),
                 new PackageIdentity("Newtonsoft.Json", "12.0.3"),

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerVerifier.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerVerifier.cs
@@ -17,7 +17,7 @@ namespace Azure.ClientSdk.Analyzers.Tests
     {
         private static readonly ReferenceAssemblies DefaultReferenceAssemblies =
             ReferenceAssemblies.Default.AddPackages(ImmutableArray.Create(
-                new PackageIdentity("Azure.Core", "1.0.0"),
+                new PackageIdentity("Azure.Core", "1.21.0"),
                 new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "1.1.0"),
                 new PackageIdentity("System.Text.Json", "4.6.0"),
                 new PackageIdentity("Newtonsoft.Json", "12.0.3"),


### PR DESCRIPTION
i.e. the analyzer now regards client methods with either a CancellationToken or a RequestContext as complying with our cancellation guidance.