### PR TITLE
[Test-Proxy] Ensure compatibility with .NET Unit Tests

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -91,7 +91,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             var app = host.Build();
 
-            var config = app.Services.GetService<IConfiguration>();
+            var config = app.Services?.GetService<IConfiguration>();
 
             if (config != null)
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -91,8 +91,9 @@ namespace Azure.Sdk.Tools.TestProxy
 
             var app = host.Build();
 
-            var config = app.Services?.GetService<IConfiguration>();
+            app.Run();
 
+            var config = app.Services?.GetService<IConfiguration>();
             if (config != null)
             {
                 Console.WriteLine("Dumping Resolved Configuration Values:");
@@ -101,8 +102,6 @@ namespace Azure.Sdk.Tools.TestProxy
                     Console.WriteLine(c.Key + " = " + c.Value);
                 }
             }
-
-            app.Run();
 
             statusThreadCts.Cancel();
             statusThread.Join();


### PR DESCRIPTION
The .NET test framework greps the port number from server output. By dumping those configuration values BEFORE the app.run() output, we were sending unexpected input to their parser.

