### PR TITLE
Remove invalid arg to python api stub gen

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -31,7 +31,7 @@ namespace APIViewWeb
         public override string GetProcessorArguments(string originalName, string tempDirectory, string jsonPath)
         {
             return $" -m apistub --pkg-path {originalName} --temp-path {tempDirectory}" +
-                $" --out-path {jsonPath} --hide-report";
+                $" --out-path {jsonPath}";
         }
 
         private string GetPythonVirtualEnv(string tempDirectory)

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -17,7 +17,7 @@ namespace APIViewWeb
     {
         public override string Name { get; } = "Python";
         public override string Extension { get; } = ".whl";
-        public override string VersionString { get; } = "0.2.11";
+        public override string VersionString { get; } = "0.3.1";
 
         private readonly string _pythonExecutablePath;
         public override string ProcessName => _pythonExecutablePath;

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PackageNameManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PackageNameManager.cs
@@ -21,20 +21,20 @@ namespace APIViewWeb.Repositories
         static Dictionary<string, PackageModel> _packageNameMap = new();
         static TelemetryClient _telemetryClient = new(TelemetryConfiguration.CreateDefault());
 
-        public PackageNameManager()
+        public async Task<PackageModel> GetPackageDetails(string packageName)
         {
-            LoadPackageDisplayName("python");
-            LoadPackageDisplayName("java");
-            LoadPackageDisplayName("dotnet");
-            LoadPackageDisplayName("js");
-            LoadPackageDisplayName("go");
-            LoadPackageDisplayName("cpp");
-            LoadPackageDisplayName("c");
-            LoadPackageDisplayName("ios");
-        }
+            if(_packageNameMap.Count == 0)
+            {
+                await LoadPackageDisplayName("python");
+                await LoadPackageDisplayName("java");
+                await LoadPackageDisplayName("dotnet");
+                await LoadPackageDisplayName("js");
+                await LoadPackageDisplayName("go");
+                await LoadPackageDisplayName("cpp");
+                await LoadPackageDisplayName("c");
+                await LoadPackageDisplayName("ios");
+            }
 
-        public PackageModel GetPackageDetails(string packageName)
-        {
             if (packageName != null)
             {
                 if (_packageNameMap.ContainsKey(packageName))
@@ -45,18 +45,14 @@ namespace APIViewWeb.Repositories
             return null;
         }
 
-        private static void LoadPackageDisplayName(string language)
+        private async Task LoadPackageDisplayName(string language)
         {
             var url = PACKAGE_CSV_LOOKUP_URL.Replace("<langauge>", language.ToLower());
             try
             {
-                var respTask = _httpClient.GetAsync(url);
-                respTask.Wait();
-                var resp = respTask.Result;
+                var resp = await _httpClient.GetAsync(url);
                 resp.EnsureSuccessStatusCode();
-                var contentStreamTask = resp.Content.ReadAsStreamAsync();
-                contentStreamTask.Wait();
-                var contentStream = contentStreamTask.Result;
+                var contentStream = await resp.Content.ReadAsStreamAsync();
                 var csvReaderConfig = new CsvConfiguration(CultureInfo.InvariantCulture)
                 {
                     MissingFieldFound = null,

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -137,7 +137,7 @@ namespace APIViewWeb.Repositories
 
             if (review.PackageName != null && review.PackageDisplayName == null)
             {
-                var p = _packageNameManager.GetPackageDetails(review.PackageName);
+                var p = await _packageNameManager.GetPackageDetails(review.PackageName);
                 review.PackageDisplayName = p?.DisplayName;
                 review.ServiceName = p?.ServiceName;
             }
@@ -223,7 +223,7 @@ namespace APIViewWeb.Repositories
 
             if (review.PackageName != null)
             {
-                var p = _packageNameManager.GetPackageDetails(review.PackageName);
+                var p = await _packageNameManager.GetPackageDetails(review.PackageName);
                 review.PackageDisplayName = p?.DisplayName ?? review.PackageDisplayName;
                 review.ServiceName = p?.ServiceName ?? review.ServiceName;
             }


### PR DESCRIPTION
--hide-report is an invalid flag in latest api-stub-generator. Remove this unrecognized flag. 

Fixes #3356