### PR TITLE
bugfix: add the publishLog command back, for it's accidentally deleted

### DIFF
--- a/tools/sdk-generation-pipeline/packages/sdk-generation-cli/package.json
+++ b/tools/sdk-generation-pipeline/packages/sdk-generation-cli/package.json
@@ -28,6 +28,7 @@
     "runGenerateAndBuildTask": "dist/runGenerateAndBuildTaskCli.js",
     "runMockTestTask": "dist/runMockTestTaskCli.js",
     "runLiveTestTask": "dist/runLiveTestTaskCli.js",
+    "publishLog": "dist/publishLogCli.js",
     "generateResult": "dist/generateResultCli.js"
   },
   "dependencies": {


### PR DESCRIPTION
add the publishLog command back, for it's accidentally deleted
Signed-off-by: Zhou Zheng <zhouzheng@microsoft.com>