### PR TITLE
Hide Close button for automatic review and raise exception 

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -174,22 +174,25 @@
             </div>
         </div>
         <div class="col-lg-6 my-1">
-            <div class="float-right ml-2 my-1">
-                <form asp-resource="@Model.Review" class="form-inline" method="post" asp-page-handler="ToggleClosed">
-                    @if (Model.Review.IsClosed)
-                    {
-                        <button type="submit" class="btn btn-sm border shadow-sm btn-light">
-                            <i class="fa fa-sm fa-undo" aria-hidden="true"></i>&nbsp;&nbsp;Reopen
-                        </button>
-                    }
-                    else
-                    {
-                        <button type="submit" class="btn btn-sm border shadow-sm btn-light">
-                            <i class="far fa-window-close" aria-hidden="true"></i>&nbsp;&nbsp;Close
-                        </button>
-                    }
-                </form>
-            </div>
+            @if (Model.Review.FilterType != ReviewType.Automatic)
+            {
+                <div class="float-right ml-2 my-1">
+                    <form asp-resource="@Model.Review" class="form-inline" method="post" asp-page-handler="ToggleClosed">
+                        @if (Model.Review.IsClosed)
+                        {
+                            <button type="submit" class="btn btn-sm border shadow-sm btn-light">
+                                <i class="fa fa-sm fa-undo" aria-hidden="true"></i>&nbsp;&nbsp;Reopen
+                            </button>
+                        }
+                        else
+                        {
+                            <button type="submit" class="btn btn-sm border shadow-sm btn-light">
+                                <i class="far fa-window-close" aria-hidden="true"></i>&nbsp;&nbsp;Close
+                            </button>
+                        }
+                    </form>
+                </div>
+            }
             <div class="float-right ml-2 my-1">
                 <form asp-resource="@Model.Review" class="form-inline" method="post" asp-page-handler="ToggleSubscribed">
                     @if (Model.Review.GetUserEmail(User) != null)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -307,6 +307,10 @@ namespace APIViewWeb.Repositories
         {
             var review = await GetReviewAsync(user, id);
             review.IsClosed = !review.IsClosed;
+            if (review.FilterType == ReviewType.Automatic)
+            {
+                throw new AuthorizationFailedException();
+            }
             await _reviewsRepository.UpsertReviewAsync(review);
         }
 


### PR DESCRIPTION
New UI accidentally added close button for automatic reviews and user mistakenly closed automatic review. This has caused disruption to release pipeline APIView approval check workflow.