### PR TITLE
[Test-Proxy] Support Extensible Storage

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/MatcherTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/MatcherTests.cs
@@ -3,6 +3,7 @@ using Azure.Sdk.Tools.TestProxy.Matchers;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -260,7 +261,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             playbackContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             playbackContext.Request.ContentLength = body.Length;
            
-            var controller = new Playback(testRecordingHandler)
+            var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -28,7 +28,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             httpContext.Request.ContentLength = body.Length;
 
-            var controller = new Playback(testRecordingHandler)
+            var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -65,7 +65,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var playbackContext = new DefaultHttpContext();
             playbackContext.Request.Headers["x-recording-id"] = inMemId;
 
-            var playbackController = new Playback(testRecordingHandler)
+            var playbackController = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -88,7 +88,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var playbackContext = new DefaultHttpContext();
             var recordingId = Guid.NewGuid().ToString();
             playbackContext.Request.Headers["x-recording-id"] = recordingId;
-            var playbackController = new Playback(testRecordingHandler)
+            var playbackController = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -111,7 +111,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var playbackContext = new DefaultHttpContext();
             var recordingId = Guid.NewGuid().ToString();
             playbackContext.Request.Headers["x-recording-id"] = recordingId;
-            var playbackController = new Playback(testRecordingHandler)
+            var playbackController = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -135,7 +135,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             httpContext.Request.ContentLength = body.Length;
 
-            var controller = new Playback(testRecordingHandler)
+            var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -172,7 +172,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             var playbackContext = new DefaultHttpContext();
             playbackContext.Request.Headers["x-recording-id"] = inMemId;
-            var playbackController = new Playback(testRecordingHandler)
+            var playbackController = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -196,7 +196,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             httpContext.Request.ContentLength = body.Length;
 
-            var controller = new Playback(testRecordingHandler)
+            var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -189,7 +189,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             playbackContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             playbackContext.Request.ContentLength = body.Length;
 
-            var controller = new Playback(testRecordingHandler)
+            var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -762,32 +762,31 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
 
         [Theory]
-        [InlineData("hellothere", "generalkenobi")]
-        [InlineData("", "")]
-        public void TestSetRecordingOptionsHandlesValidStoreTypes(params string[] relativePaths)
+        [InlineData("{ \"AssetsStore\": \"NullStore\"}")]
+        [InlineData("{ \"AssetsStore\": \"GitStore\"}")]
+        [InlineData("{ \"AssetsStore\": \"Azure.Sdk.Tools.TestProxy.Store.GitStore\"}")]
+        [InlineData("{ \"AssetsStore\": \"Azure.Sdk.Tools.TestProxy.Store.NullStore\"}")]
+        public void TestSetRecordingOptionsHandlesValidStoreTypes(string body)
         {
-            var relativePath = Path.Combine(relativePaths);
-            var testDirectory = Path.GetTempPath();
-
-            RecordingHandler testRecordingHandler = new RecordingHandler(testDirectory);
-            testDirectory = Path.Combine(testDirectory, relativePath);
-            var body = $"{{ \"ContextDirectory\": \"{testDirectory.Replace("\\", "/")}\"}}";
-
-            var httpContext = new DefaultHttpContext();
-            Dictionary<string, object> inputBody = JsonConvert.DeserializeObject<Dictionary<string, object>>(body);
-
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            testRecordingHandler.Store = null;
+            Dictionary<string, object> inputBody = null;
+            if (!string.IsNullOrWhiteSpace(body))
+            {
+                inputBody = JsonConvert.DeserializeObject<Dictionary<string, object>>(body);
+            }
             testRecordingHandler.SetRecordingOptions(inputBody);
 
-            Assert.Equal(new Uri(testDirectory), new Uri(testRecordingHandler.ContextDirectory));
+            Assert.NotNull(testRecordingHandler.Store);
         }
 
         [Theory]
-        [InlineData("{ \"ContextDirectory\": \":/repo/\0\"}", "Unable set proxy context to target directory")]
+        [InlineData("{ \"AssetsStore\": \"NonExistent\"}", "Unable to load the specified IAssetStore class NonExistent.")]
+        [InlineData("{ \"AssetsStore\": \"\"}", "Users must provide a valid value to the key \"AssetsStore\"")]
+        [InlineData("{ \"AssetsStore\": \"GitAssetsConfiguration\"}", "Unable to create an instance of type GitAssetsConfiguration")]
         public void TestSetRecordingOptionsThrowsOnInvalidStoreTypes(string body, string errorText)
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            var httpContext = new DefaultHttpContext();
-
             Dictionary<string, object> inputBody = null;
             if (!string.IsNullOrWhiteSpace(body))
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TransformTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TransformTests.cs
@@ -2,6 +2,7 @@
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
 using System.IO;
 using System.Threading.Tasks;
 using Xunit;
@@ -31,7 +32,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             playbackContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             playbackContext.Request.ContentLength = body.Length;
 
-            var controller = new Playback(testRecordingHandler)
+            var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -74,7 +75,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             playbackContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             playbackContext.Request.ContentLength = body.Length;
 
-            var controller = new Playback(testRecordingHandler)
+            var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -110,7 +111,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             playbackContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             playbackContext.Request.ContentLength = body.Length;
 
-            var controller = new Playback(testRecordingHandler)
+            var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {
@@ -155,7 +156,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             playbackContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
             playbackContext.Request.ContentLength = body.Length;
 
-            var controller = new Playback(testRecordingHandler)
+            var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Sdk.Tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Store;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
@@ -212,7 +213,5 @@ namespace Azure.Sdk.Tools.TestProxy
                 else throw;
             }
         }
-
-
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -108,11 +108,6 @@ namespace Azure.Sdk.Tools.TestProxy
             _recordingHandler.SetRecordingOptions(options);
         }
 
-        [HttpPost]
-        public async Task Save()
-        {
-        }
-
         public object GetSanitizer(string name, JsonDocument body)
         {
             return GenerateInstance("Azure.Sdk.Tools.TestProxy.Sanitizers.", name, new HashSet<string>() { "value" }, documentBody: body);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -108,6 +108,11 @@ namespace Azure.Sdk.Tools.TestProxy
             _recordingHandler.SetRecordingOptions(options);
         }
 
+        [HttpPost]
+        public async Task Save()
+        {
+        }
+
         public object GetSanitizer(string name, JsonDocument body)
         {
             return GenerateInstance("Azure.Sdk.Tools.TestProxy.Sanitizers.", name, new HashSet<string>() { "value" }, documentBody: body);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Sdk.Tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Store;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
@@ -59,8 +60,7 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             await DebugLogger.LogRequestDetailsAsync(_logger, Request);
 
-            // TODO: handle errors
-            var pathToAssets = options["AssetsJsonLocation"].ToString();
+            var pathToAssets = StoreResolver.ParseAssetsJsonBody(options);
 
             _recordingHandler.Store.Reset(pathToAssets, _recordingHandler.ContextDirectory);
         }
@@ -70,8 +70,7 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             await DebugLogger.LogRequestDetailsAsync(_logger, Request);
 
-            // TODO: handle errors
-            var pathToAssets = options["AssetsJsonLocation"].ToString();
+            var pathToAssets = StoreResolver.ParseAssetsJsonBody(options);
 
             _recordingHandler.Store.Restore(pathToAssets, _recordingHandler.ContextDirectory);
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
@@ -56,11 +56,11 @@ namespace Azure.Sdk.Tools.TestProxy
 
 
         [HttpPost]
-        public async Task Save([FromBody()] IDictionary<string, object> options = null)
+        public async Task Push([FromBody()] IDictionary<string, object> options = null)
         {
             await DebugLogger.LogRequestDetailsAsync(_logger, Request);
             var pathToAssets = StoreResolver.ParseAssetsJsonBody(options);
-            _recordingHandler.Store.Save(pathToAssets, _recordingHandler.ContextDirectory);
+            _recordingHandler.Store.Push(pathToAssets, _recordingHandler.ContextDirectory);
         }
 
         [HttpPost]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Azure.Sdk.Tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Store;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using System;
@@ -58,13 +59,9 @@ namespace Azure.Sdk.Tools.TestProxy
         public async Task Save([FromBody()] IDictionary<string, object> options = null)
         {
             await DebugLogger.LogRequestDetailsAsync(_logger, Request);
-
-            // TODO: handle errors
-            var pathToAssets = options["AssetsJsonLocation"].ToString();
-
+            var pathToAssets = StoreResolver.ParseAssetsJsonBody(options);
             _recordingHandler.Store.Save(pathToAssets, _recordingHandler.ContextDirectory);
         }
-
 
         [HttpPost]
         [AllowEmptyBody]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
@@ -17,7 +17,6 @@ namespace Azure.Sdk.Tools.TestProxy
     public sealed class Record : ControllerBase
     {
         private readonly ILogger _logger;
-
         private readonly RecordingHandler _recordingHandler;
 
         private static readonly HttpClient RedirectableClient = Startup.Insecure ?
@@ -53,6 +52,19 @@ namespace Azure.Sdk.Tools.TestProxy
 
             _recordingHandler.StartRecording(file, Response);
         }
+
+
+        [HttpPost]
+        public async Task Save([FromBody()] IDictionary<string, object> options = null)
+        {
+            await DebugLogger.LogRequestDetailsAsync(_logger, Request);
+
+            // TODO: handle errors
+            var pathToAssets = options["AssetsJsonLocation"].ToString();
+
+            _recordingHandler.Store.Save(pathToAssets, _recordingHandler.ContextDirectory);
+        }
+
 
         [HttpPost]
         [AllowEmptyBody]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -1,6 +1,7 @@
 ﻿using Azure.Core;
 using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Sanitizers;
+using Azure.Sdk.Tools.TestProxy.Store;
 using Azure.Sdk.Tools.TestProxy.Transforms;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
@@ -31,12 +32,22 @@ namespace Azure.Sdk.Tools.TestProxy
         private const string SkipRecordingHeaderKey = "x-recording-skip";
         private const string SkipRecordingRequestBody = "request-body";
         private const string SkipRecordingRequestResponse = "request-response";
+        private IAssetsStore _store;
 
-        public RecordingHandler(string targetDirectory)
+        public RecordingHandler(string targetDirectory, IAssetsStore store = null)
         {
             ContextDirectory = targetDirectory;
 
             SetDefaultExtensions();
+
+            if (store != null)
+            {
+                _store = store;
+            }
+            else
+            {
+                _store = new NullStore();
+            }
         }
 
         private static readonly RecordedTestSanitizer defaultSanitizer = new RecordedTestSanitizer();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -512,7 +512,6 @@ namespace Azure.Sdk.Tools.TestProxy
                 {
                     var newAssetsStoreIdentifier = assetsStoreObj.ToString();
 
-                    // TODO: implement this
                     if (!string.IsNullOrWhiteSpace(newAssetsStoreIdentifier))
                     {
                         SetAssetsStore(newAssetsStoreIdentifier);
@@ -698,7 +697,6 @@ namespace Azure.Sdk.Tools.TestProxy
                 Matcher = new RecordMatcher();
             }
         }
-
 
         public string GetRecordingPath(string file)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -32,9 +32,9 @@ namespace Azure.Sdk.Tools.TestProxy
         private const string SkipRecordingHeaderKey = "x-recording-skip";
         private const string SkipRecordingRequestBody = "request-body";
         private const string SkipRecordingRequestResponse = "request-response";
-        private AssetsStore _store;
+        public IAssetsStore Store;
 
-        public RecordingHandler(string targetDirectory, AssetsStore store = null)
+        public RecordingHandler(string targetDirectory, IAssetsStore store = null)
         {
             ContextDirectory = targetDirectory;
 
@@ -42,11 +42,11 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (store != null)
             {
-                _store = store;
+                Store = store;
             }
             else
             {
-                _store = new NullStore();
+                Store = new NullStore();
             }
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -64,23 +64,16 @@ namespace Azure.Sdk.Tools.TestProxy
 
             SetDefaultExtensions();
 
+            Store = store;
             if (store == null)
             {
                 Store = new NullStore();
             }
-            else
-            {
-                Store = store;
-            }
 
-            if (storeResolver == null)
+            Resolver = storeResolver;
+            if (Resolver == null)
             {
-                // with no additional directory load context
-                Resolver = new StoreResolver(String.Empty);
-            }
-            else
-            {
-                Resolver = storeResolver;
+                Resolver = new StoreResolver();
             }
         }
         #endregion

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -506,6 +506,10 @@ namespace Azure.Sdk.Tools.TestProxy
                     {
                         SetRecordingDirectory(newSourceDirectory);
                     }
+                    else
+                    {
+                        throw new HttpException(HttpStatusCode.BadRequest, "Users must provide a valid value to the key \"ContextDirectory\" in the recording options dictionary.");
+                    }
                 }
 
                 if (options.TryGetValue("AssetsStore", out var assetsStoreObj))
@@ -515,6 +519,10 @@ namespace Azure.Sdk.Tools.TestProxy
                     if (!string.IsNullOrWhiteSpace(newAssetsStoreIdentifier))
                     {
                         SetAssetsStore(newAssetsStoreIdentifier);
+                    }
+                    else
+                    {
+                        throw new HttpException(HttpStatusCode.BadRequest, "Users must provide a valid value to the key \"AssetsStore\" in the recording options dictionary.");
                     }
                 }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -32,9 +32,9 @@ namespace Azure.Sdk.Tools.TestProxy
         private const string SkipRecordingHeaderKey = "x-recording-skip";
         private const string SkipRecordingRequestBody = "request-body";
         private const string SkipRecordingRequestResponse = "request-response";
-        private IAssetsStore _store;
+        private AssetsStore _store;
 
-        public RecordingHandler(string targetDirectory, IAssetsStore store = null)
+        public RecordingHandler(string targetDirectory, AssetsStore store = null)
         {
             ContextDirectory = targetDirectory;
 
@@ -504,11 +504,32 @@ namespace Azure.Sdk.Tools.TestProxy
                         SetRecordingDirectory(newSourceDirectory);
                     }
                 }
+
+                if (options.TryGetValue("AssetsStore", out var assetsStoreObj))
+                {
+                    var newAssetsStoreIdentifier = assetsStoreObj.ToString();
+
+                    // TODO: implement this
+                    if (!string.IsNullOrWhiteSpace(newAssetsStoreIdentifier))
+                    {
+                        SetAssetsStore(newAssetsStoreIdentifier);
+                    }
+                }
+
             }
             else
             {
                 throw new HttpException(HttpStatusCode.BadRequest, "When setting recording options, the request body is expected to be non-null and of type Dictionary<string, string>.");
             }
+        }
+
+        public void SetAssetsStore(string assetsStoreId)
+        {
+            // TODO
+            // check local assembly
+            // check provided remote assembly lookup point
+
+            _store = new GitStore();
         }
 
         public void SetRecordingDirectory(string targetDirectory)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -32,7 +32,8 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public static string TargetLocation;
         public static string TargetPlugin;
-        public static string AssemblyDirectory;
+        public static StoreResolver Resolver;
+        public static IAssetsStore DefaultStore;
 
         private static string resolveRepoLocation(string storageLocation = null)
         {
@@ -47,12 +48,14 @@ namespace Azure.Sdk.Tools.TestProxy
         /// </summary>
         /// <param name="insecure">Allow untrusted SSL certs from upstream server</param>
         /// <param name="storageLocation">The path to the target local git repo. If not provided as an argument, Environment variable TEST_PROXY_FOLDER will be consumed. Lacking both, the current working directory will be utilized.</param>
-        /// <param name="dump">Flag. Pass to dump configuration values before starting the application.</param>
         /// <param name="storagePlugin">Does the user have a preference as to a default startup plugin? Defaults to "No plugin" currently.</param>
         /// <param name="assemblyDirectory">If the user has defined a custom storage extension, they should place their DLL in a directory and said directory to this argument.</param>
+        /// <param name="command">A specific test-proxy action to be carried out. Supported options: ["Save", "Restore", "Reset"]</param>
+        /// <param name="assetsJsonPath">Only required if a "command" value is present. This should be a path to a valid assets.json within a language repository.</param>
+        /// <param name="dump">Flag. Pass to dump configuration values before starting the application.</param>
         /// <param name="version">Flag. Pass to get the version of the tool.</param>
         /// <param name="args">Unmapped arguments un-used by the test-proxy are sent directly to the ASPNET configuration provider.</param>
-        public static void Main(bool insecure = false, string storageLocation = null, bool dump = false, string storagePlugin = null, string assemblyDirectory = null, bool version = false, string[] args = null)
+        public static void Main(bool insecure = false, string storageLocation = null, string storagePlugin = null, string assemblyDirectory = null, string command = null, string assetsJsonPath = null, bool dump = false, bool version = false, string[] args = null)
         {
             if (version)
             {
@@ -65,15 +68,38 @@ namespace Azure.Sdk.Tools.TestProxy
                 Environment.Exit(0);
             }
 
-            _insecure = insecure;
+            TargetLocation = resolveRepoLocation(storageLocation);
+            Resolver = new StoreResolver(assemblyDirectory);
+            DefaultStore = Resolver.ResolveStore(storagePlugin ?? "NullStore");
 
+            if (!String.IsNullOrWhiteSpace(command))
+            {
+                if (!File.Exists(assetsJsonPath))
+                {
+                    throw new Exception($"Unable to launch a storage activity against the assets json path provided. The file \"{assetsJsonPath}\" does not exist.");
+                }
+
+                switch (command.ToLowerInvariant())
+                {
+                    case "save":
+                        DefaultStore.Save(assetsJsonPath, TargetLocation);
+                        break;
+                    case "restore":
+                        DefaultStore.Restore(assetsJsonPath, TargetLocation);
+                        break;
+                    case "reset":
+                        DefaultStore.Reset(assetsJsonPath, TargetLocation);
+                        break;
+                    default:
+                        throw new Exception($"One must provide a valid value for argument \"command\". \"{command}\" is not a valid option.");
+                }
+                    
+            }
+
+            _insecure = insecure;
             Regex.CacheSize = 0;
 
             var statusThreadCts = new CancellationTokenSource();
-
-            TargetLocation = resolveRepoLocation(storageLocation);
-            TargetPlugin = storagePlugin;
-            AssemblyDirectory = assemblyDirectory;
 
             var statusThread = PrintStatus(
                 () => $"[{DateTime.UtcNow.ToString("HH:mm:ss")}] Recorded: {RequestsRecorded}\tPlayed Back: {RequestsPlayedBack}",
@@ -144,13 +170,13 @@ namespace Azure.Sdk.Tools.TestProxy
             services.AddControllersWithViews();
             services.AddRazorPages();
 
-            var resolver = new StoreResolver(TargetLocation);
-            var store = resolver.ResolveStore(TargetPlugin);
+            
+            var store = Resolver.ResolveStore(TargetPlugin);
 
             var singleTonRecordingHandler = new RecordingHandler(
                 TargetLocation,
-                store: store,
-                storeResolver: resolver
+                store: DefaultStore,
+                storeResolver: Resolver
             );
 
             services.AddSingleton<RecordingHandler>(singleTonRecordingHandler);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -47,14 +47,13 @@ namespace Azure.Sdk.Tools.TestProxy
         /// </summary>
         /// <param name="insecure">Allow untrusted SSL certs from upstream server</param>
         /// <param name="storageLocation">The path to the target local git repo. If not provided as an argument, Environment variable TEST_PROXY_FOLDER will be consumed. Lacking both, the current working directory will be utilized.</param>
-        /// <param name="storagePlugin">Does the user have a preference as to a default startup plugin? Defaults to "No plugin" currently.</param>
-        /// <param name="assemblyDirectory">If the user has defined a custom storage extension, they should place their DLL in a directory and said directory to this argument.</param>
+        /// <param name="storagePlugin">Does the user have a preference as to a default storage plugin? Defaults to "No plugin" currently.</param>
         /// <param name="command">A specific test-proxy action to be carried out. Supported options: ["Save", "Restore", "Reset"]</param>
         /// <param name="assetsJsonPath">Only required if a "command" value is present. This should be a path to a valid assets.json within a language repository.</param>
         /// <param name="dump">Flag. Pass to dump configuration values before starting the application.</param>
         /// <param name="version">Flag. Pass to get the version of the tool.</param>
         /// <param name="args">Unmapped arguments un-used by the test-proxy are sent directly to the ASPNET configuration provider.</param>
-        public static void Main(bool insecure = false, string storageLocation = null, string storagePlugin = null, string assemblyDirectory = null, string command = null, string assetsJsonPath = null, bool dump = false, bool version = false, string[] args = null)
+        public static void Main(bool insecure = false, string storageLocation = null, string storagePlugin = null, string command = null, string assetsJsonPath = null, bool dump = false, bool version = false, string[] args = null)
         {
             if (version)
             {
@@ -68,7 +67,7 @@ namespace Azure.Sdk.Tools.TestProxy
             }
 
             TargetLocation = resolveRepoLocation(storageLocation);
-            Resolver = new StoreResolver(assemblyDirectory);
+            Resolver = new StoreResolver();
             DefaultStore = Resolver.ResolveStore(storagePlugin ?? "NullStore");
 
             if (!String.IsNullOrWhiteSpace(command))
@@ -163,13 +162,13 @@ namespace Azure.Sdk.Tools.TestProxy
             services.AddControllersWithViews();
             services.AddRazorPages();
 
-            var singleTonRecordingHandler = new RecordingHandler(
+            var singletonRecordingHandler = new RecordingHandler(
                 TargetLocation,
                 store: DefaultStore,
                 storeResolver: Resolver
             );
 
-            services.AddSingleton<RecordingHandler>(singleTonRecordingHandler);
+            services.AddSingleton<RecordingHandler>(singletonRecordingHandler);
         }
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -76,7 +76,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 switch (command.ToLowerInvariant())
                 {
                     case "save":
-                        DefaultStore.Save(assetsJsonPath, TargetLocation);
+                        DefaultStore.Push(assetsJsonPath, TargetLocation);
                         break;
                     case "restore":
                         DefaultStore.Restore(assetsJsonPath, TargetLocation);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -74,11 +74,6 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (!String.IsNullOrWhiteSpace(command))
             {
-                if (!File.Exists(assetsJsonPath))
-                {
-                    throw new Exception($"Unable to launch a storage activity against the assets json path provided. The file \"{assetsJsonPath}\" does not exist.");
-                }
-
                 switch (command.ToLowerInvariant())
                 {
                     case "save":
@@ -93,7 +88,6 @@ namespace Azure.Sdk.Tools.TestProxy
                     default:
                         throw new Exception($"One must provide a valid value for argument \"command\". \"{command}\" is not a valid option.");
                 }
-                    
             }
 
             _insecure = insecure;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -31,7 +31,6 @@ namespace Azure.Sdk.Tools.TestProxy
         public Startup(IConfiguration configuration) { }
 
         public static string TargetLocation;
-        public static string TargetPlugin;
         public static StoreResolver Resolver;
         public static IAssetsStore DefaultStore;
 
@@ -163,9 +162,6 @@ namespace Azure.Sdk.Tools.TestProxy
             });
             services.AddControllersWithViews();
             services.AddRazorPages();
-
-            
-            var store = Resolver.ResolveStore(TargetPlugin);
 
             var singleTonRecordingHandler = new RecordingHandler(
                 TargetLocation,

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/AssetsConfiguration.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/AssetsConfiguration.cs
@@ -1,0 +1,18 @@
+namespace Azure.Sdk.Tools.TestProxy.Store
+{
+    /// <summary>
+    /// This class is used to represent any assets.json configuration. An assets.json configuration contains all the necessary configuration needed to restore an asset to the local storage directory of the test-proxy.
+    /// </summary>
+    public class AssetsConfiguration
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        public virtual string AssetsJsonRelativeLocation { get; set; }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public virtual string AssetsJsonLocation { get; set; }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
@@ -1,0 +1,29 @@
+namespace Azure.Sdk.Tools.TestProxy.Store
+{
+    /// <summary>
+    /// This class is used to represent any assets.json configuration. An assets.json configuration contains all the necessary configuration needed to restore an asset to the local storage directory of the test-proxy.
+    /// </summary>
+    public class GitAssetsConfiguration : AssetsConfiguration
+    {
+
+        /// <summary>
+        /// The targeted assets repo. EG: "Azure/azure-sdk-for-net".
+        /// </summary>
+        public string AssetsRepo { get; set; }
+
+        /// <summary>
+        /// The targeted SHA within the AssetsRepo.
+        /// </summary>
+        public string SHA { get; set;  }
+
+        /// <summary>
+        /// Within the assets repo, is there a prefix that should be inserted prior to writing out files?
+        /// </summary>
+        public string AssetsRepoPrefixPath { get; set; }
+
+        /// <summary>
+        /// The auto-commit branch.
+        /// </summary>
+        public string AssetsRepoBranch { get; set; }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -7,7 +7,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 {
     public class GitStore : IAssetsStore
     {
-        public void Save(string pathToAssetsJson, string contextPath) {
+        public void Push(string pathToAssetsJson, string contextPath) {
             var config = ParseConfigurationFile(pathToAssetsJson);
 
             throw new NotImplementedException();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using Azure.Sdk.Tools.TestProxy.Common;
+using System.Net;
+
+namespace Azure.Sdk.Tools.TestProxy.Store
+{
+    public class GitStore : AssetsStore
+    {
+        public void Save(AssetsConfiguration assetsConfig, string contextPath) {}
+
+        public void Restore(AssetsConfiguration assetsConfig, string contextPath) {}
+
+        public void Reset(AssetsConfiguration assetsConfig, string contextPath) {}
+
+        public override GitAssetsConfiguration ParseConfigurationFile(string assetsJsonPath)
+        {
+            if (!File.Exists(assetsJsonPath)) {
+                throw new HttpException(HttpStatusCode.BadRequest, $"The provided assets json path of \"{assetsJsonPath}\" does not exist.");
+            }
+
+            return new GitAssetsConfiguration();
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -4,15 +4,21 @@ using System.Net;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
-    public class GitStore : AssetsStore
+    public class GitStore : IAssetsStore
     {
-        public void Save(AssetsConfiguration assetsConfig, string contextPath) {}
+        public void Save(string pathToAssetsJson, string contextPath) {
+            var config = ParseConfigurationFile(pathToAssetsJson);
+        }
 
-        public void Restore(AssetsConfiguration assetsConfig, string contextPath) {}
+        public void Restore(string pathToAssetsJson, string contextPath) {
+            var config = ParseConfigurationFile(pathToAssetsJson);
+        }
 
-        public void Reset(AssetsConfiguration assetsConfig, string contextPath) {}
+        public void Reset(string pathToAssetsJson, string contextPath) {
+            var config = ParseConfigurationFile(pathToAssetsJson);
+        }
 
-        public override GitAssetsConfiguration ParseConfigurationFile(string assetsJsonPath)
+        public GitAssetsConfiguration ParseConfigurationFile(string assetsJsonPath)
         {
             if (!File.Exists(assetsJsonPath)) {
                 throw new HttpException(HttpStatusCode.BadRequest, $"The provided assets json path of \"{assetsJsonPath}\" does not exist.");

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using Azure.Sdk.Tools.TestProxy.Common;
 using System.Net;
+using System;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
@@ -8,14 +9,20 @@ namespace Azure.Sdk.Tools.TestProxy.Store
     {
         public void Save(string pathToAssetsJson, string contextPath) {
             var config = ParseConfigurationFile(pathToAssetsJson);
+
+            throw new NotImplementedException();
         }
 
         public void Restore(string pathToAssetsJson, string contextPath) {
             var config = ParseConfigurationFile(pathToAssetsJson);
+
+            throw new NotImplementedException();
         }
 
         public void Reset(string pathToAssetsJson, string contextPath) {
             var config = ParseConfigurationFile(pathToAssetsJson);
+
+            throw new NotImplementedException();
         }
 
         public GitAssetsConfiguration ParseConfigurationFile(string assetsJsonPath)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsOperations.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsOperations.cs
@@ -1,0 +1,35 @@
+using System.IO;
+
+namespace Azure.Sdk.Tools.TestProxy.Store
+{
+    public interface IAssetsStore
+    {
+        /// <summary>
+        /// Given a configuration, push the changes made by the test-proxy into the remote store.
+        /// </summary>
+        /// <param name="assetsConfig"></param>
+        /// <param name="contextPath"></param>
+        public void Save(AssetsConfiguration assetsConfig, string contextPath);
+
+        /// <summary>
+        /// Given a configuration, pull any remote resources down into the provided contextPath.
+        /// </summary>
+        /// <param name="assetsConfig"></param>
+        /// <param name="contextPath"></param>
+        public void Restore(AssetsConfiguration assetsConfig, string contextPath);
+
+        /// <summary>
+        /// Given a configuration, determine the state of the resources present under contextPath, reset those resources to their "fresh" state.
+        /// </summary>
+        /// <param name="assetsConfig"></param>
+        /// <param name="contextPath"></param>
+        public void Reset(AssetsConfiguration assetsConfig, string contextPath);
+
+        /// <summary>
+        /// Parses a configuration file and returns the appropriate Configuration class for further usage.
+        /// </summary>
+        /// <param name="assetsJsonPath"></param>
+        /// <returns>An object representing the configuration class. This means that call-site should cast this to their preferred Configuration type.</returns>
+        public object ParseConfigurationFile(string assetsJsonPath);
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsStore.cs
@@ -9,7 +9,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// </summary>
         /// <param name="pathToAssetsJson"></param>
         /// <param name="contextPath"></param>
-        public abstract void Save(string pathToAssetsJson, string contextPath);
+        public abstract void Push(string pathToAssetsJson, string contextPath);
 
         /// <summary>
         /// Given a configuration, pull any remote resources down into the provided contextPath.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsStore.cs
@@ -2,34 +2,34 @@ using System.IO;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
-    public interface IAssetsStore
+    public abstract class AssetsStore
     {
         /// <summary>
         /// Given a configuration, push the changes made by the test-proxy into the remote store.
         /// </summary>
         /// <param name="assetsConfig"></param>
         /// <param name="contextPath"></param>
-        public void Save(AssetsConfiguration assetsConfig, string contextPath);
+        public abstract void Save<T>(T assetsConfig, string contextPath);
 
         /// <summary>
         /// Given a configuration, pull any remote resources down into the provided contextPath.
         /// </summary>
         /// <param name="assetsConfig"></param>
         /// <param name="contextPath"></param>
-        public void Restore(AssetsConfiguration assetsConfig, string contextPath);
+        public abstract void Restore<T>(T assetsConfig, string contextPath);
 
         /// <summary>
         /// Given a configuration, determine the state of the resources present under contextPath, reset those resources to their "fresh" state.
         /// </summary>
         /// <param name="assetsConfig"></param>
         /// <param name="contextPath"></param>
-        public void Reset(AssetsConfiguration assetsConfig, string contextPath);
+        public abstract void Reset<T>(T assetsConfig, string contextPath);
 
         /// <summary>
         /// Parses a configuration file and returns the appropriate Configuration class for further usage.
         /// </summary>
         /// <param name="assetsJsonPath"></param>
         /// <returns>An object representing the configuration class. This means that call-site should cast this to their preferred Configuration type.</returns>
-        public object ParseConfigurationFile(string assetsJsonPath);
+        public abstract AssetsConfiguration ParseConfigurationFile(string assetsJsonPath);
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsStore.cs
@@ -2,34 +2,27 @@ using System.IO;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
-    public abstract class AssetsStore
+    public interface IAssetsStore
     {
         /// <summary>
         /// Given a configuration, push the changes made by the test-proxy into the remote store.
         /// </summary>
-        /// <param name="assetsConfig"></param>
+        /// <param name="pathToAssetsJson"></param>
         /// <param name="contextPath"></param>
-        public abstract void Save<T>(T assetsConfig, string contextPath);
+        public abstract void Save(string pathToAssetsJson, string contextPath);
 
         /// <summary>
         /// Given a configuration, pull any remote resources down into the provided contextPath.
         /// </summary>
-        /// <param name="assetsConfig"></param>
+        /// <param name="pathToAssetsJson"></param>
         /// <param name="contextPath"></param>
-        public abstract void Restore<T>(T assetsConfig, string contextPath);
+        public abstract void Restore(string pathToAssetsJson, string contextPath);
 
         /// <summary>
         /// Given a configuration, determine the state of the resources present under contextPath, reset those resources to their "fresh" state.
         /// </summary>
-        /// <param name="assetsConfig"></param>
+        /// <param name="pathToAssetsJson"></param>
         /// <param name="contextPath"></param>
-        public abstract void Reset<T>(T assetsConfig, string contextPath);
-
-        /// <summary>
-        /// Parses a configuration file and returns the appropriate Configuration class for further usage.
-        /// </summary>
-        /// <param name="assetsJsonPath"></param>
-        /// <returns>An object representing the configuration class. This means that call-site should cast this to their preferred Configuration type.</returns>
-        public abstract AssetsConfiguration ParseConfigurationFile(string assetsJsonPath);
+        public abstract void Reset(string pathToAssetsJson, string contextPath);
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
@@ -1,0 +1,24 @@
+using System.IO;
+using Azure.Sdk.Tools.TestProxy.Common;
+using System.Net;
+
+namespace Azure.Sdk.Tools.TestProxy.Store
+{
+    public class NullStore : IAssetsStore
+    {
+        public void Save(AssetsConfiguration assetsConfig, string contextPath) {}
+
+        public void Restore(AssetsConfiguration assetsConfig, string contextPath) {}
+
+        public void Reset(AssetsConfiguration assetsConfig, string contextPath) {}
+
+        public object ParseConfigurationFile(string assetsJsonPath)
+        {
+            if (!File.Exists(assetsJsonPath)) {
+                throw new HttpException(HttpStatusCode.BadRequest, $"The provided assets json path of \"{assetsJsonPath}\" does not exist.");
+            }
+
+            return new AssetsConfiguration();
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
@@ -4,15 +4,15 @@ using System.Net;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
-    public class NullStore : AssetsStore
+    public class NullStore : IAssetsStore
     {
-        public override void Save(AssetsConfiguration assetsConfig, string contextPath) {}
+        public void Save(string assetsJsonPath, string contextPath) {}
 
-        public override void Restore(AssetsConfiguration assetsConfig, string contextPath) {}
+        public void Restore(string assetsJsonPath, string contextPath) {}
 
-        public override void Reset(AssetsConfiguration assetsConfig, string contextPath) {}
+        public void Reset(string assetsJsonPath, string contextPath) {}
 
-        public override AssetsConfiguration ParseConfigurationFile(string assetsJsonPath)
+        public AssetsConfiguration ParseConfigurationFile(string assetsJsonPath)
         {
             if (!File.Exists(assetsJsonPath)) {
                 throw new HttpException(HttpStatusCode.BadRequest, $"The provided assets json path of \"{assetsJsonPath}\" does not exist.");

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
@@ -4,15 +4,15 @@ using System.Net;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
-    public class NullStore : IAssetsStore
+    public class NullStore : AssetsStore
     {
-        public void Save(AssetsConfiguration assetsConfig, string contextPath) {}
+        public override void Save(AssetsConfiguration assetsConfig, string contextPath) {}
 
-        public void Restore(AssetsConfiguration assetsConfig, string contextPath) {}
+        public override void Restore(AssetsConfiguration assetsConfig, string contextPath) {}
 
-        public void Reset(AssetsConfiguration assetsConfig, string contextPath) {}
+        public override void Reset(AssetsConfiguration assetsConfig, string contextPath) {}
 
-        public object ParseConfigurationFile(string assetsJsonPath)
+        public override AssetsConfiguration ParseConfigurationFile(string assetsJsonPath)
         {
             if (!File.Exists(assetsJsonPath)) {
                 throw new HttpException(HttpStatusCode.BadRequest, $"The provided assets json path of \"{assetsJsonPath}\" does not exist.");

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
@@ -6,7 +6,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 {
     public class NullStore : IAssetsStore
     {
-        public void Save(string assetsJsonPath, string contextPath) {}
+        public void Push(string assetsJsonPath, string contextPath) {}
 
         public void Restore(string assetsJsonPath, string contextPath) {}
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
@@ -1,3 +1,10 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using Azure.Sdk.Tools.TestProxy.Common;
+
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
     public class StoreResolver
@@ -6,26 +13,100 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
         public StoreResolver(string[] assemblyDirectories)
         {
-            // TODO: handle null/empty/invalid paths here.
+            foreach(var directory in assemblyDirectories)
+            {
+                if (!File.Exists(directory))
+                {
+                    throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"Provided directory {directory} does not exist.");
+                }
+            }
+
             AssemblyDirectories = assemblyDirectories;
         }
 
         public StoreResolver(string assemblyDirectory)
         {
-            // TODO: handle null/empty/invalid paths here.
+            if (!File.Exists(assemblyDirectory))
+            {
+                throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"Provided directory {assemblyDirectory} does not exist.");
+            }
+
             AssemblyDirectories = new string[] { assemblyDirectory };
+        }
+
+        private Assembly LoadAssembly(string path)
+        {
+            return null;
+        }
+
+        private Type CheckAssemblyForStore(string storeName, Assembly inputAssembly)
+        {
+            throw new NotImplementedException();
+        }
+
+        private string[] GetAssembliesFromFolder(string folder)
+        {
+            return Directory.GetFiles(folder, "*.dll");
         }
 
         /// <summary>
         /// Used to resolve the store given a name and an additional assembly directory. The provided path will be added to the existing set present within AssemblyDirectories property.
+        /// This function will take the FIRST matched assembly type by NAME.
         /// </summary>
         /// <param name="storeName"></param>
         /// <param name="additionalAssemblyDirectory"></param>
         /// <returns></returns>
         public IAssetsStore ResolveStore(string storeName, string additionalAssemblyDirectory)
         {
-            // TODO: implement
-            return new NullStore();
+            // first check if the type is present in executing assembly
+            var invokingAssembly = Assembly.GetExecutingAssembly();
+
+            var storeType = CheckAssemblyForStore(storeName, invokingAssembly);
+
+            if (storeType == null)
+            {
+                foreach(var assemblyDirectory in AssemblyDirectories)
+                {
+                    var assemblyFiles = GetAssembliesFromFolder(assemblyDirectory);
+
+                    foreach(var assemblyFile in assemblyFiles)
+                    {
+                        storeType = CheckAssemblyForStore(storeName, LoadAssembly(assemblyFile));
+
+                        if(storeType != null)
+                        {
+                            break;
+                        }
+                    }
+
+                    if (storeType != null)
+                    {
+                        break;
+                    }
+                }
+            }
+
+            if (storeType == null)
+            {
+                throw new HttpException(
+                    System.Net.HttpStatusCode.BadRequest,
+                    $"Unable to load the specified IAssetStore class {storeName}. Looked in invoking assembly as well as additional directories: [{String.Join(",", AssemblyDirectories)}]"
+                );
+            }
+
+            try
+            {
+                var generatedStore = Activator.CreateInstance(storeType);
+
+                return (IAssetsStore)generatedStore;
+            }
+            catch (Exception e)
+            {
+                throw new HttpException(
+                    System.Net.HttpStatusCode.BadRequest,
+                    $"Unable to create an instance of type {storeType.Name}. This name was generated from input {storeName}. The invoking assembly and directories [{String.Join(",", AssemblyDirectories)}] were queried for this type."
+                );
+            }
         }
 
         /// <summary>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
@@ -31,6 +31,12 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
         public StoreResolver(string assemblyDirectory = null)
         {
+            if (assemblyDirectory == null)
+            {
+                AssemblyDirectories = new string[] { };
+                return;
+            }
+
             if (!File.Exists(assemblyDirectory))
             {
                 throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"Provided directory {assemblyDirectory} does not exist.");
@@ -46,7 +52,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
         private Type GetTypeFromAssembly(string storeName, Assembly inputAssembly)
         {
-            foreach(var type in inputAssembly.GetTypes()) {
+            var allTypes = inputAssembly.GetTypes().ToList();
+
+            foreach (var type in allTypes) {
                 if (type.Name.ToLowerInvariant().Contains(storeName.ToLowerInvariant()))
                 {
                     return type;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
@@ -24,7 +24,12 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             AssemblyDirectories = assemblyDirectories;
         }
 
-        public StoreResolver(string assemblyDirectory)
+        public StoreResolver()
+        {
+            AssemblyDirectories = new string[] {};
+        }
+
+        public StoreResolver(string assemblyDirectory = null)
         {
             if (!File.Exists(assemblyDirectory))
             {
@@ -99,7 +104,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             var invokingAssembly = Assembly.GetExecutingAssembly();
             var storeType = GetTypeFromAssembly(storeName, invokingAssembly);
 
-            // then we will only do the heavy lifting of multiple assemblies if we HAVE to
+            // then we will only do the heavy lifting of multiple assembly loads if we HAVE to
             if (storeType == null)
             {
                 foreach (var assemblyDirectory in assemblyDirectories)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
@@ -55,7 +55,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             var allTypes = inputAssembly.GetTypes().ToList();
 
             foreach (var type in allTypes) {
-                if (type.Name.ToLowerInvariant().Contains(storeName.ToLowerInvariant()))
+                if (type.FullName.ToLowerInvariant().Contains(storeName.ToLowerInvariant()))
                 {
                     return type;
                 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Reflection;
 using Azure.Sdk.Tools.TestProxy.Common;
 
@@ -158,6 +159,28 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     + $"Visible Exception is \"{e.Message}\"."
                 );
             }
+        }
+
+        public static string ParseAssetsJsonBody(IDictionary<string, object> options)
+        {
+            if (!options.ContainsKey("AssetsJsonLocation"))
+            {
+                throw new HttpException(HttpStatusCode.BadRequest, "Users provide the key AssetsJsonLocation within the JSON body sent to this endpoint.");
+            }
+
+            var value = options["AssetsJsonLocation"].ToString();
+
+            if (string.IsNullOrWhiteSpace(value))
+            {
+                throw new HttpException(HttpStatusCode.BadRequest, $"A valid value to key \"AssetsJsonLocation\" is required. Received null, whitespace, or nothing.");
+            }
+
+            if (System.IO.File.Exists(value))
+            {
+                throw new HttpException(HttpStatusCode.BadRequest, $"When providing a path to the assets json, it must be locally resolvable. Input Value: \"{value}\".");
+            }
+
+            return value;
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
@@ -1,0 +1,42 @@
+namespace Azure.Sdk.Tools.TestProxy.Store
+{
+    public class StoreResolver
+    {
+        public string[] AssemblyDirectories { get; set; }
+
+        public StoreResolver(string[] assemblyDirectories)
+        {
+            // TODO: handle null/empty/invalid paths here.
+            AssemblyDirectories = assemblyDirectories;
+        }
+
+        public StoreResolver(string assemblyDirectory)
+        {
+            // TODO: handle null/empty/invalid paths here.
+            AssemblyDirectories = new string[] { assemblyDirectory };
+        }
+
+        /// <summary>
+        /// Used to resolve the store given a name and an additional assembly directory. The provided path will be added to the existing set present within AssemblyDirectories property.
+        /// </summary>
+        /// <param name="storeName"></param>
+        /// <param name="additionalAssemblyDirectory"></param>
+        /// <returns></returns>
+        public IAssetsStore ResolveStore(string storeName, string additionalAssemblyDirectory)
+        {
+            // TODO: implement
+            return new NullStore();
+        }
+
+        /// <summary>
+        /// Used to resolve the store given a name and an additional assembly directory.
+        /// </summary>
+        /// <param name="storeName"></param>
+        /// <returns></returns>
+        public IAssetsStore ResolveStore(string storeName)
+        {
+            // TODO: implement
+            return new NullStore();
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/StoreResolver.cs
@@ -10,40 +10,8 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 {
     public class StoreResolver
     {
-        public string[] AssemblyDirectories { get; set; }
-
-        public StoreResolver(string[] assemblyDirectories)
-        {
-            foreach(var directory in assemblyDirectories)
-            {
-                if (!File.Exists(directory))
-                {
-                    throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"Provided directory {directory} does not exist.");
-                }
-            }
-
-            AssemblyDirectories = assemblyDirectories;
-        }
-
         public StoreResolver()
         {
-            AssemblyDirectories = new string[] {};
-        }
-
-        public StoreResolver(string assemblyDirectory = null)
-        {
-            if (assemblyDirectory == null)
-            {
-                AssemblyDirectories = new string[] { };
-                return;
-            }
-
-            if (!File.Exists(assemblyDirectory))
-            {
-                throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"Provided directory {assemblyDirectory} does not exist.");
-            }
-
-            AssemblyDirectories = new string[] { assemblyDirectory };
         }
 
         private Assembly LoadAssembly(string path)
@@ -65,44 +33,12 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             return null;
         }
 
-        private string[] GetAssembliesFromFolder(string folder)
-        {
-            return Directory.GetFiles(folder, "*.dll");
-        }
-
-        /// <summary>
-        /// Used to resolve the store given a name and an additional assembly directory. The provided path will be added to the existing set present within AssemblyDirectories property.
-        /// This function will take the FIRST matched assembly type by NAME.
-        /// </summary>
-        /// <param name="storeName"></param>
-        /// <param name="additionalAssemblyDirectory"></param>
-        /// <returns></returns>
-        public IAssetsStore ResolveStore(string storeName, string additionalAssemblyDirectory)
-        {
-            if (!File.Exists(additionalAssemblyDirectory))
-            {
-                throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"Provided directory {additionalAssemblyDirectory} does not exist.");
-            }
-
-            var assemblyDirectories = new string[AssemblyDirectories.Length + 1];
-            AssemblyDirectories.CopyTo(assemblyDirectories, 0);
-            assemblyDirectories[assemblyDirectories.Length] = additionalAssemblyDirectory;
-
-            return ResolveStore(storeName, assemblyDirectories);
-        }
-
-
         /// <summary>
         /// Used to resolve the store given a name and an additional assembly directory.
         /// </summary>
         /// <param name="storeName"></param>
         /// <returns></returns>
         public IAssetsStore ResolveStore(string storeName)
-        {
-            return ResolveStore(storeName, AssemblyDirectories);
-        }
-
-        private IAssetsStore ResolveStore(string storeName, string[] assemblyDirectories)
         {
             if (String.IsNullOrWhiteSpace(storeName))
             {
@@ -113,35 +49,11 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             var invokingAssembly = Assembly.GetExecutingAssembly();
             var storeType = GetTypeFromAssembly(storeName, invokingAssembly);
 
-            // then we will only do the heavy lifting of multiple assembly loads if we HAVE to
-            if (storeType == null)
-            {
-                foreach (var assemblyDirectory in assemblyDirectories)
-                {
-                    var assemblyFiles = GetAssembliesFromFolder(assemblyDirectory);
-
-                    foreach (var assemblyFile in assemblyFiles)
-                    {
-                        storeType = GetTypeFromAssembly(storeName, LoadAssembly(assemblyFile));
-
-                        if (storeType != null)
-                        {
-                            break;
-                        }
-                    }
-
-                    if (storeType != null)
-                    {
-                        break;
-                    }
-                }
-            }
-
             if (storeType == null)
             {
                 throw new HttpException(
                     System.Net.HttpStatusCode.BadRequest,
-                    $"Unable to load the specified IAssetStore class {storeName}. Looked in invoking assembly as well as additional directories: [{String.Join(",", assemblyDirectories)}]"
+                    $"Unable to load the specified IAssetStore class {storeName}."
                 );
             }
 
@@ -155,7 +67,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             {
                 throw new HttpException(
                     System.Net.HttpStatusCode.BadRequest,
-                    $"Unable to create an instance of type {storeType.Name}. This name was generated from input {storeName}. The invoking assembly and directories [{String.Join(",", assemblyDirectories)}] were queried for this type."
+                    $"Unable to create an instance of type {storeType.Name}. This name was generated from input {storeName}."
                     + $"Visible Exception is \"{e.Message}\"."
                 );
             }


### PR DESCRIPTION
Fixes #3324

- [x] Add command line interface for access to functionality from new API Endpoints
- [x] Add Interface layer that will enable optional data stores, implement and default to basic `Do nothing` until `GitStore` is written 
- [x] Implement "resolve store class instance from assembly"
- [x] ...and activate" via `SetRecordingOptions` key of `"AssetsStore"` to allow users to change which store is being used
- [x] Add CLI option to select target store at startup
- [x] Add Restore/Save/Reset API Endpoints
~~- [ ] Document storage functionality in readme~~ I'll document it when adding the _actual_ functionality that will work. All that it has is `NoOp` operations right now.
- [x] Tests for new API Layer 


