### PR TITLE
[Python APIView] Support `--source-url`

### DIFF
--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## Version 0.2.11 (Unreleased)
+Added support for `--source-url` which allows you to specify a link to the
+  pull request that the APIView is generated for that will appear in the
+  APIView preamble. Intended primarily for use by other automation tools.
+
 ## Version 0.2.10 (2022-03-09)
 Added support for TypedDict classes.
 Added support to parse defaults from docstrings. Example

--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -27,9 +27,10 @@ class ApiView:
     :param str pkg_name: The package name.
     :param str namespace: The package namespace.
     :param MetadataMap metadata_map: A metadata mapping object.
+    :param str source_url: An optional source URL to display in the preamble.
     """
 
-    def __init__(self, *, pkg_name="", namespace = "", metadata_map=None):
+    def __init__(self, *, pkg_name="", namespace = "", metadata_map=None, source_url=None):
         self.name = pkg_name
         self.version = 0
         self.version_string = ""
@@ -44,6 +45,9 @@ class ApiView:
         self.metadata_map = metadata_map or MetadataMap("")
         self.add_token(Token("", TokenKind.SkipDiffRangeStart))
         self.add_literal(HEADER_TEXT)
+        if source_url:
+            self.set_blank_lines(1)
+            self.add_literal(f"# Source URL: {source_url}")
         self.add_token(Token("", TokenKind.SkipDiffRangeEnd))
         self.set_blank_lines(2)
 

--- a/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
@@ -34,41 +34,45 @@ class StubGenerator:
     def __init__(self, args=None):
         if not args:
             parser = argparse.ArgumentParser(
-                description="Parse a python package and generate json token file to be supplied to API review tool"
+                description="Parses a Python package and generates a JSON token file for consumption by the APIView tool."
             )
             parser.add_argument(
-                "--pkg-path", required=True, help=("Package root path"),
+                "--pkg-path", required=True, help=("Path to the package source root, WHL or ZIP file."),
             )
             parser.add_argument(
                 "--temp-path", 
-                help=("Temp path to extract package"),
+                help=("Extract the package to the specified temporary path. Defaults to a random temp dir."),
                 default=tempfile.gettempdir(),
             )
             parser.add_argument(
                 "--out-path",
                 default=os.getcwd(),
-                help=("Path to generate json file with parsed tokens"),
+                help=("Path at which to write the generated JSON file. Defaults to CWD."),
             )
             parser.add_argument(
                 "--mapping-path",
                 default=None,
-                help=("Path to the 'apiview_mapping.json' file.")
+                help=("Path to an 'apiview_mapping.json' file that supplies cross-langauge definition IDs.")
             )
             parser.add_argument(
                 "--verbose",
-                help=("Enable verbose logging"),
+                help=("Enable verbose logging."),
                 default=False,
                 action="store_true",
             )
             parser.add_argument(
                 "--hide-report",
-                help=("Hide diagnostic report"),
+                help=("Hide diagnostic report."),
                 default=False,
                 action="store_true",
             )
             parser.add_argument(
                 "--filter-namespace",
-                help=("Generate Api view only for a specific namespace"),
+                help=("Generate APIView only for a specific namespace."),
+            )
+            parser.add_argument(
+                "--source-url",
+                help=("URL to the pull request URL that contains the source used to generate this APIView.")
             )
             args = parser.parse_args()
 
@@ -82,14 +86,13 @@ class StubGenerator:
         self.pkg_path = args.pkg_path
         self.temp_path = args.temp_path
         self.out_path = args.out_path
+        self.source_url = args.source_url
         self.mapping_path = args.mapping_path
         self.hide_report = args.hide_report
+        self.filter_namespace = args.filter_namespace or ''
         if args.verbose:
             logging.getLogger().setLevel(logging.DEBUG)
 
-        self.filter_namespace = ''
-        if args.filter_namespace:
-            self.filter_namespace = args.filter_namespace
 
     def generate_tokens(self):
         # Extract package to temp directory if it is wheel or sdist
@@ -113,11 +116,11 @@ class StubGenerator:
             namespace = self.filter_namespace
 
         logging.debug("Generating tokens")
-        apiview = self._generate_tokens(pkg_root_path, pkg_name, version, namespace)
+        apiview = self._generate_tokens(pkg_root_path, pkg_name, namespace, source_url=self.source_url)
         if apiview.diagnostics:
             # Show error report in console
             if not self.hide_report:
-                print("************************** Error Report **************************")
+                logging.info("************************** Error Report **************************")
                 for m in self.module_dict.keys():
                     self.module_dict[m].print_errors()
             logging.info("*************** Completed parsing package with errors ***************")
@@ -165,7 +168,7 @@ class StubGenerator:
         return modules
 
 
-    def _generate_tokens(self, pkg_root_path, package_name, version, namespace):
+    def _generate_tokens(self, pkg_root_path, package_name, namespace, *, source_url):
         """This method returns a dictionary of namespace and all public classes in each namespace
         """
         # Import ModuleNode.
@@ -177,7 +180,8 @@ class StubGenerator:
         apiview = ApiView(
             pkg_name=package_name,
             namespace=namespace,
-            metadata_map=mapping
+            metadata_map=mapping,
+            source_url=source_url
         )
         modules = self._find_modules(pkg_root_path)
         logging.debug("Modules to generate tokens: {}".format(modules))

--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.2.10"
+VERSION = "0.2.11"

--- a/packages/python-packages/api-stub-generator/tests/apiview_test.py
+++ b/packages/python-packages/api-stub-generator/tests/apiview_test.py
@@ -13,6 +13,7 @@ import tempfile
 class StubGenTestArgs:
     pkg_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'apistubgentest'))
     temp_path = tempfile.gettempdir()
+    source_url = None
     out_path = None
     mapping_path = None
     hide_report = None

--- a/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
@@ -4,8 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from tkinter import Variable
-from apistub.nodes import ClassNode, KeyNode, VariableNode, FunctionNode, EnumNode
+from apistub.nodes import ClassNode, KeyNode, VariableNode, FunctionNode
 from apistubgentest.models import (
     FakeTypedDict,
     FakeObject,


### PR DESCRIPTION
Closes #2757.

https://apiview.dev/Assemblies/Review/fb60229791b043e590c31f5d7ee4b33e

The link isn't live, but can by copy-pasted. To be live, we need #2650 implemented.