### PR TITLE
Fail if the emulator doesn't start

### DIFF
--- a/eng/common/pipelines/templates/steps/cosmos-emulator.yml
+++ b/eng/common/pipelines/templates/steps/cosmos-emulator.yml
@@ -22,15 +22,3 @@ steps:
         -Stage "Launch"
       pwsh: true
     displayName: Launch Public Cosmos DB Emulator
-    continueOnError: true
-
-  - task: Powershell@2
-    inputs:
-      filePath: $(Build.SourcesDirectory)/eng/common/scripts/Cosmos-Emulator.ps1
-      arguments: >
-        -EmulatorMsiUrl "${{ parameters.EmulatorMsiUrl }}"
-        -StartParameters "${{ parameters.StartParameters }}"
-        -Stage "Launch"
-      pwsh: true
-    displayName: Retry Launch of Public Cosmos DB Emulator
-    condition: failed()


### PR DESCRIPTION
We had continueOnError set to true so if the emulator failed to start we would still try to run the tests which all fail but take a long time to run.  The timeout for this step is about 10mins of trying so that should be enough time and so we also don't really need another retry step.