### PR TITLE
[Test-Proxy] Remove Explicit List of Content-Headers

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -600,7 +600,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [InlineData("Content-Encoding:utf-8", "x-ms-version:2019-02-02", "RequestMethod:POST", "Content-Length:50")]
         public void TestCreateUpstreamRequestIncludesExpectedHeaders(params string[] incomingHeaders)
         {
-            var requestContext = _generateHttpRequestContext(incomingHeaders);
+            var requestContext = GenerateHttpRequestContext(incomingHeaders);
             var recordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var upstreamRequestContext = GenerateHttpRequestContext(incomingHeaders);
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -23,7 +23,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 {
     public class RecordingHandlerTests
     {
-        private HttpContext _generateHttpRequestContext(string[] headerValueStrings)
+        private HttpContext GenerateHttpRequestContext(string[] headerValueStrings)
         {
             HttpContext context = new DefaultHttpContext();
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -39,7 +39,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             return context;
         }
 
-        private IEnumerable<Tuple<string, StringValues>> _generateHeaderValuesTuples(string[] headerValueStrings) {
+        private IEnumerable<Tuple<string, StringValues>> GenerateHeaderValuesTuples(string[] headerValueStrings) {
             var returnedTuples = new List<Tuple<string, StringValues>>();
             foreach (var headString in headerValueStrings)
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -607,7 +607,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var output = recordingHandler.CreateUpstreamRequest(upstreamRequestContext.Request, new byte[] { });
 
             // iterate across the set we know about and confirm that GenerateUpstreamRequest worked properly!
-            var setOfHeaders = _generateHeaderValuesTuples(incomingHeaders);
+            var setOfHeaders = GenerateHeaderValuesTuples(incomingHeaders);
             {
                 foreach (var headerTuple in setOfHeaders)
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -564,6 +564,15 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var entry = await RecordingHandler.CreateEntryAsync(request);
             Assert.Equal(uri.AbsoluteUri, entry.RequestUri);
         }
+
+
+        [Theory]
+        [InlineData(new string[] { "hello" })]
+        public async Task TestCreateUpstreamRequestIncludesExpectedHeaders(string[] incomingHeaders)
+        {
+
+        }
+
     }
 
     internal class MockHttpHandler : HttpMessageHandler

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -618,13 +618,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                     {
                         inContent = output.Headers.Contains(headerTuple.Item1);
                     }
-                    catch (Exception ex) { }
+                    catch (Exception) { }
 
                     try
                     {
                         inStandard = output.Content.Headers.Contains(headerTuple.Item1);
                     }
-                    catch (Exception ex) { }
+                    catch (Exception) { }
 
                     Assert.True(inContent || inStandard);
                 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -602,7 +602,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         {
             var requestContext = _generateHttpRequestContext(incomingHeaders);
             var recordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            var upstreamRequestContext = _generateHttpRequestContext(incomingHeaders);
+            var upstreamRequestContext = GenerateHttpRequestContext(incomingHeaders);
 
             var output = recordingHandler.CreateUpstreamRequest(upstreamRequestContext.Request, new byte[] { });
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         {
             HttpContext context = new DefaultHttpContext();
 
-            foreach(var hTuple in _generateHeaderValuesTuples(headerValueStrings))
+            foreach(var hTuple in GenerateHeaderValuesTuples(headerValueStrings))
             {
 
                 context.Request.Headers.TryAdd(hTuple.Item1, hTuple.Item2);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -285,7 +285,7 @@ namespace Azure.Sdk.Tools.TestProxy
                     if(!upstreamRequest.Content.Headers.TryAddWithoutValidation(header.Key, values))
                     {
                         throw new HttpException(
-                            HttpStatusCode.InternalServerError,
+                            HttpStatusCode.BadRequest,
                             $"Encountered an unexpected exception while mapping a content header during upstreamRequest creation. Header: \"{header.Key}\". Value: \"{String.Join(",", values)}\""
                         );
                     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -259,7 +259,7 @@ namespace Azure.Sdk.Tools.TestProxy
             return incomingBody.ToArray();
         }
 
-        private HttpRequestMessage CreateUpstreamRequest(HttpRequest incomingRequest, byte[] incomingBody)
+        public HttpRequestMessage CreateUpstreamRequest(HttpRequest incomingRequest, byte[] incomingBody)
         {
             var upstreamRequest = new HttpRequestMessage();
             upstreamRequest.RequestUri = GetRequestUri(incomingRequest);
@@ -270,6 +270,13 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 IEnumerable<string> values = header.Value;
 
+                // can't handle PROXY_CONNECTION right now.
+                if (s_excludedRequestHeaders.Contains(header.Key, StringComparer.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // handle duplicates.
                 if (upstreamRequest.Headers.Contains(header.Key))
                 {
                     continue;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -46,14 +46,6 @@ namespace Azure.Sdk.Tools.TestProxy
             "Proxy-Connection",
         };
 
-        // Headers which must be set on HttpContent instead of HttpRequestMessage
-        private static readonly string[] s_contentRequestHeaders = new string[] {
-            "Content-Length",
-            "Content-Type",
-            "Content-Encoding",
-            "Content-MD5"
-        };
-
         public List<RecordedTestSanitizer> Sanitizers { get; set; }
 
         public List<ResponseTransform> Transforms { get; set; }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -276,12 +276,6 @@ namespace Azure.Sdk.Tools.TestProxy
                     continue;
                 }
 
-                // handle duplicates.
-                if (upstreamRequest.Headers.Contains(header.Key))
-                {
-                    continue;
-                }
-
                 if (!header.Key.StartsWith("x-recording"))
                 {
                     if (upstreamRequest.Headers.TryAddWithoutValidation(header.Key, values))

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -270,6 +270,11 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 IEnumerable<string> values = header.Value;
 
+                if (upstreamRequest.Headers.Contains(header.Key))
+                {
+                    continue;
+                }
+
                 if (!header.Key.StartsWith("x-recording"))
                 {
                     if (upstreamRequest.Headers.TryAddWithoutValidation(header.Key, values))


### PR DESCRIPTION
@JoshLove-msft @mikeharder 

Tested locally with record/playback of a few tables tests. Unfortunately that highlighted an issue with my previous PR during my local testing.