### PR TITLE
[Swift APIView] Support default values in willSet/didSet block expressions

### DIFF
--- a/src/swift/SwiftAPIViewCore/Sources/Models/Declarations/VariableModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/Declarations/VariableModel.swift
@@ -77,10 +77,11 @@ class VariableModel: Tokenizable, Commentable, AccessLevelProtocol {
         case let .willSetDidSetBlock(ident, typeAnno, expression, _):
             // the willSetDidSet block is irrelevant from an API perspective
             // so we ignore it.
-            initializers = [InitializerItemModel(name: ident.textDescription, typeModel: TypeAnnotationModel(from: typeAnno), defaultValue: nil)]
-            guard expression == nil else {
-                SharedLogger.fail("Expression not implemented. Please contact the SDK team.")
+            var defaultValue: String? = nil
+            if let literalExpression = expression as? LiteralExpression {
+                defaultValue = literalExpression.textDescription
             }
+            initializers = [InitializerItemModel(name: ident.textDescription, typeModel: TypeAnnotationModel(from: typeAnno), defaultValue: defaultValue)]
         }
         // Since we preserve these on a single line, base the line ID on the first name
         lineId = identifier(forName: initializers.first!.name, withPrefix: parent.definitionId)

--- a/src/swift/SwiftAPIViewCore/Sources/Models/PackageModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/PackageModel.swift
@@ -55,6 +55,8 @@ class PackageModel: Tokenizable, Linkable {
                         self.members.append(model)
                     }
                 }
+            case _ as CompilerControlStatement:
+                break
             default:
                 SharedLogger.fail("Unsupported statement type: \(statement)")
             }

--- a/src/swift/SwiftAPIViewTests/Sources/PropertiesTestFile.swift
+++ b/src/swift/SwiftAPIViewTests/Sources/PropertiesTestFile.swift
@@ -1,0 +1,44 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+public class PropertiesTestStruct {
+
+    var totalSteps: Int = 0 {
+        willSet(newTotalSteps) {
+            print("About to set totalSteps to \(newTotalSteps)")
+
+        }
+        didSet {
+            if totalSteps > oldValue  {
+                print("Added \(totalSteps - oldValue) steps")
+
+            }
+        }
+    }
+}
+

--- a/src/swift/SwiftAPIViewTests/SwiftAPIViewTests.xcodeproj/project.pbxproj
+++ b/src/swift/SwiftAPIViewTests/SwiftAPIViewTests.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		0A34D5C627FF40A3008A76A6 /* SwiftAPIViewTests.h in Headers */ = {isa = PBXBuildFile; fileRef = 0A34D5BF27FF40A2008A76A6 /* SwiftAPIViewTests.h */; };
 		0A34D5C727FF40A3008A76A6 /* OperatorTestFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A34D5C027FF40A2008A76A6 /* OperatorTestFile.swift */; };
 		0A34D5C927FF40AF008A76A6 /* FunctionsTestFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A34D5C827FF40AF008A76A6 /* FunctionsTestFile.swift */; };
+		0A35C20028298ED0008C99AD /* PropertiesTestFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A35C1FF28298ED0008C99AD /* PropertiesTestFile.swift */; };
 		0A8407B627F4B2F400801E60 /* SwiftAPIViewTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0A8407AD27F4B2F300801E60 /* SwiftAPIViewTests.framework */; };
 /* End PBXBuildFile section */
 
@@ -37,6 +38,7 @@
 		0A34D5BF27FF40A2008A76A6 /* SwiftAPIViewTests.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SwiftAPIViewTests.h; sourceTree = "<group>"; };
 		0A34D5C027FF40A2008A76A6 /* OperatorTestFile.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OperatorTestFile.swift; sourceTree = "<group>"; };
 		0A34D5C827FF40AF008A76A6 /* FunctionsTestFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FunctionsTestFile.swift; sourceTree = "<group>"; };
+		0A35C1FF28298ED0008C99AD /* PropertiesTestFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PropertiesTestFile.swift; sourceTree = "<group>"; };
 		0A8407AD27F4B2F300801E60 /* SwiftAPIViewTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SwiftAPIViewTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0A8407B527F4B2F400801E60 /* SwiftAPIViewTestsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SwiftAPIViewTestsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -69,6 +71,7 @@
 				0A34D5C827FF40AF008A76A6 /* FunctionsTestFile.swift */,
 				0A34D5BE27FF40A2008A76A6 /* GenericsTestFile.swift */,
 				0A34D5C027FF40A2008A76A6 /* OperatorTestFile.swift */,
+				0A35C1FF28298ED0008C99AD /* PropertiesTestFile.swift */,
 				0A34D5BD27FF40A2008A76A6 /* ProtocolTestFile.swift */,
 				0A34D5BF27FF40A2008A76A6 /* SwiftAPIViewTests.h */,
 			);
@@ -202,6 +205,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				0A35C20028298ED0008C99AD /* PropertiesTestFile.swift in Sources */,
 				0A34D5C227FF40A3008A76A6 /* AttributesTestFile.swift in Sources */,
 				0A34D5C727FF40A3008A76A6 /* OperatorTestFile.swift in Sources */,
 				0A34D5C327FF40A3008A76A6 /* EnumerationsTestFile.swift in Sources */,


### PR DESCRIPTION
Also ignores compiler control statements. 