### PR TITLE
Check whether there is package json files

### DIFF
--- a/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+++ b/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
@@ -88,6 +88,7 @@ steps:
 - pwsh: |
     $packageInfoJson = '${{ convertToJson(parameters.PackageInfoLocations) }}'.Trim('"').Replace("\\", "/")
     $packageInfoLocations = ConvertFrom-Json $packageInfoJson
+    if ($packageInfoLocations) {
     ${{ parameters.ScriptDirectory }}/Update-DocsMsMetadata.ps1 `
       -PackageInfoJsonLocations $packageInfoLocations `
       -DocRepoLocation "$(DocRepoLocation)" `
@@ -98,6 +99,7 @@ steps:
       -TenantId '$(opensource-aad-tenant-id)' `
       -ClientId '$(opensource-aad-app-id)' `
       -ClientSecret '$(opensource-aad-secret)' 
+    }
   displayName: Apply Documentation Updates
 
 - template: /eng/common/pipelines/templates/steps/git-push-changes.yml


### PR DESCRIPTION
The PR is to fix https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1348504&view=results

We skip docsms for spring packages, which make package json variable is empty json.

Add check to fix the failure.

Testing pipeline:https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1349849&view=results