### PR TITLE
Extend the timeout for notification pipelines

### DIFF
--- a/eng/pipelines/notifications.yml
+++ b/eng/pipelines/notifications.yml
@@ -11,7 +11,7 @@ stages:
 
   jobs:
   - job: Run
-    timeoutInMinutes: 120
+    timeoutInMinutes: 240
     strategy:
       # Running all entries simultaneously causes "Service Unavailable" errors
       maxParallel: 2


### PR DESCRIPTION
This is a short term fix for current notification pipeline failure. 
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1470791&view=logs&s=7e5a62c6-a3ae-5561-387a-bc0babb014af
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1467754&view=logs&s=7e5a62c6-a3ae-5561-387a-bc0babb014af
