### PR TITLE
Force error on failure to install Az

### DIFF
--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/Dockerfile
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/Dockerfile
@@ -1,6 +1,6 @@
 FROM mcr.microsoft.com/powershell
 
-RUN pwsh -c Install-Module Az -Force;
+RUN pwsh -c '$ErrorActionPreference = "Stop"; Install-Module Az -Force';
 
 # For local testing, run prepare.ps1 before building the docker image
 COPY ./docker_build/common /common


### PR DESCRIPTION
Transient Az install failures were not preventing docker build from succeeding and the image pipeline from pushing a bad image.
