### PR TITLE
Add Swagger review filter

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml
@@ -26,6 +26,7 @@
                         <option value="^Python$">Python</option>
                         <option value="^Protocol$">Protocol</option>
                         <option value="^Swift$">Swift</option>
+                        <option value="^Swagger$">Swagger</option>
                         <option value="^Xml$">Xml</option>
                     </select>
                 </div>


### PR DESCRIPTION
Added `swagger` in languages review filter. This will allow users to easily filter swagger reviews only.