### PR TITLE
Adding another item to logging, extending devops docs

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
@@ -56,6 +56,16 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         }
 
         /// <summary>
+        /// Simple access to the logging api. Accepts a simple message (preformatted) and logs to information logger.
+        /// </summary>
+        /// <param name="details">The content which should be logged.</param>
+        public static void LogInformation(string details)
+        {
+            logger.LogInformation(details);
+        }
+
+
+        /// <summary>
         /// Simple access to the logging api. Accepts a simple message (preformatted) and logs to debug logger.
         /// </summary>
         /// <param name="details">The content which should be logged.</param>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
@@ -54,6 +54,8 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                     Status = e.StatusCode.ToString()
                 };
 
+                DebugLogger.LogDebug(e.Message);
+
                 var body = JsonSerializer.Serialize(bodyObj);
                 await context.Response.WriteAsync(body);
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
@@ -54,7 +54,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                     Status = e.StatusCode.ToString()
                 };
 
-                DebugLogger.LogDebug(e.Message);
+                DebugLogger.LogInformation(e.Message);
 
                 var body = JsonSerializer.Serialize(bodyObj);
                 await context.Response.WriteAsync(body);

--- a/tools/test-proxy/documentation/using-in-devops.md
+++ b/tools/test-proxy/documentation/using-in-devops.md
@@ -8,13 +8,11 @@ Check out [tools/test-proxy/startup-scripts/](../startup-scripts/) for a few exa
 
 ## Adding to Your Devops Build
 
-### With Docker
-
-Test-proxy has been shipped within the `eng/common/testproxy` folder for any repo owned by the azure-sdk team.
+Test-proxy has been shipped within the `eng/common/testproxy` folder for any repo owned by the azure-sdk team. All boilerplate/integration code is present within.
 
 Important Files:
 
-```
+```text
 eng/common/testproxy/
   dotnet-devcert.crt
   dotnet-devcert.pfx
@@ -28,12 +26,20 @@ A couple notes about the above:
 - `dotnet-devcert.crt` is NOT DER encoded. This means if you need a `pem` file, you can just rename it. No binary to deal with.
 - `dotnet-devcert.pfx` can be imported with password `password` (this fact is also highlighted in [trusting-cert-per-language.md](trusting-cert-per-language.md))
 - `docker-start-proxy.ps1`: This can also be used locally to start and stop a singular instance of the test-proxy docker image.
-- `test-proxy-tool.yml`: This one installs and runs the test-proxy as a dotnet tool.
-- `test-proxy-docker.yml`: This yml pulls down the relevant docker image and runs _that_ instead of directly running the tool.
+- `test-proxy-tool.yml`: This template installs and runs the test-proxy as a dotnet tool.
+- `test-proxy-docker.yml`: This template pulls down the relevant docker image and runs _that_ instead of directly running the tool.
 
 Note that both `.yml` files can be used to start the proxy. It is up to the user to determine which methodology they wish to use. It is recommended that one uses the same method as they would recommend to the team for local testing.
 
-### SSL Support In Devops
+Examples of Proxy Invocations in a few languages:
+
+- [JS](https://github.com/Azure/azure-sdk-for-js/blob/main/eng/pipelines/templates/steps/test.yml#L30)
+- [Python](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/pipelines/templates/steps/build-test.yml#L42)
+- [Go](https://github.com/Azure/azure-sdk-for-go/blob/main/eng/pipelines/templates/steps/build-test.yml#L47)
+
+Also note that azure devops does NOT support `docker` on Mac agents. This means that installing and running the .NET tool using `test-proxy-tool.yml` is essential if recorded tests are expected to run on Mac agents.
+
+## SSL Support In Devops
 
 When running on DevOps, it is unlikely that the certificate will be trusted appropriately to ensure SSL during playback. Both the yml files provided in `eng/common/testproxy/` are intended to easily support this however.
 
@@ -52,3 +58,14 @@ If you're a bit confused as to what is meant by `<lowercase-language>`, refer to
 A bunch of the "common" functions are defined and called this way.
 
 This function will be _automatically picked up_ during all your builds once it's merged! How? Check in [eng/common/scripts/trust-proxy-certificate.ps1](../../../eng/common/scripts/trust-proxy-certificate.ps1) if you wish to understand.
+
+## Error Investigations
+
+When diagnosing failures that "only occur in CI" or on platforms where there is no way to get an actual debugging session, leverage the `debug` logging level. To take advantage of this in CI, create a build variable when queuing your build.
+
+![image](https://user-images.githubusercontent.com/45376673/153307363-521d271c-980e-425b-876a-212fb1e5e7a3.png)
+
+- Name: `Default__Logging__LogLevel`
+- Value: `Debug` (or any value from [the .NET LogLevel Enum](https://docs.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loglevel?view=dotnet-plat-ext-6.0))
+
+![image](https://user-images.githubusercontent.com/45376673/153307105-28ce55eb-73f6-47d7-b181-eaf189b3bfdc.png)


### PR DESCRIPTION
Ended up needing the additional TestMismatch logging if a client doesn't report the mismatch error in CLI output.