### PR TITLE
Cross-compile the test proxy to .net 5 in addition to .net 6

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;AZC0001;AZC0012;CA1724;CA1801;CA1812;CA1822;SA1028</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
@@ -8,7 +8,14 @@
     <ToolCommandName>test-proxy</ToolCommandName>
     <LangVersion>preview</LangVersion>
   </PropertyGroup>
-  <ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
+    <PackageReference Include="Azure.Core" Version="1.10.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
+    <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Azure.Core" Version="1.10.0" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.21216.1" />

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ApplyCondition.cs
@@ -59,7 +59,8 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 var headerProp = GetProp(nameof(ResponseHeader), jsonElement);
                 if(headerProp.Value.ValueKind != JsonValueKind.Undefined)
                 {
-                    ResponseHeader = JsonSerializer.Deserialize<HeaderCondition>(headerProp.Value, new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+                    
+                    ResponseHeader = JsonSerializer.Deserialize<HeaderCondition>(headerProp.Value.ToString(), new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
                     if (string.IsNullOrWhiteSpace(ResponseHeader.Key))
                     {
                         throw new ArgumentException("Key is required for response header conditions.");


### PR DESCRIPTION
Related #2394 

Reasoning here is that `.NET 6` is not natively on our build machines. As a result of that, we will need a manual install step added to the test proxy tool version for every pipeline that consumes it. Given that most others aren't even using .NET, I feel like it's a bit of a burden on everyone's pipelines to pay the price of downloading the tool version.

The alternative is to increase the nuget size, but ship both versions. 

As the code base changes were quite simple, and tests all still check out, I feel like this may be the easiest path forward.

May need to adjust publishing ci in this PR as well. Let's see what shakes out.