### PR TITLE
[testresources] String parsing improvements to service directory resource names

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -375,7 +375,7 @@ try {
             $BaseName = 't' + (New-Guid).ToString('n').Substring(0, 16)
             Log "Generated base name '$BaseName' for CI build"
         } else {
-            $BaseName = GetBaseName $UserName $ServiceDirectory
+            $BaseName = GetBaseName $UserName (GetServiceLeafDirectoryName $ServiceDirectory)
             Log "BaseName was not set. Using default base name '$BaseName'"
         }
     }
@@ -520,7 +520,7 @@ try {
         $ResourceGroupName
     } elseif ($CI) {
         # Format the resource group name based on resource group naming recommendations and limitations.
-        "rg-{0}-$BaseName" -f ($serviceName -replace '[\\\/:]', '-').Substring(0, [Math]::Min($serviceName.Length, 90 - $BaseName.Length - 4)).Trim('-')
+        "rg-{0}-$BaseName" -f ($serviceName -replace '[\.\\\/:]', '-').ToLowerInvariant().Substring(0, [Math]::Min($serviceName.Length, 90 - $BaseName.Length - 4)).Trim('-')
     } else {
         "rg-$BaseName"
     }

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -1,4 +1,5 @@
 function BuildServiceDirectoryPrefix([string]$serviceName) {
+    $serviceName = $serviceName -replace '[\./\\]', '_'
     return $serviceName.ToUpperInvariant() + "_"
 }
 
@@ -17,8 +18,8 @@ function GetUserName() {
 
 function GetBaseName([string]$user, [string]$serviceDirectoryName) {
     # Handle service directories in nested directories, e.g. `data/aztables`
-    $serviceDirectorySafeName = $serviceDirectoryName -replace '[/\\]', ''
-    return "$user$serviceDirectorySafeName"
+    $serviceDirectorySafeName = $serviceDirectoryName -replace '[\./\\]', ''
+    return "$user$serviceDirectorySafeName".ToLowerInvariant()
 }
 
 function ShouldMarkValueAsSecret([string]$serviceName, [string]$key, [string]$value, [array]$allowedValues = @())


### PR DESCRIPTION
These updates allow us to handle service directory parameters like `storage/Azure.Storage.Blobs`. The perf test ARM templates need to reside in directories like this. I also shortened the service name generation in local usage to only use the leaf directory name to avoid naming length restrictions with some resource types (e.g. storage).
