### PR TITLE
[stress-testing] Flexible resource naming: add BaseName to stress-test-addons helm context

### DIFF
--- a/tools/stress-cluster/chaos/README.md
+++ b/tools/stress-cluster/chaos/README.md
@@ -214,6 +214,7 @@ The following environment variables are currently populated by default into the 
 
 ```
 AZURE_CLIENT_ID=<value>
+AZURE_CLIENT_OID=<value>
 AZURE_CLIENT_SECRET=<value>
 AZURE_TENANT_ID=<value>
 AZURE_SUBSCRIPTION_ID=<value>
@@ -257,11 +258,11 @@ stress test container startup.
 The bicep/ARM file should output at least the resource group name, which will be injected into the stress test env file.
 
 ```
-// Dummy parameter to handle defaults the script passes in
-param testApplicationOid string = ''
+// Unique short string safe for naming resources like storage, service bus.
+param BaseName string = ''
 
 resource config 'Microsoft.AppConfiguration/configurationStores@2020-07-01-preview' = {
-  name: 'config-${resourceGroup().name}'
+  name: 'stress-${BaseName}'
   location: resourceGroup().location
   sku: {
     name: 'Standard'
@@ -269,7 +270,7 @@ resource config 'Microsoft.AppConfiguration/configurationStores@2020-07-01-previ
 }
 
 output RESOURCE_GROUP string = resourceGroup().name
-output AZURE_CLIENT_OID string = testApplicationOid
+output APP_CONFIG_NAME string = config.name
 ```
 
 ### Helm Chart File
@@ -318,8 +319,12 @@ are made available in the template context.
     template is being generated.
 - `{{ .Stress.ResourceGroupName }}`
   - If deploying live resources for a test job, the name of the resource group.
-  - This can also be useful for pairing up template values with resource names. The resource group name will be generated based
-    on the deployment and scenario values, and can also be referenced for naming resources in the bicep/ARM template via `resourceGroup().name`.
+- `{{ .Stress.BaseName }}`
+  - Use this value to generate a random name, prefixes or suffixes for azure resources.
+  - The value consists of random alpha characters and will always start with a lowercase letter for maximum compatibility.
+  - This can be referenced for naming resources in the bicep/ARM template by adding `param BaseName string = ''` and passing the `BaseName` to resource names.
+    See [example template](https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/chaos/examples/stress-deployment-example/stress-test-resources.bicep).
+  - Useful for pairing up template values with resource names, e.g. a DNS target to block for network chaos.
 
 ### Job Manifest
 
@@ -397,12 +402,12 @@ spec:
   externalTargets:
     # Maps to the service bus resource cname, provided the resource group name, provided
     # the service bus namespace uses the resource group name as its name in the bicep template
-    - "{{ .Stress.ResourceGroupName }}.servicebus.windows.net"
+    - "{{ .Stress.BaseName }}.servicebus.windows.net"
   mode: one
   selector:
     labelSelectors:
-      # Maps to the test pod, provided it also sets a testInstance label of {{ .Stress.ResourceGroupName }}
-      testInstance: {{ .Stress.ResourceGroupName }}
+      # Maps to the test pod, provided it also sets a testInstance label of {{ .Stress.BaseName }}
+      testInstance: {{ .Stress.BaseName }}
       chaos: "true"
     namespaces:
       - {{ .Release.Namespace }}

--- a/tools/stress-cluster/chaos/examples/network-stress-example/Chart.lock
+++ b/tools/stress-cluster/chaos/examples/network-stress-example/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.17
-digest: sha256:282e9b9fad6e60d6671b37e40c553fe06e1603d14ad8277c36250d7a8c570033
-generated: "2022-05-17T21:28:17.5646655-04:00"
+  version: 0.1.18
+digest: sha256:fe1e37c57c10f99ff6da2b5e860fc9b2b1a6d605e6f685aa93602db5d51f7476
+generated: "2022-06-28T21:21:16.7932545-04:00"

--- a/tools/stress-cluster/chaos/examples/network-stress-example/Chart.yaml
+++ b/tools/stress-cluster/chaos/examples/network-stress-example/Chart.yaml
@@ -10,5 +10,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.17
+  version: 0.1.18
   repository: "@stress-test-charts"

--- a/tools/stress-cluster/chaos/examples/stress-debug-share-example/Chart.lock
+++ b/tools/stress-cluster/chaos/examples/stress-debug-share-example/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.17
-digest: sha256:282e9b9fad6e60d6671b37e40c553fe06e1603d14ad8277c36250d7a8c570033
-generated: "2022-05-17T21:28:11.0823221-04:00"
+  version: 0.1.18
+digest: sha256:fe1e37c57c10f99ff6da2b5e860fc9b2b1a6d605e6f685aa93602db5d51f7476
+generated: "2022-06-28T21:21:07.9759557-04:00"

--- a/tools/stress-cluster/chaos/examples/stress-debug-share-example/Chart.yaml
+++ b/tools/stress-cluster/chaos/examples/stress-debug-share-example/Chart.yaml
@@ -10,5 +10,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.17
+  version: 0.1.18
   repository: "@stress-test-charts"

--- a/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.lock
+++ b/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.17
-digest: sha256:282e9b9fad6e60d6671b37e40c553fe06e1603d14ad8277c36250d7a8c570033
-generated: "2022-05-17T21:28:01.5535225-04:00"
+  version: 0.1.18
+digest: sha256:fe1e37c57c10f99ff6da2b5e860fc9b2b1a6d605e6f685aa93602db5d51f7476
+generated: "2022-06-28T21:20:02.7004525-04:00"

--- a/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.yaml
+++ b/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.yaml
@@ -10,5 +10,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.17
+  version: 0.1.18
   repository: "@stress-test-charts"

--- a/tools/stress-cluster/chaos/examples/stress-deployment-example/stress-test-resources.bicep
+++ b/tools/stress-cluster/chaos/examples/stress-deployment-example/stress-test-resources.bicep
@@ -1,8 +1,8 @@
-// Dummy parameter to handle defaults the script passes in
-param testApplicationOid string = ''
+// Unique short string safe for naming resources like storage, service bus.
+param BaseName string = ''
 
 resource config 'Microsoft.AppConfiguration/configurationStores@2020-07-01-preview' = {
-  name: 'config-${resourceGroup().name}'
+  name: 'stress-${BaseName}'
   location: resourceGroup().location
   sku: {
     name: 'Standard'
@@ -10,4 +10,4 @@ resource config 'Microsoft.AppConfiguration/configurationStores@2020-07-01-previ
 }
 
 output RESOURCE_GROUP string = resourceGroup().name
-output AZURE_CLIENT_OID string = testApplicationOid
+output APP_CONFIG_NAME string = config.name

--- a/tools/stress-cluster/chaos/examples/stress-deployment-example/templates/deploy-job.yaml
+++ b/tools/stress-cluster/chaos/examples/stress-deployment-example/templates/deploy-job.yaml
@@ -13,6 +13,6 @@ spec:
             source $ENV_FILE &&
             az login --service-principal -u $AZURE_CLIENT_ID -p $AZURE_CLIENT_SECRET --tenant $AZURE_TENANT_ID &&
             az account set -s $AZURE_SUBSCRIPTION_ID &&
-            az group show -g $RESOURCE_GROUP -o json
+            az appconfig show -n $APP_CONFIG_NAME -g $RESOURCE_GROUP -o json
       {{- include "stress-test-addons.container-env" . | nindent 6 }}
 {{- end -}}

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/CHANGELOG.md
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release History
 
+## 0.1.18 (2022-06-28)
+
+### Features Added
+
+* Added a 6 character random string `{{ .Stress.BaseName }}` that can be used for naming that doesn't break
+  validation for resources like service bus, storage, etc. Bicep templates can consume this by adding a `BaseName`
+  parameter.
+* Inject `BASE_NAME` environment variable to deployment init container.
+* Add resourceGroupName and baseName labels to job template.
+
+### Breaking Changes
+
+### Bugs Fixed
+
+### Other Changes
+
 ## 0.1.17 (2022-05-17)
 
 ### Features Added

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: stress-test-addons
 description: Baseline resources and templates for stress testing clusters
 
-version: 0.1.17
+version: 0.1.18
 appVersion: v0.1

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/deploy-stress-test-resources.ps1
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/deploy-stress-test-resources.ps1
@@ -17,7 +17,7 @@ Copy-Item "/mnt/testresources/*" -Destination "/azure/"
 
 # Capture output so we don't print environment variable secrets
 $env = & /common/TestResources/New-TestResources.ps1 `
-    -BaseName $env:RESOURCE_GROUP_NAME `
+    -BaseName $env:BASE_NAME `
     -ResourceGroupName $env:RESOURCE_GROUP_NAME `
     -SubscriptionId $secrets.AZURE_SUBSCRIPTION_ID `
     -TenantId $secrets.AZURE_TENANT_ID `

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
@@ -3,9 +3,9 @@ entries:
   stress-test-addons:
   - apiVersion: v2
     appVersion: v0.1
-    created: "2022-06-28T21:14:09.8155647-04:00"
+    created: "2022-06-29T18:40:52.9995426-04:00"
     description: Baseline resources and templates for stress testing clusters
-    digest: 7e25466013350450acea77f9ef736fb63a91f19af5099a2377d09314505cf371
+    digest: c579efd3868e48b0ab40a22335e16de67ea6361e394c09e4f589154b068a7060
     name: stress-test-addons
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.18.tgz
@@ -136,4 +136,4 @@ entries:
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.2.tgz
     version: 0.1.2
-generated: "2022-06-28T21:14:09.8023445-04:00"
+generated: "2022-06-29T18:40:52.9862338-04:00"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
@@ -3,6 +3,15 @@ entries:
   stress-test-addons:
   - apiVersion: v2
     appVersion: v0.1
+    created: "2022-06-28T21:14:09.8155647-04:00"
+    description: Baseline resources and templates for stress testing clusters
+    digest: 7e25466013350450acea77f9ef736fb63a91f19af5099a2377d09314505cf371
+    name: stress-test-addons
+    urls:
+    - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.18.tgz
+    version: 0.1.18
+  - apiVersion: v2
+    appVersion: v0.1
     created: "2022-05-17T21:25:11.1546837-04:00"
     description: Baseline resources and templates for stress testing clusters
     digest: 8b99f79f770e655d63710b1332cd5b09827c8780030e1d43ca50b1463e53ae58
@@ -127,4 +136,4 @@ entries:
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.2.tgz
     version: 0.1.2
-generated: "2022-05-17T21:25:11.1473996-04:00"
+generated: "2022-06-28T21:14:09.8023445-04:00"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_init_deploy.tpl
@@ -16,6 +16,8 @@
       value: /mnt/outputs/.env
     - name: RESOURCE_GROUP_NAME
       value: {{ .Stress.ResourceGroupName }}
+    - name: BASE_NAME
+      value: {{ .Stress.BaseName }}
   volumeMounts:
     - name: "{{ .Release.Name }}-{{ .Release.Revision }}-test-resources"
       mountPath: /mnt/testresources

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_stress_test.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_stress_test.tpl
@@ -13,6 +13,8 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     scenario: {{ .Stress.Scenario }}
+    resourceGroupName: {{ .Stress.ResourceGroupName }}
+    baseName: {{ .Stress.BaseName }}
 spec:
   backoffLimit: 0
   template:
@@ -64,6 +66,8 @@ metadata:
   labels:
     release: {{ .Release.Name }}
     scenario: {{ .Stress.Scenario }}
+    resourceGroupName: {{ .Stress.ResourceGroupName }}
+    baseName: {{ .Stress.BaseName }}
 spec:
   backoffLimit: 0
   template:

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_util.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_util.tpl
@@ -27,6 +27,7 @@ Fields added to global context and returned:
 .Stress.Scenario - A `.` value passed down from a range loop over a scenarios list
             from values.yaml or a default value "stress".
 .Stress.ResourceGroupName - A pre-calculated resource group name value that can be passed down to various configurations that require it.
+.Stress.BaseName - A six character unique id derived from .Stress.ResourceGroupName that can be used in contexts with strict naming restrictions.
 
 See https://github.com/Masterminds/sprig/tree/master/docs for template function reference
 */}}
@@ -34,9 +35,11 @@ See https://github.com/Masterminds/sprig/tree/master/docs for template function 
 {{- /* Copy scenario name into top level keys of global context */}}
 {{- $_global := index . 0 -}}
 {{- $_scenario := index . 1 -}}
-{{ $resourceGroupName := lower (print $_global.Release.Namespace "-" $_scenario "-" $_global.Release.Name "-" $_global.Release.Revision) }}
+{{- $uniqueTestName := lower (print $_global.Release.Namespace "-" $_scenario "-" $_global.Release.Name "-" $_global.Release.Revision) -}}
+{{- /* Use lowercase alpha characters for maximum azure resource naming compatibility */ -}}
+{{- $uniqueTestId := lower (randAlpha 6) -}}
 {{- /* Create add Stress context to top level keys of global context */}}
-{{- $_stress := dict "Scenario" $_scenario "ResourceGroupName" $resourceGroupName -}}
+{{- $_stress := dict "Scenario" $_scenario "ResourceGroupName" $uniqueTestName "BaseName" $uniqueTestId -}}
 {{- $_instance := deepCopy ($_global | merge (dict "Stress" $_stress )) -}}
 {{ toYaml ($_instance) }}
 {{- end -}}

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_util.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_util.tpl
@@ -27,7 +27,7 @@ Fields added to global context and returned:
 .Stress.Scenario - A `.` value passed down from a range loop over a scenarios list
             from values.yaml or a default value "stress".
 .Stress.ResourceGroupName - A pre-calculated resource group name value that can be passed down to various configurations that require it.
-.Stress.BaseName - A six character unique id derived from .Stress.ResourceGroupName that can be used in contexts with strict naming restrictions.
+.Stress.BaseName - A random, six character, lowercase alpha string that can be used for naming and is valid for most azure resources.
 
 See https://github.com/Masterminds/sprig/tree/master/docs for template function reference
 */}}
@@ -35,11 +35,11 @@ See https://github.com/Masterminds/sprig/tree/master/docs for template function 
 {{- /* Copy scenario name into top level keys of global context */}}
 {{- $_global := index . 0 -}}
 {{- $_scenario := index . 1 -}}
-{{- $uniqueTestName := lower (print $_global.Release.Namespace "-" $_scenario "-" $_global.Release.Name "-" $_global.Release.Revision) -}}
+{{- $resourceGroupName := lower (print $_global.Release.Namespace "-" $_scenario "-" $_global.Release.Name "-" $_global.Release.Revision) -}}
 {{- /* Use lowercase alpha characters for maximum azure resource naming compatibility */ -}}
 {{- $uniqueTestId := lower (randAlpha 6) -}}
 {{- /* Create add Stress context to top level keys of global context */}}
-{{- $_stress := dict "Scenario" $_scenario "ResourceGroupName" $uniqueTestName "BaseName" $uniqueTestId -}}
+{{- $_stress := dict "Scenario" $_scenario "ResourceGroupName" $resourceGroupName "BaseName" $uniqueTestId -}}
 {{- $_instance := deepCopy ($_global | merge (dict "Stress" $_stress )) -}}
 {{ toYaml ($_instance) }}
 {{- end -}}


### PR DESCRIPTION
Resolves #3263

* Adds a 6 character random string `{{ .Stress.BaseName }}` that can be used for naming that doesn't break
  validation for resources like service bus, storage, etc. Bicep templates can consume this by adding a `BaseName`
  parameter.
* Inject `BASE_NAME` environment variable to deployment init container.
* Add resourceGroupName and baseName labels to job template.