### PR TITLE
[sdk-generation-package] Bump `colors.js` dependency to address CG alert

### DIFF
--- a/tools/sdk-generation-pipeline/packages/sdk-generation-lib/package.json
+++ b/tools/sdk-generation-pipeline/packages/sdk-generation-lib/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@azure/storage-blob": "^12.8.0",
     "ajv": "^6.12.6",
-    "colors": "^1.4.0",
+    "colors": "1.4.0",
     "convict": "^6.2.1",
     "jsonc-parser": "^3.0.0",
     "winston": "^3.3.3"


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-tools/security/dependabot?q=is%3Aopen

The drama with the NPM package has subsided, but we can clear this out of our CG alerts as well.