### PR TITLE
Update long running background tasks to BackgroundHostedService

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
@@ -41,7 +41,7 @@ namespace APIViewWeb.HostedServices
             {
                 try
                 {
-                    _reviewManager.UpdateReviewBackground();
+                    await _reviewManager.UpdateReviewBackground();
                     //return ArchiveInactiveReviews(stoppingToken, _autoArchiveInactiveGracePeriodMonths);
                 }
                 catch(Exception ex)
@@ -49,7 +49,7 @@ namespace APIViewWeb.HostedServices
                     _telemetryClient.TrackException(ex);
                 }
             }
-            return Task.CompletedTask;
+            //return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken stoppingToken)

--- a/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.Hosting;
 
 namespace APIViewWeb.HostedServices
 {
-    public class ReviewBackgroundHostedService : IHostedService, IDisposable
+    public class ReviewBackgroundHostedService : BackgroundService
     {
         private readonly bool _isDisabled;
         private readonly ReviewManager _reviewManager;
@@ -35,28 +35,21 @@ namespace APIViewWeb.HostedServices
             }
         }
 
-        public async Task StartAsync(CancellationToken stoppingToken)
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
             if (!_isDisabled)
             {
                 try
                 {
-                    //await _reviewManager.UpdateReviewBackground();
+                    await _reviewManager.UpdateReviewBackground();
                     await ArchiveInactiveReviews(stoppingToken, _autoArchiveInactiveGracePeriodMonths);
                 }
-                catch(Exception ex)
+                catch (Exception ex)
                 {
                     _telemetryClient.TrackException(ex);
                 }
             }
         }
-
-        public Task StopAsync(CancellationToken stoppingToken)
-        {
-            return Task.CompletedTask;
-        }
-
-        public void Dispose(){}
 
         private async Task ArchiveInactiveReviews(CancellationToken stoppingToken, int archiveAfter)
         {

--- a/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
@@ -41,15 +41,14 @@ namespace APIViewWeb.HostedServices
             {
                 try
                 {
-                    await _reviewManager.UpdateReviewBackground();
-                    //return ArchiveInactiveReviews(stoppingToken, _autoArchiveInactiveGracePeriodMonths);
+                    //await _reviewManager.UpdateReviewBackground();
+                    await ArchiveInactiveReviews(stoppingToken, _autoArchiveInactiveGracePeriodMonths);
                 }
                 catch(Exception ex)
                 {
                     _telemetryClient.TrackException(ex);
                 }
             }
-            //return Task.CompletedTask;
         }
 
         public Task StopAsync(CancellationToken stoppingToken)

--- a/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
@@ -35,14 +35,14 @@ namespace APIViewWeb.HostedServices
             }
         }
 
-        public Task StartAsync(CancellationToken stoppingToken)
+        public async Task StartAsync(CancellationToken stoppingToken)
         {
             if (!_isDisabled)
             {
                 try
                 {
                     _reviewManager.UpdateReviewBackground();
-                    return ArchiveInactiveReviews(stoppingToken, _autoArchiveInactiveGracePeriodMonths);
+                    //return ArchiveInactiveReviews(stoppingToken, _autoArchiveInactiveGracePeriodMonths);
                 }
                 catch(Exception ex)
                 {

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -524,7 +524,7 @@ namespace APIViewWeb.Repositories
             return null;
         }
 
-        public async void UpdateReviewBackground()
+        public async Task UpdateReviewBackground()
         {
             var reviews = await _reviewsRepository.GetReviewsAsync(false, "All");
             foreach (var review in reviews.Where(r => IsUpdateAvailable(r)))

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -135,12 +135,12 @@ namespace APIViewWeb.Repositories
                 });
             }
 
-            if (review.PackageName != null && review.PackageDisplayName == null)
+            /*if (review.PackageName != null && review.PackageDisplayName == null)
             {
                 var p = await _packageNameManager.GetPackageDetails(review.PackageName);
                 review.PackageDisplayName = p?.DisplayName;
                 review.ServiceName = p?.ServiceName;
-            }
+            }*/
 
             return review;
         }
@@ -221,12 +221,12 @@ namespace APIViewWeb.Repositories
 
             review.Revisions.Add(revision);
 
-            if (review.PackageName != null)
+            /*if (review.PackageName != null)
             {
                 var p = await _packageNameManager.GetPackageDetails(review.PackageName);
                 review.PackageDisplayName = p?.DisplayName ?? review.PackageDisplayName;
                 review.ServiceName = p?.ServiceName ?? review.ServiceName;
-            }
+            }*/
 
             // auto subscribe revision creation user
             await _notificationManager.SubscribeAsync(review, user);

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -135,12 +135,12 @@ namespace APIViewWeb.Repositories
                 });
             }
 
-            /*if (review.PackageName != null && review.PackageDisplayName == null)
+            if (review.PackageName != null && review.PackageDisplayName == null)
             {
                 var p = await _packageNameManager.GetPackageDetails(review.PackageName);
                 review.PackageDisplayName = p?.DisplayName;
                 review.ServiceName = p?.ServiceName;
-            }*/
+            }
 
             return review;
         }
@@ -221,12 +221,12 @@ namespace APIViewWeb.Repositories
 
             review.Revisions.Add(revision);
 
-            /*if (review.PackageName != null)
+            if (review.PackageName != null)
             {
                 var p = await _packageNameManager.GetPackageDetails(review.PackageName);
                 review.PackageDisplayName = p?.DisplayName ?? review.PackageDisplayName;
                 review.ServiceName = p?.ServiceName ?? review.ServiceName;
-            }*/
+            }
 
             // auto subscribe revision creation user
             await _notificationManager.SubscribeAsync(review, user);


### PR DESCRIPTION
Host service methods to upgrade reviews and archive pull requests are long running operations and these are run from hosted service start method. Start method should not run longer tasks and this should be run by background hosted service.