### PR TITLE
Spell-check skippable by variable

### DIFF
--- a/eng/common/pipelines/templates/steps/check-spelling.yml
+++ b/eng/common/pipelines/templates/steps/check-spelling.yml
@@ -16,14 +16,14 @@ parameters:
 steps:
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     - task: NodeTool@0
-      condition: and(suceededOrFailed(), ne(variables['Skip.SpellCheck'],'true'))
+      condition: and(succeededOrFailed(), ne(variables['Skip.SpellCheck'],'true'))
       inputs:
         versionSpec: 16.x
       displayName: Use Node.js 16.x
 
     - task: PowerShell@2
       displayName: Check spelling (cspell)
-      condition: and(suceededOrFailed(), ne(variables['Skip.SpellCheck'],'true'))
+      condition: and(succeededOrFailed(), ne(variables['Skip.SpellCheck'],'true'))
       continueOnError: ${{ parameters.ContinueOnError }}
       inputs:
         targetType: filePath

--- a/eng/common/pipelines/templates/steps/check-spelling.yml
+++ b/eng/common/pipelines/templates/steps/check-spelling.yml
@@ -5,6 +5,9 @@
 # TargetBranch      - Target ref (e.g. main) to compare to create file change
 #                     list.
 # CspellConfigPath  - Path to cspell.json config location
+#
+# This check recognizes the setting of variable "Skip.SpellCheck"
+# if set to 'true', spellchecking will not be invoked.
 
 parameters:
   ContinueOnError: true
@@ -13,12 +16,14 @@ parameters:
 steps:
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
     - task: NodeTool@0
+      condition: and(suceededOrFailed(), ne(variables['Skip.SpellCheck'],'true'))
       inputs:
         versionSpec: 16.x
       displayName: Use Node.js 16.x
 
     - task: PowerShell@2
       displayName: Check spelling (cspell)
+      condition: and(suceededOrFailed(), ne(variables['Skip.SpellCheck'],'true'))
       continueOnError: ${{ parameters.ContinueOnError }}
       inputs:
         targetType: filePath


### PR DESCRIPTION
For the most part, this being present is not a big deal. When onboarding services though, ignoring spellcheck errors is usually pretty nice to begin with. It's only after getting all the other integration points figured out do we actually care about those errors.

