### PR TITLE
[Python Dev Feed] Create Pipeline Definition for uploading packages from PyPI

### DIFF
--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -38,8 +38,7 @@ jobs:
         displayName: Install Requirements
 
       - pwsh: |
-          $configurations = '${{ convertToJson(parameters.PackageSpecifiers) }}' -replace '\\', '/' 
-          Write-Host $configurations
+          $configurations = '${{ convertToJson(parameters.PackageSpecifiers) }}' -replace '\\', '/' -replace '"' '`"'
           python $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages.py $configurations --dest-dir='$(Build.ArtifactStagingDirectory)'
         displayName: 'Download Targeted Packages'
 

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -64,7 +64,7 @@ jobs:
                 Write-Host "Failure to upload $($result)"
               }
 
-              Write-Host "Uploaded whl `"$($file.Name)`" to devops feed "${{ parameters.DevFeed }}"
+              Write-Host "Uploaded whl `"$($file.Name)`" to devops feed `"${{ parameters.DevFeed }}`""
             }
             catch{
               Write-Host $_

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -56,11 +56,12 @@ jobs:
       - pwsh: |
           $results = Get-ChildItem -Force -Path $(Build.ArtifactStagingDirectory)
           foreach($file in $results){
+            Write-Host "Uploading $file"
             try {
               $result = twine upload --repository "${{ parameters.DevFeed }}" --config-file $(PYPIRC_PATH) $($file.Name)
   
               if ($LASTEXITCODE -gt 0) {
-                Write-Host "Failure to Upload: $($result)"
+                Write-Host "Failure to upload $($result)"
               }
 
               Write-Host "Uploaded whl `"$($file.Name)`" to devops feed "${{ parameters.DevFeed }}"

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -39,6 +39,7 @@ jobs:
 
       - pwsh: |
           $configurations = '${{ convertToJson(parameters.PackageSpecifiers) }}' -replace '\\', '/' 
+          Write-Host $configurations
           python $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages.py $configurations --dest-dir='$(Build.ArtifactStagingDirectory)'
         displayName: 'Download Targeted Packages'
 

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -56,7 +56,20 @@ jobs:
       - pwsh: |
           $results = Get-ChildItem -Force -Path $(Build.ArtifactStagingDirectory)
           foreach($file in $results){
-            Write-Host "$file.Name"
+            try {
+              $result = twine upload --repository "${{ parameters.DevFeed }}" --config-file $(PYPIRC_PATH) $($file.Name)
+  
+              if ($LASTEXITCODE -gt 0) {
+                Write-Host "Failure to Upload: $($result)"
+              }
+
+              Write-Host "Uploaded whl `"$($file.Name)`" to devops feed "${{ parameters.DevFeed }}"
+            }
+            catch{
+              Write-Host $_
+              Write-Host $error
+            }
           }
         displayName: 'Publish Packages to Dev Feed'
+        continueOnError: true
 

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -42,9 +42,16 @@ jobs:
           python $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages.py $configurations --dest-dir='$(Build.ArtifactStagingDirectory)'
         displayName: 'Download Targeted Packages'
 
-      - template: /eng/pipelines/templates/steps/auth-dev-feed.yml
-        parameters:
-          DevFeedName: ${{ parameters.DevFeed }}
+      - task: TwineAuthenticate@0
+        displayName: 'Twine Authenticate to feed'
+        inputs:
+          artifactFeeds: ${{ parameters.DevFeed }}
+
+      - task: PipAuthenticate@1
+        displayName: 'Pip Authenticate to feed'
+        inputs:
+          artifactFeeds: ${{ parameters.DevFeed }}
+          onlyAddExtraIndex: false
 
       - pwsh: |
           $results = Get-ChildItem -Force -Path $(Build.ArtifactStagingDirectory)

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -39,7 +39,7 @@ jobs:
 
       - pwsh: |
           $configurations = '${{ convertToJson(parameters.PackageSpecifiers) }}' -replace '\\', '/' 
-          python scripts/devops_tasks/download_targeted_packages.py $configurations --dest-dir='$(Build.ArtifactStagingDirectory)'
+          python $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages.py $configurations --dest-dir='$(Build.ArtifactStagingDirectory)'
         displayName: 'Download Targeted Packages'
 
       - template: /eng/pipelines/templates/steps/auth-dev-feed.yml

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -38,7 +38,7 @@ jobs:
         displayName: Install Requirements
 
       - pwsh: |
-          $configurations = '${{ convertToJson(parameters.PackageSpecifiers) }}' -replace '\\', '/' -replace '"' '`"'
+          $configurations = '${{ convertToJson(parameters.PackageSpecifiers) }}' -replace '\\', '/' -replace '"', '`"'
           python $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages.py $configurations --dest-dir='$(Build.ArtifactStagingDirectory)'
         displayName: 'Download Targeted Packages'
 

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -21,8 +21,8 @@ jobs:
     displayName: Mirror From PyPI
 
     pool:
-      Pool: 'azsdk-pool-mms-ubuntu-2004-general'
-      vmImage: 'MMSUbuntu20.04'
+      name: azsdk-pool-mms-ubuntu-2004-general
+      vmImage: MMSUbuntu20.04
 
     variables:
       - template: /eng/pipelines/templates/variables/globals.yml

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -55,21 +55,10 @@ jobs:
 
       - pwsh: |
           $results = Get-ChildItem -Force -Path $(Build.ArtifactStagingDirectory)
-          foreach($file in $results){
+          foreach ($file in $results) {
             Write-Host "Uploading $file"
-            try {
-              $result = twine upload --repository "${{ parameters.DevFeed }}" --config-file $(PYPIRC_PATH) $($file.Name)
-  
-              if ($LASTEXITCODE -gt 0) {
-                Write-Host "Failure to upload $($result)"
-              }
-
-              Write-Host "Uploaded whl `"$($file.Name)`" to devops feed `"${{ parameters.DevFeed }}`""
-            }
-            catch{
-              Write-Host $_
-              Write-Host $error
-            }
+            
+            twine upload --repository "${{ parameters.DevFeed }}" --config-file $(PYPIRC_PATH) $($file.FullName)
           }
         displayName: 'Publish Packages to Dev Feed'
         continueOnError: true

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -1,0 +1,55 @@
+parameters:
+  - name: PackageSpecifiers
+    type: object
+    default: []
+  - name: PythonVersionOverride
+    type: string
+    default: "3.9"
+  - name: DevFeed
+    type: string
+    default: "public/azure-sdk-for-python"
+
+# this package takes a yaml list of target packages. This list should look something like
+#
+# - azure-storage-blob==12.2.0
+# - astroid==2.11.3
+#
+# other specifiers that aren't "==" are supported, but user beware, you won't get a deterministic result then!
+
+jobs:
+  - job: Mirror_From_PyPI
+    displayName: Mirror From PyPI
+
+    pool:
+      Pool: 'azsdk-pool-mms-ubuntu-2004-general'
+      vmImage: 'MMSUbuntu20.04'
+
+    variables:
+      - template: /eng/pipelines/templates/variables/globals.yml
+
+    steps:
+      - task: UsePythonVersion@0
+        inputs:
+          versionSpec: ${{ parameters.PythonVersionOverride }}
+
+      - script: |
+          set -e
+          pip install -r $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages_requirements.txt
+        displayName: Install Requirements
+
+      - pwsh: |
+          $configurations = '${{ convertToJson(parameters.PackageSpecifiers) }}' -replace '\\', '/' 
+          python scripts/devops_tasks/download_targeted_packages.py $configurations --dest-dir='$(Build.ArtifactStagingDirectory)'
+        displayName: 'Download Targeted Packages'
+
+      - template: /eng/pipelines/templates/steps/auth-dev-feed.yml
+        parameters:
+          DevFeedName: ${{ parameters.DevFeed }}
+
+      - pwsh: |
+          $results = Get-ChildItem -Force -Path $(Build.ArtifactStagingDirectory)
+          foreach($file in $results){
+            Write-Host "$file.Name"
+          }
+        displayName: 'Publish Packages to Dev Feed'
+

--- a/eng/scripts/download_targeted_packages.py
+++ b/eng/scripts/download_targeted_packages.py
@@ -137,6 +137,7 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
+    print(args.target_packages)
 
     pkg_list = read_package_list(args.target_packages)
     assembled_package_list = set()

--- a/eng/scripts/download_targeted_packages.py
+++ b/eng/scripts/download_targeted_packages.py
@@ -97,12 +97,13 @@ def get_dependencies(package_specifier: str) -> List[str]:
         error_encountered = True
         output = ""
 
-    print(output)
-
     if output:
         json_output = json.loads(output)
 
-    return [key + "==" + json_output[key] for key in json_output]
+        return [key + "==" + json_output[key] for key in json_output]
+    else:
+        print("Unable to get output from pipgrip invocation.")
+        return []
 
 
 def download_dependencies(targeted_packages: Set[str], target_folder: str) -> None:
@@ -142,8 +143,6 @@ if __name__ == "__main__":
     
     # powershell does some weird escaping. Leaving behind just the '`' in what would normally look like '`"`.
     pkg_list = read_package_list(args.target_packages.replace("`", "\""))
-
-    print(pkg_list)
 
     assembled_package_list = set()
 

--- a/eng/scripts/download_targeted_packages.py
+++ b/eng/scripts/download_targeted_packages.py
@@ -1,0 +1,150 @@
+# this script uses the package pipgrip to evaluate the targeted packages and return the full list of dependencies
+import argparse
+import os
+import shutil
+import re
+import json
+import bs4
+import requests
+from typing import List, Set, Tuple
+import subprocess
+
+def get_file(url: str, dest_folder: str) -> None:
+    """
+    Downloads a targeted URL to a destination folder.
+    """
+    file_name = url.split("/")[-1].replace(" ", "_")
+    file_name = file_name.split("#")[0]
+    file_path = os.path.join(dest_folder, file_name)
+
+    r = requests.get(url, stream=True)
+    if r.status_code == 200:
+        with open(file_path, "wb") as f:
+            for chunk in r.iter_content(chunk_size=1024 * 8):
+                if chunk:
+                    f.write(chunk)
+                    f.flush()
+                    os.fsync(f.fileno())
+    else:
+        print('Download failed with status code "{}" and error "{}".'.format(r.status_code, r.text))
+
+
+def get_pkg_tuple(package_specifier: str) -> Tuple[str, str]:
+    """
+    Takes a specifier of form "azure-core==1.20.0" and returns ("azure-core", "1.20.0")
+
+    If no specific version is specified, the latter part of the tuple will be None.
+    """
+    result = re.split(r"[><=]", package_specifier)
+
+    if len(result) == 3:
+        package_name = result[0]
+        package_version = result[2]
+
+    elif len(result) == 2:
+        package_name = result[0]
+        package_version = ""
+
+    return package_name, package_version
+
+
+def get_pkg_files(package_specifier: str) -> List[str]:
+    """
+    Given a package specifier "azure-core==1.20.0", find all wheels and source distributions that match that version.
+
+    Retrieves using the PyPI simple index. This will provide up-to-date CDN links to each download.
+    """
+    pkg_name, pkg_version = get_pkg_tuple(package_specifier)
+
+    if not pkg_version:
+        print("This script does not support a specifier-less target package. Please specify an exact version.")
+        return []
+
+    retrieval_string = "https://pypi.org/simple/{0}".format(pkg_name)
+    result = requests.get(retrieval_string)
+    soup = bs4.BeautifulSoup(result.text, "html.parser")
+
+    all_links = soup.find_all("a")
+
+    def check_link(input_str: str) -> bool:
+        return (
+            "{}-".format(pkg_version) in input_str
+            or input_str.endswith("{}.tar.gz".format(pkg_version))
+            or input_str.endswith("{}.zip".format(pkg_version))
+        )
+
+    return [link["href"] for link in all_links if check_link(link.text)]
+
+
+def read_package_list(json_string: str) -> List[str]:
+    """
+    Gets the python representation of a json array string.
+    """
+    return json.loads(json_string)
+
+
+def get_dependencies(package_specifier: str) -> List[str]:
+    """
+    Evaluates a presented specifier and retrieves the complete dependency web in the form of package specifiers.
+
+    azure-core==1.20.0
+    azure-storage-blob==12.3.0
+    """
+
+    try:
+        output = subprocess.check_output(["pipgrip", package_specifier, "--json"])
+    except Exception as f:
+        error_encountered = True
+        output = ""
+
+    if output:
+        json_output = json.loads(output)
+
+    return [key + "==" + json_output[key] for key in json_output]
+
+
+def download_dependencies(targeted_packages: Set[str], target_folder: str) -> None:
+    """
+    Downloads all the wheel and source distribution files for a given set of targeted packages.
+
+    An individual item will have the standard specifier form of "azure-core==1.20.0".
+    """
+
+    if not os.path.exists(target_folder):
+        os.mkdir(target_folder)
+    else:
+        shutil.rmtree(target_folder)
+        os.mkdir(target_folder)
+
+    for targeted_package in targeted_packages:
+        files = get_pkg_files(targeted_package)
+        for file in files:
+            get_file(file, target_folder)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Download wheels and source distributions (if possible) for a set of targeted specifiers."
+    )
+
+    parser.add_argument("target_packages", nargs="?", help=("An array of targeted specifiers, in a json string."))
+
+    parser.add_argument(
+        "-d",
+        "--dest-dir",
+        dest="dest_dir",
+        help="Temporary Location of downloaded bits.",
+    )
+
+    args = parser.parse_args()
+
+    pkg_list = read_package_list(args.target_packages)
+    assembled_package_list = set()
+
+    for pkg in pkg_list:
+        full_dependencies = get_dependencies(pkg)
+
+        for dep in full_dependencies:
+            assembled_package_list.add(dep)
+
+    download_dependencies(assembled_package_list, args.dest_dir)

--- a/eng/scripts/download_targeted_packages.py
+++ b/eng/scripts/download_targeted_packages.py
@@ -97,6 +97,8 @@ def get_dependencies(package_specifier: str) -> List[str]:
         error_encountered = True
         output = ""
 
+    print(output)
+
     if output:
         json_output = json.loads(output)
 
@@ -140,6 +142,9 @@ if __name__ == "__main__":
     
     # powershell does some weird escaping. Leaving behind just the '`' in what would normally look like '`"`.
     pkg_list = read_package_list(args.target_packages.replace("`", "\""))
+
+    print(pkg_list)
+
     assembled_package_list = set()
 
     for pkg in pkg_list:

--- a/eng/scripts/download_targeted_packages.py
+++ b/eng/scripts/download_targeted_packages.py
@@ -137,9 +137,9 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    print(args.target_packages)
-
-    pkg_list = read_package_list(args.target_packages)
+    
+    # powershell does some weird escaping. Leaving behind just the '`' in what would normally look like '`"`.
+    pkg_list = read_package_list(args.target_packages.replace("`", "\""))
     assembled_package_list = set()
 
     for pkg in pkg_list:

--- a/eng/scripts/download_targeted_packages_requirements.txt
+++ b/eng/scripts/download_targeted_packages_requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4>=4.11.1
+requests>=2.27.1
+twine>=4.0.0

--- a/eng/scripts/download_targeted_packages_requirements.txt
+++ b/eng/scripts/download_targeted_packages_requirements.txt
@@ -1,4 +1,4 @@
 beautifulsoup4>=4.11.1
 requests>=2.27.1
-twine>=4.0.0
+twine==3.1.1
 pipgrip>=0.8.0

--- a/eng/scripts/download_targeted_packages_requirements.txt
+++ b/eng/scripts/download_targeted_packages_requirements.txt
@@ -1,3 +1,4 @@
 beautifulsoup4>=4.11.1
 requests>=2.27.1
 twine>=4.0.0
+pipgrip>=0.8.0


### PR DESCRIPTION
This has been brewing for a while. I finally hit a situation with

- `api-stub-generator`
- `pylint-guidelines-checker` 

That I couldn't elegantly solve. I don't want to have people needing to remember some wonky installation order or

> install dependencies of package first through this script, then install the package

As such, I will just populate our dev feed with a few packages (and make it super easy to add more). 

@tjprescott  We will be able to target our dev feed as the index url and _no other feeds_, keeping ourselves secure and also making it super easy on command side.

The pipelines in this PR will

- Take the top level packages passed in as parameters
- Evaluate them for their complete dependency tree
- Deduplicate the total dependency tree, find all associated wheels/sdists for that target version
- Download filtered set of files for the complete dependency tree
- Upload each file to our dev feed

![image](https://user-images.githubusercontent.com/45376673/165836771-03610b67-fd3a-4fcb-a871-16333420a365.png)
