### PR TITLE
Sort by service name first

### DIFF
--- a/eng/common/docgeneration/Generate-DocIndex.ps1
+++ b/eng/common/docgeneration/Generate-DocIndex.ps1
@@ -126,7 +126,7 @@ function GenerateDocfxTocContent([Hashtable]$tocContent, [String]$lang, [String]
     New-Item -Path $YmlPath -Name "toc.yml" -Force
     $visitedService = @{}
     # Sort and display toc service name by alphabetical order, and then sort artifact by order.
-    $sortedToc = $tocContent.Values | Sort-Object NewIndex, TypeIndex, ServiceName, DisplayName, Artifact
+    $sortedToc = $tocContent.Values | Sort-Object ServiceName, NewIndex, TypeIndex, DisplayName, Artifact
     foreach ($serviceMapping in $sortedToc) {
         $artifact = $serviceMapping.Artifact
         $serviceName = $serviceMapping.ServiceName


### PR DESCRIPTION
Fixed the toc.yml order by sorting service name first.
<img width="108" alt="image" src="https://user-images.githubusercontent.com/48036328/163849788-1144b20f-f451-4ba4-ab32-1c074ab06620.png">


After the fix. 
<img width="221" alt="image" src="https://user-images.githubusercontent.com/48036328/163849831-d80d809c-8b70-4e4f-8057-f88fdaac995c.png">
