### PR TITLE
[Test-Proxy] Remove Reliance on Appsettings, Update Startup.cs

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -15,6 +15,7 @@ using System.Text.RegularExpressions;
 using Azure.Sdk.Tools.TestProxy.Common;
 using Microsoft.Extensions.Logging;
 using System.Reflection;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 
 namespace Azure.Sdk.Tools.TestProxy
 {
@@ -87,6 +88,10 @@ namespace Azure.Sdk.Tools.TestProxy
                         });
                         loggingBuilder.AddDebug();
                         loggingBuilder.AddEventSourceLogger();
+                    })
+                    .ConfigureKestrel(options =>
+                    {
+                        options.ConfigureEndpointDefaults(lo => lo.Protocols = HttpProtocols.Http1);
                     })
                 );
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/appsettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/appsettings.json
@@ -6,6 +6,5 @@
       "Microsoft.Hosting.Lifetime": "Information"
     }
   },
-  "Kestrel": {"EndpointDefaults": {"Protocols": "Http1"}},
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
After beating my face into why [builds fail]() it's due to the fact that when running as a tool relying on the appsettings, something is resolving wonkily within the CI runs for go. 

Specifically, it is still allowing HTTP/2.0 traffic to flow. I can tell this because when I run `test-proxy` locally using the CI-targeted version, it is _still getting_ a `:method` header value and sending with protocol `http/2`.

F5-ed through VS it did _not_ have these issues. That tells me it's something in the resolution of appsettings vs launchsettings vs startup.cs. 

I have confirmed `go` tests pass just fine locally using the version of test-proxy published from this PR branch. Will do another eng/common update and remove the go-override tomorrow.

