### PR TITLE
Support removing all test resources created by a single pipeline job

### DIFF
--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -4,6 +4,7 @@
 parameters:
   ServiceDirectory: ''
   SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+  RemoveMultipleForJob: false
 
 # SubscriptionConfiguration will be splat into the parameters of the test
 # resources script. It should be JSON in the form:
@@ -27,12 +28,19 @@ steps:
         ${{ parameters.SubscriptionConfiguration }}
       "@ | ConvertFrom-Json -AsHashtable;
 
+      $resourceGroupParameter = @{}
+      if ($${{ parameters.RemoveMultipleForJob }}) {
+        $resourceGroupParameter.ResourceGroupTags = @{ BuildId = "$(Build.BuildId)"; BuildJob = "$(Agent.JobName)" }
+      } else {
+        $resourceGroupParameter.ResourceGroupName = "${env:AZURE_RESOURCEGROUP_NAME}"
+      }
+
       eng/common/TestResources/Remove-TestResources.ps1 `
-        -ResourceGroupName "${env:AZURE_RESOURCEGROUP_NAME}" `
         -ServiceDirectory "${{ parameters.ServiceDirectory }}" `
+        @resourceGroupParameter `
         @subscriptionConfiguration `
         -Force `
         -Verbose
     displayName: Remove test resources
-    condition: ne(variables['AZURE_RESOURCEGROUP_NAME'], '')
+    condition: or(ne(variables['AZURE_RESOURCEGROUP_NAME'], ''), eq(parameters.RemoveMultipleForJob, true))
     continueOnError: true


### PR DESCRIPTION
Fixes #1904

**NOTE:** On second thought, this has the downside of not supporting per-directory pre-remove scripts. I've opened https://github.com/Azure/azure-sdk-tools/pull/3067 which I think is a simpler approach for solving #1904.

For the above issue, there were a couple options: write a file with resource groups, create a csv environment variable with all the groups, etc. I think it's a better approach to query the resource groups created by the pipeline job based on the pre-existing tags that get added to the test resource groups (pipeline build id, pipeline job unique name). This way we don't need to struggle with moving state from one pipeline step to the next via devops special methods. Also I could see this functionality being useful for cases where we need to take manual intervention to clean up large amounts of resources from various automation sources that circumvent our cleanup happy path.