### PR TITLE
Pylint Guidelines Checker 0.0.3 -> 0.0.4

### DIFF
--- a/tools/pylint-extensions/pylint-guidelines-checker/setup.py
+++ b/tools/pylint-extensions/pylint-guidelines-checker/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="pylint-guidelines-checker",
-    version="0.0.3",
+    version="0.0.4",
     url='http://github.com/Azure/azure-sdk-for-python',
     license='MIT License',
     description="A pylint plugin which enforces azure sdk guidelines.",


### PR DESCRIPTION
Released 0.0.3 to fix error URL syntax.