### PR TITLE
Create consolidated APIView comment

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosPullRequestsRepository.cs
@@ -48,5 +48,11 @@ namespace APIViewWeb
             }
             return allRequests;
         }
+
+        public async Task<List<PullRequestModel>> GetPullRequestsAsync(int pullRequestNumber, string repoName)
+        {
+            var query = $"SELECT * FROM PullRequests c WHERE c.PullRequestNumber = {pullRequestNumber} and c.RepoName = '{repoName}'";
+            return await GetPullRequestFromQueryAsync(query);
+        }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -281,13 +281,8 @@ namespace APIViewWeb.Repositories
                 var renderedCodeFile = new RenderedCodeFile(codeFile);
                 if (await IsReviewSame(review, renderedCodeFile))
                 {
-                    //Do not update the comment if review was already created and it matches with current revision.
-                    if (pullRequestModel.ReviewId != null)
-                        return "";
-
-                    //Baseline review was not created earlier or this is the first commit of PR
-                    stringBuilder.Append($"API changes are not detected in this pull request for `{codeFile.PackageName}`");
-                    return stringBuilder.ToString();
+                    // Disable the comment when API change is not detected.
+                    return "";
                 }
 
                 if (pullRequestModel.ReviewId != null)
@@ -300,10 +295,7 @@ namespace APIViewWeb.Repositories
                     review.ReviewId = pullRequestModel.ReviewId;
                     if (await IsReviewSame(review, renderedCodeFile))
                     {
-                        // We will run into this if some one makes unintended API changes in a PR and then reverts it back.
-                        // We must clear previous comment and update it to show no changes found.
-                        stringBuilder.Append($"API changes are not detected in this pull request for `{codeFile.PackageName}`");
-                        return stringBuilder.ToString();
+                        return "";
                     }
                     // Update revision ID to previous revision ID so existing comments linked to previous revision 
                     // will not become invalid. Similarly previously generated link will still be valid.

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -95,7 +95,7 @@ namespace APIViewWeb.Repositories
                 originalFileName = originalFileName ?? codeFileName;
                 string[] repoInfo = repoName.Split("/");
                 var pullRequestModel = await GetPullRequestModel(prNumber, repoName, packageName, originalFileName);
-                if (pullRequestModel.Commits.Any(c=> c== commitSha))
+                if (pullRequestModel == null || pullRequestModel.Commits.Any(c=> c== commitSha))
                 {
                     // PR commit is already processed. No need to reprocess it again.
                     return "";
@@ -163,6 +163,12 @@ namespace APIViewWeb.Repositories
             {
                 string[] repoInfo = repoName.Split("/");
                 var issue = await _githubClient.Issue.Get(repoInfo[0], repoInfo[1], prNumber);
+                if(issue?.PullRequest?.Draft == true)
+                {
+                    // Do not check for api changes if pull request is in draft state
+                    return null;
+                }
+
                 pullRequestModel = new PullRequestModel()
                 {
                     RepoName = repoName,

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -162,8 +162,8 @@ namespace APIViewWeb.Repositories
             if (pullRequestModel == null)
             {
                 string[] repoInfo = repoName.Split("/");
-                var issue = await _githubClient.Issue.Get(repoInfo[0], repoInfo[1], prNumber);
-                if(issue?.PullRequest?.Draft == true)
+                var pullRequest = await _githubClient.PullRequest.Get(repoInfo[0], repoInfo[1], prNumber);
+                if(pullRequest.Draft == true)
                 {
                     // Do not check for api changes if pull request is in draft state
                     return null;
@@ -174,7 +174,7 @@ namespace APIViewWeb.Repositories
                     RepoName = repoName,
                     PullRequestNumber = prNumber,
                     FilePath = originalFile,
-                    Author = issue.User.Login,
+                    Author = pullRequest.User.Login,
                     PackageName = packageName
                 };
             }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -154,7 +154,7 @@ namespace APIViewWeb.Repositories
             bldr.Append(Environment.NewLine).Append(Environment.NewLine);            
             if(prReviews.Count > 0)
             {
-                bldr.Append(PR_APIVIEW_BOT_COMMENT);
+                bldr.Append(PR_APIVIEW_BOT_COMMENT).Append(Environment.NewLine).Append(Environment.NewLine);
                 foreach (var p in prReviews)
                 {
                     var reviewLink = REVIEW_URL.Replace("{hostName}", hostName).Replace("{ReviewId}", p.ReviewId);

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -204,7 +204,7 @@ namespace APIViewWeb.Repositories
             {
                 // Check for comment created for current package.
                 // GitHub issue comment unfortunately doesn't have any key to verify. So we need to check actual body to find the comment.
-                return comments.Where(c => c.Body.Contains(PR_APIVIEW_BOT_COMMENT_DENTIFIER)).LastOrDefault();
+                return comments.Where(c => c.Body.Contains(PR_APIVIEW_BOT_COMMENT_IDENTIFIER)).LastOrDefault();
             }
             return null;
         }


### PR DESCRIPTION
APIView bot writes a comment even if api changes are not present for a package. This was done as per the feedback but this is causing bot to spam with multiple comments when PR touches large number of packages. Disabling no change comment as interim solution until we come up with a solution to create single bot comment from apiview for entire PR.