### PR TITLE
Generate weekly unified pipelines. Make variant naming consistent

### DIFF
--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -147,7 +147,7 @@ jobs:
     env:
       PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
   - script: |
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator --organization https://dev.azure.com/azure-sdk --project internal --prefix $(Prefix) --path $(Pipeline.Workspace)/$(RepositoryName)/sdk --endpoint Azure --repository Azure/$(RepositoryName) --convention weekly --agentpool Hosted --branch refs/heads/$(DefaultBranch) --patvar PATVAR --debug $(TestOptions)
+      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator --organization https://dev.azure.com/azure-sdk --project internal --prefix $(Prefix) --path $(Pipeline.Workspace)/$(RepositoryName)/sdk --endpoint Azure --repository Azure/$(RepositoryName) --convention testsweekly --agentpool Hosted --branch refs/heads/$(DefaultBranch) --patvar PATVAR --debug $(TestOptions)
     displayName: 'Generate weekly test pipelines (multi-cloud) for: $(RepositoryName)'
     condition: and(succeeded(), ne(variables['TestOptions'],''))
     env:

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -121,6 +121,7 @@ jobs:
           --variablegroup ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           --variablegroup ${{ parameters.APIReview_AutoCreate_Configurations }}
           --variablegroup ${{ parameters.Secrets_for_Resource_Provisioner }}
+        GenerateUnifiedWeekly: true
   steps:
   - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
   - script: |
@@ -149,6 +150,12 @@ jobs:
       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator --organization https://dev.azure.com/azure-sdk --project internal --prefix $(Prefix) --path $(Pipeline.Workspace)/$(RepositoryName)/sdk --endpoint Azure --repository Azure/$(RepositoryName) --convention weekly --agentpool Hosted --branch refs/heads/$(DefaultBranch) --patvar PATVAR --debug $(TestOptions)
     displayName: 'Generate weekly test pipelines (multi-cloud) for: $(RepositoryName)'
     condition: and(succeeded(), ne(variables['TestOptions'],''))
+    env:
+      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+  - script: |
+      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator --organization https://dev.azure.com/azure-sdk --project internal --prefix $(Prefix) --path $(Pipeline.Workspace)/$(RepositoryName)/sdk --endpoint Azure --repository Azure/$(RepositoryName) --convention upweekly --agentpool Hosted --branch refs/heads/$(DefaultBranch) --patvar PATVAR --debug $(InternalOptions) $(TestOptions)
+    displayName: 'Generate weekly unified test pipelines (multi-cloud) for: $(RepositoryName)'
+    condition: and(succeeded(), ne(variables['GenerateUnifiedWeekly'],''))
     env:
       PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
@@ -18,7 +18,10 @@ namespace PipelineGenerator.Conventions
 
         public override string GetDefinitionName(SdkComponent component)
         {
-            return component.Variant == null ? $"{Context.Prefix} - {component.Name} - tests" : $"{Context.Prefix} - {component.Name} - tests.{component.Variant}";
+            var baseName = component.Variant == null
+                            ? $"{Context.Prefix} - {component.Name}"
+                            : $"{Context.Prefix} - {component.Name} - {component.Variant}";
+            return baseName + " - tests";
         }
 
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/IntegrationTestingPipelineConvention.cs
@@ -10,19 +10,12 @@ namespace PipelineGenerator.Conventions
 {
     public class IntegrationTestingPipelineConvention : PipelineConvention
     {
-        public override string SearchPattern => "tests.yml";
-
         public IntegrationTestingPipelineConvention(ILogger logger, PipelineGenerationContext context) : base(logger, context)
         {
         }
 
-        public override string GetDefinitionName(SdkComponent component)
-        {
-            var baseName = component.Variant == null
-                            ? $"{Context.Prefix} - {component.Name}"
-                            : $"{Context.Prefix} - {component.Name} - {component.Variant}";
-            return baseName + " - tests";
-        }
+        public override string SearchPattern => "tests.yml";
+        public override string PipelineNameSuffix => " - tests";
 
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)
         {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -19,14 +19,21 @@ namespace PipelineGenerator.Conventions
         }
 
         private const string ReportBuildStatusKey = "reportBuildStatus";
+
         private Dictionary<string, BuildDefinitionReference> pipelineReferences;
 
         protected ILogger Logger { get; }
         protected PipelineGenerationContext Context { get; }
-
         public abstract string SearchPattern { get; }
+        public abstract string PipelineNameSuffix { get; }
 
-        public abstract string GetDefinitionName(SdkComponent component);
+        public string GetDefinitionName(SdkComponent component)
+        {
+            var baseName = component.Variant == null
+                            ? $"{Context.Prefix} - {component.Name}"
+                            : $"{Context.Prefix} - {component.Name} - {component.Variant}";
+            return baseName + PipelineNameSuffix;
+        }
 
         public async Task<BuildDefinition> DeleteDefinitionAsync(SdkComponent component, CancellationToken cancellationToken)
         {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
@@ -14,15 +14,8 @@ namespace PipelineGenerator.Conventions
         {
         }
 
-        public override string GetDefinitionName(SdkComponent component)
-        {
-            var baseName = component.Variant == null
-                            ? $"{Context.Prefix} - {component.Name}"
-                            : $"{Context.Prefix} - {component.Name} - {component.Variant}";
-            return baseName + " - ci";
-        }
-
         public override string SearchPattern => "ci.yml";
+        public override string PipelineNameSuffix => " - ci";
 
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)
         {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PullRequestValidationPipelineConvention.cs
@@ -16,7 +16,10 @@ namespace PipelineGenerator.Conventions
 
         public override string GetDefinitionName(SdkComponent component)
         {
-            return component.Variant == null ? $"{Context.Prefix} - {component.Name} - ci" : $"{Context.Prefix} - {component.Name} - ci.{component.Variant}";
+            var baseName = component.Variant == null
+                            ? $"{Context.Prefix} - {component.Name}"
+                            : $"{Context.Prefix} - {component.Name} - {component.Variant}";
+            return baseName + " - ci";
         }
 
         public override string SearchPattern => "ci.yml";

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/UnifiedPipelineConvention.cs
@@ -14,12 +14,8 @@ namespace PipelineGenerator.Conventions
         {
         }
 
-        public override string GetDefinitionName(SdkComponent component)
-        {
-            return component.Variant == null ? $"{Context.Prefix} - {component.Name}" : $"{Context.Prefix} - {component.Name} - {component.Variant}";
-        }
-
         public override string SearchPattern => "ci.yml";
+        public override string PipelineNameSuffix => "";
 
         protected override async Task<bool> ApplyConventionAsync(BuildDefinition definition, SdkComponent component)
         {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
@@ -9,14 +9,7 @@ namespace PipelineGenerator.Conventions
         {
         }
 
-        public override string GetDefinitionName(SdkComponent component)
-        {
-
-            var baseName = component.Variant == null
-                            ? $"{Context.Prefix} - {component.Name}"
-                            : $"{Context.Prefix} - {component.Name} - {component.Variant}";
-            return baseName + " - tests-weekly";
-        }
+        public override string PipelineNameSuffix => " - tests-weekly";
 
         protected override Schedule CreateScheduleFromDefinition(BuildDefinition definition)
         {

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyIntegrationTestingPipelineConvention.cs
@@ -11,11 +11,11 @@ namespace PipelineGenerator.Conventions
 
         public override string GetDefinitionName(SdkComponent component)
         {
-            var definitionName = $"{Context.Prefix} - {component.Name} - tests-weekly";
-            if (component.Variant != null) {
-                definitionName += $".{component.Variant}";
-            }
-            return definitionName;
+
+            var baseName = component.Variant == null
+                            ? $"{Context.Prefix} - {component.Name}"
+                            : $"{Context.Prefix} - {component.Name} - {component.Variant}";
+            return baseName + " - tests-weekly";
         }
 
         protected override Schedule CreateScheduleFromDefinition(BuildDefinition definition)

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyUnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyUnifiedPipelineConvention.cs
@@ -1,0 +1,27 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace PipelineGenerator.Conventions
+{
+    public class WeeklyUnifiedPipelineConvention : WeeklyIntegrationTestingPipelineConvention
+    {
+        public WeeklyUnifiedPipelineConvention(ILogger logger, PipelineGenerationContext context) : base(logger, context)
+        {
+        }
+
+        public override string GetDefinitionName(SdkComponent component)
+        {
+            var baseName = component.Variant == null
+                            ? $"{Context.Prefix} - {component.Name}"
+                            : $"{Context.Prefix} - {component.Name} - {component.Variant}";
+            return baseName + " - weekly";
+        }
+
+        public override string SearchPattern => "ci.yml";
+    }
+}

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyUnifiedPipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/WeeklyUnifiedPipelineConvention.cs
@@ -14,14 +14,7 @@ namespace PipelineGenerator.Conventions
         {
         }
 
-        public override string GetDefinitionName(SdkComponent component)
-        {
-            var baseName = component.Variant == null
-                            ? $"{Context.Prefix} - {component.Name}"
-                            : $"{Context.Prefix} - {component.Name} - {component.Variant}";
-            return baseName + " - weekly";
-        }
-
         public override string SearchPattern => "ci.yml";
+        public override string PipelineNameSuffix => " - weekly";
     }
 }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
@@ -119,6 +119,10 @@ namespace PipelineGenerator
                     var upLogger = serviceProvider.GetService<ILogger<UnifiedPipelineConvention>>();
                     return new UnifiedPipelineConvention(upLogger, context);
 
+                case "upweekly":
+                    var upWeeklyTestLogger = serviceProvider.GetService<ILogger<WeeklyUnifiedPipelineConvention>>();
+                    return new WeeklyUnifiedPipelineConvention(upWeeklyTestLogger, context);
+
                 case "tests":
                     var testLogger = serviceProvider.GetService<ILogger<IntegrationTestingPipelineConvention>>();
                     return new IntegrationTestingPipelineConvention(testLogger, context);

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
@@ -127,7 +127,7 @@ namespace PipelineGenerator
                     var testLogger = serviceProvider.GetService<ILogger<IntegrationTestingPipelineConvention>>();
                     return new IntegrationTestingPipelineConvention(testLogger, context);
 
-                case "weekly":
+                case "testsweekly":
                     var weeklyTestLogger = serviceProvider.GetService<ILogger<WeeklyIntegrationTestingPipelineConvention>>();
                     return new WeeklyIntegrationTestingPipelineConvention(weeklyTestLogger, context);
 


### PR DESCRIPTION
This updates the pipeline generator tool to be able to generate weekly pipelines for repositories using a unified pipeline model (i.e. ci.yml runs both CI and live tests).

This also makes the pipeline variant naming consistent.

Before:
- ci - `lang - service - variant`
- pr - `lang - service - ci.variant`
- live tests - `lang - service - tests.variant`
- live tests weekly - `lang - service - tests-weekly.variant`

After:
- ci/unified - `lang - service - variant`
- weekly unified - `lang - service - variant - weekly`
- pr - `lang - service - variant - ci`
- live tests - `lang - service - variant - tests`
- live tests weekly - `lang - service - variant - tests-weekly`

Resolves #2678 