### PR TITLE
Move Set-StrictMode to run after PSModule-Helpers.ps1 operations

### DIFF
--- a/eng/common/scripts/Update-DocsMsToc.ps1
+++ b/eng/common/scripts/Update-DocsMsToc.ps1
@@ -38,11 +38,12 @@ param(
   [Parameter(Mandatory = $true)]
   [string] $OutputLocation
 )
-Set-StrictMode -Version 3
 . $PSScriptRoot/common.ps1
 . $PSScriptRoot/Helpers/PSModule-Helpers.ps1
 
 Install-ModuleIfNotInstalled "powershell-yaml" "0.4.1" | Import-Module
+
+Set-StrictMode -Version 3
 
 function GetClientPackageNode($clientPackage) {
   $packageInfo = &$GetDocsMsTocDataFn `


### PR DESCRIPTION
Move Set-StrictMode to run after PSModule-Helpers.ps1 operations which violate strict mode and cause a falure as in https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1389880&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739&t=61cf404c-fb38-582c-ffd7-16eb9e7ec7ac&l=97

Successful run after moving Set-StrictMode -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1390051&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739&t=61cf404c-fb38-582c-ffd7-16eb9e7ec7ac

@benbp -- PTAL 