### PR TITLE
[Test-Proxy] Publish an ARM64 Image

### DIFF
--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -35,6 +35,13 @@ extends:
       dockerFile: 'tools/test-proxy/docker/dockerfile'
       stableTags:
       - 'latest'
+    - name: test_proxy_linux_arm64
+      pool: 'ubuntu-20.04'
+      dockerRepo: 'engsys/testproxy-lin-arm64'
+      prepareScript: tools/test-proxy/docker/prepare.ps1
+      dockerFile: 'tools/test-proxy/docker/dockerfile-arm64'
+      stableTags:
+      - 'latest'
     - name: test_proxy_windows
       pool: 'windows-2019'
       dockerRepo: 'engsys/testproxy-win'

--- a/tools/test-proxy/docker/dockerfile-arm64
+++ b/tools/test-proxy/docker/dockerfile-arm64
@@ -1,0 +1,49 @@
+FROM mcr.microsoft.com/dotnet/sdk:6.0.102-alpine3.14-amd64 AS build
+
+# copy the code
+COPY docker_build/Azure.Sdk.Tools.TestProxy/ /proxyservercode
+
+# publish the package
+RUN cd /proxyservercode && dotnet publish -c Release -o /proxyserver -f net6.0
+
+FROM mcr.microsoft.com/dotnet/aspnet:6.0-alpine3.14-amd64
+
+ENV \
+    NO_AT_BRIDGE=1 \
+    CERT_FOLDER=/var/certwork \
+    CERT_IMPORT_SH=apply-dev-cert.sh \
+    ASPNETCORE_ENVIRONMENT=Development \
+    # this override allows the tool server to listen to traffic over the docker bridge.
+    # default URL of localhost:5000 or localhost:50001 are not usable from outside the container
+    ASPNETCORE_URLS="http://0.0.0.0:5000;https://0.0.0.0:5001" \
+    Logging__Console__FormatterName= \
+    Logging__LogLevel__Default=Information \
+    Logging__LogLevel__Microsoft=Information
+
+
+# dotnet-dev-certs tool is not included in aspnet image, so manually copy from sdk image
+COPY --from=build /usr/share/dotnet/sdk/6.0.102/DotnetTools/dotnet-dev-certs/6.0.2-servicing.22064.12/tools/net6.0/any/ /dotnet-dev-certs
+
+# prep the machine dev certificate
+COPY docker_build/$CERT_IMPORT_SH docker_build/dotnet-devcert.pfx docker_build/dotnet-devcert.crt $CERT_FOLDER/
+
+RUN \
+    # Install bash and certutil
+    apk add --no-cache bash nss-tools \
+    # Fix line endings
+    && sed -i -e 's/\r$//' $CERT_FOLDER/$CERT_IMPORT_SH \
+    # Use copied dotnet-dev-certs tool
+    && sed -i -e 's|dotnet dev-certs|dotnet /dotnet-dev-certs/dotnet-dev-certs.dll|' $CERT_FOLDER/$CERT_IMPORT_SH \
+    # Run script to import certificate
+    && chmod +x $CERT_FOLDER/$CERT_IMPORT_SH \
+    && $CERT_FOLDER/$CERT_IMPORT_SH \
+    && rm $CERT_FOLDER/$CERT_IMPORT_SH \
+    && mkdir -p /srv/testproxy
+
+EXPOSE 5000 5001
+
+WORKDIR /proxyserver
+
+COPY --from=build /proxyserver .
+
+ENTRYPOINT ["dotnet", "Azure.Sdk.Tools.TestProxy.dll", "--storage-location", "/srv/testproxy"]


### PR DESCRIPTION
@HarshaNalluru unfortunately this doesn't address the issue yet, as recall in a local `concurrent` invocation starts your tests and starts the test-proxy by a _specific target image_.

This PR merely adds a ARM64 image so you can unblock them with a local patch. I don't know if there is any magic I can do behind the scenes on our container registry that would allow us to simply pull from `testproxy-lin` repo and get an appropriate platform. Checking into that now.