### PR TITLE
Add skip variable for remove test resources to support debugging

### DIFF
--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -34,5 +34,5 @@ steps:
         -Force `
         -Verbose
     displayName: Remove test resources
-    condition: eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true')
+    condition: and(eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'), ne(variables['Skip.RemoveTestResources'], 'true'))
     continueOnError: true


### PR DESCRIPTION
In case people want to leave their resources around for debugging after test failures.

The naming format was chosen to be consistent with our other user-facing Skip variables used in the release pipelines (e.g. [here](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/pipelines/templates/stages/archetype-net-release.yml#L97)).