### PR TITLE
Preprocess the target branch + Add checks on delete/rename files

### DIFF
--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -7,8 +7,9 @@ parameters:
 steps:
 - pwsh: |
     if ("$(Build.Reason)" -eq 'PullRequest') {
-      (git diff "origin/$(System.PullRequest.TargetBranch)" HEAD --name-only)
-      | ForEach-Object { Add-Content -Path "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$_"}
+      $targetBranch = "origin/$(System.PullRequest.TargetBranch)" -replace "/refs/heads/"
+      $changedFiles = git diff $targetBranch HEAD --name-only --diff-filter=d
+      $changedFiles | ForEach-Object { Add-Content -Path "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$_"}
     }
     else {
       Set-Content "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/sdk/${{ parameters.ServiceDirectory }}"


### PR DESCRIPTION
Failures: 
https://dev.azure.com/azure-sdk/public/_build/results?buildId=1356766&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca&t=a6c890d8-b83f-504d-afc5-f7ec178ffaaf
https://dev.azure.com/azure-sdk/public/_build/results?buildId=1356945&view=logs&jobId=bc67675d-56bf-581f-e0a2-208848ba68ca&j=bc67675d-56bf-581f-e0a2-208848ba68ca&t=27a9db8a-8f0c-5ed5-0322-7c4d0e71b2e0

Reason: The targetbranch returns `refs/heads/main` instead of `main`. + Exclude the delete files and the renamed files.

Fix: Trim the 'refs/heads' and make the target branch as parameters.
Add common scripts for all changed files.

Testing pipelines: 
(Passed)~~https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1357479&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca~~
(Passed)~~https://dev.azure.com/azure-sdk/public/_build/results?buildId=1357485&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca&t=58109539-7962-5216-67ea-44a5e0baca32~~
https://dev.azure.com/azure-sdk/public/_build/results?buildId=1357518&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca