### PR TITLE
[Swift APIView] Improve definition ID creation

### DIFF
--- a/src/swift/SwiftAPIView.xcworkspace/contents.xcworkspacedata
+++ b/src/swift/SwiftAPIView.xcworkspace/contents.xcworkspacedata
@@ -7,4 +7,10 @@
    <FileRef
       location = "group:SwiftAPIView/SwiftAPIView.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:SwiftAPIView/../CHANGELOG.md">
+   </FileRef>
+   <FileRef
+      location = "group:SwiftAPIView/../README.md">
+   </FileRef>
 </Workspace>

--- a/src/swift/SwiftAPIViewCore/Sources/Extensions/DeclarationModifier+Extensions.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Extensions/DeclarationModifier+Extensions.swift
@@ -64,6 +64,12 @@ extension FunctionDeclaration {
             value += "\(label)[\(type)]:"
         }
         value += ")"
+        if self.signature.asyncKind == .async {
+            value += "[async]"
+        }
+        if self.signature.throwsKind != .nothrowing {
+            value += "[\(self.signature.throwsKind.textDescription)]"
+        }
         return value.replacingOccurrences(of: " ", with: "")
     }
 }

--- a/src/swift/SwiftAPIViewCore/TestFiles/TestFile2.swifttxt
+++ b/src/swift/SwiftAPIViewCore/TestFiles/TestFile2.swifttxt
@@ -73,3 +73,17 @@ public class Owner {
         self.myDogs = [Dog?]()
     }
 }
+
+public class AsyncEnabledObject {
+    public func act(using data: Data?) -> String {
+        return ""
+    }
+
+    public func act(using data: Data?, completionHandler handler: @escaping (String, Error?) -> Void) {
+        handler(("", nil))
+    }
+
+    public func act(using data: Data?) async -> String {
+        return ""
+    }
+}


### PR DESCRIPTION
Ensures that the async nature of a function and whether it throws is used to generate the definition ID.

Fixes #2579