### PR TITLE
Skip parser version from comparison for Python reviews

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -42,7 +42,9 @@ class ApiView:
         self.namespace = namespace
         self.nodeindex = nodeindex
         self.PackageName = pkg_name
+        self.add_token(Token("", TokenKind.SkipDiffRangeStart))
         self.add_literal(HEADER_TEXT)
+        self.add_token(Token("", TokenKind.SkipDiffRangeEnd))
         self.add_new_line(2)
 
     def add_token(self, token):

--- a/packages/python-packages/api-stub-generator/apistub/_token_kind.py
+++ b/packages/python-packages/api-stub-generator/apistub/_token_kind.py
@@ -12,3 +12,10 @@ class TokenKind(Enum):
     MemberName = 7
     StringLiteral = 8
     Literal = 9
+    Comment = 10
+    DocumentRangeStart = 11
+    DocumentRangeEnd = 12
+    DeprecatedRangeStart = 13
+    DeprecatedRangeEnd = 14
+    SkipDiffRangeStart = 15
+    SkipDiffRangeEnd = 16


### PR DESCRIPTION
Python reviews get a new version whenever parser version is changed even if APIs are not changed. This PS is to skip comparing parser version line.