### PR TITLE
Sanitize table foldableClass to be valid css

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -10,7 +10,7 @@
         _ => ""
     };
 
-    string foldableClass = Model.CodeLine.LineClass.ToLower().Replace(".","-");
+    string foldableClass = Model.CodeLine.LineClass.ToLower().Replace(".","-").Replace("/","").Replace("{","").Replace("}","").Replace("_","");
     string collapseClass = foldableClass.EndsWith("-content") ? "d-none" : "";
 }
 


### PR DESCRIPTION
- Remove invalid characters from foldableClass so that it is a valid css class name.