### PR TITLE
Fixed the failure from strict mode.

### DIFF
--- a/eng/common/scripts/Helpers/Metadata-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Metadata-Helpers.ps1
@@ -40,7 +40,7 @@ function GetMsAliasFromGithub ($TenantId, $ClientId, $ClientSecret, $GithubUser)
     $resp | Write-Verbose
 
     if ($resp.aad) {
-        Write-Host "Fetched aad identity $($resp.aad.alias) for github user $GithubUser."
+        Write-Host "Fetched aad identity $($resp.aad.alias) for github user $GithubUser. "
         return $resp.aad.alias
     }
     Write-Warning "Failed to retrieve the aad identity from given github user: $GithubName"

--- a/eng/common/scripts/Helpers/Metadata-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Metadata-Helpers.ps1
@@ -33,7 +33,7 @@ function GetMsAliasFromGithub ($TenantId, $ClientId, $ClientSecret, $GithubUser)
         $resp = Invoke-RestMethod $OpensourceAPIBaseURI -Method 'GET' -Headers $Headers
     }
     catch { 
-        Write-Error $_
+        Write-Warning $_
         return $null
     }
 
@@ -43,7 +43,7 @@ function GetMsAliasFromGithub ($TenantId, $ClientId, $ClientSecret, $GithubUser)
         Write-Host "Fetched aad identity $($resp.aad.alias) for github user $GithubUser."
         return $resp.aad.alias
     }
-    Write-Error "Failed to retrieve the aad identity from given github user: $GithubName"
+    Write-Warning "Failed to retrieve the aad identity from given github user: $GithubName"
     return $null
 }
 
@@ -54,6 +54,6 @@ function GetPrimaryCodeOwner ($TargetDirectory)
         Write-Host "Code Owners are $codeOwnerArray."
         return $codeOwnerArray[0]
     }
-    Write-Error "No code owner found in $TargetDirectory."
+    Write-Warning "No code owner found in $TargetDirectory."
     return $null
 }

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -225,10 +225,6 @@ foreach ($packageInfoLocation in $PackageInfoJsonLocations) {
   if ($ValidateDocsMsPackagesFn -and (Test-Path "Function:$ValidateDocsMsPackagesFn")) {
     Write-Host "Validating the package..."
     &$ValidateDocsMsPackagesFn -PackageInfo $packageInfo -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $DocValidationImageId -DocRepoLocation $DocRepoLocation
-    if ($LASTEXITCODE) {
-      LogError "The package failed Doc.Ms validation. Check https://aka.ms/azsdk/docs/docker for more details on how to diagnose this issue."
-      exit $LASTEXITCODE
-    }
   }
   Write-Host "Updating the package json ..."
   UpdateDocsMsMetadataForPackage $packageInfoLocation $packageInfo


### PR DESCRIPTION
We got several issues when enable the strict mode from scripts.
JS - mgmt pipeline: Failed at $LastExitCode not retrieved.
[Pipeline](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1343628&view=logs&j=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b&t=26ac1571-47fc-5d52-3897-39c8bdecf4db)

Doc msauthor failed by `Write-Error`, change to `Write-Warning`
[Pipeline](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1343627&view=logs&j=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b&t=4ddc76a6-85f2-526e-fa3e-b1020f31ed12)


