### PR TITLE
Do not fail remove test resources step when env var is not set.

### DIFF
--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -135,8 +135,8 @@ if (!$ResourceGroupName) {
         $envVarName = (BuildServiceDirectoryPrefix (GetServiceLeafDirectoryName $ServiceDirectory)) + "RESOURCE_GROUP"
         $ResourceGroupName = [Environment]::GetEnvironmentVariable($envVarName)
         if (!$ResourceGroupName) {
-            Write-Error "Could not find resource group name environment variable '$envVarName'"
-            exit 1
+            Write-Error "Could not find resource group name environment variable '$envVarName'. This is likely due to an earlier failure in the 'Deploy Test Resources' step above."
+            exit 0
         }
     } else {
         if (!$BaseName) {

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -132,6 +132,10 @@ $context = Get-AzContext
 
 if (!$ResourceGroupName) {
     if ($CI) {
+        if (!$ServiceDirectory) {
+            Write-Warning "ServiceDirectory parameter is empty, nothing to remove"
+            exit 0
+        }
         $envVarName = (BuildServiceDirectoryPrefix (GetServiceLeafDirectoryName $ServiceDirectory)) + "RESOURCE_GROUP"
         $ResourceGroupName = [Environment]::GetEnvironmentVariable($envVarName)
         if (!$ResourceGroupName) {

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -5,7 +5,7 @@ function BuildServiceDirectoryPrefix([string]$serviceName) {
 # If the ServiceDirectory has multiple segments use the last directory name
 # e.g. D:\foo\bar -> bar or foo/bar -> bar
 function GetServiceLeafDirectoryName([string]$serviceDirectory) {
-    return Split-Path -Leaf $serviceDirectory
+    return $serviceDirectory ? (Split-Path -Leaf $serviceDirectory) : ""
 }
 
 function GetUserName() {


### PR DESCRIPTION
When the deploy test resources step fails before setting the env var, the current error condition can be misleading. We
should still warn but not fail.

[Example](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1495413&view=logs&j=0f4ab11a-fb23-53e2-ab9a-978e66fa5cd6&t=85c56a18-30b3-577e-de2a-38f6e10423b8&l=24)

Also rolling in a fix to handle empty service directories failing with a misleading/inscrutable error:

```
Remove-TestResources.ps1: Cannot bind argument to parameter 'Path' because it is an empty string.
```
