### PR TITLE
Support staging URl to run detect API changes in test env

### DIFF
--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -9,7 +9,6 @@ steps:
     displayName: "Set API change detect request URL"
     condition: eq(variables['ApiChangeDetectRequestUrl'], '')
 
-
   - task: Powershell@2
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/common/scripts/Detect-Api-Changes.ps1

--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -3,6 +3,13 @@ parameters:
   Artifacts: []
 
 steps:
+  - pwsh: |
+      $apiChangeDetectRequestUrl = "https://apiview.dev/PullRequest/DetectApiChanges"
+      echo "##vso[task.setvariable variable=ApiChangeDetectRequestUrl]$apiChangeDetectRequestUrl"
+    displayName: "Set API change detect request URL"
+    condition: eq(variables['ApiChangeDetectRequestUrl'], '')
+
+
   - task: Powershell@2
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/common/scripts/Detect-Api-Changes.ps1
@@ -13,6 +20,7 @@ steps:
         -BuildId $(Build.BuildId)
         -PullRequestNumber $(System.PullRequest.PullRequestNumber)
         -RepoFullName $(Build.Repository.Name)
+        -APIViewUri $(ApiChangeDetectRequestUrl)
       pwsh: true
     displayName: Detect API changes
     condition: and(succeededOrFailed(), eq(variables['Build.Reason'],'PullRequest'))

--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -10,9 +10,9 @@ Param (
   [string] $CommitSha,
   [Parameter(Mandatory=$True)]
   [array] $ArtifactList,
+  [string] $APIViewUri,
   [string] $RepoFullName = "",
   [string] $ArtifactName = "packages",
-  [string] $APIViewUri = "https://apiview.dev/PullRequest/DetectApiChanges",
   [string] $TargetBranch = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/")
 )
 


### PR DESCRIPTION
Currently API detection step sends request to APIView production instance. This PR is to support alternate environment to test API change detection from test pipeline (specially to test SDK automation).