### PR TITLE
Check API changes only if package is modified

### DIFF
--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -14,6 +14,5 @@ steps:
         -PullRequestNumber $(System.PullRequest.PullRequestNumber)
         -RepoFullName $(Build.Repository.Name)
       pwsh: true
-      workingDirectory: $(Pipeline.Workspace)
     displayName: Detect API changes
     condition: and(succeededOrFailed(), eq(variables['Build.Reason'],'PullRequest'))

--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -12,7 +12,8 @@ Param (
   [array] $ArtifactList,
   [string] $RepoFullName = "",
   [string] $ArtifactName = "packages",
-  [string] $APIViewUri = "https://apiview.dev/PullRequest/DetectApiChanges"
+  [string] $APIViewUri = "https://apiview.dev/PullRequest/DetectApiChanges",
+  [string] $TargetBranch = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/")
 )
 
 # Submit API review request and return status whether current revision is approved or pending or failed to create review
@@ -59,8 +60,12 @@ function Should-Process-Package($pkgPath, $packageName)
     }
     # Get package info from json file created before updating version to daily dev
     $pkgInfo = Get-Content $pkgPropPath | ConvertFrom-Json
-    Write-Host "SDK Type: $($pkgInfo.SdkType)"
-    return $pkgInfo.IsNewSdk
+    $packagePath = $pkgInfo.DirectoryPath
+    $modifiedFiles = git diff --name-only --relative $TargetBranch HEAD
+    $modifiedFiles = $modifiedFiles.Where({$_.startswith($packagePath)})
+    $filteredFileCount = $modifiedFiles.Count
+    Write-Host "Number of modified files for package: $filteredFileCount"
+    return ($filteredFileCount -gt 0 -and $pkgInfo.IsNewSdk)
 }
 
 function Log-Input-Params()
@@ -94,7 +99,9 @@ foreach ($artifact in $ArtifactList)
     if ($packages)
     {
         $pkgPath = $packages.Values[0]
-        if (Should-Process-Package -pkgPath $pkgPath -packageName $artifact.name)
+        $isRequired = Should-Process-Package -pkgPath $pkgPath -packageName $artifact.name
+        Write-Host "Is API change detect required for $($artifact.name):$($isRequired)"
+        if ($isRequired -eq $True)
         {
             $filePath = $pkgPath.Replace($ArtifactPath , "").Replace("\", "/")
             $respCode = Submit-Request -filePath $filePath -packageName $artifact.name
@@ -102,6 +109,10 @@ foreach ($artifact in $ArtifactList)
             {
                 $responses[$artifact.name] = $respCode
             }
+        }
+        else
+        {
+            Write-Host "Pull request does not have any change for $($artifact.name). Skipping API change detect."
         }
     }
     else


### PR DESCRIPTION
Pipeline submits request to APIView to find any change in API surface level for all packages in artifact list even if no file is modified  for that package in that PR. This causes issue when someone else merges API level changes to main branch at the same time when PR is created since this will lead to show changes just merged to main branch as new changes PR since baseline is incorrect at that point until new CI completes the run to update baseline.

This PR is to make sure package is modified when we submit request to verify if API changes are present in PR.