### PR TITLE
Support local test resources behavior with provisioner config

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -406,8 +406,7 @@ try {
         Write-Verbose "Location was not set. Using default location for environment: '$Location'"
     }
 
-    if (!$CI) {
-
+    if (!$CI -and $PSCmdlet.ParameterSetName -ne "Provisioner") {
         # Make sure the user is logged in to create a service principal.
         $context = Get-AzContext;
         if (!$context) {


### PR DESCRIPTION
There are cases where it useful to run the provision script locally, but with a subscription config object like we do in
our pipelines. For example, when testing new subscription configs, or when using test credentials for sovereign clouds
instead of provisioning sovereign cloud domain-joined user accounts. Currently to use the provisioner parameter set,
you must also pass `-CI` otherwise you get an error like below:

```
Set-AzContext: /home/ben/sdk/azure-sdk-for-python/eng/common/TestResources/New-TestResources.ps1:410
Line |
 410 |  …           $null = Select-AzSubscription -Subscription $SubscriptionId
     |                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
     | Please provide a valid tenant or a valid subscription.
```

The downside to passing `-CI` when running locally is that the script does not print out the helpful commands for
setting env variables in your shell, as well as adding a bunch of verbose devops logging commands.
