### PR TITLE
[Test-Proxy] Enable Optional Verbose Logging

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -4,6 +4,7 @@ using Azure.Sdk.Tools.TestProxy.Sanitizers;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.IO;
 using System.Linq;
@@ -25,6 +26,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
     /// </summary>
     public class AdminTests
     {
+        private NullLoggerFactory _nullLogger = new NullLoggerFactory();
+
         [Fact]
         public async void TestAddSanitizerThrowsOnInvalidAbstractionId()
         {
@@ -32,7 +35,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["x-abstraction-identifier"] = "AnInvalidSanitizer";
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -53,7 +56,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -75,7 +78,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["x-abstraction-identifier"] = "AnInvalidTransform";
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -96,7 +99,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -118,7 +121,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["x-abstraction-identifier"] = "AnInvalidMatcher";
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -138,7 +141,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -160,7 +163,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Headers["x-abstraction-identifier"] = "BodilessMatcher";
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{}");
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -185,7 +188,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             // content length must be set for the body to be parsed in SetMatcher
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -217,7 +220,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             // content length must be set for the body to be parsed in SetMatcher
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -244,7 +247,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Headers["x-abstraction-identifier"] = "BodilessMatcher";
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{}");
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -266,7 +269,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Headers["x-abstraction-identifier"] = "BodilessMatcher";
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{}");
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -290,7 +293,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
             httpContext.Request.ContentLength = 92;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -316,7 +319,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Headers["Content-Length"] = new string[] { "34" };
             httpContext.Request.Headers["Content-Type"] = new string[] { "application/json" };
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -339,7 +342,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
             httpContext.Request.ContentLength = 92;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -363,7 +366,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"\" }");
             httpContext.Request.ContentLength = 92;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -389,7 +392,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
             httpContext.Request.ContentLength = 92;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -412,7 +415,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\" }");
             httpContext.Request.ContentLength = 92;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -436,7 +439,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{\"value\":\"replacementValue\",\"regex\":[\"a_regex_goes_here_but_this_test_is_after_another_error\"]}");
             httpContext.Request.ContentLength = 199;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -463,7 +466,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{\"value\":\"replacementValue\",\"regex\":\"[\"}");
             httpContext.Request.ContentLength = 25;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -491,7 +494,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Headers["x-api-version"] = apiVersion;
             httpContext.Request.Headers["x-abstraction-identifier"] = "ApiVersionTransform";
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -516,7 +519,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 "{ \"key\": \"Location\", \"value\": \"https://fakeazsdktestaccount.table.core.windows.net/Tables\", \"condition\": { \"uriRegex\": \".*/token\", \"responseHeader\": { \"key\": \"Location\", \"valueRegex\": \".*/value\" } }}");
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -549,7 +552,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -576,7 +579,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Headers["x-abstraction-identifier"] = "ApiVersionTransform";
             httpContext.Request.Headers["x-recording-id"] = recordingId;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -599,7 +602,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Headers["x-abstraction-identifier"] = "ApiVersionTransform";
             httpContext.Request.Headers["x-recording-id"] = "bad-recording-id";
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -626,7 +629,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(requestBody);
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -655,7 +658,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(requestBody);
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -687,7 +690,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(requestBody);
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -718,7 +721,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -744,7 +747,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{\"value\":\"replacementValue\"}");
             httpContext.Request.ContentLength = 33;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -774,7 +777,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{\"target\":\"" + targetString + "\", \"key\":\"" + targetKey + "\"}");
             httpContext.Request.ContentLength = 79;
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -4,6 +4,7 @@ using Azure.Sdk.Tools.TestProxy.Sanitizers;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using System;
 using System.IO;
 using System.Linq;
@@ -15,6 +16,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 {
     public class PlaybackTests
     {
+
+        private NullLoggerFactory _nullLogger = new NullLoggerFactory();
+
         [Fact]
         public async void TestStartPlaybackSimple()
         {
@@ -45,7 +49,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             // get a recordingId that can be used for in-mem
             var recordContext = new DefaultHttpContext();
-            var recordController = new Record(testRecordingHandler)
+            var recordController = new Record(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -154,7 +158,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             // get a recordingId that can be used for in-mem
             var recordContext = new DefaultHttpContext();
-            var recordController = new Record(testRecordingHandler)
+            var recordController = new Record(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -18,6 +18,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 {
     public class RecordTests
     {
+        private NullLoggerFactory _nullLogger = new NullLoggerFactory();
+
         [Fact]
         public async Task TestStartRecordSimple()
         {
@@ -46,7 +48,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
 
-            var controller = new Record(testRecordingHandler)
+            var controller = new Record(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -72,7 +74,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             httpContext.Request.ContentLength = body.Length;
 
-            var controller = new Record(testRecordingHandler)
+            var controller = new Record(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -96,7 +98,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
 
             var recordContext = new DefaultHttpContext();
-            var recordController = new Record(testRecordingHandler)
+            var recordController = new Record(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -5,6 +5,7 @@ using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -26,7 +27,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             httpContext.Request.ContentLength = body.Length;
 
-            var controller = new Record(testRecordingHandler)
+            var controller = new Record(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -4,6 +4,7 @@ using Azure.Sdk.Tools.TestProxy.Sanitizers;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -16,6 +17,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 {
     public class RecordingHandlerTests
     {
+
+        private NullLoggerFactory _nullLogger = new NullLoggerFactory();
 
         [Flags]
         enum CheckSkips
@@ -58,7 +61,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["x-test-presence"] = "This header has a value";
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -75,7 +78,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -94,7 +97,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
 
-            var controller = new Admin(testRecordingHandler)
+            var controller = new Admin(testRecordingHandler, _nullLogger)
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -182,6 +185,53 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             _checkDefaultExtensions(testRecordingHandler);
         }
+
+        [Fact]
+        public void TestResetExtensionsFailsWithActiveSessions()
+        {
+            // with multiple active sessions, if fire a generalized reset, this should 400.
+
+            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            //var httpContext = new DefaultHttpContext();
+            //testRecordingHandler.StartRecording("recordingings/cool.json", httpContext.Response);
+            //var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
+
+            //testRecordingHandler.Sanitizers.Clear();
+            //testRecordingHandler.Sanitizers.Add(new BodyRegexSanitizer("sanitized", ".*"));
+            //testRecordingHandler.Transforms.Clear();
+            //testRecordingHandler.AddSanitizerToRecording(recordingId, new GeneralRegexSanitizer("sanitized", ".*"));
+            //testRecordingHandler.SetDefaultExtensions();
+            //var session = testRecordingHandler.RecordingSessions.First().Value;
+
+            //Assert.Single(session.ModifiableSession.AdditionalSanitizers);
+            //Assert.IsType<GeneralRegexSanitizer>(session.ModifiableSession.AdditionalSanitizers[0]);
+
+            //_checkDefaultExtensions(testRecordingHandler);
+        }
+
+        [Fact]
+        public void TestResetExtensionsSucceedsOnSingleTargetedSession()
+        {
+            // if we have multiple sessions active, if we send a reset at a specific recordingId we should not throw.
+
+            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            //var httpContext = new DefaultHttpContext();
+            //testRecordingHandler.StartRecording("recordingings/cool.json", httpContext.Response);
+            //var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
+
+            //testRecordingHandler.Sanitizers.Clear();
+            //testRecordingHandler.Sanitizers.Add(new BodyRegexSanitizer("sanitized", ".*"));
+            //testRecordingHandler.Transforms.Clear();
+            //testRecordingHandler.AddSanitizerToRecording(recordingId, new GeneralRegexSanitizer("sanitized", ".*"));
+            //testRecordingHandler.SetDefaultExtensions();
+            //var session = testRecordingHandler.RecordingSessions.First().Value;
+
+            //Assert.Single(session.ModifiableSession.AdditionalSanitizers);
+            //Assert.IsType<GeneralRegexSanitizer>(session.ModifiableSession.AdditionalSanitizers[0]);
+
+            //_checkDefaultExtensions(testRecordingHandler);
+        }
+
 
         [Fact]
         public async Task TestInMemoryPurgesSucessfully()

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -187,7 +187,6 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             testRecordingHandler.StopRecording(recordingId);
 
             // then verify that the session level is NOT reset.
-
             Assert.Single(testRecordingHandler.Sanitizers);
             Assert.IsType<BodyRegexSanitizer>(testRecordingHandler.Sanitizers.First());
         }
@@ -195,49 +194,17 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [Fact]
         public void TestResetExtensionsFailsWithActiveSessions()
         {
-            // with multiple active sessions, if fire a generalized reset, this should 400.
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var httpContext = new DefaultHttpContext();
+            testRecordingHandler.StartRecording("recordingings/cool.json", httpContext.Response);
+            var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
 
-            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            //var httpContext = new DefaultHttpContext();
-            //testRecordingHandler.StartRecording("recordingings/cool.json", httpContext.Response);
-            //var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
+            var assertion = Assert.Throws<HttpException>(
+                () => testRecordingHandler.SetDefaultExtensions()
+            );
 
-            //testRecordingHandler.Sanitizers.Clear();
-            //testRecordingHandler.Sanitizers.Add(new BodyRegexSanitizer("sanitized", ".*"));
-            //testRecordingHandler.Transforms.Clear();
-            //testRecordingHandler.AddSanitizerToRecording(recordingId, new GeneralRegexSanitizer("sanitized", ".*"));
-            //testRecordingHandler.SetDefaultExtensions();
-            //var session = testRecordingHandler.RecordingSessions.First().Value;
-
-            //Assert.Single(session.ModifiableSession.AdditionalSanitizers);
-            //Assert.IsType<GeneralRegexSanitizer>(session.ModifiableSession.AdditionalSanitizers[0]);
-
-            //_checkDefaultExtensions(testRecordingHandler);
+            Assert.StartsWith("There are a total of 1 active sessions. Remove these sessions before hitting Admin/Reset.", assertion.Message);
         }
-
-        [Fact]
-        public void TestResetExtensionsSucceedsOnSingleTargetedSession()
-        {
-            // if we have multiple sessions active, if we send a reset at a specific recordingId we should not throw.
-
-            //RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            //var httpContext = new DefaultHttpContext();
-            //testRecordingHandler.StartRecording("recordingings/cool.json", httpContext.Response);
-            //var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
-
-            //testRecordingHandler.Sanitizers.Clear();
-            //testRecordingHandler.Sanitizers.Add(new BodyRegexSanitizer("sanitized", ".*"));
-            //testRecordingHandler.Transforms.Clear();
-            //testRecordingHandler.AddSanitizerToRecording(recordingId, new GeneralRegexSanitizer("sanitized", ".*"));
-            //testRecordingHandler.SetDefaultExtensions();
-            //var session = testRecordingHandler.RecordingSessions.First().Value;
-
-            //Assert.Single(session.ModifiableSession.AdditionalSanitizers);
-            //Assert.IsType<GeneralRegexSanitizer>(session.ModifiableSession.AdditionalSanitizers[0]);
-
-            //_checkDefaultExtensions(testRecordingHandler);
-        }
-
 
         [Fact]
         public async Task TestInMemoryPurgesSucessfully()

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -177,13 +177,19 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             testRecordingHandler.Sanitizers.Add(new BodyRegexSanitizer("sanitized", ".*"));
             testRecordingHandler.Transforms.Clear();
             testRecordingHandler.AddSanitizerToRecording(recordingId, new GeneralRegexSanitizer("sanitized", ".*"));
-            testRecordingHandler.SetDefaultExtensions();
+            testRecordingHandler.SetDefaultExtensions(recordingId);
             var session = testRecordingHandler.RecordingSessions.First().Value;
 
-            Assert.Single(session.ModifiableSession.AdditionalSanitizers);
-            Assert.IsType<GeneralRegexSanitizer>(session.ModifiableSession.AdditionalSanitizers[0]);
+            // check that the individual session had reset sanitizers
+            Assert.Empty(session.ModifiableSession.AdditionalSanitizers);
 
-            _checkDefaultExtensions(testRecordingHandler);
+            // stop the recording to clear out the session cache
+            testRecordingHandler.StopRecording(recordingId);
+
+            // then verify that the session level is NOT reset.
+
+            Assert.Single(testRecordingHandler.Sanitizers);
+            Assert.IsType<BodyRegexSanitizer>(testRecordingHandler.Sanitizers.First());
         }
 
         [Fact]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -30,25 +30,25 @@ namespace Azure.Sdk.Tools.TestProxy
         }
 
         [HttpPost]
-        public void Reset()
+        public async Task Reset()
         {
-            HttpRequestInteractions.LogDebugDetails(_logger, Request);
+            await DebugLogger.LogRequestDetailsAsync(_logger, Request);
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
 
             _recordingHandler.SetDefaultExtensions(recordingId);
         }
 
         [HttpGet]
-        public void IsAlive()
+        public async Task IsAlive()
         {
-            HttpRequestInteractions.LogDebugDetails(_logger, Request);
+            await DebugLogger.LogRequestDetailsAsync(_logger, Request);
             Response.StatusCode = 200;
         }
 
         [HttpPost]
         public async Task AddTransform()
         {
-            HttpRequestInteractions.LogDebugDetails(_logger, Request);
+            await DebugLogger.LogRequestDetailsAsync(_logger, Request);
             var tName = RecordingHandler.GetHeader(Request, "x-abstraction-identifier");
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
 
@@ -67,7 +67,7 @@ namespace Azure.Sdk.Tools.TestProxy
         [HttpPost]
         public async Task AddSanitizer()
         {
-            HttpRequestInteractions.LogDebugDetails(_logger, Request);
+            await DebugLogger.LogRequestDetailsAsync(_logger, Request);
             var sName = RecordingHandler.GetHeader(Request, "x-abstraction-identifier");
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
 
@@ -86,7 +86,7 @@ namespace Azure.Sdk.Tools.TestProxy
         [HttpPost]
         public async Task SetMatcher()
         {
-            HttpRequestInteractions.LogDebugDetails(_logger, Request);
+            await DebugLogger.LogRequestDetailsAsync(_logger, Request);
             var mName = RecordingHandler.GetHeader(Request, "x-abstraction-identifier");
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
 
@@ -137,6 +137,11 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 if (documentBody != null && documentBody.RootElement.TryGetProperty(param.Name, out var jsonElement))
                 {
+                    if (DebugLogger.CheckLogLevel(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Request Body Content" + JsonSerializer.Serialize(documentBody.RootElement));
+                    }
+
                     object argumentValue = null;
                     switch (jsonElement.ValueKind)
                     {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -4,6 +4,7 @@
 using Azure.Sdk.Tools.TestProxy.Common;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -20,12 +21,18 @@ namespace Azure.Sdk.Tools.TestProxy
     public sealed class Admin : ControllerBase
     {
         private readonly RecordingHandler _recordingHandler;
+        private readonly ILogger _logger;
 
-        public Admin(RecordingHandler recordingHandler) => _recordingHandler = recordingHandler;
+        public Admin(RecordingHandler recordingHandler, ILoggerFactory loggingFactory)
+        {
+            _recordingHandler = recordingHandler;
+            _logger = loggingFactory.CreateLogger<Admin>();
+        }
 
         [HttpPost]
         public void Reset()
         {
+            HttpRequestInteractions.LogDebugDetails(_logger, Request);
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
 
             _recordingHandler.SetDefaultExtensions(recordingId);
@@ -34,12 +41,16 @@ namespace Azure.Sdk.Tools.TestProxy
         [HttpGet]
         public void IsAlive()
         {
+            HttpRequestInteractions.LogDebugDetails(_logger, Request);
+            _logger.LogDebug("WHAT");
+            _logger.LogInformation("");
             Response.StatusCode = 200;
         }
 
         [HttpPost]
         public async Task AddTransform()
         {
+            HttpRequestInteractions.LogDebugDetails(_logger, Request);
             var tName = RecordingHandler.GetHeader(Request, "x-abstraction-identifier");
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
 
@@ -58,6 +69,7 @@ namespace Azure.Sdk.Tools.TestProxy
         [HttpPost]
         public async Task AddSanitizer()
         {
+            HttpRequestInteractions.LogDebugDetails(_logger, Request);
             var sName = RecordingHandler.GetHeader(Request, "x-abstraction-identifier");
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
 
@@ -76,6 +88,7 @@ namespace Azure.Sdk.Tools.TestProxy
         [HttpPost]
         public async Task SetMatcher()
         {
+            HttpRequestInteractions.LogDebugDetails(_logger, Request);
             var mName = RecordingHandler.GetHeader(Request, "x-abstraction-identifier");
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -42,8 +42,6 @@ namespace Azure.Sdk.Tools.TestProxy
         public void IsAlive()
         {
             HttpRequestInteractions.LogDebugDetails(_logger, Request);
-            _logger.LogDebug("WHAT");
-            _logger.LogInformation("");
             Response.StatusCode = 200;
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
@@ -1,0 +1,110 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+using System.Text;
+using System.IO;
+using System;
+using System.Text.Json;
+using Microsoft.AspNetCore.Http.Extensions;
+
+namespace Azure.Sdk.Tools.TestProxy.Common
+{
+    /// <summary>
+    /// Outside of DI, there is no way to use the ASP.NET logging instances elsewhere in your classes libraries.
+    /// Given that RecordingHandler is a singleton, and therefore not injectable, we have to use a static
+    /// set methodology to get access to the same logging stack as the controllers. This static class allows class libraries 
+    /// that are not part of the ASP.NET server stack directly to still log useful information.
+    /// 
+    ///  and ConfigureLogger(loggerFactory) should definitely be called in Startup.cs Configure() function.
+    /// 
+    /// Yes, we could instantiate a new RecordingHandler for each recording as it comes in, but that is 
+    ///  A) Not the most fun to debug issues with
+    ///  B) Just slower than re-using the same instance
+    ///  C) There is no real reason (other than to get access to DI-ed parameters) to switch the existing method.
+    /// </summary>
+    public static class DebugLogger
+    {
+        private static ILogger logger = null;
+
+        public static void ConfigureLogger(ILoggerFactory factory)
+        {
+            if (logger == null)
+            {
+                logger = factory.CreateLogger<HttpRequestInteractions>();
+            }
+
+        }
+
+        /// <summary>
+        /// Used to retrieve the final log level setting. This is a "runtime" setting that is checking the result AFTER
+        /// accounting for launchSettings, appSettings, and environment variable settings.
+        /// </summary>
+        /// <param name="level">A log level. If that level is enabled, returns true. False otherwise.</param>
+        /// <returns></returns>
+        public static bool CheckLogLevel(LogLevel level)
+        {
+            return logger.IsEnabled(LogLevel.Debug);
+        }
+
+        /// <summary>
+        /// Simple access to the logging api. Accepts a simple message (preformatted) and logs to debug logger.
+        /// </summary>
+        /// <param name="details">The content which should be logged.</param>
+        public static void LogDebug(string details)
+        {
+            logger.LogDebug(details);
+        }
+
+        /// <summary>
+        /// Helper function used to evaluate an incoming httprequest and non-destructively log some information about it using a provided logger instance. When not
+        /// actually logging anything, this function is entirely passthrough.
+        /// </summary>
+        /// <param name="loggerInstance">Usually will be the DI-ed individual ILogger instance from a controller. However any valid ILogger instance is fine here.</param>
+        /// <param name="req">The http request which needs to be detailed.</param>
+        /// <returns></returns>
+        public static async Task LogRequestDetailsAsync(ILogger loggerInstance, HttpRequest req)
+        {
+            if(CheckLogLevel(LogLevel.Debug))
+            {
+                loggerInstance.LogDebug(await _generateLogLine(req));
+            }
+        }
+
+        /// <summary>
+        /// Helper function used to evaluate an incoming httprequest and non-destructively log some information about it using the non-DI logger instance. When not
+        /// actually logging anything, this function is entirely passthrough.
+        /// </summary>
+        /// <param name="req">The http request which needs to be detailed.</param>
+        /// <returns></returns>
+        public static async Task LogRequestDetailsAsync(HttpRequest req)
+        {
+            if (CheckLogLevel(LogLevel.Debug))
+            {
+                logger.LogDebug(await _generateLogLine(req));
+            }
+        }
+
+        /// <summary>
+        /// Generate a line of data from an http request. This is non-destructive, which means it does not mess 
+        /// with the request Body stream at all.
+        /// </summary>
+        /// <param name="req"></param>
+        /// <returns></returns>
+        private static async Task<string> _generateLogLine(HttpRequest req)
+        {
+            StringBuilder sb = new StringBuilder();
+            string headers = string.Empty;
+
+            using (MemoryStream ms = new MemoryStream())
+            {
+                await JsonSerializer.SerializeAsync(ms, req.Headers);
+                headers = Encoding.UTF8.GetString(ms.ToArray());
+            }
+
+            sb.AppendLine("URI: [ " + req.GetDisplayUrl() + "]");
+            sb.AppendLine("Headers: [" + headers + "]");
+
+            return sb.ToString();
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
@@ -43,7 +43,16 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// <returns></returns>
         public static bool CheckLogLevel(LogLevel level)
         {
-            return logger.IsEnabled(LogLevel.Debug);
+            var result = logger?.IsEnabled(LogLevel.Debug);
+
+            if (result.HasValue)
+            {
+                return result.Value;
+            }
+            else
+            {
+                return false;
+            }
         }
 
         /// <summary>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
@@ -44,7 +44,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 if(e is TestRecordingMismatchException)
                 {
                     response.Headers.Add("x-request-mismatch", "true");
-                    response.Headers.Add("x-request-mismatch-error", e.Message);
+                    // response.Headers.Add("x-request-mismatch-error", e.Message); need to encode this data.
                 }
                 
                 var bodyObj = new

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
@@ -44,7 +45,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 if(e is TestRecordingMismatchException)
                 {
                     response.Headers.Add("x-request-mismatch", "true");
-                    // response.Headers.Add("x-request-mismatch-error", e.Message); need to encode this data.
+                    response.Headers.Add("x-request-mismatch-error", Convert.ToBase64String(Encoding.UTF8.GetBytes(e.Message)));
                 }
                 
                 var bodyObj = new

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpRequestInteractions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpRequestInteractions.cs
@@ -29,15 +29,18 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             }
         }
 
-
         public static void LogDebugDetails(string details)
         {
-            logger.LogDebug(details);
+            logger.LogInformation("Information Log from within non-DI logging factory.");
+            logger.LogDebug("Debug Log from within non-DI logging factory.");
+            logger.LogTrace("Trace Log from within non-DI logging factory.");
         }
 
         public static void LogDebugDetails(ILogger loggerInstance, HttpRequest req)
         {
-            loggerInstance.LogDebug("Hello, World");
+            loggerInstance.LogInformation("Information Log from within DI logging factory.");
+            loggerInstance.LogDebug("Debug Log from within DI logging factory.");
+            loggerInstance.LogTrace("Trace Log from within DI logging factory.");
         }
         
         public static JsonProperty GetProp(string name, JsonElement jsonElement)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpRequestInteractions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpRequestInteractions.cs
@@ -17,32 +17,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 {
     public class HttpRequestInteractions
     {
-        /// Outside of DI, there is no way to use the default logging instances elsewhere in your classes.
-        /// Short of re-writing to nlog or serilog, the best way here is to have Startup.Configure() set this static setting
-        private static ILogger logger = null;
-
-        public static void ConfigureLogger(ILoggerFactory factory)
-        {
-            if(logger == null)
-            {
-                logger = factory.CreateLogger<HttpRequestInteractions>();
-            }
-        }
-
-        public static void LogDebugDetails(string details)
-        {
-            logger.LogInformation("Information Log from within non-DI logging factory.");
-            logger.LogDebug("Debug Log from within non-DI logging factory.");
-            logger.LogTrace("Trace Log from within non-DI logging factory.");
-        }
-
-        public static void LogDebugDetails(ILogger loggerInstance, HttpRequest req)
-        {
-            loggerInstance.LogInformation("Information Log from within DI logging factory.");
-            loggerInstance.LogDebug("Debug Log from within DI logging factory.");
-            loggerInstance.LogTrace("Trace Log from within DI logging factory.");
-        }
-        
         public static JsonProperty GetProp(string name, JsonElement jsonElement)
         {
             return jsonElement.EnumerateObject()

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpRequestInteractions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpRequestInteractions.cs
@@ -3,8 +3,8 @@
 
 using Azure.Core;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -17,7 +17,29 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 {
     public class HttpRequestInteractions
     {
+        /// Outside of DI, there is no way to use the default logging instances elsewhere in your classes.
+        /// Short of re-writing to nlog or serilog, the best way here is to have Startup.Configure() set this static setting
+        private static ILogger logger = null;
 
+        public static void ConfigureLogger(ILoggerFactory factory)
+        {
+            if(logger == null)
+            {
+                logger = factory.CreateLogger<HttpRequestInteractions>();
+            }
+        }
+
+
+        public static void LogDebugDetails(string details)
+        {
+            logger.LogDebug(details);
+        }
+
+        public static void LogDebugDetails(ILogger loggerInstance, HttpRequest req)
+        {
+            loggerInstance.LogDebug("Hello, World");
+        }
+        
         public static JsonProperty GetProp(string name, JsonElement jsonElement)
         {
             return jsonElement.EnumerateObject()

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
@@ -4,6 +4,7 @@
 using Azure.Sdk.Tools.TestProxy.Common;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
+using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -16,10 +17,15 @@ namespace Azure.Sdk.Tools.TestProxy
     [Route("[controller]/[action]")]
     public sealed class Record : ControllerBase
     {
+        private readonly ILogger _logger;
+
         private readonly RecordingHandler _recordingHandler;
-        public Record(RecordingHandler recordingHandler) => _recordingHandler = recordingHandler;
-
-
+        public Record(RecordingHandler recordingHandler, ILoggerFactory loggerFactory)
+        {
+            _recordingHandler = recordingHandler;
+            _logger = loggerFactory.CreateLogger<Record>();
+        }
+        
         private static readonly HttpClient s_client = Startup.Insecure ?
             new HttpClient(new HttpClientHandler() {  ServerCertificateCustomValidationCallback = (_, _, _, _) => true })
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -27,8 +27,6 @@ namespace Azure.Sdk.Tools.TestProxy
         public string CurrentBranch = "master";
         public string RepoPath;
 
-        ILogger _logger;
-
         public RecordingHandler(string targetDirectory)
         {
             RepoPath = targetDirectory;
@@ -131,6 +129,8 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public async Task HandleRecordRequest(string recordingId, HttpRequest incomingRequest, HttpResponse outgoingResponse, HttpClient client)
         {
+            await DebugLogger.LogRequestDetailsAsync(incomingRequest);
+
             if (!RecordingSessions.TryGetValue(recordingId, out var session))
             {
                 throw new HttpException(HttpStatusCode.BadRequest, $"There is no active recording session under id {recordingId}.");
@@ -328,6 +328,8 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public async Task HandlePlaybackRequest(string recordingId, HttpRequest incomingRequest, HttpResponse outgoingResponse)
         {
+            await DebugLogger.LogRequestDetailsAsync(incomingRequest);
+
             if (!PlaybackSessions.TryGetValue(recordingId, out var session))
             {
                 throw new HttpException(HttpStatusCode.BadRequest, $"There is no active playback session under recording id {recordingId}.");
@@ -465,6 +467,49 @@ namespace Azure.Sdk.Tools.TestProxy
             }
             else
             {
+                var countPlayback = PlaybackSessions.Count;
+                var countInMem = InMemorySessions.Count;
+                var countRecording = RecordingSessions.Count;
+                var countTotal = countPlayback + countInMem + countRecording;
+
+                if (countTotal > 0)
+                {
+                    StringBuilder sb = new StringBuilder();
+
+                    sb.Append($"There are a total of {countTotal} active sessions. Remove these sessions before hitting Admin/Reset." + Environment.NewLine);
+
+                    if(countPlayback > 0)
+                    {
+                        sb.Append("Active Playback Sessions: [");
+                        lock (PlaybackSessions)
+                        {
+                            sb.Append(string.Join(", ", PlaybackSessions.Keys.ToArray()));
+                        }
+                        sb.Append("]. ");
+                    }
+
+                    if (countInMem > 0)
+                    {
+                        sb.Append("Active InMem Sessions: [");
+                        lock (InMemorySessions)
+                        {
+                            sb.Append(string.Join(", ", InMemorySessions.Keys.ToArray()));
+                        }
+                        sb.Append("]. ");
+                    }
+
+                    if (countRecording > 0)
+                    {
+                        sb.Append($"{countRecording} Active Recording Sessions: [");
+                        lock (RecordingSessions)
+                        {
+                            sb.Append(string.Join(", ", RecordingSessions.Keys.ToArray()));
+                        }
+                        sb.Append("]. ");
+                    }
+
+                    throw new HttpException(HttpStatusCode.BadRequest, sb.ToString());               
+                }
                 Sanitizers = new List<RecordedTestSanitizer>
                 {
                     new RecordedTestSanitizer()

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -3,6 +3,7 @@ using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Primitives;
 using System;
 using System.Collections.Concurrent;
@@ -25,6 +26,8 @@ namespace Azure.Sdk.Tools.TestProxy
         #region constructor and common variables
         public string CurrentBranch = "master";
         public string RepoPath;
+
+        ILogger _logger;
 
         public RecordingHandler(string targetDirectory)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -73,7 +73,7 @@ namespace Azure.Sdk.Tools.TestProxy
             host.ConfigureWebHostDefaults(
                 builder => 
                     builder.UseStartup<Startup>()
-                    // ripped directly from implemenation of ConfigureWebDefaults@https://github.dev/dotnet/aspnetcore/blob/a779227cc2694a50b074a097889ed9e80d15cd77/src/DefaultBuilder/src/WebHost.cs#L176
+                    // ripped directly from implementation of ConfigureWebDefaults@https://github.dev/dotnet/aspnetcore/blob/a779227cc2694a50b074a097889ed9e80d15cd77/src/DefaultBuilder/src/WebHost.cs#L176
                     .ConfigureLogging((hostBuilder, loggingBuilder) =>
                     {
                         loggingBuilder.ClearProviders();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -78,7 +78,10 @@ namespace Azure.Sdk.Tools.TestProxy
                     {
                         loggingBuilder.ClearProviders();
                         loggingBuilder.AddConfiguration(hostBuilder.Configuration.GetSection("Logging"));
-                        loggingBuilder.AddConsole();
+                        loggingBuilder.AddSimpleConsole(options =>
+                        {
+                            options.TimestampFormat = "[HH:mm:ss] ";
+                        });
                         loggingBuilder.AddDebug();
                         loggingBuilder.AddEventSourceLogger();
                     })
@@ -122,7 +125,7 @@ namespace Azure.Sdk.Tools.TestProxy
             app.UseCors("DefaultPolicy");
             app.UseMiddleware<HttpExceptionMiddleware>();
 
-            HttpRequestInteractions.ConfigureLogger(loggerFactory);
+            DebugLogger.ConfigureLogger(loggerFactory);
 
             MapRecording(app);
             app.UseRouting();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/appsettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Debug",
+      "Default": "Information",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/appsettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/appsettings.json
@@ -1,7 +1,7 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Information",
+      "Default": "Debug",
       "Microsoft": "Warning",
       "Microsoft.Hosting.Lifetime": "Information"
     }


### PR DESCRIPTION
## Description

This PR enables verbose logging of requests. 
- Uri/Headers for all requests (including during record/playback)
- Also dumps request bodies for parsable JSON running through the Admin controller.

As I've been digging through these "parallization" errors, A lot of the time I'm not finding real bugs, so much as test orchestration bugs. EG `python` firing admin/reset during test run, `go` doing the same.

### Features

- To enable deeper logging in CI, set build time variable `Logging__LogLevel__Default`=`Debug`
  - This works the same way locally `set Logging__LogLevel__Default=Debug`
- Makes it a hard error the Admin/Reset when there are playback or recording sessions in progress.

TODO:
- [x] Handle error content in header. We want to ensure no non-ascii characters are there and add the test mismatch error back into it
- [x]  ~~Test-proxy-docker should pull in above build time variable if it's present. we need to pass it as an additional argument to `docker run`~~ That will be an eng/common update. I'll do that when I bump the proxy version for this PR.