### PR TITLE
Prevent panic on unnamed receiver

### DIFF
--- a/src/go/cmd/token_builders.go
+++ b/src/go/cmd/token_builders.go
@@ -156,8 +156,10 @@ func makeMethodTokens(receiverVar, receiver string, isPointer bool, name string,
 	makeToken(nil, nil, "func", keyword, list)
 	makeToken(nil, nil, " ", whitespace, list)
 	makeToken(nil, nil, "(", punctuation, list)
-	makeToken(nil, nil, receiverVar, memberName, list)
-	makeToken(nil, nil, " ", whitespace, list)
+	if receiverVar != "" {
+		makeToken(nil, nil, receiverVar, memberName, list)
+		makeToken(nil, nil, " ", whitespace, list)
+	}
 	if isPointer {
 		makeToken(nil, nil, "*", memberName, list)
 	}


### PR DESCRIPTION
Go doesn't require a name for method receivers. For example, this is valid:
```go
type Foo struct {}

// unnamed receiver of type Foo
func (Foo) Bar() {}
```
There are a couple places where apiview assumes a receiver has a name. This PR adjusts them so we get e.g. `func (AuthenticationFailedError) NonRetriable()` as output instead of a panic or malformed signature.