### PR TITLE
Improve logging in PipelineWitness

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/ApplicationInsights/ApplicationVersionTelemetryInitializer.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/ApplicationInsights/ApplicationVersionTelemetryInitializer.cs
@@ -5,7 +5,7 @@ using Microsoft.ApplicationInsights.Extensibility;
 
 namespace Azure.Sdk.Tools.PipelineWitness.ApplicationInsights
 {
-    public class ApplicationVersionTelemetryInitializer<T> : ITelemetryInitializer
+    public class ApplicationVersionTelemetryInitializer : ITelemetryInitializer
     {
         private static string _version = GetVersion();
 
@@ -19,7 +19,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.ApplicationInsights
         
         private static string GetVersion()
         {
-            var assembly = typeof(T).Assembly;
+            var assembly = typeof(ApplicationVersionTelemetryInitializer).Assembly;
             
             var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
                 ?? assembly.GetName().Version.ToString();

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/PipelineWitnessSettings.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/PipelineWitnessSettings.cs
@@ -62,5 +62,15 @@ namespace Azure.Sdk.Tools.PipelineWitness
         /// Gets or sets the amount of time between iterations of the build definition upload loop
         /// </summary>
         public TimeSpan BuildDefinitionLoopPeriod { get; set; } = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// Gets or sets the number of concurrent log bundle queue workers to register
+        /// </summary>
+        public int BuildLogBundlesWorkerCount { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the number of concurrent build complete queue workers to register
+        /// </summary>
+        public int BuildCompleteWorkerCount { get; set; } = 1;
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildCompleteQueueWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildCompleteQueueWorker.cs
@@ -23,12 +23,12 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services
             BlobUploadProcessor runProcessor,
             QueueServiceClient queueServiceClient,
             TelemetryClient telemetryClient,
-            IOptions<PipelineWitnessSettings> options)
+            IOptionsMonitor<PipelineWitnessSettings> options)
             : base(
                 logger, 
                 telemetryClient,
                 queueServiceClient,
-                options.Value.BuildCompleteQueueName, 
+                options.CurrentValue.BuildCompleteQueueName, 
                 options)
         {
             this.logger = logger;

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogBundleQueueWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogBundleQueueWorker.cs
@@ -22,12 +22,12 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services
             BlobUploadProcessor runProcessor,
             QueueServiceClient queueServiceClient,
             TelemetryClient telemetryClient,
-            IOptions<PipelineWitnessSettings> options)
+            IOptionsMonitor<PipelineWitnessSettings> options)
             : base(
                   logger,
                   telemetryClient,
                   queueServiceClient,
-                  options?.Value?.BuildLogBundlesQueueName,
+                  options?.CurrentValue?.BuildLogBundlesQueueName,
                   options)
         {
             this.logger = logger;

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.development.json
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.development.json
@@ -1,17 +1,31 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning",
+      "Default": "Debug",
       "Microsoft.Hosting": "Information",
       "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
       "Azure.Sdk.Tools.PipelineWitness": "Warning",
-      "Azure.Core": "Error"
+      "Azure.Sdk.Tools.PipelineWitness.Services": "Debug"
+    },
+    "Console": {
+      "FormatterName": "simple",
+      "FormatterOptions": {
+        "SingleLine": true,
+        "IncludeScopes": true,
+        "TimestampFormat": "HH:mm:ss ",
+        "UseUtcTimestamp": true,
+        "JsonWriterOptions": {
+          "Indented": true
+        }
+      }
     }
   },
   "PipelineWitness": {
     "KeyVaultUri": "https://pipelinewitnessstaging.vault.azure.net/",
     "QueueStorageAccountUri": "https://pipelinewitnessstaging.queue.core.windows.net",
     "BlobStorageAccountUri": "https://pipelinelogsstaging.blob.core.windows.net",
-    "BuildDefinitionLoopPeriod": "00:01:00"
+    "BuildDefinitionLoopPeriod": "00:01:00",
+    "BuildCompleteWorkerCount": 1,
+    "BuildLogBundlesWorkerCount": 1
   }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.json
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.json
@@ -4,7 +4,7 @@
       "Default": "Warning",
       "Microsoft.Hosting": "Information",
       "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
-      "Azure.Sdk.Tools": "Information",
+      "Azure.Sdk.Tools.PipelineWitness": "Debug",
       "Azure.Core": "Error"
     }
   },
@@ -17,9 +17,11 @@
     "QueueStorageAccountUri": "https://pipelinewitnessprod.queue.core.windows.net",
     "BlobStorageAccountUri": "https://azsdkengsyspipelinelogs.blob.core.windows.net",
     "BuildCompleteQueueName": "azurepipelines-build-completed",
+    "BuildCompleteWorkerCount": 5,
     "BuildLogBundlesQueueName": "azurepipelines-build-log-bundle",
+    "BuildLogBundlesWorkerCount": 5,
     "BuildLogBundleSize": 50,
-    "MessageLeasePeriod": "00:00:30",
+    "MessageLeasePeriod": "00:03:00",
     "MessageErrorSleepPeriod": "00:00:10",
     "MaxDequeueCount": 5,
     "Account": "azure-sdk",


### PR DESCRIPTION
- Improve logging in PipelineWitness
- Add support for multiple workers per queue (in-process scaling)
- Add support for updating config at runtime (useful when locally debugging)
- Stop enqueueing messages for async log processing.  Because failure analysis requires loading log files and because we no longer have a function execution time limit, we should stay in process and complete the build blobs as a single queue message
- The queue processing loop should throw an exception if the message renewal task cannot extend a message lease