### PR TITLE
Add k8s namespace to stress test resource group name

### DIFF
--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: stress-test-addons
 description: Baseline resources and templates for stress testing clusters
 
-version: 0.1.13
+version: 0.1.14
 appVersion: v0.1

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
@@ -3,6 +3,15 @@ entries:
   stress-test-addons:
   - apiVersion: v2
     appVersion: v0.1
+    created: "2022-03-22T19:16:14.3599204-04:00"
+    description: Baseline resources and templates for stress testing clusters
+    digest: bc56677a0218bc7cf7a2d709da8dd2291ae160737a6c53d859de98c488cb1990
+    name: stress-test-addons
+    urls:
+    - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.14.tgz
+    version: 0.1.14
+  - apiVersion: v2
+    appVersion: v0.1
     created: "2021-12-02T17:54:52.7194418-05:00"
     description: Baseline resources and templates for stress testing clusters
     digest: 1e944bd23f2a7697d539d06abdc6216ac1549e2a29d65752442aef3e4286f38a
@@ -100,4 +109,4 @@ entries:
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.2.tgz
     version: 0.1.2
-generated: "2021-12-02T17:54:52.7127566-05:00"
+generated: "2022-03-22T19:16:14.3463496-04:00"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
@@ -14,7 +14,7 @@
     - name: ENV_FILE
       value: /mnt/outputs/.env
     - name: RESOURCE_GROUP_NAME
-      value: '{{ lower .Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}'
+      value: '{{ .Release.Namespace }}-{{ lower .Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}'
   volumeMounts:
     - name: "{{ .Release.Name }}-{{ .Release.Revision }}-test-resources"
       mountPath: /mnt/testresources


### PR DESCRIPTION
There is an issue where if the same stress test is deployed to two different namespaces, the generated resource group names will be identical. This causes issues with test overlap, but also when a test in namespace A completes and the resource group deletion triggers, it will remove the test resource targets used by the test in namespace B.

Fixes #2954 