### PR TITLE
[Test-Proxy] Allow Default `Host` header setting

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
@@ -27,11 +27,11 @@ namespace Azure.Sdk.Tools.TestProxy
         }
         
         private static readonly HttpClient s_client = Startup.Insecure ?
-            new HttpClient(new HttpClientHandler() {  ServerCertificateCustomValidationCallback = (_, _, _, _) => true })
+            new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false, ServerCertificateCustomValidationCallback = (_, _, _, _) => true })
             {
-                Timeout = TimeSpan.FromSeconds(600)
+                Timeout = TimeSpan.FromSeconds(600),
             } :
-            new HttpClient() {
+            new HttpClient(new HttpClientHandler() { AllowAutoRedirect = false }) {
                 Timeout = TimeSpan.FromSeconds(600)
             };
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -43,7 +43,6 @@ namespace Azure.Sdk.Tools.TestProxy
         private static readonly string[] s_excludedRequestHeaders = new string[] {
             // Only applies to request between client and proxy
             // TODO, we need to handle this properly, there are tests that actually test proxy functionality.
-            "Host",
             "Proxy-Connection",
         };
 
@@ -294,6 +293,8 @@ namespace Azure.Sdk.Tools.TestProxy
                     }
                 }
             }
+
+            upstreamRequest.Headers.Host = upstreamRequest.RequestUri.Host;
 
             return upstreamRequest;
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -43,6 +43,7 @@ namespace Azure.Sdk.Tools.TestProxy
         private static readonly string[] s_excludedRequestHeaders = new string[] {
             // Only applies to request between client and proxy
             // TODO, we need to handle this properly, there are tests that actually test proxy functionality.
+            "Host",
             "Proxy-Connection",
         };
 
@@ -137,6 +138,7 @@ namespace Azure.Sdk.Tools.TestProxy
             var entry = await CreateEntryAsync(incomingRequest).ConfigureAwait(false);
 
             var upstreamRequest = CreateUpstreamRequest(incomingRequest, entry.Request.Body);
+
             var upstreamResponse = await client.SendAsync(upstreamRequest).ConfigureAwait(false);
 
             var headerListOrig = incomingRequest.Headers.Select(x => String.Format("{0}: {1}", x.Key, x.Value.First())).ToList();
@@ -292,8 +294,6 @@ namespace Azure.Sdk.Tools.TestProxy
                     }
                 }
             }
-
-            upstreamRequest.Headers.Host = upstreamRequest.RequestUri.Host;
 
             return upstreamRequest;
         }

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -1,4 +1,22 @@
-# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
+parameters:
+- name: DockerDeployments
+  type: object
+  default:
+  - name: test_proxy_linux
+    pool: 'ubuntu-20.04'
+    dockerRepo: 'engsys/testproxy-lin'
+    prepareScript: tools/test-proxy/docker/prepare.ps1
+    dockerFile: 'tools/test-proxy/docker/dockerfile'
+    stableTags:
+    - 'latest'
+  - name: test_proxy_windows
+    pool: 'windows-2019'
+    dockerRepo: 'engsys/testproxy-win'
+    prepareScript: tools/test-proxy/docker/prepare.ps1
+    dockerFile: 'tools/test-proxy/docker/dockerfile-win'
+    stableTags:
+    - 'latest'
+
 trigger:
   branches:
     include:
@@ -27,18 +45,4 @@ extends:
     ToolDirectory: tools/test-proxy
     DotNetCoreVersion: "6.x"
     DockerTagPrefix: '1.0.0-dev.'
-    DockerDeployments:
-    - name: test_proxy_linux
-      pool: 'ubuntu-20.04'
-      dockerRepo: 'engsys/testproxy-lin'
-      prepareScript: tools/test-proxy/docker/prepare.ps1
-      dockerFile: 'tools/test-proxy/docker/dockerfile'
-      stableTags:
-      - 'latest'
-    - name: test_proxy_windows
-      pool: 'windows-2019'
-      dockerRepo: 'engsys/testproxy-win'
-      prepareScript: tools/test-proxy/docker/prepare.ps1
-      dockerFile: 'tools/test-proxy/docker/dockerfile-win'
-      stableTags:
-      - 'latest'
+    DockerDeployments: ${{ parameters.DockerDeployments }}


### PR DESCRIPTION
In cases like [timo encountered](https://github.com/Azure/azure-sdk-tools/issues/2982), we are running into an issue where the HOST on the request doesn't match the SSL cert of the redirected-to resource, so we fail SSL validation, 

The alternative is to disable redirect. @mikeharder what do you think here?

~~As far as I can tell, removal of this explicit header does _not_ downgrade the http requests to 1.1. At least not as far as debugging goes.~~

Going to disable redirect and provide a test image.
