### PR TITLE
[Python APIView] Fix alias display names and enum values

### DIFF
--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -14,6 +14,7 @@ Fixed issue where APIView would add a false-alarm warning to
 Fixed issue where aliased models would be displayed with their non-public,
   unaliased name. APIView will issue a diagnostic warning if `__name__` is
   not updated to match the alias.
+Fixed issue where enums that correspond to the same value would be omitted.
 
 ## Version 0.2.9 (Unreleased)
 Fixed issue where Python 3-style type hints stopped displaying

--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -11,6 +11,9 @@ Added support for "CrossLanguageDefinitionId" and a --mapping-path
 Fixed issue where required keyword-only arguments displayed as optional.
 Fixed issue where APIView would add a false-alarm warning to
   paged types.
+Fixed issue where aliased models would be displayed with their non-public,
+  unaliased name. APIView will issue a diagnostic warning if `__name__` is
+  not updated to match the alias.
 
 ## Version 0.2.9 (Unreleased)
 Fixed issue where Python 3-style type hints stopped displaying

--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -5,6 +5,7 @@ import importlib
 import inspect
 import platform
 
+from ._node_index import NodeIndex
 from ._token import Token
 from ._token_kind import TokenKind
 from ._version import VERSION
@@ -23,12 +24,12 @@ SOURCE_LINK_NOT_AVAILABLE = "Source definition link is not available for [{0}]. 
 
 class ApiView:
     """Entity class that holds API view for all namespaces within a package
-    :param NodeIndex: nodeindex
-    :param str: pkg_name
-    :param str: ver_string
+    :param str pkg_name: The package name.
+    :param str namespace: The package namespace.
+    :param MetadataMap metadata_map: A metadata mapping object.
     """
 
-    def __init__(self, nodeindex, pkg_name="", namespace = "", metadata_map=None):
+    def __init__(self, *, pkg_name="", namespace = "", metadata_map=None):
         self.name = pkg_name
         self.version = 0
         self.version_string = ""
@@ -38,7 +39,7 @@ class ApiView:
         self.diagnostics = []
         self.indent = 0    
         self.namespace = namespace
-        self.nodeindex = nodeindex
+        self.node_index = NodeIndex()
         self.package_name = pkg_name
         self.metadata_map = metadata_map or MetadataMap("")
         self.add_token(Token("", TokenKind.SkipDiffRangeStart))
@@ -148,7 +149,7 @@ class ApiView:
         token = Token(type_name, TokenKind.TypeName)
         type_full_name = type_name[1:] if type_name.startswith("~") else type_name
         token.value = type_full_name.split(".")[-1]
-        navigate_to_id = self.nodeindex.get_id(type_full_name)
+        navigate_to_id = self.node_index.get_id(type_full_name)
         if navigate_to_id:
             token.navigate_to_id = navigate_to_id
         elif type_name.startswith("~") and line_id:

--- a/packages/python-packages/api-stub-generator/apistub/_node_index.py
+++ b/packages/python-packages/api-stub-generator/apistub/_node_index.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python
+
+# --------------------------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for license information.
+# --------------------------------------------------------------------------------------------
+
+
+class NodeIndex:
+    """Maintains name to navigation ID"""
+    def __init__(self):
+        self.index = {}
+
+    def add(self, name, node):
+        if name in self.index:
+            raise ValueError("Index already has {} node".format(name))
+        self.index[name] = node
+
+    def get(self, name):
+        return self.index.get(name, None)
+
+    def get_id(self, name):
+        node = self.get(name)
+        if node and hasattr(node, "namespace_id"):
+            return node.namespace_id
+        return None
+

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
@@ -1,6 +1,5 @@
 from inspect import Parameter
 import re
-from typing import Optional
 
 keyword_regex = re.compile(r"<(class|enum) '([a-zA-Z._]+)'>")
 forward_ref_regex = re.compile(r"ForwardRef\('([a-zA-Z._]+)'\)")

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_enum_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_enum_node.py
@@ -9,9 +9,9 @@ class EnumNode(NodeEntityBase):
     """Enum node represents any Enum value
     """
 
-    def __init__(self, namespace, parent_node, obj):
+    def __init__(self, *, name, namespace, parent_node, obj):
         super().__init__(namespace, parent_node, obj)
-        self.name = obj.name
+        self.name = name
         self.value = obj.value
         self.namespace_id = self.generate_id()
 

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
@@ -42,7 +42,13 @@ class ModuleNode(NodeEntityBase):
                 continue
 
             if inspect.isclass(member_obj):
-                class_node = ClassNode(self.namespace, self, member_obj, self.pkg_root_namespace)
+                class_node = ClassNode(
+                    name=name,
+                    namespace=self.namespace,
+                    parent_node=self,
+                    obj=member_obj,
+                    pkg_root_namespace=self.pkg_root_namespace
+                )
                 key = "{0}.{1}".format(self.namespace, class_node.name)
                 self.nodeindex.add(key, class_node)
                 self.child_nodes.append(class_node)

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_module_node.py
@@ -18,13 +18,13 @@ class ModuleNode(NodeEntityBase):
     """ModuleNode represents module level node and all it's children
     :param str: namespace
     :param module: module
-    :param dict: nodeindex
+    :param dict: node_index
     """
 
-    def __init__(self, namespace, module, nodeindex, pkg_root_namespace):
+    def __init__(self, namespace, module, node_index, pkg_root_namespace):
         super().__init__(namespace, None, module)
         self.namespace_id = self.generate_id()
-        self.nodeindex = nodeindex
+        self.node_index = node_index
         self.pkg_root_namespace = pkg_root_namespace
         self._inspect()
 
@@ -50,12 +50,12 @@ class ModuleNode(NodeEntityBase):
                     pkg_root_namespace=self.pkg_root_namespace
                 )
                 key = "{0}.{1}".format(self.namespace, class_node.name)
-                self.nodeindex.add(key, class_node)
+                self.node_index.add(key, class_node)
                 self.child_nodes.append(class_node)
             elif inspect.isroutine(member_obj):
                 func_node = FunctionNode(self.namespace, self, member_obj, True)
                 key = "{0}.{1}".format(self.namespace, func_node.name)
-                self.nodeindex.add(key, func_node)
+                self.node_index.add(key, func_node)
                 self.child_nodes.append(func_node)
             else:
                 logging.debug("Skipping unknown type member in module: {}".format(name))

--- a/packages/python-packages/api-stub-generator/tests/apiview_test.py
+++ b/packages/python-packages/api-stub-generator/tests/apiview_test.py
@@ -4,10 +4,23 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from apistub import ApiView, TokenKind
+from unicodedata import name
+from apistub import ApiView, TokenKind, StubGenerator
+import os
+import tempfile
+
+
+class StubGenTestArgs:
+    pkg_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'apistubgentest'))
+    temp_path = tempfile.gettempdir()
+    out_path = None
+    mapping_path = None
+    hide_report = None
+    verbose = None
+    filter_namespace = None
+
 
 class TestApiView:
-
     def _count_newlines(self, apiview):
         newline_count = 0
         for token in apiview.tokens[::-1]:
@@ -18,7 +31,7 @@ class TestApiView:
         return newline_count
 
     def test_multiple_newline_only_add_one(self):
-        apiview = ApiView(None, "test", "0.0", "test")
+        apiview = ApiView()
         apiview.add_text(None, "Something")
         apiview.add_newline()
         # subsequent calls result in no change
@@ -27,7 +40,7 @@ class TestApiView:
         assert self._count_newlines(apiview) == 1
 
     def test_set_blank_lines(self):
-        apiview = ApiView(None, "test", "0.0", "test")
+        apiview = ApiView()
         apiview.set_blank_lines(3)
         assert self._count_newlines(apiview) == 4 # +1 for carriage return
 
@@ -39,3 +52,10 @@ class TestApiView:
         apiview.set_blank_lines(2)
         assert self._count_newlines(apiview) == 3 # +1 for carriage return
 
+    def test_api_view_diagnostic_warnings(self):
+        args = StubGenTestArgs()
+        print(args.pkg_path)
+        stub_gen = StubGenerator(args=args)
+        apiview = stub_gen.generate_tokens()
+        # ensure we have only the expected diagnostics when testing apistubgentest
+        assert len(apiview.diagnostics) == 1

--- a/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
@@ -5,11 +5,12 @@
 # --------------------------------------------------------------------------
 
 from tkinter import Variable
-from apistub.nodes import ClassNode, KeyNode, VariableNode, FunctionNode
+from apistub.nodes import ClassNode, KeyNode, VariableNode, FunctionNode, EnumNode
 from apistubgentest.models import (
     FakeTypedDict,
     FakeObject,
     ObjectWithDefaults,
+    PetEnum,
     PublicPrivateClass,
     RequiredKwargObject,
     SomeAwesomelyNamedObject
@@ -83,3 +84,9 @@ class TestClassParsing:
     def test_model_aliases(self):
         class_node = ClassNode(name="SomeAwesomelyNamedObject", namespace="test", parent_node=None, obj=SomeAwesomelyNamedObject, pkg_root_namespace=self.pkg_namespace)
         assert class_node.name == "SomeAwesomelyNamedObject"
+
+    def test_enum(self):
+        class_node = ClassNode(name="PetEnum", namespace="test", parent_node=None, obj=PetEnum, pkg_root_namespace=self.pkg_namespace)
+        assert len(class_node.child_nodes) == 3
+        names = [x.name for x in class_node.child_nodes]
+        assert names == ["CAT", "DEFAULT", "DOG"]

--- a/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
@@ -11,7 +11,8 @@ from apistubgentest.models import (
     FakeObject,
     ObjectWithDefaults,
     PublicPrivateClass,
-    RequiredKwargObject
+    RequiredKwargObject,
+    SomeAwesomelyNamedObject
 )
 
 
@@ -31,7 +32,7 @@ class TestClassParsing:
                 assert actual_type == check_type
 
     def test_typed_dict_class(self):
-        class_node = ClassNode("test", None, FakeTypedDict, self.pkg_namespace)
+        class_node = ClassNode(name="FakeTypedDict", namespace="test", parent_node=None, obj=FakeTypedDict, pkg_root_namespace=self.pkg_namespace)
         self._check_nodes(class_node.child_nodes, [
             (KeyNode, '"age"', "int"),
             (KeyNode, '"name"', "str"),
@@ -39,7 +40,7 @@ class TestClassParsing:
         ])
 
     def test_object(self):
-        class_node = ClassNode("test", None, FakeObject, self.pkg_namespace)
+        class_node = ClassNode(name="FakeObject", namespace="test", parent_node=None, obj=FakeObject, pkg_root_namespace=self.pkg_namespace)
         self._check_nodes(class_node.child_nodes, [
             (VariableNode, "PUBLIC_CONST", "str"),
             (VariableNode, "age", "int"),
@@ -49,7 +50,7 @@ class TestClassParsing:
         ])
 
     def test_public_private(self):
-        class_node = ClassNode("test", None, PublicPrivateClass, self.pkg_namespace)
+        class_node = ClassNode(name="PublicPrivateClass", namespace="test", parent_node=None, obj=PublicPrivateClass, pkg_root_namespace=self.pkg_namespace)
         self._check_nodes(class_node.child_nodes, [
             (VariableNode, "public_dict", "dict"),
             (VariableNode, "public_var", "str"),
@@ -58,7 +59,7 @@ class TestClassParsing:
         ])
 
     def test_required_kwargs(self):
-        class_node = ClassNode("test", None, RequiredKwargObject, self.pkg_namespace)
+        class_node = ClassNode(name="RequiredKwargObject", namespace="test", parent_node=None, obj=RequiredKwargObject, pkg_root_namespace=self.pkg_namespace)
         kwargs = class_node.child_nodes[0].kw_args
         args = class_node.child_nodes[0].args
         assert args["id"].is_required == True
@@ -71,10 +72,14 @@ class TestClassParsing:
         assert kwargs["other"].is_required == False
 
     def test_default_values(self):
-        class_node = ClassNode("test", None, ObjectWithDefaults, self.pkg_namespace)
+        class_node = ClassNode(name="ObjectWithDefaults", namespace="test", parent_node=None, obj=ObjectWithDefaults, pkg_root_namespace=self.pkg_namespace)
         assert len(class_node.child_nodes) == 1
         init_args = class_node.child_nodes[0].args
         assert init_args["name"].default == "Bob"
         assert init_args["age"].default == "21"
         assert init_args["is_awesome"].default == "True"
         assert init_args["pet"].default == "PetEnum.DOG"
+
+    def test_model_aliases(self):
+        class_node = ClassNode(name="SomeAwesomelyNamedObject", namespace="test", parent_node=None, obj=SomeAwesomelyNamedObject, pkg_root_namespace=self.pkg_namespace)
+        assert class_node.name == "SomeAwesomelyNamedObject"

--- a/packages/python-packages/apistubgentest/apistubgentest/models/__init__.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/__init__.py
@@ -8,7 +8,8 @@
 
 from ._models import (
     DocstringClass, FakeInventoryItemDataClass, FakeObject, FakeTypedDict, ObjectWithDefaults,
-    PetEnum, PublicPrivateClass, RequiredKwargObject
+    PetEnum, PublicPrivateClass, RequiredKwargObject,
+    SomePoorlyNamedObject as SomeAwesomelyNamedObject
 )
 
 
@@ -20,5 +21,6 @@ __all__ = (
     "ObjectWithDefaults",
     "PetEnum",
     "PublicPrivateClass",
-    "RequiredKwargObject"
+    "RequiredKwargObject",
+    "SomeAwesomelyNamedObject"
 )

--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -139,3 +139,8 @@ class ObjectWithDefaults:
         self.age = age
         self.is_awesome = is_awesome
         self.pet = pet
+
+class SomePoorlyNamedObject:
+
+    def __init__(self, name: str):
+        self.name = name

--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -54,6 +54,7 @@ class PetEnum(str, Enum, metaclass=_CaseInsensitiveEnumMeta):
     """
     DOG = "dog"
     CAT = "cat"
+    DEFAULT = "cat"
 
 
 class FakeObject(object):


### PR DESCRIPTION
Fixes #2865. Fixes how aliases are displayed and creates diagnostic warning if there is a mismatch.
Fixes #1963. Fix so that enums that map to the same value are all displayed.

No diff to AzureCore from this change:
https://apiviewstaging.azurewebsites.net/Assemblies/Review/037455a30cce4057ae52ed9357ba66d3/446bf344023c4158ae2fff6ced4a9fff?diffRevisionId=cd3145dc03aa42bfacd3100fe0128f15&doc=False&diffOnly=True