### PR TITLE
Don't Fail codesnippet-maven-plugin when Sources Don't Exist

### DIFF
--- a/packages/java-packages/codesnippet-maven-plugin/pom.xml
+++ b/packages/java-packages/codesnippet-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.azure.tools</groupId>
   <artifactId>codesnippet-maven-plugin</artifactId>
-  <version>1.0.0-beta.4</version>
+  <version>1.0.0-beta.5</version>
   <packaging>maven-plugin</packaging>
 
   <name>Codesnippet Maven Plugin</name>


### PR DESCRIPTION
This PR updates `codesnippet-maven-plugin` to no-op when no Java source files and no README files for injection exist.