### PR TITLE
Enable API change detection for track2 management package

### DIFF
--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -60,7 +60,7 @@ function Should-Process-Package($pkgPath, $packageName)
     # Get package info from json file created before updating version to daily dev
     $pkgInfo = Get-Content $pkgPropPath | ConvertFrom-Json
     Write-Host "SDK Type: $($pkgInfo.SdkType)"
-    return ($pkgInfo.SdkType -eq "client" -and $pkgInfo.IsNewSdk)
+    return $pkgInfo.IsNewSdk
 }
 
 function Log-Input-Params()


### PR DESCRIPTION
API change detection currently works only for dataplane packages. This PR is to enable API change detection for track2 management plane also.