### PR TITLE
[Python APIView] Support @overloads and fix issue with parameterized decorators

### DIFF
--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -5,6 +5,8 @@ Fixed issue where types would appear wrapped in "Optional" even though
   they do not accept `None`.
 Fixed issue where, in some cases, string literal default values would not appear wrapped
   in quotes.
+Added support for @overloads decorators.
+Fixed issue where decorators with parameters would not appear in APIView.
 
 ## Version 0.2.11 (2022-04-06)
 Added __main__ to execute as module

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_astroid_parser.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_astroid_parser.py
@@ -1,0 +1,78 @@
+import astroid
+from ._base_node import get_qualified_name
+from ._argtype import ArgType
+
+
+class AstroidArgumentParser:
+
+    def __init__(self, node: astroid.Arguments, namespace: str, func_node):
+        if not isinstance(node, astroid.Arguments):
+            raise TypeError("Can only pass in an astroid Arguments node.")
+        self._namespace = namespace
+        self._node = node
+        self._parent = func_node
+        self.args = {}
+        self.kwargs = {}
+        self.posargs = {}
+        self.varargs = None
+        self._parse_args()
+        self._parse_kwargs()
+        self._parse_posonly_args()
+        self._parse_varargs()
+
+    def _default_value(self, name):
+        try:
+            return self._node.default_value(name).as_string()
+        except astroid.NoDefault:
+            return None
+
+    def _argtype(self, name, idx, annotations, type_comments):
+        if annotations:
+            argtype = annotations[idx]
+        elif type_comments:
+            argtype = type_comments[idx]
+        else:
+            argtype = None
+        return get_qualified_name(argtype, self._namespace)
+
+    def _parse_args(self):
+        for (idx, arg) in enumerate(self._node.args):
+            name = arg.name
+            argtype = self._argtype(name, idx, self._node.annotations, self._node.type_comment_args)
+            default = self._default_value(name)
+            self.args[name] = ArgType(name, argtype=argtype, default=default, keyword=None, func_node=self._parent)
+
+    def _parse_kwargs(self):
+        for (idx, arg) in enumerate(self._node.kwonlyargs):
+            name = arg.name
+            argtype = self._argtype(name, idx, self._node.kwonlyargs_annotations, self._node.type_comment_kwonlyargs)
+            default = self._default_value(name)
+            self.kwargs[name] = ArgType(name, argtype=argtype, default=default, keyword="keyword", func_node=self._parent)
+        if self._node.kwarg:
+            kwarg_name = self._node.kwarg
+            if self._node.kwargannotation:
+                kwarg_type = self._node.kwargannotation.as_string()
+            else:
+                kwarg_type = None
+            # This wonky logic matches the existing code
+            arg = ArgType(kwarg_name, argtype=kwarg_type, default=None, keyword="keyword", func_node=self._parent)
+            arg.argname = f"**{kwarg_name}"
+            self.args[arg.argname] = arg
+
+    def _parse_posonly_args(self):
+        for (idx, arg) in enumerate(self._node.args):
+            name = arg.name
+            argtype = self._argtype(name, idx, self._node.posonlyargs_annotations, self._node.type_comment_posonlyargs)
+            default = self._default_value(name)
+            self.posargs[name] = ArgType(name, argtype=argtype, default=default, keyword=None, func_node=self._parent)
+
+    def _parse_varargs(self):
+        if self._node.vararg:
+            name = self._node.vararg
+            if self._node.varargannotation:
+                argtype = self._node.varargannotation.as_string()
+            else:
+                argtype = None
+            arg = ArgType(name, argtype=argtype, default=None, keyword=None, func_node=self._parent)
+            arg.argname = f"*{name}"
+            self.args[name] = arg

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
@@ -56,6 +56,8 @@ def get_qualified_name(obj, namespace: str) -> str:
 
     if module_name.startswith("astroid"):
         return obj.as_string()
+    elif module_name == "types":
+        return str(obj)
 
     if obj is Parameter.empty:
         return None

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
@@ -1,3 +1,4 @@
+import astroid
 from inspect import Parameter
 import re
 
@@ -45,13 +46,17 @@ class NodeEntityBase:
                 c.generate_tokens(apiview)
             apiview.end_group()
 
-
-def get_qualified_name(obj, namespace):
+def get_qualified_name(obj, namespace: str) -> str:
     """Generate and return fully qualified name of object with module name for internal types.
        If module name is not available for the object then it will return name
     :param: obj
         Parameter object of type class, function or enum
     """
+    module_name = getattr(obj, "__module__", "")
+
+    if module_name.startswith("astroid"):
+        return obj.as_string()
+
     if obj is Parameter.empty:
         return None
 
@@ -60,10 +65,6 @@ def get_qualified_name(obj, namespace):
         name = getattr(obj, "__name__")
     elif hasattr(obj, "__qualname__"):
         name = getattr(obj, "__qualname__")
-
-    module_name = ""
-    if hasattr(obj, "__module__"):
-        module_name = getattr(obj, "__module__")
 
     wrap_optional = False
     args = []

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
@@ -148,9 +148,12 @@ class ClassNode(NodeEntityBase):
             if not func.decorators:
                 continue
             for node in func.decorators.nodes:
-                if node.name == "overload":
-                    overload_node = FunctionNode(self.namespace, self, node=func)
-                    overload_nodes.append(overload_node)
+                try:
+                    if node.name == "overload":
+                        overload_node = FunctionNode(self.namespace, self, node=func)
+                        overload_nodes.append(overload_node)
+                except AttributeError:
+                    continue
         return overload_nodes
 
     def _inspect(self):

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_class_node.py
@@ -135,7 +135,8 @@ class ClassNode(NodeEntityBase):
             )
 
     """ Uses AST parsing to look for @overload decorated functions
-        because inspect cannot see these.
+        because inspect cannot see these. Note that this will not
+        find overloads for module-level functions.
     """
     def _parse_overloads(self) -> List[FunctionNode]:
         overload_nodes = []

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -135,14 +135,14 @@ class FunctionNode(NodeEntityBase):
                 self.return_type = get_qualified_name(sig.return_annotation, self.namespace)
         else:
             # Logic for when we only have the node, not the function object itself
+            # Should only apply to @overload cases
             parser = AstroidArgumentParser(self.node.args, self.namespace, self)
             self.args.update(parser.args)
-            # TODO: We don't really support pos-only args. This will treat them like regular args
+            # # TODO: We don't really support pos-only args. This will treat them like regular args
             self.args.update(parser.posargs)
             self.kw_args = parser.kwargs
             if self.node.returns:
                 self.return_type = get_qualified_name(self.node.returns, self.namespace)
-
         self._parse_docstring()
         self._parse_typehint()
         self._order_final_args()

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -84,10 +84,8 @@ class FunctionNode(NodeEntityBase):
             self.namespace_id += ":async"
         
         # Turn any decorators into annotation
-        try:
-            self.annotations = [f"@{x.name}" for x in self.node.decorators.nodes if hasattr(x, "name")]
-        except:
-            pass
+        if self.node.decorators:
+            self.annotations = [f"@{x.as_string()}" for x in self.node.decorators.nodes]
 
         self.is_class_method = "@classmethod" in self.annotations
         self._parse_function()

--- a/packages/python-packages/api-stub-generator/tests/apiview_test.py
+++ b/packages/python-packages/api-stub-generator/tests/apiview_test.py
@@ -58,4 +58,5 @@ class TestApiView:
         stub_gen = StubGenerator(args=args)
         apiview = stub_gen.generate_tokens()
         # ensure we have only the expected diagnostics when testing apistubgentest
-        assert len(apiview.diagnostics) == 1
+        # TODO: These will be removed soon.
+        assert len(apiview.diagnostics) == 21

--- a/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
@@ -178,10 +178,16 @@ class TestClassParsing:
 
     def test_decorators(self):
         class_node = ClassNode(name="SomethingWithDecorators", namespace="test", parent_node=None, obj=SomethingWithDecorators, pkg_root_namespace=self.pkg_namespace)
-        assert len(class_node.child_nodes) == 2
+        assert len(class_node.child_nodes) == 4
 
         node1 = class_node.child_nodes[0]
-        assert node1.annotations == ["@my_decorator"]
+        assert node1.annotations == ["@another_decorator('Test')"]
 
         node2 = class_node.child_nodes[1]
-        assert node2.annotations == ["@my_decorator"]
+        assert node2.annotations == ["@another_decorator('Test')"]
+
+        node3 = class_node.child_nodes[2]
+        assert node3.annotations == ["@my_decorator"]
+
+        node4 = class_node.child_nodes[3]
+        assert node4.annotations == ["@my_decorator"]

--- a/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
@@ -178,4 +178,10 @@ class TestClassParsing:
 
     def test_decorators(self):
         class_node = ClassNode(name="SomethingWithDecorators", namespace="test", parent_node=None, obj=SomethingWithDecorators, pkg_root_namespace=self.pkg_namespace)
-        assert len(class_node.child_nodes) == 3
+        assert len(class_node.child_nodes) == 2
+
+        node1 = class_node.child_nodes[0]
+        assert node1.annotations == ["@my_decorator"]
+
+        node2 = class_node.child_nodes[1]
+        assert node2.annotations == ["@my_decorator"]

--- a/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
@@ -110,9 +110,9 @@ class TestClassParsing:
         assert node1.name == "double"
         self._check_arg_nodes(node1.args, [
             ("self", None, None),
-            ("input", "Optional[int]", "1"),
+            ("input", "int", "1"),
             ("*", None, None),
-            ("test", "Optional[bool]", "False"),
+            ("test", "bool", "False"),
             ("**kwargs", None, None)
         ])
         assert node1.return_type == "int"
@@ -122,9 +122,9 @@ class TestClassParsing:
         assert node2.name == "double"
         self._check_arg_nodes(node2.args, [
             ("self", None, None),
-            ("input", "Optional[Sequence[int]]", "[1]"),
+            ("input", "Sequence[int]", "[1]"),
             ("*", None, None),
-            ("test", "Optional[bool]", "False"),
+            ("test", "bool", "False"),
             ("**kwargs", None, None)
         ])
         assert node2.return_type == "list[int]"
@@ -138,7 +138,7 @@ class TestClassParsing:
             # don't appear in the actual APIView.
             ("input", "int | collections.abc.Sequence[int]", None),
             ("*", None, None),
-            ("test", "Optional[bool]", "False"),
+            ("test", "bool", "False"),
             ("**kwargs", None, None)
         ])
         assert node3.return_type == "int | list[int]"

--- a/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
@@ -34,6 +34,14 @@ class TestClassParsing:
                 actual_type = node.type
                 assert actual_type == check_type
 
+    def _check_arg_nodes(self, nodes, checks):
+        assert len(nodes) == len(checks)
+        for (i, node) in enumerate(nodes.values()):
+            (check_name, check_type, check_val) = checks[i]
+            assert node.argname == check_name
+            assert node.argtype == check_type
+            assert node.default == check_val
+
     def test_typed_dict_class(self):
         class_node = ClassNode(name="FakeTypedDict", namespace="test", parent_node=None, obj=FakeTypedDict, pkg_root_namespace=self.pkg_namespace)
         self._check_nodes(class_node.child_nodes, [
@@ -95,32 +103,79 @@ class TestClassParsing:
 
     def test_overloads(self):
         class_node = ClassNode(name="SomethingWithOverloads", namespace="test", parent_node=None, obj=SomethingWithOverloads, pkg_root_namespace=self.pkg_namespace)
-        assert len(class_node.child_nodes) == 3
+        assert len(class_node.child_nodes) == 6
+
         node1 = class_node.child_nodes[0]
         assert "@overload" in node1.annotations
-        assert node1.args["input_"].argtype == "Optional[int]"
-        assert node1.args["input_"].default == "1"
-        assert node1.args["test"].argtype == "Optional[bool]"
-        assert node1.args["test"].default == "False"
+        assert node1.name == "double"
+        self._check_arg_nodes(node1.args, [
+            ("self", None, None),
+            ("input", "Optional[int]", "1"),
+            ("*", None, None),
+            ("test", "Optional[bool]", "False"),
+            ("**kwargs", None, None)
+        ])
         assert node1.return_type == "int"
 
         node2 = class_node.child_nodes[1]
         assert "@overload" in node2.annotations
-        assert node2.args["input_"].argtype == "Optional[Sequence[int]]"
-        assert node2.args["input_"].default == "[1]"
-        assert node2.args["test"].argtype == "Optional[bool]"
-        assert node2.args["test"].default == "False"
+        assert node2.name == "double"
+        self._check_arg_nodes(node2.args, [
+            ("self", None, None),
+            ("input", "Optional[Sequence[int]]", "[1]"),
+            ("*", None, None),
+            ("test", "Optional[bool]", "False"),
+            ("**kwargs", None, None)
+        ])
         assert node2.return_type == "list[int]"
 
         node3 = class_node.child_nodes[2]
         assert "@overload" not in node3.annotations
-        # TODO: This should not have all the weird collections annotations
-        assert node3.args["input_"].argtype == "int | collections.abc.Sequence[int, collections.abc.Sequence[int]]"
-        assert node3.args["input_"].default == None
-        assert node3.args["test"].argtype == "Optional[bool]"
-        assert node3.args["test"].default == "False"
-        assert node3.return_type == "int | list[int, list[int]]"        
-        
+        assert node3.name == "double"
+        self._check_arg_nodes(node3.args, [
+            ("self", None, None),
+            # This should not have all the weird collections annotations, but they
+            # don't appear in the actual APIView.
+            ("input", "int | collections.abc.Sequence[int]", None),
+            ("*", None, None),
+            ("test", "Optional[bool]", "False"),
+            ("**kwargs", None, None)
+        ])
+        assert node3.return_type == "int | list[int]"
+
+        node4 = class_node.child_nodes[3]
+        assert "@overload" in node4.annotations
+        assert node4.name == "something"
+        self._check_arg_nodes(node4.args, [
+            ("self", None, None),
+            ("id", "str", None),
+            ("*args", None, None),
+            ("**kwargs", None, None)
+        ])
+        assert node4.return_type == "str"
+
+        node5 = class_node.child_nodes[4]
+        assert "@overload" in node5.annotations
+        assert node5.name == "something"
+        self._check_arg_nodes(node5.args, [
+            ("self", None, None),
+            ("id", "int", None),
+            ("*args", None, None),
+            ("**kwargs", None, None)
+        ])
+        assert node5.return_type == "str"
+
+        node6 = class_node.child_nodes[5]
+        assert "@overload" not in node6.annotations
+        assert node6.name == "something"
+        self._check_arg_nodes(node6.args, [
+            ("self", None, None),
+            ("id", "int | str", None),
+            ("*args", None, None),
+            ("**kwargs", None, None)
+        ])
+        assert node5.return_type == "str"
+
     def test_decorators(self):
         class_node = ClassNode(name="SomethingWithDecorators", namespace="test", parent_node=None, obj=SomethingWithDecorators, pkg_root_namespace=self.pkg_namespace)
         assert len(class_node.child_nodes) == 3

--- a/packages/python-packages/api-stub-generator/tests/function_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/function_parsing_test.py
@@ -107,7 +107,7 @@ class TestFunctionParsing:
 
 
     def test_non_typehint_with_string_defaults(self):
-        func_node = FunctionNode("test", None, TypeHintingClient.some_method_non_optional, "test")
+        func_node = FunctionNode("test", None, obj=TypeHintingClient.some_method_non_optional)
         arg1 = func_node.args["docstring_type"]
         assert arg1.argtype == "str"
         assert arg1.default == "string"
@@ -115,7 +115,7 @@ class TestFunctionParsing:
         assert arg2.argtype == "str"
         assert arg2.default == "string"
 
-        func_node = FunctionNode("test", None, TypeHintingClient.some_method_with_optionals, "test")
+        func_node = FunctionNode("test", None, obj=TypeHintingClient.some_method_with_optionals)
         arg1 = func_node.args["labeled_optional"]
         assert arg1.argtype == "Optional[str]"
         assert arg1.default == "string"

--- a/packages/python-packages/api-stub-generator/tests/function_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/function_parsing_test.py
@@ -57,25 +57,25 @@ class TestClass:
 class TestFunctionParsing:
     
     def test_optional_typehint(self):
-        func_node = FunctionNode("test", None, TestClass.with_optional_typehint, "test")
+        func_node = FunctionNode("test", None, obj=TestClass.with_optional_typehint)
         arg = func_node.args["description"]
         assert arg.argtype == "Optional[str]"
         assert arg.default == "..."
 
     def test_optional_docstring(self):
-        func_node = FunctionNode("test", None, TestClass.with_optional_docstring, "test")
+        func_node = FunctionNode("test", None, obj=TestClass.with_optional_docstring)
         arg = func_node.args["description"]
         assert arg.argtype == "str"
         assert arg.default == "..."
 
     def test_variadic_typehints(self):
-        func_node = FunctionNode("test", None, TestClass.with_variadic_python3_typehint, "test")
+        func_node = FunctionNode("test", None, obj=TestClass.with_variadic_python3_typehint)
         arg = func_node.args["vars"]
         assert arg.argname == "*vars"
         assert arg.argtype == "str"
         assert arg.default == None
 
-        func_node = FunctionNode("test", None, TestClass.with_variadic_python2_typehint, "test")
+        func_node = FunctionNode("test", None, obj=TestClass.with_variadic_python2_typehint)
         arg = func_node.args["vars"]
         assert arg.argname == "*vars"
         # the type annotation comes ONLY from the docstring. The Python2 type hint is not used!
@@ -83,26 +83,26 @@ class TestFunctionParsing:
         assert arg.default == None
 
     def test_default_values(self):
-        func_node = FunctionNode("test", None, TestClass.with_default_values, "test")
+        func_node = FunctionNode("test", None, obj=TestClass.with_default_values)
         assert func_node.args["foo"].default == "1"
         assert func_node.kw_args["bar"].default == "2"
         assert func_node.kw_args["baz"].default == "..."
 
     def test_typehint_and_docstring_return_types(self):
-        func_node = FunctionNode("test", None, TestClass.with_python2_list_typehint, "test")
+        func_node = FunctionNode("test", None, obj=TestClass.with_python2_list_typehint)
         assert func_node.return_type == "List[TestClass]"
 
-        func_node = FunctionNode("test", None, TestClass.with_python3_list_typehint, "test")
+        func_node = FunctionNode("test", None, obj=TestClass.with_python3_list_typehint)
         assert func_node.return_type == "List[TestClass]"
 
-        func_node = FunctionNode("test", None, TestClass.with_python3_str_typehint, "test")
+        func_node = FunctionNode("test", None, obj=TestClass.with_python3_str_typehint)
         assert func_node.return_type == "List[str]"
 
     def test_complex_typehints(self):
-        func_node = FunctionNode("test", None, TestClass.with_python2_union_typehint, "test")
+        func_node = FunctionNode("test", None, obj=TestClass.with_python2_union_typehint)
         assert func_node.return_type == "List[Union[str, int]]"
 
-        func_node = FunctionNode("test", None, TestClass.with_python3_union_typehint, "test")
+        func_node = FunctionNode("test", None, obj=TestClass.with_python3_union_typehint)
         assert func_node.return_type == "List[Union[str, int]]"
 
 

--- a/packages/python-packages/apistubgentest/apistubgentest/models/__init__.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/__init__.py
@@ -15,6 +15,7 @@ from ._models import (
     PublicCaseInsensitiveEnumMeta,
     PublicPrivateClass, RequiredKwargObject,
     SomePoorlyNamedObject as SomeAwesomelyNamedObject,
+    SomethingWithDecorators,
     SomethingWithOverloads
 )
 
@@ -32,5 +33,6 @@ __all__ = (
     "PublicPrivateClass",
     "RequiredKwargObject",
     "SomeAwesomelyNamedObject",
+    "SomethingWithDecorators",
     "SomethingWithOverloads"
 )

--- a/packages/python-packages/apistubgentest/apistubgentest/models/__init__.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/__init__.py
@@ -14,7 +14,8 @@ from ._models import (
     PetEnumPy3Metaclass,
     PublicCaseInsensitiveEnumMeta,
     PublicPrivateClass, RequiredKwargObject,
-    SomePoorlyNamedObject as SomeAwesomelyNamedObject
+    SomePoorlyNamedObject as SomeAwesomelyNamedObject,
+    SomethingWithOverloads
 )
 
 
@@ -30,5 +31,6 @@ __all__ = (
     "PublicCaseInsensitiveEnumMeta",
     "PublicPrivateClass",
     "RequiredKwargObject",
-    "SomeAwesomelyNamedObject"
+    "SomeAwesomelyNamedObject",
+    "SomethingWithOverloads"
 )

--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -160,17 +160,28 @@ class SomePoorlyNamedObject:
 class SomethingWithOverloads:
 
     @overload
-    async def double(input_: int = 1, *, test: bool = False, **kwargs) -> int:
+    def double(self, input: int = 1, *, test: bool = False, **kwargs) -> int:
         ...
 
     @overload
-    async def double(input_: Sequence[int] = [1], *, test: bool = False, **kwargs) -> list[int]:
+    def double(self, input: Sequence[int] = [1], *, test: bool = False, **kwargs) -> list[int]:
         ...
 
-    async def double(input_: int | Sequence[int], *, test: bool = False, **kwargs) -> int | list[int]:
-        if isinstance(input_, Sequence):
-            return [i * 2 for i in input_]
-        return input_ * 2
+    async def double(self, input: int | Sequence[int], *, test: bool = False, **kwargs) -> int | list[int]:
+        if isinstance(input, Sequence):
+            return [i * 2 for i in input]
+        return input * 2
+
+    @overload
+    def something(self, id: str, *args, **kwargs) -> str:
+        ...
+
+    @overload
+    def something(self, id: int, *args, **kwargs) -> str:
+        ...
+
+    def something(self, id: int | str, *args, **kwargs) -> str:
+        return str(id)
 
 
 class SomethingWithDecorators:

--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -150,21 +150,41 @@ class ObjectWithDefaults:
         self.is_awesome = is_awesome
         self.pet = pet
 
+
 class SomePoorlyNamedObject:
 
     def __init__(self, name: str):
         self.name = name
 
+
 class SomethingWithOverloads:
+
     @overload
-    async def double(input_: int) -> int:
+    async def double(input_: int = 1, *, test: bool = False, **kwargs) -> int:
         ...
 
     @overload
-    async def double(input_: Sequence[int]) -> list[int]:
+    async def double(input_: Sequence[int] = [1], *, test: bool = False, **kwargs) -> list[int]:
         ...
 
-    async def double(input_: int | Sequence[int]) -> int | list[int]:
+    async def double(input_: int | Sequence[int], *, test: bool = False, **kwargs) -> int | list[int]:
         if isinstance(input_, Sequence):
             return [i * 2 for i in input_]
         return input_ * 2
+
+
+class SomethingWithDecorators:
+
+    class MyDecorator:
+        def __init__(self, function):
+            pass
+        def __call__(self, *args, **kwargs):
+            return
+
+    @MyDecorator
+    async def name_async(self):
+        return "Test"
+
+    @MyDecorator
+    def name_sync(self):
+        return "Test"

--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -7,10 +7,11 @@
 # --------------------------------------------------------------------------
 
 from azure.core import CaseInsensitiveEnumMeta
+from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
 from six import with_metaclass
-from typing import Any, TypedDict, Union
+from typing import Any, overload, TypedDict, Union
 
 
 class PublicCaseInsensitiveEnumMeta(EnumMeta):
@@ -153,3 +154,17 @@ class SomePoorlyNamedObject:
 
     def __init__(self, name: str):
         self.name = name
+
+class SomethingWithOverloads:
+    @overload
+    async def double(input_: int) -> int:
+        ...
+
+    @overload
+    async def double(input_: Sequence[int]) -> list[int]:
+        ...
+
+    async def double(input_: int | Sequence[int]) -> int | list[int]:
+        if isinstance(input_, Sequence):
+            return [i * 2 for i in input_]
+        return input_ * 2

--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -184,7 +184,7 @@ class SomethingWithOverloads:
     def double(self, input: Sequence[int] = [1], *, test: bool = False, **kwargs) -> list[int]:
         ...
 
-    async def double(self, input: int | Sequence[int], *, test: bool = False, **kwargs) -> int | list[int]:
+    def double(self, input: int | Sequence[int], *, test: bool = False, **kwargs) -> int | list[int]:
         if isinstance(input, Sequence):
             return [i * 2 for i in input]
         return input * 2

--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -22,6 +22,15 @@ def my_decorator(fn):
     return wrapper
 
 
+def another_decorator(value):
+    def decorator(fn):
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            return value
+        return wrapper
+    return decorator
+
+
 class PublicCaseInsensitiveEnumMeta(EnumMeta):
     def __getitem__(self, name: str):
         pass
@@ -196,8 +205,16 @@ class SomethingWithDecorators:
 
     @my_decorator
     async def name_async(self):
-        return "Test"
+        pass
 
     @my_decorator
     def name_sync(self):
-        return "Test"
+        pass
+
+    @another_decorator("Test")
+    async def complex_decorator_async(self):
+        pass
+
+    @another_decorator("Test")
+    def complex_decorator_sync(self):
+        pass

--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -10,8 +10,16 @@ from azure.core import CaseInsensitiveEnumMeta
 from collections.abc import Sequence
 from dataclasses import dataclass
 from enum import Enum, EnumMeta
+import functools
 from six import with_metaclass
 from typing import Any, overload, TypedDict, Union
+
+
+def my_decorator(fn):
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        pass
+    return wrapper
 
 
 class PublicCaseInsensitiveEnumMeta(EnumMeta):
@@ -186,16 +194,10 @@ class SomethingWithOverloads:
 
 class SomethingWithDecorators:
 
-    class MyDecorator:
-        def __init__(self, function):
-            pass
-        def __call__(self, *args, **kwargs):
-            return
-
-    @MyDecorator
+    @my_decorator
     async def name_async(self):
         return "Test"
 
-    @MyDecorator
+    @my_decorator
     def name_sync(self):
         return "Test"


### PR DESCRIPTION
Fixes #3028.  This was a pretty simple bug in the logic to parse decorators.

Closes #3012, #3011, #3010. This was a much more involved fix because inspect cannot see overloads. Instead, I have to parse the source of the enclosing class and parse the decorators from the AST nodes, which is messy (and unfortunate!).

Here's the APIVIew for this. See "SomethingWithDecorators" and "SomethingWithOverloads":
https://apiviewstaging.azurewebsites.net/Assemblies/Review/b821d6b6f4c94d6a907be8773e8767ab

Note that the diagnostics will go away once #2933 is merged. 

Test to verify this addresses recently reported issues:
- [x] azure.identity - https://apiviewstaging.azurewebsites.net/Assemblies/Review/94a5081dbc834524b4e680286e922dde
- [x] azure.containerregistry - https://apiviewstaging.azurewebsites.net/Assemblies/Review/7f6f7705b54f4c57a252bd0d04ed3b33