### PR TITLE
Add link to triggering tools repo update run

### DIFF
--- a/eng/pipelines/templates/steps/ref-updater.yml
+++ b/eng/pipelines/templates/steps/ref-updater.yml
@@ -39,6 +39,7 @@ steps:
       PRBranchName: UpdateRepositoryRefsFor${{ parameters.ToolRepo }}
       CommitMsg: Update ${{ parameters.ToolRepo }} Repository Resource Refs in Yaml files
       PRTitle: Update ${{ parameters.ToolRepo }} Repository Resource Refs in Yaml files
+      PRBody: Update triggered by - $(System.CollectionUri)/$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)
       PushArgs: -f
       WorkingDirectory: $(System.DefaultWorkingDirectory)/${{ repo.key }}
       ScriptDirectory: ${{ parameters.ToolsRepoPath }}/eng/common/scripts


### PR DESCRIPTION
Add link to the run that triggers a repo version update.
Should resolve https://github.com/Azure/azure-sdk-tools/issues/2501
Result of sample run https://github.com/Azure/azure-sdk/pull/3750