### PR TITLE
Only update/override powershell module path when in CI on module script import

### DIFF
--- a/eng/common/scripts/Helpers/PSModule-Helpers.ps1
+++ b/eng/common/scripts/Helpers/PSModule-Helpers.ps1
@@ -1,7 +1,7 @@
 $DefaultPSRepositoryUrl = "https://www.powershellgallery.com/api/v2"
 $global:CurrentUserModulePath = ""
 
-function Update-PSModulePath()
+function Update-PSModulePathForCI()
 {
   # Information on PSModulePath taken from docs
   # https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_psmodulepath
@@ -101,4 +101,6 @@ function Install-ModuleIfNotInstalled()
   return $modules[0]
 }
 
-Update-PSModulePath
+if ($null -ne $env:SYSTEM_TEAMPROJECTID) {
+    Update-PSModulePathForCI
+}

--- a/tools/stress-cluster/chaos/README.md
+++ b/tools/stress-cluster/chaos/README.md
@@ -206,8 +206,10 @@ test container can be found in a file at path `$ENV_FILE` (usually `/mnt/outputs
 can be [loaded](https://www.npmjs.com/package/dotenv) [via](https://pypi.org/project/python-dotenv/)
 [various](https://mvnrepository.com/artifact/io.github.cdimascio/dotenv-java) [packages](https://www.nuget.org/packages/dotenv.net/).
 
-Stress tests should publish telemetry and logs to Application Insights via the $APPINSIGHTS_INSTRUMENTATIONKEY environment variable
-injected into the container.
+Stress tests should publish telemetry and logs to Application Insights via the `$APPINSIGHTS_CONNECTION_STRING` environment variable
+injected into the container. An `$APPINSIGHTS_INSTRUMENTATIONKEY` environment variable is also made available for
+backwards compatibility, but using the connection string is recommended as the app insights service is deprecating the
+instrumentation key approach.
 
 The following environment variables are currently populated by default into the env file, in addition to any
 [bicep template outputs](https://docs.microsoft.com/azure/azure-resource-manager/bicep/outputs) specified.
@@ -217,6 +219,7 @@ AZURE_CLIENT_ID=<value>
 AZURE_CLIENT_SECRET=<value>
 AZURE_TENANT_ID=<value>
 AZURE_SUBSCRIPTION_ID=<value>
+APPINSIGHTS_CONNECTION_STRING=<value>
 APPINSIGHTS_INSTRUMENTATIONKEY=<value>
 
 # Bicep template outputs inserted here as well, for example


### PR DESCRIPTION
Fixes #3497 #3354

The common powershell module helper script contains functions used both in CI scripts and local scripts. However, the script was originally written to target azure pipelines agents. As a result, it does not always work for people when run locally. This PR moves powershell module path overwriting behind a flag so it only runs when needed in CI environments.

Also I'm shoehorning in a minor doc update on app insights keys.