### PR TITLE
Sdk automation branch cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,3 +28,4 @@
 /tools/js-sdk-release-tools/     @dw511214992 @qiaozha @MaryGao
 /tools/keyvault-mock-attestation @maorleger
 /tools/sdk-generation-pipeline   @dw511214992 @chunyu3 @zzvswxy
+/tools/sdk-automation-branch-cleanup   @dw511214992 @chunyu3 @zzvswxy @weshaggard

--- a/tools/sdk-automation-branch-cleanup/package.json
+++ b/tools/sdk-automation-branch-cleanup/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@azure-tools/sdk-automation-branch-cleanup",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "build": "rimraf dist && tsc -p ."
+  },
+  "author": "Microsoft Corporation",
+  "license": "MIT",
+  "dependencies": {
+    "@octokit/rest": "18.12.0",
+    "command-line-args": "5.1.1",
+    "tslib": "1.9.3"
+  },
+  "devDependencies": {
+    "@types/node": "17.0.31",
+    "rimraf": "3.0.2",
+    "typescript": "3.9.7"
+  }
+}

--- a/tools/sdk-automation-branch-cleanup/sdk-automation-branch-cleanup.yml
+++ b/tools/sdk-automation-branch-cleanup/sdk-automation-branch-cleanup.yml
@@ -1,0 +1,45 @@
+parameters:
+- name: Repos
+  type: object
+  default:
+    - Azure/azure-powershell-pr
+    - Azure/azure-sdk-for-go-pr
+    - Azure/azure-sdk-for-java-pr
+    - Azure/azure-sdk-for-js-pr
+    - Azure/azure-sdk-for-net-pr
+    - Azure/azure-sdk-for-python-pr
+
+- name: BranchPrefix
+  type: string
+  default: 'sdkAuto'
+
+- name: PRCreator
+  type: string
+  default: 'azure-sdk'
+
+jobs:
+  - job: SDKAutomationBranchCleanUp
+    pool:
+      name: "azsdk-pool-mms-ubuntu-2004-general"
+      vmImage: "MMSUbuntu20.04"
+    variables:
+      - template: ../../eng/pipelines/templates/variables/globals.yml
+    steps:
+      - task: NodeTool@0
+        inputs:
+          versionSpec: '14.x'
+        displayName: 'Install Node.js'
+
+      - script: |
+          npm install
+          npm run build
+        displayName: 'npm install and build'
+        workingDirectory: $(System.DefaultWorkingDirectory)/tools/sdk-automation-branch-cleanup
+
+      - ${{if ne(variables['Build.Reason'], 'PullRequest')}}:
+        - ${{ each repo in parameters.Repos }}:
+          - bash: |
+              set -e
+              node dist/cleanupBranch.js --repo=${{ repo }} --auth-token=$(azuresdk-github-pat) --branch-prefix=${{ parameters.BranchPrefix }} --pr-creator=${{ parameters.PRCreator }}
+            displayName: Cleanup Branch in ${{ repo }}
+            workingDirectory: $(System.DefaultWorkingDirectory)/tools/sdk-automation-branch-cleanup

--- a/tools/sdk-automation-branch-cleanup/src/cleanupBranch.ts
+++ b/tools/sdk-automation-branch-cleanup/src/cleanupBranch.ts
@@ -1,0 +1,90 @@
+import commandLineArgs from 'command-line-args'
+import { Octokit } from '@octokit/rest'
+
+async function listAllPrs(octokit, owner: string, repo: string) {
+    const allPrs = await octokit.paginate(`Get /repos/{owner}/{repo}/pulls`, {
+        owner: owner,
+        repo: repo
+    },
+        response => response.data);
+    return allPrs;
+}
+
+function initializeOctokit(authToken: string) {
+    return new Octokit({
+        auth: authToken.trim()
+    });
+}
+
+function splitRepoInfo(repoInfo: string) {
+    const repoInfoSplits = repoInfo.split('/');
+    return {
+        owner: repoInfoSplits[0],
+        repo: repoInfoSplits[1]
+    }
+}
+
+async function swaggerPrIsClosed(octokit: Octokit, body: string) {
+    if (!body) return false;
+    const match = /https:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/([0-9]+)/gm.exec(body);
+    if (!match || match.length != 4) return false;
+    const owner = match[1];
+    const repo = match[2];
+    const prNumber = parseInt(match[3]);
+    const swaggerPr = await octokit.rest.pulls.get({
+        owner: owner,
+        repo: repo,
+        pull_number: prNumber
+    });
+    return swaggerPr?.data?.state === 'closed';
+}
+
+async function closePR(octokit: Octokit, owner: string, repo: string, prNumber: number, htmlUrl: string) {
+    console.log(`close PR: ${owner}/${repo}: ${htmlUrl}`);
+    await octokit.pulls.update({
+        owner: owner,
+        repo: repo,
+        pull_number: prNumber,
+        state: 'closed'
+    });
+}
+
+async function deleteBranch(octokit: Octokit, owner: string, repo: string, branchName: string) {
+    console.log(`delete branch: ${owner}/${repo}: ${branchName}`);
+    await octokit.git.deleteRef({
+        owner: owner,
+        repo: repo,
+        ref: `heads/${branchName}`
+    });
+}
+
+async function cleanupBranch(repoInfo: string, branchPrefix: string, prCreator: string, authToken: string) {
+    const octokit: Octokit = initializeOctokit(authToken);
+    const {owner, repo} = splitRepoInfo(repoInfo);
+    const allPrs = await listAllPrs(octokit, owner, repo);
+    for (const pr of allPrs) {
+        if (pr.user.login === prCreator && pr.head.ref.startsWith(branchPrefix)) {
+            if (await swaggerPrIsClosed(octokit, pr.body)) {
+                if (pr.state === 'open') {
+                    await closePR(octokit, owner, repo, pr.number, pr.html_url);
+                }
+                await deleteBranch(octokit, owner, repo, pr.head.ref);
+            } else {
+                console.log(`skip processing ${pr.html_url} because corresponding swagger PR is not closed/merged or linked`);
+            }
+        }
+    }
+}
+
+const optionDefinitions = [
+    {name: 'repo', type: String},
+    {name: 'branch-prefix', type: String},
+    {name: 'pr-creator', type: String},
+    {name: 'auth-token', type: String},
+];
+
+const options = commandLineArgs(optionDefinitions);
+cleanupBranch(options['repo'], options['branch-prefix'], options['pr-creator'], options['auth-token']).catch(e => {
+    console.log(e);
+    process.exit(1);
+})

--- a/tools/sdk-automation-branch-cleanup/tsconfig.json
+++ b/tools/sdk-automation-branch-cleanup/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "es6",
+    "module": "commonjs",
+    "lib": [
+      "ES6"
+    ],
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "./dist",
+    "rootDir": "src",
+    "importHelpers": true,
+    "downlevelIteration": true,
+    "strict": true,
+    "noImplicitAny": false,
+    "esModuleInterop": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  }
+}


### PR DESCRIPTION
It's not good to add specific logic to  `branch-cleanup.yml` to cleanup branches created by sdk automation pipeline. So, I create a new tool to cleanup the branches.

The logic to cleanup branches in this tool is:
1. Get all open PRs in sdk repo.
1. Check whether each sdk PR meets the following requirements:
   a. PR's creator is `azure-sdk`.
   b. PR's source branch name is prefixed with `sdkAuto`.
   c. The corresponding swagger PR is merged/closed.
1. Close the sdk PR and delete the source branch if it meets all conditions.