### PR TITLE
Use valid characters for notification team name prefix

### DIFF
--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -64,7 +64,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
             IEnumerable<WebApiTeam> teams,
             bool persistChanges)
         {
-            string teamName = $"[{pipeline.Id}] ";
+            string teamName = $"{pipeline.Id} ";
 
             if (purpose == TeamPurpose.ParentNotificationTeam)
             {


### PR DESCRIPTION
This wasn't caught in the dry run (is there a server side validation API we could be using?)

```
Unhandled exception: Microsoft.TeamFoundation.Core.WebApi.InvalidTeamNameException: TF400472:
The following team name is not valid: [88] azure-uamqp-python - client.
Verify that the name does not exceed the maximum character limit, only contains valid characters, and is not a reserved name.
The following characters are not valid: @ ~ ;  ' + = , < > | / \ ? : & $ * " # [ ]
```
