### PR TITLE
Read the ms.service value from csv metadata

### DIFF
--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -87,7 +87,6 @@ function GetAdjustedReadmeContent($ReadmeContent, $PackageInfo, $PackageMetadata
     $service = $PackageMetadata.MSDocService
   }
 
-
   # Generate the release tag for use in link substitution
   $tag = "$($PackageInfo.Name)_$($PackageInfo.Version)"
   Write-Host "The tag of package: $tag"

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -80,13 +80,13 @@ $TITLE_REGEX = "(\#\s+(?<filetitle>Azure .+? (?:client|plugin|shared) library fo
 function GetAdjustedReadmeContent($ReadmeContent, $PackageInfo, $PackageMetadata) {
   # The $PackageMetadata could be $null if there is no associated metadata entry
   # based on how the metadata CSV is filtered
-  $service = $PackageInfo.ServiceDirectory.ToLower()
-  if ($PackageMetadata -and $PackageMetadata.ServiceName) {
-    # Normalize service name "Key Vault" -> "keyvault"
+  $service = $PackageInfo.ServiceDirectory.ToLower()    
+  if ($PackageMetadata -and $PackageMetadata.MSDocService) {
+    # Use MSDocService in csv metadata to override the service directory
     # TODO: Use taxonomy for service name -- https://github.com/Azure/azure-sdk-tools/issues/1442
-    # probably from metadata
-    $service = $PackageMetadata.ServiceName.ToLower().Replace(" ", "")
+    $service = $PackageMetadata.MSDocService
   }
+
 
   # Generate the release tag for use in link substitution
   $tag = "$($PackageInfo.Name)_$($PackageInfo.Version)"

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -86,7 +86,7 @@ function GetAdjustedReadmeContent($ReadmeContent, $PackageInfo, $PackageMetadata
     # TODO: Use taxonomy for service name -- https://github.com/Azure/azure-sdk-tools/issues/1442
     $service = $PackageMetadata.MSDocService
   }
-
+  Write-Host "The service of package: $service"
   # Generate the release tag for use in link substitution
   $tag = "$($PackageInfo.Name)_$($PackageInfo.Version)"
   Write-Host "The tag of package: $tag"

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -80,7 +80,7 @@ $TITLE_REGEX = "(\#\s+(?<filetitle>Azure .+? (?:client|plugin|shared) library fo
 function GetAdjustedReadmeContent($ReadmeContent, $PackageInfo, $PackageMetadata) {
   # The $PackageMetadata could be $null if there is no associated metadata entry
   # based on how the metadata CSV is filtered
-  $service = $PackageInfo.ServiceDirectory.ToLower()    
+  $service = $PackageInfo.ServiceDirectory.ToLower()
   if ($PackageMetadata -and $PackageMetadata.MSDocService) {
     # Use MSDocService in csv metadata to override the service directory
     # TODO: Use taxonomy for service name -- https://github.com/Azure/azure-sdk-tools/issues/1442


### PR DESCRIPTION
Our original `ms.service` assign value as follows:
1. If csv `ServiceName` exists, then Normalize `Key Vault - > keyvault`
2. Otherwise, use the service directory

The proposal:
1. If csv `MSDocService` exists, then use the value directly. PM or service owner will update this to the right value
2. Otherwise, use the service directory

Testing pipeline on redis:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1432407&view=results
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1432410&view=results