### PR TITLE
Perf framework

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
@@ -77,7 +77,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
         public override async Task<IterationResult> RunAsync(string project, string languageVersion,
             IDictionary<string, string> packageVersions, string testName, string arguments, string context)
         {
-            var processArguments = $"-jar {context} -- {testName} {arguments}";
+            var processArguments = $"-XX:InitialRAMPercentage=75 -XX:MaxRAMPercentage=75 -jar {context} -- {testName} {arguments}";
 
             var result = await Util.RunAsync("java", processArguments, WorkingDirectory, throwOnError: false);
 


### PR DESCRIPTION
Make initial and max heap equal to avoid resizing. But make them depend on RAM size instead of hardcoding.

For reference
https://stackoverflow.com/questions/43651167/is-there-any-advantage-in-setting-xms-and-xmx-to-the-same-value
https://developer.jboss.org/thread/149559