### PR TITLE
Change credscan to use v3 and enable scan entire repo

### DIFF
--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -13,7 +13,7 @@ steps:
     }
     else {
       $scanFolder = ""
-      if (${{parameters.ServiceDirectory}}) {
+      if ("${{ parameters.ServiceDirectory }}" -ne '') {
         $scanFolder = sdk/${{ parameters.ServiceDirectory }}
       }
       Set-Content "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$scanFolder"

--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -12,15 +12,17 @@ steps:
       $changedFiles | ForEach-Object { Add-Content -Path "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$_"}
     }
     else {
-      Set-Content "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/sdk/${{ parameters.ServiceDirectory }}"
+      $scanFolder = ""
+      if (${{parameters.ServiceDirectory}}) {
+        $scanFolder = sdk/${{ parameters.ServiceDirectory }}
+      }
+      Set-Content "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$scanFolder"
     }
     Get-Content "${{ parameters.SourceDirectory }}/credscan.tsv"
   displayName: CredScan setup
-- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@2
+- task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
   displayName: CredScan running
   inputs:
-    toolMajorVersion: V2
-    toolVersion: latest
     scanFolder: "${{ parameters.SourceDirectory }}/credscan.tsv"
     suppressionsFile: ${{ parameters.SuppressionFilePath }}
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2

--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -14,7 +14,7 @@ steps:
     else {
       $scanFolder = ""
       if ("${{ parameters.ServiceDirectory }}" -ne '') {
-        $scanFolder = sdk/${{ parameters.ServiceDirectory }}
+        $scanFolder = "sdk/${{ parameters.ServiceDirectory }}"
       }
       Set-Content "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$scanFolder"
     }


### PR DESCRIPTION
The PR is to fix the version issue. 
Aggregate-report currently using V3 which reports less errors than v2.
We clean up the errors based v3 instead of v2. 
We will use V3 for all pipelines as aggregate-report runs into OOM issue using v2.
Also, make changes to support the entire repo scanning.
