### PR TITLE
[Swift APIView] Do not display empty extensions

### DIFF
--- a/src/swift/CHANGELOG.md
+++ b/src/swift/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## Version 0.1.2 (Unreleased)
+- Fixed issue where empty extension blocks were displayed.
+- Temporarily will allow duplicate IDs. This will result in
+  APIView not crashing, but may result in abnormalities
+  when attempting to comment on the APIView. This will be
+  fixed in an upcoming version. 
+
 ## Version 0.1.1 (Unreleased)
 - Fixed issue where getter/setter blocks would fail to process.
 - Fixed issue where function initializers would fail to process.

--- a/src/swift/SwiftAPIView/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
+++ b/src/swift/SwiftAPIView/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
@@ -56,11 +56,15 @@
             isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
+            argument = "--source=/Users/travisprescott/repos/communication-ui-library-ios/AzureCommunicationUI"
+            isEnabled = "YES">
+         </CommandLineArgument>
+         <CommandLineArgument
             argument = "--package-version=0.0.0"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--package-name=TestFile2"
+            argument = "--package-name=AzureCommunicationUI"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
@@ -73,7 +77,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--source=/Users/travisprescott/repos/azure-sdk-tools/src/swift/SwiftAPIViewCore/TestFiles/TestFile2.swifttxt"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
       </CommandLineArguments>
       <LocationScenarioReference

--- a/src/swift/SwiftAPIViewCore/Sources/Extensions/DeclarationModifier+Extensions.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Extensions/DeclarationModifier+Extensions.swift
@@ -27,6 +27,33 @@
 import AST
 import Foundation
 
+extension Declaration {
+    var accessLevel: AccessLevelModifier? {
+        switch self {
+        case let decl as ClassDeclaration:
+            return decl.accessLevelModifier
+        case let decl as FunctionDeclaration:
+            return decl.modifiers.accessLevel
+        case let decl as EnumDeclaration:
+            return decl.accessLevelModifier
+        case let decl as ConstantDeclaration:
+            return decl.modifiers.accessLevel
+        case let decl as VariableDeclaration:
+            return decl.modifiers.accessLevel
+        case let decl as TypealiasDeclaration:
+            return decl.accessLevelModifier
+        case let decl as StructDeclaration:
+            return decl.accessLevelModifier
+        case let decl as InitializerDeclaration:
+            return decl.modifiers.accessLevel
+        case let decl as SubscriptDeclaration:
+            return decl.modifiers.accessLevel
+        default:
+            return nil
+        }
+    }
+}
+
 extension DeclarationModifiers {
 
     var accessLevel: AccessLevelModifier? {
@@ -110,5 +137,27 @@ extension OperatorDeclaration {
         case let .prefix(opName):
             return opName
         }
+    }
+}
+
+extension ExtensionDeclaration {
+
+    var isPublic: Bool {
+        let publicModifiers: [AccessLevelModifier] = [.public, .open]
+        return publicModifiers.contains(self.accessLevelModifier ?? .internal)
+    }
+
+    var hasPublicMembers: Bool {
+        let publicModifiers: [AccessLevelModifier] = [.public, .open]
+        for member in self.members {
+            switch member {
+            case let .declaration(decl):
+                guard let accessLevel = decl.accessLevel else { continue }
+                if publicModifiers.contains(accessLevel) { return true }
+            case .compilerControl(_):
+                break
+            }
+        }
+        return false
     }
 }


### PR DESCRIPTION
Partially addresses #2536. Ultimately, there will be significant work needed to correctly support extensions, but this PR ensures that extensions that are not themselves public or have any public members are not displayed.

This PR will temporarily allow duplicate IDs, which will revive the potential that comments will not appear correctly in APIView. Commenting on an extension will act like you are commenting on the original thing. For now, this is preferable to making APIView crash since the ultimate fix is non-trivial. 