### PR TITLE
Clean up Test-Proxy docker update. Bugfix for docker tag name

### DIFF
--- a/eng/containers/ci.yml
+++ b/eng/containers/ci.yml
@@ -29,7 +29,6 @@ trigger:
   paths:
     include:
     - eng/containers/
-    - tools/test-proxy/docker/
     - tools/keyvault-mock-attestation/Dockerfile
     - tools/stress-cluster/services/Stress.Watcher/
     - tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/
@@ -41,7 +40,6 @@ pr:
   paths:
     include:
     - eng/containers/
-    - tools/test-proxy/docker/
     - tools/keyvault-mock-attestation/Dockerfile
     - tools/stress-cluster/services/Stress.Watcher/
     - tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -26,7 +26,7 @@ extends:
   parameters:
     ToolDirectory: tools/test-proxy
     DotNetCoreVersion: "6.x"
-    DockerTagPrefix: '1.0.0-dev'
+    DockerTagPrefix: '1.0.0-dev.'
     DockerDeployments:
     - name: test_proxy_linux
       pool: 'ubuntu-20.04'


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/45376673/155627977-c164119f-f72a-4422-986e-ccc315150dda.png)

This needed to have a period in the name. Like the nuget package: `1.0.0-dev.20220210.1`

