### PR TITLE
[stress testing] Add resource group name to helm context. Add chaos wrapper.

### DIFF
--- a/tools/stress-cluster/chaos/README.md
+++ b/tools/stress-cluster/chaos/README.md
@@ -14,6 +14,7 @@ The chaos environment is an AKS cluster (Azure Kubernetes Service) with several 
      * [Stress Test File Share](#stress-test-file-share)
      * [Stress Test Azure Resources](#stress-test-azure-resources)
      * [Helm Chart Dependencies](#helm-chart-dependencies)
+     * [Manifest Special Fields](#manifest-special-fields)
      * [Job Manifest](#job-manifest)
      * [Chaos Manifest](#chaos-manifest)
      * [Scenarios and values.yaml](#scenarios-and-valuesyaml)
@@ -287,9 +288,28 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.6
+  version: 0.1.16
   repository: https://stresstestcharts.blob.core.windows.net/helm/
 ```
+
+The `stress-test-addons` dependency is a [helm library chart](https://helm.sh/docs/topics/library_charts/), which
+pre-defines a lot of the kubernetes config boilerplate needed to configure stress tests correctly.
+
+### Manifest Special Fields
+
+For kubernetes manifests in in the stress test helm chart `templates` directory that are wrapped by any of the
+`stress-test-addons` (see [examples](#job-manifest)[below](#chaos-manifest)) templates, several special helper fields
+are made available in the template context.
+
+- `{{ .Values.image }}`
+  - The docker image published by the stress test deploy script
+- `{{ .Stress.Scenario }}`
+  - If using [Scenarios](#scenarios-and-valuesyaml), this value maps to the individual scenario a template for which a
+    template is being generated.
+- `{{ .Stress.ResourceGroupName }}`
+  - If deploying live resources for a test job, the name of the resource group.
+  - This can also be useful for pairing up template values with resource names. The resource group name will be generated based
+    on the deployment and scenario values, and can also be referenced for naming resources in the bicep/ARM template via `resourceGroup().name`.
 
 ### Job Manifest
 
@@ -329,9 +349,7 @@ spec:
 ### Chaos Manifest
 
 The most common way of configuring stress against test jobs is via [Chaos Mesh](https://chaos-mesh.org/).
-
 Any chaos experiment manifests can be placed in the `<stress test directory>/templates/`.
-
 Chaos experiments can be targeted against test jobs via namespace and label selectors.
 
 Given a pod metadata like:
@@ -353,6 +371,35 @@ selector:
     chaos: "true"
   namespaces:
     - {{ .Release.Namespace }}
+```
+
+In the example below, the "stress-test-addons.chaos-wrapper.tpl" template is used, which will contain 
+[special fields](#manifest-special-fields) useful for correlating chaos targets with individual test jobs and pods.
+
+```
+{{- include "stress-test-addons.chaos-wrapper.tpl" (list . "stress.azservicebus-network") -}}
+{{- define "stress.azservicebus-network" -}}
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+spec:
+  action: loss
+  direction: to
+  externalTargets:
+    # Maps to the service bus resource cname, provided the resource group name, provided
+    # the service bus namespace uses the resource group name as its name in the bicep template
+    - "{{ .Stress.ResourceGroupName }}.servicebus.windows.net"
+  mode: one
+  selector:
+    labelSelectors:
+      # Maps to the test pod, provided it also sets a testInstance label of {{ .Stress.ResourceGroupName }}
+      testInstance: {{ .Stress.ResourceGroupName }}
+      chaos: "true"
+    namespaces:
+      - {{ .Release.Namespace }}
+  loss:
+    loss: "100"
+    correlation: "100"
+{{- end -}}
 ```
 
 For more detailed examples, see:
@@ -382,7 +429,7 @@ src/
 The pod command in the job manifest could be configured to run a variable file name:
 
 ```
-command: ["node", "app/{{ .Scenario }}.js"]
+command: ["node", "app/{{ .Stress.Scenario }}.js"]
 ```
 
 In order to accomplish this, add the scenarios list to `values.yaml`

--- a/tools/stress-cluster/chaos/README.md
+++ b/tools/stress-cluster/chaos/README.md
@@ -297,14 +297,14 @@ pre-defines a lot of the kubernetes config boilerplate needed to configure stres
 
 ### Manifest Special Fields
 
-For kubernetes manifests in in the stress test helm chart `templates` directory that are wrapped by any of the
+For kubernetes manifests in the stress test helm chart `templates` directory that are wrapped by any of the
 `stress-test-addons` (see [examples](#job-manifest)[below](#chaos-manifest)) templates, several special helper fields
 are made available in the template context.
 
 - `{{ .Values.image }}`
   - The docker image published by the stress test deploy script
 - `{{ .Stress.Scenario }}`
-  - If using [Scenarios](#scenarios-and-valuesyaml), this value maps to the individual scenario a template for which a
+  - If using [Scenarios](#scenarios-and-valuesyaml), this value maps to the individual scenario for which a
     template is being generated.
 - `{{ .Stress.ResourceGroupName }}`
   - If deploying live resources for a test job, the name of the resource group.

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: stress-test-addons
 description: Baseline resources and templates for stress testing clusters
 
-version: 0.1.14
+version: 0.1.16
 appVersion: v0.1

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
@@ -3,6 +3,15 @@ entries:
   stress-test-addons:
   - apiVersion: v2
     appVersion: v0.1
+    created: "2022-04-11T19:46:09.6261738-04:00"
+    description: Baseline resources and templates for stress testing clusters
+    digest: 9508ea6f2335aa4297de3a37c2ffb5e46a1e6f047d126352409f1eec3582bd54
+    name: stress-test-addons
+    urls:
+    - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.16.tgz
+    version: 0.1.16
+  - apiVersion: v2
+    appVersion: v0.1
     created: "2022-03-22T19:16:14.3599204-04:00"
     description: Baseline resources and templates for stress testing clusters
     digest: bc56677a0218bc7cf7a2d709da8dd2291ae160737a6c53d859de98c488cb1990
@@ -109,4 +118,4 @@ entries:
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.2.tgz
     version: 0.1.2
-generated: "2022-03-22T19:16:14.3463496-04:00"
+generated: "2022-04-11T19:46:09.6189395-04:00"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
@@ -3,9 +3,9 @@ entries:
   stress-test-addons:
   - apiVersion: v2
     appVersion: v0.1
-    created: "2022-04-11T19:46:09.6261738-04:00"
+    created: "2022-04-15T16:00:43.4512334-04:00"
     description: Baseline resources and templates for stress testing clusters
-    digest: 9508ea6f2335aa4297de3a37c2ffb5e46a1e6f047d126352409f1eec3582bd54
+    digest: 4573bd063182030f8cd39a4ae0fc31abf03f642bed41721a3abc41ac315ba65f
     name: stress-test-addons
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.16.tgz
@@ -118,4 +118,4 @@ entries:
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.2.tgz
     version: 0.1.2
-generated: "2022-04-11T19:46:09.6189395-04:00"
+generated: "2022-04-15T16:00:43.4428463-04:00"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_chaos.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_chaos.tpl
@@ -1,0 +1,14 @@
+{{- define "stress-test-addons.chaos-wrapper.tpl" -}}
+{{- $global := index . 0 -}}
+{{- $chaosTemplate := index . 1 -}}
+{{- range (default (list "stress") $global.Values.scenarios) }}
+---
+{{ $chaosCtx := fromYaml (include "stress-test-addons.util.mergeStressContext" (list $global . )) }}
+metadata:
+  name: "{{ lower $chaosCtx.Stress.Scenario }}-{{ $chaosCtx.Release.Name }}-{{ $chaosCtx.Release.Revision }}"
+  namespace: {{ $chaosCtx.Release.Namespace }}
+  annotations:
+    'experiment.chaos-mesh.org/pause': 'true'
+{{ include $chaosTemplate $chaosCtx }}
+{{- end -}}
+{{- end -}}

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_container_env.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_container_env.tpl
@@ -15,7 +15,7 @@ env:
   - name: DEBUG_SHARE_ROOT
     value: /mnt/share/
 volumeMounts:
-  - name: test-env-{{ lower .Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}
+  - name: test-env-{{ lower .Stress.Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}
     mountPath: /mnt/outputs
   - name: debug-file-share-{{ .Release.Name }}
     mountPath: /mnt/share

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_env_volumes.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_env_volumes.tpl
@@ -1,5 +1,5 @@
 {{ define "stress-test-addons.env-volumes" }}
-- name: test-env-{{ lower .Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}
+- name: test-env-{{ lower .Stress.Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}
   emptyDir: {}
 - name: debug-file-share-config-{{ .Release.Name }}
   csi:

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
@@ -14,11 +14,11 @@
     - name: ENV_FILE
       value: /mnt/outputs/.env
     - name: RESOURCE_GROUP_NAME
-      value: '{{ .Release.Namespace }}-{{ lower .Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}'
+      value: {{ .Stress.ResourceGroupName }}
   volumeMounts:
     - name: "{{ .Release.Name }}-{{ .Release.Revision }}-test-resources"
       mountPath: /mnt/testresources
-    - name: test-env-{{ lower .Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}
+    - name: test-env-{{ lower .Stress.Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}
       mountPath: /mnt/outputs
     - name: "static-secrets-{{ .Release.Name }}"
       mountPath: "/mnt/secrets/static"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
@@ -3,6 +3,7 @@
   # Please use 'testing' for the image repo name when testing
   # e.g. azsdkengsys.azurecr.io/testing/deploy-test-resources
   image: azsdkengsys.azurecr.io/stress/deploy-test-resources
+  imagePullPolicy: Always
   command:
     - 'pwsh'
     - '-NonInteractive'

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_env.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_env.tpl
@@ -10,7 +10,7 @@
     - name: ENV_FILE
       value: /mnt/outputs/.env
   volumeMounts:
-    - name: test-env-{{ lower .Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}
+    - name: test-env-{{ lower .Stress.Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}
       mountPath: /mnt/outputs
     - name: static-secrets-{{ .Release.Name }}
       mountPath: "/mnt/secrets/static"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_stress_test.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_stress_test.tpl
@@ -8,18 +8,18 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ lower .Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}"
+  name: "{{ lower .Stress.Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}"
   namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}
-    scenario: {{ .Scenario }}
+    scenario: {{ .Stress.Scenario }}
 spec:
   backoffLimit: 0
   template:
     metadata:
       labels:
         release: {{ .Release.Name }}
-        scenario: {{ .Scenario }}
+        scenario: {{ .Stress.Scenario }}
     spec:
       # In cases where a stress test has higher resource requirements or needs a dedicated node,
       # a new nodepool can be provisioned and labeled to allow custom scheduling.
@@ -48,10 +48,9 @@ spec:
 {{- include "stress-test-addons.deploy-configmap" $global }}
 {{- range (default (list "stress") $global.Values.scenarios) }}
 ---
-{{- /* Copy scenario name into top level key of global context */}}
-{{ $instance := deepCopy $global | merge (dict "Scenario" . ) -}}
-{{- $jobOverride := fromYaml (include "stress-test-addons.job-wrapper.tpl" (list $instance $podDefinition)) -}}
-{{- $tpl := fromYaml (include "stress-test-addons.deploy-job-template.tpl" $instance) -}}
+{{ $jobCtx := fromYaml (include "stress-test-addons.util.mergeStressContext" (list $global . )) }}
+{{- $jobOverride := fromYaml (include "stress-test-addons.job-wrapper.tpl" (list $jobCtx $podDefinition)) -}}
+{{- $tpl := fromYaml (include "stress-test-addons.deploy-job-template.tpl" $jobCtx) -}}
 {{- toYaml (merge $jobOverride $tpl) -}}
 {{- end }}
 {{- end -}}
@@ -60,18 +59,18 @@ spec:
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}"
+  name: "{{ .Stress.Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}"
   namespace: {{ .Release.Namespace }}
   labels:
     release: {{ .Release.Name }}
-    scenario: {{ .Scenario }}
+    scenario: {{ .Stress.Scenario }}
 spec:
   backoffLimit: 0
   template:
     metadata:
       labels:
         release: {{ .Release.Name }}
-        scenario: {{ .Scenario }}
+        scenario: {{ .Stress.Scenario }}
     spec:
       nodeSelector:
         sku: 'default'
@@ -93,9 +92,9 @@ spec:
 {{- range (default (list "stress") $global.Values.scenarios) }}
 ---
 {{- /* Copy scenario name into top level key of global context */}}
-{{ $instance := deepCopy $global | merge (dict "Scenario" . ) -}}
-{{- $jobOverride := fromYaml (include "stress-test-addons.job-wrapper.tpl" (list $instance $podDefinition)) -}}
-{{- $tpl := fromYaml (include "stress-test-addons.env-job-template.tpl" $instance) -}}
+{{ $jobCtx := fromYaml (include "stress-test-addons.util.mergeStressContext" (list $global . )) }}
+{{- $jobOverride := fromYaml (include "stress-test-addons.job-wrapper.tpl" (list $jobCtx $podDefinition)) -}}
+{{- $tpl := fromYaml (include "stress-test-addons.env-job-template.tpl" $jobCtx) -}}
 {{- toYaml (merge $jobOverride $tpl) -}}
 {{- end }}
 {{- end -}}

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_util.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_util.tpl
@@ -13,3 +13,30 @@ See https://github.com/Masterminds/sprig/tree/master/docs for template function 
 {{- $tpl := fromYaml (include (index . 2) $top) | default (dict ) -}}
 {{- toYaml (merge $overrides $tpl) -}}
 {{- end -}}
+
+{{- /*
+stress-test-addons.util.mergeStressContext will copy/add/default stress related context
+values into an object containing both the $global context and any local or range loop context values.
+
+This takes an array of two values:
+- the top global context
+- A string (Scenario context item from a range loop)
+
+Fields added to global context and returned:
+
+.Stress.Scenario - A `.` value passed down from a range loop over a scenarios list
+            from values.yaml or a default value "stress".
+.Stress.ResourceGroupName - A pre-calculated resource group name value that can be passed down to various configurations that require it.
+
+See https://github.com/Masterminds/sprig/tree/master/docs for template function reference
+*/}}
+{{- define "stress-test-addons.util.mergeStressContext" -}}
+{{- /* Copy scenario name into top level keys of global context */}}
+{{- $_global := index . 0 -}}
+{{- $_scenario := index . 1 -}}
+{{ $resourceGroupName := lower (print $_global.Release.Namespace "-" $_scenario "-" $_global.Release.Name "-" $_global.Release.Revision) }}
+{{- /* Create add Stress context to top level keys of global context */}}
+{{- $_stress := dict "Scenario" $_scenario "ResourceGroupName" $resourceGroupName -}}
+{{- $_instance := deepCopy ($_global | merge (dict "Stress" $_stress )) -}}
+{{ toYaml ($_instance) }}
+{{- end -}}

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/stress-test-cluster-secret-provider.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/stress-test-cluster-secret-provider.yaml
@@ -1,4 +1,4 @@
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: stress-cluster-kv-{{ .Release.Name }}

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/stress-test-file-share-secret-provider.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/stress-test-file-share-secret-provider.yaml
@@ -1,4 +1,4 @@
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: stress-file-share-kv-{{ .Release.Name }}

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/stress-test-static-secret-provider.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/stress-test-static-secret-provider.yaml
@@ -1,4 +1,4 @@
-apiVersion: secrets-store.csi.x-k8s.io/v1alpha1
+apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
   name: stress-static-kv-{{ .Release.Name }}


### PR DESCRIPTION
- Fixes #2816
- Moves `.Scenario` into a new helm context `.Stress`, which includes `.Stress.Scenario` and `.Stress.ResourceGroupName`
- Adds a chaos template wrapper to add in custom helm contexts
- Updates stress-test-addons to 0.1.16 which also includes #3047
