### PR TITLE
[Test-Proxy] Add content length to ignored headers

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -62,7 +62,8 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             "sec-ch-ua-platform",
             "Referrer",
             "Referer",
-            "Origin"
+            "Origin",
+            "Content-Length"
         };
 
         /// <summary>


### PR DESCRIPTION
- We always compare body content if matching against the body. `Content-Length` header is almost immaterial given that.
- If we _don't_ compare body (aka `bodilessmatcher`) then the value of Content-Length doesn't matter anyway

In cases where the Content-Length values don't align (specifically due to bugfixes in test-proxy), it will likely be a test failure, when the Content-Length doesn't actually matter. This most recent proxy release stopped sanitizing binary content. This means that we have a bunch of content that's been sanitized differently in such a way that playback of tests won't fail, but the _matching_ now fails because the Content-Length doesn't align.

We obviously don't want to have this happen often, but we'll future-proof just in case.