### PR TITLE
Add support for service names containing a forward slash

### DIFF
--- a/eng/common/scripts/Update-DocsMsToc.ps1
+++ b/eng/common/scripts/Update-DocsMsToc.ps1
@@ -207,8 +207,7 @@ foreach ($service in $serviceNameList) {
     }
   }
 
-  $serviceReadmeBaseName = $service.ToLower().Replace(' ', '-')
-
+  $serviceReadmeBaseName = $service.ToLower().Replace(' ', '-').Replace('/', '-')
   $serviceTocEntry = [PSCustomObject]@{
     name            = $service;
     href            = "~/docs-ref-services/{moniker}/$serviceReadmeBaseName.md"


### PR DESCRIPTION
Encountered this when auto-generating ToC for `Database for MySQL/PostgreSQL` service from [Python metadata](https://github.com/Azure/azure-sdk/blob/main/_data/releases/latest/python-packages.csv). 

