### PR TITLE
Disable the config of encoding path in git

### DIFF
--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -12,7 +12,7 @@ steps:
       # Add config of disable the quote and encoding on unix path. 
       # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-quoted-file-names
       # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-commit-message-transcoding
-      $changedFiles = git diff -c core.quotepath=off -c i18n.logoutputencoding=utf-8 $targetBranch HEAD --name-only --diff-filter=d
+      $changedFiles = git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff origin/main HEAD --name-only --diff-filter=d
       $changedFiles | ForEach-Object { Add-Content -Path "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$_"}
     }
     else {

--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -9,7 +9,7 @@ steps:
     if ("$(Build.Reason)" -eq 'PullRequest') {
       $targetBranch = "origin/$(System.PullRequest.TargetBranch)" -replace "refs/heads/"
 
-      # Add config of disable the quote and encoding on unix path. 
+      # Add config to disable the quote and encoding on file name. 
       # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-quoted-file-names
       # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-commit-message-transcoding
       $changedFiles = git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff origin/main HEAD --name-only --diff-filter=d

--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -12,7 +12,7 @@ steps:
       # Disable the unix path encoding.
       git config --unset i18n.logoutputencoding
 
-      $changedFiles = git diff $targetBranch HEAD --name-only --diff-filter=d
+      $changedFiles = git diff -c core.quotepath=off -c i18n.logoutputencoding=utf-8 $targetBranch HEAD --name-only --diff-filter=d
       $changedFiles | ForEach-Object { Add-Content -Path "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$_"}
     }
     else {

--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -8,10 +8,10 @@ steps:
 - pwsh: |
     if ("$(Build.Reason)" -eq 'PullRequest') {
       $targetBranch = "origin/$(System.PullRequest.TargetBranch)" -replace "refs/heads/"
-      git config core.quotepath off
-      # Disable the unix path encoding.
-      git config --unset i18n.logoutputencoding
 
+      # Add config of disable the quote and encoding on unix path. 
+      # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-quoted-file-names
+      # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-commit-message-transcoding
       $changedFiles = git diff -c core.quotepath=off -c i18n.logoutputencoding=utf-8 $targetBranch HEAD --name-only --diff-filter=d
       $changedFiles | ForEach-Object { Add-Content -Path "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$_"}
     }

--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -12,7 +12,7 @@ steps:
       # Add config to disable the quote and encoding on file name. 
       # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-quoted-file-names
       # Ref: https://github.com/msysgit/msysgit/wiki/Git-for-Windows-Unicode-Support#disable-commit-message-transcoding
-      $changedFiles = git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff origin/main HEAD --name-only --diff-filter=d
+      $changedFiles = git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff $targetBranch HEAD --name-only --diff-filter=d
       $changedFiles | ForEach-Object { Add-Content -Path "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$_"}
     }
     else {

--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -8,6 +8,10 @@ steps:
 - pwsh: |
     if ("$(Build.Reason)" -eq 'PullRequest') {
       $targetBranch = "origin/$(System.PullRequest.TargetBranch)" -replace "refs/heads/"
+      git config core.quotepath off
+      # Disable the unix path encoding.
+      git config --unset i18n.logoutputencoding
+
       $changedFiles = git diff $targetBranch HEAD --name-only --diff-filter=d
       $changedFiles | ForEach-Object { Add-Content -Path "${{ parameters.SourceDirectory }}/credscan.tsv" -Value "${{ parameters.SourceDirectory }}/$_"}
     }


### PR DESCRIPTION
The PR is to fix: https://dev.azure.com/azure-sdk/public/_build/results?buildId=1363756&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca&t=27a9db8a-8f0c-5ed5-0322-7c4d0e71b2e0

If the path contains special char, we scan the parent folder instead of the path

Testing pipeline:https://dev.azure.com/azure-sdk/public/_build/results?buildId=1369441&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76
command config
https://dev.azure.com/azure-sdk/public/_build/results?buildId=1369513&view=logs&s=6884a131-87da-5381-61f3-d7acc3b91d76