### PR TITLE
[Swift APIView] Fix issue with throwing inits

### DIFF
--- a/src/swift/SwiftAPIViewCore/Sources/Extensions/ThrowsKind+Extensions.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Extensions/ThrowsKind+Extensions.swift
@@ -29,11 +29,8 @@ import Foundation
 
 extension ThrowsKind: Tokenizable {
     func tokenize(apiview a: APIViewModel) {
-        switch self {
-        case .throwing, .rethrowing:
-            a.keyword("throws", prefixSpace: true, postfixSpace: true)
-        case .nothrowing:
-            return
-        }
+        let throwString = self.textDescription
+        guard throwString != "" else { return }
+        a.keyword(throwString, prefixSpace: true, postfixSpace: true)
     }
 }

--- a/src/swift/SwiftAPIViewCore/Sources/Models/Declarations/InitializerModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/Declarations/InitializerModel.swift
@@ -63,7 +63,7 @@ class InitializerModel: Tokenizable, Commentable, AccessLevelProtocol {
         }
         genericParamClause = GenericParameterModel(from: decl.genericParameterClause)
         genericWhereClause = GenericWhereModel(from: decl.genericWhereClause)
-        signature = SignatureModel(params: decl.parameterList, result: nil, resultAttributes: nil)
+        signature = SignatureModel(params: decl.parameterList, result: nil, resultAttributes: nil, throwsKind: decl.throwsKind)
     }
 
     init(from decl: ProtocolDeclaration.InitializerMember, parent: ProtocolModel) {
@@ -82,7 +82,7 @@ class InitializerModel: Tokenizable, Commentable, AccessLevelProtocol {
         }
         genericParamClause = GenericParameterModel(from: decl.genericParameter)
         genericWhereClause = GenericWhereModel(from: decl.genericWhere)
-        signature = SignatureModel(params: decl.parameterList, result: nil, resultAttributes: nil)
+        signature = SignatureModel(params: decl.parameterList, result: nil, resultAttributes: nil, throwsKind: decl.throwsKind)
     }
 
     func tokenize(apiview a: APIViewModel) {

--- a/src/swift/SwiftAPIViewCore/Sources/Models/Declarations/SubscriptModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/Declarations/SubscriptModel.swift
@@ -51,7 +51,7 @@ class SubscriptModel: Tokenizable, Commentable, AccessLevelProtocol {
         modifiers = DeclarationModifiersModel(from: decl.modifiers)
         genericParamClause = GenericParameterModel(from: decl.genericParameterClause)
         genericWhereClause = GenericWhereModel(from: decl.genericWhereClause)
-        signature = SignatureModel(params: decl.parameterList, result: decl.resultType, resultAttributes: decl.resultAttributes)
+        signature = SignatureModel(params: decl.parameterList, result: decl.resultType, resultAttributes: decl.resultAttributes, throwsKind: nil)
     }
 
     init(from decl: ProtocolDeclaration.SubscriptMember, parent: ProtocolModel) {
@@ -61,7 +61,7 @@ class SubscriptModel: Tokenizable, Commentable, AccessLevelProtocol {
         accessLevel = modifiers.accessLevel ?? .internal
         genericParamClause = GenericParameterModel(from: decl.genericParameter)
         genericWhereClause = GenericWhereModel(from: decl.genericWhere)
-        signature = SignatureModel(params: decl.parameterList, result: decl.resultType, resultAttributes: decl.resultAttributes)
+        signature = SignatureModel(params: decl.parameterList, result: decl.resultType, resultAttributes: decl.resultAttributes, throwsKind: nil)
     }
 
     func tokenize(apiview a: APIViewModel) {

--- a/src/swift/SwiftAPIViewCore/Sources/Models/Miscellaneous/SignatureModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/Miscellaneous/SignatureModel.swift
@@ -31,7 +31,7 @@ class SignatureModel: Tokenizable {
 
     var parameters: [ParameterModel]
     var async: String?
-    var throwing: String?
+    var throwing: ThrowsKind?
     var result: TypeModel?
 
     struct ParameterModel: Tokenizable {
@@ -70,9 +70,7 @@ class SignatureModel: Tokenizable {
         case .notasync:
             async = nil
         }
-
-        throwing = sig.throwsKind.textDescription
-
+        throwing = sig.throwsKind
         parameters = [ParameterModel]()
         sig.parameterList.forEach { param in
             parameters.append(ParameterModel(from: param))
@@ -86,7 +84,7 @@ class SignatureModel: Tokenizable {
 
     init(params: [FunctionSignature.Parameter], result: Type?, resultAttributes: Attributes?, throwsKind: ThrowsKind?) {
         async = nil
-        throwing = throwsKind?.textDescription
+        throwing = throwsKind
         if let resultType = result {
             self.result = resultType.toTokenizable()!
         }
@@ -109,9 +107,7 @@ class SignatureModel: Tokenizable {
         if let async = async {
             a.keyword(async, postfixSpace: true)
         }
-        if let throwing = throwing {
-            a.keyword(throwing, postfixSpace: true)
-        }
+        throwing?.tokenize(apiview: a)
         if let result = result {
             a.punctuation("->", prefixSpace: true, postfixSpace: true)
             result.tokenize(apiview: a)

--- a/src/swift/SwiftAPIViewCore/Sources/Models/Miscellaneous/SignatureModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/Miscellaneous/SignatureModel.swift
@@ -71,14 +71,7 @@ class SignatureModel: Tokenizable {
             async = nil
         }
 
-        switch sig.throwsKind {
-        case .throwing:
-            throwing = "throws"
-        case .nothrowing:
-            throwing = nil
-        case .rethrowing:
-            throwing = "rethrow"
-        }
+        throwing = sig.throwsKind.textDescription
 
         parameters = [ParameterModel]()
         sig.parameterList.forEach { param in
@@ -91,9 +84,9 @@ class SignatureModel: Tokenizable {
         }
     }
 
-    init(params: [FunctionSignature.Parameter], result: Type?, resultAttributes: Attributes?) {
+    init(params: [FunctionSignature.Parameter], result: Type?, resultAttributes: Attributes?, throwsKind: ThrowsKind?) {
         async = nil
-        throwing = nil
+        throwing = throwsKind?.textDescription
         if let resultType = result {
             self.result = resultType.toTokenizable()!
         }

--- a/src/swift/SwiftAPIViewTests/Sources/InitializersTestFile.swift
+++ b/src/swift/SwiftAPIViewTests/Sources/InitializersTestFile.swift
@@ -1,0 +1,38 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+class InitializersTestClass {
+
+    // Throwing initializer
+
+    init(withThrowable: String) throws {}
+
+    // Failable initializer
+
+    init?(withFailable: String) {}
+}


### PR DESCRIPTION
Recent refactor dropped `throws` annotations from throwing inits. This PR restores them. 