### PR TITLE
Non stop on errors.

### DIFF
--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -70,7 +70,7 @@ param(
   [Parameter(Mandatory = $false)]
   [string]$ClientSecret
 )
-
+Set-StrictMode -Version 3
 . (Join-Path $PSScriptRoot common.ps1)
 . (Join-Path $PSScriptRoot Helpers Metadata-Helpers.ps1)
 
@@ -145,7 +145,7 @@ function GetPackageInfoJson ($packageInfoJsonLocation) {
     LogWarning "Package metadata not found for $packageInfoJsonLocation"
     return
   }
-  
+
   $packageInfoJson = Get-Content $packageInfoJsonLocation -Raw
   $packageInfo = ConvertFrom-Json $packageInfoJson
   if ($packageInfo.DevVersion) {
@@ -165,8 +165,10 @@ function GetPackageInfoJson ($packageInfoJsonLocation) {
 
 function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation, $packageInfo) { 
   $originalVersion = [AzureEngSemanticVersion]::ParseVersionString($packageInfo.Version)
-
-  $packageMetadataArray = (Get-CSVMetadata).Where({ $_.Package -eq $packageInfo.Name -and $_.GroupId -eq $packageInfo.Group -and $_.Hide -ne 'true' -and $_.New -eq 'true' })
+  $packageMetadataArray = (Get-CSVMetadata).Where({ $_.Package -eq $packageInfo.Name -and $_.Hide -ne 'true' -and $_.New -eq 'true' })
+  if ($packageInfo.Group) {
+    $packageMetadataArray = ($packageMetadataArray).Where({$_.GroupId -eq $packageInfo.Group})
+  }
   if ($packageMetadataArray.Count -eq 0) { 
     LogWarning "Could not retrieve metadata for $($packageInfo.Name) from metadata CSV. Using best effort defaults."
     $packageMetadata = $null
@@ -176,25 +178,6 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation, $packageInfo) 
   } else {
     $packageMetadata = $packageMetadataArray[0]
   }
-
-  $readmeContent = Get-Content $packageInfo.ReadMePath -Raw
-  $outputReadmeContent = "" 
-  if ($readmeContent) { 
-    $outputReadmeContent = GetAdjustedReadmeContent $readmeContent $packageInfo $packageMetadata
-  }
-
-  $docsMsMetadata = &$GetDocsMsMetadataForPackageFn $packageInfo
-  $readMePath = $docsMsMetadata.LatestReadMeLocation
-  if ($originalVersion.IsPrerelease) { 
-    $readMePath = $docsMsMetadata.PreviewReadMeLocation
-  }
-
-  $suffix = $docsMsMetadata.Suffix
-  $readMeName = "$($docsMsMetadata.DocsMsReadMeName.ToLower())-readme${suffix}.md"
-
-  $readmeLocation = Join-Path $DocRepoLocation $readMePath $readMeName
-
-  Set-Content -Path $readmeLocation -Value $outputReadmeContent
 
   # Copy package info file to the docs repo
   $metadataMoniker = 'latest'
@@ -208,20 +191,45 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation, $packageInfo) 
   Set-Content `
     -Path $packageInfoLocation/$packageMetadataName `
     -Value $packageInfoJson
+
+  # Update Readme Content
+  if (!$packageInfo.ReadMePath -or !(Test-Path $packageInfo.ReadMePath)) {
+    Write-Warning "$packageInfo.Name does not have Readme file. Skipping update readme."
+    return
+  }
+  
+  $readmeContent = Get-Content $packageInfo.ReadMePath -Raw
+  $outputReadmeContent = "" 
+  if ($readmeContent) { 
+    $outputReadmeContent = GetAdjustedReadmeContent $readmeContent $packageInfo $packageMetadata
+  }
+  $docsMsMetadata = &$GetDocsMsMetadataForPackageFn $packageInfo
+  $readMePath = $docsMsMetadata.LatestReadMeLocation
+  if ($originalVersion.IsPrerelease) { 
+    $readMePath = $docsMsMetadata.PreviewReadMeLocation
+  }
+
+  $suffix = $docsMsMetadata.Suffix
+  $readMeName = "$($docsMsMetadata.DocsMsReadMeName.ToLower())-readme${suffix}.md"
+
+  $readmeLocation = Join-Path $DocRepoLocation $readMePath $readMeName
+
+  Set-Content -Path $readmeLocation -Value $outputReadmeContent
 }
 
 foreach ($packageInfoLocation in $PackageInfoJsonLocations) {
   Write-Host "Updating metadata for package: $packageInfoLocation"
-
   # Convert package metadata json file to metadata json property.
   $packageInfo = GetPackageInfoJson $packageInfoLocation
   # Add validation step for daily update and release
   if ($ValidateDocsMsPackagesFn -and (Test-Path "Function:$ValidateDocsMsPackagesFn")) {
+    Write-Host "Validating the package..."
     &$ValidateDocsMsPackagesFn -PackageInfo $packageInfo -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $DocValidationImageId -DocRepoLocation $DocRepoLocation
     if ($LASTEXITCODE) {
       LogError "The package failed Doc.Ms validation. Check https://aka.ms/azsdk/docs/docker for more details on how to diagnose this issue."
       exit $LASTEXITCODE
     }
   }
+  Write-Host "Updating the package json ..."
   UpdateDocsMsMetadataForPackage $packageInfoLocation $packageInfo
 }

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -194,7 +194,7 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation, $packageInfo) 
 
   # Update Readme Content
   if (!$packageInfo.ReadMePath -or !(Test-Path $packageInfo.ReadMePath)) {
-    Write-Warning "$packageInfo.Name does not have Readme file. Skipping update readme."
+    Write-Warning "$($packageInfo.Name) does not have Readme file. Skipping update readme."
     return
   }
   


### PR DESCRIPTION
The PR is to fix the pipeline: 
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1323052&view=results

The reason for the failure is track 1 package does not contain readme. We do not want to fail the pipeline in this case. Just printout message and pass the pipeline.

Pipeline got passed.
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1330650&view=logs&j=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b&t=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b