### PR TITLE
Lock modifiable session when adding sanitizers, return an entry AFTER we have exited the lock on Entries

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
@@ -91,16 +91,18 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             // normalize request body with STJ using relaxed escaping to match behavior when Deserializing from session files
             RecordEntry.NormalizeJsonBody(requestEntry.Request);
 
+            RecordEntry entry = null;
+
             lock (Entries)
             {
-                RecordEntry entry = matcher.FindMatch(requestEntry, Entries);
+                entry = matcher.FindMatch(requestEntry, Entries);
                 if (remove)
                 {
                     Entries.Remove(entry);
                 }
-
-                return entry;
             }
+
+            return entry;
         }
 
         public void Sanitize(RecordedTestSanitizer sanitizer)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
@@ -91,18 +91,16 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             // normalize request body with STJ using relaxed escaping to match behavior when Deserializing from session files
             RecordEntry.NormalizeJsonBody(requestEntry.Request);
 
-            RecordEntry entry = null;
-
             lock (Entries)
             {
-                entry = matcher.FindMatch(requestEntry, Entries);
+                RecordEntry entry = matcher.FindMatch(requestEntry, Entries);
                 if (remove)
                 {
                     Entries.Remove(entry);
                 }
-            }
 
-            return entry;
+                return entry;
+            }
         }
 
         public void Sanitize(RecordedTestSanitizer sanitizer)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Matchers/CustomDefaultMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Matchers/CustomDefaultMatcher.cs
@@ -16,7 +16,7 @@ namespace Azure.Sdk.Tools.TestProxy.Matchers
         /// </summary>
         /// <param name="compareBodies">Should the body value be compared during lookup operations?</param>
         /// <param name="excludedHeaders">A comma separated list of additional headers that should be excluded during matching.</param>
-        /// /// <param name="ignoredHeaders">A comma separated list of additional headers that should be ignored during matching.</param>
+        /// <param name="ignoredHeaders">A comma separated list of additional headers that should be ignored during matching.</param>
         /// <param name="ignoreQueryOrdering">By default, the test-proxy does not sort query params before matching. Setting true will sort query params alphabetically before comparing URI.</param>
         public CustomDefaultMatcher(bool compareBodies = true, string excludedHeaders = "", string ignoredHeaders = "", bool ignoreQueryOrdering = false) : base(compareBodies: compareBodies, ignoreQueryOrdering: ignoreQueryOrdering)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -394,17 +394,26 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             if (PlaybackSessions.TryGetValue(recordingId, out var playbackSession))
             {
-                playbackSession.AdditionalSanitizers.Add(sanitizer);
+                lock (playbackSession)
+                {
+                    playbackSession.AdditionalSanitizers.Add(sanitizer);
+                }
             }
 
             if (RecordingSessions.TryGetValue(recordingId, out var recordingSession))
             {
-                recordingSession.ModifiableSession.AdditionalSanitizers.Add(sanitizer);
+                lock (recordingSession.ModifiableSession)
+                {
+                    recordingSession.ModifiableSession.AdditionalSanitizers.Add(sanitizer);
+                }
             }
 
             if (InMemorySessions.TryGetValue(recordingId, out var inMemSession))
             {
-                inMemSession.AdditionalSanitizers.Add(sanitizer);
+                lock (inMemSession)
+                {
+                    inMemSession.AdditionalSanitizers.Add(sanitizer);
+                }
             }
 
             if (inMemSession == null && recordingSession == (null, null) && playbackSession == null)


### PR DESCRIPTION
I'm hoping this PR addresses:

#2612 
#2451

@kristapratico I will release a tool update once this goes in, then run your build on repeat until it either succeeds or we  get another repro on "collection".