### PR TITLE
Disable detached head warnings on sparse checkout to commit

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -59,8 +59,9 @@ steps:
 
             # sparse-checkout commands after initial checkout will auto-checkout again
             if (!$hasInitialized) {
-              Write-Host "git checkout $($repository.Commitish)"
-              git checkout $($repository.Commitish)  # this will use the default branch if repo.Commitish is empty
+              Write-Host "git -c advice.detachedHead=false checkout $($repository.Commitish)"
+              # This will use the default branch if repo.Commitish is empty
+              git -c advice.detachedHead=false checkout $($repository.Commitish)
             } else {
               Write-Host "Skipping checkout as repo has already been initialized"
             }


### PR DESCRIPTION
This will disable those pesky `You are in 'detached HEAD' state` warnings we get in the sparse checkout logs.
