### PR TITLE
Add continueOnError to publish-artifact.yml

### DIFF
--- a/eng/common/pipelines/templates/steps/publish-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-artifact.yml
@@ -10,12 +10,12 @@ parameters:
   ArtifactName: ''
   ArtifactPath: ''
   CustomCondition: true
-  ContinueOnError: false
+  ContinueOnFirstAttemptError: false
 
 steps:
   - task: PublishPipelineArtifact@1
     condition: and(succeeded(), ${{ parameters.CustomCondition }})
-    continueOnError: ${{ parameters.ContinueOnError }}
+    continueOnError: ${{ parameters.ContinueOnFirstAttemptError }}
     displayName: 'Publish ${{ parameters.ArtifactName }} Artifacts'
     inputs:
       artifactName: '${{ parameters.ArtifactName }}'

--- a/eng/common/pipelines/templates/steps/publish-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-artifact.yml
@@ -10,10 +10,12 @@ parameters:
   ArtifactName: ''
   ArtifactPath: ''
   CustomCondition: true
+  ContinueOnError: false
 
 steps:
   - task: PublishPipelineArtifact@1
     condition: and(succeeded(), ${{ parameters.CustomCondition }})
+    continueOnError: ${{ parameters.ContinueOnError }}
     displayName: 'Publish ${{ parameters.ArtifactName }} Artifacts'
     inputs:
       artifactName: '${{ parameters.ArtifactName }}'


### PR DESCRIPTION
We've seen failures of pipelines on successful artifact publishes: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1484310&view=logs&j=388f89ee-ae78-56aa-430e-88b5fa782a43&t=d6be4723-717b-525d-d8a0-718a92b853c4

In this case, some jobs ran and timed out. Given the complexity of the matrix the team frequently opts to retry failed pipelines (which they can now no longer do). In this case (because we always publish SBOM artifacts on ever run) the artifact had already been published. Subsequent publishes also succeeded in the [fallback case](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1484310&view=logs&j=a7fb2f1a-6ee3-51e3-38f8-bd83245e217a&t=3e27b900-a2e3-51a1-de5a-e30ad127ada1&s=ff05ad62-bb9a-53b6-ce9f-72f329a63e7c) but the whole pipeline failed because the initial attempt failed and marked the whole job red. 

This PR proposes to enable setting `continueOnError` in the first publish attempt so the job doesn't get marked red. The parameter has a default that preserves existing functionality for those who may rely on it. 