### PR TITLE
Update mgmt toc structure

### DIFF
--- a/eng/common/scripts/Helpers/Metadata-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Metadata-Helpers.ps1
@@ -93,12 +93,10 @@ function GetDocsMsService($packageInfo, $serviceName)
   return $service
 }
 
-function GenerateDocsMsMetadata($language, $langTitle = "", $serviceName, $tenantId, $clientId, $clientSecret, $msService) 
+function GenerateDocsMsMetadata($language, $languageDisplayName, $serviceName, $tenantId, $clientId, $clientSecret, $msService) 
 {
-  if (!$langTitle) {
-    $langTitle = "Azure $serviceName SDK for $language"
-  }
-  $langDescription = "Reference for Azure $serviceName SDK for $language"
+  $langTitle = "Azure $serviceName SDK for $languageDisplayName"
+  $langDescription = "Reference for Azure $serviceName SDK for $languageDisplayName"
   # Github url for source code: e.g. https://github.com/Azure/azure-sdk-for-js
   $serviceBaseName = $serviceName.ToLower().Replace(' ', '').Replace('/', '-')
   $author = GetPrimaryCodeOwner -TargetDirectory "/sdk/$serviceBaseName/"


### PR DESCRIPTION
Our current mgmt toc structure does not have readme in place.
arm packages have their dedicated readme copied to docs repo. It is not linked anywhere in toc. 
The PR is to align mgmt with client packages.
Proposed structure:
```
Overview
    Client1
        Overview
        APIs
    Client2
        Overview
        APIs
    Management
        Mgmt1
            Overview
            APIs
        Mgmt2
            Overview
            APIs
```

Here is the testing review site:
https://review.docs.microsoft.com/en-us/javascript/api/overview/azure/?view=azure-node-latest&branch=daily%2F2022-05-02-ci-succeeded

Testing in other langs:
1. Java:https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1685594&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739
Diff in Java:
https://github.com/Azure/azure-docs-sdk-java/commit/a162d01837990b84e6beaa262147a219cea23267
Review site: https://review.docs.microsoft.com/en-us/java/api/overview/azure/?view=azure-java-stable&branch=main
3. Python: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1685597&view=logs&j=dc056dfc-c0cf-5958-c8c4-8da4f91a3739&t=e46219be-c7b4-5507-b52e-861c0e0c34d1
Diff in Python:
https://github.com/MicrosoftDocs/azure-docs-sdk-python/commit/46b9cfff880673c849cfd7a6ca2d5bb775fa49aa#diff-66355581b7f76c540b239a41f1f63242c7a14380a03f10ed943a758bc03ac6c7
Review site: 
https://review.docs.microsoft.com/en-us/python/api/overview/azure/mgmt-advisor-readme?view=azure-python&branch=daily%2F2022-05-02-ci-succeeded