### PR TITLE
[Perf] Upgrade storage-blob packages to latest preview

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -73,8 +73,8 @@ Services:
         azure-core: 1.29.1
         reactor-core: 3.4.17
       - azure-storage-blob: 12.18.0-beta.1
-        azure-storage-file-share: 12.14.0-beta.1
-        azure-storage-file-datalake: 12.11.0-beta.1
+        azure-storage-file-share: 12.13.1
+        azure-storage-file-datalake: 12.10.1
         azure-core-http-netty: 1.12.2
         azure-core-http-okhttp: 1.10.1
         azure-core: 1.29.1
@@ -223,7 +223,6 @@ Services:
       Project: sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj
       PackageVersions:
       - Azure.Storage.Files.Shares: 12.10.0
-      - Azure.Storage.Files.Shares: 12.11.0-beta.1
       - Azure.Storage.Files.Shares: source
     Java:
       Project: sdk/storage/azure-storage-perf
@@ -239,7 +238,6 @@ Services:
       Project: sdk/storage/azure-storage-file-share
       PackageVersions:
       - azure-storage-file-share: 12.8.0
-      - azure-storage-file-share: 12.9.0b1
       - azure-storage-file-share: source
 
   Tests:
@@ -265,7 +263,6 @@ Services:
       Project: sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Azure.Storage.Files.DataLake.Perf.csproj
       PackageVersions:
       - Azure.Storage.Files.DataLake: 12.10.0
-      - Azure.Storage.Files.DataLake: 12.11.0-beta.1
       - Azure.Storage.Files.DataLake: source
     Java:
       Project: sdk/storage/azure-storage-perf
@@ -281,7 +278,6 @@ Services:
       Project: sdk/storage/azure-storage-file-datalake
       PackageVersions:
       - azure-storage-file-datalake: 12.7.0
-      - azure-storage-file-datalake: 12.8.0b1
       - azure-storage-file-datalake: source
 
   Tests:

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -59,6 +59,7 @@ Services:
       Project: sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj
       PackageVersions:
       - Azure.Storage.Blobs: 12.12.0
+      - Azure.Storage.Blobs: 12.13.0-beta.1
       - Azure.Storage.Blobs: source
     Java:
       Project: sdk/storage/azure-storage-perf
@@ -67,6 +68,13 @@ Services:
       - azure-storage-blob: 12.17.1
         azure-storage-file-share: 12.13.1
         azure-storage-file-datalake: 12.10.1
+        azure-core-http-netty: 1.12.2
+        azure-core-http-okhttp: 1.10.1
+        azure-core: 1.29.1
+        reactor-core: 3.4.17
+      - azure-storage-blob: 12.18.0-beta.1
+        azure-storage-file-share: 12.14.0-beta.1
+        azure-storage-file-datalake: 12.11.0-beta.1
         azure-core-http-netty: 1.12.2
         azure-core-http-okhttp: 1.10.1
         azure-core: 1.29.1
@@ -92,6 +100,7 @@ Services:
       PackageVersions:
       # TODO: Pin version of core to align with older version of storage
       - azure-storage-blob: 12.12.0
+      - azure-storage-blob: 12.13.0b1
       - azure-storage-blob: source
     Cpp:
       Project: azure-storage-blobs-perf
@@ -214,6 +223,7 @@ Services:
       Project: sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj
       PackageVersions:
       - Azure.Storage.Files.Shares: 12.10.0
+      - Azure.Storage.Files.Shares: 12.11.0-beta.1
       - Azure.Storage.Files.Shares: source
     Java:
       Project: sdk/storage/azure-storage-perf
@@ -224,11 +234,12 @@ Services:
       Project: sdk/storage/perf-tests/storage-file-share
       PackageVersions:
       - "@azure/storage-file-share": 12.10.0
-      - "@azure/storage-file-share": source      
+      - "@azure/storage-file-share": source
     Python:
       Project: sdk/storage/azure-storage-file-share
       PackageVersions:
       - azure-storage-file-share: 12.8.0
+      - azure-storage-file-share: 12.9.0b1
       - azure-storage-file-share: source
 
   Tests:
@@ -254,6 +265,7 @@ Services:
       Project: sdk/storage/Azure.Storage.Files.DataLake/perf/Azure.Storage.Files.DataLake.Perf/Azure.Storage.Files.DataLake.Perf.csproj
       PackageVersions:
       - Azure.Storage.Files.DataLake: 12.10.0
+      - Azure.Storage.Files.DataLake: 12.11.0-beta.1
       - Azure.Storage.Files.DataLake: source
     Java:
       Project: sdk/storage/azure-storage-perf
@@ -269,6 +281,7 @@ Services:
       Project: sdk/storage/azure-storage-file-datalake
       PackageVersions:
       - azure-storage-file-datalake: 12.7.0
+      - azure-storage-file-datalake: 12.8.0b1
       - azure-storage-file-datalake: source
 
   Tests:

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -238,7 +238,7 @@ Services:
       Project: sdk/storage/azure-storage-file-share
       PackageVersions:
       - azure-storage-file-share: 12.8.0
-      - azure-storage-file-share: source
+      - azure-storage-file-share: source      
 
   Tests:
   - Test: download

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -233,12 +233,12 @@ Services:
       Project: sdk/storage/perf-tests/storage-file-share
       PackageVersions:
       - "@azure/storage-file-share": 12.10.0
-      - "@azure/storage-file-share": source
+      - "@azure/storage-file-share": source      
     Python:
       Project: sdk/storage/azure-storage-file-share
       PackageVersions:
       - azure-storage-file-share: 12.8.0
-      - azure-storage-file-share: source      
+      - azure-storage-file-share: source
 
   Tests:
   - Test: download

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -58,20 +58,12 @@ Services:
     Net:
       Project: sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj
       PackageVersions:
-      - Azure.Storage.Blobs: 12.12.0
       - Azure.Storage.Blobs: 12.13.0-beta.1
       - Azure.Storage.Blobs: source
     Java:
       Project: sdk/storage/azure-storage-perf
       PrimaryPackage: azure-storage-blob
       PackageVersions: &java-storage-package-versions
-      - azure-storage-blob: 12.17.1
-        azure-storage-file-share: 12.13.1
-        azure-storage-file-datalake: 12.10.1
-        azure-core-http-netty: 1.12.2
-        azure-core-http-okhttp: 1.10.1
-        azure-core: 1.29.1
-        reactor-core: 3.4.17
       - azure-storage-blob: 12.18.0-beta.1
         azure-storage-file-share: 12.13.1
         azure-storage-file-datalake: 12.10.1
@@ -99,7 +91,6 @@ Services:
       Project: sdk/storage/azure-storage-blob
       PackageVersions:
       # TODO: Pin version of core to align with older version of storage
-      - azure-storage-blob: 12.12.0
       - azure-storage-blob: 12.13.0b1
       - azure-storage-blob: source
     Cpp:


### PR DESCRIPTION
- .NET, Java, and Python are adding storage-blob perf tests that require the latest preview to compile and/or run
- Verified no regressions between latest GA and latest preview, so it's safe to use latest preview as the new baseline
- Fixes #3529
