### PR TITLE
Update the order of remarks and examples to align with docs.ms

### DIFF
--- a/eng/common/docgeneration/templates/matthews/partials/class.header.tmpl.partial
+++ b/eng/common/docgeneration/templates/matthews/partials/class.header.tmpl.partial
@@ -87,14 +87,14 @@
 </table>
 {{/syntax.typeParameters.0}}
 
-{{#remarks}}
-<h5 id="{{id}}_remarks"><strong>{{__global.remarks}}</strong></h5>
-<div class="markdown level0 remarks">{{{remarks}}}</div>
-{{/remarks}}
-
 {{#example.0}}
-<h5 id="{{id}}_examples"><strong>{{__global.examples}}</strong></h5>
+<h5 id="{{id}}_examples">{{__global.examples}}</h5>
 {{/example.0}}
 {{#example}}
 {{{.}}}
 {{/example}}
+
+{{#remarks}}
+<h5 id="{{id}}_remarks">{{__global.remarks}}</h5>
+<div class="markdown level0 remarks">{{{remarks}}}</div>
+{{/remarks}}

--- a/eng/common/docgeneration/templates/matthews/partials/class.tmpl.partial
+++ b/eng/common/docgeneration/templates/matthews/partials/class.tmpl.partial
@@ -24,8 +24,8 @@
 <h4 id="{{id}}" data-uid="{{uid}}"><a href="#collapsible-{{id}}" class="expander" data-toggle="collapse">{{name.0.value}}</a></h4>
 
 <div id="collapsible-{{id}}" class="collapse in">
-<div class="markdown level1 summary">{{{summary}}}</div>
-<div class="markdown level1 conceptual">{{{conceptual}}}</div>
+<div class="markdown level0 summary">{{{summary}}}</div>
+<div class="markdown level0 conceptual">{{{conceptual}}}</div>
 <h5 class="decalaration">{{__global.declaration}}</h5>
 
 {{#syntax}}
@@ -141,7 +141,7 @@
 
 {{#remarks}}
 <h5 id="{{id}}_remarks">{{__global.remarks}}</h5>
-<div class="markdown level1 remarks">{{{remarks}}}</div>
+<div class="markdown level0 remarks">{{{remarks}}}</div>
 {{/remarks}}
 
 {{#exceptions.0}}

--- a/eng/common/docgeneration/templates/matthews/partials/class.tmpl.partial
+++ b/eng/common/docgeneration/templates/matthews/partials/class.tmpl.partial
@@ -132,17 +132,17 @@
   {{/definition}}
 {{/implements}}
 
-{{#remarks}}
-<h5 id="{{id}}_remarks">{{__global.remarks}}</h5>
-<div class="markdown level1 remarks">{{{remarks}}}</div>
-{{/remarks}}
-
 {{#example.0}}
 <h5 id="{{id}}_examples">{{__global.examples}}</h5>
 {{/example.0}}
 {{#example}}
 {{{.}}}
 {{/example}}
+
+{{#remarks}}
+<h5 id="{{id}}_remarks">{{__global.remarks}}</h5>
+<div class="markdown level1 remarks">{{{remarks}}}</div>
+{{/remarks}}
 
 {{#exceptions.0}}
 <h5 class="exceptions">{{__global.exceptions}}</h5>

--- a/eng/common/docgeneration/templates/matthews/partials/class.tmpl.partial
+++ b/eng/common/docgeneration/templates/matthews/partials/class.tmpl.partial
@@ -24,8 +24,8 @@
 <h4 id="{{id}}" data-uid="{{uid}}"><a href="#collapsible-{{id}}" class="expander" data-toggle="collapse">{{name.0.value}}</a></h4>
 
 <div id="collapsible-{{id}}" class="collapse in">
-<div class="markdown level0 summary">{{{summary}}}</div>
-<div class="markdown level0 conceptual">{{{conceptual}}}</div>
+<div class="markdown level1 summary">{{{summary}}}</div>
+<div class="markdown level1 conceptual">{{{conceptual}}}</div>
 <h5 class="decalaration">{{__global.declaration}}</h5>
 
 {{#syntax}}
@@ -141,7 +141,7 @@
 
 {{#remarks}}
 <h5 id="{{id}}_remarks">{{__global.remarks}}</h5>
-<div class="markdown level0 remarks">{{{remarks}}}</div>
+<div class="markdown level1 remarks">{{{remarks}}}</div>
 {{/remarks}}
 
 {{#exceptions.0}}


### PR DESCRIPTION
We have different definition for the order of `<remarks>` and `<examples>`.
Update our template to align with mdoc.

[Link](https://ceapex.visualstudio.com/Engineering/_git/docs-ui?path=/packages/docfx-templates/partials/dotnet/member.tmpl.partial&version=GBmaster&line=14&lineEnd=22&lineStartColumn=1&lineEndColumn=13&lineStyle=plain&_a=contents)

In github io: 
<img width="517" alt="image" src="https://user-images.githubusercontent.com/48036328/173645002-1b52a92c-664d-430d-a10a-741887f711b9.png">

In Docs.ms:
<img width="787" alt="image" src="https://user-images.githubusercontent.com/48036328/173645656-2d92f20f-3c88-48e1-9b19-385f87163563.png">

