### PR TITLE
Add helm file plugin and local dependency chart usage readme

### DIFF
--- a/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/Chart.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/Chart.yaml
@@ -30,4 +30,4 @@ dependencies:
   condition: deploy.chaosmesh
 - name: stress-test-addons
   version: 0.1.16
-  repository: "@stresstestcharts"
+  repository: https://stresstestcharts.blob.core.windows.net/helm/

--- a/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/Chart.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/Chart.yaml
@@ -29,5 +29,5 @@ dependencies:
   repository: https://charts.chaos-mesh.org
   condition: deploy.chaosmesh
 - name: stress-test-addons
-  version: 0.1.12
-  repository: https://stresstestcharts.blob.core.windows.net/helm/
+  version: 0.1.16
+  repository: "@stresstestcharts"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin/README.md
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin/README.md
@@ -1,0 +1,47 @@
+Simple helm plugin to enable the file protocol for `helm repo add file://` paths in order to simplify
+local development of the stress-test-addon library chart with stress test charts that take it as a dependency.
+Requires powershell core.
+
+Example usage to override remove chart dependencies with a local version below.
+
+For a helm chart with a named chart dependency `@stresstestcharts`:
+
+```
+$ tail Chart.yaml -n 3
+
+- name: stress-test-addons
+  version: 0.1.16
+  repository: "@stresstestcharts"
+```
+
+Install named `stresstestcharts` repository from remote ur:
+
+```
+helm repo add stresstestcharts https://stresstestcharts.blob.core.windows.net/helm/
+```
+
+Install remote library chart from stresstestcharts repositor:
+
+```
+helm dependency update
+```
+
+Add file plugin to support `file://` repositories, this only has to be done once:
+
+```
+helm plugin add ../stress-test-addons/file-plugin
+```
+
+Use local version of named `stresstestcharts` library chart:
+
+```
+helm repo add --force-update stresstestcharts file:///home/ben/sdk/azure-sdk-tools/tools/stress-cluster/cluster/kubernetes/stress-test-addons
+helm dependency update
+```
+
+Revert to remote version of library chart
+
+```
+helm repo add --force-update stresstestcharts https://stresstestcharts.blob.core.windows.net/helm/
+helm dependency update
+```

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin/README.md
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin/README.md
@@ -35,7 +35,7 @@ helm plugin add ../stress-test-addons/file-plugin
 Use local version of named `stresstestcharts` library chart:
 
 ```
-helm repo add --force-update stresstestcharts file:///home/ben/sdk/azure-sdk-tools/tools/stress-cluster/cluster/kubernetes/stress-test-addons
+helm repo add --force-update stresstestcharts file:///<local-path>/azure-sdk-tools/tools/stress-cluster/cluster/kubernetes/stress-test-addons
 helm dependency update
 ```
 

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin/README.md
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin/README.md
@@ -29,13 +29,13 @@ helm dependency update
 Add file plugin to support `file://` repositories, this only has to be done once:
 
 ```
-helm plugin add ../stress-test-addons/file-plugin
+helm plugin add <git root>/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin
 ```
 
 Use local version of named `stresstestcharts` library chart:
 
 ```
-helm repo add --force-update stresstestcharts file:///<local-path>/azure-sdk-tools/tools/stress-cluster/cluster/kubernetes/stress-test-addons
+helm repo add --force-update stresstestcharts file:///<git root>/azure-sdk-tools/tools/stress-cluster/cluster/kubernetes/stress-test-addons
 helm dependency update
 ```
 

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin/bin/file.ps1
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin/bin/file.ps1
@@ -1,0 +1,12 @@
+#!/usr/bin/env pwsh
+
+# See https://helm.sh/docs/topics/plugins/#downloader-plugins
+param(
+    [string]$certFile,
+    [string]$keyFile,
+    [string]$caFile,
+    [string]$url
+)
+
+$path = $url -replace "file://"
+Get-Content "$path" -Raw

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin/plugin.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/file-plugin/plugin.yaml
@@ -1,0 +1,7 @@
+name: file
+version: 0.1
+description: Enables file:// protocol for helm repositories
+downloaders:
+  - command: "bin/file.ps1"
+    protocols:
+      - "file"


### PR DESCRIPTION
This PR adds a helm plugin to make switching between remote and local versions of the stress-test-addons library chart much easier to do. The references can be switched by adding/changing the URL of the stresstestcharts helm repository via the `helm repo` command (which does not support the `file://` by default).
