### PR TITLE
Update the verify-readme script/template to take a single or multiple paths

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-readme.yml
+++ b/eng/common/pipelines/templates/steps/verify-readme.yml
@@ -22,7 +22,7 @@ steps:
   inputs:
     filePath: "eng/common/scripts/Verify-Readme.ps1"
     arguments: >
-      -DocWardenVersion '${{ parameters.DocWardenVersion }}''
+      -DocWardenVersion '${{ parameters.DocWardenVersion }}'
       -ScanPaths '${{ coalesce(parameters.ScanPath, parameters.ScanPaths) }}'
       -RepoRoot ${{ parameters.RepoRoot }}
       -SettingsPath ${{ parameters.SettingsPath }}

--- a/eng/common/pipelines/templates/steps/verify-readme.yml
+++ b/eng/common/pipelines/templates/steps/verify-readme.yml
@@ -14,7 +14,7 @@ parameters:
   default: '$(Build.SourcesDirectory)/eng/.docsettings.yml'
 - name: DocWardenVersion
   type: string
-  default: '0.7.2'
+  default: ''
 
 steps:
 - task: PowerShell@2
@@ -22,9 +22,8 @@ steps:
   inputs:
     filePath: "eng/common/scripts/Verify-Readme.ps1"
     arguments: >
-      -DocWardenVersion ${{ parameters.DocWardenVersion }}
-      -ScanPath ${{ parameters.ScanPath }}
-      -ScanPaths '${{ parameters.ScanPaths }}'
+      -DocWardenVersion '${{ parameters.DocWardenVersion }}''
+      -ScanPaths '${{ coalesce(parameters.ScanPath, parameters.ScanPaths) }}'
       -RepoRoot ${{ parameters.RepoRoot }}
       -SettingsPath ${{ parameters.SettingsPath }}
     pwsh: true

--- a/eng/common/pipelines/templates/steps/verify-readme.yml
+++ b/eng/common/pipelines/templates/steps/verify-readme.yml
@@ -1,8 +1,20 @@
 parameters:
-  ScanPath: $(Build.SourcesDirectory)
-  RepoRoot: $(Build.SourcesDirectory)
-  SettingsPath: '$(Build.SourcesDirectory)/eng/.docsettings.yml'
-  DocWardenVersion : '0.7.2'
+- name: ScanPath
+  type: string
+  default: ''
+  # Where ScanPath takes a single path, ScanPaths takes a comma separated list of paths to scan
+- name: ScanPaths
+  type: string
+  default: ''
+- name: RepoRoot
+  type: string
+  default: $(Build.SourcesDirectory)
+- name: SettingsPath
+  type: string
+  default: '$(Build.SourcesDirectory)/eng/.docsettings.yml'
+- name: DocWardenVersion
+  type: string
+  default: '0.7.2'
 
 steps:
 - task: PowerShell@2
@@ -12,6 +24,7 @@ steps:
     arguments: >
       -DocWardenVersion ${{ parameters.DocWardenVersion }}
       -ScanPath ${{ parameters.ScanPath }}
+      -ScanPaths '${{ parameters.ScanPaths }}'
       -RepoRoot ${{ parameters.RepoRoot }}
       -SettingsPath ${{ parameters.SettingsPath }}
     pwsh: true

--- a/eng/common/scripts/Verify-Readme.ps1
+++ b/eng/common/scripts/Verify-Readme.ps1
@@ -49,11 +49,14 @@ if (!(Test-Path -Path $SettingsPath -PathType leaf)) {
   $script:FoundError = $true
 }
 
+$scanPathsArray = @()
+
 # Verify that either ScanPath or ScanPaths were set but not both or neither
 if ([String]::IsNullOrWhiteSpace($ScanPaths)) {
   LogError "ScanPaths cannot be empty."
 } else {
-  foreach ($path in $ScanPaths.Split(',')) {
+  $scanPathsArray = $ScanPaths.Split(',')
+  foreach ($path in $scanPathsArray) {
     if (!(Test-Path -Path $path -PathType Container)) {
       LogError "path, $path, doesn't exist or isn't a directory"
       $script:FoundError = $true
@@ -92,7 +95,7 @@ if ($LASTEXITCODE -ne 0) {
 }
 
 # Finally, do the scanning
-foreach ($path in $ScanPaths.Split(',')) {
+foreach ($path in $scanPathsArray) {
   Test-Readme-Files $SettingsPath $path $RepoRoot
 }
 

--- a/eng/common/scripts/Verify-Readme.ps1
+++ b/eng/common/scripts/Verify-Readme.ps1
@@ -1,24 +1,113 @@
 # Wrapper Script for Readme Verification
 [CmdletBinding()]
 param (
-  [Parameter(Mandatory = $true)]
+  [Parameter(Mandatory = $false)]
   [string]$DocWardenVersion,
-  [Parameter(Mandatory = $true)]
-  [string]$ScanPath,
   [string]$RepoRoot,
+  [string]$ScanPath,
+  [AllowEmptyCollection()]
+  [array] $ScanPaths,
   [Parameter(Mandatory = $true)]
   [string]$SettingsPath
 )
+. (Join-Path $PSScriptRoot common.ps1)
+$script:FoundError = $false
 
+function Test-Readme-Files {
+  param(
+    [string]$SettingsPath,
+    [string]$ScanPath,
+    [string]$RepoRoot)
+
+      Write-Host "Scanning..."
+
+      if ($RepoRoot)
+      {
+        Write-Host "ward scan -d $ScanPath -u $RepoRoot -c $SettingsPath"
+        ward scan -d $ScanPath -u $RepoRoot -c $SettingsPath
+      }
+      else
+      {
+        Write-Host "ward scan -d $ScanPath -c $SettingsPath"
+        ward scan -d $ScanPath -c $SettingsPath
+      }
+      # ward scan is what returns the non-zero exit code on failure.
+      # Since it's being called from a function, that error needs to
+      # be propagated back so the script can exit appropriately
+      if ($LASTEXITCODE -ne 0) {
+        $script:FoundError = $true
+      }
+}
+
+# Verify all of the inputs before running anything
+if ([String]::IsNullOrWhiteSpace($DocWardenVersion)) {
+  LogError "DocWardenVersion cannot be null or empty"
+  $script:FoundError = $true
+}
+
+# verify the doc settings file exists
+if (!(Test-Path -Path $SettingsPath -PathType leaf)) {
+  LogError "Setting file, $SettingsPath, does not exist"
+  $script:FoundError = $true
+}
+
+# Verify that either ScanPath or ScanPaths were set but not both or neither
+if (![String]::IsNullOrWhiteSpace($ScanPath) -and $ScanPaths.Count -gt 0) {
+  LogError "Only ScanPath or ScanPaths can be set but not both."
+  $script:FoundError = $true
+} elseif ([String]::IsNullOrWhiteSpace($ScanPath) -and $ScanPaths.Count -eq 0) {
+  LogError "ScanPath or ScanPaths, one or the other, must be set."
+  $script:FoundError = $true
+}
+
+# Exit out now if there were any argument issues
+if ($script:FoundError) {
+  LogError "There were argument failures, please see above for specifics"
+  exit 1
+}
+
+# Echo back the settings
+Write-Host "DocWardenVersion=$DocWardenVersion"
+Write-Host "SettingsPath=$SettingsPath"
+
+if ($RepoRoot) {
+  Write-Host "RepoRoot=$RepoRoot"
+}
+if (![String]::IsNullOrWhiteSpace($ScanPath)) {
+  Write-Host "ScanPath=$ScanPath"
+}
+if ($ScanPaths.Count -gt 0) {
+  Write-Host "ScanPaths="
+  foreach ($path in $ScanPaths) {
+    Write-Host "  $path"
+  }
+}
+
+
+Write-Host "Installing setup tools and DocWarden"
+Write-Host "pip install setuptools wheel --quiet"
 pip install setuptools wheel --quiet
+if ($LASTEXITCODE -ne 0) {
+  LogError "pip install setuptools wheel --quiet failed with exit code $LASTEXITCODE"
+  exit 1
+}
+Write-Host "pip install doc-warden==$DocWardenVersion --quiet"
 pip install doc-warden==$DocWardenVersion --quiet
-
-if ($RepoRoot)
-{
-  ward scan -d $ScanPath -u $RepoRoot -c $SettingsPath
-}
-else
-{
-  ward scan -d $ScanPath -c $SettingsPath
+if ($LASTEXITCODE -ne 0) {
+  LogError "pip install doc-warden==$DocWardenVersion --quiet failed with exit code $LASTEXITCODE"
+  exit 1
 }
 
+# Finally, do the scanning
+if ($ScanPaths.Count -gt 0) {
+  foreach ($path in $ScanPaths) {
+    Test-Readme-Files $SettingsPath $path $RepoRoot
+  }
+} else {
+  Test-Readme-Files $SettingsPath $ScanPath $RepoRoot
+}
+
+if ($script:FoundError) {
+  LogError "There were README verification failures, scroll up to see the issue(s)"
+  exit 1
+}


### PR DESCRIPTION
The current verify-readme only takes a single path and there's a need, in Java, to be able to scan multiple paths with a single template call. The changes are as follows:
1. Changed ScanPath to ScanPaths in the powershell script which can now take a single path or a comma delimited list.
2. Coalesce the template variables so we only have a single one being passed into the script. 
3. Overhauled the script adding verification of the inputs, verification that the pip install commands were successful.
For existing pipeline usages, nothing should change.
