### PR TITLE
Add github action based check enforcer

### DIFF
--- a/.github/workflows/event.yaml
+++ b/.github/workflows/event.yaml
@@ -1,0 +1,16 @@
+name: GitHub Event Handler
+
+on:
+  check_suite:
+    types: [completed]
+  issue_comment:
+    types: [created]
+
+jobs:
+  event-handler:
+    name: Handle ${{ github.event_name }} ${{ github.event.action }} event
+    runs-on: ubuntu-latest
+    steps:
+      - uses: benbp/azure-sdk-actions@test
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/event.yaml
+++ b/.github/workflows/event.yaml
@@ -11,6 +11,6 @@ jobs:
     name: Handle ${{ github.event_name }} ${{ github.event.action }} event
     runs-on: ubuntu-latest
     steps:
-      - uses: benbp/azure-sdk-actions@test
+      - uses: azure/azure-sdk-actions@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
**NOTE** Based on feedback, I have moved the main action implementation into its own repository [here](https://github.com/Azure/azure-sdk-actions/pull/1). This PR now contains a simple yaml file for referencing the external repository action.

<hr>

This adds a new implementation of check enforcer intended to be run within a github actions context. To see an example of it running for a repository, check out the [actions in my fork](https://github.com/benbp/azure-sdk-tools/actions).

## Design Goals and Current Problems:

- Reduce ongoing maintenance and knowledge costs of the current check enforcer. By using github actions we won't have to maintain a check enforcer service ourselves.
- Improve check enforcer scaling. While the current check enforcer app can process webhook events much more quickly than github actions (since it does not have to spin up a runner VM per event), it hits a few key limitations:

## Details

- Check enforcer maintenance
    - There is a lot of work that needs to be done to improve scaling problems with check enforcer and support rapid development and safe deployments, detailed in https://github.com/Azure/azure-sdk-tools/issues/3033. Moving to this github action seems is less work for more benefit.
- Check enforcer scaling issues
    - The github API has a secondary rate limit for parallel requests from a single github app identity.
    - check enforcer handles events for all of our repositories.
    - check enforcer operates as part of a check suite, and queries the status of all check runs in the suite every time an individual run completes. When a large changeset is put in a pull request or merged to main, it causes a build storm and therefore a check run storm. Check enforcer not only has to query all check runs for each of these, but github paginates the responses multiplying the high number of requests by around 50 in the worst cases.
    - The above and other behaviors cause big queue backups due to github throttling in extreme cases, which happen with relative frequency (every few weeks) and bring check enforcer to a halt for hours.
- Github action benefits to scaling
    - When github runs an action, it passes a generated token in the [workflow context](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow) that can be used for requests. From what I can tell, this token will not have the same "one request at a time" limitations as our current github app identity, but I need to do more load testing from the action to understand when we'll get rate limited.
    - Since actions are local to the repo, even if we hit throttling issues due to build storms (or queueing issues due to event storms), this will only affect a single repo rather than all repos.

## Design Decisions

There are a few key design decisions made with this change, that I am eager will spark discussion.

1. As an organization we are starting to recognize more areas in which github actions can provide value that is not available today via an azure pipelines solution. These primarily center around ease of onboarding, discovery and understanding, as well as much more flexibility around various repository events.
    - As we continue to add github actions, I think it is going to be optimal to provide common platform support from the engsys team. Some ideas I have here are having centralized action configs for each event type, to prevent more than one action being queued for the same event. We can handle all the event details, routing, status checking, logging, testing, etc. and reduce duplicate efforts by providing a framework that developers can build their actions in.
1. The tool is written in Go. This decision is influenced by a future vision for our usage of github actions as an organization.
    - A top-level design goal should be to reduce the overhead of running the tool as much as possible, as our usage of actions grows (especially if we move more of our internal pipeline workloads into actions).
    - This tool or similar tools are likely to grow in complexity, usage and coverage. Tasks that contribute to setup time could include tool downloading, dependency installation, runtime startup, JIT compiling, etc. Go has a very minimal overhead in this area vs. Python, C#, Powershell, etc.
    - Any approach we choose needs to be easy to pick up by different language teams. Currently we use powershell as a common denominator, but there are many benefits to using a static language with static binaries that powershell cannot offer. Additionally, enforcing powershell quality, conventions and testing standards is extremely difficult today. Go has a much more opinionated and strict approach to how programs are written, which will help with consistency and ease of understanding of programs written across the repositories.

## Implementation Details

The program is currently written to take a single argument which is a path to a payload file. The payload is expected to be some form of a github event. Currently, it supports two payloads: [check_suite](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#check_suite) and [issue_comment](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#issue_comment).

Currently I wrote the program with no dependencies (except for local testing) in order to support the fastest possible runtime of a check enforcer action. If we go with this approach and roll it out, and things look good, I plan to design and add support for publishing a tool instead of building and running from source. At this point dependencies won't have as large of a download overhead and we can introduce them. Primarily I plan to replace my homerolled github client with the primary [github client for go](https://github.com/google/go-github).

For behavior and UX details, as well as instructions to enable, see the README file in this PR at `tools/check-enforcer-actions/README.md`. This tool has functional parity with the current check enforcer.