### PR TITLE
[Credscan] Compliance w/out changed files shouldn't crash

### DIFF
--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -25,9 +25,13 @@ steps:
     if(Test-Path "${{ parameters.SourceDirectory }}/credscan.tsv") {
       Get-Content "${{ parameters.SourceDirectory }}/credscan.tsv"
     }
+    else {
+      Write-Host "##vso[task.setvariable variable=CREDSCAN_UNNEEDED]true"
+    }
   displayName: CredScan setup
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
   displayName: CredScan running
+  condition: and(succeededOrFailed(), ne('CREDSCAN_UNNEEDED', true))
   inputs:
     toolVersion: 2.2.7.8 
     scanFolder: "${{ parameters.SourceDirectory }}/credscan.tsv"

--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -38,6 +38,7 @@ steps:
     suppressionsFile: ${{ parameters.SuppressionFilePath }}
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
   displayName: CredScan result analysis
+  condition: and(succeededOrFailed(), ne('CREDSCAN_UNNEEDED', true))
   inputs:
     GdnBreakBaselineFiles: ${{ parameters.BaselineFilePath }}
     GdnBreakAllTools: false
@@ -47,8 +48,7 @@ steps:
     # Used for generating baseline file.
     # GdnBreakOutputBaselineFile: baseline
     # GdnBreakOutputBaseline: baseline
-  condition: succeededOrFailed()
 - pwsh: |
     Write-Host "Please check https://aka.ms/azsdk/credscan for more information about the cred scan failure."
   displayName: CredScan troubleshooting guide
-  condition: failed()
+  condition: and(failed(), ne('CREDSCAN_UNNEEDED', true))

--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -26,19 +26,19 @@ steps:
       Get-Content "${{ parameters.SourceDirectory }}/credscan.tsv"
     }
     else {
-      Write-Host "##vso[task.setvariable variable=CREDSCAN_UNNEEDED]true"
+      Write-Host "##vso[task.setvariable variable=SKIP_CREDSCAN]true"
     }
   displayName: CredScan setup
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
   displayName: CredScan running
-  condition: and(succeededOrFailed(), ne('CREDSCAN_UNNEEDED', true))
+  condition: and(succeededOrFailed(), ne('SKIP_CREDSCAN', true))
   inputs:
     toolVersion: 2.2.7.8 
     scanFolder: "${{ parameters.SourceDirectory }}/credscan.tsv"
     suppressionsFile: ${{ parameters.SuppressionFilePath }}
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-postanalysis.PostAnalysis@2
   displayName: CredScan result analysis
-  condition: and(succeededOrFailed(), ne('CREDSCAN_UNNEEDED', true))
+  condition: and(succeededOrFailed(), ne('SKIP_CREDSCAN', true))
   inputs:
     GdnBreakBaselineFiles: ${{ parameters.BaselineFilePath }}
     GdnBreakAllTools: false
@@ -51,4 +51,4 @@ steps:
 - pwsh: |
     Write-Host "Please check https://aka.ms/azsdk/credscan for more information about the cred scan failure."
   displayName: CredScan troubleshooting guide
-  condition: and(failed(), ne('CREDSCAN_UNNEEDED', true))
+  condition: and(failed(), ne('SKIP_CREDSCAN', true))


### PR DESCRIPTION
Hey @sima-zhu I was looking into an issue posted by @ArthurMa1978 and I discovered this scenario.

Effectively, we never generate a `credscan.tsv` because we don't find any service folders with changed files. That's due to the fact that Azure/azure-sdk-for-net#27448 only _deletes_ two files. There is nothing to run compliance _on_!

I am now catching this explicitly with this conditional.

Another way we could handle this is adjust the `diff` call to also show deleted files I think, but that has the downside of running credscan when you've only _deleted files_.
