### PR TITLE
Disable automatic translation of revision pages

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_Layout.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_Layout.cshtml
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
+    <meta name="google" content="notranslate" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>@ViewData["Title"] - apiview.dev</title>
 


### PR DESCRIPTION
In some packages' revision page Edge offers to translate *from* Portuguese. `<html lang="en">` was added to no avail. After digging into the problem and asking internally, adding a "notranslate" meta prevents the automatic suggestion, but the page still is detected as Portuguese if you right-click and choose to translate anyway. Seems there's no way to change that. Typical language elements/attributes seem to be ignored in modern browsers.
