### PR TITLE
Add exception handling for notification pipeline

### DIFF
--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -191,7 +191,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
 
                 if (repoUrl != null)
                 {
-                    repoUrl = new Uri(Regex.Replace(repoUrl.ToString(), @"`.git$", String.Empty));
+                    repoUrl = new Uri(Regex.Replace(repoUrl.ToString(), @"\.git$", String.Empty));
                 }
                 else
                 {

--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -13,6 +13,7 @@ using System.Threading.Tasks;
 using Azure.Sdk.Tools.NotificationConfiguration.Helpers;
 using System;
 using Azure.Sdk.Tools.CodeOwnersParser;
+using System.Text.RegularExpressions;
 
 namespace Azure.Sdk.Tools.NotificationConfiguration
 {
@@ -186,17 +187,18 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
 
                 // Get contents of CODEOWNERS
                 logger.LogInformation("Fetching CODEOWNERS file");
-                var managementUrl = default(Uri);
-                if (pipeline.Repository.Properties.ContainsKey("manageUrl"))
+                var repoUrl = pipeline.Repository.Url;
+
+                if (repoUrl != null)
                 {
-                    managementUrl = new Uri(pipeline.Repository.Properties["manageUrl"]);
+                    repoUrl = new Uri(Regex.Replace(repoUrl.ToString(), @"`.git$", String.Empty));
                 }
-                if (managementUrl == null)
+                else
                 {
-                    logger.LogWarning("There is no url in pipeline. Url: ", pipeline.Repository.Url);
+                    logger.LogWarning("No reposatory url returned from pipeline. Repo id: {0}", pipeline.Repository.Id);
                     return;
                 }
-                var codeOwnerEntries = await gitHubService.GetCodeownersFile(managementUrl);
+                var codeOwnerEntries = await gitHubService.GetCodeownersFile(repoUrl);
 
                 if (codeOwnerEntries == default)
                 {

--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -195,7 +195,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
                 }
                 else
                 {
-                    logger.LogWarning("No reposatory url returned from pipeline. Repo id: {0}", pipeline.Repository.Id);
+                    logger.LogWarning("No repository url returned from pipeline. Repo id: {0}", pipeline.Repository.Id);
                     return;
                 }
                 var codeOwnerEntries = await gitHubService.GetCodeownersFile(repoUrl);

--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -187,7 +187,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
 
                 // Get contents of CODEOWNERS
                 logger.LogInformation("Fetching CODEOWNERS file");
-                var repoUrl = pipeline.Repository.Url;
+                Uri repoUrl = pipeline.Repository.Url;
 
                 if (repoUrl != null)
                 {
@@ -195,7 +195,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
                 }
                 else
                 {
-                    logger.LogWarning("No repository url returned from pipeline. Repo id: {0}", pipeline.Repository.Id);
+                    logger.LogError("No repository url returned from pipeline. Repo id: {0}", pipeline.Repository.Id);
                     return;
                 }
                 var codeOwnerEntries = await gitHubService.GetCodeownersFile(repoUrl);

--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -186,7 +186,16 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
 
                 // Get contents of CODEOWNERS
                 logger.LogInformation("Fetching CODEOWNERS file");
-                var managementUrl = new Uri(pipeline.Repository.Properties["manageUrl"]);
+                var managementUrl = default(Uri);
+                if (pipeline.Repository.Properties.ContainsKey("manageUrl"))
+                {
+                    managementUrl = new Uri(pipeline.Repository.Properties["manageUrl"]);
+                }
+                if (managementUrl == null)
+                {
+                    logger.LogWarning("There is no url in pipeline. Url: ", pipeline.Repository.Url);
+                    return;
+                }
                 var codeOwnerEntries = await gitHubService.GetCodeownersFile(managementUrl);
 
                 if (codeOwnerEntries == default)


### PR DESCRIPTION
Fix failed pipeline:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1561441&view=results

Root cause:
The failed pipeline is from our pipeline-generator scripts. We used to put {"manageUrl":"\<url\>"} in pipeline repository properties. Since we cannot fetch the properties after renew the devOp PAT, we decided not to generate properties them from repository. This affect notification pipeline which read the repo url from pipeline repository `manageUrl`. The PR is to use another way of retrieving the codeowner

Testing pipeline:https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1561040&view=logs&s=7e5a62c6-a3ae-5561-387a-bc0babb014af