### PR TITLE
Update image tag and version at eng/common for proxy tool

### DIFF
--- a/eng/common/testproxy/docker-start-proxy.ps1
+++ b/eng/common/testproxy/docker-start-proxy.ps1
@@ -31,7 +31,7 @@ catch {
     Write-Error "Please check your docker invocation and try running the script again."
 }
 
-$SELECTED_IMAGE_TAG = "1209124"
+$SELECTED_IMAGE_TAG = "1294199"
 $CONTAINER_NAME = "ambitious_azsdk_test_proxy"
 $LINUX_IMAGE_SOURCE = "azsdkengsys.azurecr.io/engsys/testproxy-lin:${SELECTED_IMAGE_TAG}"
 $WINDOWS_IMAGE_SOURCE = "azsdkengsys.azurecr.io/engsys/testproxy-win:${SELECTED_IMAGE_TAG}"

--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -16,7 +16,7 @@ steps:
       dotnet tool install azure.sdk.tools.testproxy `
         --tool-path $(Build.BinariesDirectory)/test-proxy `
         --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json `
-        --version 1.0.0-dev.20211118.3
+        --version 1.0.0-dev.20220113.1
     displayName: "Install test-proxy"
 
   - pwsh: |


### PR DESCRIPTION
`docker image` = `"1294199"`
`dotnet tool version` = `1.0.0-dev.20220113.1`
These versions were tested at https://github.com/Azure/azure-sdk-for-js/pull/19724.

This PR will sync all 8 repos to get the newer proxy tool everywhere.