### PR TITLE
[Perf] Add JVM flag to crash on OutOfMemoryError

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
@@ -77,7 +77,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
         public override async Task<IterationResult> RunAsync(string project, string languageVersion,
             IDictionary<string, string> packageVersions, string testName, string arguments, string context)
         {
-            var processArguments = $"-jar {context} -- {testName} {arguments}";
+            var processArguments = $"-XX:+CrashOnOutOfMemoryError -jar {context} -- {testName} {arguments}";
 
             var result = await Util.RunAsync("java", processArguments, WorkingDirectory, throwOnError: false);
 


### PR DESCRIPTION
- In some scenarios, if there is an OutOfMemoryError inside a Reactor operation, the process may hang instead of crashing
- Adding this flag ensures the test process will crash immediately.