### PR TITLE
Support resource group name override in remove test resources template

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -512,7 +512,7 @@ try {
         $ProvisionerApplicationOid = $sp.Id
     }
 
-    $serviceName = GetServiceName $ServiceDirectory
+    $serviceName = GetServiceLeafDirectoryName $ServiceDirectory
 
     $ResourceGroupName = if ($ResourceGroupName) {
         $ResourceGroupName

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -368,18 +368,13 @@ try {
         exit
     }
 
-    $UserName =  if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
-    # Remove spaces, etc. that may be in $UserName
-    $UserName = $UserName -replace '\W'
+    $UserName = GetUserName
 
-    # Make sure $BaseName is set.
     if ($CI) {
         $BaseName = 't' + (New-Guid).ToString('n').Substring(0, 16)
         Log "Generated base name '$BaseName' for CI build"
     } elseif (!$BaseName) {
-        # Handle service directories in nested directories, e.g. `data/aztables`
-        $serviceDirectorySafeName = $ServiceDirectory -replace '[/\\]', ''
-        $BaseName = "$UserName$serviceDirectorySafeName"
+        $BaseName = GetBaseName $UserName $ServiceDirectory
         Log "BaseName was not set. Using default base name '$BaseName'"
     }
 

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -139,13 +139,9 @@ if (!$ResourceGroupName) {
             exit 1
         }
     } else {
-        # Make sure $BaseName is set.
         if (!$BaseName) {
-            $UserName = if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
-            # Remove spaces, etc. that may be in $UserName
-            $UserName = $UserName -replace '\W'
-
-            $BaseName = "$UserName$ServiceDirectory"
+            $UserName = GetUserName
+            $BaseName = GetBaseName $UserName $ServiceDirectory
             Log "BaseName was not set. Using default base name '$BaseName'"
         }
 

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -16,8 +16,8 @@ param (
     [ValidatePattern('^[-a-zA-Z0-9\.\(\)_]{0,80}(?<=[a-zA-Z0-9\(\)])$')]
     [string] $BaseName,
 
-    [Parameter(ParameterSetName = 'ResourceGroup', Mandatory = $true)]
-    [Parameter(ParameterSetName = 'ResourceGroup+Provisioner', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'ResourceGroup')]
+    [Parameter(ParameterSetName = 'ResourceGroup+Provisioner')]
     [string] $ResourceGroupName,
 
     [Parameter(ParameterSetName = 'Default+Provisioner', Mandatory = $true)]
@@ -48,6 +48,10 @@ param (
     [ValidateSet('AzureCloud', 'AzureUSGovernment', 'AzureChinaCloud', 'Dogfood')]
     [string] $Environment = 'AzureCloud',
 
+    [Parameter(ParameterSetName = 'ResourceGroup')]
+    [Parameter(ParameterSetName = 'ResourceGroup+Provisioner')]
+    [switch] $CI,
+
     [Parameter()]
     [switch] $Force,
 
@@ -73,6 +77,7 @@ trap {
     $exitActions.Invoke()
 }
 
+. $PSScriptRoot/SubConfig-Helpers.ps1
 # Source helpers to purge resources.
 . "$PSScriptRoot\..\scripts\Helpers\Resource-Helpers.ps1"
 
@@ -126,18 +131,27 @@ if ($ProvisionerApplicationId) {
 $context = Get-AzContext
 
 if (!$ResourceGroupName) {
-    # Make sure $BaseName is set.
-    if (!$BaseName) {
-        $UserName = if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
-        # Remove spaces, etc. that may be in $UserName
-        $UserName = $UserName -replace '\W'
+    if ($CI) {
+        $envVarName = (BuildServiceDirectoryPrefix (GetServiceName $ServiceDirectory)) + "RESOURCE_GROUP"
+        $ResourceGroupName = [Environment]::GetEnvironmentVariable($envVarName)
+        if (!$ResourceGroupName) {
+            Write-Error "Could not find resource group name environment variable '$envVarName'"
+            exit 1
+        }
+    } else {
+        # Make sure $BaseName is set.
+        if (!$BaseName) {
+            $UserName = if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
+            # Remove spaces, etc. that may be in $UserName
+            $UserName = $UserName -replace '\W'
 
-        $BaseName = "$UserName$ServiceDirectory"
-        Log "BaseName was not set. Using default base name '$BaseName'"
+            $BaseName = "$UserName$ServiceDirectory"
+            Log "BaseName was not set. Using default base name '$BaseName'"
+        }
+
+        # Format the resource group name like in New-TestResources.ps1.
+        $ResourceGroupName = "rg-$BaseName"
     }
-
-    # Format the resource group name like in New-TestResources.ps1.
-    $ResourceGroupName = "rg-$BaseName"
 }
 
 # If no subscription was specified, try to select the Azure SDK Developer Playground subscription.
@@ -281,6 +295,9 @@ specified - in which to discover pre removal script named 'remove-test-resources
 .PARAMETER Environment
 Name of the cloud environment. The default is the Azure Public Cloud
 ('PublicCloud')
+
+.PARAMETER CI
+Run script in CI mode. Infers various environment variable names based on CI convention.
 
 .PARAMETER Force
 Force removal of resource group without asking for user confirmation

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -132,7 +132,7 @@ $context = Get-AzContext
 
 if (!$ResourceGroupName) {
     if ($CI) {
-        $envVarName = (BuildServiceDirectoryPrefix (GetServiceName $ServiceDirectory)) + "RESOURCE_GROUP"
+        $envVarName = (BuildServiceDirectoryPrefix (GetServiceLeafDirectoryName $ServiceDirectory)) + "RESOURCE_GROUP"
         $ResourceGroupName = [Environment]::GetEnvironmentVariable($envVarName)
         if (!$ResourceGroupName) {
             Write-Error "Could not find resource group name environment variable '$envVarName'"

--- a/eng/common/TestResources/Remove-TestResources.ps1.md
+++ b/eng/common/TestResources/Remove-TestResources.ps1.md
@@ -31,14 +31,14 @@ Remove-TestResources.ps1 -BaseName <String> -TenantId <String> [-SubscriptionId 
 ```
 Remove-TestResources.ps1 -ResourceGroupName <String> -TenantId <String> [-SubscriptionId <String>]
  -ProvisionerApplicationId <String> -ProvisionerApplicationSecret <String> [[-ServiceDirectory] <String>]
- [-Environment <String>] [-Force] [-RemoveTestResourcesRemainingArguments <Object>] [-WhatIf] [-Confirm]
+ [-Environment <String>] [-CI] [-Force] [-RemoveTestResourcesRemainingArguments <Object>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
 ### ResourceGroup
 ```
 Remove-TestResources.ps1 -ResourceGroupName <String> [-SubscriptionId <String>] [[-ServiceDirectory] <String>]
- [-Environment <String>] [-Force] [-RemoveTestResourcesRemainingArguments <Object>] [-WhatIf] [-Confirm]
+ [-Environment <String>] [-CI] [-Force] [-RemoveTestResourcesRemainingArguments <Object>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
 ```
 
@@ -231,6 +231,9 @@ Default value: AzureCloud
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
+
+### -CI
+Run script in CI mode. Infers various environment variable names based on CI convention.
 
 ### -Force
 Force removal of resource group without asking for user confirmation

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -8,6 +8,19 @@ function GetServiceName([string]$serviceDirectory) {
     return Split-Path -Leaf $serviceDirectory
 }
 
+function GetUserName() {
+    $UserName = $env:USER ?? $env:USERNAME
+    # Remove spaces, etc. that may be in $UserName
+    $UserName = $UserName -replace '\W'
+    return $UserName
+}
+
+function GetBaseName([string]$user, [string]$serviceDirectoryName) {
+    # Handle service directories in nested directories, e.g. `data/aztables`
+    $serviceDirectorySafeName = $serviceDirectoryName -replace '[/\\]', ''
+    return "$user$serviceDirectorySafeName"
+}
+
 function ShouldMarkValueAsSecret([string]$serviceName, [string]$key, [string]$value, [array]$allowedValues = @())
 {
     $logOutputNonSecret = @(

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -2,6 +2,17 @@ function BuildServiceDirectoryPrefix([string]$serviceName) {
     return $serviceName.ToUpperInvariant() + "_"
 }
 
+# If the ServiceDirectory has multiple segments use the last directory name
+# e.g. D:\foo\bar -> bar or foo/bar -> bar
+function GetServiceName([string]$serviceDirectory) {
+    $serviceName = if (Split-Path $serviceDirectory) {
+        Split-Path -Leaf $serviceDirectory
+    } else {
+        $serviceDirectory.Trim('/')
+    }
+    return $serviceName
+}
+
 function ShouldMarkValueAsSecret([string]$serviceName, [string]$key, [string]$value, [array]$allowedValues = @())
 {
     $logOutputNonSecret = @(

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -4,7 +4,7 @@ function BuildServiceDirectoryPrefix([string]$serviceName) {
 
 # If the ServiceDirectory has multiple segments use the last directory name
 # e.g. D:\foo\bar -> bar or foo/bar -> bar
-function GetServiceName([string]$serviceDirectory) {
+function GetServiceLeafDirectoryName([string]$serviceDirectory) {
     return Split-Path -Leaf $serviceDirectory
 }
 

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -5,12 +5,7 @@ function BuildServiceDirectoryPrefix([string]$serviceName) {
 # If the ServiceDirectory has multiple segments use the last directory name
 # e.g. D:\foo\bar -> bar or foo/bar -> bar
 function GetServiceName([string]$serviceDirectory) {
-    $serviceName = if (Split-Path $serviceDirectory) {
-        Split-Path -Leaf $serviceDirectory
-    } else {
-        $serviceDirectory.Trim('/')
-    }
-    return $serviceName
+    return Split-Path -Leaf $serviceDirectory
 }
 
 function ShouldMarkValueAsSecret([string]$serviceName, [string]$key, [string]$value, [array]$allowedValues = @())

--- a/eng/common/TestResources/Update-TestResources.ps1
+++ b/eng/common/TestResources/Update-TestResources.ps1
@@ -30,6 +30,8 @@ param (
     [int] $DeleteAfterHours = 48
 )
 
+. $PSScriptRoot/SubConfig-Helpers.ps1
+
 # By default stop for any error.
 if (!$PSBoundParameters.ContainsKey('ErrorAction')) {
     $ErrorActionPreference = 'Stop'
@@ -71,11 +73,8 @@ $exitActions = @({
 if (!$ResourceGroupName) {
     # Make sure $BaseName is set.
     if (!$BaseName) {
-        $UserName = if ($env:USER) { $env:USER } else { "${env:USERNAME}" }
-        # Remove spaces, etc. that may be in $UserName
-        $UserName = $UserName -replace '\W'
-
-        $BaseName = "$UserName$ServiceDirectory"
+        $UserName = GetUserName
+        $BaseName = GetBaseName $UserName $ServiceDirectory
         Log "BaseName was not set. Using default base name '$BaseName'"
     }
 

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -1,5 +1,5 @@
 # Assumes steps in deploy-test-resources.yml was run previously. Requires
-# environment variable: AZURE_RESOURCEGROUP_NAME and Az PowerShell module
+# environment variable: <ServiceDirectory>_RESOURCE_GROUP and Az PowerShell module
 
 parameters:
   ServiceDirectory: ''
@@ -28,11 +28,11 @@ steps:
       "@ | ConvertFrom-Json -AsHashtable;
 
       eng/common/TestResources/Remove-TestResources.ps1 `
-        -ResourceGroupName "${env:AZURE_RESOURCEGROUP_NAME}" `
-        -ServiceDirectory "${{ parameters.ServiceDirectory }}" `
         @subscriptionConfiguration `
+        -ServiceDirectory "${{ parameters.ServiceDirectory }}" `
+        -CI `
         -Force `
         -Verbose
     displayName: Remove test resources
-    condition: ne(variables['AZURE_RESOURCEGROUP_NAME'], '')
+    condition: eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true')
     continueOnError: true


### PR DESCRIPTION
Fixes #1904

This changes the remove resources script to stop referencing the static `AZURE_RESOURCEGROUP_NAME` variable and instead reference the `<SERVICEDIRECTORY>_RESOURCE_GROUP` variable, which can support scenarios where multiple groups are deployed in a pipeline.