### PR TITLE
Update stress examples/generator to set imagePullPolicy: Always

### DIFF
--- a/tools/stress-cluster/chaos/README.md
+++ b/tools/stress-cluster/chaos/README.md
@@ -113,6 +113,7 @@ spec:
       containers:
       - name: <container name, pick anything>
         image: <container image name>
+        imagePullPolicy: Always
         command: ["test entrypoint command/binary"]
         args: [<args string array for your test command>]
       restartPolicy: Never
@@ -321,6 +322,7 @@ spec:
   containers:
     - name: deployment-example
       image: mcr.microsoft.com/azure-cli
+      imagePullPolicy: Always
       command: ['bash', '-c']
       args:
         - |

--- a/tools/stress-cluster/chaos/examples/network-stress-example/templates/testjob.yaml
+++ b/tools/stress-cluster/chaos/examples/network-stress-example/templates/testjob.yaml
@@ -11,6 +11,7 @@ spec:
   containers:
     - name: network-example
       command: ["bash", "poll.sh"]
+      imagePullPolicy: Always
       image: {{ .Values.image }}
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}

--- a/tools/stress-cluster/cluster/kubernetes/generator/Stress.Generator/Resources/Job.cs
+++ b/tools/stress-cluster/cluster/kubernetes/generator/Stress.Generator/Resources/Job.cs
@@ -26,6 +26,7 @@ spec:
   containers:
     - name: (( Name ))
       command: (( Command ))
+      imagePullPolicy: Always
       # Only override this if needed for local development, otherwise it will be calculated by deployment scripts.
       image: {{ default '' .Values.repository }}/(( ImageName )):{{ default 'v1' .Values.tag }}
       {{- include 'stress-test-addons.container-env' . | nindent 6 }}


### PR DESCRIPTION
As we don't use the latest tag for images, this can cause annoying issues in local development where a tag is re-used but the image does not get updated after deploying. See [image pull policy defaults](https://kubernetes.io/docs/concepts/containers/images/#imagepullpolicy-defaulting).
