### PR TITLE
Skip yml files for which parsing failed

### DIFF
--- a/eng/common/scripts/Verify-Resource-Ref.ps1
+++ b/eng/common/scripts/Verify-Resource-Ref.ps1
@@ -7,7 +7,16 @@ foreach ($file in $ymlfiles)
 {
   Write-Host "Verifying '${file}'"
   $ymlContent = Get-Content $file.FullName -Raw
-  $ymlObject = ConvertFrom-Yaml $ymlContent -Ordered
+
+  try
+  {
+    $ymlObject = ConvertFrom-Yaml $ymlContent -Ordered
+  }
+  catch
+  {
+    Write-Output "Failed to parse yml file $($file.FullName)"
+    continue
+  }
 
   if ($ymlObject -and ($ymlObject.Contains("resources")))
   {


### PR DESCRIPTION
- Skip checking yml file if it parsing fails.
- For https://github.com/Azure/azure-sdk-tools/issues/3540#event-6920318338