### PR TITLE
[test resources] Add max value to DeleteAfter of 168 hours

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -53,7 +53,7 @@ param (
     [string] $ProvisionerApplicationSecret,
 
     [Parameter()]
-    [ValidateRange(1, [int]::MaxValue)]
+    [ValidateRange(1, 7*24)]
     [int] $DeleteAfterHours = 120,
 
     [Parameter()]

--- a/eng/common/TestResources/Update-TestResources.ps1
+++ b/eng/common/TestResources/Update-TestResources.ps1
@@ -26,7 +26,7 @@ param (
     [string] $SubscriptionId,
 
     [Parameter()]
-    [ValidateRange(1, [int]::MaxValue)]
+    [ValidateRange(1, 7*24)]
     [int] $DeleteAfterHours = 48
 )
 


### PR DESCRIPTION
Updating the maximum lifespan of a resource group lease in accordance with the upcoming [resource management guidelines](https://github.com/Azure/azure-sdk-tools/pull/2663).
