### PR TITLE
[Perf] Update Java storage packages to latest GA versions

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -64,12 +64,12 @@ Services:
       Project: sdk/storage/azure-storage-perf
       PrimaryPackage: azure-storage-blob
       PackageVersions: &java-storage-package-versions
-      - azure-storage-blob: 12.17.0
-        azure-storage-file-share: 12.13.0
-        azure-storage-file-datalake: 12.10.0
-        azure-core-http-netty: 1.12.0
-        azure-core-http-okhttp: 1.9.0
-        azure-core: 1.28.0
+      - azure-storage-blob: 12.17.1
+        azure-storage-file-share: 12.13.1
+        azure-storage-file-datalake: 12.10.1
+        azure-core-http-netty: 1.12.2
+        azure-core-http-okhttp: 1.10.1
+        azure-core: 1.29.1
         reactor-core: 3.4.17
       - azure-storage-blob: source
         azure-storage-file-share: source


### PR DESCRIPTION
Update the Java storage packages to the latest GA versions.  This is specific to Java, since the other languages have not released new GA packages since the last update.

Currently, the perf `tests.yml` needs to be manually updated when new GA packages are released.  This is a known issue that will be addressed soon, either as part of the perf automation refactoring, or sooner as a tactical fix.