### PR TITLE
[Python APIView] Fix for Python 3.9

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
@@ -92,7 +92,7 @@ def get_qualified_name(obj, namespace):
         # strip the module name if it isn't the namespace (example: typing)
         value = value[len(module_name) +1:]
 
-    if args:
+    if args and "[" not in value:
         arg_string = ", ".join(args)
         value = f"{value}[{arg_string}]"
     return value


### PR DESCRIPTION
Prevent `SomeType[Blah][Blah]` on Python 3.9. Instead will display as `SomeType[Blah]`. Necessary in order to use stable Python 3.9 because 3.10 is introducing instability to APIView. 

https://apiviewstaging.azurewebsites.net/Assemblies/Review/a52112cbbdb64806b476d9fe0f444ef5