### PR TITLE
Update codesnippet-maven-plugin

### DIFF
--- a/packages/java-packages/codesnippet-maven-plugin/pom.xml
+++ b/packages/java-packages/codesnippet-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.azure.tools</groupId>
   <artifactId>codesnippet-maven-plugin</artifactId>
-  <version>1.0.0-beta.5</version>
+  <version>1.0.0-beta.6</version>
   <packaging>maven-plugin</packaging>
 
   <name>Codesnippet Maven Plugin</name>

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/RootAndGlob.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/RootAndGlob.java
@@ -3,7 +3,6 @@
 
 package com.azure.tools.codesnippetplugin;
 
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugins.annotations.Parameter;
 
 import java.io.File;
@@ -89,20 +88,10 @@ public final class RootAndGlob {
     /**
      * Gets the list of files that are included based on the root and glob.
      *
-     * @param validate Whether an exception is thrown if the root isn't a directory.
      * @return The list of files contained in the root directory that match the glob.
      * @throws IOException If an I/O failure occurs while walking the root directory.
-     * @throws MojoFailureException If the root file isn't a directory and {@code validate} is true.
      */
-    public List<Path> globFiles(boolean validate) throws IOException, MojoFailureException {
-        if (!root.isDirectory()) {
-            if (validate) {
-                throw new MojoFailureException(String.format("Expected '%s' to be a directory but it wasn't.", root));
-            } else {
-                return new ArrayList<>();
-            }
-        }
-
+    public List<Path> globFiles() throws IOException {
         List<Path> locatedPaths = new ArrayList<>();
         PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + glob);
 

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/RootAndGlob.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/RootAndGlob.java
@@ -1,0 +1,126 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package com.azure.tools.codesnippetplugin;
+
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.FileSystems;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.nio.file.SimpleFileVisitor;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Contains a search root and file glob that is used to determine which files to include in processing.
+ */
+public final class RootAndGlob {
+    @Parameter
+    private File root;
+
+    @Parameter
+    private String glob;
+
+    /**
+     * Creates a new {@link RootAndGlob}.
+     */
+    public RootAndGlob() {
+    }
+
+    /**
+     * Gets the root directory to begin searching.
+     *
+     * @return The root directory where searching begins.
+     */
+    public File getRoot() {
+        return root;
+    }
+
+    /**
+     * Sets the root directory to begin searching.
+     *
+     * @param root The root directory where searching begins.
+     * @return The updated RootAndGlob object.
+     * @throws NullPointerException If {@code root} is null.
+     */
+    public RootAndGlob setRoot(File root) {
+        this.root = Objects.requireNonNull(root, "'root' cannot be null.");
+        return this;
+    }
+
+    /**
+     * Gets whether the root directory exists.
+     *
+     * @return Whether the root directory exists.
+     */
+    public boolean rootExists() {
+        return root.exists();
+    }
+
+    /**
+     * Gets the glob that determines which files to include.
+     *
+     * @return The glob that determines which files to include.
+     */
+    public String getGlob() {
+        return glob;
+    }
+
+    /**
+     * Sets the glob that determines which files to include.
+     *
+     * @param glob The glob that determines which files to include.
+     * @return The updated RootAndGlob object.
+     * @throws NullPointerException If {@code glob} is null.
+     */
+    public RootAndGlob setGlob(String glob) {
+        this.glob = Objects.requireNonNull(glob, "'glob' cannot be null.");
+        return this;
+    }
+
+    /**
+     * Gets the list of files that are included based on the root and glob.
+     *
+     * @param validate Whether an exception is thrown if the root isn't a directory.
+     * @return The list of files contained in the root directory that match the glob.
+     * @throws IOException If an I/O failure occurs while walking the root directory.
+     * @throws MojoFailureException If the root file isn't a directory and {@code validate} is true.
+     */
+    public List<Path> globFiles(boolean validate) throws IOException, MojoFailureException {
+        if (!root.isDirectory()) {
+            if (validate) {
+                throw new MojoFailureException(String.format("Expected '%s' to be a directory but it wasn't.", root));
+            } else {
+                return new ArrayList<>();
+            }
+        }
+
+        List<Path> locatedPaths = new ArrayList<>();
+        PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + glob);
+
+        Files.walkFileTree(root.toPath(), new SimpleFileVisitor<Path>() {
+            @Override
+            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
+                if (pathMatcher.matches(file)) {
+                    locatedPaths.add(file);
+                }
+                return FileVisitResult.CONTINUE;
+            }
+
+            @Override
+            public FileVisitResult visitFileFailed(Path file, IOException exc) {
+                return FileVisitResult.CONTINUE;
+            }
+        });
+
+        return locatedPaths;
+    }
+}

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
@@ -140,18 +140,18 @@ public final class SnippetReplacer {
         List<Path> sourceFiles = Collections.emptyList();
         if (includeSources && sourcesRootAndGlob.rootExists()) {
             // Get the files that match the sources glob and are contained in the sources root directory.
-            sourceFiles = sourcesRootAndGlob.globFiles(true);
+            sourceFiles = sourcesRootAndGlob.globFiles();
         }
 
         // Only get the README files if READMEs are included in the update.
         List<Path> readmeFiles = new ArrayList<>();
         if (includeReadme) {
             if (readmeRootAndGlob.rootExists()) {
-                readmeFiles = readmeRootAndGlob.globFiles(true);
+                readmeFiles = readmeRootAndGlob.globFiles();
             }
 
             for (RootAndGlob additionalReadme : additionalReadmes) {
-                readmeFiles.addAll(additionalReadme.globFiles(true));
+                readmeFiles.addAll(additionalReadme.globFiles());
             }
         }
 
@@ -161,9 +161,9 @@ public final class SnippetReplacer {
         }
 
         // Get the files that match the codesnippet glob and are contained in the codesnippet root directory.
-        List<Path> codesnippetFiles = codesnippetRootAndGlob.globFiles(false);
+        List<Path> codesnippetFiles = codesnippetRootAndGlob.globFiles();
         for (RootAndGlob additionalCodesnippet : additionalCodesnippets) {
-            codesnippetFiles.addAll(additionalCodesnippet.globFiles(false));
+            codesnippetFiles.addAll(additionalCodesnippet.globFiles());
         }
 
         // scan the sample files for all the snippet files

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
@@ -6,7 +6,6 @@ package com.azure.tools.codesnippetplugin.implementation;
 import com.azure.tools.codesnippetplugin.ExecutionMode;
 import com.azure.tools.codesnippetplugin.RootAndGlob;
 import org.apache.maven.plugin.MojoExecutionException;
-import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
 
 import java.io.BufferedWriter;
@@ -69,7 +68,7 @@ public final class SnippetReplacer {
     public static void verifyCodesnippets(RootAndGlob codesnippetRootAndGlob, List<RootAndGlob> additionalCodesnippets,
         RootAndGlob sourcesRootAndGlob, boolean includeSources, RootAndGlob readmeRootAndGlob,
         List<RootAndGlob> additionalReadmes, boolean includeReadme, int maxLineLength, boolean failOnError, Log logger)
-        throws IOException, MojoExecutionException, MojoFailureException {
+        throws IOException, MojoExecutionException {
         runCodesnippets(codesnippetRootAndGlob, additionalCodesnippets, sourcesRootAndGlob, includeSources,
             readmeRootAndGlob, additionalReadmes, includeReadme, maxLineLength, failOnError, ExecutionMode.VERIFY,
             logger);
@@ -120,7 +119,7 @@ public final class SnippetReplacer {
     public static void updateCodesnippets(RootAndGlob codesnippetRootAndGlob, List<RootAndGlob> additionalCodesnippets,
         RootAndGlob sourcesRootAndGlob, boolean includeSources, RootAndGlob readmeRootAndGlob,
         List<RootAndGlob> additionalReadmes, boolean includeReadme, int maxLineLength, boolean failOnError, Log logger)
-        throws IOException, MojoExecutionException, MojoFailureException {
+        throws IOException, MojoExecutionException {
         runCodesnippets(codesnippetRootAndGlob, additionalCodesnippets, sourcesRootAndGlob, includeSources,
             readmeRootAndGlob, additionalReadmes, includeReadme, maxLineLength, failOnError, ExecutionMode.UPDATE,
             logger);
@@ -129,7 +128,7 @@ public final class SnippetReplacer {
     private static void runCodesnippets(RootAndGlob codesnippetRootAndGlob, List<RootAndGlob> additionalCodesnippets,
         RootAndGlob sourcesRootAndGlob, boolean includeSources, RootAndGlob readmeRootAndGlob,
         List<RootAndGlob> additionalReadmes, boolean includeReadme, int maxLineLength, boolean failOnError,
-        ExecutionMode mode, Log logger) throws IOException, MojoExecutionException, MojoFailureException {
+        ExecutionMode mode, Log logger) throws IOException, MojoExecutionException {
         // Neither sources nor README is included in the update, there is no work to be done.
         if (!includeSources && !includeReadme) {
             logger.debug("Neither sources or README were included. No codesnippet updating will be done.");

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
@@ -4,6 +4,7 @@
 package com.azure.tools.codesnippetplugin.implementation;
 
 import com.azure.tools.codesnippetplugin.ExecutionMode;
+import com.azure.tools.codesnippetplugin.RootAndGlob;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.apache.maven.plugin.logging.Log;
@@ -11,13 +12,8 @@ import org.apache.maven.plugin.logging.Log;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.FileSystems;
-import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.PathMatcher;
-import java.nio.file.SimpleFileVisitor;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,8 +30,8 @@ public final class SnippetReplacer {
     private static final Pattern SNIPPET_DEF_END = Pattern.compile(String.format("\\s*//\\s*END:%s", SNIPPET_ID_CAPTURE));
     private static final Pattern SNIPPET_SRC_CALL_BEGIN = Pattern.compile(String.format("(\\s*)\\*?\\s*<!--\\s+src_embed%s-->", SNIPPET_ID_CAPTURE));
     private static final Pattern SNIPPET_SRC_CALL_END = Pattern.compile(String.format("(\\s*)\\*?\\s*<!--\\s+end%s-->", SNIPPET_ID_CAPTURE));
-    private static final Pattern SNIPPET_README_CALL_BEGIN = Pattern.compile(String.format("```(\\s*)?java%s", SNIPPET_ID_CAPTURE));
-    private static final Pattern SNIPPET_README_CALL_END = Pattern.compile("```\\s*");
+    private static final Pattern SNIPPET_README_CALL_BEGIN = Pattern.compile(String.format("(\\s*)?```(\\s*)?java%s", SNIPPET_ID_CAPTURE));
+    private static final Pattern SNIPPET_README_CALL_END = Pattern.compile("(\\s*)?```\\s*");
     private static final Pattern WHITESPACE_EXTRACTION = Pattern.compile("(\\s*)(.*)");
     private static final Pattern END_OF_LINE_WHITESPACES = Pattern.compile("\\s+$");
 
@@ -67,27 +63,28 @@ public final class SnippetReplacer {
      *
      * A "bad snippet call" is simply calling for a snippet whose Id has no definition.
      *
-     * See {@link #updateCodesnippets(Path, String, Path, String, boolean, Path, String, boolean, int, boolean, Log)}
+     * See {@link #updateCodesnippets(RootAndGlob, List, RootAndGlob, boolean, RootAndGlob, List, boolean, int, boolean, Log)}
      * for details on actually defining and calling snippets.
      */
-    public static void verifyCodesnippets(Path codesnippetRootDirectory, String codesnippetGlob,
-        Path sourcesRootDirectory, String sourcesGlob, boolean includeSources, Path readmeRootDirectory,
-        String readmeGlob, boolean includeReadme, int maxLineLength, boolean failOnError, Log logger)
+    public static void verifyCodesnippets(RootAndGlob codesnippetRootAndGlob, List<RootAndGlob> additionalCodesnippets,
+        RootAndGlob sourcesRootAndGlob, boolean includeSources, RootAndGlob readmeRootAndGlob,
+        List<RootAndGlob> additionalReadmes, boolean includeReadme, int maxLineLength, boolean failOnError, Log logger)
         throws IOException, MojoExecutionException, MojoFailureException {
-        runCodesnippets(codesnippetRootDirectory, codesnippetGlob, sourcesRootDirectory, sourcesGlob, includeSources,
-            readmeRootDirectory, readmeGlob, includeReadme, maxLineLength, failOnError, ExecutionMode.VERIFY, logger);
+        runCodesnippets(codesnippetRootAndGlob, additionalCodesnippets, sourcesRootAndGlob, includeSources,
+            readmeRootAndGlob, additionalReadmes, includeReadme, maxLineLength, failOnError, ExecutionMode.VERIFY,
+            logger);
     }
 
     static List<CodesnippetError> verifyReadmeCodesnippets(Path file, Map<String, Codesnippet> snippetMap)
         throws IOException {
-        return verifySnippets(file, SNIPPET_README_CALL_BEGIN, SNIPPET_README_CALL_END, snippetMap, "", "", 0, "",
-            Collections.emptyMap(), Integer.MAX_VALUE);
+        return verifySnippets(file, SNIPPET_README_CALL_BEGIN, 3, SNIPPET_README_CALL_END, snippetMap, "", "", 0, "",
+            Collections.emptyMap(), Integer.MAX_VALUE, true);
     }
 
     static List<CodesnippetError> verifySourceCodeSnippets(Path file, Map<String, Codesnippet> snippetMap,
         int maxLineLength) throws IOException {
-        return verifySnippets(file, SNIPPET_SRC_CALL_BEGIN, SNIPPET_SRC_CALL_END, snippetMap, JAVADOC_PRE_FENCE,
-            JAVADOC_POST_FENCE, 1, "* ", JAVADOC_REPLACEMENTS, maxLineLength);
+        return verifySnippets(file, SNIPPET_SRC_CALL_BEGIN, 2, SNIPPET_SRC_CALL_END, snippetMap, JAVADOC_PRE_FENCE,
+            JAVADOC_POST_FENCE, 1, "* ", JAVADOC_REPLACEMENTS, maxLineLength, false);
     }
 
     /**
@@ -120,18 +117,19 @@ public final class SnippetReplacer {
      * After finishing update operations, this function will throw a MojoExecutionException after reporting all snippet
      * CALLS that have no DEFINITION.
      */
-    public static void updateCodesnippets(Path codesnippetRootDirectory, String codesnippetGlob,
-        Path sourcesRootDirectory, String sourcesGlob, boolean includeSources, Path readmeRootDirectory,
-        String readmeGlob, boolean includeReadme, int maxLineLength, boolean failOnError, Log logger)
-            throws IOException, MojoExecutionException, MojoFailureException {
-        runCodesnippets(codesnippetRootDirectory, codesnippetGlob, sourcesRootDirectory, sourcesGlob, includeSources,
-            readmeRootDirectory, readmeGlob, includeReadme, maxLineLength, failOnError, ExecutionMode.UPDATE, logger);
+    public static void updateCodesnippets(RootAndGlob codesnippetRootAndGlob, List<RootAndGlob> additionalCodesnippets,
+        RootAndGlob sourcesRootAndGlob, boolean includeSources, RootAndGlob readmeRootAndGlob,
+        List<RootAndGlob> additionalReadmes, boolean includeReadme, int maxLineLength, boolean failOnError, Log logger)
+        throws IOException, MojoExecutionException, MojoFailureException {
+        runCodesnippets(codesnippetRootAndGlob, additionalCodesnippets, sourcesRootAndGlob, includeSources,
+            readmeRootAndGlob, additionalReadmes, includeReadme, maxLineLength, failOnError, ExecutionMode.UPDATE,
+            logger);
     }
 
-    private static void runCodesnippets(Path codesnippetRootDirectory, String codesnippetGlob,
-        Path sourcesRootDirectory, String sourcesGlob, boolean includeSources, Path readmeRootDirectory,
-        String readmeGlob, boolean includeReadme, int maxLineLength, boolean failOnError, ExecutionMode mode,
-        Log logger) throws IOException, MojoExecutionException, MojoFailureException {
+    private static void runCodesnippets(RootAndGlob codesnippetRootAndGlob, List<RootAndGlob> additionalCodesnippets,
+        RootAndGlob sourcesRootAndGlob, boolean includeSources, RootAndGlob readmeRootAndGlob,
+        List<RootAndGlob> additionalReadmes, boolean includeReadme, int maxLineLength, boolean failOnError,
+        ExecutionMode mode, Log logger) throws IOException, MojoExecutionException, MojoFailureException {
         // Neither sources nor README is included in the update, there is no work to be done.
         if (!includeSources && !includeReadme) {
             logger.debug("Neither sources or README were included. No codesnippet updating will be done.");
@@ -140,15 +138,21 @@ public final class SnippetReplacer {
 
         // Only get the source files if sources are included in the update.
         List<Path> sourceFiles = Collections.emptyList();
-        if (includeSources && sourcesRootDirectory.toFile().exists()) {
+        if (includeSources && sourcesRootAndGlob.rootExists()) {
             // Get the files that match the sources glob and are contained in the sources root directory.
-            sourceFiles = globFiles(sourcesRootDirectory, sourcesGlob, true);
+            sourceFiles = sourcesRootAndGlob.globFiles(true);
         }
 
         // Only get the README files if READMEs are included in the update.
-        List<Path> readmeFiles = Collections.emptyList();
-        if (includeReadme && readmeRootDirectory.toFile().exists()) {
-            readmeFiles = globFiles(readmeRootDirectory, readmeGlob, true);
+        List<Path> readmeFiles = new ArrayList<>();
+        if (includeReadme) {
+            if (readmeRootAndGlob.rootExists()) {
+                readmeFiles = readmeRootAndGlob.globFiles(true);
+            }
+
+            for (RootAndGlob additionalReadme : additionalReadmes) {
+                readmeFiles.addAll(additionalReadme.globFiles(true));
+            }
         }
 
         if (sourceFiles.isEmpty() && readmeFiles.isEmpty()) {
@@ -157,7 +161,10 @@ public final class SnippetReplacer {
         }
 
         // Get the files that match the codesnippet glob and are contained in the codesnippet root directory.
-        List<Path> codesnippetFiles = globFiles(codesnippetRootDirectory, codesnippetGlob, false);
+        List<Path> codesnippetFiles = codesnippetRootAndGlob.globFiles(false);
+        for (RootAndGlob additionalCodesnippet : additionalCodesnippets) {
+            codesnippetFiles.addAll(additionalCodesnippet.globFiles(false));
+        }
 
         // scan the sample files for all the snippet files
         Map<String, Codesnippet> foundSnippets = getAllSnippets(codesnippetFiles);
@@ -195,19 +202,20 @@ public final class SnippetReplacer {
 
     static List<CodesnippetError> updateReadmeCodesnippets(Path file, Map<String, Codesnippet> snippetMap)
         throws IOException {
-        return updateSnippets(file, SNIPPET_README_CALL_BEGIN, SNIPPET_README_CALL_END, snippetMap, "", "", 0, "",
-            Collections.emptyMap(), Integer.MAX_VALUE);
+        return updateSnippets(file, SNIPPET_README_CALL_BEGIN, SNIPPET_README_CALL_END, 3, snippetMap, "", "", 0, "",
+            Collections.emptyMap(), Integer.MAX_VALUE, true);
     }
 
     static List<CodesnippetError> updateSourceCodeSnippets(Path file, Map<String, Codesnippet> snippetMap,
         int maxLineLength) throws IOException {
-        return updateSnippets(file, SNIPPET_SRC_CALL_BEGIN, SNIPPET_SRC_CALL_END, snippetMap, JAVADOC_PRE_FENCE,
-            JAVADOC_POST_FENCE, 1, "* ", JAVADOC_REPLACEMENTS, maxLineLength);
+        return updateSnippets(file, SNIPPET_SRC_CALL_BEGIN, SNIPPET_SRC_CALL_END, 2, snippetMap, JAVADOC_PRE_FENCE,
+            JAVADOC_POST_FENCE, 1, "* ", JAVADOC_REPLACEMENTS, maxLineLength, false);
     }
 
     private static List<CodesnippetError> updateSnippets(Path file, Pattern beginRegex, Pattern endRegex,
-        Map<String, Codesnippet> snippetMap, String preFence, String postFence, int prefixGroupNum,
-        String additionalLinePrefix, Map<Pattern, String> replacements, int maxLineLength) throws IOException {
+        int snippetIdGroup, Map<String, Codesnippet> snippetMap, String preFence, String postFence, int prefixGroupNum,
+        String additionalLinePrefix, Map<Pattern, String> replacements, int maxLineLength,
+        boolean prependSnippetTagIdentation) throws IOException {
         List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
 
         List<CodesnippetError> updateErrors = new ArrayList<>();
@@ -217,6 +225,7 @@ public final class SnippetReplacer {
         String lineSep = System.lineSeparator();
         String currentSnippetId = "";
 
+        int snippetTagIdentation = 0;
         for (String line : lines) {
             Matcher begin = beginRegex.matcher(line);
             Matcher end = endRegex.matcher(line);
@@ -224,7 +233,10 @@ public final class SnippetReplacer {
             if (begin.matches()) {
                 modifiedLines.add(line);
                 modifiedLines.add(lineSep);
-                currentSnippetId = begin.group(2);
+                currentSnippetId = begin.group(snippetIdGroup);
+                if (prependSnippetTagIdentation) {
+                    snippetTagIdentation = begin.group(1).length();
+                }
                 inSnippet = true;
             } else if (end.matches()) {
                 if (inSnippet) {
@@ -248,12 +260,17 @@ public final class SnippetReplacer {
                     String linePrefix = prefixFunction(end, prefixGroupNum, additionalLinePrefix);
 
                     int longestSnippetLine = 0;
+                    StringBuilder snippetIndentationBuilder = new StringBuilder();
+                    for (int i = 0; i < snippetTagIdentation; i++) {
+                        snippetIndentationBuilder.append(" ");
+                    }
+                    String snippetIndentation = snippetIndentationBuilder.toString();
                     for (String snippet : respaceLines(newSnippets.getContent())) {
                         longestSnippetLine = Math.max(longestSnippetLine, snippet.length());
                         String modifiedSnippet = applyReplacements(snippet, replacements);
                         modifiedSnippets.add(modifiedSnippet.length() == 0
                             ? END_OF_LINE_WHITESPACES.matcher(linePrefix).replaceAll("") + lineSep
-                            : linePrefix + modifiedSnippet + lineSep);
+                            : snippetIndentation + linePrefix + modifiedSnippet + lineSep);
                     }
 
                     if (longestSnippetLine > maxLineLength) {
@@ -302,9 +319,10 @@ public final class SnippetReplacer {
         return updateErrors;
     }
 
-    private static List<CodesnippetError> verifySnippets(Path file, Pattern beginRegex, Pattern endRegex,
-        Map<String, Codesnippet> snippetMap, String preFence, String postFence, int prefixGroupNum,
-        String additionalLinePrefix, Map<Pattern, String> replacements, int maxLineLength) throws IOException {
+    private static List<CodesnippetError> verifySnippets(Path file, Pattern beginRegex, int snippetIdGroup,
+        Pattern endRegex, Map<String, Codesnippet> snippetMap, String preFence, String postFence, int prefixGroupNum,
+        String additionalLinePrefix, Map<Pattern, String> replacements, int maxLineLength,
+        boolean prependSnippetTagIdentation) throws IOException {
         List<String> lines = Files.readAllLines(file, StandardCharsets.UTF_8);
 
         boolean inSnippet = false;
@@ -313,13 +331,17 @@ public final class SnippetReplacer {
         List<CodesnippetError> verificationErrors = new ArrayList<>();
         String currentSnippetId = "";
 
+        int snippetTagIdentation = 0;
         for (String line : lines) {
             Matcher begin = beginRegex.matcher(line);
             Matcher end = endRegex.matcher(line);
 
             if (begin.matches()) {
-                currentSnippetId = begin.group(2);
+                currentSnippetId = begin.group(snippetIdGroup);
                 inSnippet = true;
+                if (prependSnippetTagIdentation) {
+                    snippetTagIdentation = begin.group(1).length();
+                }
                 currentSnippetSet = new ArrayList<>();
             } else if (end.matches()) {
                 if (inSnippet) {
@@ -339,12 +361,17 @@ public final class SnippetReplacer {
                     String linePrefix = prefixFunction(end, prefixGroupNum, additionalLinePrefix);
 
                     int longestSnippetLine = 0;
+                    StringBuilder snippetIndentationBuilder = new StringBuilder();
+                    for (int i = 0; i < snippetTagIdentation; i++) {
+                        snippetIndentationBuilder.append(" ");
+                    }
+                    String snippetIndentation = snippetIndentationBuilder.toString();
                     for (String snippet : respaceLines(newSnippets.getContent())) {
                         longestSnippetLine = Math.max(longestSnippetLine, snippet.length());
                         String modifiedSnippet = applyReplacements(snippet, replacements);
                         modifiedSnippets.add(modifiedSnippet.length() == 0
                             ? END_OF_LINE_WHITESPACES.matcher(linePrefix).replaceAll("") + lineSep
-                            : linePrefix + modifiedSnippet + lineSep);
+                            : snippetIndentation + linePrefix + modifiedSnippet + lineSep);
                     }
 
                     if (longestSnippetLine > maxLineLength) {
@@ -494,38 +521,6 @@ public final class SnippetReplacer {
         }
 
         return snippet;
-    }
-
-    private static List<Path> globFiles(Path rootFolder, String glob, boolean validate)
-        throws IOException, MojoFailureException {
-        if (rootFolder == null || !rootFolder.toFile().isDirectory()) {
-            if (validate) {
-                throw new MojoFailureException(String.format("Expected '%s' to be a directory but it wasn't.",
-                    rootFolder));
-            } else {
-                return new ArrayList<>();
-            }
-        }
-
-        List<Path> locatedPaths = new ArrayList<>();
-        PathMatcher pathMatcher = FileSystems.getDefault().getPathMatcher("glob:" + glob);
-
-        Files.walkFileTree(rootFolder, new SimpleFileVisitor<Path>() {
-            @Override
-            public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) {
-                if (pathMatcher.matches(file)) {
-                    locatedPaths.add(file);
-                }
-                return FileVisitResult.CONTINUE;
-            }
-
-            @Override
-            public FileVisitResult visitFileFailed(Path file, IOException exc) {
-                return FileVisitResult.CONTINUE;
-            }
-        });
-
-        return locatedPaths;
     }
 
     private static String createErrorMessage(String operationKind, int allowedLength, List<CodesnippetError> errors) {


### PR DESCRIPTION
This PR updates `codesnippet-maven-plugin` to handle additional scenarios that have been found in the `azure-sdk-for-java` repository while attempting to remove that last usage of `embedme`. The following changes were made:

Support for indented README code blocks was added. Some READMEs use indented code blocks when inserting a code sample into a list. Before `codesnippet-maven-plugin` expected the README code tag to match the beginning regex:

````
^```java
````

now it matches

````
^(\s*)?```java
````

to capture the number of spaces the README code block is indented. When inserted the sample it indents each line so that the README generates correctly.

Support for additional codesnippets and READMEs was added with new configurations `additionalCodesnippets` and `additionalReadmes`. Each is a list of root directories to search and a glob used to match files. This was added as some projects pull codesnippets from other areas in the repository, for example the codeless Spring libraries have their README samples contained in azure-spring-boot, and some projects maintain READMEs outside of their root directory, for example azure-resourcemanager manages the resourcemanager group's root README and docs READMEs.