### PR TITLE
Wait for test proxy startup

### DIFF
--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -11,7 +11,7 @@ steps:
   - pwsh: |
       $version = $(Get-Content "$(Build.SourcesDirectory)/eng/common/testproxy/target_version.txt" -Raw).Trim()
       $overrideVersion = "${{ parameters.targetVersion }}"
-      
+
       if($overrideVersion) {
         Write-Host "Overriding default target proxy version of '$version' with override $overrideVersion."
         $version = $overrideVersion
@@ -47,3 +47,18 @@ steps:
       displayName: "Run the testproxy - linux/mac"
       condition: and(succeeded(), ne(variables['Agent.OS'],'Windows_NT'))
       workingDirectory: "${{ parameters.rootFolder }}"
+
+    - pwsh: |
+        for ($i = 0; $i -lt 10; $i++) {
+            try {
+                Invoke-WebRequest -Uri "http://localhost:5000/Admin/IsAlive" | Out-Null
+                exit 0
+            } catch {
+                Write-Warning "Failed to successfully connect to test proxy. Retrying..."
+                Start-Sleep 6
+            }
+        }
+        Write-Error "Could not connect to test proxy."
+        exit 1
+      displayName: Test Proxy IsAlive
+


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-for-go/issues/17461

After adding this and testing it, it seems like it's really just a couple seconds that's needed to ensure the proxy is ready to receive requests. We could consider adding `Start-Sleep 2` as an alternative to all this extra checking.

CC @chlowell 
