### PR TITLE
Reduce APIView startup time

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -543,33 +543,6 @@ namespace APIViewWeb.Repositories
                     _telemetryClient.StopOperation(operation);
                 }
             }
-
-            await SyncPackageDisplayServiceName();
-        }
-
-        private async Task SyncPackageDisplayServiceName()
-        {
-            var reviews = await _reviewsRepository.GetReviewsAsync(false, "All");
-            foreach (var review in reviews.Where(r => r.ServiceName == null || r.ServiceName == "Other"))
-            {
-                var newServiceName = review.ServiceName ?? "Other";
-                var newDisplayName = review.PackageDisplayName ?? "Other";
-                var pkg = _packageNameManager.GetPackageDetails(review.PackageName);
-                if (pkg != null)
-                {
-                    newServiceName = pkg.ServiceName;
-                    newDisplayName = pkg.DisplayName;
-                }
-
-                if (newServiceName != review.ServiceName || newDisplayName != review.PackageDisplayName)
-                {
-                    review.ServiceName = newServiceName;
-                    review.PackageDisplayName = newDisplayName;
-                    await _reviewsRepository.UpsertReviewAsync(review);
-                }
-                // Wait before processing next review to delay background task
-                await Task.Delay(1000);
-            }
         }
 
         public async Task<CodeFile> GetCodeFile(string repoName,


### PR DESCRIPTION
APIView startup runs background tasks continuously for a longer time to update service name and package name and this causes sometimes startup task to time out. This PR is to add a delay between each review details sync so startup task will not have to wait until it's completed.