### PR TITLE
Delete PR and branch which central PR is closed

### DIFF
--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -88,7 +88,7 @@ foreach ($res in $responses)
   }
 
   foreach ($openPullRequest in $openPullRequests) {
-    LogDebug "Open pull Request [ $($openPullRequest.html_url) ] will be closed after branch deletion."
+    Write-Host "Open pull Request [ $($openPullRequest.html_url) ] will be closed after branch deletion."
   }
 
   # If there is date filter, then check if branch last commit older than the date.

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -20,61 +20,6 @@ param(
 
 . (Join-Path $PSScriptRoot common.ps1)
 
-# RetrievePRAndClose will go to central repo to fetch the central PR using the given $pullRequetNumver, check whether it is closed or open. 
-# If central PR is merged/closed, then go ahead close sync PRs. Return true to the function.
-# If central PR is open, then return false to the function.
-function RetrievePRAndClose {
-  [CmdletBinding(SupportsShouldProcess)]
-  param (
-    $pullRequestNumber
-  )
-
-  if (!$pullRequestNumber) {    
-    LogError "Failed to fetch PR number from regex: $BranchRegex."
-    exit 1
-  }
-  try {
-    $centralPR = Get-GitHubPullRequest -RepoId $CentralRepoId -PullRequestNumber $pullRequestNumber -AuthToken $AuthToken
-    if ($centralPR.state -ne "closed") {
-      return $false
-    }
-    LogDebug "Found closed/merged pull request: $($centralPR.html_url)"
-  }
-  catch 
-  {
-    LogError "Get-GitHubPullRequests failed with exception:`n$_"
-    exit 1
-  }
-  
-  try {
-    $head = "${RepoId}:${branchName}"
-    LogDebug "Operating on branch [ $branchName ]"
-    $pullRequests = Get-GitHubPullRequests -RepoId $RepoId -State "all" -Head $head -AuthToken $AuthToken
-  }
-  catch
-  {
-    LogError "Get-GitHubPullRequests failed with exception:`n$_"
-    exit 1
-  }
-  $openPullRequests = $pullRequests | ? { $_.State -eq "open" }
-
-  foreach ($openPullRequest in $openPullRequests) {
-    try 
-    {
-      if ($PSCmdlet.ShouldProcess("[ $($openPullRequest.html_url) ] with branch [ $branchName ] in [ $RepoId ]", "Closing the pull request")) {
-        #Close-GithubPullRequest -apiurl $openPullRequest.url -AuthToken $AuthToken | Out-Null
-        Write-Host "Open pull Request [ $($openPullRequest.html_url) ] has been closed."
-      }
-    }
-    catch
-    {
-      LogError "Close-GithubPullRequest failed with exception:`n$_"
-      exit 1
-    }
-  }
-  return $true
-}
-
 LogDebug "Operating on Repo [ $RepoId ]"
 
 try{
@@ -97,13 +42,65 @@ foreach ($res in $responses)
   if (!($branchName -match $BranchRegex)) {
     continue
   }
-  $hasCentralPRClosedOrSkipChecking = $true
-  if ($CentralRepoId) {
-    # RetrievePRAndClose will go to central repo to fetch the central PR, check whether it is closed or merged. 
-    # If central PR is merged/closed, then go ahead close sync PRs. Return true to the function.
-    # If central PR is open, then return false to the function.
-    $hasCentralPRClosedOrSkipChecking = RetrievePRAndClose -pullRequestNumber $Matches["PrNumber"] 
+
+  # check central PR
+  # If central PR exist and open, then skip
+  $pullRequestNumber = $Matches["PrNumber"]
+    
+  # Get all open sync PRs associate with branch.
+  try {
+    $head = "${RepoId}:${branchName}"
+    LogDebug "Operating on branch [ $branchName ]"
+    $pullRequests = Get-GitHubPullRequests -RepoId $RepoId -State "all" -Head $head -AuthToken $AuthToken
   }
+  catch
+  {
+    LogError "Get-GitHubPullRequests failed with exception:`n$_"
+    exit 1
+  }
+  $openPullRequests = $pullRequests | ? { $_.State -eq "open" }
+
+  # If no central PR numver retrieved from branch regex, and there are open sync PR(s) associate with branch.
+  if (!$pullRequestNumber -and $openPullRequest.Count -gt 0) {
+    LogError "PR number not found from $CentralPRRegex. And there are open sync PR(s) associate with branch. Skipping."
+    continue
+  } 
+  if ($pullRequestNumber) {
+    try {
+      $centralPR = Get-GitHubPullRequest -RepoId $CentralRepoId -PullRequestNumber $pullRequestNumber -AuthToken $AuthToken
+      if ($centralPR.state -ne "closed") {
+        continue
+      }
+      LogDebug "Found closed/merged pull request: $($centralPR.html_url)"
+    }
+    catch 
+    {
+      if ($openPullRequest.Count -gt 0) {
+        LogDebug "PR number [ $pullRequestNumber ] from [ $CentralRepoId ]. And there are open sync PR(s) associate with branch. Skipping."
+        continue
+      }
+    }
+  }
+
+  # Two conditions to close sync open PRs.
+  # 2. Central repo PR not exist and no open sync PRs
+  # 2. Central repo PR exists and closed.
+  foreach ($openPullRequest in $openPullRequests) {
+    try 
+    {
+      if ($PSCmdlet.ShouldProcess("[ $($openPullRequest.html_url) ] with branch [ $branchName ] in [ $RepoId ]", "Closing the pull request")) {
+        Close-GithubPullRequest -apiurl $openPullRequest.url -AuthToken $AuthToken | Out-Null
+        Write-Host "Open pull Request [ $($openPullRequest.html_url) ] has been closed."
+      }
+    }
+    catch
+    {
+      LogError "Close-GithubPullRequest failed with exception:`n$_"
+      exit 1
+    }
+  }
+
+  # If there is date filter, then check if branch last commit older than the date.
   if ($LastCommitOlderThan) {
     if (!$res.object -or !$res.object.url) {
       LogWarning "No commit url returned from response. Skipping... "
@@ -130,7 +127,7 @@ foreach ($res in $responses)
   
   try {
     if ($hasCentralPRClosedOrSkipChecking -and $PSCmdlet.ShouldProcess("[ $branchName ] in [ $RepoId ]", "Deleting branches on cleanup script")) {
-      #Remove-GitHubSourceReferences -RepoId $RepoId -Ref $branch -AuthToken $AuthToken
+      Remove-GitHubSourceReferences -RepoId $RepoId -Ref $branch -AuthToken $AuthToken
       Write-Host "The branch [ $branchName ] with sha [$($res.object.sha)] in [ $RepoId ] has been deleted."
     }
   }

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -10,7 +10,7 @@ param(
   $CentralRepoId,
   # We start from the sync PRs, use the branch name to get the PR number of central repo. E.g. sync-eng/common-(<branchName>)-(<PrNumber>). Have group name on PR number.
   # For sync-eng/common work, we use regex as "^sync-eng/common.*-(?<PrNumber>\d+).*$".
-  $CentralPRRegex,
+  $BranchRegex,
   # Date format: e.g. Tuesday, April 12, 2022 1:36:02 PM. Allow to use other date format.
   [AllowNull()]
   [DateTime]$LastCommitOlderThan,
@@ -30,7 +30,7 @@ function RetrievePRAndClose {
   )
 
   if (!$pullRequestNumber) {    
-    LogError "Failed to fetch PR number from regex: $CentralPRRegex."
+    LogError "Failed to fetch PR number from regex: $BranchRegex."
     exit 1
   }
   try {
@@ -89,12 +89,12 @@ catch {
 foreach ($res in $responses)
 {
   if (!$res -or !$res.ref) {
-    LogDebug "No branch returned from the branch prefix $CentralPRRegex on $Repo. Skipping..."
+    LogDebug "No branch returned from the branch prefix $BranchRegex on $Repo. Skipping..."
     continue
   }
   $branch = $res.ref
   $branchName = $branch.Replace("refs/heads/","")
-  if (!($branchName -match $CentralPRRegex)) {
+  if (!($branchName -match $BranchRegex)) {
     continue
   }
   $hasCentralPRClosedOrSkipChecking = $true

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -66,7 +66,7 @@ foreach ($res in $responses)
     $pullRequestNumber = $Matches["PrNumber"]
     # If central PR number found, then skip
     if (!$pullRequestNumber) {
-      LogWarning "No PR number fetched from the branch. Please check the branch name [ $branchName ]. Skipping..."
+      LogError "No PR number found in the branch name. Please check the branch name [ $branchName ]. Skipping..."
       continue
     }
       

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -1,3 +1,4 @@
+[CmdletBinding(SupportsShouldProcess)]
 param(
   # The repo owner: e.g. Azure
   $RepoOwner,
@@ -5,8 +6,11 @@ param(
   $RepoName,
   # Please use the RepoOwner/RepoName format: e.g. Azure/azure-sdk-for-java
   $RepoId="$RepoOwner/$RepoName",
-  [Parameter(Mandatory = $true)]
-  $BranchPrefix,  
+  # CentralRepoId the original PR to generate sync PR. E.g Azure/azure-sdk-tools for eng/common
+  $CentralRepoId,
+  # We start from the sync PRs, use the branch name to get the PR number of central repo. E.g. sync-eng/common-(<branchName>)-(<PrNumber>). Have group name on PR number.
+  # For sync-eng/common work, we use regex as "^sync-eng/common.*-(?<PrNumber>\d+)$".
+  $CentralPRRegex,
   # Date format: e.g. Tuesday, April 12, 2022 1:36:02 PM. Allow to use other date format.
   [AllowNull()]
   [DateTime]$LastCommitOlderThan,
@@ -16,24 +20,32 @@ param(
 
 . (Join-Path $PSScriptRoot common.ps1)
 
-LogDebug "Operating on Repo [ $RepoId ]"
+# RetrievePRAndClose will go to central repo to fetch the central PR using the given $pullRequetNumver, check whether it is closed or open. 
+# If central PR is merged/closed, then go ahead close sync PRs. Return true to the function.
+# If central PR is open, then return false to the function.
+function RetrievePRAndClose {
+  [CmdletBinding(SupportsShouldProcess)]
+  param (
+    $pullRequestNumber
+  )
 
-try{
-  $responses = Get-GitHubSourceReferences -RepoId $RepoId -Ref "heads/$BranchPrefix" -AuthToken $AuthToken
-}
-catch {
-  LogError "Get-GitHubSourceReferences failed with exception:`n$_"
-  exit 1
-}
-
-foreach ($res in $responses)
-{
-  if (!$res -or !$res.ref) {
-    LogDebug "No branch returned from the branch prefix $BranchPrefix on $Repo. Skipping..."
-    continue
+  if (!$pullRequestNumber) {    
+    LogError "Failed to fetch PR number from regex: $CentralPRRegex."
+    exit 1
   }
-  $branch = $res.ref
-  $branchName = $branch.Replace("refs/heads/","")
+  try {
+    Write-Host "The repo [ $CentralRepoId ] pull request number is [ $pullRequestNumber ] "
+    $centralPR = Get-GitHubPullRequest -RepoId $CentralRepoId -PullRequestNumber $pullRequestNumber -AuthToken $AuthToken
+    if ($centralPR.state -ne "closed") {
+      return $false
+    }
+  }
+  catch 
+  {
+    LogError "Get-GitHubPullRequests failed with exception:`n$_"
+    exit 1
+  }
+  
   try {
     $head = "${RepoId}:${branchName}"
     LogDebug "Operating on branch [ $branchName ]"
@@ -44,16 +56,54 @@ foreach ($res in $responses)
     LogError "Get-GitHubPullRequests failed with exception:`n$_"
     exit 1
   }
-
   $openPullRequests = $pullRequests | ? { $_.State -eq "open" }
-  if ($openPullRequests.Count -gt 0)
-  {
-    LogDebug "Branch [ $branchName ] in repo [ $RepoId ] has open pull Requests. Skipping"
-    LogDebug $openPullRequests.url
+
+  foreach ($openPullRequest in $openPullRequests) {
+    try 
+    {
+      if ($PSCmdlet.ShouldProcess("[ $($openPullRequest.url)] with branch [ $branchName ] in [ $RepoId ]", "Closing the pull request")) {
+        Close-GithubPullRequest -apiurl $openPullRequest.url -AuthToken $AuthToken | Out-Null
+        Write-Host "Open pull Request [ $($openPullRequest.url)] associate with branch [ $branchName ] in repo [ $RepoId ] has been closed."
+      }
+    }
+    catch
+    {
+      LogError "Close-GithubPullRequest failed with exception:`n$_"
+      exit 1
+    }
+  }
+  return $true
+}
+
+LogDebug "Operating on Repo [ $RepoId ]"
+
+try{
+  # pull all branches.
+  $responses = Get-GitHubSourceReferences -RepoId $RepoId -Ref "heads" -AuthToken $AuthToken
+}
+catch {
+  LogError "Get-GitHubSourceReferences failed with exception:`n$_"
+  exit 1
+}
+
+foreach ($res in $responses)
+{
+  if (!$res -or !$res.ref) {
+    LogDebug "No branch returned from the branch prefix $CentralPRRegex on $Repo. Skipping..."
     continue
   }
-
-  LogDebug "Branch [ $branchName ] in repo [ $RepoId ] has no associated open Pull Request. "
+  $branch = $res.ref
+  $branchName = $branch.Replace("refs/heads/","")
+  if (!($branchName -match $CentralPRRegex)) {
+    continue
+  }
+  $hasCentralPRClosedOrSkipChecking = $true
+  if ($CentralRepoId) {
+    # RetrievePRAndClose will go to central repo to fetch the central PR, check whether it is closed or merged. 
+    # If central PR is merged/closed, then go ahead close sync PRs. Return true to the function.
+    # If central PR is open, then return false to the function.
+    $hasCentralPRClosedOrSkipChecking = RetrievePRAndClose -pullRequestNumber $Matches["PrNumber"] 
+  }
   if ($LastCommitOlderThan) {
     if (!$res.object -or !$res.object.url) {
       LogWarning "No commit url returned from response. Skipping... "
@@ -61,8 +111,7 @@ foreach ($res in $responses)
     }
     try {
       $commitDate = Get-GithubReferenceCommitDate -commitUrl $res.object.url -AuthToken $AuthToken
-      if (!$commitDate) 
-      {
+      if (!$commitDate) {
         LogDebug "No last commit date found. Skipping."
         continue
       }
@@ -78,9 +127,12 @@ foreach ($res in $responses)
       exit 1
     }
   } 
+  
   try {
-    Remove-GitHubSourceReferences -RepoId $RepoId -Ref $branch -AuthToken $AuthToken
-    LogDebug "The branch [ $branchName ] in [ $RepoId ] has been deleted."
+    if ($hasCentralPRClosedOrSkipChecking -and $PSCmdlet.ShouldProcess("[ $branchName ] in [ $RepoId ]", "Deleting branches on cleanup script")) {
+      #Remove-GitHubSourceReferences -RepoId $RepoId -Ref $branch -AuthToken $AuthToken
+      Write-Host "The branch [ $branchName ] with sha [$($res.object.sha)] in [ $RepoId ] has been deleted."
+    }
   }
   catch {
     LogError "Remove-GitHubSourceReferences failed with exception:`n$_"

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -57,7 +57,7 @@ foreach ($res in $responses)
   $openPullRequests = $pullRequests | ? { $_.State -eq "open" }
 
   if (!$CentralRepoId -and $openPullRequests.Count -gt 0) {
-    LogDebug "Central PR check is disabled and found open PRs associate with branch [ $branchName ]. Skipping..."
+    LogDebug "CentralRepoId is not configured and found open PRs associate with branch [ $branchName ]. Skipping..."
     continue
   }
 

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -9,7 +9,7 @@ param(
   # CentralRepoId the original PR to generate sync PR. E.g Azure/azure-sdk-tools for eng/common
   $CentralRepoId,
   # We start from the sync PRs, use the branch name to get the PR number of central repo. E.g. sync-eng/common-(<branchName>)-(<PrNumber>). Have group name on PR number.
-  # For sync-eng/common work, we use regex as "^sync-eng/common.*-(?<PrNumber>\d+)$".
+  # For sync-eng/common work, we use regex as "^sync-eng/common.*-(?<PrNumber>\d+).*$".
   $CentralPRRegex,
   # Date format: e.g. Tuesday, April 12, 2022 1:36:02 PM. Allow to use other date format.
   [AllowNull()]

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -56,7 +56,7 @@ foreach ($res in $responses)
   }
   $openPullRequests = $pullRequests | ? { $_.State -eq "open" }
 
-  if (!CentralRepoId -and $openPullRequests.Count -gt 0) {
+  if (!$CentralRepoId -and $openPullRequests.Count -gt 0) {
     LogDebug "Central PR check is disabled and found open PRs associate with branch [ $branchName ]. Skipping..."
     continue
   }

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -75,7 +75,7 @@ foreach ($res in $responses)
     }
     catch 
     {
-      if ($openPullRequest.Count -gt 0) {
+      if ($openPullRequests.Count -gt 0) {
         LogDebug "PR number [ $pullRequestNumber ] from [ $CentralRepoId ]. And there are open sync PR(s) associate with branch. Skipping."
         continue
       }

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -68,10 +68,10 @@ foreach ($res in $responses)
   if ($pullRequestNumber) {
     try {
       $centralPR = Get-GitHubPullRequest -RepoId $CentralRepoId -PullRequestNumber $pullRequestNumber -AuthToken $AuthToken
+      LogDebug "Found closed/merged pull request: $($centralPR.html_url)"
       if ($centralPR.state -ne "closed") {
         continue
       }
-      LogDebug "Found closed/merged pull request: $($centralPR.html_url)"
     }
     catch 
     {
@@ -126,7 +126,7 @@ foreach ($res in $responses)
   } 
   
   try {
-    if ($hasCentralPRClosedOrSkipChecking -and $PSCmdlet.ShouldProcess("[ $branchName ] in [ $RepoId ]", "Deleting branches on cleanup script")) {
+    if ($PSCmdlet.ShouldProcess("[ $branchName ] in [ $RepoId ]", "Deleting branches on cleanup script")) {
       Remove-GitHubSourceReferences -RepoId $RepoId -Ref $branch -AuthToken $AuthToken
       Write-Host "The branch [ $branchName ] with sha [$($res.object.sha)] in [ $RepoId ] has been deleted."
     }

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -130,7 +130,7 @@ foreach ($res in $responses)
   
   try {
     if ($hasCentralPRClosedOrSkipChecking -and $PSCmdlet.ShouldProcess("[ $branchName ] in [ $RepoId ]", "Deleting branches on cleanup script")) {
-      #Remove-GitHubSourceReferences -RepoId $RepoId -Ref $branch -AuthToken $AuthToken
+      Remove-GitHubSourceReferences -RepoId $RepoId -Ref $branch -AuthToken $AuthToken
       Write-Host "The branch [ $branchName ] with sha [$($res.object.sha)] in [ $RepoId ] has been deleted."
     }
   }

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -61,9 +61,9 @@ function RetrievePRAndClose {
   foreach ($openPullRequest in $openPullRequests) {
     try 
     {
-      if ($PSCmdlet.ShouldProcess("[ $($openPullRequest.url)] with branch [ $branchName ] in [ $RepoId ]", "Closing the pull request")) {
-        Close-GithubPullRequest -apiurl $openPullRequest.url -AuthToken $AuthToken | Out-Null
-        Write-Host "Open pull Request [ $($openPullRequest.url)] associate with branch [ $branchName ] in repo [ $RepoId ] has been closed."
+      if ($PSCmdlet.ShouldProcess("[ $($openPullRequest.html_url) ] with branch [ $branchName ] in [ $RepoId ]", "Closing the pull request")) {
+        #Close-GithubPullRequest -apiurl $openPullRequest.url -AuthToken $AuthToken | Out-Null
+        Write-Host "Open pull Request [ $($openPullRequest.html_url) ] has been closed."
       }
     }
     catch
@@ -130,7 +130,7 @@ foreach ($res in $responses)
   
   try {
     if ($hasCentralPRClosedOrSkipChecking -and $PSCmdlet.ShouldProcess("[ $branchName ] in [ $RepoId ]", "Deleting branches on cleanup script")) {
-      Remove-GitHubSourceReferences -RepoId $RepoId -Ref $branch -AuthToken $AuthToken
+      #Remove-GitHubSourceReferences -RepoId $RepoId -Ref $branch -AuthToken $AuthToken
       Write-Host "The branch [ $branchName ] with sha [$($res.object.sha)] in [ $RepoId ] has been deleted."
     }
   }

--- a/eng/common/scripts/Delete-RemoteBranches.ps1
+++ b/eng/common/scripts/Delete-RemoteBranches.ps1
@@ -34,11 +34,11 @@ function RetrievePRAndClose {
     exit 1
   }
   try {
-    Write-Host "The repo [ $CentralRepoId ] pull request number is [ $pullRequestNumber ] "
     $centralPR = Get-GitHubPullRequest -RepoId $CentralRepoId -PullRequestNumber $pullRequestNumber -AuthToken $AuthToken
     if ($centralPR.state -ne "closed") {
       return $false
     }
+    LogDebug "Found closed/merged pull request: $($centralPR.html_url)"
   }
   catch 
   {

--- a/eng/common/scripts/Invoke-GitHubAPI.ps1
+++ b/eng/common/scripts/Invoke-GitHubAPI.ps1
@@ -95,10 +95,9 @@ function Get-GitHubSourceReferences {
 
 function Get-GitHubPullRequest {
   param (
-    [Parameter(Mandatory = $true)]
     $RepoOwner,
-    [Parameter(Mandatory = $true)]
     $RepoName,
+    $RepoId = "$RepoOwner/$RepoName",
     [Parameter(Mandatory = $true)]
     $PullRequestNumber,
     [ValidateNotNullOrEmpty()]
@@ -106,7 +105,7 @@ function Get-GitHubPullRequest {
     $AuthToken
   )
 
-  $uri = "$GithubAPIBaseURI/$RepoOwner/$RepoName/pulls/$PullRequestNumber"
+  $uri = "$GithubAPIBaseURI/$RepoId/pulls/$PullRequestNumber"
 
   return Invoke-RestMethod `
           -Method GET `
@@ -148,6 +147,27 @@ function New-GitHubPullRequest {
           -Method POST `
           -Body ($parameters | ConvertTo-Json) `
           -Uri $uri `
+          -Headers (Get-GitHubApiHeaders -token $AuthToken) `
+          -MaximumRetryCount 3
+}
+
+function Close-GitHubPullRequest {
+  param (
+    [Parameter(Mandatory = $true)]
+    $apiurl,
+    [ValidateNotNullOrEmpty()]
+    [Parameter(Mandatory = $true)]
+    $AuthToken
+  )
+
+  $parameters = @{
+    state                 = "closed"
+  }
+
+  return Invoke-RestMethod `
+          -Method PATCH `
+          -Uri $apiurl `
+          -Body ($parameters | ConvertTo-Json) `
           -Headers (Get-GitHubApiHeaders -token $AuthToken) `
           -MaximumRetryCount 3
 }

--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -51,7 +51,7 @@ jobs:
             arguments: >
               -RepoId ${{ repo }} 
               -CentralRepoId "Azure/azure-sdk-tools"\
-              -CentralPRRegex "^sync-eng/common.*-(?<PrNumber>\d+).*$"
+              -BranchRegex "^sync-eng/common.*-(?<PrNumber>\d+).*$"
               -AuthToken $(azuresdk-github-pat)
               -WhatIf:$${{parameters.WhatIfPreference}}
       - ${{ each repo in parameters.SDKPrivate }}:
@@ -66,7 +66,7 @@ jobs:
             arguments: >
               -RepoId ${{ repo }}
               -CentralRepoId "Azure/azure-rest-api-specs-pr"\
-              -CentralPRRegex "^sdkAuto/(?<PrNumber>\d+)/.*$"
+              -BranchRegex "^sdkAuto/(?<PrNumber>\d+)/.*$"
               -AuthToken $(azuresdk-github-pat)
               -WhatIf:$${{parameters.WhatIfPreference}}
       - ${{ each repo in parameters.DailyBranchRepos }}:
@@ -79,7 +79,7 @@ jobs:
             filePath: $(System.DefaultWorkingDirectory)/eng/common/scripts/Delete-RemoteBranches.ps1
             arguments: >
               -RepoId ${{ repo }}
-              -CentralPRRegex "^daily"
+              -BranchRegex "^daily"
               -LastCommitOlderThan ((Get-Date).AddDays(-7))
               -AuthToken $(azuresdk-github-pat) 
               -WhatIf:$${{parameters.WhatIfPreference}}

--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -51,7 +51,7 @@ jobs:
             arguments: >
               -RepoId ${{ repo }} 
               -CentralRepoId "Azure/azure-sdk-tools"\
-              -CentralPRRegex "^sync-eng/common.*-(?<PrNumber>\d+)-.*$"
+              -CentralPRRegex "^sync-eng/common.*-(?<PrNumber>\d+).*$"
               -AuthToken $(azuresdk-github-pat)
               -WhatIf:$${{parameters.WhatIfPreference}}
       - ${{ each repo in parameters.SDKPrivate }}:

--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -71,7 +71,7 @@ jobs:
               -WhatIf:$${{parameters.WhatIfPreference}}
       - ${{ each repo in parameters.DailyBranchRepos }}:
         - task: PowerShell@2
-          displayName: Clean Up Docs Daily Branches
+          displayName: Clean Up ${{ repo }} Docs Daily Branches
           condition: succeededOrFailed()
           inputs:
             pwsh: true

--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -50,7 +50,7 @@ jobs:
             filePath: $(System.DefaultWorkingDirectory)/eng/common/scripts/Delete-RemoteBranches.ps1
             arguments: >
               -RepoId ${{ repo }} 
-              -CentralRepoId "Azure/azure-sdk-tools"\
+              -CentralRepoId "Azure/azure-sdk-tools"
               -BranchRegex "^sync-eng/common.*-(?<PrNumber>\d+).*$"
               -AuthToken $(azuresdk-github-pat)
               -WhatIf:$${{parameters.WhatIfPreference}}

--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -1,4 +1,7 @@
 parameters:
+- name: WhatIfPreference
+  type: boolean
+  default: false
 - name: Repos
   type: object
   default:
@@ -11,6 +14,17 @@ parameters:
     - Azure/azure-sdk-for-js
     - Azure/azure-sdk-for-net
     - Azure/azure-sdk-for-python
+
+- name: SDKPrivate
+  type: object
+  default:
+    - Azure/azure-powershell-pr
+    - Azure/azure-sdk-for-go-pr
+    - Azure/azure-sdk-for-java-pr
+    - Azure/azure-sdk-for-js-pr
+    - Azure/azure-sdk-for-net-pr
+    - Azure/azure-sdk-for-python-pr
+
 - name: DailyBranchRepos
   type: object
   default:
@@ -35,9 +49,26 @@ jobs:
             workingDirectory: $(System.DefaultWorkingDirectory)
             filePath: $(System.DefaultWorkingDirectory)/eng/common/scripts/Delete-RemoteBranches.ps1
             arguments: >
-              -RepoId ${{ repo }}
-              -BranchPrefix "sync-eng/common-" 
+              -RepoId ${{ repo }} 
+              -CentralRepoId "Azure/azure-sdk-tools"\
+              -CentralPRRegex "^sync-eng/common.*-(?<PrNumber>\d+)-.*$"
               -AuthToken $(azuresdk-github-pat)
+              -WhatIf:$${{parameters.WhatIfPreference}}
+      - ${{ each repo in parameters.SDKPrivate }}:
+        - task: PowerShell@2
+          displayName: Clean Up swagger private SDK PR and branches 
+          condition: succeededOrFailed()
+          continueOnError: true
+          inputs:
+            pwsh: true
+            workingDirectory: $(System.DefaultWorkingDirectory)
+            filePath: $(System.DefaultWorkingDirectory)/eng/common/scripts/Delete-RemoteBranches.ps1
+            arguments: >
+              -RepoId ${{ repo }}
+              -CentralRepoId "Azure/azure-rest-api-specs-pr"\
+              -CentralPRRegex "^sdkAuto/(?<PrNumber>\d+)/.*$"
+              -AuthToken $(azuresdk-github-pat)
+              -WhatIf:$${{parameters.WhatIfPreference}}
       - ${{ each repo in parameters.DailyBranchRepos }}:
         - task: PowerShell@2
           displayName: Clean Up Docs Daily Branches
@@ -48,7 +79,7 @@ jobs:
             filePath: $(System.DefaultWorkingDirectory)/eng/common/scripts/Delete-RemoteBranches.ps1
             arguments: >
               -RepoId ${{ repo }}
-              -BranchPrefix "daily"
+              -CentralPRRegex "^daily"
               -LastCommitOlderThan ((Get-Date).AddDays(-7))
-              -AuthToken $(azuresdk-github-pat)
-            
+              -AuthToken $(azuresdk-github-pat) 
+              -WhatIf:$${{parameters.WhatIfPreference}}

--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -56,7 +56,7 @@ jobs:
               -WhatIf:$${{parameters.WhatIfPreference}}
       - ${{ each repo in parameters.SDKPrivate }}:
         - task: PowerShell@2
-          displayName: Clean Up swagger private SDK PR and branches 
+          displayName: Clean Up ${{ repo }} swagger private SDK PR and branches 
           condition: succeededOrFailed()
           continueOnError: true
           inputs:

--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -65,7 +65,7 @@ jobs:
             filePath: $(System.DefaultWorkingDirectory)/eng/common/scripts/Delete-RemoteBranches.ps1
             arguments: >
               -RepoId ${{ repo }}
-              -CentralRepoId "Azure/azure-rest-api-specs-pr"\
+              -CentralRepoId "Azure/azure-rest-api-specs-pr"
               -BranchRegex "^sdkAuto/(?<PrNumber>\d+)/.*$"
               -AuthToken $(azuresdk-github-pat)
               -WhatIf:$${{parameters.WhatIfPreference}}

--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -41,7 +41,7 @@ jobs:
     steps:
       - ${{ each repo in parameters.Repos }}:
         - task: PowerShell@2
-          displayName: Clean Up Sync Common Branches
+          displayName: Clean Up ${{ repo }} Sync Common Branches
           condition: succeededOrFailed()
           continueOnError: true
           inputs:

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -201,7 +201,7 @@ stages:
                         arguments: >
                           -RepoOwner "Azure"
                           -RepoName ${{ repo }}
-                          -CentralPRRegex "sync-${{ parameters.DirectoryToSync }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
+                          -BranchRegex "sync-${{ parameters.DirectoryToSync }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
                           -AuthToken $(azuresdk-github-pat)
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -201,7 +201,7 @@ stages:
                         arguments: >
                           -RepoOwner "Azure"
                           -RepoName ${{ repo }}
-                          -BranchPrefix "sync-${{ parameters.DirectoryToSync }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
+                          -CentralPRRegex "sync-${{ parameters.DirectoryToSync }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
                           -AuthToken $(azuresdk-github-pat)
 
   - ${{ if ne(variables['Build.Reason'], 'PullRequest') }}:


### PR DESCRIPTION
Testing on whatif enabled:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1594264&view=logs&j=80f7b2d8-9c8c-53b8-36c5-63dcddd43cb4&t=fd53712b-8238-551a-0702-451e8924fb63
| Central PR | Sync PR status | Sync PR status after work | Branch | Test branch                                                | 
|------------|----------------|---------------------------|--------|------------------------------------------------------------|
| Not exist | Open           | No change | Keep   | sync-eng/common-branch_cleanups-13342                      | 
| Not exist | Otherwise      | No change                 | keep | sync-eng/common-branch_clean-13343                         | 
| Open       | Open           | No change | Keep   | sync-eng/common-branch_cleanup-3342                        |  
| Open       | Otherwise      | No change                 | Keep   | sync-eng/common-add-lang-product-slug-3368 | 
| Closed     | Open           | closed                    | delete | sync-eng/common-test_cleanup-3351                          |  
| Closed     | Otherwise      | No change                 | delete | sync-eng/common-branch_cleanup_test-3367                   |  
| Not configure | Open           |  No change | keep | daily/2022-05-02-ci-failed(js)                        |  
| Not configure | Otherwise      | No change                 | delete | daily/2022-05-02-ci-succeeded(js)              |  

_**Notes: `Otherwise` means PR not exist or closed.**_