### PR TITLE
Set notification team type as a prefix to avoid long name duplicates

### DIFF
--- a/tools/identity-resolution/identity-resolution/Models/TeamMetadata.cs
+++ b/tools/identity-resolution/identity-resolution/Models/TeamMetadata.cs
@@ -16,6 +16,11 @@ namespace Azure.Sdk.Tools.NotificationConfiguration.Models
         public int PipelineId { get; set; }
 
         /// <summary>
+        /// Name of associated alert pipeline
+        /// </summary>
+        public string PipelineName { get; set; }
+
+        /// <summary>
         /// Team's purpose
         /// </summary>
         public TeamPurpose Purpose { get; set; }

--- a/tools/identity-resolution/identity-resolution/Services/AzureDevOpsService.cs
+++ b/tools/identity-resolution/identity-resolution/Services/AzureDevOpsService.cs
@@ -47,7 +47,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration.Services
             this.logger = logger;
         }
 
-        private async Task<T> GetClientAsync<T>() 
+        private async Task<T> GetClientAsync<T>()
             where T : VssHttpClientBase
         {
             var type = typeof(T);
@@ -55,7 +55,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration.Services
             await clientCacheSemaphore.WaitAsync();
             if (clientCache.ContainsKey(type))
             {
-                
+
                 result = (T)clientCache[type];
             }
             else
@@ -193,7 +193,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration.Services
         public async Task<bool> CheckMembershipAsync(string parent, string child)
         {
             var client = await GetClientAsync<GraphHttpClient>();
-            
+
             logger.LogInformation("CheckMembership ParentId = {0} ChildId = {1}", parent, child);
             var result = await client.CheckMembershipExistenceAsync(child, parent);
 
@@ -244,14 +244,14 @@ namespace Azure.Sdk.Tools.NotificationConfiguration.Services
 
             logger.LogInformation("GetMembersAsync TeamId = {0}, TeamName = {1}", team.Id, team.Name);
             var members = await client.GetTeamMembersWithExtendedPropertiesAsync(
-                team.ProjectId.ToString(), 
+                team.ProjectId.ToString(),
                 team.Id.ToString()
             );
             return members;
         }
-        
+
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="id"></param>
         /// <returns></returns>

--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -28,9 +28,9 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
         }
 
         public async Task ConfigureNotifications(
-            string projectName, 
-            string projectPath, 
-            bool persistChanges = true, 
+            string projectName,
+            string projectPath,
+            bool persistChanges = true,
             PipelineSelectionStrategy strategy = PipelineSelectionStrategy.Scheduled)
         {
             var pipelines = await GetPipelinesAsync(projectName, projectPath, strategy);
@@ -38,22 +38,14 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
 
             foreach (var pipeline in pipelines)
             {
-                // If the pipeline name length is max or greater there is no
-                // room to add differentiators like "-- Sync Notifications"
-                // and this will result in team name collisions.
-                if (pipeline.Name.Length >= MaxTeamNameLength)
-                {
-                    throw new Exception($"Pipeline Name outside of character limit: Max = {MaxTeamNameLength}, Actual = {pipeline.Name.Length}, Name = {pipeline.Name}");
-                }
-
                 using (logger.BeginScope("Evaluate Pipeline Name = {0}, Path = {1}, Id = {2}", pipeline.Name, pipeline.Path, pipeline.Id))
                 {
-                    var parentTeam = await EnsureTeamExists(pipeline, "Notifications", TeamPurpose.ParentNotificationTeam, teams, persistChanges);
-                    var childTeam = await EnsureTeamExists(pipeline, "Sync Notifications", TeamPurpose.SynchronizedNotificationTeam, teams, persistChanges);
+                    var parentTeam = await EnsureTeamExists(pipeline, "[ntfy]", TeamPurpose.ParentNotificationTeam, teams, persistChanges);
+                    var childTeam = await EnsureTeamExists(pipeline, "[sync]", TeamPurpose.SynchronizedNotificationTeam, teams, persistChanges);
 
                     if (!persistChanges && (parentTeam == default || childTeam == default))
                     {
-                        // Skip team nesting and notification work if 
+                        // Skip team nesting and notification work if
                         logger.LogInformation("Skipping Teams and Notifications because parent or child team does not exist");
                         continue;
                     }
@@ -61,21 +53,25 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
                     await EnsureSynchronizedNotificationTeamIsChild(parentTeam, childTeam, persistChanges);
                     await EnsureScheduledBuildFailSubscriptionExists(pipeline, parentTeam, persistChanges);
 
-                    // Associate 
+                    // Associate
                 }
             }
         }
 
         private async Task<WebApiTeam> EnsureTeamExists(
             BuildDefinition pipeline,
-            string suffix,
+            string prefix,
             TeamPurpose purpose,
-            IEnumerable<WebApiTeam> teams, 
+            IEnumerable<WebApiTeam> teams,
             bool persistChanges)
         {
             // Ensure team name fits within maximum 64 character limit
             // https://docs.microsoft.com/en-us/azure/devops/organizations/settings/naming-restrictions?view=azure-devops#teams
-            string teamName = StringHelper.MaxLength($"{pipeline.Name} -- {suffix}", MaxTeamNameLength);
+            string fullTeamName = $"{prefix} {pipeline.Name}";
+            string teamName = StringHelper.MaxLength(fullTeamName, MaxTeamNameLength);
+            if (fullTeamName.Length > teamName.Length) {
+                logger.LogWarning($"Notification Name (length {fullTeamName.Length}) will be truncated to {teamName}");
+            }
             bool updateMetadataAndName = false;
             var result = teams.FirstOrDefault(
                 team =>
@@ -111,7 +107,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
 
             if (result == default)
             {
-                logger.LogInformation("Team Not Found Suffix = {0}", suffix);
+                logger.LogInformation("Team Not Found prefix = {0}", prefix);
                 var teamMetadata = new TeamMetadata
                 {
                     PipelineId = pipeline.Id,


### PR DESCRIPTION
We are having some issues where pipeline names that are just under the 64 character team name length limit, like `python - azure-communication-networktraversal - tests-weekly`. In these cases, they won't throw an error condition, but with the prefix separator `--` they hit the max and the team names are identical, when they need to be suffixed for either Notifications or Sync Notifications. If we move the suffix to a short prefix, it will avoid this name overlap issue altogether. Also, since the suffix often gets truncated down to a few characters anyway, I don't think we're losing any clarity of purpose, since the automation will also provide a clear description field like `purpose: ParentNotificationTeam` which gets shown in the team list view.

Trying to figure out the best way to test this, but I wanted to throw the PR up to get feedback on the approach.