### PR TITLE
[Test-Proxy] Enforce Http 1.1 only

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -296,10 +296,12 @@ namespace Azure.Sdk.Tools.TestProxy
                         continue;
                     }
 
-                    // if the above didn't work, then it must be a Content header
                     if(!upstreamRequest.Content.Headers.TryAddWithoutValidation(header.Key, values))
                     {
-                        DebugLogger.LogInformation($"Omitting header {header.Key} of value {string.Join(",", values)}");
+                        throw new HttpException(
+                            HttpStatusCode.BadRequest,
+                            $"Encountered an unexpected exception while mapping a content header during upstreamRequest creation. Header: \"{header.Key}\". Value: \"{String.Join(",", values)}\""
+                        );
                     }
                 }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -297,7 +297,10 @@ namespace Azure.Sdk.Tools.TestProxy
                     }
 
                     // if the above didn't work, then it must be a Content header
-                    upstreamRequest.Content.Headers.TryAddWithoutValidation(header.Key, values);
+                    if(!upstreamRequest.Content.Headers.TryAddWithoutValidation(header.Key, values))
+                    {
+                        DebugLogger.LogInformation($"Omitting header {header.Key} of value {string.Join(",", values)}");
+                    }
                 }
 
                 if(header.Key == "x-recording-upstream-host-header")

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -296,13 +296,8 @@ namespace Azure.Sdk.Tools.TestProxy
                         continue;
                     }
 
-                    if(!upstreamRequest.Content.Headers.TryAddWithoutValidation(header.Key, values))
-                    {
-                        throw new HttpException(
-                            HttpStatusCode.BadRequest,
-                            $"Encountered an unexpected exception while mapping a content header during upstreamRequest creation. Header: \"{header.Key}\". Value: \"{String.Join(",", values)}\""
-                        );
-                    }
+                    // if the above didn't work, then it must be a Content header
+                    upstreamRequest.Content.Headers.TryAddWithoutValidation(header.Key, values);
                 }
 
                 if(header.Key == "x-recording-upstream-host-header")

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/appsettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/appsettings.json
@@ -6,5 +6,6 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
+  "Kestrel": {"EndpointDefaults": {"Protocols": "Http1"}},
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
~~On both `go 1.17` and `go 1.18` we generate some wonky headers.~~

- `:authority`
- `:method`

~~It is an artifact of the client, as per my understanding these aren't actually used by the service. Correct me if I'm wrong @seankane-msft~~

~~In the past, we were actually silently omitting them, but we got explicit with [this PR](https://github.com/Azure/azure-sdk-tools/commit/80fc22045fefe1140565e46ae0a768c42c057c3d).~~

~~This PR brings it back to excluding them by default.~~

Kestrel by default listens for both `http/1.1` and `http/2` communication. The issue is that because we were allowing both, the `go` clients don't know which to select. This is why we are seemingly randomly getting `:authority` and `:method` headers. The go client thinks it's talking http/2!

By disallowing test-proxy from _listening_ on http/2, we don't get those wonky headers sent anymore. The go client selects the correct protocol based on what our server tells it.
