### PR TITLE
Use --no-cone in pipeline sparse checkout script

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -44,8 +44,10 @@ steps:
               Write-Host "git sparse-checkout init"
               git sparse-checkout init
 
-              Write-Host "git sparse-checkout set '/*' '!/*/' '/eng'"
-              git sparse-checkout set '/*' '!/*/' '/eng'
+              # Set non-cone mode otherwise path filters will not work in git >= 2.37.0
+              # See https://github.blog/2022-06-27-highlights-from-git-2-37/#tidbits
+              Write-Host "git sparse-checkout set --no-cone '/*' '!/*/' '/eng'"
+              git sparse-checkout set --no-cone '/*' '!/*/' '/eng'
             }
 
             # Prevent wildcard expansion in Invoke-Expression (e.g. for checkout path '/*')


### PR DESCRIPTION
The latest update to git 2.37.0 adds cone and non-cone mode options [explanation](https://github.blog/2022-06-27-highlights-from-git-2-37/#tidbits). In code mode, our previously used sparse checkout pattern filtering does not work, as the command expects directories instead. This PR updates our sparse checkout command to set `--no-cone` for no cone mode.
