### PR TITLE
Create json package property parent directory

### DIFF
--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -109,7 +109,7 @@ if ($allPackageProperties)
         $outputPath = Join-Path -Path $outDirectory "$configFilePrefix.json"
         Write-Host "Output path of json file: $outputPath"
         $outDir = Split-Path $outputPath -parent
-        if (-not (Test-Path -path outDir))
+        if (-not (Test-Path -path $outDir))
         {
           Write-Host "Creating directory $($outDir) for json property file"
           New-Item -ItemType Directory -Path $outDir

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -108,6 +108,12 @@ if ($allPackageProperties)
         }
         $outputPath = Join-Path -Path $outDirectory "$configFilePrefix.json"
         Write-Host "Output path of json file: $outputPath"
+        $outDir = Split-Path $outputPath -parent
+        if (-not (Test-Path -path outDir))
+        {
+          Write-Host "Creating directory $($outDir) for json property file"
+          New-Item -ItemType Directory -Path $outDir
+        }
         SetOutput $outputPath $pkg
     }
 


### PR DESCRIPTION
Go package name contains path delimiter and this break current assumption of generated path for json property file for package. This PR is to create property file in nested path based on the package name. for e.g. package name for go is `sdk/template/aztemplate`  then aztemplate.json will be created in `<outdir>/sdk/template/aztemplate.json`