### PR TITLE
fix: body is too long when create github release

### DIFF
--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -11,6 +11,10 @@ function CreateReleases($pkgList, $releaseApiUrl, $releaseSha) {
     if ($pkgInfo.ReleaseNotes -ne $null) {
       $releaseNotes = $pkgInfo.ReleaseNotes
     }
+    # As github api limit the body param length with 125000 characters, we have to truncate the release note if needed.
+    if ($releaseNotes.Length -gt 124996) {
+      $releaseNotes = $releaseNotes.SubString(0, 124996) + " ..."
+    }
 
     $isPrerelease = $False
 


### PR DESCRIPTION
As github api limit the body param length with 125000 characters, we have to truncate the release note if needed. Try to fix: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1293270&view=logs&j=6a8552c2-2ada-5ee5-a4d2-6fcf45f87c55&t=3cc31b8c-ba6f-566f-31dd-15c31084f71a