### PR TITLE
fix incidentally added path addition

### DIFF
--- a/eng/common/docgeneration/Generate-DocIndex.ps1
+++ b/eng/common/docgeneration/Generate-DocIndex.ps1
@@ -119,7 +119,9 @@ function GenerateDocfxTocContent([Hashtable]$tocContent, [String]$lang, [String]
         $serviceName = $serviceMapping.Value[0]
         $displayName = $serviceMapping.Value[1]
 
-        $fileName = ($serviceName -replace '\s', '').ToLower().Trim()
+        # handle spaces in service name, EG "Confidential Ledger"
+        # handle / in service name, EG "Database for MySQL/PostgreSQL". Leaving a "/" present will generate a bad link location.
+        $fileName = ($serviceName -replace '\s', '').Replace("/","").ToLower().Trim()
         if ($visitedService.ContainsKey($serviceName)) {
             if ($displayName) {
                 Add-Content -Path "$($YmlPath)/${fileName}.md" -Value "#### $artifact`n##### ($displayName)"


### PR DESCRIPTION
@sima-zhu I was investigating Azure/azure-sdk-for-python#16794 and discovered this.

In the case where there is a "/" in the name it gets used directly! This means on a _browser_ that the link to the landing page won't ever render because a `/` means "next folder in" on a webserver!

So for the service `Database for MySQL/PostGreSQL`, this turns into path `databaseformysql/postgresql.html`. This is 404ing.