### PR TITLE
Fix azuresdkpartnerdrops-to-nugetfeed.yml parameters

### DIFF
--- a/eng/pipelines/azuresdkpartnerdrops-to-devops.yml
+++ b/eng/pipelines/azuresdkpartnerdrops-to-devops.yml
@@ -2,6 +2,12 @@ parameters:
 - name: PartnerDropsBlobSourceSuffix
   type: string
   default: ''
+- name: ShouldSign
+  type: string
+  default: true
+- name: ShouldPublish
+  type: string
+  default: true
 - name: DevOpsFeedID
   type: string
   # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
@@ -12,3 +18,5 @@ extends:
   parameters:
     DevOpsFeedID: ${{ parameters.DevOpsFeedID }}
     PartnerDropsBlobSourceSuffix: ${{ parameters.PartnerDropsBlobSourceSuffix }}
+    ShouldSign: ${{ parameters.ShouldSign }}
+    ShouldPublish: ${{ parameters.ShouldPublish }}

--- a/eng/pipelines/azuresdkpartnerdrops-to-nuget.yml
+++ b/eng/pipelines/azuresdkpartnerdrops-to-nuget.yml
@@ -2,8 +2,16 @@ parameters:
 - name: PartnerDropsBlobSourceSuffix
   type: string
   default: ''
+- name: ShouldSign
+  type: string
+  default: true
+- name: ShouldPublish
+  type: string
+  default: true
 
 extends:
   template: /eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
   parameters:
     PartnerDropsBlobSourceSuffix: ${{ parameters.PartnerDropsBlobSourceSuffix }}
+    ShouldSign: ${{ parameters.ShouldSign }}
+    ShouldPublish: ${{ parameters.ShouldPublish }}

--- a/eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
+++ b/eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
@@ -67,7 +67,7 @@ jobs:
           AZCOPY_SPA_CLIENT_SECRET: $(azuresdkpartnerdrops-service-principal-key)
         condition: and(succeeded(), ne(variables['SkipCopyFromPartnerDrops'], 'true'))
 
-      - ${{ if eq(parameters.ShouldSign, 'true') }}:
+      - ${{ if eq(parameters.ShouldSign, true) }}:
         - template: pipelines/steps/net-signing.yml@azure-sdk-build-tools
           parameters:
             PackagesPath: ${{ parameters.ArtifactsPath }}

--- a/eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
+++ b/eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
@@ -37,6 +37,12 @@ parameters:
   - name: PartnerDropsBlobDestPrefix
     type: string
     default: '$(Release.DefinitionName)\$(Release.ReleaseId)-$(Release.AttemptNumber)'
+  - name: ShouldSign
+    type: boolean
+    default: true
+  - name: ShouldPublish
+    type: boolean
+    default: true
 
 jobs:
   - job: AzurePartnerDropsToNuget
@@ -61,53 +67,52 @@ jobs:
           AZCOPY_SPA_CLIENT_SECRET: $(azuresdkpartnerdrops-service-principal-key)
         condition: and(succeeded(), ne(variables['SkipCopyFromPartnerDrops'], 'true'))
 
-      - ${{ if ne(variables['SkipSigning'], 'true') }}:
+      - ${{ if eq(parameters.ShouldSign, 'true') }}:
         - template: pipelines/steps/net-signing.yml@azure-sdk-build-tools
           parameters:
             PackagesPath: ${{ parameters.ArtifactsPath }}
             BuildToolsPath: ${{ parameters.BuildToolsRepoPath }}
 
-      - task: MSBuild@1
-        displayName: 'Upload Symbols'
+      - ${{ if eq(parameters.ShouldPublish, 'true') }}:
+        - task: MSBuild@1
+          displayName: 'Upload Symbols'
+          inputs:
+            solution: '${{ parameters.BuildToolsRepoPath }}/tools/symboltool/SymbolUploader.proj'
+            msbuildArguments: >
+              /p:PackagesPath=${{ parameters.ArtifactsPath }}
+              /p:MSPublicSymbolsPAT=$(azuresdk-microsoftpublicsymbols-devops-pat)
+              /p:MSSymbolsPAT=$(azuresdk-microsoft-devops-pat)
+              /p:AzureSDKSymbolsPAT=$(azuresdk-azure-sdk-devops-pat)
+
+        - task: NuGetToolInstaller@1
+          displayName: 'Use NuGet ${{ parameters.NugetVersion }}'
+          inputs:
+            versionSpec: ${{ parameters.NugetVersion }}
+
+        - ${{ if ne(parameters.DevOpsFeedID, '') }}:
+          - task: NuGetCommand@2
+            displayName: 'Publish to DevOps Feed'
+            inputs:
+              command: push
+              packagesToPush: '${{ parameters.ArtifactsPath }}/**/*.nupkg;!${{ parameters.ArtifactsPath }}/**/*.symbols.nupkg'
+              publishVstsFeed: ${{ parameters.DevOpsFeedID }}
+
+        - ${{ if eq(parameters.DevOpsFeedID, '') }}:
+          - task: NuGetCommand@2
+            displayName: 'Publish to Nuget'
+            inputs:
+              command: push
+              packagesToPush: '${{ parameters.ArtifactsPath }}/**/*.nupkg;!${{ parameters.ArtifactsPath }}/**/*.symbols.nupkg'
+              nuGetFeedType: external
+              publishFeedCredentials: Nuget.org
+
+      - task: AzureFileCopy@2
+        displayName: 'Copy Signed Files to Blob'
         inputs:
-          solution: '${{ parameters.BuildToolsRepoPath }}/tools/symboltool/SymbolUploader.proj'
-          msbuildArguments: >
-            /p:PackagesPath=${{ parameters.ArtifactsPath }}
-            /p:MSPublicSymbolsPAT=$(azuresdk-microsoftpublicsymbols-devops-pat)
-            /p:MSSymbolsPAT=$(azuresdk-microsoft-devops-pat)
-            /p:AzureSDKSymbolsPAT=$(azuresdk-azure-sdk-devops-pat)
-        condition: and(succeeded(), ne(variables['SkipPublishSymbols'], 'true'))
-
-      - task: NuGetToolInstaller@1
-        displayName: 'Use NuGet ${{ parameters.NugetVersion }}'
-        inputs:
-          versionSpec: ${{ parameters.NugetVersion }}
-        condition: and(succeeded(), ne(variables['SkipPublishToNuget'], 'true'))
-
-      - ${{ if ne(parameters.DevOpsFeedID, '') }}:
-        - task: NuGetCommand@2
-          displayName: 'Publish to DevOps Feed'
-          inputs:
-            command: push
-            packagesToPush: '${{ parameters.ArtifactsPath }}/**/*.nupkg;!${{ parameters.ArtifactsPath }}/**/*.symbols.nupkg'
-            publishVstsFeed: ${{ parameters.DevOpsFeedID }}
-
-      - ${{ if eq(parameters.DevOpsFeedID, '') }}:
-        - task: NuGetCommand@2
-          displayName: 'Publish to Nuget'
-          inputs:
-            command: push
-            packagesToPush: '${{ parameters.ArtifactsPath }}/**/*.nupkg;!${{ parameters.ArtifactsPath }}/**/*.symbols.nupkg'
-            nuGetFeedType: external
-            publishFeedCredentials: Nuget.org
-
-        - task: AzureFileCopy@2
-          displayName: 'Copy Signed Files to Blob'
-          inputs:
-            SourcePath: '${{ parameters.ArtifactsPath }}'
-            azureSubscription: '${{ parameters.PartnerDropsSubscription }}'
-            Destination: AzureBlob
-            storage: '${{ parameters.PartnerDropsStorageName }}'
-            ContainerName: '${{ parameters.PartnerDropsContainerName }}'
-            BlobPrefix: '${{ parameters.PartnerDropsBlobDestPrefix }}'
-          condition: and(succeeded(), ne(variables['SkipCopySignedFilestoBlob'], 'true'))
+          SourcePath: '${{ parameters.ArtifactsPath }}'
+          azureSubscription: '${{ parameters.PartnerDropsSubscription }}'
+          Destination: AzureBlob
+          storage: '${{ parameters.PartnerDropsStorageName }}'
+          ContainerName: '${{ parameters.PartnerDropsContainerName }}'
+          BlobPrefix: '${{ parameters.PartnerDropsBlobDestPrefix }}'
+        condition: and(succeeded(), ne(variables['SkipCopySignedFilestoBlob'], 'true'))

--- a/eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
+++ b/eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
@@ -73,7 +73,7 @@ jobs:
             PackagesPath: ${{ parameters.ArtifactsPath }}
             BuildToolsPath: ${{ parameters.BuildToolsRepoPath }}
 
-      - ${{ if eq(parameters.ShouldPublish, 'true') }}:
+      - ${{ if eq(parameters.ShouldPublish, true) }}:
         - task: MSBuild@1
           displayName: 'Upload Symbols'
           inputs:


### PR DESCRIPTION
- Update parameters for azuresdkpartnerdrops-to-nugetfeed.yml.
Pipelines to replace old UI release pipelines.
[net - partnerdrops-to-devOps-feed](https://dev.azure.com/azure-sdk/internal/_build?definitionId=4583&_a=summary) for [azuresdkpartnerdrops to (nuget)devOps Feed](https://dev.azure.com/azure-sdk/internal/_release?_a=releases&view=all&definitionId=101)
[net - partnerdrops-to-nuget-feed](https://dev.azure.com/azure-sdk/internal/_build?definitionId=4442&_a=summary) for [azuresdkpartnerdrops to nuget](https://dev.azure.com/azure-sdk/internal/_release?_a=releases&view=mine&definitionId=3)