### PR TITLE
Print example docker commands after building stress image

### DIFF
--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -169,6 +169,15 @@ function DeployStressPackage(
 
         Run docker build -t $imageTag -f $dockerFile $dockerBuildFolder
         if ($LASTEXITCODE) { return }
+
+        Write-Host "`nContainer image '$imageTag' successfully built. To run commands on the container locally:" -ForegroundColor Blue
+        Write-Host "  docker run -it $imageTag" -ForegroundColor DarkBlue
+        Write-Host "  docker run -it $imageTag <shell, e.g. 'bash' 'pwsh' 'sh'>" -ForegroundColor DarkBlue
+        Write-Host "To show installed container images:" -ForegroundColor Blue
+        Write-Host "  docker image ls" -ForegroundColor DarkBlue
+        Write-Host "To show running containers:" -ForegroundColor Blue
+        Write-Host "  docker ps" -ForegroundColor DarkBlue
+
         Run docker push $imageTag
         if ($LASTEXITCODE) {
             if ($login) {


### PR DESCRIPTION
Example output:

```
...
--> ebc92fc6db6
Successfully tagged stresstesttbiruti6oi24k.azurecr.io/ben/network-example:local
ebc92fc6db6a01318bb59c8bf8ab2eb8ca185e20e0fe06ac409bde4fca6fbc4c

Container image 'stresstesttbiruti6oi24k.azurecr.io/ben/network-example:local' successfully built. To run commands on the container locally:
  docker run -it stresstesttbiruti6oi24k.azurecr.io/ben/network-example:local
  docker run -it stresstesttbiruti6oi24k.azurecr.io/ben/network-example:local <shell, e.g. 'bash' 'pwsh' 'sh'>
To show installed container images:
  docker image ls
To show running containers:
  docker ps
```