### PR TITLE
Update set-test-pipeline-version logic to handle one or more packages

### DIFF
--- a/eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
+++ b/eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
@@ -1,5 +1,6 @@
 parameters:
   PackageName: ''
+  PackageNames: ''
   ServiceDirectory: ''
   TestPipeline: false
 
@@ -7,9 +8,12 @@ steps:
 - ${{ if eq(parameters.TestPipeline, 'true') }}:
     - task: PowerShell@2
       displayName: Prep template pipeline for release
-      condition: and(succeeded(), ne(variables['Skip.SetTestPipelineVersion'], 'true')) 
+      condition: and(succeeded(), ne(variables['Skip.SetTestPipelineVersion'], 'true'))
       inputs:
-        pwsh: true
         workingDirectory: $(Build.SourcesDirectory)
         filePath: $(Build.SourcesDirectory)/eng/common/scripts/SetTestPipelineVersion.ps1
-        arguments: '-BuildID $(Build.BuildId) -PackageName ${{ parameters.PackageName }} -ServiceDirectory ${{ parameters.ServiceDirectory }}'
+        arguments: >
+          -BuildID $(Build.BuildId)
+          -PackageNames '${{ coalesce(parameters.PackageName, parameters.PackageNames) }}'
+          -ServiceDirectory '${{ parameters.ServiceDirectory }}'
+        pwsh: true


### PR DESCRIPTION
This is the same type of changes I've made to verify-readme and verify-samples. Add an argument to the yml file, PackageNames, that'll accept a comma separated list of package names. Coalesce PackageName and PackageNames to snag whichever one is set.

The script file just splits on comma into an array and processes them individually. 

The reason I'm doing this is because Java has multiple template libraries and instead having [3 consecutive templates](https://github.com/Azure/azure-sdk-for-java/blob/main/eng/pipelines/templates/stages/archetype-java-release-batch.yml#L95), one for each library, in several different places, I want to use the template once and give it all 3 of our template libraries.