### PR TITLE
Fix issue where matrix replace was not using imported display names

### DIFF
--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -117,7 +117,7 @@ function GenerateMatrix(
     }
 
     $matrix = FilterMatrix $matrix $filters
-    $matrix = ProcessReplace $matrix $replace $config.displayNamesLookup
+    $matrix = ProcessReplace $matrix $replace $combinedDisplayNameLookup
     $matrix = FilterMatrixDisplayName $matrix $displayNameFilter
     return $matrix
 }
@@ -352,7 +352,7 @@ function ProcessImport([MatrixParameter[]]$matrix, [String]$selection, [Array]$n
         }
     }
     if ((!$matrix -and !$importPath) -or !$importPath) {
-        return $matrix, @()
+        return $matrix, @(), @{}
     }
 
     if (!(Test-Path $importPath)) {
@@ -370,7 +370,7 @@ function ProcessImport([MatrixParameter[]]$matrix, [String]$selection, [Array]$n
         $combinedDisplayNameLookup[$lookup.Name] = $lookup.Value
     }
 
-    return $matrix, $importedMatrix, $importedMatrixConfig.displayNamesLookup
+    return $matrix, $importedMatrix, $combinedDisplayNameLookup
 }
 
 function CombineMatrices([Array]$matrix1, [Array]$matrix2, [Hashtable]$displayNamesLookup = @{})


### PR DESCRIPTION
This was resulting in verbose job titles where imported matrix display name filters were not being applied.
