### PR TITLE
Enable verify-samples to handle multiple service directories

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-samples.yml
+++ b/eng/common/pipelines/templates/steps/verify-samples.yml
@@ -1,15 +1,25 @@
 parameters:
   - name: ServiceDirectory
     type: string
-    default: not-specified
+    default: ''
+  - name: ServiceDirectories
+    type: string
+    default: ''
   - name: ScriptDirectory
     type: string
     default: eng/common/scripts
 
 steps:
   - pwsh: |
-      # If the last path segment is an absolute path it will be used entirely.
-      $root = [System.IO.Path]::Combine('$(Build.SourcesDirectory)', 'sdk', '${{ parameters.ServiceDirectory }}')
-      Get-ChildItem $root -Filter *.md -Recurse | ${{ parameters.ScriptDirectory }}/Test-SampleMetadata.ps1 -AllowParentProducts
+      # Take whichever parameter has been set. If set, ServiceDirectory will be a single path or
+      # ServiceDirectories will be a comma separated list.
+      $ServiceDirectories = '${{ coalesce(parameters.ServiceDirectory, parameters.ServiceDirectories) }}'
+      $ScanPaths = @()
+      foreach ($ServiceDirectory in $ServiceDirectories.Split(',')) {
+        $ScanPath = [System.IO.Path]::Combine('$(Build.SourcesDirectory)', 'sdk', $ServiceDirectory)
+        Write-Host "Adding $ScanPath to the scanned paths"
+        $ScanPaths += $ScanPath
+      }
+      Get-ChildItem $ScanPaths -Filter *.md -Recurse | ${{ parameters.ScriptDirectory }}/Test-SampleMetadata.ps1 -AllowParentProducts
     displayName: Verify sample metadata
     workingDirectory: $(Build.SourcesDirectory)


### PR DESCRIPTION
Similar to the [verify-readme.yml](https://github.com/Azure/azure-sdk-tools/pull/3510) changes, update verify-samples to handle multiple service directories.