### PR TITLE
Verify Changelog Like ForRelease

### DIFF
--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -167,7 +167,7 @@ function Confirm-ChangeLogEntry {
 
   if ($ForRelease -eq $True)
   {
-    LogDebug "Verifying like its a release build because ForRelease paramert is set to true"
+    LogDebug "Verifying like it's a release build because ForRelease parameter is set to true"
     return Confirm-LikeForRelease -changeLogEntry $changeLogEntry
   }
 

--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -360,7 +360,7 @@ function Confirm-LikeForRelease {
     $isValid = $false
   }
 
-  $foundRecomendedSection = $false
+  $foundRecommendedSection = $false
   $emptySections = @()
   foreach ($key in $changeLogEntry.Sections.Keys)
   {

--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -379,7 +379,7 @@ function Confirm-LikeForRelease {
     LogError "The changelog entry has the following sections with no content ($($emptySections -join ', ')). Please ensure to either remove the empty sections or add content to the section."
     $isValid = $false
   }
-  if (!$foundRecomendedSection)
+  if (!$foundRecommendedSection)
   {
     LogWarning "The changelog entry did not contain any of the recommended sections ($($RecommendedSectionHeaders -join ', ')), please add at least one. See https://aka.ms/azsdk/guideline/changelogs for more info."
   }

--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -175,7 +175,7 @@ function Confirm-ChangeLogEntry {
   $status = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
   if ($status -as [DateTime])
   {
-    LogDebug "Verifying like its a release build because the changelog entry has a valid date."
+    LogDebug "Verifying like it's a release build because the changelog entry has a valid date."
     return Confirm-LikeForRelease -changeLogEntry $changeLogEntry
   }
 

--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -165,61 +165,20 @@ function Confirm-ChangeLogEntry {
     return $false
   }
 
-  if ($ForRelease -eq $True) {
-    if ($changeLogEntry.ReleaseStatus -eq $CHANGELOG_UNRELEASED_STATUS) {
-      LogError "Entry has no release date set. Please ensure to set a release date with format '$CHANGELOG_DATE_FORMAT'. See https://aka.ms/azsdk/guideline/changelogs for more info."
-      return $false
-    }
-    else {
-      $status = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
-      try {
-        $releaseDate = [DateTime]$status
-        if ($status -ne ($releaseDate.ToString($CHANGELOG_DATE_FORMAT)))
-        {
-          LogError "Date must be in the format $($CHANGELOG_DATE_FORMAT). See https://aka.ms/azsdk/guideline/changelogs for more info."
-          return $false
-        }
-        if (((Get-Date).AddMonths(-1) -gt $releaseDate) -or ($releaseDate -gt (Get-Date).AddMonths(1)))
-        {
-          LogError "The date must be within +/- one month from today. See https://aka.ms/azsdk/guideline/changelogs for more info."
-          return $false
-        }
-      }
-      catch {
-          LogError "Invalid date [ $status ] passed as status for Version [$($changeLogEntry.ReleaseVersion)]. See https://aka.ms/azsdk/guideline/changelogs for more info."
-          return $false
-      }
-    }
-
-    if ([System.String]::IsNullOrWhiteSpace($changeLogEntry.ReleaseContent)) {
-      LogError "Entry has no content. Please ensure to provide some content of what changed in this version. See https://aka.ms/azsdk/guideline/changelogs for more info."
-      return $false
-    }
-
-    $foundRecomendedSection = $false
-    $emptySections = @()
-    foreach ($key in $changeLogEntry.Sections.Keys)
-    {
-      $sectionContent = $changeLogEntry.Sections[$key]
-      if ([System.String]::IsNullOrWhiteSpace(($sectionContent | Out-String)))
-      {
-        $emptySections += $key
-      }
-      if ($RecommendedSectionHeaders -contains $key)
-      {
-        $foundRecomendedSection = $true
-      }
-    }
-    if ($emptySections.Count -gt 0)
-    {
-      LogError "The changelog entry has the following sections with no content ($($emptySections -join ', ')). Please ensure to either remove the empty sections or add content to the section."
-      return $false
-    }
-    if (!$foundRecomendedSection)
-    {
-      LogWarning "The changelog entry did not contain any of the recommended sections ($($RecommendedSectionHeaders -join ', ')), pease add at least one. See https://aka.ms/azsdk/guideline/changelogs for more info."
-    }
+  if ($ForRelease -eq $True)
+  {
+    LogDebug "Verifying like its a release build because ForRelease paramert is set to true"
+    return Confirm-LikeForRelease -changeLogEntry $changeLogEntry
   }
+
+  # If the release status is a valid date then verify like its about to be released
+  $status = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
+  if ($status -as [DateTime])
+  {
+    LogDebug "Verifying like its a release build because the changelog entry has a valid date."
+    return Confirm-LikeForRelease -changeLogEntry $changeLogEntry
+  }
+
   return $true
 }
 
@@ -362,4 +321,68 @@ function  Get-LatestReleaseDateFromChangeLog
   $changeLogEntries = Get-ChangeLogEntries -ChangeLogLocation $ChangeLogLocation
   $latestVersion = $changeLogEntries[0].ReleaseStatus.Trim("()")
   return ($latestVersion -as [DateTime])
+}
+
+function Confirm-LikeForRelease {
+  param (
+    [Parameter(Mandatory = $true)]
+    $changeLogEntry
+  )
+
+  $isValid = $true
+  if ($changeLogEntry.ReleaseStatus -eq $CHANGELOG_UNRELEASED_STATUS) {
+    LogError "Entry has no release date set. Please ensure to set a release date with format '$CHANGELOG_DATE_FORMAT'. See https://aka.ms/azsdk/guideline/changelogs for more info."
+    $isValid = $false
+  }
+  else {
+    $status = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
+    try {
+      $releaseDate = [DateTime]$status
+      if ($status -ne ($releaseDate.ToString($CHANGELOG_DATE_FORMAT)))
+      {
+        LogError "Date must be in the format $($CHANGELOG_DATE_FORMAT). See https://aka.ms/azsdk/guideline/changelogs for more info."
+        $isValid = $false
+      }
+      if (((Get-Date).AddMonths(-1) -gt $releaseDate) -or ($releaseDate -gt (Get-Date).AddMonths(1)))
+      {
+        LogError "The date must be within +/- one month from today. See https://aka.ms/azsdk/guideline/changelogs for more info."
+        $isValid = $false
+      }
+    }
+    catch {
+        LogError "Invalid date [ $status ] passed as status for Version [$($changeLogEntry.ReleaseVersion)]. See https://aka.ms/azsdk/guideline/changelogs for more info."
+        $isValid = $false
+    }
+  }
+
+  if ([System.String]::IsNullOrWhiteSpace($changeLogEntry.ReleaseContent)) {
+    LogError "Entry has no content. Please ensure to provide some content of what changed in this version. See https://aka.ms/azsdk/guideline/changelogs for more info."
+    $isValid = $false
+  }
+
+  $foundRecomendedSection = $false
+  $emptySections = @()
+  foreach ($key in $changeLogEntry.Sections.Keys)
+  {
+    $sectionContent = $changeLogEntry.Sections[$key]
+    if ([System.String]::IsNullOrWhiteSpace(($sectionContent | Out-String)))
+    {
+      $emptySections += $key
+    }
+    if ($RecommendedSectionHeaders -contains $key)
+    {
+      $foundRecomendedSection = $true
+    }
+  }
+  if ($emptySections.Count -gt 0)
+  {
+    LogError "The changelog entry has the following sections with no content ($($emptySections -join ', ')). Please ensure to either remove the empty sections or add content to the section."
+    $isValid = $false
+  }
+  if (!$foundRecomendedSection)
+  {
+    LogWarning "The changelog entry did not contain any of the recommended sections ($($RecommendedSectionHeaders -join ', ')), please add at least one. See https://aka.ms/azsdk/guideline/changelogs for more info."
+  }
+  Write-Host "Changelog validation failed. Please fix errors above and try again."
+  return $isValid
 }

--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -371,7 +371,7 @@ function Confirm-LikeForRelease {
     }
     if ($RecommendedSectionHeaders -contains $key)
     {
-      $foundRecomendedSection = $true
+      $foundRecommendedSection = $true
     }
   }
   if ($emptySections.Count -gt 0)

--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -167,7 +167,7 @@ function Confirm-ChangeLogEntry {
 
   if ($ForRelease -eq $True)
   {
-    LogDebug "Verifying like it's a release build because ForRelease parameter is set to true"
+    LogDebug "Verifying as a release build because ForRelease parameter is set to true"
     return Confirm-ChangeLogForRelease -changeLogEntry $changeLogEntry -changeLogEntries $changeLogEntries
   }
 
@@ -358,8 +358,7 @@ function Confirm-ChangeLogForRelease {
         $isValid = $false
       }
 
-      $dateHistory = $entries.ReleaseStatus | ForEach-Object { $_.Trim().Trim("()") }
-      if (@($dateHistory)[0] -ne $status)
+      if (@($entries.ReleaseStatus)[0] -ne $changeLogEntry.ReleaseStatus)
       {
         LogError "Invalid date [ $status ]. The date for the changelog being released must be the latest in the file."
         $isValid = $false
@@ -399,6 +398,5 @@ function Confirm-ChangeLogForRelease {
   {
     LogWarning "The changelog entry did not contain any of the recommended sections ($($RecommendedSectionHeaders -join ', ')), please add at least one. See https://aka.ms/azsdk/guideline/changelogs for more info."
   }
-  Write-Host "Changelog validation failed. Please fix errors above and try again."
   return $isValid
 }


### PR DESCRIPTION
- If the version being verified has a date as the release status verify the changelog like it is being released. 
- Removed the strict date verification that check to make sure the date is within the current month. Now it just checks to make sure the date for the verified version is the latest in the CHANGELOG file.
-This should finally resolve https://github.com/Azure/azure-sdk/issues/3690