### PR TITLE
Ensure Credscan job works properly even when wonkiness is auto-injected

### DIFF
--- a/eng/common/pipelines/templates/steps/credscan.yml
+++ b/eng/common/pipelines/templates/steps/credscan.yml
@@ -28,6 +28,8 @@ steps:
       Write-Host "##vso[task.setvariable variable=SKIP_CREDSCAN]true"
     }
   displayName: CredScan setup
+  condition: succeededOrFailed()
+
 - task: securedevelopmentteam.vss-secure-development-tools.build-task-credscan.CredScan@3
   displayName: CredScan running
   condition: and(succeededOrFailed(), ne(variables['SKIP_CREDSCAN'], true))


### PR DESCRIPTION
See [this failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1617183&view=logs&j=bc67675d-56bf-581f-e0a2-208848ba68ca&t=27a9db8a-8f0c-5ed5-0322-7c4d0e71b2e0) as an example.

A supply-chain governance task was auto-injected and failed. As a result of incorrect condition settings, we don't run the `setup` of credscan, and as such fail to run it.

This PR will remain on-hold until after release week.