### PR TITLE
[Python APIView] fix typehint parsing in Python 3.10

### DIFF
--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Version 0.2.9 (Unreleased)
 Fixed issue where Python 3-style type hints stopped displaying
   their inner types.
+Fixed issue where docstring annotations were preferred over
+  Python 2-style type hints for return types. Since docstrings
+  have a 2-line limit, this preference didn't make sense.
 
 ## Version 0.2.8 (Unreleased)
 Kwargs that were previously displayed as "type = ..." will now

--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## Version 0.2.9 (Unreleased)
+Fixed issue where Python 3-style type hints stopped displaying
+  their inner types.
+
 ## Version 0.2.8 (Unreleased)
 Kwargs that were previously displayed as "type = ..." will now
   be displayed as "Optional[type] = ..." to align with syntax

--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.2.8"
+VERSION = "0.2.9"

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
@@ -2,8 +2,8 @@ from inspect import Parameter
 import re
 from typing import Optional
 
-class_regex = re.compile(r"<class '([a-zA-Z]+)'>")
-forward_ref_regex = re.compile(r"ForwardRef\('([a-zA-Z]+)'\)")
+class_regex = re.compile(r"<class '([a-zA-Z._]+)'>")
+forward_ref_regex = re.compile(r"ForwardRef\('([a-zA-Z._]+)'\)")
 
 class NodeEntityBase:
     """This is the base class for all node types
@@ -86,7 +86,7 @@ def get_qualified_name(obj, namespace):
 
     value = name
     if module_name and module_name.startswith(namespace):
-        value = f"{module_name}.{name}".format(module_name, name)
+        value = f"{module_name}.{name}"
     if args:
         arg_string = ", ".join(args)
         value = f"{value}[{arg_string}]"

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
@@ -1,5 +1,9 @@
 from inspect import Parameter
+import re
 from typing import Optional
+
+class_regex = re.compile(r"<class '([a-zA-Z]+)'>")
+forward_ref_regex = re.compile(r"ForwardRef\('([a-zA-Z]+)'\)")
 
 class NodeEntityBase:
     """This is the base class for all node types
@@ -55,17 +59,35 @@ def get_qualified_name(obj, namespace):
     name = str(obj)
     if hasattr(obj, "__name__"):
         name = getattr(obj, "__name__")
-        # workaround because typing.Optional __name__ is just Optional in Python 3.10
-        # but not in previous versions
-        if name == "Optional":
-            name = str(obj)
     elif hasattr(obj, "__qualname__"):
         name = getattr(obj, "__qualname__")
+
+    args = []
+    # newer versions of Python extract inner types into __args__
+    # and are no longer part of the name
+    if hasattr(obj, "__args__"):
+        for arg in getattr(obj, "__args__"):
+            arg_string = str(arg)
+            if class_regex.match(arg_string):
+                value = class_regex.search(arg_string).group(1)
+                # we ignore NoneType since Optional implies that NoneType is
+                # acceptable
+                if value != "NoneType":
+                    args.append(value)
+            elif forward_ref_regex.match(arg_string):
+                value = forward_ref_regex.search(arg_string).group(1)
+                args.append(value)
+            else:
+                args.append(arg_string)
 
     module_name = ""
     if hasattr(obj, "__module__"):
         module_name = getattr(obj, "__module__")
-    if module_name and module_name.startswith(namespace):
-        return "{0}.{1}".format(module_name, name)
 
-    return name
+    value = name
+    if module_name and module_name.startswith(namespace):
+        value = f"{module_name}.{name}".format(module_name, name)
+    if args:
+        arg_string = ", ".join(args)
+        value = f"{value}[{arg_string}]"
+    return value

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -266,9 +266,7 @@ class FunctionNode(NodeEntityBase):
                 self.add_error("Typehint is missing for method {}".format(self.name))
             return
 
-        if not self.return_type:
-            self.return_type = type_hint_ret_type
-        else:
+        if self.return_type:
             # Verify return type is same in docstring and typehint if typehint is available
             short_return_type = self._generate_short_type(self.return_type)
             long_ret_type = self.return_type
@@ -276,6 +274,9 @@ class FunctionNode(NodeEntityBase):
                 logging.info("Long type: {0}, Short type: {1}, Type hint return type: {2}".format(long_ret_type, short_return_type, type_hint_ret_type))
                 error_message = "The return type is described in both a type hint and docstring, but they do not match."
                 self.add_error(error_message)
+        # because the typehint isn't subject to the 2-line limit, prefer it over
+        # a type parsed from the docstring.
+        self.return_type = type_hint_ret_type or self.return_type
 
 
     def _generate_signature_token(self, apiview):

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_typehint_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_typehint_parser.py
@@ -3,7 +3,7 @@ import inspect
 import logging
 
 
-find_type_hint_ret_type = "(?<!#)\\s?->\\s?([^\n:]*)"
+find_type_hint_ret_type = "(?<!#)\\s?->\\s?([^\n:#]*)"
 
 class TypeHintParser:
     """TypeHintParser helps to find return type from type hint is type hint is available
@@ -24,6 +24,6 @@ class TypeHintParser:
         ret_type = re.search(find_type_hint_ret_type, source)
         # Don't return None as string literal
         if ret_type and ret_type != "None":
-            return ret_type.groups()[-1]
+            return ret_type.groups()[-1].strip().replace('"', "")
         else:
             return None

--- a/packages/python-packages/api-stub-generator/tests/function_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/function_parsing_test.py
@@ -6,7 +6,7 @@
 
 from apistub.nodes import ClassNode, FunctionNode
 
-from typing import Optional, Any
+from typing import Optional, Any, List
 
 class TestClass:
     """ Function parsing tests."""
@@ -35,13 +35,26 @@ class TestClass:
     def with_default_values(self, foo="1", *, bar="2", baz=None):
         return None
 
+    def with_python2_typehint_and_docstring(self):
+        # type: () -> List[TestClass]
+        """ Testing Python2 typehints and docstring
+        :rtype: List[TestClass]
+        """
+        return TestClass()
+
+    def with_python3_typehint_and_docstring(self) -> List["TestClass"]:
+        """ Testing Python2 typehints and docstring
+        :rtype: List[TestClass]
+        """
+        return TestClass()
+
 
 class TestFunctionParsing:
     
     def test_optional_typehint(self):
         func_node = FunctionNode("test", None, TestClass.with_optional_typehint, "test")
         arg = func_node.args["description"]
-        assert arg.argtype == "typing.Optional[str]"
+        assert arg.argtype == "Optional[str]"
         assert arg.default == "..."
 
     def test_optional_docstring(self):
@@ -69,3 +82,10 @@ class TestFunctionParsing:
         assert func_node.args["foo"].default == "1"
         assert func_node.kw_args["bar"].default == "2"
         assert func_node.kw_args["baz"].default == "..."
+
+    def test_typehint_and_docstring_return_types(self):
+        func_node = FunctionNode("test", None, TestClass.with_python2_typehint_and_docstring, "test")
+        assert func_node.return_type == "List[TestClass]"
+
+        func_node = FunctionNode("test", None, TestClass.with_python3_typehint_and_docstring, "test")
+        assert func_node.return_type == "List[TestClass]"

--- a/packages/python-packages/api-stub-generator/tests/function_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/function_parsing_test.py
@@ -35,19 +35,16 @@ class TestClass:
     def with_default_values(self, foo="1", *, bar="2", baz=None):
         return None
 
-    def with_python2_typehint_and_docstring(self):
+    def with_python2_list_typehint(self):
         # type: () -> List[TestClass]
-        """ Testing Python2 typehints and docstring
-        :rtype: List[TestClass]
-        """
         return TestClass()
 
-    def with_python3_typehint_and_docstring(self) -> List["TestClass"]:
-        """ Testing Python2 typehints and docstring
-        :rtype: List[TestClass]
-        """
+    def with_python3_list_typehint(self) -> List["TestClass"]:
         return TestClass()
 
+    def with_python3_str_typehint(self) -> List[str]:
+        return TestClass()
+    
 
 class TestFunctionParsing:
     
@@ -84,8 +81,11 @@ class TestFunctionParsing:
         assert func_node.kw_args["baz"].default == "..."
 
     def test_typehint_and_docstring_return_types(self):
-        func_node = FunctionNode("test", None, TestClass.with_python2_typehint_and_docstring, "test")
+        func_node = FunctionNode("test", None, TestClass.with_python2_list_typehint, "test")
         assert func_node.return_type == "List[TestClass]"
 
-        func_node = FunctionNode("test", None, TestClass.with_python3_typehint_and_docstring, "test")
+        func_node = FunctionNode("test", None, TestClass.with_python3_list_typehint, "test")
         assert func_node.return_type == "List[TestClass]"
+
+        func_node = FunctionNode("test", None, TestClass.with_python3_str_typehint, "test")
+        assert func_node.return_type == "List[str]"

--- a/packages/python-packages/api-stub-generator/tests/typehint_parser_test.py
+++ b/packages/python-packages/api-stub-generator/tests/typehint_parser_test.py
@@ -4,6 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from cmath import exp
 from apistub.nodes import TypeHintParser
 
 
@@ -25,4 +26,12 @@ class TestTypeHintParser:
         return val
         """
         expected = "str"
+        assert parser._parse_typehint(code) == expected
+
+    def test_typehint_with_pylint_disable(self):
+        parser = TypeHintParser([])
+        code = """
+        # type: (...) -> AnalyzeHealthcareEntitiesLROPoller[ItemPaged[Union[AnalyzeHealthcareEntitiesResult, DocumentError]]]  # pylint: disable=line-too-long
+        """
+        expected = "AnalyzeHealthcareEntitiesLROPoller[ItemPaged[Union[AnalyzeHealthcareEntitiesResult, DocumentError]]]"
         assert parser._parse_typehint(code) == expected


### PR DESCRIPTION
Fixes #2540. Fixes #2550.

**servicebus**
https://apiviewstaging.azurewebsites.net/Assemblies/Review/045e0b979aee451c936cb329c5074b82?diffRevisionId=513a37376cf74d51af0bb85f74d7a2f5&doc=False&diffOnly=True

**text-analytics**
https://apiviewstaging.azurewebsites.net/Assemblies/Review/24d470153e844ada80ced5d3f8b5ad16?diffRevisionId=a1661465606643ef8e5c66dcd2d182b4&doc=False&diffOnly=True