### PR TITLE
[Test-PRoxy] Optional <configuration> requirement

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -95,9 +95,9 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (config != null)
             {
+                Console.WriteLine("Dumping Resolved Configuration Values:");
                 foreach (var c in config.AsEnumerable())
                 {
-                    Console.WriteLine("Dumping Resolved Configuration Values:");
                     Console.WriteLine(c.Key + " = " + c.Value);
                 }
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -73,7 +73,7 @@ namespace Azure.Sdk.Tools.TestProxy
             var host = Host.CreateDefaultBuilder(args);
 
             host.ConfigureWebHostDefaults(
-                builder => 
+                builder =>
                     builder.UseStartup<Startup>()
                     // ripped directly from implementation of ConfigureWebDefaults@https://github.dev/dotnet/aspnetcore/blob/a779227cc2694a50b074a097889ed9e80d15cd77/src/DefaultBuilder/src/WebHost.cs#L176
                     .ConfigureLogging((hostBuilder, loggingBuilder) =>
@@ -91,12 +91,15 @@ namespace Azure.Sdk.Tools.TestProxy
 
             var app = host.Build();
 
-            var config = app.Services.GetRequiredService<IConfiguration>();
+            var config = app.Services.GetService<IConfiguration>();
 
-            foreach (var c in config.AsEnumerable())
+            if (config != null)
             {
-                Console.WriteLine("Dumping Resolved Configuration Values:");
-                Console.WriteLine(c.Key + " = " + c.Value);
+                foreach (var c in config.AsEnumerable())
+                {
+                    Console.WriteLine("Dumping Resolved Configuration Values:");
+                    Console.WriteLine(c.Key + " = " + c.Value);
+                }
             }
 
             app.Run();


### PR DESCRIPTION
We were using `GetRequiredService<>` which will fail if requested service can't be loaded. .NET test framework don't have that service accessible, and so are broken on startup.

Swapping to `GetService` to avoid the startup error. @JoshLove-msft 