### PR TITLE
[stress testing] Fail helm deployments when ARM template does not exist

### DIFF
--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_deploy_configmap.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_deploy_configmap.tpl
@@ -6,5 +6,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   template: |
-    {{- .Files.Get "stress-test-resources.json" | nindent 4 }}
+    {{ $template := .Files.Get "stress-test-resources.json" }}
+    {{ if eq (len $template) 0 }}
+      {{ fail "File `stress-test-resources.json` was empty or not found for live resource deployment configmap. Perhaps the `stress-test-resources.bicep` file is missing or the `az bicep build` command failed when running the deployment script?" }}
+    {{ end }}
+    {{- $template | nindent 4 }}
 {{ end }}


### PR DESCRIPTION
I have another change coming soon for addons so I'll hold off on bumping the version and release until then.

@richardpark-msft @m-redding this should fix the hidden error issue with missing ARM templates.