### PR TITLE
[Swift APIView] Allow attributes in type inheritance clauses

### DIFF
--- a/src/swift/SwiftAPIViewCore/Sources/Models/Miscellaneous/TypeModels/TypeIdentifierModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/Miscellaneous/TypeModels/TypeIdentifierModel.swift
@@ -52,9 +52,15 @@ struct TypeIdentifierModel: TypeModel {
 
     var optional = OptionalKind.none
     var opaque = OpaqueKind.none
+    var attributes: AttributesModel?
     var names: [TypeNameModel]
 
     init(from source: TypeIdentifier) {
+        if let attrs = source.attributes {
+            attributes = AttributesModel(from: attrs)
+        } else {
+            attributes = nil
+        }
         names = [TypeNameModel]()
         source.names.forEach { item in
             names.append(TypeNameModel(from: item))
@@ -67,6 +73,7 @@ struct TypeIdentifierModel: TypeModel {
 
     func tokenize(apiview a: APIViewModel) {
         opaque.tokenize(apiview: a)
+        attributes?.tokenize(apiview: a)
         let stopIdx = names.count - 1
         for (idx, name) in names.enumerated() {
             name.tokenize(apiview: a)

--- a/src/swift/SwiftAPIViewTests/Sources/AttributesTestFile.swift
+++ b/src/swift/SwiftAPIViewTests/Sources/AttributesTestFile.swift
@@ -57,3 +57,13 @@ public class ExampleClass: NSObject {
         return true
     }
 }
+
+// Use of @unchecked Sendable
+
+public class SomeSendable: @unchecked Sendable {
+    public let name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}

--- a/src/swift/SwiftAPIViewTests/Sources/EnumerationsTestFile.swift
+++ b/src/swift/SwiftAPIViewTests/Sources/EnumerationsTestFile.swift
@@ -45,9 +45,9 @@ public enum Barcode {
 // RawValue enum
 
 public enum ASCIIControlCharacter: Character {
-    case tab = "\\t"
-    case lineFeed = "\\n"
-    case carriageReturn = "\\r"
+    case tab = "\t"
+    case lineFeed = "\n"
+    case carriageReturn = "\r"
 }
 
 // Implicitly assigned value enum


### PR DESCRIPTION
Fixes #3192.

Here's the APIView showing the `@unchecked Sendable` annotation that was breaking (and is new in Swift 5.x):
https://apiviewstaging.azurewebsites.net/Assemblies/Review/b48cf38e94c34e73afdcd02b492ad273