### PR TITLE
Handle startup exceptions and add it to telemetry

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -160,6 +160,8 @@ namespace APIViewWeb.Repositories
                     {
                         var fileOriginal = await _originalsRepository.GetOriginalAsync(file.ReviewFileId);
                         var languageService = GetLanguageService(file.Language);
+                        if (languageService == null)
+                            continue;
 
                         // file.Name property has been repurposed to store package name and version string
                         // This is causing issue when updating review using latest parser since it expects Name field as file name
@@ -319,7 +321,7 @@ namespace APIViewWeb.Repositories
 
         private LanguageService GetLanguageService(string language)
         {
-           return _languageServices.Single(service => service.Name == language);
+           return _languageServices.FirstOrDefault(service => service.Name == language);
         }
 
         private async Task AssertReviewOwnerAsync(ClaimsPrincipal user, ReviewModel reviewModel)
@@ -378,7 +380,7 @@ namespace APIViewWeb.Repositories
         {
             return review.Revisions
                .SelectMany(r => r.Files)
-               .Any(f => f.HasOriginal && GetLanguageService(f.Language).CanUpdate(f.VersionString));
+               .Any(f => f.HasOriginal && GetLanguageService(f.Language)?.CanUpdate(f.VersionString) == true);
         }
 
         public async Task<bool> IsReviewSame(ReviewRevisionModel revision, RenderedCodeFile renderedCodeFile)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -527,7 +527,6 @@ namespace APIViewWeb.Repositories
         public async void UpdateReviewBackground()
         {
             var reviews = await _reviewsRepository.GetReviewsAsync(false, "All");
-            await SyncPackageDisplayServiceName(reviews);
             foreach (var review in reviews.Where(r => IsUpdateAvailable(r)))
             {
                 var requestTelemetry = new RequestTelemetry { Name = "Updating Review " + review.ReviewId };
@@ -544,28 +543,6 @@ namespace APIViewWeb.Repositories
                 finally
                 {
                     _telemetryClient.StopOperation(operation);
-                }
-            }
-        }
-
-        private async Task SyncPackageDisplayServiceName(IEnumerable<ReviewModel> reviews)
-        {
-            foreach (var review in reviews)
-            {
-                var newServiceName = review.ServiceName ?? "Other";
-                var newDisplayName = review.PackageDisplayName ?? "Other";
-                var pkg = _packageNameManager.GetPackageDetails(review.PackageName);
-                if (pkg != null)
-                {
-                    newServiceName = pkg.ServiceName;
-                    newDisplayName = pkg.DisplayName;
-                }
-
-                if (newServiceName != review.ServiceName || newDisplayName != review.PackageDisplayName)
-                {
-                    review.ServiceName = newServiceName;
-                    review.PackageDisplayName = newDisplayName;
-                    await _reviewsRepository.UpsertReviewAsync(review);
                 }
             }
         }


### PR DESCRIPTION
Currently we don't have any details in app insights about any failure in background tasks. This PR has changes to report exception from background tasks.