### PR TITLE
Update package name in Go APIView token file

### DIFF
--- a/src/go/cmd/api_view.go
+++ b/src/go/cmd/api_view.go
@@ -74,5 +74,6 @@ func createReview(pkgDir string) (PackageReview, error) {
 		Name:        m.Name,
 		Navigation:  nav,
 		Tokens:      *tokenList,
+		PackageName: m.Name,
 	}, nil
 }

--- a/src/go/cmd/models.go
+++ b/src/go/cmd/models.go
@@ -36,6 +36,7 @@ type PackageReview struct {
 	Name        string       `json:"Name,omitempty"`
 	Tokens      []Token      `json:"Tokens,omitempty"`
 	Navigation  []Navigation `json:"Navigation,omitempty"`
+	PackageName string       `json:"PackageName,omitempty"`
 }
 
 // Token ...


### PR DESCRIPTION
PackageName field is not set in Go APIView token file and we use this field to identify automatic review created for a package.

This PR is to set PackageName field.