### PR TITLE
The common scripts of PR git diff changes.

### DIFF
--- a/eng/common/scripts/git-diff-changes.ps1
+++ b/eng/common/scripts/git-diff-changes.ps1
@@ -17,7 +17,7 @@ param (
   [string] $SourceCommittish = ${env:BUILD_SOURCEVERSION},
   [string] $TargetCommittish = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/")
 )
-# Git PR diff: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons
+# Git PR diff: https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons
 Write-Host "git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff $TargetCommittish...$SourceCommittish --name-only --diff-filter=d"
 $changedFiles = (git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff "$TargetCommittish...$SourceCommittish"  --name-only --diff-filter=d)
 if(!$changedFiles) {

--- a/eng/common/scripts/git-diff-changes.ps1
+++ b/eng/common/scripts/git-diff-changes.ps1
@@ -14,7 +14,7 @@
 #>
 [CmdletBinding()]
 param (
-  [string] $SourceCommittish = ${env:BUILD_SOURCEVERSION},
+  [string] $SourceCommittish = "${env:BUILD_SOURCEVERSION}",
   [string] $TargetCommittish = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/")
 )
 
@@ -27,9 +27,10 @@ if ($TargetCommittish -eq "origin/") {
 Write-Host "git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff $TargetCommittish...$SourceCommittish --name-only --diff-filter=d"
 $changedFiles = (git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff "$TargetCommittish...$SourceCommittish"  --name-only --diff-filter=d)
 if(!$changedFiles) {
-Write-Host "No changed files in git diff between $TargetCommittish and $SourceCommittish"
+    Write-Host "No changed files in git diff between $TargetCommittish and $SourceCommittish"
 }
+Write-Host "Here are the diff files:"
 foreach ($file in $changedFiles) {
-Write-Host "The diff file is: $file"
+    Write-Host "    $file"
 }
 return $changedFiles

--- a/eng/common/scripts/git-diff-changes.ps1
+++ b/eng/common/scripts/git-diff-changes.ps1
@@ -1,0 +1,29 @@
+<#
+  .SYNOPSIS
+  Returns git diff changes in pull request.
+
+  .DESCRIPTION
+  The script is to return diff changes in pull request.
+
+  .PARAMETER SourceCommittish
+  The branch committish PR merges from.
+  Definition of committish: https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefcommit-ishacommit-ishalsocommittish
+
+  .PARAMETER TargetCommittish
+  The branch committish PR targets to merge into.
+#>
+[CmdletBinding()]
+param (
+  [string] $SourceCommittish = ${env:BUILD_SOURCEVERSION},
+  [string] $TargetCommittish = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/")
+)
+# Git PR diff: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons
+Write-Host "git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff $TargetCommittish...$SourceCommittish --name-only --diff-filter=d"
+$changedFiles = (git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff "$TargetCommittish...$SourceCommittish"  --name-only --diff-filter=d)
+if(!$changedFiles) {
+Write-Host "No changed files in git diff between $TargetCommittish and $SourceCommittish"
+}
+foreach ($file in $changedFiles) {
+Write-Host "The diff file is: $file"
+}
+return $changedFiles

--- a/eng/common/scripts/git-diff-changes.ps1
+++ b/eng/common/scripts/git-diff-changes.ps1
@@ -17,6 +17,12 @@ param (
   [string] $SourceCommittish = ${env:BUILD_SOURCEVERSION},
   [string] $TargetCommittish = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/")
 )
+
+# If ${env:SYSTEM_PULLREQUEST_TARGETBRANCH} is empty, then return empty.
+if ($TargetCommittish -eq "origin/") {
+    Write-Host "There is no target branch passed in. "
+    return ""
+} 
 # Git PR diff: https://docs.github.com/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-comparing-branches-in-pull-requests#three-dot-and-two-dot-git-diff-comparisons
 Write-Host "git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff $TargetCommittish...$SourceCommittish --name-only --diff-filter=d"
 $changedFiles = (git -c core.quotepath=off -c i18n.logoutputencoding=utf-8 diff "$TargetCommittish...$SourceCommittish"  --name-only --diff-filter=d)


### PR DESCRIPTION
Have a common script for git diff changes.
Test proposal:
PR triggered(Compliance credscan): https://github.com/Azure/azure-sdk-for-js/pull/20643
Manually triggered(Build print diff): https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1407323&view=results
Test on Add, Update, Delete, Rename cases(Compliance credscan): https://github.com/Azure/azure-sdk-for-js/pull/20643
Test on sparse-checkout cases(Build print diff): https://github.com/Azure/azure-sdk-for-java/pull/27335

<img width="643" alt="image" src="https://user-images.githubusercontent.com/48036328/156621379-bb1f93e3-4be7-40ef-84f8-806e9d3645cd.png">
The git diff changes will add the file outside of the sparse checkout