### PR TITLE
Update to github-codeowner-subscriber version and use env variable

### DIFF
--- a/eng/pipelines/notifications.yml
+++ b/eng/pipelines/notifications.yml
@@ -77,13 +77,17 @@ stages:
             --organization $(Organization) `
             --project $(Project) `
             --path-prefix "\$(PathPrefix)" `
-            --dev-ops-token-var $(azure-sdk-notification-tools-pat) `
-            --aad-app-id-var $(opensource-aad-app-id) `
-            --aad-app-secret-var $(opensource-aad-secret) `
-            --aad-tenant-var $(opensource-aad-tenant-id) `
+            --dev-ops-token-var DEVOPS_TOKEN `
+            --aad-app-id-var OPENSOURCE_AAD_APP_ID `
+            --aad-app-secret-var OPENSOURCE_AAD_APP_SECRET `
+            --aad-tenant-var OPENSOURCE_AAD_TENANT_ID `
             $(AdditionalParameters)
         displayName: 'Run GitHub CODEOWNER Subscriber'
         env:
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
+          DEVOPS_TOKEN: $(azure-sdk-notification-tools-pat)
+          OPENSOURCE_AAD_APP_ID: $(opensource-aad-app-id)
+          OPENSOURCE_AAD_APP_SECRET: $(opensource-aad-secret)
+          OPENSOURCE_AAD_TENANT_ID: $(opensource-aad-tenant-id

--- a/eng/pipelines/notifications.yml
+++ b/eng/pipelines/notifications.yml
@@ -90,4 +90,4 @@ stages:
           DEVOPS_TOKEN: $(azure-sdk-notification-tools-pat)
           OPENSOURCE_AAD_APP_ID: $(opensource-aad-app-id)
           OPENSOURCE_AAD_APP_SECRET: $(opensource-aad-secret)
-          OPENSOURCE_AAD_TENANT_ID: $(opensource-aad-tenant-id
+          OPENSOURCE_AAD_TENANT_ID: $(opensource-aad-tenant-id)

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -4,4 +4,4 @@ variables:
   DotNetCoreVersion: '3.1.405'
   NugetSecurityAnalysisWarningLevel: 'none'
   NotificationsCreatorVersion: '1.0.0-dev.20220125.1'
-  CodeOwnersSubscriberVersion: '1.0.0-dev.20220214.1'
+  CodeOwnersSubscriberVersion: '1.0.0-dev.20220302.2'


### PR DESCRIPTION
We update the code of the github-codeowner-subscriber to use the env var.
The PR is to use the latest version.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1405006&view=results