### PR TITLE
[mock-attestation] - Update node-jose

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,3 +26,4 @@
 /tools/mock-service-host/        @changlong-liu @tadelesh
 /tools/sdk-testgen/              @changlong-liu @tadelesh
 /tools/js-sdk-release-tools/     @dw511214992 @qiaozha @MaryGao
+/tools/keyvault-mock-attestation @maorleger

--- a/tools/keyvault-mock-attestation/index.js
+++ b/tools/keyvault-mock-attestation/index.js
@@ -13,7 +13,7 @@ async function initKeys() {
   const { publicKey, privateKey } = crypto.generateKeyPairSync("rsa", {
     modulusLength: 2048,
     publicKeyEncoding: { type: "spki", format: "pem" },
-    privateKeyEncoding: { type: "pkcs8", format: "pem" }
+    privateKeyEncoding: { type: "pkcs8", format: "pem" },
   });
   const keystore = jose.JWK.createKeyStore();
 
@@ -22,7 +22,7 @@ async function initKeys() {
     signingKeyId: key.kid,
     privateKey,
     publicKey,
-    keyStore: keystore
+    keyStore: keystore,
   };
 }
 
@@ -32,7 +32,7 @@ function initApp({ keyStore, privateKey, signingKeyId }) {
 
   app.get("/.well-known/openid-configuration", (req, res) => {
     res.json({
-      jwks_uri: `${baseUrl(req)}/keys`
+      jwks_uri: `${baseUrl(req)}/keys`,
     });
   });
 
@@ -44,7 +44,7 @@ function initApp({ keyStore, privateKey, signingKeyId }) {
     // create a fake release key to wrap a token with.
     const releaseKey = await jose.JWK.createKey("RSA", 2048, {
       use: "enc",
-      kid: "fake-release-key"
+      kid: "fake-release-key",
     });
 
     // sdk-test will be the claim used for tests.
@@ -53,9 +53,8 @@ function initApp({ keyStore, privateKey, signingKeyId }) {
       "sdk-test": true,
       "x-ms-inittime": {},
       "x-ms-runtime": {
-        keys: [releaseKey.toJSON(false)]
+        keys: [releaseKey.toJSON(false)],
       },
-      "maa-ehd": "sdk-test"
     };
 
     const token = jwt.sign(tokenData, privateKey, {
@@ -63,8 +62,8 @@ function initApp({ keyStore, privateKey, signingKeyId }) {
       expiresIn: "7 days",
       header: {
         jku: `${baseUrl(req)}/keys`,
-        kid: signingKeyId
-      }
+        kid: signingKeyId,
+      },
     });
 
     res.json({ token });

--- a/tools/keyvault-mock-attestation/package-lock.json
+++ b/tools/keyvault-mock-attestation/package-lock.json
@@ -46,12 +46,12 @@
       }
     },
     "buffer": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
-      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "requires": {
         "base64-js": "^1.3.1",
-        "ieee754": "^1.1.13"
+        "ieee754": "^1.2.1"
       }
     },
     "buffer-equal-constant-time": {
@@ -318,9 +318,9 @@
       "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
     },
     "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.0.tgz",
+      "integrity": "sha512-9RTUNjK60eJbx3uz+TEGF7fUr29ZDxR5QzXcyDpeSfeH28S9ycINflOgOlppit5U+4kNTe83KQnMEerw7GmE8w=="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -366,24 +366,24 @@
       "integrity": "sha512-hZXc7K2e+PgeI1eDBe/10Ard4ekbfrrqG8Ep+8Jmf4JID2bNg7NvCPOZN+kfF574pFQI7mum2AUqDidoKqcTOw=="
     },
     "node-forge": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
-      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.0.tgz",
+      "integrity": "sha512-08ARB91bUi6zNKzVmaj3QO7cr397uiDT2nJ63cHjyNtCTWIgvS47j3eT0WfzUwS9+6Z5YshRaoasFkXCKrIYbA=="
     },
     "node-jose": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-2.0.0.tgz",
-      "integrity": "sha512-j8zoFze1gijl8+DK/dSXXqX7+o2lMYv1XS+ptnXgGV/eloQaqq1YjNtieepbKs9jBS4WTnMOqyKSaQuunJzx0A==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/node-jose/-/node-jose-2.1.0.tgz",
+      "integrity": "sha512-Zmm8vFPJabphGBc5Wz1/LUMPS+1cynqw16RIhgVNQMEI2yEQrvl7Gx2EwN9GhP8tkm8f7SH53K2nIx8TeNTIdg==",
       "requires": {
         "base64url": "^3.0.1",
-        "buffer": "^5.5.0",
+        "buffer": "^6.0.3",
         "es6-promise": "^4.2.8",
-        "lodash": "^4.17.15",
-        "long": "^4.0.0",
-        "node-forge": "^0.10.0",
-        "pako": "^1.0.11",
+        "lodash": "^4.17.21",
+        "long": "^5.2.0",
+        "node-forge": "^1.2.1",
+        "pako": "^2.0.4",
         "process": "^0.11.10",
-        "uuid": "^3.3.3"
+        "uuid": "^8.3.2"
       }
     },
     "on-finished": {
@@ -395,9 +395,9 @@
       }
     },
     "pako": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
-      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-2.0.4.tgz",
+      "integrity": "sha512-v8tweI900AUkZN6heMU/4Uy4cXRc2AYNRggVmTR+dEncawDJgCdLMximOVA2p4qO57WMynangsfGRb5WD6L1Bg=="
     },
     "parseurl": {
       "version": "1.3.3",
@@ -532,9 +532,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "vary": {
       "version": "1.1.2",

--- a/tools/keyvault-mock-attestation/package.json
+++ b/tools/keyvault-mock-attestation/package.json
@@ -12,7 +12,7 @@
     "body-parser": "^1.19.0",
     "express": "^4.17.1",
     "jsonwebtoken": "^8.5.1",
-    "node-jose": "^2.0.0"
+    "node-jose": "^2.1.0"
   },
   "devDependencies": {}
 }


### PR DESCRIPTION
## What

- Bump the min-version of node-jose to 2.1.0 as the min-version
- Remove the maa-ehd field

## Why

- Fixes a few vulnerabilities in our dependency tree (mainly identified
vulnerabilities in node-forge < 1.0.0)
- maa-ehd is not necessary and if supplied we shouldn't just put any string in
there. While not harmful for our tests, it's not correct either.
