### PR TITLE
Make the temp docs repo as parameters

### DIFF
--- a/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+++ b/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
@@ -32,11 +32,14 @@ parameters:
   - name: DocValidationImageId
     type: string
     default: ''
+  - name: DocRepoLocation
+    type: string
+    default: 'docs'
 steps:
 - template: /eng/common/pipelines/templates/steps/enable-long-path-support.yml
 
 - pwsh: |
-    Write-Host "###vso[task.setvariable variable=DocRepoLocation]${{ parameters.WorkingDirectory }}/doc"
+    Write-Host "###vso[task.setvariable variable=DocRepoLocation]${{ parameters.WorkingDirectory }}/${{ parameters.DocRepoLocation }}"
   displayName: Set $(DocRepoLocation)
 
 - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml


### PR DESCRIPTION
This is to fix the failure pipeline:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1356364&view=results

Reason: Both azure-sdk-for-java and docs repo are under `System.DefaultWorkingDirectory`. Java recently checked in the folder named `doc` which is the same as docs repo `doc`. That's why sparse-checkout do not initialize the repo in empty folder anymore.
https://github.com/Azure/azure-sdk-for-java/tree/main/doc

Fix: Use some other docs repo name, and make it as parameter for different lang repo