### PR TITLE
Use the batch version of ValidateDocsMsPackagesFn

### DIFF
--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -153,7 +153,8 @@ function GetPackageInfoJson ($packageInfoJsonLocation) {
     # version is always 'dev' when interacting with NPM.
     if ($GetDocsMsDevLanguageSpecificPackageInfoFn -and (Test-Path "Function:$GetDocsMsDevLanguageSpecificPackageInfoFn")) {
       $packageInfo = &$GetDocsMsDevLanguageSpecificPackageInfoFn $packageInfo
-    } else {
+    }
+    else {
       # Default: use the dev version from package info as the version for
       # downstream processes
       $packageInfo.Version = $packageInfo.DevVersion
@@ -168,15 +169,17 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation) {
   $originalVersion = [AzureEngSemanticVersion]::ParseVersionString($packageInfo.Version)
   $packageMetadataArray = (Get-CSVMetadata).Where({ $_.Package -eq $packageInfo.Name -and $_.Hide -ne 'true' -and $_.New -eq 'true' })
   if ($packageInfo.Group) {
-    $packageMetadataArray = ($packageMetadataArray).Where({$_.GroupId -eq $packageInfo.Group})
+    $packageMetadataArray = ($packageMetadataArray).Where({ $_.GroupId -eq $packageInfo.Group })
   }
   if ($packageMetadataArray.Count -eq 0) {
     LogWarning "Could not retrieve metadata for $($packageInfo.Name) from metadata CSV. Using best effort defaults."
     $packageMetadata = $null
-  } elseif ($packageMetadataArray.Count -gt 1) {
+  }
+  elseif ($packageMetadataArray.Count -gt 1) {
     LogWarning "Multiple metadata entries for $($packageInfo.Name) in metadata CSV. Using first entry."
     $packageMetadata = $packageMetadataArray[0]
-  } else {
+  }
+  else {
     $packageMetadata = $packageMetadataArray[0]
   }
 
@@ -220,7 +223,7 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation) {
 if ($ValidateDocsMsPackagesFn -and (Test-Path "Function:$ValidateDocsMsPackagesFn")) {
   Write-Host "Validating the packages..."
 
-  $packageInfos = @($PackageInfoJsonLocations | GetPackageInfoJson)
+  $packageInfos = @($PackageInfoJsonLocations | ForEach-Object { GetPackageInfoJson $_ })
 
   &$ValidateDocsMsPackagesFn -PackageInfos $packageInfos -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $DocValidationImageId -DocRepoLocation $DocRepoLocation
 }


### PR DESCRIPTION
Refactor `Update-DocsMsMetadata.ps1` to support batch processing in `$ValidateDocsMsPackagesFn`

It appears that only azure-sdk-for-java and azure-sdk-for-python implement `$ValidateDocsMsPackagesFn`.  Both repos have been updated to support the `-PackageInfos` parameter to `$ValidateDocsMsPackagesFn`