### PR TITLE
Perf undo heap settings.

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
@@ -77,7 +77,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
         public override async Task<IterationResult> RunAsync(string project, string languageVersion,
             IDictionary<string, string> packageVersions, string testName, string arguments, string context)
         {
-            var processArguments = $"-XX:InitialRAMPercentage=50.0 -XX:MaxRAMPercentage=50.0 -jar {context} -- {testName} {arguments}";
+            var processArguments = $"-jar {context} -- {testName} {arguments}";
 
             var result = await Util.RunAsync("java", processArguments, WorkingDirectory, throwOnError: false);
 


### PR DESCRIPTION
Experiments indicated this has affected results negatively.
Reverting for now to not affect release prep comparisons.