### PR TITLE
Fix mock-service-host and go-testgen

### DIFF
--- a/tools/mock-service-host/src/mid/coordinator.ts
+++ b/tools/mock-service-host/src/mid/coordinator.ts
@@ -416,7 +416,9 @@ export class Coordinator {
     private setStatusToSuccess(ret: any) {
         // set status to succeed to stop polling
         if (ret) {
-            ret.status = 'Succeeded'
+            if (_.has(ret, 'status')) {
+                ret.status = 'Succeeded'
+            }
         } else {
             ret = { status: 'Succeeded' }
         }

--- a/tools/mock-service-host/src/mid/responser.ts
+++ b/tools/mock-service-host/src/mid/responser.ts
@@ -168,7 +168,7 @@ export class ResponseGenerator {
         return { exampleParameter: parameters as SwaggerExampleParameter, parameterTypes: types }
     }
 
-    private resolveValue(paramSpec: any, value: string | string[]): any {
+    private resolveValue(paramSpec: any, value: any): any {
         if (!paramSpec.type) {
             paramSpec = paramSpec.schema
         }
@@ -178,7 +178,7 @@ export class ResponseGenerator {
             case 'number':
                 return _.toNumber(value)
             case 'boolean':
-                return value === 'true'
+                return value === 'true' || value === true
             case 'array':
                 return _.map(value, (s) => {
                     return this.resolveValue(paramSpec.items, s)

--- a/tools/sdk-testgen/packages/autorest.gotest/src/generator/exampleGenerator.ts
+++ b/tools/sdk-testgen/packages/autorest.gotest/src/generator/exampleGenerator.ts
@@ -5,9 +5,8 @@
 
 import { BaseCodeGenerator } from './baseGenerator';
 import { Config } from '../common/constant';
-import { ExampleModel, ExampleValue, MockTestDefinitionModel } from '@autorest/testmodeler/dist/src/core/model';
+import { ExampleModel, MockTestDefinitionModel } from '@autorest/testmodeler/dist/src/core/model';
 import { GoExampleModel } from '../common/model';
-import { Helper } from '@autorest/testmodeler/dist/src/util/helper';
 import { MockTestDataRender } from './mockTestGenerator';
 import { getAPIParametersSig, getClientParametersSig } from '../util/codegenBridge';
 

--- a/tools/sdk-testgen/packages/autorest.gotest/src/generator/exampleGenerator.ts
+++ b/tools/sdk-testgen/packages/autorest.gotest/src/generator/exampleGenerator.ts
@@ -17,14 +17,6 @@ export class ExampleDataRender extends MockTestDataRender {
         example.methodParametersPlaceholderOutput = this.toParametersOutput(getAPIParametersSig(op), example.methodParameters);
         example.clientParametersPlaceholderOutput = this.toParametersOutput(getClientParametersSig(example.operationGroup), example.clientParameters);
     }
-
-    protected getRawValue(exampleValue: ExampleValue) {
-        let rawValue = exampleValue.rawValue;
-        if (this.getLanguageName(exampleValue.schema) === 'string' && exampleValue.language) {
-            rawValue = '<' + Helper.toKebabCase(this.getLanguageName(exampleValue)) + '>';
-        }
-        return rawValue;
-    }
 }
 
 export class ExampleCodeGenerator extends BaseCodeGenerator {

--- a/tools/sdk-testgen/packages/autorest.gotest/src/template/mockTest.go.njk
+++ b/tools/sdk-testgen/packages/autorest.gotest/src/template/mockTest.go.njk
@@ -9,8 +9,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
-	"runtime/debug"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -18,151 +16,37 @@ import (
     "github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
     "github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
-	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/testutil"
+	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/http2"
 )
 {{imports}}
 
-var (
-	ctx            context.Context
-    options        arm.ClientOptions
-	cred           azcore.TokenCredential
-	err            error
-	mockHost       string
-)
+type MockTestSuite struct {
+	suite.Suite
 
-{% for exampleGroup in exampleGroups %}
-{% if exampleGroup.operation.language.default.name == exampleGroup.operation.language.go.name %}
-func Test{{exampleGroup.operationGroup.language.go.name}}_{{exampleGroup.operation.language.go.name}}(t *testing.T) {
-{%- for example in exampleGroup.examples %}
-    // From example {{example.originalFile}}
-	{%- if sendExampleId %}
-	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
-        "example-id": {"{{example.name.split('\\').join('\\\\').split('"').join('\\"')}}"},
-    })
-	{%- endif %}
-	{%- if loop.first %}
-	client, err := {{packageName}}.{{example.operationGroup.language.go.clientCtorName}}({{example.clientParametersOutput + ", " if example.clientParametersOutput else ""}}cred, &options)
-    if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
-    {%- else %}
-    client, err = {{packageName}}.{{example.operationGroup.language.go.clientCtorName}}({{example.clientParametersOutput + ", " if example.clientParametersOutput else ""}}cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
-    {%- endif %}
-	{%- if example.returnInfo.length == 2 %}
-        {%- if example.isLRO %}
-            poller, err {% if loop.first %}:{% endif %}= client.{{example.opName}}({{example.methodParametersOutput}})
-        {%- else %}
-            {% if example.checkResponse %}res{% else %}_{% endif %}, err {% if loop.first and example.checkResponse %}:{% endif %}= client.{{example.opName}}({{example.methodParametersOutput}})
-        {%- endif %}
-        if err != nil {
-            t.Fatalf("Failed to get result for example {{example.originalFile}}: %v", err)
-        }
-        {%- if example.isLRO %}
-            {% if example.checkResponse %}res{% else %}_{% endif %}, err {% if loop.first and example.checkResponse %}:{% endif %}= poller.PollUntilDone(ctx, 30*time.Second)
-            if err != nil {
-                t.Fatalf("Failed to get LRO result for example {{example.originalFile}}: %v", err)
-            }
-        {%- endif %}
-    {%- elif  (example.returnInfo.length == 1) and (example.isPageable) %}
-        pager {% if loop.first %}:{% endif %}= client.{{example.opName}}({{example.methodParametersOutput}})
-        for pager.More() {
-            {% if example.checkResponse and verifyResponse%}nextResult{% else %}_{% endif %}, err := pager.NextPage(ctx)
-            if err != nil {
-                t.Fatalf("Failed to advance page for example {{example.originalFile}}: %v", err)
-                break
-            }
-            {%- if example.checkResponse and verifyResponse%}
-            // Response check
-            pagerExampleRes := {{example.responseOutput}}
-            if !reflect.DeepEqual(pagerExampleRes, {% if example.responseTypePointer %}*{% endif %}nextResult{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %}) {
-                exampleResJson, _ := json.Marshal(pagerExampleRes)
-                mockResJson, _ := json.Marshal({% if example.responseTypePointer %}*{% endif %}nextResult{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %})
-                t.Fatalf("Mock response is not equal to example response for example {{example.originalFile}}:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
-            }
-            {%- endif %}
-        }
-    {%- else %}
-        client.{{example.opName}}({{example.methodParametersOutput}})
-    {%- endif %}
-
-    {%- if example.isLRO and example.isPageable and example.checkResponse %}
-        for res.More() {
-            {% if example.checkResponse and verifyResponse%}nextResult{% else %}_{% endif %}, err := res.NextPage(ctx)
-            if err != nil {
-                t.Fatalf("Failed to advance page for example {{example.originalFile}}: %v", err)
-                break
-            }
-            {%- if example.checkResponse and verifyResponse%}
-            // Response check
-            pagerExampleRes := {{example.responseOutput}}
-            if !reflect.DeepEqual(pagerExampleRes, {% if example.responseTypePointer %}*{% endif %}nextResult{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %}) {
-                exampleResJson, _ := json.Marshal(pagerExampleRes)
-                mockResJson, _ := json.Marshal({% if example.responseTypePointer %}*{% endif %}nextResult{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %})
-                t.Fatalf("Mock response is not equal to example response for example {{example.originalFile}}:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
-            }
-            {%- endif %}
-        }
-    {%- endif %}
-        
-    {%- if example.checkResponse and not example.isPageable and verifyResponse%}
-        // Response check
-        exampleRes {%- if loop.first %}:{% endif %}= {{example.responseOutput}}
-        if !reflect.DeepEqual(exampleRes, {% if example.responseTypePointer %}*{% endif %}res{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %}) {
-            exampleResJson, _ := json.Marshal(exampleRes)
-            mockResJson, _ := json.Marshal({% if example.responseTypePointer %}*{% endif %}res{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %})
-            t.Fatalf("Mock response is not equal to example response for example {{example.originalFile}}:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
-        }
-    {%- endif %}
-    {%- if not loop.last %}
-
-    {% endif %}
-{%- endfor %}
-{%- if exampleGroup.examples|length <=0 %}
-	t.Skip("Warning: No test steps for this operation!")
-{%- endif %}
-}
-{%- endif %}
-{% endfor %}
-
-// TestMain will exec each test
-func TestMain(m *testing.M) {
-	setUp()
-	retCode := m.Run() // exec test and this returns an exit code to pass to os
-	tearDown()
-	os.Exit(retCode)
+	cred              azcore.TokenCredential
+	options           arm.ClientOptions
 }
 
-func getEnv(key, fallback string) string {
-    if value, ok := os.LookupEnv(key); ok {
-        return value
-    }
-    return fallback
-}
-
-func setUp() {
-	ctx = context.Background()
-	mockHost = getEnv("AZURE_VIRTUAL_SERVER_HOST", "https://localhost:8443")
+func (testsuite *MockTestSuite) SetupSuite() {
+	mockHost := testutil.GetEnv("AZURE_VIRTUAL_SERVER_HOST", "https://localhost:8443")
 
 	tr := &http.Transport{}
-	if err := http2.ConfigureTransport(tr); err != nil {
-		fmt.Printf("Failed to configure http2 transport: %v", err)
-	}
+	err := http2.ConfigureTransport(tr)
+	testsuite.Require().NoError(err, "Failed to configure http2 transport")
 	tr.TLSClientConfig.InsecureSkipVerify = true
 	client := &http.Client{Transport: tr}
-	
-    cred = &MockCredential{}
 
-	options = arm.ClientOptions{
+	testsuite.cred = &MockCredential{}
+
+	testsuite.options = arm.ClientOptions{
 		ClientOptions: policy.ClientOptions{
 			Logging: policy.LogOptions{
 				IncludeBody: true,
 			},
 			Transport: client,
-            Cloud: cloud.Configuration{
+			Cloud: cloud.Configuration{
 				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
 					cloud.ResourceManager: {
 						Audience: mockHost,
@@ -174,9 +58,94 @@ func setUp() {
 	}
 }
 
-func tearDown() {
-
+func TestMockTest(t *testing.T) {
+	suite.Run(t, new(MockTestSuite))
 }
+
+{% for exampleGroup in exampleGroups %}
+{% if exampleGroup.operation.language.default.name == exampleGroup.operation.language.go.name %}
+func (testsuite *MockTestSuite) Test{{exampleGroup.operationGroup.language.go.name}}_{{exampleGroup.operation.language.go.name}}() {
+{%- if exampleGroup.examples|length <=0 %}
+	testsuite.T().Skip("Warning: No test steps for this operation!")
+{%- else -%}
+    ctx := context.Background()
+{%- endif %}
+{%- for example in exampleGroup.examples %}
+    // From example {{example.originalFile}}
+	{%- if sendExampleId %}
+	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
+        "example-id": {"{{example.name.split('\\').join('\\\\').split('"').join('\\"')}}"},
+    })
+	{%- endif %}
+	{%- if loop.first %}
+	client, err := {{packageName}}.{{example.operationGroup.language.go.clientCtorName}}({{example.clientParametersOutput + ", " if example.clientParametersOutput else ""}}testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, "Failed to create client")
+    {%- else %}
+    client, err = {{packageName}}.{{example.operationGroup.language.go.clientCtorName}}({{example.clientParametersOutput + ", " if example.clientParametersOutput else ""}}testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
+    {%- endif %}
+	{%- if example.returnInfo.length == 2 %}
+        {%- if example.isLRO %}
+            poller, err {% if loop.first %}:{% endif %}= client.{{example.opName}}({{example.methodParametersOutput}})
+        {%- else %}
+            {% if example.checkResponse %}res{% else %}_{% endif %}, err {% if loop.first and example.checkResponse %}:{% endif %}= client.{{example.opName}}({{example.methodParametersOutput}})
+        {%- endif %}
+        testsuite.Require().NoError(err, "Failed to get result for example {{example.originalFile}}")
+        {%- if example.isLRO %}
+            {% if example.checkResponse %}res{% else %}_{% endif %}, err {% if loop.first and example.checkResponse %}:{% endif %}= poller.PollUntilDone(ctx, 30*time.Second)
+            testsuite.Require().NoError(err, "Failed to get LRO result for example {{example.originalFile}}")
+        {%- endif %}
+    {%- elif  (example.returnInfo.length == 1) and (example.isPageable) %}
+        pager {% if loop.first %}:{% endif %}= client.{{example.opName}}({{example.methodParametersOutput}})
+        for pager.More() {
+            {% if example.checkResponse and verifyResponse%}nextResult{% else %}_{% endif %}, err := pager.NextPage(ctx)
+            testsuite.Require().NoError(err, "Failed to advance page for example {{example.originalFile}}")
+            {%- if example.checkResponse and verifyResponse%}
+            // Response check
+            pagerExampleRes := {{example.responseOutput}}
+            if !reflect.DeepEqual(pagerExampleRes, {% if example.responseTypePointer %}*{% endif %}nextResult{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %}) {
+                exampleResJson, _ := json.Marshal(pagerExampleRes)
+                mockResJson, _ := json.Marshal({% if example.responseTypePointer %}*{% endif %}nextResult{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %})
+                testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example {{example.originalFile}}:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+            }
+            {%- endif %}
+        }
+    {%- else %}
+        client.{{example.opName}}({{example.methodParametersOutput}})
+    {%- endif %}
+
+    {%- if example.isLRO and example.isPageable and example.checkResponse %}
+        for res.More() {
+            {% if example.checkResponse and verifyResponse%}nextResult{% else %}_{% endif %}, err := res.NextPage(ctx)
+            testsuite.Require().NoError(err, "Failed to advance page for example {{example.originalFile}}")
+            {%- if example.checkResponse and verifyResponse%}
+            // Response check
+            pagerExampleRes := {{example.responseOutput}}
+            if !reflect.DeepEqual(pagerExampleRes, {% if example.responseTypePointer %}*{% endif %}nextResult{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %}) {
+                exampleResJson, _ := json.Marshal(pagerExampleRes)
+                mockResJson, _ := json.Marshal({% if example.responseTypePointer %}*{% endif %}nextResult{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %})
+                testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example {{example.originalFile}}:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+            }
+            {%- endif %}
+        }
+    {%- endif %}
+        
+    {%- if example.checkResponse and not example.isPageable and verifyResponse%}
+        // Response check
+        exampleRes {%- if loop.first %}:{% endif %}= {{example.responseOutput}}
+        if !reflect.DeepEqual(exampleRes, {% if example.responseTypePointer %}*{% endif %}res{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %}) {
+            exampleResJson, _ := json.Marshal(exampleRes)
+            mockResJson, _ := json.Marshal({% if example.responseTypePointer %}*{% endif %}res{% if not example.responseIsDiscriminator %}.{{example.responseType}}{% endif %})
+            testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example {{example.originalFile}}:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+        }
+    {%- endif %}
+    {%- if not loop.last %}
+
+    {% endif %}
+{%- endfor %}
+}
+{%- endif %}
+{% endfor %}
 
 type MockCredential struct {
 }

--- a/tools/sdk-testgen/packages/autorest.gotest/src/template/sampleContent.go.njk
+++ b/tools/sdk-testgen/packages/autorest.gotest/src/template/sampleContent.go.njk
@@ -46,17 +46,17 @@
             {%- set pagerVariable = clientVariable + example.opName + 'Pager' %}
             {{pagerVariable}} {%- if allVariables.indexOf(pagerVariable)<0 %}:{%- set _ = allVariables.push(pagerVariable) %}{%- endif %}= {{clientVariable}}.{{example.opName}}({{example.methodParametersOutput}})
             for {{pagerVariable}}.More() {
+                {% if example.checkResponse %}nextResult{% else %}_{% endif %}, err := {{pagerVariable}}.NextPage(ctx)
+                if err != nil {
+                    panic(err)
+                }
                 {%- if example.checkResponse %}
-                    nextResult, err := {{pagerVariable}}.NextPage(ctx)
-                    if err != nil {
-                        panic(err)
-                    }
                     {%- for outputVariableName, variableConfigs in step.outputVariablesModel%}
                         {% set newVariableConfigs = variableConfigs.slice(1) %}
                         {{outputVariableName}} = {% if step.outputVariables[outputVariableName]["isPtr"] %}*{% endif %}nextResult.{{example.pageableItemName}}{% for variableConfig in newVariableConfigs %}{{variableConfig.languageName}}{% endfor %}
                     {%- endfor %}
-                    break
                 {%- endif %}
+                break
             }
         {%- else %}
             {{clientVariable}}.{{example.opName}}({{example.methodParametersOutput}})
@@ -64,17 +64,17 @@
 
         {%- if example.isLRO and example.isPageable %}
             for {{resVariable}}.More() {
+                {% if example.checkResponse %}nextResult{% else %}_{% endif %}, err := {{pagerVariable}}.NextPage(ctx)
+                if err != nil {
+                    panic(err)
+                }
                 {%- if example.checkResponse %}
-                    nextResult, err := {{pagerVariable}}.NextPage(ctx)
-                    if err != nil {
-                        panic(err)
-                    }
                     {%- for outputVariableName, variableConfigs in step.outputVariablesModel%}
                         {% set newVariableConfigs = variableConfigs.slice(1) %}
                         {% if globalVariables.indexOf(outputVariableName)>=0 %}testsuite.{% endif %}{{outputVariableName}} = {% if step.outputVariables[outputVariableName]["isPtr"] %}*{% endif %}nextResult.{{example.pageableItemName}}{% for variableConfig in newVariableConfigs %}{{variableConfig.languageName}}{% endfor %}
                     {%- endfor %}
-                    break
                 {%- endif %}
+                break
             }
         {%- endif %}
 

--- a/tools/sdk-testgen/packages/autorest.gotest/src/template/scenarioContent.go.njk
+++ b/tools/sdk-testgen/packages/autorest.gotest/src/template/scenarioContent.go.njk
@@ -46,15 +46,15 @@ var err error
             {%- set pagerVariable = clientVariable + example.opName %}
             {{pagerVariable}} {%- if allVariables.indexOf(pagerVariable)<0 %}:{%- set _ = allVariables.push(pagerVariable) %}{%- endif %}= {{clientVariable}}.{{example.opName}}({{example.methodParametersOutput}})
             for {{pagerVariable}}.More() {
+                {% if example.checkResponse %}nextResult{% else %}_{% endif %}, err := {{pagerVariable}}.NextPage(ctx)
+                testsuite.Require().NoError(err)
                 {%- if example.checkResponse %}
-                    nextResult, err := {{pagerVariable}}.NextPage(ctx)
-                    testsuite.Require().NoError(err)
                     {%- for outputVariableName, variableConfigs in step.outputVariablesModel%}
                         {% set newVariableConfigs = variableConfigs.slice(1) %}
                         {% if globalVariables.indexOf(outputVariableName)>=0 %}testsuite.{% endif %}{{outputVariableName}} = {% if step.outputVariables[outputVariableName]["isPtr"] %}*{% endif %}nextResult.{{example.pageableItemName}}{% for variableConfig in newVariableConfigs %}{{variableConfig.languageName}}{% endfor %}
                     {%- endfor %}
-                    break
                 {%- endif %}
+                break
             }
         {%- else %}
             {{clientVariable}}.{{example.opName}}({{example.methodParametersOutput}})
@@ -62,15 +62,15 @@ var err error
 
         {%- if example.isLRO and example.isPageable %}
             for {{resVariable}}.More() {
+                {% if example.checkResponse %}nextResult{% else %}_{% endif %}, err := {{pagerVariable}}.NextPage(ctx)
+                testsuite.Require().NoError(err)
                 {%- if example.checkResponse %}
-                    nextResult, err := {{pagerVariable}}.NextPage(ctx)
-                    testsuite.Require().NoError(err)
                     {%- for outputVariableName, variableConfigs in step.outputVariablesModel%}
                         {% set newVariableConfigs = variableConfigs.slice(1) %}
                         {% if globalVariables.indexOf(outputVariableName)>=0 %}testsuite.{% endif %}{{outputVariableName}} = {% if step.outputVariables[outputVariableName]["isPtr"] %}*{% endif %}nextResult.{{example.pageableItemName}}{% for variableConfig in newVariableConfigs %}{{variableConfig.languageName}}{% endfor %}
                     {%- endfor %}
-                    break
                 {%- endif %}
+                break
             }
         {%- endif %}
 

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/__debug/go-tester.yaml
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/__debug/go-tester.yaml
@@ -20391,7 +20391,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -20412,8 +20412,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               nil
             opName: Get
             operation: *ref_780
@@ -20649,7 +20649,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -20722,18 +20722,18 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               test.ServiceResource{
-              Location: to.Ptr("<location>"),
+              Location: to.Ptr("eastus"),
               Tags: map[string]*string{
               "key1": to.Ptr("value1"),
               },
               Properties: &test.ClusterResourceProperties{
               },
               SKU: &test.SKU{
-              Name: to.Ptr("<name>"),
-              Tier: to.Ptr("<tier>"),
+              Name: to.Ptr("S0"),
+              Tier: to.Ptr("Standard"),
               },
               },
               nil
@@ -21280,7 +21280,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -21385,25 +21385,25 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               test.ServiceResource{
-              Location: to.Ptr("<location>"),
+              Location: to.Ptr("eastus"),
               Tags: map[string]*string{
               "key1": to.Ptr("value1"),
               },
               Properties: &test.ClusterResourceProperties{
               NetworkProfile: &test.NetworkProfile{
-              AppNetworkResourceGroup: to.Ptr("<app-network-resource-group>"),
-              AppSubnetID: to.Ptr("<app-subnet-id>"),
-              ServiceCidr: to.Ptr("<service-cidr>"),
-              ServiceRuntimeNetworkResourceGroup: to.Ptr("<service-runtime-network-resource-group>"),
-              ServiceRuntimeSubnetID: to.Ptr("<service-runtime-subnet-id>"),
+              AppNetworkResourceGroup: to.Ptr("my-app-network-rg"),
+              AppSubnetID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork/subnets/apps"),
+              ServiceCidr: to.Ptr("10.8.0.0/16,10.244.0.0/16,10.245.0.1/16"),
+              ServiceRuntimeNetworkResourceGroup: to.Ptr("my-service-runtime-network-rg"),
+              ServiceRuntimeSubnetID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/myVirtualNetwork/subnets/serviceRuntime"),
               },
               },
               SKU: &test.SKU{
-              Name: to.Ptr("<name>"),
-              Tier: to.Ptr("<tier>"),
+              Name: to.Ptr("S0"),
+              Tier: to.Ptr("Standard"),
               },
               },
               nil
@@ -22012,7 +22012,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -22033,8 +22033,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               nil
             opName: BeginDelete
             operation: *ref_818
@@ -22066,7 +22066,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -22139,18 +22139,18 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               test.ServiceResource{
-              Location: to.Ptr("<location>"),
+              Location: to.Ptr("eastus"),
               Tags: map[string]*string{
               "key1": to.Ptr("value1"),
               },
               Properties: &test.ClusterResourceProperties{
               },
               SKU: &test.SKU{
-              Name: to.Ptr("<name>"),
-              Tier: to.Ptr("<tier>"),
+              Name: to.Ptr("S0"),
+              Tier: to.Ptr("Standard"),
               },
               },
               nil
@@ -22546,7 +22546,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -22567,8 +22567,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               nil
             opName: ListTestKeys
             operation: *ref_829
@@ -22632,7 +22632,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -22666,8 +22666,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               test.RegenerateTestKeyRequestPayload{
               KeyType: to.Ptr(test.TestKeyTypePrimary),
               },
@@ -22734,7 +22734,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -22755,8 +22755,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               nil
             opName: DisableTestEndpoint
             operation: *ref_844
@@ -22785,7 +22785,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -22806,8 +22806,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               nil
             opName: EnableTestEndpoint
             operation: *ref_847
@@ -22871,7 +22871,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -22904,10 +22904,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<location>",
+              "eastus",
               test.NameAvailabilityParameters{
-              Name: to.Ptr("<name>"),
-              Type: to.Ptr("<type>"),
+              Name: to.Ptr("myservice"),
+              Type: to.Ptr("Microsoft.AppPlatform/Spring"),
               },
               nil
             opName: CheckNameAvailability
@@ -22962,7 +22962,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_861
@@ -23213,7 +23213,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_865
@@ -23227,7 +23227,7 @@ testModel:
               "myResourceGroup",
               nil
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
+              "myResourceGroup",
               nil
             opName: NewListPager
             operation: *ref_863
@@ -23473,7 +23473,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -23494,8 +23494,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               nil
             opName: Get
             operation: *ref_868
@@ -23603,7 +23603,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -23671,16 +23671,16 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               test.ConfigServerResource{
               Properties: &test.ConfigServerProperties{
               ConfigServer: &test.ConfigServerSettings{
               GitProperty: &test.ConfigServerGitProperty{
-              Label: to.Ptr("<label>"),
+              Label: to.Ptr("master"),
               SearchPaths: []*string{
               to.Ptr("/")},
-              URI: to.Ptr("<uri>"),
+              URI: to.Ptr("https://github.com/fake-user/fake-repository.git"),
               },
               },
               },
@@ -23854,7 +23854,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -23922,16 +23922,16 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               test.ConfigServerResource{
               Properties: &test.ConfigServerProperties{
               ConfigServer: &test.ConfigServerSettings{
               GitProperty: &test.ConfigServerGitProperty{
-              Label: to.Ptr("<label>"),
+              Label: to.Ptr("master"),
               SearchPaths: []*string{
               to.Ptr("/")},
-              URI: to.Ptr("<uri>"),
+              URI: to.Ptr("https://github.com/fake-user/fake-repository.git"),
               },
               },
               },
@@ -24106,7 +24106,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -24160,14 +24160,14 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               test.ConfigServerSettings{
               GitProperty: &test.ConfigServerGitProperty{
-              Label: to.Ptr("<label>"),
+              Label: to.Ptr("master"),
               SearchPaths: []*string{
               to.Ptr("/")},
-              URI: to.Ptr("<uri>"),
+              URI: to.Ptr("https://github.com/fake-user/fake-repository.git"),
               },
               },
               nil
@@ -24221,7 +24221,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -24242,8 +24242,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               nil
             opName: Get
             operation: *ref_902
@@ -24346,7 +24346,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -24397,11 +24397,11 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               test.MonitoringSettingResource{
               Properties: &test.MonitoringSettingProperties{
-              AppInsightsInstrumentationKey: to.Ptr("<app-insights-instrumentation-key>"),
+              AppInsightsInstrumentationKey: to.Ptr("00000000-0000-0000-0000-000000000000"),
               AppInsightsSamplingRate: to.Ptr[float64](10),
               TraceEnabled: to.Ptr(true),
               },
@@ -24567,7 +24567,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -24618,11 +24618,11 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               test.MonitoringSettingResource{
               Properties: &test.MonitoringSettingProperties{
-              AppInsightsInstrumentationKey: to.Ptr("<app-insights-instrumentation-key>"),
+              AppInsightsInstrumentationKey: to.Ptr("00000000-0000-0000-0000-000000000000"),
               AppInsightsSamplingRate: to.Ptr[float64](10),
               TraceEnabled: to.Ptr(true),
               },
@@ -24789,7 +24789,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -24817,9 +24817,9 @@ testModel:
               }
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
               &test.AppsClientGetOptions{SyncStatus: nil,
               }
             opName: Get
@@ -24992,7 +24992,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -25102,23 +25102,23 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
               test.AppResource{
-              Location: to.Ptr("<location>"),
+              Location: to.Ptr("eastus"),
               Properties: &test.AppResourceProperties{
-              ActiveDeploymentName: to.Ptr("<active-deployment-name>"),
+              ActiveDeploymentName: to.Ptr("mydeployment1"),
               EnableEndToEndTLS: to.Ptr(false),
-              Fqdn: to.Ptr("<fqdn>"),
+              Fqdn: to.Ptr("myapp.mydomain.com"),
               HTTPSOnly: to.Ptr(false),
               PersistentDisk: &test.PersistentDisk{
-              MountPath: to.Ptr("<mount-path>"),
+              MountPath: to.Ptr("/mypersistentdisk"),
               SizeInGB: to.Ptr[int32](2),
               },
               Public: to.Ptr(true),
               TemporaryDisk: &test.TemporaryDisk{
-              MountPath: to.Ptr("<mount-path>"),
+              MountPath: to.Ptr("/mytemporarydisk"),
               SizeInGB: to.Ptr[int32](2),
               },
               },
@@ -25519,7 +25519,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -25546,9 +25546,9 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
               nil
             opName: BeginDelete
             operation: *ref_962
@@ -25580,7 +25580,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -25706,26 +25706,26 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
               test.AppResource{
               Identity: &test.ManagedIdentityProperties{
               Type: to.Ptr(test.ManagedIdentityTypeSystemAssigned),
               },
-              Location: to.Ptr("<location>"),
+              Location: to.Ptr("eastus"),
               Properties: &test.AppResourceProperties{
-              ActiveDeploymentName: to.Ptr("<active-deployment-name>"),
+              ActiveDeploymentName: to.Ptr("mydeployment1"),
               EnableEndToEndTLS: to.Ptr(false),
-              Fqdn: to.Ptr("<fqdn>"),
+              Fqdn: to.Ptr("myapp.mydomain.com"),
               HTTPSOnly: to.Ptr(false),
               PersistentDisk: &test.PersistentDisk{
-              MountPath: to.Ptr("<mount-path>"),
+              MountPath: to.Ptr("/mypersistentdisk"),
               SizeInGB: to.Ptr[int32](2),
               },
               Public: to.Ptr(true),
               TemporaryDisk: &test.TemporaryDisk{
-              MountPath: to.Ptr("<mount-path>"),
+              MountPath: to.Ptr("/mytemporarydisk"),
               SizeInGB: to.Ptr[int32](2),
               },
               },
@@ -26015,7 +26015,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_976
@@ -26035,8 +26035,8 @@ testModel:
               "myservice",
               nil
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               nil
             opName: NewListPager
             operation: *ref_973
@@ -26218,7 +26218,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -26245,9 +26245,9 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
               nil
             opName: GetResourceUploadURL
             operation: *ref_980
@@ -26301,7 +26301,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -26341,11 +26341,11 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
               test.CustomDomainValidatePayload{
-              Name: to.Ptr("<name>"),
+              Name: to.Ptr("mydomain.io"),
               },
               nil
             opName: ValidateDomain
@@ -26395,7 +26395,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -26428,10 +26428,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<binding-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mybinding",
               nil
             opName: Get
             operation: *ref_997
@@ -26549,7 +26549,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -26633,18 +26633,18 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<binding-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mybinding",
               test.BindingResource{
               Properties: &test.BindingResourceProperties{
               BindingParameters: map[string]interface{}{
               "apiType": "SQL",
               "databaseName": "db1",
               },
-              Key: to.Ptr("<key>"),
-              ResourceID: to.Ptr("<resource-id>"),
+              Key: to.Ptr("xxxx"),
+              ResourceID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/my-cosmosdb-1"),
               },
               },
               nil
@@ -26905,7 +26905,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -26938,10 +26938,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<binding-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mybinding",
               nil
             opName: BeginDelete
             operation: *ref_1022
@@ -26973,7 +26973,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -27052,17 +27052,17 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<binding-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mybinding",
               test.BindingResource{
               Properties: &test.BindingResourceProperties{
               BindingParameters: map[string]interface{}{
               "apiType": "SQL",
               "databaseName": "db1",
               },
-              Key: to.Ptr("<key>"),
+              Key: to.Ptr("xxxx"),
               },
               },
               nil
@@ -27254,7 +27254,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_1038
@@ -27280,9 +27280,9 @@ testModel:
               "myapp",
               nil
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
               nil
             opName: NewListPager
             operation: *ref_1035
@@ -27410,7 +27410,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -27437,9 +27437,9 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<certificate-name>",
+              "myResourceGroup",
+              "myservice",
+              "mycertificate",
               nil
             opName: Get
             operation: *ref_1042
@@ -27569,7 +27569,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -27626,14 +27626,14 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<certificate-name>",
+              "myResourceGroup",
+              "myservice",
+              "mycertificate",
               test.CertificateResource{
               Properties: &test.CertificateProperties{
-              CertVersion: to.Ptr("<cert-version>"),
-              KeyVaultCertName: to.Ptr("<key-vault-cert-name>"),
-              VaultURI: to.Ptr("<vault-uri>"),
+              CertVersion: to.Ptr("08a219d06d874795a96db47e06fbb01e"),
+              KeyVaultCertName: to.Ptr("mycert"),
+              VaultURI: to.Ptr("https://myvault.vault.azure.net"),
               },
               },
               nil
@@ -27924,7 +27924,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -27951,9 +27951,9 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<certificate-name>",
+              "myResourceGroup",
+              "myservice",
+              "mycertificate",
               nil
             opName: BeginDelete
             operation: *ref_1067
@@ -27985,7 +27985,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_1074
@@ -28005,8 +28005,8 @@ testModel:
               "myService",
               nil
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myService",
               nil
             opName: NewListPager
             operation: *ref_1070
@@ -28150,7 +28150,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -28183,10 +28183,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<domain-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydomain.com",
               nil
             opName: Get
             operation: *ref_1079
@@ -28272,7 +28272,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -28330,14 +28330,14 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<domain-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydomain.com",
               test.CustomDomainResource{
               Properties: &test.CustomDomainProperties{
-              CertName: to.Ptr("<cert-name>"),
-              Thumbprint: to.Ptr("<thumbprint>"),
+              CertName: to.Ptr("mycert"),
+              Thumbprint: to.Ptr("934367bf1c97033f877db0f15cb1b586957d3133"),
               },
               },
               nil
@@ -28516,7 +28516,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -28549,10 +28549,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<domain-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydomain.com",
               nil
             opName: BeginDelete
             operation: *ref_1099
@@ -28584,7 +28584,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -28642,14 +28642,14 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<domain-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydomain.com",
               test.CustomDomainResource{
               Properties: &test.CustomDomainProperties{
-              CertName: to.Ptr("<cert-name>"),
-              Thumbprint: to.Ptr("<thumbprint>"),
+              CertName: to.Ptr("mycert"),
+              Thumbprint: to.Ptr("934367bf1c97033f877db0f15cb1b586957d3133"),
               },
               },
               nil
@@ -28784,7 +28784,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_1116
@@ -28810,9 +28810,9 @@ testModel:
               "myapp",
               nil
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
               nil
             opName: NewListPager
             operation: *ref_1112
@@ -28912,7 +28912,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -28945,10 +28945,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<deployment-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydeployment",
               nil
             opName: Get
             operation: *ref_1121
@@ -29155,7 +29155,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -29271,10 +29271,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<deployment-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydeployment",
               test.DeploymentResource{
               Properties: &test.DeploymentResourceProperties{
               DeploymentSettings: &test.DeploymentSettings{
@@ -29282,15 +29282,15 @@ testModel:
               EnvironmentVariables: map[string]*string{
               "env": to.Ptr("test"),
               },
-              JvmOptions: to.Ptr("<jvm-options>"),
+              JvmOptions: to.Ptr("-Xms1G -Xmx3G"),
               MemoryInGB: to.Ptr[int32](3),
               RuntimeVersion: to.Ptr(test.RuntimeVersionJava8),
               },
               Source: &test.UserSourceInfo{
               Type: to.Ptr(test.UserSourceTypeSource),
-              ArtifactSelector: to.Ptr("<artifact-selector>"),
-              RelativePath: to.Ptr("<relative-path>"),
-              Version: to.Ptr("<version>"),
+              ArtifactSelector: to.Ptr("sub-module-1"),
+              RelativePath: to.Ptr("resources/a172cedcae47474b615c54d510a5d84a8dea3032e958587430b413538be3f333-2019082605-e3095339-1723-44b7-8b5e-31b1003978bc"),
+              Version: to.Ptr("1.0"),
               },
               },
               },
@@ -29777,7 +29777,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -29810,10 +29810,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<deployment-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydeployment",
               nil
             opName: BeginDelete
             operation: *ref_1160
@@ -29845,7 +29845,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -29924,17 +29924,17 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<deployment-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydeployment",
               test.DeploymentResource{
               Properties: &test.DeploymentResourceProperties{
               Source: &test.UserSourceInfo{
               Type: to.Ptr(test.UserSourceTypeSource),
-              ArtifactSelector: to.Ptr("<artifact-selector>"),
-              RelativePath: to.Ptr("<relative-path>"),
-              Version: to.Ptr("<version>"),
+              ArtifactSelector: to.Ptr("sub-module-1"),
+              RelativePath: to.Ptr("resources/a172cedcae47474b615c54d510a5d84a8dea3032e958587430b413538be3f333-2019082605-e3095339-1723-44b7-8b5e-31b1003978bc"),
+              Version: to.Ptr("1.0"),
               },
               },
               },
@@ -30284,7 +30284,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_1176
@@ -30311,9 +30311,9 @@ testModel:
               &test.DeploymentsClientListOptions{Version: []string{},
               }
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
               &test.DeploymentsClientListOptions{Version: []string{},
               }
             opName: NewListPager
@@ -30531,7 +30531,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_1181
@@ -30552,8 +30552,8 @@ testModel:
               &test.DeploymentsClientListForClusterOptions{Version: []string{},
               }
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
-              "<service-name>",
+              "myResourceGroup",
+              "myservice",
               &test.DeploymentsClientListForClusterOptions{Version: []string{},
               }
             opName: NewListForClusterPager
@@ -30771,7 +30771,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -30804,10 +30804,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<deployment-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydeployment",
               nil
             opName: BeginStart
             operation: *ref_1186
@@ -30839,7 +30839,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -30872,10 +30872,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<deployment-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydeployment",
               nil
             opName: BeginStop
             operation: *ref_1192
@@ -30907,7 +30907,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -30940,10 +30940,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<deployment-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydeployment",
               nil
             opName: BeginRestart
             operation: *ref_1198
@@ -30975,7 +30975,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -31008,10 +31008,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<service-name>",
-              "<app-name>",
-              "<deployment-name>",
+              "myResourceGroup",
+              "myservice",
+              "myapp",
+              "mydeployment",
               nil
             opName: GetLogFileURL
             operation: *ref_1204
@@ -31273,7 +31273,7 @@ testModel:
                   language: *ref_777
                 parameter: *ref_281
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_1248

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/spring/main.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/spring/main.go
@@ -358,6 +358,11 @@ func springSample() {
 		serviceName,
 		nil)
 	for certificatesClientNewListPagerPager.More() {
+		_, err := certificatesClientNewListPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step ConfigServers_Validate
@@ -651,6 +656,11 @@ func springSample() {
 		serviceName,
 		nil)
 	for appsClientNewListPagerPager.More() {
+		_, err := appsClientNewListPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step Bindings_Create
@@ -727,6 +737,11 @@ func springSample() {
 		appName,
 		nil)
 	for bindingsClientNewListPagerPager.More() {
+		_, err := bindingsClientNewListPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step Bindings_Delete
@@ -822,6 +837,11 @@ func springSample() {
 		appName,
 		nil)
 	for customDomainsClientNewListPagerPager.More() {
+		_, err := customDomainsClientNewListPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step Apps_GetResourceUploadUrl
@@ -1026,6 +1046,11 @@ func springSample() {
 		appName,
 		&test.DeploymentsClientListOptions{Version: []string{}})
 	for deploymentsClientNewListPagerPager.More() {
+		_, err := deploymentsClientNewListPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step Deployments_ListForCluster
@@ -1033,17 +1058,32 @@ func springSample() {
 		serviceName,
 		&test.DeploymentsClientListForClusterOptions{Version: []string{}})
 	for deploymentsClientNewListForClusterPagerPager.More() {
+		_, err := deploymentsClientNewListForClusterPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step Services_List
 	servicesClientNewListPagerPager := servicesClient.NewListPager(resourceGroupName,
 		nil)
 	for servicesClientNewListPagerPager.More() {
+		_, err := servicesClientNewListPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step Services_ListBySubscription
 	servicesClientNewListBySubscriptionPagerPager := servicesClient.NewListBySubscriptionPager(nil)
 	for servicesClientNewListBySubscriptionPagerPager.More() {
+		_, err := servicesClientNewListBySubscriptionPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step Deployments_Delete
@@ -1128,6 +1168,11 @@ func springSample() {
 	}
 	sKUsClientNewListPagerPager := sKUsClient.NewListPager(nil)
 	for sKUsClientNewListPagerPager.More() {
+		_, err := sKUsClientNewListPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step Operations_List
@@ -1137,6 +1182,11 @@ func springSample() {
 	}
 	operationsClientNewListPagerPager := operationsClient.NewListPager(nil)
 	for operationsClientNewListPagerPager.More() {
+		_, err := operationsClientNewListPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 }
 

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_apps_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_apps_client_test.go
@@ -25,14 +25,14 @@ func ExampleAppsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewAppsClient("<subscription-id>", cred, nil)
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
 		&test.AppsClientGetOptions{SyncStatus: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -48,28 +48,28 @@ func ExampleAppsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewAppsClient("<subscription-id>", cred, nil)
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
 		test.AppResource{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("eastus"),
 			Properties: &test.AppResourceProperties{
-				ActiveDeploymentName: to.Ptr("<active-deployment-name>"),
+				ActiveDeploymentName: to.Ptr("mydeployment1"),
 				EnableEndToEndTLS:    to.Ptr(false),
-				Fqdn:                 to.Ptr("<fqdn>"),
+				Fqdn:                 to.Ptr("myapp.mydomain.com"),
 				HTTPSOnly:            to.Ptr(false),
 				PersistentDisk: &test.PersistentDisk{
-					MountPath: to.Ptr("<mount-path>"),
+					MountPath: to.Ptr("/mypersistentdisk"),
 					SizeInGB:  to.Ptr[int32](2),
 				},
 				Public: to.Ptr(true),
 				TemporaryDisk: &test.TemporaryDisk{
-					MountPath: to.Ptr("<mount-path>"),
+					MountPath: to.Ptr("/mytemporarydisk"),
 					SizeInGB:  to.Ptr[int32](2),
 				},
 			},
@@ -93,14 +93,14 @@ func ExampleAppsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewAppsClient("<subscription-id>", cred, nil)
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -118,31 +118,31 @@ func ExampleAppsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewAppsClient("<subscription-id>", cred, nil)
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
 		test.AppResource{
 			Identity: &test.ManagedIdentityProperties{
 				Type: to.Ptr(test.ManagedIdentityTypeSystemAssigned),
 			},
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("eastus"),
 			Properties: &test.AppResourceProperties{
-				ActiveDeploymentName: to.Ptr("<active-deployment-name>"),
+				ActiveDeploymentName: to.Ptr("mydeployment1"),
 				EnableEndToEndTLS:    to.Ptr(false),
-				Fqdn:                 to.Ptr("<fqdn>"),
+				Fqdn:                 to.Ptr("myapp.mydomain.com"),
 				HTTPSOnly:            to.Ptr(false),
 				PersistentDisk: &test.PersistentDisk{
-					MountPath: to.Ptr("<mount-path>"),
+					MountPath: to.Ptr("/mypersistentdisk"),
 					SizeInGB:  to.Ptr[int32](2),
 				},
 				Public: to.Ptr(true),
 				TemporaryDisk: &test.TemporaryDisk{
-					MountPath: to.Ptr("<mount-path>"),
+					MountPath: to.Ptr("/mytemporarydisk"),
 					SizeInGB:  to.Ptr[int32](2),
 				},
 			},
@@ -166,12 +166,12 @@ func ExampleAppsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewAppsClient("<subscription-id>", cred, nil)
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<service-name>",
+	pager := client.NewListPager("myResourceGroup",
+		"myservice",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -192,16 +192,16 @@ func ExampleAppsClient_ValidateDomain() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewAppsClient("<subscription-id>", cred, nil)
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.ValidateDomain(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
 		test.CustomDomainValidatePayload{
-			Name: to.Ptr("<name>"),
+			Name: to.Ptr("mydomain.io"),
 		},
 		nil)
 	if err != nil {

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_bindings_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_bindings_client_test.go
@@ -25,15 +25,15 @@ func ExampleBindingsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewBindingsClient("<subscription-id>", cred, nil)
+	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<binding-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mybinding",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -49,23 +49,23 @@ func ExampleBindingsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewBindingsClient("<subscription-id>", cred, nil)
+	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<binding-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mybinding",
 		test.BindingResource{
 			Properties: &test.BindingResourceProperties{
 				BindingParameters: map[string]interface{}{
 					"apiType":      "SQL",
 					"databaseName": "db1",
 				},
-				Key:        to.Ptr("<key>"),
-				ResourceID: to.Ptr("<resource-id>"),
+				Key:        to.Ptr("xxxx"),
+				ResourceID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/myResourceGroup/providers/Microsoft.DocumentDB/databaseAccounts/my-cosmosdb-1"),
 			},
 		},
 		nil)
@@ -87,15 +87,15 @@ func ExampleBindingsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewBindingsClient("<subscription-id>", cred, nil)
+	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<binding-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mybinding",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -113,22 +113,22 @@ func ExampleBindingsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewBindingsClient("<subscription-id>", cred, nil)
+	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<binding-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mybinding",
 		test.BindingResource{
 			Properties: &test.BindingResourceProperties{
 				BindingParameters: map[string]interface{}{
 					"apiType":      "SQL",
 					"databaseName": "db1",
 				},
-				Key: to.Ptr("<key>"),
+				Key: to.Ptr("xxxx"),
 			},
 		},
 		nil)
@@ -150,13 +150,13 @@ func ExampleBindingsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewBindingsClient("<subscription-id>", cred, nil)
+	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
+	pager := client.NewListPager("myResourceGroup",
+		"myservice",
+		"myapp",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_certificates_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_certificates_client_test.go
@@ -25,14 +25,14 @@ func ExampleCertificatesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCertificatesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<certificate-name>",
+		"myResourceGroup",
+		"myservice",
+		"mycertificate",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -48,19 +48,19 @@ func ExampleCertificatesClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCertificatesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<certificate-name>",
+		"myResourceGroup",
+		"myservice",
+		"mycertificate",
 		test.CertificateResource{
 			Properties: &test.CertificateProperties{
-				CertVersion:      to.Ptr("<cert-version>"),
-				KeyVaultCertName: to.Ptr("<key-vault-cert-name>"),
-				VaultURI:         to.Ptr("<vault-uri>"),
+				CertVersion:      to.Ptr("08a219d06d874795a96db47e06fbb01e"),
+				KeyVaultCertName: to.Ptr("mycert"),
+				VaultURI:         to.Ptr("https://myvault.vault.azure.net"),
 			},
 		},
 		nil)
@@ -82,14 +82,14 @@ func ExampleCertificatesClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCertificatesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<certificate-name>",
+		"myResourceGroup",
+		"myservice",
+		"mycertificate",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -107,12 +107,12 @@ func ExampleCertificatesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCertificatesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<service-name>",
+	pager := client.NewListPager("myResourceGroup",
+		"myService",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_configservers_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_configservers_client_test.go
@@ -25,13 +25,13 @@ func ExampleConfigServersClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewConfigServersClient("<subscription-id>", cred, nil)
+	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -47,21 +47,21 @@ func ExampleConfigServersClient_BeginUpdatePut() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewConfigServersClient("<subscription-id>", cred, nil)
+	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdatePut(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		test.ConfigServerResource{
 			Properties: &test.ConfigServerProperties{
 				ConfigServer: &test.ConfigServerSettings{
 					GitProperty: &test.ConfigServerGitProperty{
-						Label: to.Ptr("<label>"),
+						Label: to.Ptr("master"),
 						SearchPaths: []*string{
 							to.Ptr("/")},
-						URI: to.Ptr("<uri>"),
+						URI: to.Ptr("https://github.com/fake-user/fake-repository.git"),
 					},
 				},
 			},
@@ -85,21 +85,21 @@ func ExampleConfigServersClient_BeginUpdatePatch() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewConfigServersClient("<subscription-id>", cred, nil)
+	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdatePatch(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		test.ConfigServerResource{
 			Properties: &test.ConfigServerProperties{
 				ConfigServer: &test.ConfigServerSettings{
 					GitProperty: &test.ConfigServerGitProperty{
-						Label: to.Ptr("<label>"),
+						Label: to.Ptr("master"),
 						SearchPaths: []*string{
 							to.Ptr("/")},
-						URI: to.Ptr("<uri>"),
+						URI: to.Ptr("https://github.com/fake-user/fake-repository.git"),
 					},
 				},
 			},
@@ -123,19 +123,19 @@ func ExampleConfigServersClient_BeginValidate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewConfigServersClient("<subscription-id>", cred, nil)
+	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginValidate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		test.ConfigServerSettings{
 			GitProperty: &test.ConfigServerGitProperty{
-				Label: to.Ptr("<label>"),
+				Label: to.Ptr("master"),
 				SearchPaths: []*string{
 					to.Ptr("/")},
-				URI: to.Ptr("<uri>"),
+				URI: to.Ptr("https://github.com/fake-user/fake-repository.git"),
 			},
 		},
 		nil)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_customdomains_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_customdomains_client_test.go
@@ -25,15 +25,15 @@ func ExampleCustomDomainsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCustomDomainsClient("<subscription-id>", cred, nil)
+	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<domain-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydomain.com",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -49,19 +49,19 @@ func ExampleCustomDomainsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCustomDomainsClient("<subscription-id>", cred, nil)
+	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<domain-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydomain.com",
 		test.CustomDomainResource{
 			Properties: &test.CustomDomainProperties{
-				CertName:   to.Ptr("<cert-name>"),
-				Thumbprint: to.Ptr("<thumbprint>"),
+				CertName:   to.Ptr("mycert"),
+				Thumbprint: to.Ptr("934367bf1c97033f877db0f15cb1b586957d3133"),
 			},
 		},
 		nil)
@@ -83,15 +83,15 @@ func ExampleCustomDomainsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCustomDomainsClient("<subscription-id>", cred, nil)
+	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<domain-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydomain.com",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -109,19 +109,19 @@ func ExampleCustomDomainsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCustomDomainsClient("<subscription-id>", cred, nil)
+	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<domain-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydomain.com",
 		test.CustomDomainResource{
 			Properties: &test.CustomDomainProperties{
-				CertName:   to.Ptr("<cert-name>"),
-				Thumbprint: to.Ptr("<thumbprint>"),
+				CertName:   to.Ptr("mycert"),
+				Thumbprint: to.Ptr("934367bf1c97033f877db0f15cb1b586957d3133"),
 			},
 		},
 		nil)
@@ -143,13 +143,13 @@ func ExampleCustomDomainsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCustomDomainsClient("<subscription-id>", cred, nil)
+	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
+	pager := client.NewListPager("myResourceGroup",
+		"myservice",
+		"myapp",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_deployments_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_deployments_client_test.go
@@ -25,15 +25,15 @@ func ExampleDeploymentsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDeploymentsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<deployment-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydeployment",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -49,15 +49,15 @@ func ExampleDeploymentsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDeploymentsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<deployment-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydeployment",
 		test.DeploymentResource{
 			Properties: &test.DeploymentResourceProperties{
 				DeploymentSettings: &test.DeploymentSettings{
@@ -65,15 +65,15 @@ func ExampleDeploymentsClient_BeginCreateOrUpdate() {
 					EnvironmentVariables: map[string]*string{
 						"env": to.Ptr("test"),
 					},
-					JvmOptions:     to.Ptr("<jvm-options>"),
+					JvmOptions:     to.Ptr("-Xms1G -Xmx3G"),
 					MemoryInGB:     to.Ptr[int32](3),
 					RuntimeVersion: to.Ptr(test.RuntimeVersionJava8),
 				},
 				Source: &test.UserSourceInfo{
 					Type:             to.Ptr(test.UserSourceTypeSource),
-					ArtifactSelector: to.Ptr("<artifact-selector>"),
-					RelativePath:     to.Ptr("<relative-path>"),
-					Version:          to.Ptr("<version>"),
+					ArtifactSelector: to.Ptr("sub-module-1"),
+					RelativePath:     to.Ptr("resources/a172cedcae47474b615c54d510a5d84a8dea3032e958587430b413538be3f333-2019082605-e3095339-1723-44b7-8b5e-31b1003978bc"),
+					Version:          to.Ptr("1.0"),
 				},
 			},
 		},
@@ -96,15 +96,15 @@ func ExampleDeploymentsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDeploymentsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<deployment-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydeployment",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -122,22 +122,22 @@ func ExampleDeploymentsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDeploymentsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<deployment-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydeployment",
 		test.DeploymentResource{
 			Properties: &test.DeploymentResourceProperties{
 				Source: &test.UserSourceInfo{
 					Type:             to.Ptr(test.UserSourceTypeSource),
-					ArtifactSelector: to.Ptr("<artifact-selector>"),
-					RelativePath:     to.Ptr("<relative-path>"),
-					Version:          to.Ptr("<version>"),
+					ArtifactSelector: to.Ptr("sub-module-1"),
+					RelativePath:     to.Ptr("resources/a172cedcae47474b615c54d510a5d84a8dea3032e958587430b413538be3f333-2019082605-e3095339-1723-44b7-8b5e-31b1003978bc"),
+					Version:          to.Ptr("1.0"),
 				},
 			},
 		},
@@ -160,13 +160,13 @@ func ExampleDeploymentsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDeploymentsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
+	pager := client.NewListPager("myResourceGroup",
+		"myservice",
+		"myapp",
 		&test.DeploymentsClientListOptions{Version: []string{}})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -187,12 +187,12 @@ func ExampleDeploymentsClient_NewListForClusterPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDeploymentsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListForClusterPager("<resource-group-name>",
-		"<service-name>",
+	pager := client.NewListForClusterPager("myResourceGroup",
+		"myservice",
 		&test.DeploymentsClientListForClusterOptions{Version: []string{}})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -213,15 +213,15 @@ func ExampleDeploymentsClient_BeginStart() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDeploymentsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginStart(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<deployment-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydeployment",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -239,15 +239,15 @@ func ExampleDeploymentsClient_BeginStop() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDeploymentsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginStop(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<deployment-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydeployment",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -265,15 +265,15 @@ func ExampleDeploymentsClient_BeginRestart() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDeploymentsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginRestart(ctx,
-		"<resource-group-name>",
-		"<service-name>",
-		"<app-name>",
-		"<deployment-name>",
+		"myResourceGroup",
+		"myservice",
+		"myapp",
+		"mydeployment",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_monitoringsettings_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_monitoringsettings_client_test.go
@@ -25,13 +25,13 @@ func ExampleMonitoringSettingsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewMonitoringSettingsClient("<subscription-id>", cred, nil)
+	client, err := test.NewMonitoringSettingsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -47,16 +47,16 @@ func ExampleMonitoringSettingsClient_BeginUpdatePut() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewMonitoringSettingsClient("<subscription-id>", cred, nil)
+	client, err := test.NewMonitoringSettingsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdatePut(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		test.MonitoringSettingResource{
 			Properties: &test.MonitoringSettingProperties{
-				AppInsightsInstrumentationKey: to.Ptr("<app-insights-instrumentation-key>"),
+				AppInsightsInstrumentationKey: to.Ptr("00000000-0000-0000-0000-000000000000"),
 				AppInsightsSamplingRate:       to.Ptr[float64](10),
 				TraceEnabled:                  to.Ptr(true),
 			},
@@ -80,16 +80,16 @@ func ExampleMonitoringSettingsClient_BeginUpdatePatch() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewMonitoringSettingsClient("<subscription-id>", cred, nil)
+	client, err := test.NewMonitoringSettingsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdatePatch(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		test.MonitoringSettingResource{
 			Properties: &test.MonitoringSettingProperties{
-				AppInsightsInstrumentationKey: to.Ptr("<app-insights-instrumentation-key>"),
+				AppInsightsInstrumentationKey: to.Ptr("00000000-0000-0000-0000-000000000000"),
 				AppInsightsSamplingRate:       to.Ptr[float64](10),
 				TraceEnabled:                  to.Ptr(true),
 			},

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_services_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_services_client_test.go
@@ -25,13 +25,13 @@ func ExampleServicesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -47,22 +47,22 @@ func ExampleServicesClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		test.ServiceResource{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("eastus"),
 			Tags: map[string]*string{
 				"key1": to.Ptr("value1"),
 			},
 			Properties: &test.ClusterResourceProperties{},
 			SKU: &test.SKU{
-				Name: to.Ptr("<name>"),
-				Tier: to.Ptr("<tier>"),
+				Name: to.Ptr("S0"),
+				Tier: to.Ptr("Standard"),
 			},
 		},
 		nil)
@@ -84,13 +84,13 @@ func ExampleServicesClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -108,22 +108,22 @@ func ExampleServicesClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		test.ServiceResource{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("eastus"),
 			Tags: map[string]*string{
 				"key1": to.Ptr("value1"),
 			},
 			Properties: &test.ClusterResourceProperties{},
 			SKU: &test.SKU{
-				Name: to.Ptr("<name>"),
-				Tier: to.Ptr("<tier>"),
+				Name: to.Ptr("S0"),
+				Tier: to.Ptr("Standard"),
 			},
 		},
 		nil)
@@ -145,13 +145,13 @@ func ExampleServicesClient_ListTestKeys() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.ListTestKeys(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -167,13 +167,13 @@ func ExampleServicesClient_RegenerateTestKey() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.RegenerateTestKey(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		test.RegenerateTestKeyRequestPayload{
 			KeyType: to.Ptr(test.TestKeyTypePrimary),
 		},
@@ -192,13 +192,13 @@ func ExampleServicesClient_DisableTestEndpoint() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	_, err = client.DisableTestEndpoint(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -212,13 +212,13 @@ func ExampleServicesClient_EnableTestEndpoint() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.EnableTestEndpoint(ctx,
-		"<resource-group-name>",
-		"<service-name>",
+		"myResourceGroup",
+		"myservice",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -234,15 +234,15 @@ func ExampleServicesClient_CheckNameAvailability() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.CheckNameAvailability(ctx,
-		"<location>",
+		"eastus",
 		test.NameAvailabilityParameters{
-			Name: to.Ptr("<name>"),
-			Type: to.Ptr("<type>"),
+			Name: to.Ptr("myservice"),
+			Type: to.Ptr("Microsoft.AppPlatform/Spring"),
 		},
 		nil)
 	if err != nil {
@@ -259,7 +259,7 @@ func ExampleServicesClient_NewListBySubscriptionPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
@@ -283,11 +283,11 @@ func ExampleServicesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
+	pager := client.NewListPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_skus_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/ze_generated_example_skus_client_test.go
@@ -22,7 +22,7 @@ func ExampleSKUsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSKUsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSKUsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/zt_generated_mock_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/zt_generated_mock_test.go
@@ -10,10 +10,7 @@ package test_test
 
 import (
 	"context"
-	"fmt"
-	"log"
 	"net/http"
-	"os"
 	"testing"
 
 	"encoding/json"
@@ -26,33 +23,64 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/testutil"
+	"github.com/stretchr/testify/suite"
 	"golang.org/x/net/http2"
 )
 
-var (
-	ctx      context.Context
-	options  arm.ClientOptions
-	cred     azcore.TokenCredential
-	err      error
-	mockHost string
-)
+type MockTestSuite struct {
+	suite.Suite
 
-func TestServices_Get(t *testing.T) {
+	cred    azcore.TokenCredential
+	options arm.ClientOptions
+}
+
+func (testsuite *MockTestSuite) SetupSuite() {
+	mockHost := testutil.GetEnv("AZURE_VIRTUAL_SERVER_HOST", "https://localhost:8443")
+
+	tr := &http.Transport{}
+	err := http2.ConfigureTransport(tr)
+	testsuite.Require().NoError(err, "Failed to configure http2 transport")
+	tr.TLSClientConfig.InsecureSkipVerify = true
+	client := &http.Client{Transport: tr}
+
+	testsuite.cred = &MockCredential{}
+
+	testsuite.options = arm.ClientOptions{
+		ClientOptions: policy.ClientOptions{
+			Logging: policy.LogOptions{
+				IncludeBody: true,
+			},
+			Transport: client,
+			Cloud: cloud.Configuration{
+				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
+					cloud.ResourceManager: {
+						Audience: mockHost,
+						Endpoint: mockHost,
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestMockTest(t *testing.T) {
+	suite.Run(t, new(MockTestSuite))
+}
+
+func (testsuite *MockTestSuite) TestServices_Get() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Get.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_Get"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.Get(ctx,
 		"myResourceGroup",
 		"myservice",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Get.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Get.json")
 	// Response check
 	exampleRes := test.ServiceResource{
 		Name:     to.Ptr("myservice"),
@@ -106,19 +134,18 @@ func TestServices_Get(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.ServiceResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.ServiceResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestServices_CreateOrUpdate(t *testing.T) {
+func (testsuite *MockTestSuite) TestServices_CreateOrUpdate() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_CreateOrUpdate"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginCreateOrUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -134,13 +161,9 @@ func TestServices_CreateOrUpdate(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate.json")
 	// Response check
 	exampleRes := test.ServiceResource{
 		Name:     to.Ptr("myservice"),
@@ -194,17 +217,15 @@ func TestServices_CreateOrUpdate(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.ServiceResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.ServiceResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate_VNetInjection.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_CreateOrUpdate_VNetInjection"},
 	})
-	client, err = test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err = test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err = client.BeginCreateOrUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -228,13 +249,9 @@ func TestServices_CreateOrUpdate(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate_VNetInjection.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate_VNetInjection.json")
 	res, err = poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate_VNetInjection.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate_VNetInjection.json")
 	// Response check
 	exampleRes = test.ServiceResource{
 		Name:     to.Ptr("myservice"),
@@ -292,41 +309,35 @@ func TestServices_CreateOrUpdate(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.ServiceResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.ServiceResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate_VNetInjection.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CreateOrUpdate_VNetInjection.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestServices_Delete(t *testing.T) {
+func (testsuite *MockTestSuite) TestServices_Delete() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Delete.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_Delete"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginDelete(ctx,
 		"myResourceGroup",
 		"myservice",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Delete.json")
 	_, err = poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Delete.json")
 }
 
-func TestServices_Update(t *testing.T) {
+func (testsuite *MockTestSuite) TestServices_Update() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Update.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_Update"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -342,13 +353,9 @@ func TestServices_Update(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Update.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Update.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Update.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Update.json")
 	// Response check
 	exampleRes := test.ServiceResource{
 		Name:     to.Ptr("myservice"),
@@ -402,26 +409,23 @@ func TestServices_Update(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.ServiceResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.ServiceResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Update.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_Update.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestServices_ListTestKeys(t *testing.T) {
+func (testsuite *MockTestSuite) TestServices_ListTestKeys() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_ListTestKeys.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_ListTestKeys"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.ListTestKeys(ctx,
 		"myResourceGroup",
 		"myservice",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_ListTestKeys.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_ListTestKeys.json")
 	// Response check
 	exampleRes := test.Keys{
 		Enabled:               to.Ptr(true),
@@ -433,19 +437,18 @@ func TestServices_ListTestKeys(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.Keys) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.Keys)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_ListTestKeys.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_ListTestKeys.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestServices_RegenerateTestKey(t *testing.T) {
+func (testsuite *MockTestSuite) TestServices_RegenerateTestKey() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_RegenerateTestKey.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_RegenerateTestKey"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.RegenerateTestKey(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -453,9 +456,7 @@ func TestServices_RegenerateTestKey(t *testing.T) {
 			KeyType: to.Ptr(test.TestKeyTypePrimary),
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_RegenerateTestKey.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_RegenerateTestKey.json")
 	// Response check
 	exampleRes := test.Keys{
 		Enabled:               to.Ptr(true),
@@ -467,44 +468,38 @@ func TestServices_RegenerateTestKey(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.Keys) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.Keys)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_RegenerateTestKey.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_RegenerateTestKey.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestServices_DisableTestEndpoint(t *testing.T) {
+func (testsuite *MockTestSuite) TestServices_DisableTestEndpoint() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_DisableTestEndpoint.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_DisableTestEndpoint"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	_, err = client.DisableTestEndpoint(ctx,
 		"myResourceGroup",
 		"myservice",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_DisableTestEndpoint.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_DisableTestEndpoint.json")
 }
 
-func TestServices_EnableTestEndpoint(t *testing.T) {
+func (testsuite *MockTestSuite) TestServices_EnableTestEndpoint() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_EnableTestEndpoint.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_EnableTestEndpoint"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.EnableTestEndpoint(ctx,
 		"myResourceGroup",
 		"myservice",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_EnableTestEndpoint.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_EnableTestEndpoint.json")
 	// Response check
 	exampleRes := test.Keys{
 		Enabled:               to.Ptr(true),
@@ -516,19 +511,18 @@ func TestServices_EnableTestEndpoint(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.Keys) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.Keys)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_EnableTestEndpoint.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_EnableTestEndpoint.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestServices_CheckNameAvailability(t *testing.T) {
+func (testsuite *MockTestSuite) TestServices_CheckNameAvailability() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CheckNameAvailability.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_CheckNameAvailability"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.CheckNameAvailability(ctx,
 		"eastus",
 		test.NameAvailabilityParameters{
@@ -536,9 +530,7 @@ func TestServices_CheckNameAvailability(t *testing.T) {
 			Type: to.Ptr("Microsoft.AppPlatform/Spring"),
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CheckNameAvailability.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CheckNameAvailability.json")
 	// Response check
 	exampleRes := test.NameAvailability{
 		Message:       to.Ptr("The name is already used."),
@@ -548,26 +540,22 @@ func TestServices_CheckNameAvailability(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.NameAvailability) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.NameAvailability)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CheckNameAvailability.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_CheckNameAvailability.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestServices_ListBySubscription(t *testing.T) {
+func (testsuite *MockTestSuite) TestServices_ListBySubscription() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_ListBySubscription.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_ListBySubscription"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	pager := client.NewListBySubscriptionPager(nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
-		if err != nil {
-			t.Fatalf("Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_ListBySubscription.json: %v", err)
-			break
-		}
+		testsuite.Require().NoError(err, "Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_ListBySubscription.json")
 		// Response check
 		pagerExampleRes := test.ServiceResourceList{
 			Value: []*test.ServiceResource{
@@ -624,28 +612,24 @@ func TestServices_ListBySubscription(t *testing.T) {
 		if !reflect.DeepEqual(pagerExampleRes, nextResult.ServiceResourceList) {
 			exampleResJson, _ := json.Marshal(pagerExampleRes)
 			mockResJson, _ := json.Marshal(nextResult.ServiceResourceList)
-			t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_ListBySubscription.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+			testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_ListBySubscription.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 		}
 	}
 }
 
-func TestServices_List(t *testing.T) {
+func (testsuite *MockTestSuite) TestServices_List() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_List.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Services_List"},
 	})
-	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewServicesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	pager := client.NewListPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
-		if err != nil {
-			t.Fatalf("Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_List.json: %v", err)
-			break
-		}
+		testsuite.Require().NoError(err, "Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_List.json")
 		// Response check
 		pagerExampleRes := test.ServiceResourceList{
 			Value: []*test.ServiceResource{
@@ -702,27 +686,24 @@ func TestServices_List(t *testing.T) {
 		if !reflect.DeepEqual(pagerExampleRes, nextResult.ServiceResourceList) {
 			exampleResJson, _ := json.Marshal(pagerExampleRes)
 			mockResJson, _ := json.Marshal(nextResult.ServiceResourceList)
-			t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+			testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Services_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 		}
 	}
 }
 
-func TestConfigServers_Get(t *testing.T) {
+func (testsuite *MockTestSuite) TestConfigServers_Get() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Get.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"ConfigServers_Get"},
 	})
-	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.Get(ctx,
 		"myResourceGroup",
 		"myservice",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Get.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Get.json")
 	// Response check
 	exampleRes := test.ConfigServerResource{
 		Name: to.Ptr("default"),
@@ -743,19 +724,18 @@ func TestConfigServers_Get(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.ConfigServerResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.ConfigServerResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestConfigServers_UpdatePut(t *testing.T) {
+func (testsuite *MockTestSuite) TestConfigServers_UpdatePut() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePut.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"ConfigServers_UpdatePut"},
 	})
-	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginUpdatePut(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -772,13 +752,9 @@ func TestConfigServers_UpdatePut(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePut.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePut.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePut.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePut.json")
 	// Response check
 	exampleRes := test.ConfigServerResource{
 		Name: to.Ptr("default"),
@@ -799,19 +775,18 @@ func TestConfigServers_UpdatePut(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.ConfigServerResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.ConfigServerResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePut.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePut.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestConfigServers_UpdatePatch(t *testing.T) {
+func (testsuite *MockTestSuite) TestConfigServers_UpdatePatch() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePatch.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"ConfigServers_UpdatePatch"},
 	})
-	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginUpdatePatch(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -828,13 +803,9 @@ func TestConfigServers_UpdatePatch(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePatch.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePatch.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePatch.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePatch.json")
 	// Response check
 	exampleRes := test.ConfigServerResource{
 		Name: to.Ptr("default"),
@@ -855,19 +826,18 @@ func TestConfigServers_UpdatePatch(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.ConfigServerResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.ConfigServerResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePatch.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_UpdatePatch.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestConfigServers_Validate(t *testing.T) {
+func (testsuite *MockTestSuite) TestConfigServers_Validate() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Validate.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"ConfigServers_Validate"},
 	})
-	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewConfigServersClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginValidate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -880,13 +850,9 @@ func TestConfigServers_Validate(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Validate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Validate.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Validate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Validate.json")
 	// Response check
 	exampleRes := test.ConfigServerSettingsValidateResult{
 		IsValid: to.Ptr(true),
@@ -894,26 +860,23 @@ func TestConfigServers_Validate(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.ConfigServerSettingsValidateResult) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.ConfigServerSettingsValidateResult)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Validate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/ConfigServers_Validate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestMonitoringSettings_Get(t *testing.T) {
+func (testsuite *MockTestSuite) TestMonitoringSettings_Get() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_Get.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"MonitoringSettings_Get"},
 	})
-	client, err := test.NewMonitoringSettingsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewMonitoringSettingsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.Get(ctx,
 		"myResourceGroup",
 		"myservice",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_Get.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_Get.json")
 	// Response check
 	exampleRes := test.MonitoringSettingResource{
 		Name: to.Ptr("default"),
@@ -932,19 +895,18 @@ func TestMonitoringSettings_Get(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.MonitoringSettingResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.MonitoringSettingResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestMonitoringSettings_UpdatePut(t *testing.T) {
+func (testsuite *MockTestSuite) TestMonitoringSettings_UpdatePut() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePut.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"MonitoringSettings_UpdatePut"},
 	})
-	client, err := test.NewMonitoringSettingsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewMonitoringSettingsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginUpdatePut(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -956,13 +918,9 @@ func TestMonitoringSettings_UpdatePut(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePut.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePut.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePut.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePut.json")
 	// Response check
 	exampleRes := test.MonitoringSettingResource{
 		Name: to.Ptr("default"),
@@ -981,19 +939,18 @@ func TestMonitoringSettings_UpdatePut(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.MonitoringSettingResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.MonitoringSettingResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePut.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePut.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestMonitoringSettings_UpdatePatch(t *testing.T) {
+func (testsuite *MockTestSuite) TestMonitoringSettings_UpdatePatch() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePatch.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"MonitoringSettings_UpdatePatch"},
 	})
-	client, err := test.NewMonitoringSettingsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewMonitoringSettingsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginUpdatePatch(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -1005,13 +962,9 @@ func TestMonitoringSettings_UpdatePatch(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePatch.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePatch.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePatch.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePatch.json")
 	// Response check
 	exampleRes := test.MonitoringSettingResource{
 		Name: to.Ptr("default"),
@@ -1030,27 +983,24 @@ func TestMonitoringSettings_UpdatePatch(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.MonitoringSettingResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.MonitoringSettingResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePatch.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/MonitoringSettings_UpdatePatch.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestApps_Get(t *testing.T) {
+func (testsuite *MockTestSuite) TestApps_Get() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Get.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Apps_Get"},
 	})
-	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.Get(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		&test.AppsClientGetOptions{SyncStatus: nil})
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Get.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Get.json")
 	// Response check
 	exampleRes := test.AppResource{
 		Name: to.Ptr("myapp"),
@@ -1084,19 +1034,18 @@ func TestApps_Get(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.AppResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.AppResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestApps_CreateOrUpdate(t *testing.T) {
+func (testsuite *MockTestSuite) TestApps_CreateOrUpdate() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_CreateOrUpdate.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Apps_CreateOrUpdate"},
 	})
-	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginCreateOrUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -1120,13 +1069,9 @@ func TestApps_CreateOrUpdate(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_CreateOrUpdate.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_CreateOrUpdate.json")
 	// Response check
 	exampleRes := test.AppResource{
 		Name: to.Ptr("myapp"),
@@ -1160,42 +1105,36 @@ func TestApps_CreateOrUpdate(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.AppResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.AppResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestApps_Delete(t *testing.T) {
+func (testsuite *MockTestSuite) TestApps_Delete() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Delete.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Apps_Delete"},
 	})
-	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginDelete(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Delete.json")
 	_, err = poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Delete.json")
 }
 
-func TestApps_Update(t *testing.T) {
+func (testsuite *MockTestSuite) TestApps_Update() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Update.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Apps_Update"},
 	})
-	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -1222,13 +1161,9 @@ func TestApps_Update(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Update.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Update.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Update.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Update.json")
 	// Response check
 	exampleRes := test.AppResource{
 		Name: to.Ptr("myapp"),
@@ -1262,28 +1197,24 @@ func TestApps_Update(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.AppResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.AppResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Update.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_Update.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestApps_List(t *testing.T) {
+func (testsuite *MockTestSuite) TestApps_List() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_List.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Apps_List"},
 	})
-	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	pager := client.NewListPager("myResourceGroup",
 		"myservice",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
-		if err != nil {
-			t.Fatalf("Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_List.json: %v", err)
-			break
-		}
+		testsuite.Require().NoError(err, "Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_List.json")
 		// Response check
 		pagerExampleRes := test.AppResourceCollection{
 			Value: []*test.AppResource{
@@ -1320,20 +1251,19 @@ func TestApps_List(t *testing.T) {
 		if !reflect.DeepEqual(pagerExampleRes, nextResult.AppResourceCollection) {
 			exampleResJson, _ := json.Marshal(pagerExampleRes)
 			mockResJson, _ := json.Marshal(nextResult.AppResourceCollection)
-			t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+			testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 		}
 	}
 }
 
-func TestApps_ValidateDomain(t *testing.T) {
+func (testsuite *MockTestSuite) TestApps_ValidateDomain() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_ValidateDomain.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Apps_ValidateDomain"},
 	})
-	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewAppsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.ValidateDomain(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -1342,9 +1272,7 @@ func TestApps_ValidateDomain(t *testing.T) {
 			Name: to.Ptr("mydomain.io"),
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_ValidateDomain.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_ValidateDomain.json")
 	// Response check
 	exampleRes := test.CustomDomainValidateResult{
 		IsValid: to.Ptr(false),
@@ -1353,28 +1281,25 @@ func TestApps_ValidateDomain(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.CustomDomainValidateResult) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.CustomDomainValidateResult)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_ValidateDomain.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Apps_ValidateDomain.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestBindings_Get(t *testing.T) {
+func (testsuite *MockTestSuite) TestBindings_Get() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Get.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Bindings_Get"},
 	})
-	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.Get(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		"mybinding",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Get.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Get.json")
 	// Response check
 	exampleRes := test.BindingResource{
 		Name: to.Ptr("mybinding"),
@@ -1396,19 +1321,18 @@ func TestBindings_Get(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.BindingResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.BindingResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestBindings_CreateOrUpdate(t *testing.T) {
+func (testsuite *MockTestSuite) TestBindings_CreateOrUpdate() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_CreateOrUpdate.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Bindings_CreateOrUpdate"},
 	})
-	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginCreateOrUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -1425,13 +1349,9 @@ func TestBindings_CreateOrUpdate(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_CreateOrUpdate.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_CreateOrUpdate.json")
 	// Response check
 	exampleRes := test.BindingResource{
 		Name: to.Ptr("mybinding"),
@@ -1453,43 +1373,37 @@ func TestBindings_CreateOrUpdate(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.BindingResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.BindingResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestBindings_Delete(t *testing.T) {
+func (testsuite *MockTestSuite) TestBindings_Delete() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Delete.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Bindings_Delete"},
 	})
-	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginDelete(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		"mybinding",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Delete.json")
 	_, err = poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Delete.json")
 }
 
-func TestBindings_Update(t *testing.T) {
+func (testsuite *MockTestSuite) TestBindings_Update() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Update.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Bindings_Update"},
 	})
-	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -1505,13 +1419,9 @@ func TestBindings_Update(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Update.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Update.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Update.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Update.json")
 	// Response check
 	exampleRes := test.BindingResource{
 		Name: to.Ptr("mybinding"),
@@ -1533,29 +1443,25 @@ func TestBindings_Update(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.BindingResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.BindingResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Update.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_Update.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestBindings_List(t *testing.T) {
+func (testsuite *MockTestSuite) TestBindings_List() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_List.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Bindings_List"},
 	})
-	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewBindingsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	pager := client.NewListPager("myResourceGroup",
 		"myservice",
 		"myapp",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
-		if err != nil {
-			t.Fatalf("Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_List.json: %v", err)
-			break
-		}
+		testsuite.Require().NoError(err, "Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_List.json")
 		// Response check
 		pagerExampleRes := test.BindingResourceCollection{
 			Value: []*test.BindingResource{
@@ -1580,28 +1486,25 @@ func TestBindings_List(t *testing.T) {
 		if !reflect.DeepEqual(pagerExampleRes, nextResult.BindingResourceCollection) {
 			exampleResJson, _ := json.Marshal(pagerExampleRes)
 			mockResJson, _ := json.Marshal(nextResult.BindingResourceCollection)
-			t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+			testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Bindings_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 		}
 	}
 }
 
-func TestCertificates_Get(t *testing.T) {
+func (testsuite *MockTestSuite) TestCertificates_Get() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_Get.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Certificates_Get"},
 	})
-	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.Get(ctx,
 		"myResourceGroup",
 		"myservice",
 		"mycertificate",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_Get.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_Get.json")
 	// Response check
 	exampleRes := test.CertificateResource{
 		Name: to.Ptr("mycertificate"),
@@ -1626,19 +1529,18 @@ func TestCertificates_Get(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.CertificateResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.CertificateResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestCertificates_CreateOrUpdate(t *testing.T) {
+func (testsuite *MockTestSuite) TestCertificates_CreateOrUpdate() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_CreateOrUpdate.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Certificates_CreateOrUpdate"},
 	})
-	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginCreateOrUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -1651,13 +1553,9 @@ func TestCertificates_CreateOrUpdate(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_CreateOrUpdate.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_CreateOrUpdate.json")
 	// Response check
 	exampleRes := test.CertificateResource{
 		Name: to.Ptr("mycertificate"),
@@ -1682,51 +1580,42 @@ func TestCertificates_CreateOrUpdate(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.CertificateResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.CertificateResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestCertificates_Delete(t *testing.T) {
+func (testsuite *MockTestSuite) TestCertificates_Delete() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_Delete.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Certificates_Delete"},
 	})
-	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginDelete(ctx,
 		"myResourceGroup",
 		"myservice",
 		"mycertificate",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_Delete.json")
 	_, err = poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_Delete.json")
 }
 
-func TestCertificates_List(t *testing.T) {
+func (testsuite *MockTestSuite) TestCertificates_List() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_List.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Certificates_List"},
 	})
-	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewCertificatesClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	pager := client.NewListPager("myResourceGroup",
 		"myService",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
-		if err != nil {
-			t.Fatalf("Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_List.json: %v", err)
-			break
-		}
+		testsuite.Require().NoError(err, "Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_List.json")
 		// Response check
 		pagerExampleRes := test.CertificateResourceCollection{
 			Value: []*test.CertificateResource{
@@ -1754,29 +1643,26 @@ func TestCertificates_List(t *testing.T) {
 		if !reflect.DeepEqual(pagerExampleRes, nextResult.CertificateResourceCollection) {
 			exampleResJson, _ := json.Marshal(pagerExampleRes)
 			mockResJson, _ := json.Marshal(nextResult.CertificateResourceCollection)
-			t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+			testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Certificates_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 		}
 	}
 }
 
-func TestCustomDomains_Get(t *testing.T) {
+func (testsuite *MockTestSuite) TestCustomDomains_Get() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Get.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"CustomDomains_Get"},
 	})
-	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.Get(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		"mydomain.com",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Get.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Get.json")
 	// Response check
 	exampleRes := test.CustomDomainResource{
 		Name: to.Ptr("mydomain.com"),
@@ -1791,19 +1677,18 @@ func TestCustomDomains_Get(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.CustomDomainResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.CustomDomainResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestCustomDomains_CreateOrUpdate(t *testing.T) {
+func (testsuite *MockTestSuite) TestCustomDomains_CreateOrUpdate() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_CreateOrUpdate.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"CustomDomains_CreateOrUpdate"},
 	})
-	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginCreateOrUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -1816,13 +1701,9 @@ func TestCustomDomains_CreateOrUpdate(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_CreateOrUpdate.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_CreateOrUpdate.json")
 	// Response check
 	exampleRes := test.CustomDomainResource{
 		Name: to.Ptr("mydomain.com"),
@@ -1837,43 +1718,37 @@ func TestCustomDomains_CreateOrUpdate(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.CustomDomainResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.CustomDomainResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestCustomDomains_Delete(t *testing.T) {
+func (testsuite *MockTestSuite) TestCustomDomains_Delete() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Delete.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"CustomDomains_Delete"},
 	})
-	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginDelete(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		"mydomain.com",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Delete.json")
 	_, err = poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Delete.json")
 }
 
-func TestCustomDomains_Update(t *testing.T) {
+func (testsuite *MockTestSuite) TestCustomDomains_Update() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Update.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"CustomDomains_Update"},
 	})
-	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -1886,13 +1761,9 @@ func TestCustomDomains_Update(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Update.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Update.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Update.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Update.json")
 	// Response check
 	exampleRes := test.CustomDomainResource{
 		Name: to.Ptr("mydomain.com"),
@@ -1907,29 +1778,25 @@ func TestCustomDomains_Update(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.CustomDomainResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.CustomDomainResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Update.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_Update.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestCustomDomains_List(t *testing.T) {
+func (testsuite *MockTestSuite) TestCustomDomains_List() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_List.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"CustomDomains_List"},
 	})
-	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewCustomDomainsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	pager := client.NewListPager("myResourceGroup",
 		"myservice",
 		"myapp",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
-		if err != nil {
-			t.Fatalf("Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_List.json: %v", err)
-			break
-		}
+		testsuite.Require().NoError(err, "Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_List.json")
 		// Response check
 		pagerExampleRes := test.CustomDomainResourceCollection{
 			Value: []*test.CustomDomainResource{
@@ -1947,29 +1814,26 @@ func TestCustomDomains_List(t *testing.T) {
 		if !reflect.DeepEqual(pagerExampleRes, nextResult.CustomDomainResourceCollection) {
 			exampleResJson, _ := json.Marshal(pagerExampleRes)
 			mockResJson, _ := json.Marshal(nextResult.CustomDomainResourceCollection)
-			t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+			testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/CustomDomains_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 		}
 	}
 }
 
-func TestDeployments_Get(t *testing.T) {
+func (testsuite *MockTestSuite) TestDeployments_Get() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Get.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Deployments_Get"},
 	})
-	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.Get(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		"mydeployment",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Get.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Get.json")
 	// Response check
 	exampleRes := test.DeploymentResource{
 		Name: to.Ptr("mydeployment"),
@@ -2012,19 +1876,18 @@ func TestDeployments_Get(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.DeploymentResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.DeploymentResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Get.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestDeployments_CreateOrUpdate(t *testing.T) {
+func (testsuite *MockTestSuite) TestDeployments_CreateOrUpdate() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_CreateOrUpdate.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Deployments_CreateOrUpdate"},
 	})
-	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginCreateOrUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -2050,13 +1913,9 @@ func TestDeployments_CreateOrUpdate(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_CreateOrUpdate.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_CreateOrUpdate.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_CreateOrUpdate.json")
 	// Response check
 	exampleRes := test.DeploymentResource{
 		Name: to.Ptr("mydeployment"),
@@ -2099,43 +1958,37 @@ func TestDeployments_CreateOrUpdate(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.DeploymentResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.DeploymentResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_CreateOrUpdate.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestDeployments_Delete(t *testing.T) {
+func (testsuite *MockTestSuite) TestDeployments_Delete() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Delete.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Deployments_Delete"},
 	})
-	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginDelete(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		"mydeployment",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Delete.json")
 	_, err = poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Delete.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Delete.json")
 }
 
-func TestDeployments_Update(t *testing.T) {
+func (testsuite *MockTestSuite) TestDeployments_Update() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Update.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Deployments_Update"},
 	})
-	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginUpdate(ctx,
 		"myResourceGroup",
 		"myservice",
@@ -2152,13 +2005,9 @@ func TestDeployments_Update(t *testing.T) {
 			},
 		},
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Update.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Update.json")
 	res, err := poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Update.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Update.json")
 	// Response check
 	exampleRes := test.DeploymentResource{
 		Name: to.Ptr("mydeployment"),
@@ -2201,29 +2050,25 @@ func TestDeployments_Update(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.DeploymentResource) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.DeploymentResource)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Update.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Update.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestDeployments_List(t *testing.T) {
+func (testsuite *MockTestSuite) TestDeployments_List() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_List.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Deployments_List"},
 	})
-	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	pager := client.NewListPager("myResourceGroup",
 		"myservice",
 		"myapp",
 		&test.DeploymentsClientListOptions{Version: []string{}})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
-		if err != nil {
-			t.Fatalf("Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_List.json: %v", err)
-			break
-		}
+		testsuite.Require().NoError(err, "Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_List.json")
 		// Response check
 		pagerExampleRes := test.DeploymentResourceCollection{
 			Value: []*test.DeploymentResource{
@@ -2269,29 +2114,25 @@ func TestDeployments_List(t *testing.T) {
 		if !reflect.DeepEqual(pagerExampleRes, nextResult.DeploymentResourceCollection) {
 			exampleResJson, _ := json.Marshal(pagerExampleRes)
 			mockResJson, _ := json.Marshal(nextResult.DeploymentResourceCollection)
-			t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+			testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 		}
 	}
 }
 
-func TestDeployments_ListForCluster(t *testing.T) {
+func (testsuite *MockTestSuite) TestDeployments_ListForCluster() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_ListForCluster.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Deployments_ListForCluster"},
 	})
-	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	pager := client.NewListForClusterPager("myResourceGroup",
 		"myservice",
 		&test.DeploymentsClientListForClusterOptions{Version: []string{}})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
-		if err != nil {
-			t.Fatalf("Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_ListForCluster.json: %v", err)
-			break
-		}
+		testsuite.Require().NoError(err, "Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_ListForCluster.json")
 		// Response check
 		pagerExampleRes := test.DeploymentResourceCollection{
 			Value: []*test.DeploymentResource{
@@ -2337,99 +2178,80 @@ func TestDeployments_ListForCluster(t *testing.T) {
 		if !reflect.DeepEqual(pagerExampleRes, nextResult.DeploymentResourceCollection) {
 			exampleResJson, _ := json.Marshal(pagerExampleRes)
 			mockResJson, _ := json.Marshal(nextResult.DeploymentResourceCollection)
-			t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_ListForCluster.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+			testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_ListForCluster.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 		}
 	}
 }
 
-func TestDeployments_Start(t *testing.T) {
+func (testsuite *MockTestSuite) TestDeployments_Start() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Start.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Deployments_Start"},
 	})
-	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginStart(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		"mydeployment",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Start.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Start.json")
 	_, err = poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Start.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Start.json")
 }
 
-func TestDeployments_Stop(t *testing.T) {
+func (testsuite *MockTestSuite) TestDeployments_Stop() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Stop.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Deployments_Stop"},
 	})
-	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginStop(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		"mydeployment",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Stop.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Stop.json")
 	_, err = poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Stop.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Stop.json")
 }
 
-func TestDeployments_Restart(t *testing.T) {
+func (testsuite *MockTestSuite) TestDeployments_Restart() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Restart.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Deployments_Restart"},
 	})
-	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewDeploymentsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	poller, err := client.BeginRestart(ctx,
 		"myResourceGroup",
 		"myservice",
 		"myapp",
 		"mydeployment",
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Restart.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Restart.json")
 	_, err = poller.PollUntilDone(ctx, 30*time.Second)
-	if err != nil {
-		t.Fatalf("Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Restart.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get LRO result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Deployments_Restart.json")
 }
 
-func TestOperations_List(t *testing.T) {
+func (testsuite *MockTestSuite) TestOperations_List() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Operations_List.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Operations_List"},
 	})
-	client, err := test.NewOperationsClient(cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewOperationsClient(testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	pager := client.NewListPager(nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
-		if err != nil {
-			t.Fatalf("Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Operations_List.json: %v", err)
-			break
-		}
+		testsuite.Require().NoError(err, "Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Operations_List.json")
 		// Response check
 		pagerExampleRes := test.AvailableOperations{
 			Value: []*test.OperationDetail{
@@ -2449,25 +2271,22 @@ func TestOperations_List(t *testing.T) {
 		if !reflect.DeepEqual(pagerExampleRes, nextResult.AvailableOperations) {
 			exampleResJson, _ := json.Marshal(pagerExampleRes)
 			mockResJson, _ := json.Marshal(nextResult.AvailableOperations)
-			t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Operations_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+			testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Operations_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 		}
 	}
 }
 
-func TestRuntimeVersions_ListRuntimeVersions(t *testing.T) {
+func (testsuite *MockTestSuite) TestRuntimeVersions_ListRuntimeVersions() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/RuntimeVersions_ListRuntimeVersions.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"RuntimeVersions_ListRuntimeVersions"},
 	})
-	client, err := test.NewRuntimeVersionsClient(cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewRuntimeVersionsClient(testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	res, err := client.ListRuntimeVersions(ctx,
 		nil)
-	if err != nil {
-		t.Fatalf("Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/RuntimeVersions_ListRuntimeVersions.json: %v", err)
-	}
+	testsuite.Require().NoError(err, "Failed to get result for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/RuntimeVersions_ListRuntimeVersions.json")
 	// Response check
 	exampleRes := test.AvailableRuntimeVersions{
 		Value: []*test.SupportedRuntimeVersion{
@@ -2490,26 +2309,22 @@ func TestRuntimeVersions_ListRuntimeVersions(t *testing.T) {
 	if !reflect.DeepEqual(exampleRes, res.AvailableRuntimeVersions) {
 		exampleResJson, _ := json.Marshal(exampleRes)
 		mockResJson, _ := json.Marshal(res.AvailableRuntimeVersions)
-		t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/RuntimeVersions_ListRuntimeVersions.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+		testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/RuntimeVersions_ListRuntimeVersions.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 	}
 }
 
-func TestSKUs_List(t *testing.T) {
+func (testsuite *MockTestSuite) TestSKUs_List() {
+	ctx := context.Background()
 	// From example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Skus_List.json
 	ctx = runtime.WithHTTPHeader(ctx, map[string][]string{
 		"example-id": {"Skus_List"},
 	})
-	client, err := test.NewSKUsClient("00000000-0000-0000-0000-000000000000", cred, &options)
-	if err != nil {
-		log.Fatalf("failed to create client: %v", err)
-	}
+	client, err := test.NewSKUsClient("00000000-0000-0000-0000-000000000000", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, "Failed to create client")
 	pager := client.NewListPager(nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
-		if err != nil {
-			t.Fatalf("Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Skus_List.json: %v", err)
-			break
-		}
+		testsuite.Require().NoError(err, "Failed to advance page for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Skus_List.json")
 		// Response check
 		pagerExampleRes := test.ResourceSKUCollection{
 			Value: []*test.ResourceSKU{
@@ -2537,59 +2352,9 @@ func TestSKUs_List(t *testing.T) {
 		if !reflect.DeepEqual(pagerExampleRes, nextResult.ResourceSKUCollection) {
 			exampleResJson, _ := json.Marshal(pagerExampleRes)
 			mockResJson, _ := json.Marshal(nextResult.ResourceSKUCollection)
-			t.Fatalf("Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Skus_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
+			testsuite.Failf("Failed to validate response", "Mock response is not equal to example response for example specification/appplatform/resource-manager/Microsoft.AppPlatform/preview/2020-11-01-preview/examples/Skus_List.json:\nmock response: %s\nexample response: %s", mockResJson, exampleResJson)
 		}
 	}
-}
-
-// TestMain will exec each test
-func TestMain(m *testing.M) {
-	setUp()
-	retCode := m.Run() // exec test and this returns an exit code to pass to os
-	tearDown()
-	os.Exit(retCode)
-}
-
-func getEnv(key, fallback string) string {
-	if value, ok := os.LookupEnv(key); ok {
-		return value
-	}
-	return fallback
-}
-
-func setUp() {
-	ctx = context.Background()
-	mockHost = getEnv("AZURE_VIRTUAL_SERVER_HOST", "https://localhost:8443")
-
-	tr := &http.Transport{}
-	if err := http2.ConfigureTransport(tr); err != nil {
-		fmt.Printf("Failed to configure http2 transport: %v", err)
-	}
-	tr.TLSClientConfig.InsecureSkipVerify = true
-	client := &http.Client{Transport: tr}
-
-	cred = &MockCredential{}
-
-	options = arm.ClientOptions{
-		ClientOptions: policy.ClientOptions{
-			Logging: policy.LogOptions{
-				IncludeBody: true,
-			},
-			Transport: client,
-			Cloud: cloud.Configuration{
-				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
-					cloud.ResourceManager: {
-						Audience: mockHost,
-						Endpoint: mockHost,
-					},
-				},
-			},
-		},
-	}
-}
-
-func tearDown() {
-
 }
 
 type MockCredential struct {

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/zt_generated_spring_live_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/appplatform/test/zt_generated_spring_live_test.go
@@ -355,6 +355,9 @@ func (testsuite *SpringTestSuite) TestSpring() {
 		testsuite.serviceName,
 		nil)
 	for certificatesClientNewListPager.More() {
+		_, err := certificatesClientNewListPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step ConfigServers_Validate
@@ -596,6 +599,9 @@ func (testsuite *SpringTestSuite) TestSpring() {
 		testsuite.serviceName,
 		nil)
 	for appsClientNewListPager.More() {
+		_, err := appsClientNewListPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step Bindings_Create
@@ -660,6 +666,9 @@ func (testsuite *SpringTestSuite) TestSpring() {
 		testsuite.appName,
 		nil)
 	for bindingsClientNewListPager.More() {
+		_, err := bindingsClientNewListPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step Bindings_Delete
@@ -737,6 +746,9 @@ func (testsuite *SpringTestSuite) TestSpring() {
 		testsuite.appName,
 		nil)
 	for customDomainsClientNewListPager.More() {
+		_, err := customDomainsClientNewListPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step Apps_GetResourceUploadUrl
@@ -918,6 +930,9 @@ func (testsuite *SpringTestSuite) TestSpring() {
 		testsuite.appName,
 		&test.DeploymentsClientListOptions{Version: []string{}})
 	for deploymentsClientNewListPager.More() {
+		_, err := deploymentsClientNewListPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step Deployments_ListForCluster
@@ -925,17 +940,26 @@ func (testsuite *SpringTestSuite) TestSpring() {
 		testsuite.serviceName,
 		&test.DeploymentsClientListForClusterOptions{Version: []string{}})
 	for deploymentsClientNewListForClusterPager.More() {
+		_, err := deploymentsClientNewListForClusterPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step Services_List
 	servicesClientNewListPager := servicesClient.NewListPager(testsuite.resourceGroupName,
 		nil)
 	for servicesClientNewListPager.More() {
+		_, err := servicesClientNewListPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step Services_ListBySubscription
 	servicesClientNewListBySubscriptionPager := servicesClient.NewListBySubscriptionPager(nil)
 	for servicesClientNewListBySubscriptionPager.More() {
+		_, err := servicesClientNewListBySubscriptionPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step Deployments_Delete
@@ -998,6 +1022,9 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	testsuite.Require().NoError(err)
 	sKUsClientNewListPager := sKUsClient.NewListPager(nil)
 	for sKUsClientNewListPager.More() {
+		_, err := sKUsClientNewListPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step Operations_List
@@ -1005,6 +1032,9 @@ func (testsuite *SpringTestSuite) TestSpring() {
 	testsuite.Require().NoError(err)
 	operationsClientNewListPager := operationsClient.NewListPager(nil)
 	for operationsClientNewListPager.More() {
+		_, err := operationsClientNewListPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 }
 

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_availabilitysets_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_availabilitysets_client_test.go
@@ -23,15 +23,15 @@ func ExampleAvailabilitySetsClient_CreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewAvailabilitySetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewAvailabilitySetsClient("1", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.CreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<availability-set-name>",
+		"myResourceGroup",
+		"myAvailabilitySet",
 		test.AvailabilitySet{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("westus"),
 			AdditionalProperties: map[string]*string{
 				"anyProperty": to.Ptr("fakeValue"),
 			},
@@ -55,11 +55,11 @@ func ExampleAvailabilitySetsClient_NewListBySubscriptionPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewAvailabilitySetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewAvailabilitySetsClient("{subscriptionId}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListBySubscriptionPager(&test.AvailabilitySetsClientListBySubscriptionOptions{Expand: to.Ptr("<expand>")})
+	pager := client.NewListBySubscriptionPager(&test.AvailabilitySetsClientListBySubscriptionOptions{Expand: to.Ptr("Faked for test: +ge+2020, %3E2012")})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
 		if err != nil {

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_cloudserviceoperatingsystems_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_cloudserviceoperatingsystems_client_test.go
@@ -22,13 +22,13 @@ func ExampleCloudServiceOperatingSystemsClient_GetOSVersion() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceOperatingSystemsClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceOperatingSystemsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.GetOSVersion(ctx,
-		"<location>",
-		"<os-version-name>",
+		"westus2",
+		"WA-GUEST-OS-3.90_202010-02",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -44,11 +44,11 @@ func ExampleCloudServiceOperatingSystemsClient_NewListOSVersionsPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceOperatingSystemsClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceOperatingSystemsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListOSVersionsPager("<location>",
+	pager := client.NewListOSVersionsPager("westus2",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -69,13 +69,13 @@ func ExampleCloudServiceOperatingSystemsClient_GetOSFamily() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceOperatingSystemsClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceOperatingSystemsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.GetOSFamily(ctx,
-		"<location>",
-		"<os-family-name>",
+		"westus2",
+		"3",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -91,11 +91,11 @@ func ExampleCloudServiceOperatingSystemsClient_NewListOSFamiliesPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceOperatingSystemsClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceOperatingSystemsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListOSFamiliesPager("<location>",
+	pager := client.NewListOSFamiliesPager("westus2",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_cloudserviceroleinstances_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_cloudserviceroleinstances_client_test.go
@@ -24,14 +24,14 @@ func ExampleCloudServiceRoleInstancesClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceRoleInstancesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceRoleInstancesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<role-instance-name>",
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"{roleInstance-name}",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -49,14 +49,14 @@ func ExampleCloudServiceRoleInstancesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceRoleInstancesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceRoleInstancesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<role-instance-name>",
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"{roleInstance-name}",
+		"ConstosoRG",
+		"{cs-name}",
 		&test.CloudServiceRoleInstancesClientGetOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -72,14 +72,14 @@ func ExampleCloudServiceRoleInstancesClient_GetInstanceView() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceRoleInstancesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceRoleInstancesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.GetInstanceView(ctx,
-		"<role-instance-name>",
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"{roleInstance-name}",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -95,12 +95,12 @@ func ExampleCloudServiceRoleInstancesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceRoleInstancesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceRoleInstancesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<cloud-service-name>",
+	pager := client.NewListPager("ConstosoRG",
+		"{cs-name}",
 		&test.CloudServiceRoleInstancesClientListOptions{Expand: nil})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -121,14 +121,14 @@ func ExampleCloudServiceRoleInstancesClient_BeginRestart() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceRoleInstancesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceRoleInstancesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginRestart(ctx,
-		"<role-instance-name>",
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"{roleInstance-name}",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -146,14 +146,14 @@ func ExampleCloudServiceRoleInstancesClient_BeginReimage() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceRoleInstancesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceRoleInstancesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginReimage(ctx,
-		"<role-instance-name>",
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"{roleInstance-name}",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -171,14 +171,14 @@ func ExampleCloudServiceRoleInstancesClient_BeginRebuild() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceRoleInstancesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceRoleInstancesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginRebuild(ctx,
-		"<role-instance-name>",
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"{roleInstance-name}",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_cloudserviceroles_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_cloudserviceroles_client_test.go
@@ -22,14 +22,14 @@ func ExampleCloudServiceRolesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceRolesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceRolesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<role-name>",
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"{role-name}",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -45,12 +45,12 @@ func ExampleCloudServiceRolesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServiceRolesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServiceRolesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<cloud-service-name>",
+	pager := client.NewListPager("ConstosoRG",
+		"{cs-name}",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_cloudservices_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_cloudservices_client_test.go
@@ -25,51 +25,51 @@ func ExampleCloudServicesClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		&test.CloudServicesClientBeginCreateOrUpdateOptions{Parameters: &test.CloudService{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("westus"),
 			Properties: &test.CloudServiceProperties{
-				Configuration: to.Ptr("<configuration>"),
+				Configuration: to.Ptr("{ServiceConfiguration}"),
 				NetworkProfile: &test.CloudServiceNetworkProfile{
 					LoadBalancerConfigurations: []*test.LoadBalancerConfiguration{
 						{
-							Name: to.Ptr("<name>"),
+							Name: to.Ptr("contosolb"),
 							Properties: &test.LoadBalancerConfigurationProperties{
 								FrontendIPConfigurations: []*test.LoadBalancerFrontendIPConfiguration{
 									{
-										Name: to.Ptr("<name>"),
+										Name: to.Ptr("contosofe"),
 										Properties: &test.LoadBalancerFrontendIPConfigurationProperties{
 											PublicIPAddress: &test.SubResource{
-												ID: to.Ptr("<id>"),
+												ID: to.Ptr("/subscriptions/{subscription-id}/resourceGroups/ConstosoRG/providers/Microsoft.Network/publicIPAddresses/contosopublicip"),
 											},
 										},
 									}},
 							},
 						}},
 				},
-				PackageURL: to.Ptr("<package-url>"),
+				PackageURL: to.Ptr("{PackageUrl}"),
 				RoleProfile: &test.CloudServiceRoleProfile{
 					Roles: []*test.CloudServiceRoleProfileProperties{
 						{
-							Name: to.Ptr("<name>"),
+							Name: to.Ptr("ContosoFrontend"),
 							SKU: &test.CloudServiceRoleSKU{
-								Name:     to.Ptr("<name>"),
+								Name:     to.Ptr("Standard_D1_v2"),
 								Capacity: to.Ptr[int64](1),
-								Tier:     to.Ptr("<tier>"),
+								Tier:     to.Ptr("Standard"),
 							},
 						},
 						{
-							Name: to.Ptr("<name>"),
+							Name: to.Ptr("ContosoBackend"),
 							SKU: &test.CloudServiceRoleSKU{
-								Name:     to.Ptr("<name>"),
+								Name:     to.Ptr("Standard_D1_v2"),
 								Capacity: to.Ptr[int64](1),
-								Tier:     to.Ptr("<tier>"),
+								Tier:     to.Ptr("Standard"),
 							},
 						}},
 				},
@@ -95,13 +95,13 @@ func ExampleCloudServicesClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		&test.CloudServicesClientBeginUpdateOptions{Parameters: &test.CloudServiceUpdate{
 			Tags: map[string]*string{
 				"Documentation": to.Ptr("RestAPI"),
@@ -126,13 +126,13 @@ func ExampleCloudServicesClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -150,13 +150,13 @@ func ExampleCloudServicesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -172,13 +172,13 @@ func ExampleCloudServicesClient_GetInstanceView() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.GetInstanceView(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -194,7 +194,7 @@ func ExampleCloudServicesClient_NewListAllPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
@@ -218,11 +218,11 @@ func ExampleCloudServicesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
+	pager := client.NewListPager("ConstosoRG",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -243,13 +243,13 @@ func ExampleCloudServicesClient_BeginStart() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginStart(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -267,13 +267,13 @@ func ExampleCloudServicesClient_BeginPowerOff() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginPowerOff(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -291,13 +291,13 @@ func ExampleCloudServicesClient_BeginRestart() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginRestart(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		&test.CloudServicesClientBeginRestartOptions{Parameters: &test.RoleInstances{
 			RoleInstances: []*string{
 				to.Ptr("ContosoFrontend_IN_0"),
@@ -320,13 +320,13 @@ func ExampleCloudServicesClient_BeginReimage() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginReimage(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		&test.CloudServicesClientBeginReimageOptions{Parameters: &test.RoleInstances{
 			RoleInstances: []*string{
 				to.Ptr("ContosoFrontend_IN_0"),
@@ -349,13 +349,13 @@ func ExampleCloudServicesClient_BeginRebuild() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginRebuild(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		&test.CloudServicesClientBeginRebuildOptions{Parameters: &test.RoleInstances{
 			RoleInstances: []*string{
 				to.Ptr("ContosoFrontend_IN_0"),
@@ -378,13 +378,13 @@ func ExampleCloudServicesClient_BeginDeleteInstances() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDeleteInstances(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		&test.CloudServicesClientBeginDeleteInstancesOptions{Parameters: &test.RoleInstances{
 			RoleInstances: []*string{
 				to.Ptr("ContosoFrontend_IN_0"),

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_cloudservicesupdatedomain_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_cloudservicesupdatedomain_client_test.go
@@ -24,13 +24,13 @@ func ExampleCloudServicesUpdateDomainClient_BeginWalkUpdateDomain() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesUpdateDomainClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesUpdateDomainClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginWalkUpdateDomain(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		1,
 		&test.CloudServicesUpdateDomainClientBeginWalkUpdateDomainOptions{Parameters: nil})
 	if err != nil {
@@ -49,13 +49,13 @@ func ExampleCloudServicesUpdateDomainClient_GetUpdateDomain() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesUpdateDomainClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesUpdateDomainClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.GetUpdateDomain(ctx,
-		"<resource-group-name>",
-		"<cloud-service-name>",
+		"ConstosoRG",
+		"{cs-name}",
 		1,
 		nil)
 	if err != nil {
@@ -72,12 +72,12 @@ func ExampleCloudServicesUpdateDomainClient_NewListUpdateDomainsPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewCloudServicesUpdateDomainClient("<subscription-id>", cred, nil)
+	client, err := test.NewCloudServicesUpdateDomainClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListUpdateDomainsPager("<resource-group-name>",
-		"<cloud-service-name>",
+	pager := client.NewListUpdateDomainsPager("ConstosoRG",
+		"{cs-name}",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_dedicatedhostgroups_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_dedicatedhostgroups_client_test.go
@@ -23,15 +23,15 @@ func ExampleDedicatedHostGroupsClient_CreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDedicatedHostGroupsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDedicatedHostGroupsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.CreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<host-group-name>",
+		"myResourceGroup",
+		"myDedicatedHostGroup",
 		test.DedicatedHostGroup{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("westus"),
 			Tags: map[string]*string{
 				"department": to.Ptr("finance"),
 			},
@@ -57,13 +57,13 @@ func ExampleDedicatedHostGroupsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDedicatedHostGroupsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDedicatedHostGroupsClient("{subscriptionId}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<host-group-name>",
+		"myResourceGroup",
+		"myDedicatedHostGroup",
 		&test.DedicatedHostGroupsClientGetOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_dedicatedhosts_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_dedicatedhosts_client_test.go
@@ -25,16 +25,16 @@ func ExampleDedicatedHostsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDedicatedHostsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDedicatedHostsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<host-group-name>",
-		"<host-name>",
+		"myResourceGroup",
+		"myDedicatedHostGroup",
+		"myDedicatedHost",
 		test.DedicatedHost{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("westus"),
 			Tags: map[string]*string{
 				"department": to.Ptr("HR"),
 			},
@@ -42,7 +42,7 @@ func ExampleDedicatedHostsClient_BeginCreateOrUpdate() {
 				PlatformFaultDomain: to.Ptr[int32](1),
 			},
 			SKU: &test.SKU{
-				Name: to.Ptr("<name>"),
+				Name: to.Ptr("DSv3-Type1"),
 			},
 		},
 		nil)
@@ -64,14 +64,14 @@ func ExampleDedicatedHostsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDedicatedHostsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDedicatedHostsClient("{subscriptionId}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<host-group-name>",
-		"<host-name>",
+		"myResourceGroup",
+		"myDedicatedHostGroup",
+		"myHost",
 		&test.DedicatedHostsClientGetOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_diskaccesses_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_diskaccesses_client_test.go
@@ -25,15 +25,15 @@ func ExampleDiskAccessesClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<disk-access-name>",
+		"myResourceGroup",
+		"myDiskAccess",
 		test.DiskAccess{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 		},
 		nil)
 	if err != nil {
@@ -54,13 +54,13 @@ func ExampleDiskAccessesClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<disk-access-name>",
+		"myResourceGroup",
+		"myDiskAccess",
 		test.DiskAccessUpdate{
 			Tags: map[string]*string{
 				"department": to.Ptr("Development"),
@@ -86,13 +86,13 @@ func ExampleDiskAccessesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<disk-access-name>",
+		"myResourceGroup",
+		"myDiskAccess",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -108,13 +108,13 @@ func ExampleDiskAccessesClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<disk-access-name>",
+		"myResourceGroup",
+		"myDiskAccess",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -132,11 +132,11 @@ func ExampleDiskAccessesClient_NewListByResourceGroupPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByResourceGroupPager("<resource-group-name>",
+	pager := client.NewListByResourceGroupPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -157,7 +157,7 @@ func ExampleDiskAccessesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
@@ -181,13 +181,13 @@ func ExampleDiskAccessesClient_GetPrivateLinkResources() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.GetPrivateLinkResources(ctx,
-		"<resource-group-name>",
-		"<disk-access-name>",
+		"myResourceGroup",
+		"myDiskAccess",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -203,18 +203,18 @@ func ExampleDiskAccessesClient_BeginUpdateAPrivateEndpointConnection() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdateAPrivateEndpointConnection(ctx,
-		"<resource-group-name>",
-		"<disk-access-name>",
-		"<private-endpoint-connection-name>",
+		"myResourceGroup",
+		"myDiskAccess",
+		"myPrivateEndpointConnection",
 		test.PrivateEndpointConnection{
 			Properties: &test.PrivateEndpointConnectionProperties{
 				PrivateLinkServiceConnectionState: &test.PrivateLinkServiceConnectionState{
-					Description: to.Ptr("<description>"),
+					Description: to.Ptr("Approving myPrivateEndpointConnection"),
 					Status:      to.Ptr(test.PrivateEndpointServiceConnectionStatusApproved),
 				},
 			},
@@ -238,14 +238,14 @@ func ExampleDiskAccessesClient_GetAPrivateEndpointConnection() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.GetAPrivateEndpointConnection(ctx,
-		"<resource-group-name>",
-		"<disk-access-name>",
-		"<private-endpoint-connection-name>",
+		"myResourceGroup",
+		"myDiskAccess",
+		"myPrivateEndpointConnection",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -261,14 +261,14 @@ func ExampleDiskAccessesClient_BeginDeleteAPrivateEndpointConnection() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDeleteAPrivateEndpointConnection(ctx,
-		"<resource-group-name>",
-		"<disk-access-name>",
-		"<private-endpoint-connection-name>",
+		"myResourceGroup",
+		"myDiskAccess",
+		"myPrivateEndpointConnection",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -286,12 +286,12 @@ func ExampleDiskAccessesClient_NewListPrivateEndpointConnectionsPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskAccessesClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskAccessesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPrivateEndpointConnectionsPager("<resource-group-name>",
-		"<disk-access-name>",
+	pager := client.NewListPrivateEndpointConnectionsPager("myResourceGroup",
+		"myDiskAccess",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_diskencryptionsets_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_diskencryptionsets_client_test.go
@@ -25,21 +25,21 @@ func ExampleDiskEncryptionSetsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskEncryptionSetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskEncryptionSetsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<disk-encryption-set-name>",
+		"myResourceGroup",
+		"myDiskEncryptionSet",
 		test.DiskEncryptionSet{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Identity: &test.EncryptionSetIdentity{
 				Type: to.Ptr(test.DiskEncryptionSetIdentityTypeSystemAssigned),
 			},
 			Properties: &test.EncryptionSetProperties{
 				ActiveKey: &test.KeyForDiskEncryptionSet{
-					KeyURL: to.Ptr("<key-url>"),
+					KeyURL: to.Ptr("https://myvaultdifferentsub.vault-int.azure-int.net/keys/{key}"),
 				},
 				EncryptionType: to.Ptr(test.DiskEncryptionSetTypeEncryptionAtRestWithCustomerKey),
 			},
@@ -63,20 +63,20 @@ func ExampleDiskEncryptionSetsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskEncryptionSetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskEncryptionSetsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<disk-encryption-set-name>",
+		"myResourceGroup",
+		"myDiskEncryptionSet",
 		test.DiskEncryptionSetUpdate{
 			Identity: &test.EncryptionSetIdentity{
 				Type: to.Ptr(test.DiskEncryptionSetIdentityTypeSystemAssigned),
 			},
 			Properties: &test.DiskEncryptionSetUpdateProperties{
 				ActiveKey: &test.KeyForDiskEncryptionSet{
-					KeyURL: to.Ptr("<key-url>"),
+					KeyURL: to.Ptr("https://myvaultdifferentsub.vault-int.azure-int.net/keys/keyName/keyVersion1"),
 				},
 				EncryptionType:                    to.Ptr(test.DiskEncryptionSetTypeEncryptionAtRestWithCustomerKey),
 				RotationToLatestKeyVersionEnabled: to.Ptr(true),
@@ -101,13 +101,13 @@ func ExampleDiskEncryptionSetsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskEncryptionSetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskEncryptionSetsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<disk-encryption-set-name>",
+		"myResourceGroup",
+		"myDiskEncryptionSet",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -123,13 +123,13 @@ func ExampleDiskEncryptionSetsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskEncryptionSetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskEncryptionSetsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<disk-encryption-set-name>",
+		"myResourceGroup",
+		"myDiskEncryptionSet",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -147,11 +147,11 @@ func ExampleDiskEncryptionSetsClient_NewListByResourceGroupPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskEncryptionSetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskEncryptionSetsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByResourceGroupPager("<resource-group-name>",
+	pager := client.NewListByResourceGroupPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -172,7 +172,7 @@ func ExampleDiskEncryptionSetsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskEncryptionSetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskEncryptionSetsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
@@ -196,12 +196,12 @@ func ExampleDiskEncryptionSetsClient_NewListAssociatedResourcesPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskEncryptionSetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskEncryptionSetsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListAssociatedResourcesPager("<resource-group-name>",
-		"<disk-encryption-set-name>",
+	pager := client.NewListAssociatedResourcesPager("myResourceGroup",
+		"myDiskEncryptionSet",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_diskrestorepoint_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_diskrestorepoint_client_test.go
@@ -22,15 +22,15 @@ func ExampleDiskRestorePointClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskRestorePointClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskRestorePointClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<restore-point-collection-name>",
-		"<vm-restore-point-name>",
-		"<disk-restore-point-name>",
+		"myResourceGroup",
+		"rpc",
+		"vmrp",
+		"TestDisk45ceb03433006d1baee0_b70cd924-3362-4a80-93c2-9415eaa12745",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -46,13 +46,13 @@ func ExampleDiskRestorePointClient_NewListByRestorePointPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDiskRestorePointClient("<subscription-id>", cred, nil)
+	client, err := test.NewDiskRestorePointClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByRestorePointPager("<resource-group-name>",
-		"<restore-point-collection-name>",
-		"<vm-restore-point-name>",
+	pager := client.NewListByRestorePointPager("myResourceGroup",
+		"rpc",
+		"vmrp",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_disks_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_disks_client_test.go
@@ -25,20 +25,20 @@ func ExampleDisksClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDisksClient("<subscription-id>", cred, nil)
+	client, err := test.NewDisksClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<disk-name>",
+		"myResourceGroup",
+		"myDisk",
 		test.Disk{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Properties: &test.DiskProperties{
 				CreationData: &test.CreationData{
 					CreateOption: to.Ptr(test.DiskCreateOptionEmpty),
 				},
-				DiskAccessID:        to.Ptr("<disk-access-id>"),
+				DiskAccessID:        to.Ptr("/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskAccesses/{existing-diskAccess-name}"),
 				DiskSizeGB:          to.Ptr[int32](200),
 				NetworkAccessPolicy: to.Ptr(test.NetworkAccessPolicyAllowPrivate),
 			},
@@ -62,13 +62,13 @@ func ExampleDisksClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDisksClient("<subscription-id>", cred, nil)
+	client, err := test.NewDisksClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<disk-name>",
+		"myResourceGroup",
+		"myDisk",
 		test.DiskUpdate{
 			Properties: &test.DiskUpdateProperties{
 				BurstingEnabled: to.Ptr(true),
@@ -94,13 +94,13 @@ func ExampleDisksClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDisksClient("<subscription-id>", cred, nil)
+	client, err := test.NewDisksClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<disk-name>",
+		"myResourceGroup",
+		"myManagedDisk",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -116,11 +116,11 @@ func ExampleDisksClient_NewListByResourceGroupPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDisksClient("<subscription-id>", cred, nil)
+	client, err := test.NewDisksClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByResourceGroupPager("<resource-group-name>",
+	pager := client.NewListByResourceGroupPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -141,7 +141,7 @@ func ExampleDisksClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewDisksClient("<subscription-id>", cred, nil)
+	client, err := test.NewDisksClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_galleries_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_galleries_client_test.go
@@ -25,17 +25,17 @@ func ExampleGalleriesClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleriesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleriesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
+		"myResourceGroup",
+		"myGalleryName",
 		test.Gallery{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Properties: &test.GalleryProperties{
-				Description: to.Ptr("<description>"),
+				Description: to.Ptr("This is the gallery description."),
 				SharingProfile: &test.SharingProfile{
 					Permissions: to.Ptr(test.GallerySharingPermissionTypesGroups),
 				},
@@ -60,16 +60,16 @@ func ExampleGalleriesClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleriesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleriesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
+		"myResourceGroup",
+		"myGalleryName",
 		test.GalleryUpdate{
 			Properties: &test.GalleryProperties{
-				Description: to.Ptr("<description>"),
+				Description: to.Ptr("This is the gallery description."),
 			},
 		},
 		nil)
@@ -91,13 +91,13 @@ func ExampleGalleriesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleriesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleriesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
+		"myResourceGroup",
+		"myGalleryName",
 		&test.GalleriesClientGetOptions{Select: to.Ptr(test.SelectPermissionsPermissions)})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -113,13 +113,13 @@ func ExampleGalleriesClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleriesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleriesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
+		"myResourceGroup",
+		"myGalleryName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -137,11 +137,11 @@ func ExampleGalleriesClient_NewListByResourceGroupPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleriesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleriesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByResourceGroupPager("<resource-group-name>",
+	pager := client.NewListByResourceGroupPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -162,7 +162,7 @@ func ExampleGalleriesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleriesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleriesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_galleryapplications_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_galleryapplications_client_test.go
@@ -25,21 +25,21 @@ func ExampleGalleryApplicationsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryApplicationsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryApplicationsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-application-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryApplicationName",
 		test.GalleryApplication{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Properties: &test.GalleryApplicationProperties{
-				Description:         to.Ptr("<description>"),
-				Eula:                to.Ptr("<eula>"),
-				PrivacyStatementURI: to.Ptr("<privacy-statement-uri>"),
-				ReleaseNoteURI:      to.Ptr("<release-note-uri>"),
+				Description:         to.Ptr("This is the gallery application description."),
+				Eula:                to.Ptr("This is the gallery application EULA."),
+				PrivacyStatementURI: to.Ptr("myPrivacyStatementUri}"),
+				ReleaseNoteURI:      to.Ptr("myReleaseNoteUri"),
 				SupportedOSType:     to.Ptr(test.OperatingSystemTypesWindows),
 			},
 		},
@@ -62,20 +62,20 @@ func ExampleGalleryApplicationsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryApplicationsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryApplicationsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-application-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryApplicationName",
 		test.GalleryApplicationUpdate{
 			Properties: &test.GalleryApplicationProperties{
-				Description:         to.Ptr("<description>"),
-				Eula:                to.Ptr("<eula>"),
-				PrivacyStatementURI: to.Ptr("<privacy-statement-uri>"),
-				ReleaseNoteURI:      to.Ptr("<release-note-uri>"),
+				Description:         to.Ptr("This is the gallery application description."),
+				Eula:                to.Ptr("This is the gallery application EULA."),
+				PrivacyStatementURI: to.Ptr("myPrivacyStatementUri}"),
+				ReleaseNoteURI:      to.Ptr("myReleaseNoteUri"),
 				SupportedOSType:     to.Ptr(test.OperatingSystemTypesWindows),
 			},
 		},
@@ -98,14 +98,14 @@ func ExampleGalleryApplicationsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryApplicationsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryApplicationsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-application-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryApplicationName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -121,14 +121,14 @@ func ExampleGalleryApplicationsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryApplicationsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryApplicationsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-application-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryApplicationName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -146,12 +146,12 @@ func ExampleGalleryApplicationsClient_NewListByGalleryPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryApplicationsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryApplicationsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByGalleryPager("<resource-group-name>",
-		"<gallery-name>",
+	pager := client.NewListByGalleryPager("myResourceGroup",
+		"myGalleryName",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_galleryapplicationversions_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_galleryapplicationversions_client_test.go
@@ -25,17 +25,17 @@ func ExampleGalleryApplicationVersionsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryApplicationVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryApplicationVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-application-name>",
-		"<gallery-application-version-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryApplicationName",
+		"1.0.0",
 		test.GalleryApplicationVersion{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Properties: &test.GalleryApplicationVersionProperties{
 				PublishingProfile: &test.GalleryApplicationVersionPublishingProfile{
 					EndOfLifeDate:      to.Ptr(func() time.Time { t, _ := time.Parse(time.RFC3339Nano, "2019-07-01T07:00:00Z"); return t }()),
@@ -43,16 +43,16 @@ func ExampleGalleryApplicationVersionsClient_BeginCreateOrUpdate() {
 					StorageAccountType: to.Ptr(test.StorageAccountTypeStandardLRS),
 					TargetRegions: []*test.TargetRegion{
 						{
-							Name:                 to.Ptr("<name>"),
+							Name:                 to.Ptr("West US"),
 							RegionalReplicaCount: to.Ptr[int32](1),
 							StorageAccountType:   to.Ptr(test.StorageAccountTypeStandardLRS),
 						}},
 					ManageActions: &test.UserArtifactManage{
-						Install: to.Ptr("<install>"),
-						Remove:  to.Ptr("<remove>"),
+						Install: to.Ptr("powershell -command \"Expand-Archive -Path package.zip -DestinationPath C:\\package\""),
+						Remove:  to.Ptr("del C:\\package "),
 					},
 					Source: &test.UserArtifactSource{
-						MediaLink: to.Ptr("<media-link>"),
+						MediaLink: to.Ptr("https://mystorageaccount.blob.core.windows.net/mycontainer/package.zip?{sasKey}"),
 					},
 				},
 			},
@@ -76,15 +76,15 @@ func ExampleGalleryApplicationVersionsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryApplicationVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryApplicationVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-application-name>",
-		"<gallery-application-version-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryApplicationName",
+		"1.0.0",
 		test.GalleryApplicationVersionUpdate{
 			Properties: &test.GalleryApplicationVersionProperties{
 				PublishingProfile: &test.GalleryApplicationVersionPublishingProfile{
@@ -93,16 +93,16 @@ func ExampleGalleryApplicationVersionsClient_BeginUpdate() {
 					StorageAccountType: to.Ptr(test.StorageAccountTypeStandardLRS),
 					TargetRegions: []*test.TargetRegion{
 						{
-							Name:                 to.Ptr("<name>"),
+							Name:                 to.Ptr("West US"),
 							RegionalReplicaCount: to.Ptr[int32](1),
 							StorageAccountType:   to.Ptr(test.StorageAccountTypeStandardLRS),
 						}},
 					ManageActions: &test.UserArtifactManage{
-						Install: to.Ptr("<install>"),
-						Remove:  to.Ptr("<remove>"),
+						Install: to.Ptr("powershell -command \"Expand-Archive -Path package.zip -DestinationPath C:\\package\""),
+						Remove:  to.Ptr("del C:\\package "),
 					},
 					Source: &test.UserArtifactSource{
-						MediaLink: to.Ptr("<media-link>"),
+						MediaLink: to.Ptr("https://mystorageaccount.blob.core.windows.net/mycontainer/package.zip?{sasKey}"),
 					},
 				},
 			},
@@ -126,15 +126,15 @@ func ExampleGalleryApplicationVersionsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryApplicationVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryApplicationVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-application-name>",
-		"<gallery-application-version-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryApplicationName",
+		"1.0.0",
 		&test.GalleryApplicationVersionsClientGetOptions{Expand: to.Ptr(test.ReplicationStatusTypesReplicationStatus)})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -150,15 +150,15 @@ func ExampleGalleryApplicationVersionsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryApplicationVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryApplicationVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-application-name>",
-		"<gallery-application-version-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryApplicationName",
+		"1.0.0",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -176,13 +176,13 @@ func ExampleGalleryApplicationVersionsClient_NewListByGalleryApplicationPager() 
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryApplicationVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryApplicationVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByGalleryApplicationPager("<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-application-name>",
+	pager := client.NewListByGalleryApplicationPager("myResourceGroup",
+		"myGalleryName",
+		"myGalleryApplicationName",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_galleryimages_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_galleryimages_client_test.go
@@ -25,22 +25,22 @@ func ExampleGalleryImagesClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-image-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryImageName",
 		test.GalleryImage{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Properties: &test.GalleryImageProperties{
 				HyperVGeneration: to.Ptr(test.HyperVGenerationV1),
 				Identifier: &test.GalleryImageIdentifier{
-					Offer:     to.Ptr("<offer>"),
-					Publisher: to.Ptr("<publisher>"),
-					SKU:       to.Ptr("<sku>"),
+					Offer:     to.Ptr("myOfferName"),
+					Publisher: to.Ptr("myPublisherName"),
+					SKU:       to.Ptr("mySkuName"),
 				},
 				OSState: to.Ptr(test.OperatingSystemStateTypesGeneralized),
 				OSType:  to.Ptr(test.OperatingSystemTypesWindows),
@@ -65,21 +65,21 @@ func ExampleGalleryImagesClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-image-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryImageName",
 		test.GalleryImageUpdate{
 			Properties: &test.GalleryImageProperties{
 				HyperVGeneration: to.Ptr(test.HyperVGenerationV1),
 				Identifier: &test.GalleryImageIdentifier{
-					Offer:     to.Ptr("<offer>"),
-					Publisher: to.Ptr("<publisher>"),
-					SKU:       to.Ptr("<sku>"),
+					Offer:     to.Ptr("myOfferName"),
+					Publisher: to.Ptr("myPublisherName"),
+					SKU:       to.Ptr("mySkuName"),
 				},
 				OSState: to.Ptr(test.OperatingSystemStateTypesGeneralized),
 				OSType:  to.Ptr(test.OperatingSystemTypesWindows),
@@ -104,14 +104,14 @@ func ExampleGalleryImagesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-image-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryImageName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -127,14 +127,14 @@ func ExampleGalleryImagesClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-image-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryImageName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -152,12 +152,12 @@ func ExampleGalleryImagesClient_NewListByGalleryPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByGalleryPager("<resource-group-name>",
-		"<gallery-name>",
+	pager := client.NewListByGalleryPager("myResourceGroup",
+		"myGalleryName",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_galleryimageversions_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_galleryimageversions_client_test.go
@@ -25,52 +25,52 @@ func ExampleGalleryImageVersionsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryImageVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryImageVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-image-name>",
-		"<gallery-image-version-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryImageName",
+		"1.0.0",
 		test.GalleryImageVersion{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Properties: &test.GalleryImageVersionProperties{
 				PublishingProfile: &test.GalleryImageVersionPublishingProfile{
 					TargetRegions: []*test.TargetRegion{
 						{
-							Name: to.Ptr("<name>"),
+							Name: to.Ptr("West US"),
 							Encryption: &test.EncryptionImages{
 								DataDiskImages: []*test.DataDiskImageEncryption{
 									{
-										DiskEncryptionSetID: to.Ptr("<disk-encryption-set-id>"),
+										DiskEncryptionSetID: to.Ptr("/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskEncryptionSet/myOtherWestUSDiskEncryptionSet"),
 										Lun:                 to.Ptr[int32](0),
 									},
 									{
-										DiskEncryptionSetID: to.Ptr("<disk-encryption-set-id>"),
+										DiskEncryptionSetID: to.Ptr("/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskEncryptionSet/myWestUSDiskEncryptionSet"),
 										Lun:                 to.Ptr[int32](1),
 									}},
 								OSDiskImage: &test.OSDiskImageEncryption{
-									DiskEncryptionSetID: to.Ptr("<disk-encryption-set-id>"),
+									DiskEncryptionSetID: to.Ptr("/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskEncryptionSet/myWestUSDiskEncryptionSet"),
 								},
 							},
 							RegionalReplicaCount: to.Ptr[int32](1),
 						},
 						{
-							Name: to.Ptr("<name>"),
+							Name: to.Ptr("East US"),
 							Encryption: &test.EncryptionImages{
 								DataDiskImages: []*test.DataDiskImageEncryption{
 									{
-										DiskEncryptionSetID: to.Ptr("<disk-encryption-set-id>"),
+										DiskEncryptionSetID: to.Ptr("/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskEncryptionSet/myOtherEastUSDiskEncryptionSet"),
 										Lun:                 to.Ptr[int32](0),
 									},
 									{
-										DiskEncryptionSetID: to.Ptr("<disk-encryption-set-id>"),
+										DiskEncryptionSetID: to.Ptr("/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskEncryptionSet/myEastUSDiskEncryptionSet"),
 										Lun:                 to.Ptr[int32](1),
 									}},
 								OSDiskImage: &test.OSDiskImageEncryption{
-									DiskEncryptionSetID: to.Ptr("<disk-encryption-set-id>"),
+									DiskEncryptionSetID: to.Ptr("/subscriptions/{subscriptionId}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskEncryptionSet/myEastUSDiskEncryptionSet"),
 								},
 							},
 							RegionalReplicaCount: to.Ptr[int32](2),
@@ -79,7 +79,7 @@ func ExampleGalleryImageVersionsClient_BeginCreateOrUpdate() {
 				},
 				StorageProfile: &test.GalleryImageVersionStorageProfile{
 					Source: &test.GalleryArtifactVersionSource{
-						ID: to.Ptr("<id>"),
+						ID: to.Ptr("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/virtualMachines/{vmName}"),
 					},
 				},
 			},
@@ -103,32 +103,32 @@ func ExampleGalleryImageVersionsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryImageVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryImageVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-image-name>",
-		"<gallery-image-version-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryImageName",
+		"1.0.0",
 		test.GalleryImageVersionUpdate{
 			Properties: &test.GalleryImageVersionProperties{
 				PublishingProfile: &test.GalleryImageVersionPublishingProfile{
 					TargetRegions: []*test.TargetRegion{
 						{
-							Name:                 to.Ptr("<name>"),
+							Name:                 to.Ptr("West US"),
 							RegionalReplicaCount: to.Ptr[int32](1),
 						},
 						{
-							Name:                 to.Ptr("<name>"),
+							Name:                 to.Ptr("East US"),
 							RegionalReplicaCount: to.Ptr[int32](2),
 							StorageAccountType:   to.Ptr(test.StorageAccountTypeStandardZRS),
 						}},
 				},
 				StorageProfile: &test.GalleryImageVersionStorageProfile{
 					Source: &test.GalleryArtifactVersionSource{
-						ID: to.Ptr("<id>"),
+						ID: to.Ptr("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroup}/providers/Microsoft.Compute/images/{imageName}"),
 					},
 				},
 			},
@@ -152,15 +152,15 @@ func ExampleGalleryImageVersionsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryImageVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryImageVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-image-name>",
-		"<gallery-image-version-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryImageName",
+		"1.0.0",
 		&test.GalleryImageVersionsClientGetOptions{Expand: to.Ptr(test.ReplicationStatusTypesReplicationStatus)})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -176,15 +176,15 @@ func ExampleGalleryImageVersionsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryImageVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryImageVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-image-name>",
-		"<gallery-image-version-name>",
+		"myResourceGroup",
+		"myGalleryName",
+		"myGalleryImageName",
+		"1.0.0",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -202,13 +202,13 @@ func ExampleGalleryImageVersionsClient_NewListByGalleryImagePager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGalleryImageVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewGalleryImageVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByGalleryImagePager("<resource-group-name>",
-		"<gallery-name>",
-		"<gallery-image-name>",
+	pager := client.NewListByGalleryImagePager("myResourceGroup",
+		"myGalleryName",
+		"myGalleryImageName",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_gallerysharingprofile_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_gallerysharingprofile_client_test.go
@@ -25,13 +25,13 @@ func ExampleGallerySharingProfileClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewGallerySharingProfileClient("<subscription-id>", cred, nil)
+	client, err := test.NewGallerySharingProfileClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<gallery-name>",
+		"myResourceGroup",
+		"myGalleryName",
 		test.SharingUpdate{
 			Groups: []*test.SharingProfileGroup{
 				{

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_images_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_images_client_test.go
@@ -25,21 +25,21 @@ func ExampleImagesClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<image-name>",
+		"myResourceGroup",
+		"myImage",
 		test.Image{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Properties: &test.ImageProperties{
 				StorageProfile: &test.ImageStorageProfile{
 					OSDisk: &test.ImageOSDisk{
-						BlobURI: to.Ptr("<blob-uri>"),
+						BlobURI: to.Ptr("https://mystorageaccount.blob.core.windows.net/osimages/osimage.vhd"),
 						DiskEncryptionSet: &test.DiskEncryptionSetParameters{
-							ID: to.Ptr("<id>"),
+							ID: to.Ptr("/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/diskEncryptionSets/{existing-diskEncryptionSet-name}"),
 						},
 						OSState: to.Ptr(test.OperatingSystemStateTypesGeneralized),
 						OSType:  to.Ptr(test.OperatingSystemTypesLinux),
@@ -66,13 +66,13 @@ func ExampleImagesClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<image-name>",
+		"myResourceGroup",
+		"myImage",
 		test.ImageUpdate{
 			Tags: map[string]*string{
 				"department": to.Ptr("HR"),
@@ -80,7 +80,7 @@ func ExampleImagesClient_BeginUpdate() {
 			Properties: &test.ImageProperties{
 				HyperVGeneration: to.Ptr(test.HyperVGenerationTypesV1),
 				SourceVirtualMachine: &test.SubResource{
-					ID: to.Ptr("<id>"),
+					ID: to.Ptr("/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVM"),
 				},
 			},
 		},
@@ -103,13 +103,13 @@ func ExampleImagesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<image-name>",
+		"myResourceGroup",
+		"myImage",
 		&test.ImagesClientGetOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -125,11 +125,11 @@ func ExampleImagesClient_NewListByResourceGroupPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByResourceGroupPager("<resource-group-name>",
+	pager := client.NewListByResourceGroupPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -150,7 +150,7 @@ func ExampleImagesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_loganalytics_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_loganalytics_client_test.go
@@ -25,14 +25,14 @@ func ExampleLogAnalyticsClient_BeginExportRequestRateByInterval() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewLogAnalyticsClient("<subscription-id>", cred, nil)
+	client, err := test.NewLogAnalyticsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginExportRequestRateByInterval(ctx,
-		"<location>",
+		"westus",
 		test.RequestRateByIntervalInput{
-			BlobContainerSasURI: to.Ptr("<blob-container-sas-uri>"),
+			BlobContainerSasURI: to.Ptr("https://somesasuri"),
 			FromTime:            to.Ptr(func() time.Time { t, _ := time.Parse(time.RFC3339Nano, "2018-01-21T01:54:06.862601Z"); return t }()),
 			GroupByResourceName: to.Ptr(true),
 			ToTime:              to.Ptr(func() time.Time { t, _ := time.Parse(time.RFC3339Nano, "2018-01-23T01:54:06.862601Z"); return t }()),
@@ -57,14 +57,14 @@ func ExampleLogAnalyticsClient_BeginExportThrottledRequests() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewLogAnalyticsClient("<subscription-id>", cred, nil)
+	client, err := test.NewLogAnalyticsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginExportThrottledRequests(ctx,
-		"<location>",
+		"westus",
 		test.ThrottledRequestsInput{
-			BlobContainerSasURI:        to.Ptr("<blob-container-sas-uri>"),
+			BlobContainerSasURI:        to.Ptr("https://somesasuri"),
 			FromTime:                   to.Ptr(func() time.Time { t, _ := time.Parse(time.RFC3339Nano, "2018-01-21T01:54:06.862601Z"); return t }()),
 			GroupByClientApplicationID: to.Ptr(false),
 			GroupByOperationName:       to.Ptr(true),

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_proximityplacementgroups_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_proximityplacementgroups_client_test.go
@@ -23,15 +23,15 @@ func ExampleProximityPlacementGroupsClient_CreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewProximityPlacementGroupsClient("<subscription-id>", cred, nil)
+	client, err := test.NewProximityPlacementGroupsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.CreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<proximity-placement-group-name>",
+		"myResourceGroup",
+		"$(resourceName)",
 		test.ProximityPlacementGroup{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("westus"),
 			Properties: &test.ProximityPlacementGroupProperties{
 				ProximityPlacementGroupType: to.Ptr(test.ProximityPlacementGroupTypeStandard),
 			},
@@ -51,13 +51,13 @@ func ExampleProximityPlacementGroupsClient_Update() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewProximityPlacementGroupsClient("<subscription-id>", cred, nil)
+	client, err := test.NewProximityPlacementGroupsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Update(ctx,
-		"<resource-group-name>",
-		"<proximity-placement-group-name>",
+		"myResourceGroup",
+		"myProximityPlacementGroup",
 		test.ProximityPlacementGroupUpdate{
 			Tags: map[string]*string{
 				"additionalProp1": to.Ptr("string"),
@@ -78,13 +78,13 @@ func ExampleProximityPlacementGroupsClient_Delete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewProximityPlacementGroupsClient("<subscription-id>", cred, nil)
+	client, err := test.NewProximityPlacementGroupsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	_, err = client.Delete(ctx,
-		"<resource-group-name>",
-		"<proximity-placement-group-name>",
+		"myResourceGroup",
+		"$(resourceName)",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -98,13 +98,13 @@ func ExampleProximityPlacementGroupsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewProximityPlacementGroupsClient("<subscription-id>", cred, nil)
+	client, err := test.NewProximityPlacementGroupsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<proximity-placement-group-name>",
+		"myResourceGroup",
+		"myProximityPlacementGroup",
 		&test.ProximityPlacementGroupsClientGetOptions{IncludeColocationStatus: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -120,7 +120,7 @@ func ExampleProximityPlacementGroupsClient_NewListBySubscriptionPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewProximityPlacementGroupsClient("<subscription-id>", cred, nil)
+	client, err := test.NewProximityPlacementGroupsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
@@ -144,11 +144,11 @@ func ExampleProximityPlacementGroupsClient_NewListByResourceGroupPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewProximityPlacementGroupsClient("<subscription-id>", cred, nil)
+	client, err := test.NewProximityPlacementGroupsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByResourceGroupPager("<resource-group-name>",
+	pager := client.NewListByResourceGroupPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_resourceskus_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_resourceskus_client_test.go
@@ -22,7 +22,7 @@ func ExampleResourceSKUsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewResourceSKUsClient("<subscription-id>", cred, nil)
+	client, err := test.NewResourceSKUsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_restorepointcollections_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_restorepointcollections_client_test.go
@@ -23,21 +23,21 @@ func ExampleRestorePointCollectionsClient_CreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewRestorePointCollectionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewRestorePointCollectionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.CreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<restore-point-collection-name>",
+		"myResourceGroup",
+		"myRpc",
 		test.RestorePointCollection{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("norwayeast"),
 			Tags: map[string]*string{
 				"myTag1": to.Ptr("tagValue1"),
 			},
 			Properties: &test.RestorePointCollectionProperties{
 				Source: &test.RestorePointCollectionSourceProperties{
-					ID: to.Ptr("<id>"),
+					ID: to.Ptr("/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/virtualMachines/myVM"),
 				},
 			},
 		},
@@ -56,13 +56,13 @@ func ExampleRestorePointCollectionsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewRestorePointCollectionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewRestorePointCollectionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<restore-point-collection-name>",
+		"myResourceGroup",
+		"myRpc",
 		&test.RestorePointCollectionsClientGetOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -78,11 +78,11 @@ func ExampleRestorePointCollectionsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewRestorePointCollectionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewRestorePointCollectionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
+	pager := client.NewListPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -103,7 +103,7 @@ func ExampleRestorePointCollectionsClient_NewListAllPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewRestorePointCollectionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewRestorePointCollectionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_restorepoints_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_restorepoints_client_test.go
@@ -25,18 +25,18 @@ func ExampleRestorePointsClient_BeginCreate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewRestorePointsClient("<subscription-id>", cred, nil)
+	client, err := test.NewRestorePointsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreate(ctx,
-		"<resource-group-name>",
-		"<restore-point-collection-name>",
-		"<restore-point-name>",
+		"myResourceGroup",
+		"rpcName",
+		"rpName",
 		test.RestorePoint{
 			ExcludeDisks: []*test.APIEntityReference{
 				{
-					ID: to.Ptr("<id>"),
+					ID: to.Ptr("/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Compute/disks/vm8768_disk2_fe6ffde4f69b491ca33fb984d5bcd89f"),
 				}},
 		},
 		nil)
@@ -56,14 +56,14 @@ func ExampleRestorePointsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewRestorePointsClient("<subscription-id>", cred, nil)
+	client, err := test.NewRestorePointsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<restore-point-collection-name>",
-		"<restore-point-name>",
+		"myResourceGroup",
+		"rpcName",
+		"rpName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_sharedgalleries_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_sharedgalleries_client_test.go
@@ -22,11 +22,11 @@ func ExampleSharedGalleriesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSharedGalleriesClient("<subscription-id>", cred, nil)
+	client, err := test.NewSharedGalleriesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<location>",
+	pager := client.NewListPager("myLocation",
 		&test.SharedGalleriesClientListOptions{SharedTo: nil})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -47,13 +47,13 @@ func ExampleSharedGalleriesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSharedGalleriesClient("<subscription-id>", cred, nil)
+	client, err := test.NewSharedGalleriesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<location>",
-		"<gallery-unique-name>",
+		"myLocation",
+		"galleryUniqueName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_sharedgalleryimages_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_sharedgalleryimages_client_test.go
@@ -22,12 +22,12 @@ func ExampleSharedGalleryImagesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSharedGalleryImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewSharedGalleryImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<location>",
-		"<gallery-unique-name>",
+	pager := client.NewListPager("myLocation",
+		"galleryUniqueName",
 		&test.SharedGalleryImagesClientListOptions{SharedTo: nil})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -48,14 +48,14 @@ func ExampleSharedGalleryImagesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSharedGalleryImagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewSharedGalleryImagesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<location>",
-		"<gallery-unique-name>",
-		"<gallery-image-name>",
+		"myLocation",
+		"galleryUniqueName",
+		"myGalleryImageName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_sharedgalleryimageversions_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_sharedgalleryimageversions_client_test.go
@@ -22,13 +22,13 @@ func ExampleSharedGalleryImageVersionsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSharedGalleryImageVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSharedGalleryImageVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<location>",
-		"<gallery-unique-name>",
-		"<gallery-image-name>",
+	pager := client.NewListPager("myLocation",
+		"galleryUniqueName",
+		"myGalleryImageName",
 		&test.SharedGalleryImageVersionsClientListOptions{SharedTo: nil})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -49,15 +49,15 @@ func ExampleSharedGalleryImageVersionsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSharedGalleryImageVersionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSharedGalleryImageVersionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<location>",
-		"<gallery-unique-name>",
-		"<gallery-image-name>",
-		"<gallery-image-version-name>",
+		"myLocation",
+		"galleryUniqueName",
+		"myGalleryImageName",
+		"myGalleryImageVersionName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_snapshots_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_snapshots_client_test.go
@@ -25,20 +25,20 @@ func ExampleSnapshotsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSnapshotsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSnapshotsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<snapshot-name>",
+		"myResourceGroup",
+		"mySnapshot1",
 		test.Snapshot{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Properties: &test.SnapshotProperties{
 				CreationData: &test.CreationData{
 					CreateOption:     to.Ptr(test.DiskCreateOptionImport),
-					SourceURI:        to.Ptr("<source-uri>"),
-					StorageAccountID: to.Ptr("<storage-account-id>"),
+					SourceURI:        to.Ptr("https://mystorageaccount.blob.core.windows.net/osimages/osimage.vhd"),
+					StorageAccountID: to.Ptr("subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Storage/storageAccounts/myStorageAccount"),
 				},
 			},
 		},
@@ -61,13 +61,13 @@ func ExampleSnapshotsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSnapshotsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSnapshotsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<snapshot-name>",
+		"myResourceGroup",
+		"mySnapshot",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -83,11 +83,11 @@ func ExampleSnapshotsClient_NewListByResourceGroupPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSnapshotsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSnapshotsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByResourceGroupPager("<resource-group-name>",
+	pager := client.NewListByResourceGroupPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -108,7 +108,7 @@ func ExampleSnapshotsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSnapshotsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSnapshotsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_sshpublickeys_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_sshpublickeys_client_test.go
@@ -23,17 +23,17 @@ func ExampleSSHPublicKeysClient_Create() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSSHPublicKeysClient("<subscription-id>", cred, nil)
+	client, err := test.NewSSHPublicKeysClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Create(ctx,
-		"<resource-group-name>",
-		"<ssh-public-key-name>",
+		"myResourceGroup",
+		"mySshPublicKeyName",
 		test.SSHPublicKeyResource{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("westus"),
 			Properties: &test.SSHPublicKeyResourceProperties{
-				PublicKey: to.Ptr("<public-key>"),
+				PublicKey: to.Ptr("{ssh-rsa public key}"),
 			},
 		},
 		nil)
@@ -51,13 +51,13 @@ func ExampleSSHPublicKeysClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSSHPublicKeysClient("<subscription-id>", cred, nil)
+	client, err := test.NewSSHPublicKeysClient("{subscriptionId}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<ssh-public-key-name>",
+		"myResourceGroup",
+		"mySshPublicKeyName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -73,13 +73,13 @@ func ExampleSSHPublicKeysClient_GenerateKeyPair() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSSHPublicKeysClient("<subscription-id>", cred, nil)
+	client, err := test.NewSSHPublicKeysClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.GenerateKeyPair(ctx,
-		"<resource-group-name>",
-		"<ssh-public-key-name>",
+		"myResourceGroup",
+		"mySshPublicKeyName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachineruncommands_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachineruncommands_client_test.go
@@ -25,11 +25,11 @@ func ExampleVirtualMachineRunCommandsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineRunCommandsClient("subid", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<location>",
+	pager := client.NewListPager("SoutheastAsia",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -50,13 +50,13 @@ func ExampleVirtualMachineRunCommandsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineRunCommandsClient("24fb23e3-6ba3-41f0-9b6e-e41131d5d61e", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<location>",
-		"<command-id>",
+		"SoutheastAsia",
+		"RunPowerShellScript",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -72,31 +72,31 @@ func ExampleVirtualMachineRunCommandsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineRunCommandsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
-		"<run-command-name>",
+		"myResourceGroup",
+		"myVM",
+		"myRunCommand",
 		test.VirtualMachineRunCommand{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Properties: &test.VirtualMachineRunCommandProperties{
 				AsyncExecution: to.Ptr(false),
 				Parameters: []*test.RunCommandInputParameter{
 					{
-						Name:  to.Ptr("<name>"),
-						Value: to.Ptr("<value>"),
+						Name:  to.Ptr("param1"),
+						Value: to.Ptr("value1"),
 					},
 					{
-						Name:  to.Ptr("<name>"),
-						Value: to.Ptr("<value>"),
+						Name:  to.Ptr("param2"),
+						Value: to.Ptr("value2"),
 					}},
-				RunAsPassword: to.Ptr("<run-as-password>"),
-				RunAsUser:     to.Ptr("<run-as-user>"),
+				RunAsPassword: to.Ptr("<runAsPassword>"),
+				RunAsUser:     to.Ptr("user1"),
 				Source: &test.VirtualMachineRunCommandScriptSource{
-					Script: to.Ptr("<script>"),
+					Script: to.Ptr("Write-Host Hello World!"),
 				},
 				TimeoutInSeconds: to.Ptr[int32](3600),
 			},
@@ -120,18 +120,18 @@ func ExampleVirtualMachineRunCommandsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineRunCommandsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
-		"<run-command-name>",
+		"myResourceGroup",
+		"myVM",
+		"myRunCommand",
 		test.VirtualMachineRunCommandUpdate{
 			Properties: &test.VirtualMachineRunCommandProperties{
 				Source: &test.VirtualMachineRunCommandScriptSource{
-					Script: to.Ptr("<script>"),
+					Script: to.Ptr("Write-Host Script Source Updated!"),
 				},
 			},
 		},
@@ -154,14 +154,14 @@ func ExampleVirtualMachineRunCommandsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineRunCommandsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
-		"<run-command-name>",
+		"myResourceGroup",
+		"myVM",
+		"myRunCommand",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -179,14 +179,14 @@ func ExampleVirtualMachineRunCommandsClient_GetByVirtualMachine() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineRunCommandsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.GetByVirtualMachine(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
-		"<run-command-name>",
+		"myResourceGroup",
+		"myVM",
+		"myRunCommand",
 		&test.VirtualMachineRunCommandsClientGetByVirtualMachineOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -202,12 +202,12 @@ func ExampleVirtualMachineRunCommandsClient_NewListByVirtualMachinePager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineRunCommandsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByVirtualMachinePager("<resource-group-name>",
-		"<vm-name>",
+	pager := client.NewListByVirtualMachinePager("myResourceGroup",
+		"myVM",
 		&test.VirtualMachineRunCommandsClientListByVirtualMachineOptions{Expand: nil})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachines_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachines_client_test.go
@@ -25,11 +25,11 @@ func ExampleVirtualMachinesClient_NewListByLocationPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscriptionId}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByLocationPager("<location>",
+	pager := client.NewListByLocationPager("eastus",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -50,15 +50,15 @@ func ExampleVirtualMachinesClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"myResourceGroup",
+		"myVM",
 		test.VirtualMachine{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("westus"),
 			Properties: &test.VirtualMachineProperties{
 				HardwareProfile: &test.HardwareProfile{
 					VMSize: to.Ptr(test.VirtualMachineSizeTypesStandardD2SV3),
@@ -66,16 +66,16 @@ func ExampleVirtualMachinesClient_BeginCreateOrUpdate() {
 				NetworkProfile: &test.NetworkProfile{
 					NetworkInterfaces: []*test.NetworkInterfaceReference{
 						{
-							ID: to.Ptr("<id>"),
+							ID: to.Ptr("/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Network/networkInterfaces/{existing-nic-name}"),
 							Properties: &test.NetworkInterfaceReferenceProperties{
 								Primary: to.Ptr(true),
 							},
 						}},
 				},
 				OSProfile: &test.OSProfile{
-					AdminPassword: to.Ptr("<admin-password>"),
-					AdminUsername: to.Ptr("<admin-username>"),
-					ComputerName:  to.Ptr("<computer-name>"),
+					AdminPassword: to.Ptr("{your-password}"),
+					AdminUsername: to.Ptr("{your-username}"),
+					ComputerName:  to.Ptr("myVM"),
 					LinuxConfiguration: &test.LinuxConfiguration{
 						PatchSettings: &test.LinuxPatchSettings{
 							AssessmentMode: to.Ptr(test.LinuxPatchAssessmentModeImageDefault),
@@ -85,13 +85,13 @@ func ExampleVirtualMachinesClient_BeginCreateOrUpdate() {
 				},
 				StorageProfile: &test.StorageProfile{
 					ImageReference: &test.ImageReference{
-						Offer:     to.Ptr("<offer>"),
-						Publisher: to.Ptr("<publisher>"),
-						SKU:       to.Ptr("<sku>"),
-						Version:   to.Ptr("<version>"),
+						Offer:     to.Ptr("UbuntuServer"),
+						Publisher: to.Ptr("Canonical"),
+						SKU:       to.Ptr("16.04-LTS"),
+						Version:   to.Ptr("latest"),
 					},
 					OSDisk: &test.OSDisk{
-						Name:         to.Ptr("<name>"),
+						Name:         to.Ptr("myVMosdisk"),
 						Caching:      to.Ptr(test.CachingTypesReadWrite),
 						CreateOption: to.Ptr(test.DiskCreateOptionTypesFromImage),
 						ManagedDisk: &test.ManagedDiskParameters{
@@ -120,13 +120,13 @@ func ExampleVirtualMachinesClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"myResourceGroup",
+		"myVM",
 		test.VirtualMachineUpdate{
 			Properties: &test.VirtualMachineProperties{
 				HardwareProfile: &test.HardwareProfile{
@@ -135,16 +135,16 @@ func ExampleVirtualMachinesClient_BeginUpdate() {
 				NetworkProfile: &test.NetworkProfile{
 					NetworkInterfaces: []*test.NetworkInterfaceReference{
 						{
-							ID: to.Ptr("<id>"),
+							ID: to.Ptr("/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Network/networkInterfaces/{existing-nic-name}"),
 							Properties: &test.NetworkInterfaceReferenceProperties{
 								Primary: to.Ptr(true),
 							},
 						}},
 				},
 				OSProfile: &test.OSProfile{
-					AdminPassword: to.Ptr("<admin-password>"),
-					AdminUsername: to.Ptr("<admin-username>"),
-					ComputerName:  to.Ptr("<computer-name>"),
+					AdminPassword: to.Ptr("{your-password}"),
+					AdminUsername: to.Ptr("{your-username}"),
+					ComputerName:  to.Ptr("myVM"),
 				},
 				StorageProfile: &test.StorageProfile{
 					DataDisks: []*test.DataDisk{
@@ -161,13 +161,13 @@ func ExampleVirtualMachinesClient_BeginUpdate() {
 							ToBeDetached: to.Ptr(false),
 						}},
 					ImageReference: &test.ImageReference{
-						Offer:     to.Ptr("<offer>"),
-						Publisher: to.Ptr("<publisher>"),
-						SKU:       to.Ptr("<sku>"),
-						Version:   to.Ptr("<version>"),
+						Offer:     to.Ptr("WindowsServer"),
+						Publisher: to.Ptr("MicrosoftWindowsServer"),
+						SKU:       to.Ptr("2016-Datacenter"),
+						Version:   to.Ptr("latest"),
 					},
 					OSDisk: &test.OSDisk{
-						Name:         to.Ptr("<name>"),
+						Name:         to.Ptr("myVMosdisk"),
 						Caching:      to.Ptr(test.CachingTypesReadWrite),
 						CreateOption: to.Ptr(test.DiskCreateOptionTypesFromImage),
 						ManagedDisk: &test.ManagedDiskParameters{
@@ -196,13 +196,13 @@ func ExampleVirtualMachinesClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"myResourceGroup",
+		"myVM",
 		&test.VirtualMachinesClientBeginDeleteOptions{ForceDeletion: to.Ptr(true)})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -220,13 +220,13 @@ func ExampleVirtualMachinesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"myResourceGroup",
+		"myVM",
 		&test.VirtualMachinesClientGetOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -242,13 +242,13 @@ func ExampleVirtualMachinesClient_InstanceView() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.InstanceView(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"myResourceGroup",
+		"myVM",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -264,13 +264,13 @@ func ExampleVirtualMachinesClient_Generalize() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	_, err = client.Generalize(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"myResourceGroup",
+		"myVMName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -284,12 +284,12 @@ func ExampleVirtualMachinesClient_NewListAvailableSizesPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListAvailableSizesPager("<resource-group-name>",
-		"<vm-name>",
+	pager := client.NewListAvailableSizesPager("myResourceGroup",
+		"myVmName",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -310,13 +310,13 @@ func ExampleVirtualMachinesClient_BeginReapply() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginReapply(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"ResourceGroup",
+		"VMName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -334,13 +334,13 @@ func ExampleVirtualMachinesClient_BeginReimage() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginReimage(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"myResourceGroup",
+		"myVMName",
 		&test.VirtualMachinesClientBeginReimageOptions{Parameters: &test.VirtualMachineReimageParameters{
 			TempDisk: to.Ptr(true),
 		},
@@ -361,13 +361,13 @@ func ExampleVirtualMachinesClient_RetrieveBootDiagnosticsData() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.RetrieveBootDiagnosticsData(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"ResourceGroup",
+		"VMName",
 		&test.VirtualMachinesClientRetrieveBootDiagnosticsDataOptions{SasURIExpirationTimeInMinutes: to.Ptr[int32](60)})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -383,13 +383,13 @@ func ExampleVirtualMachinesClient_SimulateEviction() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	_, err = client.SimulateEviction(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"ResourceGroup",
+		"VMName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -403,13 +403,13 @@ func ExampleVirtualMachinesClient_BeginAssessPatches() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginAssessPatches(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"myResourceGroupName",
+		"myVMName",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -429,15 +429,15 @@ func ExampleVirtualMachinesClient_BeginInstallPatches() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginInstallPatches(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"myResourceGroupName",
+		"myVMName",
 		test.VirtualMachineInstallPatchesParameters{
-			MaximumDuration: to.Ptr("<maximum-duration>"),
+			MaximumDuration: to.Ptr("PT4H"),
 			RebootSetting:   to.Ptr(test.VMGuestPatchRebootSettingIfRequired),
 			WindowsParameters: &test.WindowsParameters{
 				ClassificationsToInclude: []*test.VMGuestPatchClassificationWindows{
@@ -465,15 +465,15 @@ func ExampleVirtualMachinesClient_BeginRunCommand() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachinesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachinesClient("24fb23e3-6ba3-41f0-9b6e-e41131d5d61e", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginRunCommand(ctx,
-		"<resource-group-name>",
-		"<vm-name>",
+		"crptestar98131",
+		"vm3036",
 		test.RunCommandInput{
-			CommandID: to.Ptr("<command-id>"),
+			CommandID: to.Ptr("RunPowerShellScript"),
 		},
 		nil)
 	if err != nil {

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachinescalesetrollingupgrades_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachinescalesetrollingupgrades_client_test.go
@@ -24,13 +24,13 @@ func ExampleVirtualMachineScaleSetRollingUpgradesClient_BeginStartExtensionUpgra
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetRollingUpgradesClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetRollingUpgradesClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginStartExtensionUpgrade(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
+		"myResourceGroup",
+		"{vmss-name}",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachinescalesets_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachinescalesets_client_test.go
@@ -25,11 +25,11 @@ func ExampleVirtualMachineScaleSetsClient_NewListByLocationPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByLocationPager("<location>",
+	pager := client.NewListByLocationPager("eastus",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -58,7 +58,7 @@ func ExampleVirtualMachineScaleSetsClient_BeginCreateOrUpdate() {
 		"<resource-group-name>",
 		"<vm-scale-set-name>",
 		test.VirtualMachineScaleSet{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("westus"),
 			Properties: &test.VirtualMachineScaleSetProperties{
 				Overprovision: to.Ptr(true),
 				UpgradePolicy: &test.UpgradePolicy{
@@ -68,15 +68,15 @@ func ExampleVirtualMachineScaleSetsClient_BeginCreateOrUpdate() {
 					NetworkProfile: &test.VirtualMachineScaleSetNetworkProfile{
 						NetworkInterfaceConfigurations: []*test.VirtualMachineScaleSetNetworkConfiguration{
 							{
-								Name: to.Ptr("<name>"),
+								Name: to.Ptr("{vmss-name}"),
 								Properties: &test.VirtualMachineScaleSetNetworkConfigurationProperties{
 									EnableIPForwarding: to.Ptr(true),
 									IPConfigurations: []*test.VirtualMachineScaleSetIPConfiguration{
 										{
-											Name: to.Ptr("<name>"),
+											Name: to.Ptr("{vmss-name}"),
 											Properties: &test.VirtualMachineScaleSetIPConfigurationProperties{
 												Subnet: &test.APIEntityReference{
-													ID: to.Ptr("<id>"),
+													ID: to.Ptr("/subscriptions/{subscription-id}/resourceGroups/myResourceGroup/providers/Microsoft.Network/virtualNetworks/{existing-virtual-network-name}/subnets/{existing-subnet-name}"),
 												},
 											},
 										}},
@@ -85,17 +85,17 @@ func ExampleVirtualMachineScaleSetsClient_BeginCreateOrUpdate() {
 							}},
 					},
 					OSProfile: &test.VirtualMachineScaleSetOSProfile{
-						AdminPassword:      to.Ptr("<admin-password>"),
-						AdminUsername:      to.Ptr("<admin-username>"),
-						ComputerNamePrefix: to.Ptr("<computer-name-prefix>"),
+						AdminPassword:      to.Ptr("{your-password}"),
+						AdminUsername:      to.Ptr("{your-username}"),
+						ComputerNamePrefix: to.Ptr("{vmss-name}"),
 					},
 					StorageProfile: &test.VirtualMachineScaleSetStorageProfile{
 						OSDisk: &test.VirtualMachineScaleSetOSDisk{
-							Name:         to.Ptr("<name>"),
+							Name:         to.Ptr("osDisk"),
 							Caching:      to.Ptr(test.CachingTypesReadWrite),
 							CreateOption: to.Ptr(test.DiskCreateOptionTypesFromImage),
 							Image: &test.VirtualHardDisk{
-								URI: to.Ptr("<uri>"),
+								URI: to.Ptr("http://{existing-storage-account-name}.blob.core.windows.net/{existing-container-name}/{existing-generalized-os-image-blob-name}.vhd"),
 							},
 						},
 					},
@@ -121,13 +121,13 @@ func ExampleVirtualMachineScaleSetsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
+		"myResourceGroup",
+		"myvmScaleSet",
 		&test.VirtualMachineScaleSetsClientBeginDeleteOptions{ForceDeletion: to.Ptr(true)})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -145,13 +145,13 @@ func ExampleVirtualMachineScaleSetsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
+		"myResourceGroup",
+		"myVirtualMachineScaleSet",
 		&test.VirtualMachineScaleSetsClientGetOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachinescalesetvmextensions_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachinescalesetvmextensions_client_test.go
@@ -25,20 +25,20 @@ func ExampleVirtualMachineScaleSetVMExtensionsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMExtensionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMExtensionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
-		"<vm-extension-name>",
+		"myResourceGroup",
+		"myvmScaleSet",
+		"0",
+		"myVMExtension",
 		test.VirtualMachineScaleSetVMExtension{
 			Properties: &test.VirtualMachineExtensionProperties{
-				Type:                    to.Ptr("<type>"),
+				Type:                    to.Ptr("extType"),
 				AutoUpgradeMinorVersion: to.Ptr(true),
-				Publisher:               to.Ptr("<publisher>"),
+				Publisher:               to.Ptr("extPublisher"),
 				Settings: map[string]interface{}{
 					"UserName": "xyz@microsoft.com",
 					"items": []interface{}{
@@ -65,7 +65,7 @@ func ExampleVirtualMachineScaleSetVMExtensionsClient_BeginCreateOrUpdate() {
 					"styleSettings": map[string]interface{}{},
 					"test":          float64(1),
 				},
-				TypeHandlerVersion: to.Ptr("<type-handler-version>"),
+				TypeHandlerVersion: to.Ptr("1.2"),
 			},
 		},
 		nil)
@@ -87,24 +87,24 @@ func ExampleVirtualMachineScaleSetVMExtensionsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMExtensionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMExtensionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
-		"<vm-extension-name>",
+		"myResourceGroup",
+		"myvmScaleSet",
+		"0",
+		"myVMExtension",
 		test.VirtualMachineScaleSetVMExtensionUpdate{
 			Properties: &test.VirtualMachineExtensionUpdateProperties{
-				Type:                    to.Ptr("<type>"),
+				Type:                    to.Ptr("extType"),
 				AutoUpgradeMinorVersion: to.Ptr(true),
-				Publisher:               to.Ptr("<publisher>"),
+				Publisher:               to.Ptr("extPublisher"),
 				Settings: map[string]interface{}{
 					"UserName": "xyz@microsoft.com",
 				},
-				TypeHandlerVersion: to.Ptr("<type-handler-version>"),
+				TypeHandlerVersion: to.Ptr("1.2"),
 			},
 		},
 		nil)
@@ -126,15 +126,15 @@ func ExampleVirtualMachineScaleSetVMExtensionsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMExtensionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMExtensionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
-		"<vm-extension-name>",
+		"myResourceGroup",
+		"myvmScaleSet",
+		"0",
+		"myVMExtension",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -152,15 +152,15 @@ func ExampleVirtualMachineScaleSetVMExtensionsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMExtensionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMExtensionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
-		"<vm-extension-name>",
+		"myResourceGroup",
+		"myvmScaleSet",
+		"0",
+		"myVMExtension",
 		&test.VirtualMachineScaleSetVMExtensionsClientGetOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -176,14 +176,14 @@ func ExampleVirtualMachineScaleSetVMExtensionsClient_List() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMExtensionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMExtensionsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.List(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
+		"myResourceGroup",
+		"myvmScaleSet",
+		"0",
 		&test.VirtualMachineScaleSetVMExtensionsClientListOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachinescalesetvmruncommands_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachinescalesetvmruncommands_client_test.go
@@ -25,32 +25,32 @@ func ExampleVirtualMachineScaleSetVMRunCommandsClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMRunCommandsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
-		"<run-command-name>",
+		"myResourceGroup",
+		"myvmScaleSet",
+		"0",
+		"myRunCommand",
 		test.VirtualMachineRunCommand{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("West US"),
 			Properties: &test.VirtualMachineRunCommandProperties{
 				AsyncExecution: to.Ptr(false),
 				Parameters: []*test.RunCommandInputParameter{
 					{
-						Name:  to.Ptr("<name>"),
-						Value: to.Ptr("<value>"),
+						Name:  to.Ptr("param1"),
+						Value: to.Ptr("value1"),
 					},
 					{
-						Name:  to.Ptr("<name>"),
-						Value: to.Ptr("<value>"),
+						Name:  to.Ptr("param2"),
+						Value: to.Ptr("value2"),
 					}},
-				RunAsPassword: to.Ptr("<run-as-password>"),
-				RunAsUser:     to.Ptr("<run-as-user>"),
+				RunAsPassword: to.Ptr("<runAsPassword>"),
+				RunAsUser:     to.Ptr("user1"),
 				Source: &test.VirtualMachineRunCommandScriptSource{
-					Script: to.Ptr("<script>"),
+					Script: to.Ptr("Write-Host Hello World!"),
 				},
 				TimeoutInSeconds: to.Ptr[int32](3600),
 			},
@@ -74,19 +74,19 @@ func ExampleVirtualMachineScaleSetVMRunCommandsClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMRunCommandsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
-		"<run-command-name>",
+		"myResourceGroup",
+		"myvmScaleSet",
+		"0",
+		"myRunCommand",
 		test.VirtualMachineRunCommandUpdate{
 			Properties: &test.VirtualMachineRunCommandProperties{
 				Source: &test.VirtualMachineRunCommandScriptSource{
-					Script: to.Ptr("<script>"),
+					Script: to.Ptr("Write-Host Script Source Updated!"),
 				},
 			},
 		},
@@ -109,15 +109,15 @@ func ExampleVirtualMachineScaleSetVMRunCommandsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMRunCommandsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
-		"<run-command-name>",
+		"myResourceGroup",
+		"myvmScaleSet",
+		"0",
+		"myRunCommand",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -135,15 +135,15 @@ func ExampleVirtualMachineScaleSetVMRunCommandsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMRunCommandsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
-		"<run-command-name>",
+		"myResourceGroup",
+		"myvmScaleSet",
+		"0",
+		"myRunCommand",
 		&test.VirtualMachineScaleSetVMRunCommandsClientGetOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -159,13 +159,13 @@ func ExampleVirtualMachineScaleSetVMRunCommandsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMRunCommandsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMRunCommandsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
+	pager := client.NewListPager("myResourceGroup",
+		"myvmScaleSet",
+		"0",
 		&test.VirtualMachineScaleSetVMRunCommandsClientListOptions{Expand: nil})
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachinescalesetvms_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/compute/test/ze_generated_example_virtualmachinescalesetvms_client_test.go
@@ -25,14 +25,14 @@ func ExampleVirtualMachineScaleSetVMsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
+		"myResourceGroup",
+		"myvmScaleSet",
+		"0",
 		&test.VirtualMachineScaleSetVMsClientBeginDeleteOptions{ForceDeletion: to.Ptr(true)})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -50,14 +50,14 @@ func ExampleVirtualMachineScaleSetVMsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
+		"myResourceGroup",
+		"{vmss-name}",
+		"0",
 		&test.VirtualMachineScaleSetVMsClientGetOptions{Expand: nil})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -73,14 +73,14 @@ func ExampleVirtualMachineScaleSetVMsClient_GetInstanceView() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.GetInstanceView(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
+		"myResourceGroup",
+		"myVirtualMachineScaleSet",
+		"0",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -96,14 +96,14 @@ func ExampleVirtualMachineScaleSetVMsClient_RetrieveBootDiagnosticsData() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.RetrieveBootDiagnosticsData(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
+		"ResourceGroup",
+		"myvmScaleSet",
+		"0",
 		&test.VirtualMachineScaleSetVMsClientRetrieveBootDiagnosticsDataOptions{SasURIExpirationTimeInMinutes: to.Ptr[int32](60)})
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -119,14 +119,14 @@ func ExampleVirtualMachineScaleSetVMsClient_SimulateEviction() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	_, err = client.SimulateEviction(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
+		"ResourceGroup",
+		"VmScaleSetName",
+		"InstanceId",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -140,16 +140,16 @@ func ExampleVirtualMachineScaleSetVMsClient_BeginRunCommand() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewVirtualMachineScaleSetVMsClient("<subscription-id>", cred, nil)
+	client, err := test.NewVirtualMachineScaleSetVMsClient("{subscription-id}", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginRunCommand(ctx,
-		"<resource-group-name>",
-		"<vm-scale-set-name>",
-		"<instance-id>",
+		"myResourceGroup",
+		"myVirtualMachineScaleSet",
+		"0",
 		test.RunCommandInput{
-			CommandID: to.Ptr("<command-id>"),
+			CommandID: to.Ptr("RunPowerShellScript"),
 			Script: []*string{
 				to.Ptr("# Test multi-line string\r\nWrite-Host Hello World!")},
 		},

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/__debug/go-tester.yaml
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/__debug/go-tester.yaml
@@ -10057,7 +10057,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -10090,10 +10090,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<location>",
+              "eastus",
               test.NameAvailabilityParameters{
-              Name: to.Ptr("<name>"),
-              Type: to.Ptr("<type>"),
+              Name: to.Ptr("mySignalRService"),
+              Type: to.Ptr("Microsoft.SignalRService/SignalR"),
               },
               nil
             opName: CheckNameAvailability
@@ -10148,7 +10148,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_444
@@ -10814,7 +10814,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_448
@@ -10828,7 +10828,7 @@ testModel:
               "myResourceGroup",
               nil
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
+              "myResourceGroup",
               nil
             opName: NewListByResourceGroupPager
             operation: *ref_446
@@ -11489,7 +11489,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -11510,8 +11510,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<resource-name>",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: Get
             operation: *ref_451
@@ -12159,7 +12159,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -12504,10 +12504,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<resource-name>",
+              "myResourceGroup",
+              "mySignalRService",
               test.ResourceInfo{
-              Location: to.Ptr("<location>"),
+              Location: to.Ptr("eastus"),
               Tags: map[string]*string{
               "key1": to.Ptr("value1"),
               },
@@ -12528,25 +12528,25 @@ testModel:
               Flag: to.Ptr(test.FeatureFlagsServiceMode),
               Properties: map[string]*string{
               },
-              Value: to.Ptr("<value>"),
+              Value: to.Ptr("Serverless"),
               },
               {
               Flag: to.Ptr(test.FeatureFlagsEnableConnectivityLogs),
               Properties: map[string]*string{
               },
-              Value: to.Ptr("<value>"),
+              Value: to.Ptr("True"),
               },
               {
               Flag: to.Ptr(test.FeatureFlagsEnableMessagingLogs),
               Properties: map[string]*string{
               },
-              Value: to.Ptr("<value>"),
+              Value: to.Ptr("False"),
               },
               {
               Flag: to.Ptr(test.FeatureFlagsEnableLiveTrace),
               Properties: map[string]*string{
               },
-              Value: to.Ptr("<value>"),
+              Value: to.Ptr("False"),
               }},
               NetworkACLs: &test.SignalRNetworkACLs{
               DefaultAction: to.Ptr(test.ACLActionDeny),
@@ -12554,14 +12554,14 @@ testModel:
               {
               Allow: []*test.SignalRRequestType{
               to.Ptr(test.SignalRRequestTypeServerConnection)},
-              Name: to.Ptr("<name>"),
+              Name: to.Ptr("mysignalrservice.1fa229cd-bf3f-47f0-8c49-afb36723997e"),
               }},
               PublicNetwork: &test.NetworkACL{
               Allow: []*test.SignalRRequestType{
               to.Ptr(test.SignalRRequestTypeClientConnection)},
               },
               },
-              PublicNetworkAccess: to.Ptr("<public-network-access>"),
+              PublicNetworkAccess: to.Ptr("Enabled"),
               TLS: &test.SignalRTLSSettings{
               ClientCertEnabled: to.Ptr(false),
               },
@@ -12571,18 +12571,18 @@ testModel:
               Auth: &test.UpstreamAuthSettings{
               Type: to.Ptr(test.UpstreamAuthTypeManagedIdentity),
               ManagedIdentity: &test.ManagedIdentitySettings{
-              Resource: to.Ptr("<resource>"),
+              Resource: to.Ptr("api://example"),
               },
               },
-              CategoryPattern: to.Ptr("<category-pattern>"),
-              EventPattern: to.Ptr("<event-pattern>"),
-              HubPattern: to.Ptr("<hub-pattern>"),
-              URLTemplate: to.Ptr("<urltemplate>"),
+              CategoryPattern: to.Ptr("*"),
+              EventPattern: to.Ptr("connect,disconnect"),
+              HubPattern: to.Ptr("*"),
+              URLTemplate: to.Ptr("https://example.com/chat/api/connect"),
               }},
               },
               },
               SKU: &test.ResourceSKU{
-              Name: to.Ptr("<name>"),
+              Name: to.Ptr("Standard_S1"),
               Capacity: to.Ptr[int32](1),
               Tier: to.Ptr(test.SignalRSKUTierStandard),
               },
@@ -13623,7 +13623,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -13644,8 +13644,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<resource-name>",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: BeginDelete
             operation: *ref_470
@@ -13678,7 +13678,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -14023,10 +14023,10 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<resource-name>",
+              "myResourceGroup",
+              "mySignalRService",
               test.ResourceInfo{
-              Location: to.Ptr("<location>"),
+              Location: to.Ptr("eastus"),
               Tags: map[string]*string{
               "key1": to.Ptr("value1"),
               },
@@ -14047,25 +14047,25 @@ testModel:
               Flag: to.Ptr(test.FeatureFlagsServiceMode),
               Properties: map[string]*string{
               },
-              Value: to.Ptr("<value>"),
+              Value: to.Ptr("Serverless"),
               },
               {
               Flag: to.Ptr(test.FeatureFlagsEnableConnectivityLogs),
               Properties: map[string]*string{
               },
-              Value: to.Ptr("<value>"),
+              Value: to.Ptr("True"),
               },
               {
               Flag: to.Ptr(test.FeatureFlagsEnableMessagingLogs),
               Properties: map[string]*string{
               },
-              Value: to.Ptr("<value>"),
+              Value: to.Ptr("False"),
               },
               {
               Flag: to.Ptr(test.FeatureFlagsEnableLiveTrace),
               Properties: map[string]*string{
               },
-              Value: to.Ptr("<value>"),
+              Value: to.Ptr("False"),
               }},
               NetworkACLs: &test.SignalRNetworkACLs{
               DefaultAction: to.Ptr(test.ACLActionDeny),
@@ -14073,14 +14073,14 @@ testModel:
               {
               Allow: []*test.SignalRRequestType{
               to.Ptr(test.SignalRRequestTypeServerConnection)},
-              Name: to.Ptr("<name>"),
+              Name: to.Ptr("mysignalrservice.1fa229cd-bf3f-47f0-8c49-afb36723997e"),
               }},
               PublicNetwork: &test.NetworkACL{
               Allow: []*test.SignalRRequestType{
               to.Ptr(test.SignalRRequestTypeClientConnection)},
               },
               },
-              PublicNetworkAccess: to.Ptr("<public-network-access>"),
+              PublicNetworkAccess: to.Ptr("Enabled"),
               TLS: &test.SignalRTLSSettings{
               ClientCertEnabled: to.Ptr(false),
               },
@@ -14090,18 +14090,18 @@ testModel:
               Auth: &test.UpstreamAuthSettings{
               Type: to.Ptr(test.UpstreamAuthTypeManagedIdentity),
               ManagedIdentity: &test.ManagedIdentitySettings{
-              Resource: to.Ptr("<resource>"),
+              Resource: to.Ptr("api://example"),
               },
               },
-              CategoryPattern: to.Ptr("<category-pattern>"),
-              EventPattern: to.Ptr("<event-pattern>"),
-              HubPattern: to.Ptr("<hub-pattern>"),
-              URLTemplate: to.Ptr("<urltemplate>"),
+              CategoryPattern: to.Ptr("*"),
+              EventPattern: to.Ptr("connect,disconnect"),
+              HubPattern: to.Ptr("*"),
+              URLTemplate: to.Ptr("https://example.com/chat/api/connect"),
               }},
               },
               },
               SKU: &test.ResourceSKU{
-              Name: to.Ptr("<name>"),
+              Name: to.Ptr("Standard_S1"),
               Capacity: to.Ptr[int32](1),
               Tier: to.Ptr(test.SignalRSKUTierStandard),
               },
@@ -14756,7 +14756,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -14777,8 +14777,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<resource-name>",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: ListKeys
             operation: *ref_480
@@ -14817,7 +14817,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -14851,8 +14851,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<resource-name>",
+              "myResourceGroup",
+              "mySignalRService",
               test.RegenerateKeyParameters{
               KeyType: to.Ptr(test.KeyTypePrimary),
               },
@@ -14891,7 +14891,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -14912,8 +14912,8 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<resource-group-name>",
-              "<resource-name>",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: BeginRestart
             operation: *ref_491
@@ -14945,7 +14945,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_506
@@ -14959,7 +14959,7 @@ testModel:
               "eastus",
               nil
             methodParametersPlaceholderOutput: |-
-              "<location>",
+              "eastus",
               nil
             opName: NewListPager
             operation: *ref_494
@@ -15091,7 +15091,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_513
@@ -15111,8 +15111,8 @@ testModel:
               "mySignalRService",
               nil
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
-              "<resource-name>",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: NewListPager
             operation: *ref_509
@@ -15291,7 +15291,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -15318,9 +15318,9 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<private-endpoint-connection-name>",
-              "<resource-group-name>",
-              "<resource-name>",
+              "mysignalrservice.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: Get
             operation: *ref_517
@@ -15486,7 +15486,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -15557,16 +15557,16 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<private-endpoint-connection-name>",
-              "<resource-group-name>",
-              "<resource-name>",
+              "mysignalrservice.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "myResourceGroup",
+              "mySignalRService",
               test.PrivateEndpointConnection{
               Properties: &test.PrivateEndpointConnectionProperties{
               PrivateEndpoint: &test.PrivateEndpoint{
-              ID: to.Ptr("<id>"),
+              ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"),
               },
               PrivateLinkServiceConnectionState: &test.PrivateLinkServiceConnectionState{
-              ActionsRequired: to.Ptr("<actions-required>"),
+              ActionsRequired: to.Ptr("None"),
               Status: to.Ptr(test.PrivateLinkServiceConnectionStatusApproved),
               },
               },
@@ -15737,7 +15737,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -15764,9 +15764,9 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<private-endpoint-connection-name>",
-              "<resource-group-name>",
-              "<resource-name>",
+              "mysignalrservice.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: BeginDelete
             operation: *ref_529
@@ -15799,7 +15799,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_548
@@ -15819,8 +15819,8 @@ testModel:
               "mySignalRService",
               nil
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
-              "<resource-name>",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: NewListPager
             operation: *ref_533
@@ -15963,7 +15963,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             isPageable: *ref_561
@@ -15983,8 +15983,8 @@ testModel:
               "mySignalRService",
               nil
             methodParametersPlaceholderOutput: |-
-              "<resource-group-name>",
-              "<resource-name>",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: NewListPager
             operation: *ref_551
@@ -16090,7 +16090,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: false
             isMultiRespOperation: false
             methodParameters:
@@ -16117,9 +16117,9 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<shared-private-link-resource-name>",
-              "<resource-group-name>",
-              "<resource-name>",
+              "upstream",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: Get
             operation: *ref_565
@@ -16215,7 +16215,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -16272,14 +16272,14 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<shared-private-link-resource-name>",
-              "<resource-group-name>",
-              "<resource-name>",
+              "upstream",
+              "myResourceGroup",
+              "mySignalRService",
               test.SharedPrivateLinkResource{
               Properties: &test.SharedPrivateLinkResourceProperties{
-              GroupID: to.Ptr("<group-id>"),
-              PrivateLinkResourceID: to.Ptr("<private-link-resource-id>"),
-              RequestMessage: to.Ptr("<request-message>"),
+              GroupID: to.Ptr("sites"),
+              PrivateLinkResourceID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Web/sites/myWebApp"),
+              RequestMessage: to.Ptr("Please approve"),
               },
               },
               nil
@@ -16432,7 +16432,7 @@ testModel:
                   language: *ref_368
                 parameter: *ref_182
             clientParametersOutput: '"00000000-0000-0000-0000-000000000000"'
-            clientParametersPlaceholderOutput: '"<subscription-id>"'
+            clientParametersPlaceholderOutput: '"00000000-0000-0000-0000-000000000000"'
             isLRO: true
             isMultiRespOperation: false
             methodParameters:
@@ -16459,9 +16459,9 @@ testModel:
               nil
             methodParametersPlaceholderOutput: |-
               ctx,
-              "<shared-private-link-resource-name>",
-              "<resource-group-name>",
-              "<resource-name>",
+              "upstream",
+              "myResourceGroup",
+              "mySignalRService",
               nil
             opName: BeginDelete
             operation: *ref_578

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/signalr/main.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/signalr/main.go
@@ -327,17 +327,32 @@ func signalrSample() {
 	usagesClientNewListPagerPager := usagesClient.NewListPager(location,
 		nil)
 	for usagesClientNewListPagerPager.More() {
+		_, err := usagesClientNewListPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step SignalR_ListByResourceGroup
 	signalRClientNewListByResourceGroupPagerPager := signalRClient.NewListByResourceGroupPager(resourceGroupName,
 		nil)
 	for signalRClientNewListByResourceGroupPagerPager.More() {
+		_, err := signalRClientNewListByResourceGroupPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step SignalR_ListBySubscription
 	signalRClientNewListBySubscriptionPagerPager := signalRClient.NewListBySubscriptionPager(nil)
 	for signalRClientNewListBySubscriptionPagerPager.More() {
+		_, err := signalRClientNewListBySubscriptionPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step Operations_List
@@ -347,6 +362,11 @@ func signalrSample() {
 	}
 	operationsClientNewListPagerPager := operationsClient.NewListPager(nil)
 	for operationsClientNewListPagerPager.More() {
+		_, err := operationsClientNewListPagerPager.NextPage(ctx)
+		if err != nil {
+			panic(err)
+		}
+		break
 	}
 
 	// From step SignalR_Delete

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/ze_generated_example_signalr_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/ze_generated_example_signalr_client_test.go
@@ -25,15 +25,15 @@ func ExampleSignalRClient_CheckNameAvailability() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.CheckNameAvailability(ctx,
-		"<location>",
+		"eastus",
 		test.NameAvailabilityParameters{
-			Name: to.Ptr("<name>"),
-			Type: to.Ptr("<type>"),
+			Name: to.Ptr("mySignalRService"),
+			Type: to.Ptr("Microsoft.SignalRService/SignalR"),
 		},
 		nil)
 	if err != nil {
@@ -50,7 +50,7 @@ func ExampleSignalRClient_NewListBySubscriptionPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
@@ -74,11 +74,11 @@ func ExampleSignalRClient_NewListByResourceGroupPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListByResourceGroupPager("<resource-group-name>",
+	pager := client.NewListByResourceGroupPager("myResourceGroup",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -99,13 +99,13 @@ func ExampleSignalRClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<resource-group-name>",
-		"<resource-name>",
+		"myResourceGroup",
+		"mySignalRService",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -121,15 +121,15 @@ func ExampleSignalRClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<resource-group-name>",
-		"<resource-name>",
+		"myResourceGroup",
+		"mySignalRService",
 		test.ResourceInfo{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("eastus"),
 			Tags: map[string]*string{
 				"key1": to.Ptr("value1"),
 			},
@@ -149,22 +149,22 @@ func ExampleSignalRClient_BeginCreateOrUpdate() {
 					{
 						Flag:       to.Ptr(test.FeatureFlagsServiceMode),
 						Properties: map[string]*string{},
-						Value:      to.Ptr("<value>"),
+						Value:      to.Ptr("Serverless"),
 					},
 					{
 						Flag:       to.Ptr(test.FeatureFlagsEnableConnectivityLogs),
 						Properties: map[string]*string{},
-						Value:      to.Ptr("<value>"),
+						Value:      to.Ptr("True"),
 					},
 					{
 						Flag:       to.Ptr(test.FeatureFlagsEnableMessagingLogs),
 						Properties: map[string]*string{},
-						Value:      to.Ptr("<value>"),
+						Value:      to.Ptr("False"),
 					},
 					{
 						Flag:       to.Ptr(test.FeatureFlagsEnableLiveTrace),
 						Properties: map[string]*string{},
-						Value:      to.Ptr("<value>"),
+						Value:      to.Ptr("False"),
 					}},
 				NetworkACLs: &test.SignalRNetworkACLs{
 					DefaultAction: to.Ptr(test.ACLActionDeny),
@@ -172,14 +172,14 @@ func ExampleSignalRClient_BeginCreateOrUpdate() {
 						{
 							Allow: []*test.SignalRRequestType{
 								to.Ptr(test.SignalRRequestTypeServerConnection)},
-							Name: to.Ptr("<name>"),
+							Name: to.Ptr("mysignalrservice.1fa229cd-bf3f-47f0-8c49-afb36723997e"),
 						}},
 					PublicNetwork: &test.NetworkACL{
 						Allow: []*test.SignalRRequestType{
 							to.Ptr(test.SignalRRequestTypeClientConnection)},
 					},
 				},
-				PublicNetworkAccess: to.Ptr("<public-network-access>"),
+				PublicNetworkAccess: to.Ptr("Enabled"),
 				TLS: &test.SignalRTLSSettings{
 					ClientCertEnabled: to.Ptr(false),
 				},
@@ -189,18 +189,18 @@ func ExampleSignalRClient_BeginCreateOrUpdate() {
 							Auth: &test.UpstreamAuthSettings{
 								Type: to.Ptr(test.UpstreamAuthTypeManagedIdentity),
 								ManagedIdentity: &test.ManagedIdentitySettings{
-									Resource: to.Ptr("<resource>"),
+									Resource: to.Ptr("api://example"),
 								},
 							},
-							CategoryPattern: to.Ptr("<category-pattern>"),
-							EventPattern:    to.Ptr("<event-pattern>"),
-							HubPattern:      to.Ptr("<hub-pattern>"),
-							URLTemplate:     to.Ptr("<urltemplate>"),
+							CategoryPattern: to.Ptr("*"),
+							EventPattern:    to.Ptr("connect,disconnect"),
+							HubPattern:      to.Ptr("*"),
+							URLTemplate:     to.Ptr("https://example.com/chat/api/connect"),
 						}},
 				},
 			},
 			SKU: &test.ResourceSKU{
-				Name:     to.Ptr("<name>"),
+				Name:     to.Ptr("Standard_S1"),
 				Capacity: to.Ptr[int32](1),
 				Tier:     to.Ptr(test.SignalRSKUTierStandard),
 			},
@@ -224,13 +224,13 @@ func ExampleSignalRClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<resource-group-name>",
-		"<resource-name>",
+		"myResourceGroup",
+		"mySignalRService",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -248,15 +248,15 @@ func ExampleSignalRClient_BeginUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginUpdate(ctx,
-		"<resource-group-name>",
-		"<resource-name>",
+		"myResourceGroup",
+		"mySignalRService",
 		test.ResourceInfo{
-			Location: to.Ptr("<location>"),
+			Location: to.Ptr("eastus"),
 			Tags: map[string]*string{
 				"key1": to.Ptr("value1"),
 			},
@@ -276,22 +276,22 @@ func ExampleSignalRClient_BeginUpdate() {
 					{
 						Flag:       to.Ptr(test.FeatureFlagsServiceMode),
 						Properties: map[string]*string{},
-						Value:      to.Ptr("<value>"),
+						Value:      to.Ptr("Serverless"),
 					},
 					{
 						Flag:       to.Ptr(test.FeatureFlagsEnableConnectivityLogs),
 						Properties: map[string]*string{},
-						Value:      to.Ptr("<value>"),
+						Value:      to.Ptr("True"),
 					},
 					{
 						Flag:       to.Ptr(test.FeatureFlagsEnableMessagingLogs),
 						Properties: map[string]*string{},
-						Value:      to.Ptr("<value>"),
+						Value:      to.Ptr("False"),
 					},
 					{
 						Flag:       to.Ptr(test.FeatureFlagsEnableLiveTrace),
 						Properties: map[string]*string{},
-						Value:      to.Ptr("<value>"),
+						Value:      to.Ptr("False"),
 					}},
 				NetworkACLs: &test.SignalRNetworkACLs{
 					DefaultAction: to.Ptr(test.ACLActionDeny),
@@ -299,14 +299,14 @@ func ExampleSignalRClient_BeginUpdate() {
 						{
 							Allow: []*test.SignalRRequestType{
 								to.Ptr(test.SignalRRequestTypeServerConnection)},
-							Name: to.Ptr("<name>"),
+							Name: to.Ptr("mysignalrservice.1fa229cd-bf3f-47f0-8c49-afb36723997e"),
 						}},
 					PublicNetwork: &test.NetworkACL{
 						Allow: []*test.SignalRRequestType{
 							to.Ptr(test.SignalRRequestTypeClientConnection)},
 					},
 				},
-				PublicNetworkAccess: to.Ptr("<public-network-access>"),
+				PublicNetworkAccess: to.Ptr("Enabled"),
 				TLS: &test.SignalRTLSSettings{
 					ClientCertEnabled: to.Ptr(false),
 				},
@@ -316,18 +316,18 @@ func ExampleSignalRClient_BeginUpdate() {
 							Auth: &test.UpstreamAuthSettings{
 								Type: to.Ptr(test.UpstreamAuthTypeManagedIdentity),
 								ManagedIdentity: &test.ManagedIdentitySettings{
-									Resource: to.Ptr("<resource>"),
+									Resource: to.Ptr("api://example"),
 								},
 							},
-							CategoryPattern: to.Ptr("<category-pattern>"),
-							EventPattern:    to.Ptr("<event-pattern>"),
-							HubPattern:      to.Ptr("<hub-pattern>"),
-							URLTemplate:     to.Ptr("<urltemplate>"),
+							CategoryPattern: to.Ptr("*"),
+							EventPattern:    to.Ptr("connect,disconnect"),
+							HubPattern:      to.Ptr("*"),
+							URLTemplate:     to.Ptr("https://example.com/chat/api/connect"),
 						}},
 				},
 			},
 			SKU: &test.ResourceSKU{
-				Name:     to.Ptr("<name>"),
+				Name:     to.Ptr("Standard_S1"),
 				Capacity: to.Ptr[int32](1),
 				Tier:     to.Ptr(test.SignalRSKUTierStandard),
 			},
@@ -351,13 +351,13 @@ func ExampleSignalRClient_ListKeys() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.ListKeys(ctx,
-		"<resource-group-name>",
-		"<resource-name>",
+		"myResourceGroup",
+		"mySignalRService",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -373,13 +373,13 @@ func ExampleSignalRClient_BeginRegenerateKey() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginRegenerateKey(ctx,
-		"<resource-group-name>",
-		"<resource-name>",
+		"myResourceGroup",
+		"mySignalRService",
 		test.RegenerateKeyParameters{
 			KeyType: to.Ptr(test.KeyTypePrimary),
 		},
@@ -400,13 +400,13 @@ func ExampleSignalRClient_BeginRestart() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginRestart(ctx,
-		"<resource-group-name>",
-		"<resource-name>",
+		"myResourceGroup",
+		"mySignalRService",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/ze_generated_example_signalrprivateendpointconnections_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/ze_generated_example_signalrprivateendpointconnections_client_test.go
@@ -25,12 +25,12 @@ func ExampleSignalRPrivateEndpointConnectionsClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRPrivateEndpointConnectionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRPrivateEndpointConnectionsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<resource-name>",
+	pager := client.NewListPager("myResourceGroup",
+		"mySignalRService",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -51,14 +51,14 @@ func ExampleSignalRPrivateEndpointConnectionsClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRPrivateEndpointConnectionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRPrivateEndpointConnectionsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<private-endpoint-connection-name>",
-		"<resource-group-name>",
-		"<resource-name>",
+		"mysignalrservice.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+		"myResourceGroup",
+		"mySignalRService",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -74,21 +74,21 @@ func ExampleSignalRPrivateEndpointConnectionsClient_Update() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRPrivateEndpointConnectionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRPrivateEndpointConnectionsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Update(ctx,
-		"<private-endpoint-connection-name>",
-		"<resource-group-name>",
-		"<resource-name>",
+		"mysignalrservice.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+		"myResourceGroup",
+		"mySignalRService",
 		test.PrivateEndpointConnection{
 			Properties: &test.PrivateEndpointConnectionProperties{
 				PrivateEndpoint: &test.PrivateEndpoint{
-					ID: to.Ptr("<id>"),
+					ID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Network/privateEndpoints/myPrivateEndpoint"),
 				},
 				PrivateLinkServiceConnectionState: &test.PrivateLinkServiceConnectionState{
-					ActionsRequired: to.Ptr("<actions-required>"),
+					ActionsRequired: to.Ptr("None"),
 					Status:          to.Ptr(test.PrivateLinkServiceConnectionStatusApproved),
 				},
 			},
@@ -108,14 +108,14 @@ func ExampleSignalRPrivateEndpointConnectionsClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRPrivateEndpointConnectionsClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRPrivateEndpointConnectionsClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<private-endpoint-connection-name>",
-		"<resource-group-name>",
-		"<resource-name>",
+		"mysignalrservice.1fa229cd-bf3f-47f0-8c49-afb36723997e",
+		"myResourceGroup",
+		"mySignalRService",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/ze_generated_example_signalrprivatelinkresources_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/ze_generated_example_signalrprivatelinkresources_client_test.go
@@ -22,12 +22,12 @@ func ExampleSignalRPrivateLinkResourcesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRPrivateLinkResourcesClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRPrivateLinkResourcesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<resource-name>",
+	pager := client.NewListPager("myResourceGroup",
+		"mySignalRService",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/ze_generated_example_signalrsharedprivatelinkresources_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/ze_generated_example_signalrsharedprivatelinkresources_client_test.go
@@ -25,12 +25,12 @@ func ExampleSignalRSharedPrivateLinkResourcesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRSharedPrivateLinkResourcesClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRSharedPrivateLinkResourcesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<resource-group-name>",
-		"<resource-name>",
+	pager := client.NewListPager("myResourceGroup",
+		"mySignalRService",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)
@@ -51,14 +51,14 @@ func ExampleSignalRSharedPrivateLinkResourcesClient_Get() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRSharedPrivateLinkResourcesClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRSharedPrivateLinkResourcesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	res, err := client.Get(ctx,
-		"<shared-private-link-resource-name>",
-		"<resource-group-name>",
-		"<resource-name>",
+		"upstream",
+		"myResourceGroup",
+		"mySignalRService",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)
@@ -74,19 +74,19 @@ func ExampleSignalRSharedPrivateLinkResourcesClient_BeginCreateOrUpdate() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRSharedPrivateLinkResourcesClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRSharedPrivateLinkResourcesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginCreateOrUpdate(ctx,
-		"<shared-private-link-resource-name>",
-		"<resource-group-name>",
-		"<resource-name>",
+		"upstream",
+		"myResourceGroup",
+		"mySignalRService",
 		test.SharedPrivateLinkResource{
 			Properties: &test.SharedPrivateLinkResourceProperties{
-				GroupID:               to.Ptr("<group-id>"),
-				PrivateLinkResourceID: to.Ptr("<private-link-resource-id>"),
-				RequestMessage:        to.Ptr("<request-message>"),
+				GroupID:               to.Ptr("sites"),
+				PrivateLinkResourceID: to.Ptr("/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/myResourceGroup/providers/Microsoft.Web/sites/myWebApp"),
+				RequestMessage:        to.Ptr("Please approve"),
 			},
 		},
 		nil)
@@ -108,14 +108,14 @@ func ExampleSignalRSharedPrivateLinkResourcesClient_BeginDelete() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewSignalRSharedPrivateLinkResourcesClient("<subscription-id>", cred, nil)
+	client, err := test.NewSignalRSharedPrivateLinkResourcesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
 	poller, err := client.BeginDelete(ctx,
-		"<shared-private-link-resource-name>",
-		"<resource-group-name>",
-		"<resource-name>",
+		"upstream",
+		"myResourceGroup",
+		"mySignalRService",
 		nil)
 	if err != nil {
 		log.Fatalf("failed to finish the request: %v", err)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/ze_generated_example_usages_client_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/ze_generated_example_usages_client_test.go
@@ -22,11 +22,11 @@ func ExampleUsagesClient_NewListPager() {
 		log.Fatalf("failed to obtain a credential: %v", err)
 	}
 	ctx := context.Background()
-	client, err := test.NewUsagesClient("<subscription-id>", cred, nil)
+	client, err := test.NewUsagesClient("00000000-0000-0000-0000-000000000000", cred, nil)
 	if err != nil {
 		log.Fatalf("failed to create client: %v", err)
 	}
-	pager := client.NewListPager("<location>",
+	pager := client.NewListPager("eastus",
 		nil)
 	for pager.More() {
 		nextResult, err := pager.NextPage(ctx)

--- a/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/zt_generated_signalr_live_test.go
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/integrationtest/output/signalr/test/zt_generated_signalr_live_test.go
@@ -315,17 +315,26 @@ func (testsuite *SignalrTestSuite) TestSignalr() {
 	usagesClientNewListPager := usagesClient.NewListPager(testsuite.location,
 		nil)
 	for usagesClientNewListPager.More() {
+		_, err := usagesClientNewListPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step SignalR_ListByResourceGroup
 	signalRClientNewListByResourceGroupPager := signalRClient.NewListByResourceGroupPager(testsuite.resourceGroupName,
 		nil)
 	for signalRClientNewListByResourceGroupPager.More() {
+		_, err := signalRClientNewListByResourceGroupPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step SignalR_ListBySubscription
 	signalRClientNewListBySubscriptionPager := signalRClient.NewListBySubscriptionPager(nil)
 	for signalRClientNewListBySubscriptionPager.More() {
+		_, err := signalRClientNewListBySubscriptionPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step Operations_List
@@ -333,6 +342,9 @@ func (testsuite *SignalrTestSuite) TestSignalr() {
 	testsuite.Require().NoError(err)
 	operationsClientNewListPager := operationsClient.NewListPager(nil)
 	for operationsClientNewListPager.More() {
+		_, err := operationsClientNewListPager.NextPage(ctx)
+		testsuite.Require().NoError(err)
+		break
 	}
 
 	// From step SignalR_Delete

--- a/tools/sdk-testgen/packages/autorest.gotest/test/unittest/generator/__snapshots__/testGoTester.ts.snap
+++ b/tools/sdk-testgen/packages/autorest.gotest/test/unittest/generator/__snapshots__/testGoTester.ts.snap
@@ -33,14 +33,14 @@ func ExampleExtensionsClient_Create() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewExtensionsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
 	_, err = client.Create(ctx,
-\\"<extension-id>\\",
-\\"<farm-beats-resource-name>\\",
-\\"<resource-group-name>\\",
+\\"provider.extension\\",
+\\"examples-farmbeatsResourceName\\",
+\\"examples-rg\\",
 nil)
 	if err != nil {
 		log.Fatalf(\\"failed to finish the request: %v\\", err)
@@ -56,14 +56,14 @@ func ExampleExtensionsClient_Get() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewExtensionsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
 	res, err := client.Get(ctx,
-\\"<extension-id>\\",
-\\"<farm-beats-resource-name>\\",
-\\"<resource-group-name>\\",
+\\"provider.extension\\",
+\\"examples-farmbeatsResourceName\\",
+\\"examples-rg\\",
 nil)
 	if err != nil {
 		log.Fatalf(\\"failed to finish the request: %v\\", err)
@@ -81,14 +81,14 @@ func ExampleExtensionsClient_Update() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewExtensionsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
 	res, err := client.Update(ctx,
-\\"<extension-id>\\",
-\\"<farm-beats-resource-name>\\",
-\\"<resource-group-name>\\",
+\\"provider.extension\\",
+\\"examples-farmbeatsResourceName\\",
+\\"examples-rg\\",
 nil)
 	if err != nil {
 		log.Fatalf(\\"failed to finish the request: %v\\", err)
@@ -106,14 +106,14 @@ func ExampleExtensionsClient_Delete() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewExtensionsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
 	_, err = client.Delete(ctx,
-\\"<extension-id>\\",
-\\"<farm-beats-resource-name>\\",
-\\"<resource-group-name>\\",
+\\"provider.extension\\",
+\\"examples-farmbeatsResourceName\\",
+\\"examples-rg\\",
 nil)
 	if err != nil {
 		log.Fatalf(\\"failed to finish the request: %v\\", err)
@@ -129,12 +129,12 @@ func ExampleExtensionsClient_NewListByFarmBeatsPager() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewExtensionsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
-	pager := client.NewListByFarmBeatsPager(\\"<resource-group-name>\\",
-\\"<farm-beats-resource-name>\\",
+	pager := client.NewListByFarmBeatsPager(\\"examples-rg\\",
+\\"examples-farmbeatsResourceName\\",
 &armagrifood.ExtensionsClientListByFarmBeatsOptions{ExtensionIDs: []string{},
 ExtensionCategories: []string{},
 MaxPageSize: nil,
@@ -221,7 +221,7 @@ func ExampleFarmBeatsExtensionsClient_Get() {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
 	res, err := client.Get(ctx,
-\\"<farm-beats-extension-id>\\",
+\\"DTN.ContentServices\\",
 nil)
 	if err != nil {
 		log.Fatalf(\\"failed to finish the request: %v\\", err)
@@ -263,13 +263,13 @@ func ExampleFarmBeatsModelsClient_Get() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
 	res, err := client.Get(ctx,
-\\"<resource-group-name>\\",
-\\"<farm-beats-resource-name>\\",
+\\"examples-rg\\",
+\\"examples-farmBeatsResourceName\\",
 nil)
 	if err != nil {
 		log.Fatalf(\\"failed to finish the request: %v\\", err)
@@ -287,19 +287,19 @@ func ExampleFarmBeatsModelsClient_CreateOrUpdate() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
 	res, err := client.CreateOrUpdate(ctx,
-\\"<farm-beats-resource-name>\\",
-\\"<resource-group-name>\\",
+\\"examples-farmbeatsResourceName\\",
+\\"examples-rg\\",
 armagrifood.FarmBeats{
 Tags: map[string]*string{
 \\"key1\\": to.Ptr(\\"value1\\"),
 \\"key2\\": to.Ptr(\\"value2\\"),
 },
-Location: to.Ptr(\\"<location>\\"),
+Location: to.Ptr(\\"eastus2\\"),
 },
 nil)
 	if err != nil {
@@ -318,13 +318,13 @@ func ExampleFarmBeatsModelsClient_Update() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
 	res, err := client.Update(ctx,
-\\"<farm-beats-resource-name>\\",
-\\"<resource-group-name>\\",
+\\"examples-farmBeatsResourceName\\",
+\\"examples-rg\\",
 armagrifood.FarmBeatsUpdateRequestModel{
 Tags: map[string]*string{
 \\"key1\\": to.Ptr(\\"value1\\"),
@@ -348,13 +348,13 @@ func ExampleFarmBeatsModelsClient_Delete() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
 	_, err = client.Delete(ctx,
-\\"<resource-group-name>\\",
-\\"<farm-beats-resource-name>\\",
+\\"examples-rg\\",
+\\"examples-farmBeatsResourceName\\",
 nil)
 	if err != nil {
 		log.Fatalf(\\"failed to finish the request: %v\\", err)
@@ -370,7 +370,7 @@ func ExampleFarmBeatsModelsClient_NewListBySubscriptionPager() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
@@ -398,11 +398,11 @@ func ExampleFarmBeatsModelsClient_NewListByResourceGroupPager() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
-	pager := client.NewListByResourceGroupPager(\\"<resource-group-name>\\",
+	pager := client.NewListByResourceGroupPager(\\"examples-rg\\",
 &armagrifood.FarmBeatsModelsClientListByResourceGroupOptions{MaxPageSize: nil,
 SkipToken: nil,
 })
@@ -451,14 +451,14 @@ func ExampleLocationsClient_CheckNameAvailability() {
 		log.Fatalf(\\"failed to obtain a credential: %v\\", err)
 	}
 	ctx := context.Background()
-	client, err := armagrifood.NewLocationsClient(\\"<subscription-id>\\", cred, nil)
+	client, err := armagrifood.NewLocationsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, nil)
     if err != nil {
 		log.Fatalf(\\"failed to create client: %v\\", err)
 	}
 	res, err := client.CheckNameAvailability(ctx,
 armagrifood.CheckNameAvailabilityRequest{
-Name: to.Ptr(\\"<name>\\"),
-Type: to.Ptr(\\"<type>\\"),
+Name: to.Ptr(\\"existingaccountname\\"),
+Type: to.Ptr(\\"Microsoft.AgFoodPlatform/farmBeats\\"),
 },
 nil)
 	if err != nil {
@@ -531,8 +531,6 @@ import (
 	\\"context\\"
 	\\"fmt\\"
 	\\"net/http\\"
-	\\"os\\"
-	\\"runtime/debug\\"
 	\\"testing\\"
 
 	\\"github.com/Azure/azure-sdk-for-go/sdk/azcore\\"
@@ -540,7 +538,8 @@ import (
     \\"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud\\"
 	\\"github.com/Azure/azure-sdk-for-go/sdk/azcore/policy\\"
     \\"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime\\"
-	\\"github.com/Azure/azure-sdk-for-go/sdk/azidentity\\"
+	\\"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/internal/testutil\\"
+	\\"github.com/stretchr/testify/suite\\"
 	\\"golang.org/x/net/http2\\"
 )
 import (
@@ -553,346 +552,31 @@ import (
 
 
 
-var (
-	ctx            context.Context
-    options        arm.ClientOptions
-	cred           azcore.TokenCredential
-	err            error
-	mockHost       string
-)
+type MockTestSuite struct {
+	suite.Suite
 
-
-
-func TestExtensions_Create(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Create.json
-	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            _, err = client.Create(ctx,
-\\"provider.extension\\",
-\\"examples-farmbeatsResourceName\\",
-\\"examples-rg\\",
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Create.json: %v\\", err)
-        }
+	cred              azcore.TokenCredential
+	options           arm.ClientOptions
 }
 
-
-func TestExtensions_Get(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Get.json
-	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            res, err := client.Get(ctx,
-\\"provider.extension\\",
-\\"examples-farmbeatsResourceName\\",
-\\"examples-rg\\",
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Get.json: %v\\", err)
-        }
-}
-
-
-func TestExtensions_Update(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Update.json
-	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            res, err := client.Update(ctx,
-\\"provider.extension\\",
-\\"examples-farmbeatsResourceName\\",
-\\"examples-rg\\",
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Update.json: %v\\", err)
-        }
-}
-
-
-func TestExtensions_Delete(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Delete.json
-	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            _, err = client.Delete(ctx,
-\\"provider.extension\\",
-\\"examples-farmbeatsResourceName\\",
-\\"examples-rg\\",
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Delete.json: %v\\", err)
-        }
-}
-
-
-func TestExtensions_ListByFarmBeats(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_ListByFarmBeats.json
-	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-        pager := client.NewListByFarmBeatsPager(\\"examples-rg\\",
-\\"examples-farmbeatsResourceName\\",
-&armagrifood.ExtensionsClientListByFarmBeatsOptions{ExtensionIDs: []string{},
-ExtensionCategories: []string{},
-MaxPageSize: nil,
-SkipToken: nil,
-})
-        for pager.More() {
-            _, err := pager.NextPage(ctx)
-            if err != nil {
-                t.Fatalf(\\"Failed to advance page for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_ListByFarmBeats.json: %v\\", err)
-                break
-            }
-        }
-}
-
-
-func TestFarmBeatsExtensions_List(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsExtensions_List.json
-	client, err := armagrifood.NewFarmBeatsExtensionsClient(cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-        pager := client.NewListPager(&armagrifood.FarmBeatsExtensionsClientListOptions{FarmBeatsExtensionIDs: []string{},
-FarmBeatsExtensionNames: []string{},
-ExtensionCategories: []string{},
-PublisherIDs: []string{},
-MaxPageSize: nil,
-})
-        for pager.More() {
-            _, err := pager.NextPage(ctx)
-            if err != nil {
-                t.Fatalf(\\"Failed to advance page for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsExtensions_List.json: %v\\", err)
-                break
-            }
-        }
-}
-
-
-func TestFarmBeatsExtensions_Get(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsExtensions_Get.json
-	client, err := armagrifood.NewFarmBeatsExtensionsClient(cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            res, err := client.Get(ctx,
-\\"DTN.ContentServices\\",
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsExtensions_Get.json: %v\\", err)
-        }
-}
-
-
-func TestFarmBeatsModels_Get(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Get.json
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            res, err := client.Get(ctx,
-\\"examples-rg\\",
-\\"examples-farmBeatsResourceName\\",
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Get.json: %v\\", err)
-        }
-}
-
-
-func TestFarmBeatsModels_CreateOrUpdate(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_CreateOrUpdate.json
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            res, err := client.CreateOrUpdate(ctx,
-\\"examples-farmbeatsResourceName\\",
-\\"examples-rg\\",
-armagrifood.FarmBeats{
-Tags: map[string]*string{
-\\"key1\\": to.Ptr(\\"value1\\"),
-\\"key2\\": to.Ptr(\\"value2\\"),
-},
-Location: to.Ptr(\\"eastus2\\"),
-},
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_CreateOrUpdate.json: %v\\", err)
-        }
-}
-
-
-func TestFarmBeatsModels_Update(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Update.json
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            res, err := client.Update(ctx,
-\\"examples-farmBeatsResourceName\\",
-\\"examples-rg\\",
-armagrifood.FarmBeatsUpdateRequestModel{
-Tags: map[string]*string{
-\\"key1\\": to.Ptr(\\"value1\\"),
-\\"key2\\": to.Ptr(\\"value2\\"),
-},
-},
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Update.json: %v\\", err)
-        }
-}
-
-
-func TestFarmBeatsModels_Delete(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Delete.json
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            _, err = client.Delete(ctx,
-\\"examples-rg\\",
-\\"examples-farmBeatsResourceName\\",
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Delete.json: %v\\", err)
-        }
-}
-
-
-func TestFarmBeatsModels_ListBySubscription(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_ListBySubscription.json
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-        pager := client.NewListBySubscriptionPager(&armagrifood.FarmBeatsModelsClientListBySubscriptionOptions{MaxPageSize: nil,
-SkipToken: nil,
-})
-        for pager.More() {
-            _, err := pager.NextPage(ctx)
-            if err != nil {
-                t.Fatalf(\\"Failed to advance page for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_ListBySubscription.json: %v\\", err)
-                break
-            }
-        }
-}
-
-
-func TestFarmBeatsModels_ListByResourceGroup(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_ListByResourceGroup.json
-	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-        pager := client.NewListByResourceGroupPager(\\"examples-rg\\",
-&armagrifood.FarmBeatsModelsClientListByResourceGroupOptions{MaxPageSize: nil,
-SkipToken: nil,
-})
-        for pager.More() {
-            _, err := pager.NextPage(ctx)
-            if err != nil {
-                t.Fatalf(\\"Failed to advance page for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_ListByResourceGroup.json: %v\\", err)
-                break
-            }
-        }
-}
-
-
-func TestLocations_CheckNameAvailability(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Locations_CheckNameAvailability_AlreadyExists.json
-	client, err := armagrifood.NewLocationsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            res, err := client.CheckNameAvailability(ctx,
-armagrifood.CheckNameAvailabilityRequest{
-Name: to.Ptr(\\"existingaccountname\\"),
-Type: to.Ptr(\\"Microsoft.AgFoodPlatform/farmBeats\\"),
-},
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Locations_CheckNameAvailability_AlreadyExists.json: %v\\", err)
-        }
-
-    
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Locations_CheckNameAvailability_Available.json
-    client, err = armagrifood.NewLocationsClient(\\"11111111-2222-3333-4444-555555555555\\", cred, &options)
-	if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-            res, err = client.CheckNameAvailability(ctx,
-armagrifood.CheckNameAvailabilityRequest{
-Name: to.Ptr(\\"newaccountname\\"),
-Type: to.Ptr(\\"Microsoft.AgFoodPlatform/farmBeats\\"),
-},
-nil)
-        if err != nil {
-            t.Fatalf(\\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Locations_CheckNameAvailability_Available.json: %v\\", err)
-        }
-}
-
-
-func TestOperations_List(t *testing.T) {
-    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Operations_List.json
-	client, err := armagrifood.NewOperationsClient(cred, &options)
-    if err != nil {
-		log.Fatalf(\\"failed to create client: %v\\", err)
-	}
-        pager := client.NewListPager(nil)
-        for pager.More() {
-            _, err := pager.NextPage(ctx)
-            if err != nil {
-                t.Fatalf(\\"Failed to advance page for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Operations_List.json: %v\\", err)
-                break
-            }
-        }
-}
-
-
-// TestMain will exec each test
-func TestMain(m *testing.M) {
-	setUp()
-	retCode := m.Run() // exec test and this returns an exit code to pass to os
-	tearDown()
-	os.Exit(retCode)
-}
-
-func getEnv(key, fallback string) string {
-    if value, ok := os.LookupEnv(key); ok {
-        return value
-    }
-    return fallback
-}
-
-func setUp() {
-	ctx = context.Background()
-	mockHost = getEnv(\\"AZURE_VIRTUAL_SERVER_HOST\\", \\"https://localhost:8443\\")
+func (testsuite *MockTestSuite) SetupSuite() {
+	mockHost := testutil.GetEnv(\\"AZURE_VIRTUAL_SERVER_HOST\\", \\"https://localhost:8443\\")
 
 	tr := &http.Transport{}
-	if err := http2.ConfigureTransport(tr); err != nil {
-		fmt.Printf(\\"Failed to configure http2 transport: %v\\", err)
-	}
+	err := http2.ConfigureTransport(tr)
+	testsuite.Require().NoError(err, \\"Failed to configure http2 transport\\")
 	tr.TLSClientConfig.InsecureSkipVerify = true
 	client := &http.Client{Transport: tr}
-	
-    cred = &MockCredential{}
 
-	options = arm.ClientOptions{
+	testsuite.cred = &MockCredential{}
+
+	testsuite.options = arm.ClientOptions{
 		ClientOptions: policy.ClientOptions{
 			Logging: policy.LogOptions{
 				IncludeBody: true,
 			},
 			Transport: client,
-            Cloud: cloud.Configuration{
+			Cloud: cloud.Configuration{
 				Services: map[cloud.ServiceName]cloud.ServiceConfiguration{
 					cloud.ResourceManager: {
 						Audience: mockHost,
@@ -904,9 +588,237 @@ func setUp() {
 	}
 }
 
-func tearDown() {
-
+func TestMockTest(t *testing.T) {
+	suite.Run(t, new(MockTestSuite))
 }
+
+
+
+func (testsuite *MockTestSuite) TestExtensions_Create() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Create.json
+	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+            _, err = client.Create(ctx,
+\\"provider.extension\\",
+\\"examples-farmbeatsResourceName\\",
+\\"examples-rg\\",
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Create.json\\")
+}
+
+
+func (testsuite *MockTestSuite) TestExtensions_Get() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Get.json
+	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+            res, err := client.Get(ctx,
+\\"provider.extension\\",
+\\"examples-farmbeatsResourceName\\",
+\\"examples-rg\\",
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Get.json\\")
+}
+
+
+func (testsuite *MockTestSuite) TestExtensions_Update() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Update.json
+	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+            res, err := client.Update(ctx,
+\\"provider.extension\\",
+\\"examples-farmbeatsResourceName\\",
+\\"examples-rg\\",
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Update.json\\")
+}
+
+
+func (testsuite *MockTestSuite) TestExtensions_Delete() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Delete.json
+	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+            _, err = client.Delete(ctx,
+\\"provider.extension\\",
+\\"examples-farmbeatsResourceName\\",
+\\"examples-rg\\",
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_Delete.json\\")
+}
+
+
+func (testsuite *MockTestSuite) TestExtensions_ListByFarmBeats() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_ListByFarmBeats.json
+	client, err := armagrifood.NewExtensionsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+        pager := client.NewListByFarmBeatsPager(\\"examples-rg\\",
+\\"examples-farmbeatsResourceName\\",
+&armagrifood.ExtensionsClientListByFarmBeatsOptions{ExtensionIDs: []string{},
+ExtensionCategories: []string{},
+MaxPageSize: nil,
+SkipToken: nil,
+})
+        for pager.More() {
+            _, err := pager.NextPage(ctx)
+            testsuite.Require().NoError(err, \\"Failed to advance page for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Extensions_ListByFarmBeats.json\\")
+        }
+}
+
+
+func (testsuite *MockTestSuite) TestFarmBeatsExtensions_List() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsExtensions_List.json
+	client, err := armagrifood.NewFarmBeatsExtensionsClient(testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+        pager := client.NewListPager(&armagrifood.FarmBeatsExtensionsClientListOptions{FarmBeatsExtensionIDs: []string{},
+FarmBeatsExtensionNames: []string{},
+ExtensionCategories: []string{},
+PublisherIDs: []string{},
+MaxPageSize: nil,
+})
+        for pager.More() {
+            _, err := pager.NextPage(ctx)
+            testsuite.Require().NoError(err, \\"Failed to advance page for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsExtensions_List.json\\")
+        }
+}
+
+
+func (testsuite *MockTestSuite) TestFarmBeatsExtensions_Get() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsExtensions_Get.json
+	client, err := armagrifood.NewFarmBeatsExtensionsClient(testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+            res, err := client.Get(ctx,
+\\"DTN.ContentServices\\",
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsExtensions_Get.json\\")
+}
+
+
+func (testsuite *MockTestSuite) TestFarmBeatsModels_Get() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Get.json
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+            res, err := client.Get(ctx,
+\\"examples-rg\\",
+\\"examples-farmBeatsResourceName\\",
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Get.json\\")
+}
+
+
+func (testsuite *MockTestSuite) TestFarmBeatsModels_CreateOrUpdate() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_CreateOrUpdate.json
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+            res, err := client.CreateOrUpdate(ctx,
+\\"examples-farmbeatsResourceName\\",
+\\"examples-rg\\",
+armagrifood.FarmBeats{
+Tags: map[string]*string{
+\\"key1\\": to.Ptr(\\"value1\\"),
+\\"key2\\": to.Ptr(\\"value2\\"),
+},
+Location: to.Ptr(\\"eastus2\\"),
+},
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_CreateOrUpdate.json\\")
+}
+
+
+func (testsuite *MockTestSuite) TestFarmBeatsModels_Update() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Update.json
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+            res, err := client.Update(ctx,
+\\"examples-farmBeatsResourceName\\",
+\\"examples-rg\\",
+armagrifood.FarmBeatsUpdateRequestModel{
+Tags: map[string]*string{
+\\"key1\\": to.Ptr(\\"value1\\"),
+\\"key2\\": to.Ptr(\\"value2\\"),
+},
+},
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Update.json\\")
+}
+
+
+func (testsuite *MockTestSuite) TestFarmBeatsModels_Delete() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Delete.json
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+            _, err = client.Delete(ctx,
+\\"examples-rg\\",
+\\"examples-farmBeatsResourceName\\",
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_Delete.json\\")
+}
+
+
+func (testsuite *MockTestSuite) TestFarmBeatsModels_ListBySubscription() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_ListBySubscription.json
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+        pager := client.NewListBySubscriptionPager(&armagrifood.FarmBeatsModelsClientListBySubscriptionOptions{MaxPageSize: nil,
+SkipToken: nil,
+})
+        for pager.More() {
+            _, err := pager.NextPage(ctx)
+            testsuite.Require().NoError(err, \\"Failed to advance page for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_ListBySubscription.json\\")
+        }
+}
+
+
+func (testsuite *MockTestSuite) TestFarmBeatsModels_ListByResourceGroup() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_ListByResourceGroup.json
+	client, err := armagrifood.NewFarmBeatsModelsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+        pager := client.NewListByResourceGroupPager(\\"examples-rg\\",
+&armagrifood.FarmBeatsModelsClientListByResourceGroupOptions{MaxPageSize: nil,
+SkipToken: nil,
+})
+        for pager.More() {
+            _, err := pager.NextPage(ctx)
+            testsuite.Require().NoError(err, \\"Failed to advance page for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/FarmBeatsModels_ListByResourceGroup.json\\")
+        }
+}
+
+
+func (testsuite *MockTestSuite) TestLocations_CheckNameAvailability() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Locations_CheckNameAvailability_AlreadyExists.json
+	client, err := armagrifood.NewLocationsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+            res, err := client.CheckNameAvailability(ctx,
+armagrifood.CheckNameAvailabilityRequest{
+Name: to.Ptr(\\"existingaccountname\\"),
+Type: to.Ptr(\\"Microsoft.AgFoodPlatform/farmBeats\\"),
+},
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Locations_CheckNameAvailability_AlreadyExists.json\\")
+
+    
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Locations_CheckNameAvailability_Available.json
+    client, err = armagrifood.NewLocationsClient(\\"11111111-2222-3333-4444-555555555555\\", testsuite.cred, &testsuite.options)
+	testsuite.Require().NoError(err, \\"Failed to create client\\")
+            res, err = client.CheckNameAvailability(ctx,
+armagrifood.CheckNameAvailabilityRequest{
+Name: to.Ptr(\\"newaccountname\\"),
+Type: to.Ptr(\\"Microsoft.AgFoodPlatform/farmBeats\\"),
+},
+nil)
+        testsuite.Require().NoError(err, \\"Failed to get result for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Locations_CheckNameAvailability_Available.json\\")
+}
+
+
+func (testsuite *MockTestSuite) TestOperations_List() {ctx := context.Background()
+    // From example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Operations_List.json
+	client, err := armagrifood.NewOperationsClient(testsuite.cred, &testsuite.options)
+    testsuite.Require().NoError(err, \\"Failed to create client\\")
+        pager := client.NewListPager(nil)
+        for pager.More() {
+            _, err := pager.NextPage(ctx)
+            testsuite.Require().NoError(err, \\"Failed to advance page for example specification/agrifood/resource-manager/Microsoft.AgFoodPlatform/preview/2020-05-12-preview/examples/Operations_List.json\\")
+        }
+}
+
 
 type MockCredential struct {
 }
@@ -1262,6 +1174,9 @@ nil)
             usagesClientNewListPager:= usagesClient.NewListPager(testsuite.location,
 nil)
             for usagesClientNewListPager.More() {
+                _, err := usagesClientNewListPager.NextPage(ctx)
+                testsuite.Require().NoError(err)
+                break
             }
 
     
@@ -1269,12 +1184,18 @@ nil)
             signalRClientNewListByResourceGroupPager:= signalRClient.NewListByResourceGroupPager(testsuite.resourceGroupName,
 nil)
             for signalRClientNewListByResourceGroupPager.More() {
+                _, err := signalRClientNewListByResourceGroupPager.NextPage(ctx)
+                testsuite.Require().NoError(err)
+                break
             }
 
     
     // From step SignalR_ListBySubscription
             signalRClientNewListBySubscriptionPager:= signalRClient.NewListBySubscriptionPager(nil)
             for signalRClientNewListBySubscriptionPager.More() {
+                _, err := signalRClientNewListBySubscriptionPager.NextPage(ctx)
+                testsuite.Require().NoError(err)
+                break
             }
 
     
@@ -1283,6 +1204,9 @@ nil)
     testsuite.Require().NoError(err)
             operationsClientNewListPager:= operationsClient.NewListPager(nil)
             for operationsClientNewListPager.More() {
+                _, err := operationsClientNewListPager.NextPage(ctx)
+                testsuite.Require().NoError(err)
+                break
             }
 
     


### PR DESCRIPTION
fix: wrong path/head/query type parser
feat: use example value instead of placeholder of string value


feat: user testsuite to do the mock test

fix: only set object with status when lro finished