### PR TITLE
Exclude intentionally invalid files from Verify-Resource-Ref.ps1

### DIFF
--- a/eng/common/scripts/Verify-Resource-Ref.ps1
+++ b/eng/common/scripts/Verify-Resource-Ref.ps1
@@ -1,6 +1,6 @@
 . (Join-Path $PSScriptRoot common.ps1)
 Install-Module -Name powershell-yaml -RequiredVersion 0.4.1 -Force -Scope CurrentUser
-$ymlfiles = Get-ChildItem $RepoRoot -recurse | Where-Object {$_ -like '*.yml'}
+$ymlfiles = Get-ChildItem $RepoRoot -recurse | Where-Object {$_ -like '*.yml' -and $_ -notlike '*\invalid\*'}
 $affectedRepos = [System.Collections.ArrayList]::new()
 
 foreach ($file in $ymlfiles)


### PR DESCRIPTION
See https://github.com/Azure/azure-sdk-for-python/pull/24703 for a proof-of-concept PR that tests this change.

Context: recent errors have appeared in the `python - aggregate-reports` nightly pipeline ([example](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1617863&view=logs&j=09cf8b18-32ff-5ace-942c-480825d4e4bd&t=b8bbf1e3-69f9-5ed2-638f-150827b62757&l=293)). This appears to be because we're calling a method on a null object -- in this case, the `ymlObject` variable is null because an [empty YAML file](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/ml/azure-ai-ml/tests/test_configs/components/invalid/empty.yml) from `azure-ai-ml` is being evaluated.

After adding a null check to fix this error, we ran into [another error](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1619080&view=logs&j=09cf8b18-32ff-5ace-942c-480825d4e4bd&t=b8bbf1e3-69f9-5ed2-638f-150827b62757&l=295) from a different file in the same `invalid` directory. These invalid YAML files are necessary for Azure ML tests, so this PR adds a condition to exclude files in any `invalid` directory from getting processed. This exclusion doesn't affect files from any other location in the Python, .NET, JS, Java, or Go repositories.