### PR TITLE
Fix bug where job matrices with leading numbers generated duplicate job names

### DIFF
--- a/eng/common/scripts/job-matrix/Create-JobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-JobMatrix.ps1
@@ -19,6 +19,10 @@ param (
 
 . $PSScriptRoot/job-matrix-functions.ps1
 
+if (!(Test-Path $ConfigPath)) {
+    Write-Error "ConfigPath '$ConfigPath' does not exist."
+    exit 1
+}
 $config = GetMatrixConfigFromJson (Get-Content $ConfigPath)
 # Strip empty string filters in order to be able to use azure pipelines yaml join()
 $Filters = $Filters | Where-Object { $_ }

--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -355,6 +355,10 @@ function ProcessImport([MatrixParameter[]]$matrix, [String]$selection, [Array]$n
         return $matrix, @()
     }
 
+    if (!(Test-Path $importPath)) {
+        Write-Error "`$IMPORT path '$importPath' does not exist."
+        exit 1
+    }
     $importedMatrixConfig = GetMatrixConfigFromJson (Get-Content $importPath)
     $importedMatrix = GenerateMatrix `
                         -config $importedMatrixConfig `

--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -515,14 +515,11 @@ function CreateMatrixCombinationScalar([MatrixParameter[]]$permutation, [Hashtab
 
     # The maximum allowed matrix name length is 100 characters
     $name = $names -join "_"
+    if ($name -and $name[0] -match "^[0-9]") {
+        $name = "job_" + $name  # Azure Pipelines only supports job names starting with letters
+    }
     if ($name.Length -gt 100) {
         $name = $name[0..99] -join ""
-    }
-    $stripped = $name -replace "^[^A-Za-z]*", ""  # strip leading digits
-    if ($stripped -eq "") {
-        $name = "job_" + $name  # Handle names that consist entirely of numbers
-    } else {
-        $name = $stripped
     }
 
     return @{

--- a/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
+++ b/eng/common/scripts/job-matrix/tests/job-matrix-functions.tests.ps1
@@ -572,7 +572,7 @@ Describe "Platform Matrix Generation With Object Fields" -Tag "objectfields" {
     }
 }
 
-Describe "Platform Matrix Display Names" -Tag "displaynames" {
+Describe "Platform Matrix Job and Display Names" -Tag "displaynames" {
     BeforeEach {
         $matrixConfigForGenerate = @"
 {
@@ -601,7 +601,6 @@ Describe "Platform Matrix Display Names" -Tag "displaynames" {
     It "Should enforce valid display name format" {
         $generateconfig.displayNamesLookup["net461"] = '123.Some.456.Invalid_format-name$(foo)'
         $generateconfig.displayNamesLookup["netcoreapp2.1"] = (New-Object string[] 150) -join "a"
-        $dimensions = GetMatrixDimensions $generateConfig.matrixParameters
         $matrix = GenerateFullMatrix $generateconfig.matrixParameters $generateconfig.displayNamesLookup
 
         $matrix[0].name | Should -Be "ubuntu1804_123some456invalid_formatnamefoo_TestObjectValueName"
@@ -609,6 +608,43 @@ Describe "Platform Matrix Display Names" -Tag "displaynames" {
         $matrix[1].name.Length | Should -Be 100
         # The withfoo part of the argument gets cut off at the character limit
         $matrix[1].name | Should -BeLike "ubuntu1804_aaaaaaaaaaaaaaaaa*"
+    }
+
+    It "Should create a valid display name when there are leading numbers" {
+        $generateconfig.displayNamesLookup["ubuntu-18.04"] = '123_ubuntu1804'
+        $matrix = GenerateFullMatrix $generateconfig.matrixParameters $generateconfig.displayNamesLookup
+
+        $matrix[0].name | Should -Be "job_123_ubuntu1804_net461_TestObjectValueName"
+    }
+
+    It "Should create a valid job name when there are leading numbers" {
+        $matrixConfigForGenerate = @"
+{
+    "matrix": {
+        "numField1": [1, 2, 3],
+        "letterField": ["a", "b", "c"]
+    }
+}
+"@
+        $generateConfig = GetMatrixConfigFromJson $matrixConfigForGenerate
+        $matrix = GenerateFullMatrix $generateconfig.matrixParameters $generateconfig.displayNamesLookup
+        $matrix[0].name | Should -Be "job_1_a"
+    }
+
+    It "Should create a valid job name when parameter values are all numbers" {
+        $matrixConfigForGenerate = @"
+{
+    "matrix": {
+        "numField1": ["1", "2", "3"],
+        "numField2": [4, 5, 6]
+    }
+}
+"@
+        $generateConfig = GetMatrixConfigFromJson $matrixConfigForGenerate
+        $matrix = GenerateSparseMatrix $generateconfig.matrixParameters $generateconfig.displayNamesLookup
+        $matrix[0].name | Should -Be "job_1_4"
+        $matrix[1].name | Should -Be "job_2_5"
+        $matrix[2].name | Should -Be "job_3_6"
     }
 
     It "Should generate a display name with null and object values" {


### PR DESCRIPTION
Fixes #2932

- Fix bug where job matrices with leading numbers generated duplicate job names
- Fail matrix generation when config path or import paths are not found
