### PR TITLE
[apiview] Pin api-extractor-model dependency to 7.16.1

### DIFF
--- a/src/ts/ts-genapi/package.json
+++ b/src/ts/ts-genapi/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "dependencies": {
-    "@microsoft/api-extractor-model": "^7.8.13",
+    "@microsoft/api-extractor-model": "7.16.1",
     "js-tokens": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
**[Update]** it looks like pinning to the old api-extractor version in the js package acts as a workaround here. So the main fix will probably be figuring out what updates need to be done in tools to get the versions working well together?
workaround pipeline: [Pipelines - Run 20220414.5 logs (azure.com)](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1506652&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=bcf77a81-3bad-5ba0-7178-da3233d85a04)
workaround: [pull request](https://github.com/Azure/azure-sdk-for-js/pull/21414)

API View requests for javascript are failing with the following error:

```
Processor failed:
stdout:

stderr:
D:\home\site\wwwroot\node_modules\@microsoft\api-extractor-model\lib\model\ApiPackage.js:67
throw new Error(`Error loading ${apiJsonFilename}:\n` + tsdocConfigFile.getErrorSummary());
^

Error: Error loading azure-data-tables_13.1.1.api.json:
Error encountered when loading TSDoc configuration:
Error loading config file: data should NOT have additional properties

at Function.loadFromJsonFile (D:\home\site\wwwroot\node_modules\@microsoft\api-extractor-model\lib\model\ApiPackage.js:67:23)
at ApiModel.loadPackage (D:\home\site\wwwroot\node_modules\@microsoft\api-extractor-model\lib\model\ApiModel.js:61:52)
at Object.<anonymous> (D:\home\site\wwwroot\export.js:77:10)
at Module._compile (internal/modules/cjs/loader.js:1085:14)
at Object.Module._extensions..js (internal/modules/cjs/loader.js:1114:10)
at Module.load (internal/modules/cjs/loader.js:950:32)
at Function.Module._load (internal/modules/cjs/loader.js:790:12)
at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:76:12)
at internal/main/run_main_module.js:17:47
```

The issue appears to have started on 4/13:

[query link](https://ms.portal.azure.com#@72f988bf-86f1-41af-91ab-2d7cd011db47/blade/Microsoft_Azure_Monitoring_Logs/LogsBlade/resourceId/%2Fsubscriptions%2Fa18897a6-7e44-457d-9260-f2854c0aca42%2FresourceGroups%2Fapiview%2Fproviders%2Fmicrosoft.insights%2Fcomponents%2FAPIView/source/LogsBlade.AnalyticsShareLinkToQuery/q/H4sIAAAAAAAAAxXMSw7CMAxF0XlX8dRRKzFhIcCEDbiNRSw1TmQ7%252FMTiaefnXn6v3EKq%252BvDDK7Mxag%252B2C7vTg7FWDRJ1jImC4Ln2LeF6uyPTk0EpyVHThma1sYWwj%252FvKeylk8j0OXWOasXywiE4hhT2otBPOad6lsSa2nW296JrJAsPwBx1Y%252B9qXAAAA/timespan/P7D)

```
exceptions
| where outerMessage contains "data should NOT have additional properties"
| summarize count() by bin(timestamp, 1d)
| render columnchart 
```

Looking through the package.json for the API view javascript code shows a dependency on api-extractor-model: [here](https://github.com/Azure/azure-sdk-tools/blob/main/src/ts/ts-genapi/package.json#L7). The changelog for that dependency shows an update to its own TSDoc dependency the day before (on Saturday): [changelog](https://github.com/microsoft/rushstack/blob/main/libraries/api-extractor-model/CHANGELOG.md#7162). So it seems likely, given the error message is related to TSDoc, that the latest 7.16.2 update is causing API view to
break for js. The TSDoc version bump in api-extractor-model was from `0.13.2` to `0.14.1` [here](https://github.com/microsoft/rushstack/commit/5fdfededa9368618fa65c82c4111e92866c92154).

We should understand and fix the underyling issue, but in the meantime we may be able to pin the version to a known
working version to unblock API view requests for javascript packages.
