### PR TITLE
Apply static refactor cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,136 +1,188 @@
-﻿###############################
-# Core EditorConfig Options   #
-###############################
+# editorconfig.org
+
+# top-most EditorConfig file
 root = true
-# All files
-[*]
-indent_style = space
 
-# XML project files
-[*.{csproj,vbproj,vcxproj,vcxproj.filters,proj,projitems,shproj}]
-indent_size = 2
-
-# XML config files
-[*.{props,targets,ruleset,config,nuspec,resx,vsixmanifest,vsct}]
-indent_size = 2
-
-# Code files
-[*.{cs,csx,vb,vbx}]
-indent_size = 4
+# Default settings:
+# A newline ending every file
+# Use 4 spaces as indentation
+[**]
 insert_final_newline = true
+indent_style = space
+indent_size = 4
 
-###############################
-# .NET Coding Conventions     #
-###############################
-[*.{cs,vb}]
-# Organize usings
-dotnet_sort_system_directives_first = true
-# this. preferences
-dotnet_style_qualification_for_field = true:suggestion
-dotnet_style_qualification_for_property = false:silent
-dotnet_style_qualification_for_method = false:silent
-dotnet_style_qualification_for_event = false:silent
-# Language keywords vs BCL types preferences
-dotnet_style_predefined_type_for_locals_parameters_members = true:silent
-dotnet_style_predefined_type_for_member_access = true:silent
-# Parentheses preferences
-dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
-dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
-# Modifier preferences
-dotnet_style_require_accessibility_modifiers = for_non_interface_members:silent
-dotnet_style_readonly_field = true:suggestion
-# Expression-level preferences
-dotnet_style_object_initializer = true:suggestion
-dotnet_style_collection_initializer = true:suggestion
-dotnet_style_explicit_tuple_names = true:suggestion
-dotnet_style_null_propagation = true:suggestion
-dotnet_style_coalesce_expression = true:suggestion
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:silent
-dotnet_style_prefer_inferred_tuple_names = true:suggestion
-dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
-dotnet_style_prefer_auto_properties = true:silent
-dotnet_style_prefer_conditional_expression_over_assignment = true:silent
-dotnet_style_prefer_conditional_expression_over_return = true:silent
+# Xml project files
+[*.{csproj,vcxproj,vcxproj.filters,proj,nativeproj,locproj}]
+indent_size = 2
 
-###############################
-# Naming Conventions          #
-###############################
-# Style Definitions
-dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
-# Use PascalCase for constant fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
-dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
-dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_style
-dotnet_naming_symbols.constant_fields.applicable_kinds            = field
-dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
-dotnet_naming_symbols.constant_fields.required_modifiers          = const
-# Use no prefix for private fields
-dotnet_naming_rule.private_members_with_underscore.symbols  = private_fields
-dotnet_naming_rule.private_members_with_underscore.style    = prefix_underscore
-dotnet_naming_rule.private_members_with_underscore.severity = suggestion
-dotnet_naming_symbols.private_fields.applicable_kinds           = field
-dotnet_naming_symbols.private_fields.applicable_accessibilities = private
-dotnet_naming_style.prefix_underscore.capitalization = camel_case
+# Xml build files
+[*.builds]
+indent_size = 2
 
-###############################
-# C# Coding Conventions       #
-###############################
-[*.cs]
-# var preferences
-csharp_style_var_for_built_in_types = true:silent
-csharp_style_var_when_type_is_apparent = true:silent
-csharp_style_var_elsewhere = true:silent
-# Expression-bodied members
-csharp_style_expression_bodied_methods = false:silent
-csharp_style_expression_bodied_constructors = false:silent
-csharp_style_expression_bodied_operators = false:silent
-csharp_style_expression_bodied_properties = true:silent
-csharp_style_expression_bodied_indexers = true:silent
-csharp_style_expression_bodied_accessors = true:silent
-# Pattern matching preferences
-csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
-csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
-# Null-checking preferences
-csharp_style_throw_expression = true:suggestion
-csharp_style_conditional_delegate_call = true:suggestion
+# Xml files
+[*.{xml,stylecop,resx,ruleset}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+# Shell scripts
+[*.sh]
+end_of_line = lf
+[*.{cmd, bat}]
+end_of_line = crlf
+
+# C# files
+[**.cs]
+# New line preferences
+csharp_new_line_before_open_brace = all # vs-default: any
+csharp_new_line_before_else = true # vs-default: true
+csharp_new_line_before_catch = true # vs-default: true
+csharp_new_line_before_finally = true # vs-default: true
+csharp_new_line_before_members_in_object_initializers = true # vs-default: true
+csharp_new_line_before_members_in_anonymous_types = true # vs-default: true
+csharp_new_line_between_query_expression_clauses = true # vs-default: true
+
+# Indentation preferences
+csharp_indent_block_contents = true # vs-default: true
+csharp_indent_braces = false # vs-default: false
+csharp_indent_case_contents = true # vs-default: true
+csharp_indent_case_contents_when_block = true
+csharp_indent_switch_labels = true # vs-default: true
+csharp_indent_labels = one_less_than_current# vs-default: one_less_than_current
+
 # Modifier preferences
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
-# Expression-level preferences
-csharp_prefer_braces = true:silent
-csharp_style_deconstructed_variable_declaration = true:suggestion
-csharp_prefer_simple_default_expression = true:suggestion
-csharp_style_pattern_local_over_anonymous_function = true:suggestion
-csharp_style_inlined_variable_declaration = true:suggestion
 
-###############################
-# C# Formatting Rules         #
-###############################
-# New line preferences
-csharp_new_line_before_open_brace = all
-csharp_new_line_before_else = true
-csharp_new_line_before_catch = true
-csharp_new_line_before_finally = true
-csharp_new_line_before_members_in_object_initializers = true
-csharp_new_line_before_members_in_anonymous_types = true
-csharp_new_line_between_query_expression_clauses = true
-# Indentation preferences
-csharp_indent_case_contents = true
-csharp_indent_switch_labels = true
-csharp_indent_labels = flush_left
+# avoid this. unless absolutely necessary
+dotnet_style_qualification_for_field = false:suggestion # vs-default: false:none
+dotnet_style_qualification_for_property = false:suggestion # vs-default: false:none
+dotnet_style_qualification_for_method = false:suggestion # vs-default: false:none
+dotnet_style_qualification_for_event = false:suggestion # vs-default: false:none
+
+# only use var when it's obvious what the variable type is
+csharp_style_var_for_built_in_types = true:suggestion # vs-default: true:none
+csharp_style_var_when_type_is_apparent = true:suggestion # vs-default: true:none
+csharp_style_var_elsewhere = true:suggestion # vs-default: true:none
+
+# use language keywords instead of BCL types
+dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion # vs-default: true:none
+dotnet_style_predefined_type_for_member_access = true:suggestion # vs-default: true:none
+
+# name all constant fields using PascalCase
+dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols = constant_fields
+dotnet_naming_rule.constant_fields_should_be_pascal_case.style = pascal_case_style
+
+dotnet_naming_symbols.constant_fields.applicable_kinds = field
+dotnet_naming_symbols.constant_fields.required_modifiers = const
+
+dotnet_naming_style.pascal_case_style.capitalization = pascal_case
+
+# static fields should have s_ prefix
+dotnet_naming_rule.static_fields_should_have_prefix.severity = suggestion
+dotnet_naming_rule.static_fields_should_have_prefix.symbols = static_fields
+dotnet_naming_rule.static_fields_should_have_prefix.style = static_prefix_style
+
+dotnet_naming_symbols.static_fields.applicable_kinds = field
+dotnet_naming_symbols.static_fields.required_modifiers = static
+dotnet_naming_symbols.static_fields.applicable_accessibilities = private, internal, private_protected
+dotnet_naming_style.static_prefix_style.required_prefix = s_
+dotnet_naming_style.static_prefix_style.capitalization = camel_case
+
+# internal and private fields should be _camelCase
+dotnet_naming_rule.camel_case_for_private_internal_fields.severity = suggestion
+dotnet_naming_rule.camel_case_for_private_internal_fields.symbols = private_internal_fields
+dotnet_naming_rule.camel_case_for_private_internal_fields.style = camel_case_underscore_style
+
+dotnet_naming_symbols.private_internal_fields.applicable_kinds = field
+dotnet_naming_symbols.private_internal_fields.applicable_accessibilities = private, internal
+
+dotnet_naming_style.camel_case_underscore_style.required_prefix = _
+dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
+
+# Code style defaults
+csharp_using_directive_placement = outside_namespace:suggestion
+dotnet_sort_system_directives_first = true # vs-default: true
+csharp_prefer_braces = true:silent
+csharp_preserve_single_line_blocks = true # vs-default: true
+csharp_preserve_single_line_statements = false # vs-default: true
+csharp_prefer_static_local_function = true:suggestion
+csharp_prefer_simple_using_statement = false:none
+csharp_style_prefer_switch_expression = true:suggestion
+
+# Code quality
+dotnet_style_readonly_field = true:suggestion
+dotnet_code_quality_unused_parameters = non_public:suggestion
+
+# Expression-level preferences
+dotnet_style_object_initializer = true:suggestion # vs-default: true:suggestion
+dotnet_style_collection_initializer = true:suggestion # vs-default: true:suggestion
+dotnet_style_explicit_tuple_names = true:suggestion # vs-default: true:suggestion
+dotnet_style_coalesce_expression = true:suggestion # vs-default: true:suggestion
+dotnet_style_null_propagation = true:suggestion # vs-default: true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_inferred_tuple_names = true:suggestion
+dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
+dotnet_style_prefer_auto_properties = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:refactoring
+dotnet_style_prefer_conditional_expression_over_return = true:refactoring
+csharp_prefer_simple_default_expression = true:suggestion
+
+# Expression-bodied members
+csharp_style_expression_bodied_methods = false:none # vs-default: false:none
+csharp_style_expression_bodied_constructors = false:none # vs-default: false:none
+csharp_style_expression_bodied_operators = false:none # vs-default: false:none
+csharp_style_expression_bodied_properties = true:none # vs-default: true:none
+csharp_style_expression_bodied_indexers = true:none # vs-default: true:none
+csharp_style_expression_bodied_accessors = true:none # vs-default: true:none
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = true:silent
+
+# Pattern matching
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion # vs-default: true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion # vs-default: true:suggestion
+csharp_style_inlined_variable_declaration = true:suggestion # vs-default: true:suggestion
+
+# Null checking preferences
+csharp_style_throw_expression = true:suggestion # vs-default: true:suggestion
+csharp_style_conditional_delegate_call = true:suggestion # vs-default: true:suggestion
+
+# Other features
+csharp_style_prefer_index_operator = false:none
+csharp_style_prefer_range_operator = false:none
+csharp_style_pattern_local_over_anonymous_function = false:none
+
 # Space preferences
-csharp_space_after_cast = false
-csharp_space_after_keywords_in_control_flow_statements = true
-csharp_space_between_method_call_parameter_list_parentheses = false
-csharp_space_between_method_declaration_parameter_list_parentheses = false
-csharp_space_between_parentheses = false
-csharp_space_before_colon_in_inheritance_clause = true
-csharp_space_after_colon_in_inheritance_clause = true
-csharp_space_around_binary_operators = before_and_after
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false
-csharp_space_between_method_call_name_and_opening_parenthesis = false
-csharp_space_between_method_call_empty_parameter_list_parentheses = false
-# Wrapping preferences
-csharp_preserve_single_line_statements = true
-csharp_preserve_single_line_blocks = true
+csharp_space_after_cast = false # vs-default: false
+csharp_space_after_colon_in_inheritance_clause = true # vs-default: true
+csharp_space_after_comma = true # vs-default: true
+csharp_space_after_dot = false # vs-default: false
+csharp_space_after_keywords_in_control_flow_statements = true # vs-default: true
+csharp_space_after_semicolon_in_for_statement = true # vs-default: true
+csharp_space_around_binary_operators = before_and_after# vs-default: before_and_after
+csharp_space_around_declaration_statements = do_not_ignore # vs-default: false
+csharp_space_before_colon_in_inheritance_clause = true # vs-default: true
+csharp_space_before_comma = false # vs-default: false
+csharp_space_before_dot = false # vs-default: false
+csharp_space_before_open_square_brackets = false # vs-default: false
+csharp_space_before_semicolon_in_for_statement = false # vs-default: false
+csharp_space_between_empty_square_brackets = false # vs-default: false
+csharp_space_between_method_call_empty_parameter_list_parentheses = false # vs-default: false
+csharp_space_between_method_call_name_and_opening_parenthesis = false # vs-default: false
+csharp_space_between_method_call_parameter_list_parentheses = false # vs-default: false
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false # vs-default: false
+csharp_space_between_method_declaration_name_and_open_parenthesis = false # vs-default: false
+csharp_space_between_method_declaration_parameter_list_parentheses = false # vs-default: false
+csharp_space_between_parentheses = false # vs-default: false
+csharp_space_between_square_brackets = false # vs-default: false
+
+# Require accessibility modifiers
+dotnet_style_require_accessibility_modifiers = for_non_interface_members:suggestion # vs-default: for_non_interface_members:none
+
+# Analyzers
+dotnet_code_quality.ca1802.api_surface = private, internal
+
+# CA1848: Use the LoggerMessage delegates
+dotnet_diagnostic.CA1848.severity = none

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness.Tests/UnitTest1.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness.Tests/UnitTest1.cs
@@ -1,8 +1,7 @@
-using System;
-using Xunit;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Tests
 {
+    using Xunit;
+
     public class UnitTest1
     {
         [Fact]

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness.Tests/UnitTest1.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness.Tests/UnitTest1.cs
@@ -1,7 +1,7 @@
+using Xunit;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Tests
 {
-    using Xunit;
-
     public class UnitTest1
     {
         [Fact]

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/ApplicationInsights/ApplicationVersionTelemetryInitializer.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/ApplicationInsights/ApplicationVersionTelemetryInitializer.cs
@@ -1,32 +1,33 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.ApplicationInsights
-{
-    using System.Reflection;
-    using Microsoft.ApplicationInsights.Channel;
-    using Microsoft.ApplicationInsights.Extensibility;
+﻿using System.Reflection;
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
+namespace Azure.Sdk.Tools.PipelineWitness.ApplicationInsights
+{
     public class ApplicationVersionTelemetryInitializer : ITelemetryInitializer
     {
-        private static readonly string Version = GetVersion();
+        private static readonly string s_version = GetVersion();
 
         public void Initialize(ITelemetry telemetry)
         {
-            if (!string.IsNullOrEmpty(Version))
+            if (!string.IsNullOrEmpty(s_version))
             {
                 var component = telemetry.Context?.Component;
 
                 if (component != null)
                 {
-                    component.Version = Version;
+                    component.Version = s_version;
                 }
             }
         }
-        
+
         private static string GetVersion()
         {
             var assembly = typeof(ApplicationVersionTelemetryInitializer).Assembly;
-            
+
             var version = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
-                ?? assembly.GetName().Version?.ToString();
+                             ?? assembly.GetName().Version?.ToString();
 
             return version;
         }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/ApplicationInsights/ApplicationVersionTelemetryInitializer.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/ApplicationInsights/ApplicationVersionTelemetryInitializer.cs
@@ -1,23 +1,22 @@
-﻿using System.Reflection;
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
-
-namespace Azure.Sdk.Tools.PipelineWitness.ApplicationInsights
+﻿namespace Azure.Sdk.Tools.PipelineWitness.ApplicationInsights
 {
+    using System.Reflection;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
+
     public class ApplicationVersionTelemetryInitializer : ITelemetryInitializer
     {
-        private static string _version = GetVersion();
+        private static readonly string Version = GetVersion();
 
         public void Initialize(ITelemetry telemetry)
         {
-            if (!string.IsNullOrEmpty(_version))
+            if (!string.IsNullOrEmpty(Version))
             {
                 var component = telemetry.Context?.Component;
 
                 if (component != null)
                 {
-                    component.Version = _version;
+                    component.Version = Version;
                 }
             }
         }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/ApplicationInsights/BlobNotFoundTelemetryProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/ApplicationInsights/BlobNotFoundTelemetryProcessor.cs
@@ -1,25 +1,25 @@
+using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+
 namespace Azure.Sdk.Tools.PipelineWitness.ApplicationInsights
 {
-    using Microsoft.ApplicationInsights.Channel;
-    using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility;
-
     public class BlobNotFoundTelemetryProcessor : ITelemetryProcessor
     {
-        private readonly ITelemetryProcessor next;
+        private readonly ITelemetryProcessor _next;
 
         // next will point to the next TelemetryProcessor in the chain.
         public BlobNotFoundTelemetryProcessor(ITelemetryProcessor next)
         {
-            this.next = next;
+            _next = next;
         }
-  
-        public void Process(ITelemetry telemetry)
+
+        public void Process(ITelemetry item)
         {
-            if (telemetry is DependencyTelemetry { Success: false, Type: "Azure blob" or "Microsoft.Storage" } blobRequestTelemetry)
+            if (item is DependencyTelemetry { Success: false, Type: "Azure blob" or "Microsoft.Storage" } blobRequestTelemetry)
             {
                 blobRequestTelemetry.Properties.TryGetValue("Error", out var errorProperty);
-                
+
                 var isNotFound = blobRequestTelemetry.ResultCode is "404" or "409"
                     || (blobRequestTelemetry.ResultCode == "" && errorProperty?.Contains("Status: 404") == true);
 
@@ -31,7 +31,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.ApplicationInsights
                 }
             }
 
-            this.next.Process(telemetry);
+            _next.Process(item);
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/ApplicationInsights/BlobNotFoundTelemetryProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/ApplicationInsights/BlobNotFoundTelemetryProcessor.cs
@@ -1,9 +1,9 @@
-using Microsoft.ApplicationInsights.Channel;
-using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
-
 namespace Azure.Sdk.Tools.PipelineWitness.ApplicationInsights
 {
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+
     public class BlobNotFoundTelemetryProcessor : ITelemetryProcessor
     {
         private readonly ITelemetryProcessor next;

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Azure.Sdk.Tools.PipelineWitness.csproj
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Azure.Sdk.Tools.PipelineWitness.csproj
@@ -15,7 +15,6 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.AzureAppConfiguration" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="3.1.23" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
   </ItemGroup>
 

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Azure.Sdk.Tools.PipelineWitness.csproj
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Azure.Sdk.Tools.PipelineWitness.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net6.0</TargetFramework>
     <LangVersion>10.0</LangVersion>
     <UserSecretsId>bc5587e8-3503-4e1a-816c-1e219e4047f6</UserSecretsId>
+	  <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+    <AnalysisLevel>latest-Recommended</AnalysisLevel>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/BlobUploadProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/BlobUploadProcessor.cs
@@ -2,14 +2,13 @@
 {
     using System;
     using System.Collections.Generic;
-    using System.Collections.Immutable;
     using System.IO;
     using System.Linq;
     using System.Net;
     using System.Text;
     using System.Text.RegularExpressions;
     using System.Threading.Tasks;
-
+    using Azure.Sdk.Tools.PipelineWitness.Entities;
     using Azure.Sdk.Tools.PipelineWitness.Services;
     using Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis;
     using Azure.Storage.Blobs;
@@ -35,7 +34,8 @@
         private const string TestRunsContainerName = "testruns";
 
         private const string TimeFormat = @"yyyy-MM-dd\THH:mm:ss.fffffff\Z";
-        private static readonly JsonSerializerSettings jsonSettings = new JsonSerializerSettings()
+        
+        private static readonly JsonSerializerSettings jsonSettings = new()
         {
             ContractResolver = new CamelCasePropertyNamesContractResolver(),
             Converters = { new StringEnumConverter(new CamelCaseNamingStrategy()) },
@@ -334,7 +334,7 @@
                     JobCancelTimeoutInMinutes = definition.JobCancelTimeoutInMinutes,
                     JobTimeoutInMinutes = definition.JobTimeoutInMinutes,
                     ProcessType = definition.Process.Type,
-                    ProcessYamlFilename = definition.Process is YamlProcess yamlprocess ? yamlprocess.YamlFilename : null,
+                    ProcessYamlFilename = definition.Process is YamlProcess yamlProcess ? yamlProcess.YamlFilename : null,
                     RepositoryCheckoutSubmodules = definition.Repository.CheckoutSubmodules,
                     RepositoryClean = definition.Repository.Clean,
                     RepositoryDefaultBranch = definition.Repository.DefaultBranch,
@@ -345,7 +345,7 @@
                     Variables = definition.Variables,
                     Tags = definition.Tags,
                     Data = definition,
-                    EtlIngestDate = DateTimeOffset.UtcNow
+                    EtlIngestDate = DateTimeOffset.UtcNow,
                 }, jsonSettings);
 
                 await blobClient.UploadAsync(new BinaryData(content));
@@ -363,7 +363,7 @@
 
         private List<BuildLogBundle> BuildLogBundles(string account, Build build, Timeline timeline, List<BuildLog> logs)
         {
-            BuildLogBundle CreateBundle() => new BuildLogBundle
+            BuildLogBundle CreateBundle() => new()
             {
                 Account = account,
                 BuildId = build.Id,
@@ -374,7 +374,7 @@
                 FinishTime = build.FinishTime.Value,
                 DefinitionId = build.Definition.Id,
                 DefinitionName = build.Definition.Name,
-                DefinitionPath = build.Definition.Path
+                DefinitionPath = build.Definition.Path,
             };
 
             BuildLogBundle currentBundle;
@@ -426,7 +426,7 @@
                     LogCreatedOn = log.CreatedOn.Value,
                     RecordId = logRecord?.Id,
                     ParentRecordId = logRecord?.ParentId,
-                    RecordType = logRecord?.RecordType
+                    RecordType = logRecord?.RecordType,
                 });
             }
 
@@ -604,7 +604,7 @@
             try
             {
                 // we don't use FinishTime in the logs blob path to prevent duplicating logs when processing retries.
-                // i.e.  logs with a given buildid/logid are immutable and retries only add new logs.
+                // i.e.  logs with a given buildId/logId are immutable and retries only add new logs.
                 var blobPath = $"{build.ProjectName}/{build.QueueTime:yyyy/MM/dd}/{build.BuildId}-{log.LogId}.jsonl";
                 var blobClient = this.buildLogLinesContainerClient.GetBlobClient(blobPath);
 
@@ -637,7 +637,6 @@
                             break;
                         }
 
-                        var isLastLine = logReader.EndOfStream;
                         lineNumber += 1;
                         characterCount += line.Length;
 

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Failure.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Failure.cs
@@ -1,26 +1,20 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using Microsoft.TeamFoundation.Build.WebApi;
-
-#nullable disable
+﻿#nullable disable
 
 namespace Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    
     public class Failure
     {
-        public Failure()
-        {
-        }
-
         public Failure(TimelineRecord record, string classification)
         {
             this.Record = record;
             this.Classification = classification;
         }
 
-        public TimelineRecord Record { get; set; }
-        public string Classification { get; set; }
+        public TimelineRecord Record { get; }
+        
+        public string Classification { get; }
     }
 }
 

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Failure.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/AzurePipelines/Failure.cs
@@ -1,19 +1,19 @@
-﻿#nullable disable
+﻿using Microsoft.TeamFoundation.Build.WebApi;
+
+#nullable disable
 
 namespace Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines
 {
-    using Microsoft.TeamFoundation.Build.WebApi;
-    
     public class Failure
     {
         public Failure(TimelineRecord record, string classification)
         {
-            this.Record = record;
-            this.Classification = classification;
+            Record = record;
+            Classification = classification;
         }
 
         public TimelineRecord Record { get; }
-        
+
         public string Classification { get; }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/BuildLogBundle.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/BuildLogBundle.cs
@@ -1,8 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-
-namespace Azure.Sdk.Tools.PipelineWitness
+﻿namespace Azure.Sdk.Tools.PipelineWitness.Entities
 {
+    using System;
+    using System.Collections.Generic;
+
     public class BuildLogBundle
     {
         public string Account { get; set; }
@@ -25,7 +25,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
         
         public string DefinitionName { get; set; }
 
-        public List<BuildLogInfo> TimelineLogs { get; } = new List<BuildLogInfo>();
+        public List<BuildLogInfo> TimelineLogs { get; } = new();
     }
 }
 

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/BuildLogBundle.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/BuildLogBundle.cs
@@ -1,8 +1,8 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Entities
-{
-    using System;
-    using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Entities
+{
     public class BuildLogBundle
     {
         public string Account { get; set; }
@@ -14,15 +14,15 @@
         public int BuildId { get; set; }
 
         public DateTimeOffset StartTime { get; set; }
-    
+
         public DateTimeOffset FinishTime { get; set; }
-    
+
         public DateTimeOffset QueueTime { get; set; }
-        
+
         public int DefinitionId { get; set; }
-        
+
         public string DefinitionPath { get; set; }
-        
+
         public string DefinitionName { get; set; }
 
         public List<BuildLogInfo> TimelineLogs { get; } = new();

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/BuildLogInfo.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/BuildLogInfo.cs
@@ -1,4 +1,4 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness
+﻿namespace Azure.Sdk.Tools.PipelineWitness.Entities
 {
     using System;
 

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/BuildLogInfo.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Entities/BuildLogInfo.cs
@@ -1,20 +1,14 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Entities
-{
-    using System;
+﻿using System;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Entities
+{
     public class BuildLogInfo
     {
         public int LogId { get; set; }
 
-        public long LineCount { get; set; }
-
         public DateTimeOffset LogCreatedOn { get; set; }
 
-        public string RecordType { get; set; }
-        
         public Guid? RecordId { get; set; }
-        
-        public Guid? ParentRecordId { get; set; }        
     }
 }
 

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/PipelineWitnessSettings.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/PipelineWitnessSettings.cs
@@ -1,7 +1,7 @@
+using System;
+
 namespace Azure.Sdk.Tools.PipelineWitness
 {
-    using System;
-
     public class PipelineWitnessSettings
     {
         public string KeyVaultUri { get; set; }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/PipelineWitnessSettings.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/PipelineWitnessSettings.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-
 namespace Azure.Sdk.Tools.PipelineWitness
 {
+    using System;
+
     public class PipelineWitnessSettings
     {
         public string KeyVaultUri { get; set; }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Program.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Program.cs
@@ -1,10 +1,10 @@
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-
 namespace Azure.Sdk.Tools.PipelineWitness
 {
+    using System.Threading.Tasks;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+
     public class Program
     {
         public static async Task Main(params string[] args)

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Program.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Program.cs
@@ -1,10 +1,10 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
 namespace Azure.Sdk.Tools.PipelineWitness
 {
-    using System.Threading.Tasks;
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-
     public class Program
     {
         public static async Task Main(params string[] args)

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/AzurePipelinesBuildDefinitionWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/AzurePipelinesBuildDefinitionWorker.cs
@@ -1,24 +1,23 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+using System.Diagnostics;
+using Microsoft.Extensions.Options;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services
 {
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.Extensions.Logging;
-    using System.Diagnostics;
-    using Microsoft.Extensions.Options;
-
     public class AzurePipelinesBuildDefinitionWorker : BackgroundService
     {
-        private readonly BlobUploadProcessor runProcessor;
-        private readonly IOptions<PipelineWitnessSettings> options;
+        private readonly BlobUploadProcessor _runProcessor;
+        private readonly IOptions<PipelineWitnessSettings> _options;
 
         public AzurePipelinesBuildDefinitionWorker(
             BlobUploadProcessor runProcessor,
             IOptions<PipelineWitnessSettings> options)
         {
-            this.runProcessor = runProcessor;
-            this.options = options;
+            _runProcessor = runProcessor;
+            _options = options;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -26,17 +25,17 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services
             while (true)
             {
                 var stopWatch = Stopwatch.StartNew();
-                var settings = this.options.Value;
+                var settings = _options.Value;
 
                 foreach (var project in settings.Projects)
                 {
-                    await this.runProcessor.UploadBuildDefinitionBlobsAsync(settings.Account, project);
+                    await _runProcessor.UploadBuildDefinitionBlobsAsync(settings.Account, project);
                 }
 
                 var duration = settings.BuildDefinitionLoopPeriod - stopWatch.Elapsed;
                 if (duration > TimeSpan.Zero)
                 {
-                    await Task.Delay(duration);
+                    await Task.Delay(duration, stoppingToken);
                 }
             }
         }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/AzurePipelinesBuildDefinitionWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/AzurePipelinesBuildDefinitionWorker.cs
@@ -1,26 +1,22 @@
-using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Logging;
-using Microsoft.VisualStudio.Services.WebApi;
-using System.Diagnostics;
-using Microsoft.Extensions.Options;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services
 {
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.Extensions.Logging;
+    using System.Diagnostics;
+    using Microsoft.Extensions.Options;
+
     public class AzurePipelinesBuildDefinitionWorker : BackgroundService
     {
-        private readonly ILogger<AzurePipelinesBuildDefinitionWorker> logger;
         private readonly BlobUploadProcessor runProcessor;
         private readonly IOptions<PipelineWitnessSettings> options;
 
         public AzurePipelinesBuildDefinitionWorker(
-            ILogger<AzurePipelinesBuildDefinitionWorker> logger,
             BlobUploadProcessor runProcessor,
             IOptions<PipelineWitnessSettings> options)
         {
-            this.logger = logger;
             this.runProcessor = runProcessor;
             this.options = options;
         }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildCompleteQueueWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildCompleteQueueWorker.cs
@@ -1,21 +1,19 @@
-﻿using System;
-using System.Text.RegularExpressions;
-using System.Threading;
-using System.Threading.Tasks;
-using Azure.Storage.Queues;
-using Azure.Storage.Queues.Models;
-using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Newtonsoft.Json.Linq;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services
 {
+    using System;
+    using System.Text.RegularExpressions;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Storage.Queues;
+    using Azure.Storage.Queues.Models;
+    using Microsoft.ApplicationInsights;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using Newtonsoft.Json.Linq;
+
     internal class BuildCompleteQueueWorker : QueueWorkerBackgroundService
     {
         private readonly ILogger logger;
-        private readonly TelemetryClient telemetryClient;
         private readonly BlobUploadProcessor runProcessor;
 
         public BuildCompleteQueueWorker(
@@ -33,10 +31,9 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services
         {
             this.logger = logger;
             this.runProcessor = runProcessor;
-            this.telemetryClient = telemetryClient;
         }
 
-        internal override async Task ProcessMessageAsync(QueueMessage message, CancellationToken cancellationToken)
+        protected override async Task ProcessMessageAsync(QueueMessage message, CancellationToken cancellationToken)
         {
             this.logger.LogInformation("Processing build.complete event.");
 

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogBundleQueueWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogBundleQueueWorker.cs
@@ -1,16 +1,17 @@
-﻿using System;
-using System.Threading;
-using System.Threading.Tasks;
-using Azure.Storage.Queues;
-using Azure.Storage.Queues.Models;
-using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
-using Newtonsoft.Json;
-
-namespace Azure.Sdk.Tools.PipelineWitness.Services
+﻿namespace Azure.Sdk.Tools.PipelineWitness.Services
 {
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Azure.Storage.Queues;
+    using Azure.Storage.Queues.Models;
+    using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.Extensions.Options;
+    using Newtonsoft.Json;
+    using Azure.Sdk.Tools.PipelineWitness.Entities;
+
     internal class BuildLogBundleQueueWorker : QueueWorkerBackgroundService
     {
         private readonly ILogger logger;
@@ -35,7 +36,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services
             this.telemetryClient = telemetryClient;
         }
 
-        internal override async Task ProcessMessageAsync(QueueMessage message, CancellationToken cancellationToken)
+        protected override async Task ProcessMessageAsync(QueueMessage message, CancellationToken cancellationToken)
         {
             logger.LogInformation("Processing build log bundle message.");
 
@@ -59,7 +60,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services
                 throw;
             }
 
-            // TODO: Add cancellation token propatagion
+            // TODO: Add cancellation token propagation
             await runProcessor.ProcessBuildLogBundleAsync(buildLogBundle);
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogBundleQueueWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogBundleQueueWorker.cs
@@ -1,22 +1,22 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Services
-{
-    using System;
-    using System.Threading;
-    using System.Threading.Tasks;
-    using Azure.Storage.Queues;
-    using Azure.Storage.Queues.Models;
-    using Microsoft.ApplicationInsights;
-    using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.Extensions.Logging;
-    using Microsoft.Extensions.Options;
-    using Newtonsoft.Json;
-    using Azure.Sdk.Tools.PipelineWitness.Entities;
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using Azure.Sdk.Tools.PipelineWitness.Entities;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Services
+{
     internal class BuildLogBundleQueueWorker : QueueWorkerBackgroundService
     {
-        private readonly ILogger logger;
-        private readonly TelemetryClient telemetryClient;
-        private readonly BlobUploadProcessor runProcessor;
+        private readonly ILogger _logger;
+        private readonly TelemetryClient _telemetryClient;
+        private readonly BlobUploadProcessor _runProcessor;
 
         public BuildLogBundleQueueWorker(
             ILogger<BuildLogBundleQueueWorker> logger,
@@ -31,18 +31,18 @@
                   options?.CurrentValue?.BuildLogBundlesQueueName,
                   options)
         {
-            this.logger = logger;
-            this.runProcessor = runProcessor;
-            this.telemetryClient = telemetryClient;
+            _logger = logger;
+            _runProcessor = runProcessor;
+            _telemetryClient = telemetryClient;
         }
 
         protected override async Task ProcessMessageAsync(QueueMessage message, CancellationToken cancellationToken)
         {
-            logger.LogInformation("Processing build log bundle message.");
+            _logger.LogInformation("Processing build log bundle message.");
 
             if (message.InsertedOn.HasValue)
             {
-                telemetryClient.TrackMetric(new MetricTelemetry
+                _telemetryClient.TrackMetric(new MetricTelemetry
                 {
                     Name = "AzurePipelinesBuildLogBundle MessageLatencyMs",
                     Sum = DateTimeOffset.Now.Subtract(message.InsertedOn.Value).TotalMilliseconds,
@@ -56,12 +56,12 @@
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Failed to deserialize message body. Body: {MessageBody}", message.MessageText);
+                _logger.LogError(ex, "Failed to deserialize message body. Body: {MessageBody}", message.MessageText);
                 throw;
             }
 
             // TODO: Add cancellation token propagation
-            await runProcessor.ProcessBuildLogBundleAsync(buildLogBundle);
+            await _runProcessor.ProcessBuildLogBundleAsync(buildLogBundle);
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogProvider.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogProvider.cs
@@ -1,41 +1,41 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services
 {
-    using System.Collections.Generic;
-    using System.IO;
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Microsoft.Extensions.Logging;
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using Microsoft.VisualStudio.Services.WebApi;
-
     public class BuildLogProvider
     {
-        private readonly ILogger<BuildLogProvider> logger;
-        private readonly VssConnection vssConnection;
+        private readonly ILogger<BuildLogProvider> _logger;
+        private readonly VssConnection _vssConnection;
 
         public BuildLogProvider(ILogger<BuildLogProvider> logger, VssConnection vssConnection)
         {
-            this.logger = logger;
-            this.vssConnection = vssConnection;
+            _logger = logger;
+            _vssConnection = vssConnection;
         }
 
         public async Task<IReadOnlyList<string>> GetLogLinesAsync(Build build, int logId)
         {
-            logger.LogTrace("Getting logs for build {BuildId}, log {LogId} from rest api", build.Id, logId);
+            _logger.LogTrace("Getting logs for build {BuildId}, log {LogId} from rest api", build.Id, logId);
 
-            var buildHttpClient = vssConnection.GetClient<BuildHttpClient>();
+            var buildHttpClient = _vssConnection.GetClient<BuildHttpClient>();
             var response = await buildHttpClient.GetBuildLogLinesAsync(build.Project.Id, build.Id, logId);
 
-            logger.LogTrace("Received {CharacterCount} characters in {LineCount} lines for build {BuildId}, log {LogId}", response.Sum(x => x.Length), response.Count, build.Id, logId);
+            _logger.LogTrace("Received {CharacterCount} characters in {LineCount} lines for build {BuildId}, log {LogId}", response.Sum(x => x.Length), response.Count, build.Id, logId);
 
             return response;
         }
 
         public async Task<Stream> GetLogStreamAsync(string projectName, int buildId, int logId)
         {
-            logger.LogTrace("Getting logs for build {BuildId}, log {LogId} from rest api", buildId, logId);
+            _logger.LogTrace("Getting logs for build {BuildId}, log {LogId} from rest api", buildId, logId);
 
-            var buildHttpClient = vssConnection.GetClient<BuildHttpClient>();
+            var buildHttpClient = _vssConnection.GetClient<BuildHttpClient>();
             var stream = await buildHttpClient.GetBuildLogAsync(projectName, buildId, logId);
 
             return stream;

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogProvider.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildLogProvider.cs
@@ -1,15 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
-using System.Threading.Tasks;
-
-using Microsoft.Extensions.Logging;
-using Microsoft.TeamFoundation.Build.WebApi;
-using Microsoft.VisualStudio.Services.WebApi;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services
 {
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.Extensions.Logging;
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using Microsoft.VisualStudio.Services.WebApi;
+
     public class BuildLogProvider
     {
         private readonly ILogger<BuildLogProvider> logger;
@@ -21,7 +19,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services
             this.vssConnection = vssConnection;
         }
 
-        public virtual async Task<IReadOnlyList<string>> GetLogLinesAsync(Build build, int logId)
+        public async Task<IReadOnlyList<string>> GetLogLinesAsync(Build build, int logId)
         {
             logger.LogTrace("Getting logs for build {BuildId}, log {LogId} from rest api", build.Id, logId);
 
@@ -33,7 +31,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services
             return response;
         }
 
-        public virtual async Task<Stream> GetLogStreamAsync(string projectName, int buildId, int logId)
+        public async Task<Stream> GetLogStreamAsync(string projectName, int buildId, int logId)
         {
             logger.LogTrace("Getting logs for build {BuildId}, log {LogId} from rest api", buildId, logId);
 

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzureArtifactsServiceUnavailableClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzureArtifactsServiceUnavailableClassifier.cs
@@ -1,9 +1,9 @@
-﻿using Microsoft.TeamFoundation.Build.WebApi;
-using System.Linq;
-using System.Threading.Tasks;
-
-namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class AzureArtifactsServiceUnavailableClassifier : IFailureClassifier
     {
         public AzureArtifactsServiceUnavailableClassifier(BuildLogProvider buildLogProvider)
@@ -15,13 +15,12 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 
         public async Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            var failedTasks = from r in context.Timeline.Records
-                                where r.Result == TaskResult.Failed
-                                where r.RecordType == "Task"
-                                where r.Task != null
-                                where r.Name == "Publish to Java Dev Feed"
-                                where r.Log != null
-                                select r;
+            var failedTasks = context.Timeline.Records
+                .Where(r => r.Result == TaskResult.Failed && 
+                            r.RecordType == "Task" && 
+                            r.Task != null &&
+                            r.Name == "Publish to Java Dev Feed" && 
+                            r.Log != null);
 
             foreach (var failedTask in failedTasks)
             {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzureArtifactsServiceUnavailableClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzureArtifactsServiceUnavailableClassifier.cs
@@ -1,30 +1,30 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
-{
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
+﻿using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
     public class AzureArtifactsServiceUnavailableClassifier : IFailureClassifier
     {
         public AzureArtifactsServiceUnavailableClassifier(BuildLogProvider buildLogProvider)
         {
-            this.buildLogProvider = buildLogProvider;
+            _buildLogProvider = buildLogProvider;
         }
 
-        private readonly BuildLogProvider buildLogProvider;
+        private readonly BuildLogProvider _buildLogProvider;
 
         public async Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var failedTasks = context.Timeline.Records
-                .Where(r => r.Result == TaskResult.Failed && 
-                            r.RecordType == "Task" && 
-                            r.Task != null &&
-                            r.Name == "Publish to Java Dev Feed" && 
-                            r.Log != null);
+                .Where(r => r.Result == TaskResult.Failed)
+                .Where(r => r.RecordType == "Task")
+                .Where(r => r.Task != null)
+                .Where(r => r.Name == "Publish to Java Dev Feed")
+                .Where(r => r.Log != null);
 
             foreach (var failedTask in failedTasks)
             {
-                var lines = await this.buildLogProvider.GetLogLinesAsync(context.Build, failedTask.Log.Id);
+                var lines = await _buildLogProvider.GetLogLinesAsync(context.Build, failedTask.Log.Id);
 
                 if (lines.Any(line => line.Contains("Transfer failed for https://pkgs.dev.azure.com") && line.Contains("503 Service Unavailable")))
                 {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePipelinesPoolOutageClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePipelinesPoolOutageClassifier.cs
@@ -1,27 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class AzurePipelinesPoolOutageClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            var jobs = from r in context.Timeline.Records
-                       where r.RecordType == "Job"
-                       where r.Issues.Any(i => i.Message.Contains("abandoned due to an infrastructure failure"))
-                       select r;
+            var jobs = context.Timeline.Records
+                .Where(r => r.RecordType == "Job" &&
+                            r.Issues.Any(i => i.Message.Contains("abandoned due to an infrastructure failure")));
 
-            if (jobs.Count() > 0)
+            foreach (var job in jobs)
             {
-                foreach (var job in jobs)
-                {
-                    context.AddFailure(job, "Azure Pipelines Pool Outage");
-                }
+                context.AddFailure(job, "Azure Pipelines Pool Outage");
             }
+            
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePipelinesPoolOutageClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePipelinesPoolOutageClassifier.cs
@@ -1,21 +1,21 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
-{
-    using System.Linq;
-    using System.Threading.Tasks;
+﻿using System.Linq;
+using System.Threading.Tasks;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
     public class AzurePipelinesPoolOutageClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var jobs = context.Timeline.Records
-                .Where(r => r.RecordType == "Job" &&
-                            r.Issues.Any(i => i.Message.Contains("abandoned due to an infrastructure failure")));
+                .Where(r => r.RecordType == "Job")
+                .Where(r => r.Issues.Any(i => i.Message.Contains("abandoned due to an infrastructure failure")));
 
             foreach (var job in jobs)
             {
                 context.AddFailure(job, "Azure Pipelines Pool Outage");
             }
-            
+
             return Task.CompletedTask;
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePowerShellModuleInstallationFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePowerShellModuleInstallationFailureClassifier.cs
@@ -1,33 +1,27 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class AzurePowerShellModuleInstallationFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             if (context.Build.Definition.Name.EndsWith("- tests"))
             {
-                var failedTasks = from r in context.Timeline.Records
-                                  where r.Result == TaskResult.Failed
-                                  where r.RecordType == "Task"
-                                  where r.Name == "Install Azure PowerShell module"
-                                  select r;
+                var failedTasks = context.Timeline.Records
+                    .Where(r => r.Result == TaskResult.Failed && 
+                                r.RecordType == "Task" &&
+                                r.Name == "Install Azure PowerShell module");
 
-                if (failedTasks.Count() > 0)
+                foreach (var failedTask in failedTasks)
                 {
-                    foreach (var failedTask in failedTasks)
-                    {
-                        context.AddFailure(failedTask, "Azure PS Module");
-                    }
+                    context.AddFailure(failedTask, "Azure PS Module");
                 }
             }
+            
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePowerShellModuleInstallationFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzurePowerShellModuleInstallationFailureClassifier.cs
@@ -1,26 +1,27 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
-{
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
+﻿using System;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
     public class AzurePowerShellModuleInstallationFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            if (context.Build.Definition.Name.EndsWith("- tests"))
+            if (context.Build.Definition.Name.EndsWith("- tests", StringComparison.InvariantCulture))
             {
                 var failedTasks = context.Timeline.Records
-                    .Where(r => r.Result == TaskResult.Failed && 
-                                r.RecordType == "Task" &&
-                                r.Name == "Install Azure PowerShell module");
+                    .Where(r => r.Result == TaskResult.Failed)
+                    .Where(r => r.RecordType == "Task")
+                    .Where(r => r.Name == "Install Azure PowerShell module");
 
                 foreach (var failedTask in failedTasks)
                 {
                     context.AddFailure(failedTask, "Azure PS Module");
                 }
             }
-            
+
             return Task.CompletedTask;
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzuriteInstallFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzuriteInstallFailureClassifier.cs
@@ -1,23 +1,23 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+﻿using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
-    
     public class AzuriteInstallFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var failedTasks = context.Timeline.Records
-                .Where(r => r.Result == TaskResult.Failed &&
-                            r.RecordType == "Task" &&
-                            r.Name == "Install Azurite");
+                .Where(r => r.Result == TaskResult.Failed)
+                .Where(r => r.RecordType == "Task")
+                .Where(r => r.Name == "Install Azurite");
 
             foreach (var failedTask in failedTasks)
             {
                 context.AddFailure(failedTask, "Azurite Install");
             }
-            
+
             return Task.CompletedTask;
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzuriteInstallFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/AzuriteInstallFailureClassifier.cs
@@ -1,30 +1,24 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+    
     public class AzuriteInstallFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            var failedTasks = from r in context.Timeline.Records
-                                where r.Result == TaskResult.Failed
-                                where r.RecordType == "Task"
-                                where r.Name == "Install Azurite"
-                                select r;
+            var failedTasks = context.Timeline.Records
+                .Where(r => r.Result == TaskResult.Failed &&
+                            r.RecordType == "Task" &&
+                            r.Name == "Install Azurite");
 
-            if (failedTasks.Count() > 0)
+            foreach (var failedTask in failedTasks)
             {
-                foreach (var failedTask in failedTasks)
-                {
-                    context.AddFailure(failedTask, "Azurite Install");
-                }
+                context.AddFailure(failedTask, "Azurite Install");
             }
+            
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CacheFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CacheFailureClassifier.cs
@@ -1,12 +1,13 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
-{
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
+﻿using System;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
     public class CacheFailureClassifier : IFailureClassifier
     {
-        private static readonly (string MessagePrefix, string FailureName)[] failureClassifiers =
+        private static readonly (string MessagePrefix, string FailureName)[] s_failureClassifiers =
         {
             ("Chunks are not arriving in order or sizes are not matched up", "Cache Chunk Ordering" ),
             ("The task has timed out", "Cache Task Timeout" ),
@@ -14,22 +15,22 @@
             ("The HTTP request timed out after", "Cache Service HTTP Timeout"),
             ("Access to the path", "Cache Cannot Access Path"),
         };
-        
+
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var failedTasks = context.Timeline.Records
-                .Where(r => r.Result == TaskResult.Failed &&
-                            r.RecordType == "Task" &&
-                            r.Task?.Name == "Cache" &&
-                            r.Log != null);
+                .Where(r => r.Result == TaskResult.Failed)
+                .Where(r => r.RecordType == "Task")
+                .Where(r => r.Task?.Name == "Cache")
+                .Where(r => r.Log != null);
 
             var classificationFound = false;
-            
+
             foreach (var failedTask in failedTasks)
             {
-                foreach (var classifier in failureClassifiers)
+                foreach (var classifier in s_failureClassifiers)
                 {
-                    if (failedTask.Issues.Any(i => i.Message.StartsWith(classifier.MessagePrefix)))
+                    if (failedTask.Issues.Any(i => i.Message.StartsWith(classifier.MessagePrefix, StringComparison.InvariantCulture)))
                     {
                         context.AddFailure(failedTask, classifier.FailureName);
                         classificationFound = true;
@@ -41,7 +42,7 @@
                     context.AddFailure(failedTask, "Cache Failure Other");
                 }
             }
-            
+
             return Task.CompletedTask;
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CancelledTaskClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CancelledTaskClassifier.cs
@@ -1,30 +1,23 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.ComponentModel.Design;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class CancelledTaskClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            var timedOutTestTasks = from r in context.Timeline.Records
-                                    where r.RecordType == "Task"
-                                    where r.Result == TaskResult.Canceled
-                                    select r;
+            var timedOutTestTasks = context.Timeline.Records
+                .Where(r => r.RecordType == "Task" &&
+                            r.Result == TaskResult.Canceled);
 
-            if (timedOutTestTasks.Count() > 0)
+            foreach (var timedOutTestTask in timedOutTestTasks)
             {
-                foreach (var timedOutTestTask in timedOutTestTasks)
-                {
-                    context.AddFailure(timedOutTestTask, "Cancelled Task");
-                }
+                context.AddFailure(timedOutTestTask, "Cancelled Task");
             }
+            
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CancelledTaskClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CancelledTaskClassifier.cs
@@ -1,22 +1,22 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
-{
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
+﻿using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
     public class CancelledTaskClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var timedOutTestTasks = context.Timeline.Records
-                .Where(r => r.RecordType == "Task" &&
-                            r.Result == TaskResult.Canceled);
+                .Where(r => r.RecordType == "Task")
+                .Where(r => r.Result == TaskResult.Canceled);
 
             foreach (var timedOutTestTask in timedOutTestTasks)
             {
                 context.AddFailure(timedOutTestTask, "Cancelled Task");
             }
-            
+
             return Task.CompletedTask;
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CodeSigningFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CodeSigningFailureClassifier.cs
@@ -1,18 +1,18 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
-{
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Microsoft.TeamFoundation.Build.WebApi;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.TeamFoundation.Build.WebApi;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
     public class CodeSigningFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var failedTasks = context.Timeline.Records
-                .Where(r => r.Result == TaskResult.Failed &&
-                            r.RecordType == "Task" &&
-                            r.Task?.Name == "EsrpCodeSigning" &&
-                            r.Log != null);
+                .Where(r => r.Result == TaskResult.Failed)
+                .Where(r => r.RecordType == "Task")
+                .Where(r => r.Task?.Name == "EsrpCodeSigning")
+                .Where(r => r.Log != null);
 
             foreach (var failedTask in failedTasks)
             {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CodeSigningFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CodeSigningFailureClassifier.cs
@@ -1,31 +1,25 @@
-﻿using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.TeamFoundation.Build.WebApi;
-
-namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.TeamFoundation.Build.WebApi;
+
     public class CodeSigningFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            var failedTasks = from r in context.Timeline.Records
-                              where r.Result == TaskResult.Failed
-                              where r.RecordType == "Task"
-                              where r.Task != null
-                              where r.Task.Name == "EsrpCodeSigning"
-                              where r.Log != null
-                              select r;
+            var failedTasks = context.Timeline.Records
+                .Where(r => r.Result == TaskResult.Failed &&
+                            r.RecordType == "Task" &&
+                            r.Task?.Name == "EsrpCodeSigning" &&
+                            r.Log != null);
 
-            if (failedTasks.Count() > 0)
+            foreach (var failedTask in failedTasks)
             {
-                foreach (var failedTask in failedTasks)
-                {
-                    context.AddFailure(failedTask, "Code Signing");
-                }
+                context.AddFailure(failedTask, "Code Signing");
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CosmosDbEmulatorStartFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CosmosDbEmulatorStartFailureClassifier.cs
@@ -1,29 +1,24 @@
-﻿using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.TeamFoundation.Build.WebApi;
-
-namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.TeamFoundation.Build.WebApi;
+
     public class CosmosDbEmulatorStartFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            var failedTasks = from r in context.Timeline.Records
-                              where r.RecordType == "Task"
-                              where r.Name == "Start Cosmos DB Emulator"
-                              where r.Result == TaskResult.Failed
-                              select r;
+            var failedTasks = context.Timeline.Records
+                .Where(r => r.RecordType == "Task" &&
+                            r.Name == "Start Cosmos DB Emulator" &&
+                            r.Result == TaskResult.Failed);
 
-            if (failedTasks.Count() > 0)
+            foreach (var failedTask in failedTasks)
             {
-                foreach (var failedTask in failedTasks)
-                {
-                    context.AddFailure(failedTask, "Cosmos DB Emulator Failure");
-                }
+                context.AddFailure(failedTask, "Cosmos DB Emulator Failure");
             }
+            
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CosmosDbEmulatorStartFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/CosmosDbEmulatorStartFailureClassifier.cs
@@ -1,23 +1,23 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
-{
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Microsoft.TeamFoundation.Build.WebApi;
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.TeamFoundation.Build.WebApi;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
     public class CosmosDbEmulatorStartFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var failedTasks = context.Timeline.Records
-                .Where(r => r.RecordType == "Task" &&
-                            r.Name == "Start Cosmos DB Emulator" &&
-                            r.Result == TaskResult.Failed);
+                .Where(r => r.RecordType == "Task")
+                .Where(r => r.Name == "Start Cosmos DB Emulator")
+                .Where(r => r.Result == TaskResult.Failed);
 
             foreach (var failedTask in failedTasks)
             {
                 context.AddFailure(failedTask, "Cosmos DB Emulator Failure");
             }
-            
+
             return Task.CompletedTask;
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DnsResolutionFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DnsResolutionFailureClassifier.cs
@@ -1,17 +1,17 @@
-﻿namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
-{
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System;
-    using System.Linq;
-    using System.Threading.Tasks;
+﻿using Microsoft.TeamFoundation.Build.WebApi;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
+namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
+{
     public class DnsResolutionFailureClassifier : IFailureClassifier
     {
-        private readonly BuildLogProvider buildLogProvider;
+        private readonly BuildLogProvider _buildLogProvider;
 
         public DnsResolutionFailureClassifier(BuildLogProvider buildLogProvider)
         {
-            this.buildLogProvider = buildLogProvider;
+            _buildLogProvider = buildLogProvider;
         }
 
         private static bool IsDnsResolutionFailure(string line)
@@ -26,13 +26,13 @@
         public async Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var failedTasks = context.Timeline.Records
-                .Where(r => r.Result == TaskResult.Failed &&
-                            r.RecordType == "Task" &&
-                            r.Log != null);
+                .Where(r => r.Result == TaskResult.Failed)
+                .Where(r => r.RecordType == "Task")
+                .Where(r => r.Log != null);
 
             foreach (var failedTask in failedTasks)
             {
-                var lines = await buildLogProvider.GetLogLinesAsync(context.Build, failedTask.Log.Id);
+                var lines = await _buildLogProvider.GetLogLinesAsync(context.Build, failedTask.Log.Id);
 
                 if (lines.Any(IsDnsResolutionFailure))
                 {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DotnetPipelineTestFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DotnetPipelineTestFailureClassifier.cs
@@ -1,33 +1,27 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class DotnetPipelineTestFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             if (context.Build.Definition.Name.StartsWith("net - "))
             {
-                var failedTasks = from r in context.Timeline.Records
-                                  where r.Result == TaskResult.Failed
-                                  where r.RecordType == "Task"
-                                  where r.Name.StartsWith("Build & Test")
-                                  select r;
+                var failedTasks = context.Timeline.Records
+                    .Where(r => r.Result == TaskResult.Failed && 
+                                r.RecordType == "Task" && 
+                                r.Name.StartsWith("Build & Test"));
 
-                if (failedTasks.Count() > 0)
+                foreach (var failedTask in failedTasks)
                 {
-                    foreach (var failedTask in failedTasks)
-                    {
-                        context.AddFailure(failedTask, "Test Failure");
-                    }
+                    context.AddFailure(failedTask, "Test Failure");
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DotnetPipelineTestFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DotnetPipelineTestFailureClassifier.cs
@@ -1,19 +1,20 @@
+using System;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
-
     public class DotnetPipelineTestFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            if (context.Build.Definition.Name.StartsWith("net - "))
+            if (context.Build.Definition.Name.StartsWith("net - ", StringComparison.InvariantCulture))
             {
                 var failedTasks = context.Timeline.Records
-                    .Where(r => r.Result == TaskResult.Failed && 
-                                r.RecordType == "Task" && 
-                                r.Name.StartsWith("Build & Test"));
+                    .Where(r => r.Result == TaskResult.Failed)
+                    .Where(r => r.RecordType == "Task")
+                    .Where(r => r.Name.StartsWith("Build & Test", StringComparison.InvariantCulture));
 
                 foreach (var failedTask in failedTasks)
                 {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DownloadSecretsFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DownloadSecretsFailureClassifier.cs
@@ -1,23 +1,23 @@
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
-
     public class DownloadSecretsFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var failedTasks = context.Timeline.Records
-                .Where(r => r.RecordType == "Task" && 
-                            r.Result == TaskResult.Failed && 
-                            r.Name.Contains("Download secrets"));
+                .Where(r => r.RecordType == "Task")
+                .Where(r => r.Result == TaskResult.Failed)
+                .Where(r => r.Name.Contains("Download secrets"));
 
             foreach (var failedTask in failedTasks)
             {
                 context.AddFailure(failedTask, "Secrets Failure");
             }
-            
+
             return Task.CompletedTask;
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DownloadSecretsFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/DownloadSecretsFailureClassifier.cs
@@ -1,30 +1,24 @@
-﻿using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.CompilerServices;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class DownloadSecretsFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            var failedTasks = from r in context.Timeline.Records
-                              where r.RecordType == "Task"
-                              where r.Result == TaskResult.Failed
-                              where r.Name.Contains("Download secrets")
-                              select r;
+            var failedTasks = context.Timeline.Records
+                .Where(r => r.RecordType == "Task" && 
+                            r.Result == TaskResult.Failed && 
+                            r.Name.Contains("Download secrets"));
 
-            if (failedTasks.Count() > 0)
+            foreach (var failedTask in failedTasks)
             {
-                foreach (var failedTask in failedTasks)
-                {
-                    context.AddFailure(failedTask, "Secrets Failure");
-                }
+                context.AddFailure(failedTask, "Secrets Failure");
             }
+            
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzer.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzer.cs
@@ -1,45 +1,39 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using Microsoft.VisualStudio.Services.Common;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class FailureAnalyzer : IFailureAnalyzer
     {
+        private readonly IFailureClassifier[] classifiers;
+
         public FailureAnalyzer(IEnumerable<IFailureClassifier> classifiers)
         {
             this.classifiers = classifiers.ToArray();
         }
 
-        private IFailureClassifier[] classifiers;
-
-        public async Task<IEnumerable<Failure>> AnalyzeFailureAsync(Build build, Timeline timeline)
+        public async Task<IReadOnlyCollection<Failure>> AnalyzeFailureAsync(Build build, Timeline timeline)
         {
             var failures = new List<Failure>();
 
             var context = new FailureAnalyzerContext(build, timeline, failures);
+            
             foreach (var classifier in classifiers)
             {
                 await classifier.ClassifyAsync(context);
             }
 
-            if (failures.Count == 0)
+            if (failures.Count == 0 && 
+                build.Result != BuildResult.Succeeded && 
+                build.Result != BuildResult.Canceled)
             {
-                if (build.Result != BuildResult.Succeeded && 
-                    build.Result != BuildResult.Canceled)
-                {
-                    foreach (var record in timeline.Records.Where(x => x.ParentId.HasValue == false))
-                    {
-                        if (record.Result == TaskResult.Failed)
-                        {
-                            failures.Add(new Failure(record, "Unknown"));
-                        }
-                    }
-                }
+                var failedStageRecords = timeline.Records
+                    .Where(record => record.ParentId == null && record.Result == TaskResult.Failed);
+                
+                failures.AddRange(failedStageRecords.Select(record => new Failure(record, "Unknown")));
             }
 
             return failures;

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzer.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzer.cs
@@ -1,18 +1,18 @@
+using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Threading.Tasks;
-
     public class FailureAnalyzer : IFailureAnalyzer
     {
-        private readonly IFailureClassifier[] classifiers;
+        private readonly IFailureClassifier[] _classifiers;
 
         public FailureAnalyzer(IEnumerable<IFailureClassifier> classifiers)
         {
-            this.classifiers = classifiers.ToArray();
+            _classifiers = classifiers.ToArray();
         }
 
         public async Task<IReadOnlyCollection<Failure>> AnalyzeFailureAsync(Build build, Timeline timeline)
@@ -20,19 +20,20 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
             var failures = new List<Failure>();
 
             var context = new FailureAnalyzerContext(build, timeline, failures);
-            
-            foreach (var classifier in classifiers)
+
+            foreach (var classifier in _classifiers)
             {
                 await classifier.ClassifyAsync(context);
             }
 
-            if (failures.Count == 0 && 
-                build.Result != BuildResult.Succeeded && 
+            if (failures.Count == 0 &&
+                build.Result != BuildResult.Succeeded &&
                 build.Result != BuildResult.Canceled)
             {
                 var failedStageRecords = timeline.Records
-                    .Where(record => record.ParentId == null && record.Result == TaskResult.Failed);
-                
+                    .Where(record => record.ParentId == null)
+                    .Where(record => record.Result == TaskResult.Failed);
+
                 failures.AddRange(failedStageRecords.Select(record => new Failure(record, "Unknown")));
             }
 

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzerContext.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzerContext.cs
@@ -1,18 +1,18 @@
+using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Collections.Generic;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Collections.Generic;
-
     public class FailureAnalyzerContext
     {
-        private readonly IList<Failure> failures;
+        private readonly IList<Failure> _failures;
 
         public FailureAnalyzerContext(Build build, Timeline timeline, IList<Failure> failures)
         {
             Build = build;
             Timeline = timeline;
-            this.failures = failures;
+            _failures = failures;
         }
 
         public Build Build { get; }
@@ -21,7 +21,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
         public void AddFailure(TimelineRecord record, string classification)
         {
             var failure = new Failure(record, classification);
-            failures.Add(failure);
+            _failures.Add(failure);
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzerContext.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/FailureAnalyzerContext.cs
@@ -1,15 +1,13 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using Microsoft.VisualStudio.Services.Common;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Collections.Generic;
+
     public class FailureAnalyzerContext
     {
+        private readonly IList<Failure> failures;
+
         public FailureAnalyzerContext(Build build, Timeline timeline, IList<Failure> failures)
         {
             Build = build;
@@ -17,37 +15,8 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
             this.failures = failures;
         }
 
-        public Build Build { get; private set; }
-        public Timeline Timeline { get; private set; }
-
-        private IList<Failure> failures;
-
-        private string GetScope(TimelineRecord record)
-        {
-            var timelineStack = new Stack<TimelineRecord>();
-
-            var current = record;
-            while (true)
-            {
-                timelineStack.Push(current);
-
-                var parent = Timeline.Records.Where(r => r.Id == current.ParentId).SingleOrDefault();
-                if (parent == null)
-                {
-                    break;
-                }
-                else
-                {
-                    current = parent;
-                }
-            }
-
-            var scopeBuilder = new StringBuilder();
-            timelineStack.ForEach(r => scopeBuilder.Append($"/{r.RecordType}:{r.Name}"));
-
-            var scope = scopeBuilder.ToString();
-            return scope;
-        }
+        public Build Build { get; }
+        public Timeline Timeline { get; }
 
         public void AddFailure(TimelineRecord record, string classification)
         {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/GitCheckoutFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/GitCheckoutFailureClassifier.cs
@@ -1,15 +1,15 @@
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using System.Linq;
-    using System.Threading.Tasks;
-
     public class GitCheckoutFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var tasks = context.Timeline.Records
-                .Where(r => r.RecordType == "Task" &&
-                            r.Issues.Any(i => i.Message.Contains("Git fetch failed with exit code: 128")));
+                .Where(r => r.RecordType == "Task")
+                .Where(r => r.Issues.Any(i => i.Message.Contains("Git fetch failed with exit code: 128")));
 
             foreach (var task in tasks)
             {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/GitCheckoutFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/GitCheckoutFailureClassifier.cs
@@ -1,28 +1,22 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class GitCheckoutFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            var tasks = from r in context.Timeline.Records
-                       where r.RecordType == "Task"
-                       where r.Issues.Any(i => i.Message.Contains("Git fetch failed with exit code: 128"))
-                       select r;
+            var tasks = context.Timeline.Records
+                .Where(r => r.RecordType == "Task" &&
+                            r.Issues.Any(i => i.Message.Contains("Git fetch failed with exit code: 128")));
 
-            if (tasks.Count() > 0)
+            foreach (var task in tasks)
             {
-                foreach (var task in tasks)
-                {
-                    context.AddFailure(task
-                        , "Git Checkout");
-                }
+                context.AddFailure(task, "Git Checkout");
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureAnalyzer.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureAnalyzer.cs
@@ -1,10 +1,10 @@
+using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Collections.Generic;
-    using System.Threading.Tasks;
-
     public interface IFailureAnalyzer
     {
         Task<IReadOnlyCollection<Failure>> AnalyzeFailureAsync(Build build, Timeline timeline);

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureAnalyzer.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureAnalyzer.cs
@@ -1,14 +1,12 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+
     public interface IFailureAnalyzer
     {
-        Task<IEnumerable<Failure>> AnalyzeFailureAsync(Build build, Timeline timeline);
+        Task<IReadOnlyCollection<Failure>> AnalyzeFailureAsync(Build build, Timeline timeline);
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureClassifier.cs
@@ -1,12 +1,7 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using System.Threading.Tasks;
+
     public interface IFailureClassifier
     {
         Task ClassifyAsync(FailureAnalyzerContext context);

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/IFailureClassifier.cs
@@ -1,7 +1,7 @@
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using System.Threading.Tasks;
-
     public interface IFailureClassifier
     {
         Task ClassifyAsync(FailureAnalyzerContext context);

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JavaPipelineTestFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JavaPipelineTestFailureClassifier.cs
@@ -1,33 +1,27 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class JavaPipelineTestFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             if (context.Build.Definition.Name.StartsWith("java - "))
             {
-                var failedTasks = from r in context.Timeline.Records
-                                  where r.Result == TaskResult.Failed
-                                  where r.RecordType == "Task"
-                                  where r.Name.StartsWith("Run tests")
-                                  select r;
+                var failedTasks = context.Timeline.Records
+                    .Where(r => r.Result == TaskResult.Failed && 
+                                r.RecordType == "Task" && 
+                                r.Name.StartsWith("Run tests"));
 
-                if (failedTasks.Count() > 0)
+                foreach (var failedTask in failedTasks)
                 {
-                    foreach (var failedTask in failedTasks)
-                    {
-                        context.AddFailure(failedTask, "Test Failure");
-                    }
+                    context.AddFailure(failedTask, "Test Failure");
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JavaPipelineTestFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JavaPipelineTestFailureClassifier.cs
@@ -1,19 +1,20 @@
+using System;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
-
     public class JavaPipelineTestFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            if (context.Build.Definition.Name.StartsWith("java - "))
+            if (context.Build.Definition.Name.StartsWith("java - ", StringComparison.InvariantCulture))
             {
                 var failedTasks = context.Timeline.Records
-                    .Where(r => r.Result == TaskResult.Failed && 
-                                r.RecordType == "Task" && 
-                                r.Name.StartsWith("Run tests"));
+                    .Where(r => r.Result == TaskResult.Failed)
+                    .Where(r => r.RecordType == "Task")
+                    .Where(r => r.Name.StartsWith("Run tests", StringComparison.InvariantCulture));
 
                 foreach (var failedTask in failedTasks)
                 {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JavaScriptLiveTestFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JavaScriptLiveTestFailureClassifier.cs
@@ -1,21 +1,23 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.TeamFoundation.Build.WebApi;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using System.Linq;
-    using System.Threading.Tasks;
-    using Microsoft.TeamFoundation.Build.WebApi;
-
     public class JavaScriptLiveTestFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var definitionName = context.Build.Definition.Name;
-            
-            if (definitionName.StartsWith("js - ") && definitionName.EndsWith(" - tests"))
+
+            if (definitionName.StartsWith("js - ", StringComparison.InvariantCulture) &&
+                definitionName.EndsWith(" - tests", StringComparison.InvariantCulture))
             {
                 var failedTasks = context.Timeline.Records
-                    .Where(r => r.RecordType == "Task" &&
-                                r.Name == "Integration test libraries" &&
-                                r.Result == TaskResult.Failed);
+                    .Where(r => r.RecordType == "Task")
+                    .Where(r => r.Name == "Integration test libraries")
+                    .Where(r => r.Result == TaskResult.Failed);
 
                 foreach (var failedTask in failedTasks)
                 {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JavaScriptLiveTestFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JavaScriptLiveTestFailureClassifier.cs
@@ -1,32 +1,29 @@
-﻿using System;
-using System.Linq;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using Microsoft.TeamFoundation.Build.WebApi;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Microsoft.TeamFoundation.Build.WebApi;
+
     public class JavaScriptLiveTestFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            if (context.Build.Definition.Name.StartsWith("js - ") && context.Build.Definition.Name.EndsWith(" - tests"))
+            var definitionName = context.Build.Definition.Name;
+            
+            if (definitionName.StartsWith("js - ") && definitionName.EndsWith(" - tests"))
             {
-                var failedTasks = from r in context.Timeline.Records
-                                  where r.RecordType == "Task"
-                                  where r.Name == "Integration test libraries"
-                                  where r.Result == TaskResult.Failed
-                                  select r;
+                var failedTasks = context.Timeline.Records
+                    .Where(r => r.RecordType == "Task" &&
+                                r.Name == "Integration test libraries" &&
+                                r.Result == TaskResult.Failed);
 
-                if (failedTasks.Count() > 0)
+                foreach (var failedTask in failedTasks)
                 {
-                    foreach (var failedTask in failedTasks)
-                    {
-                        context.AddFailure(failedTask, "Test Failure");
-                    }
+                    context.AddFailure(failedTask, "Test Failure");
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsDevFeedPublishingFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsDevFeedPublishingFailureClassifier.cs
@@ -1,32 +1,27 @@
-﻿using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class JsDevFeedPublishingFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             if (context.Build.Definition.Name.StartsWith("js -"))
             {
-                var failedJobs = from r in context.Timeline.Records
-                                 where r.Name == "Publish package to daily feed"
-                                 where r.RecordType == "Job"
-                                 where r.Result == TaskResult.Failed
-                                 select r;
+                var failedJobs = context.Timeline.Records
+                    .Where(r => r.Name == "Publish package to daily feed" && 
+                                r.RecordType == "Job" &&
+                                r.Result == TaskResult.Failed);
 
-                if (failedJobs.Count() > 0)
+                foreach (var failedJob in failedJobs)
                 {
-                    foreach (var failedJob in failedJobs)
-                    {
-                        context.AddFailure(failedJob, "Publish Failure");
-                    }
+                    context.AddFailure(failedJob, "Publish Failure");
                 }
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsDevFeedPublishingFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsDevFeedPublishingFailureClassifier.cs
@@ -1,19 +1,20 @@
+using System;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
-
     public class JsDevFeedPublishingFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            if (context.Build.Definition.Name.StartsWith("js -"))
+            if (context.Build.Definition.Name.StartsWith("js -", StringComparison.InvariantCulture))
             {
                 var failedJobs = context.Timeline.Records
-                    .Where(r => r.Name == "Publish package to daily feed" && 
-                                r.RecordType == "Job" &&
-                                r.Result == TaskResult.Failed);
+                    .Where(r => r.Name == "Publish package to daily feed")
+                    .Where(r => r.RecordType == "Job")
+                    .Where(r => r.Result == TaskResult.Failed);
 
                 foreach (var failedJob in failedJobs)
                 {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsSamplesExecutionFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsSamplesExecutionFailureClassifier.cs
@@ -1,25 +1,26 @@
+using System;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
-
     public class JsSamplesExecutionFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            if (context.Build.Definition.Name.StartsWith("js -"))
+            if (context.Build.Definition.Name.StartsWith("js -", StringComparison.InvariantCulture))
             {
                 var failedTasks = context.Timeline.Records
-                    .Where(r => r.Name == "Execute Samples" &&
-                                r.Result == TaskResult.Failed);
+                    .Where(r => r.Name == "Execute Samples")
+                    .Where(r => r.Result == TaskResult.Failed);
 
                 foreach (var failedTask in failedTasks)
                 {
                     context.AddFailure(failedTask, "Sample Execution");
                 }
             }
-            
+
             return Task.CompletedTask;
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsSamplesExecutionFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/JsSamplesExecutionFailureClassifier.cs
@@ -1,31 +1,26 @@
-﻿using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class JsSamplesExecutionFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             if (context.Build.Definition.Name.StartsWith("js -"))
             {
-                var failedTasks = from r in context.Timeline.Records
-                                  where r.Name == "Execute Samples"
-                                  where r.Result == TaskResult.Failed
-                                  select r;
+                var failedTasks = context.Timeline.Records
+                    .Where(r => r.Name == "Execute Samples" &&
+                                r.Result == TaskResult.Failed);
 
-                if (failedTasks.Count() > 0)
+                foreach (var failedTask in failedTasks)
                 {
-                    foreach (var failedTask in failedTasks)
-                    {
-                        context.AddFailure(failedTask, "Sample Execution");
-                    }
+                    context.AddFailure(failedTask, "Sample Execution");
                 }
             }
+            
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/MavenBrokenPipeFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/MavenBrokenPipeFailureClassifier.cs
@@ -1,29 +1,29 @@
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
-
     public class MavenBrokenPipeFailureClassifier : IFailureClassifier
     {
-        private readonly BuildLogProvider buildLogProvider;
-        
+        private readonly BuildLogProvider _buildLogProvider;
+
         public MavenBrokenPipeFailureClassifier(BuildLogProvider buildLogProvider)
         {
-            this.buildLogProvider = buildLogProvider;
+            _buildLogProvider = buildLogProvider;
         }
-        
+
         public async Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var failedTasks = context.Timeline.Records
-                .Where(r => r.Result == TaskResult.Failed &&
-                            r.RecordType == "Task" &&
-                            r.Task?.Name == "Maven" &&
-                            r.Log != null);
+                .Where(r => r.Result == TaskResult.Failed)
+                .Where(r => r.RecordType == "Task")
+                .Where(r => r.Task?.Name == "Maven")
+                .Where(r => r.Log != null);
 
             foreach (var failedTask in failedTasks)
             {
-                var lines = await buildLogProvider.GetLogLinesAsync(context.Build, failedTask.Log.Id);
+                var lines = await _buildLogProvider.GetLogLinesAsync(context.Build, failedTask.Log.Id);
 
                 if (lines.Any(line => line.Contains("Connection reset") || line.Contains("Connection timed out") || line.Contains("504 Gateway Timeout")))
                 {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/MavenBrokenPipeFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/MavenBrokenPipeFailureClassifier.cs
@@ -1,32 +1,25 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using Microsoft.VisualStudio.Services.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class MavenBrokenPipeFailureClassifier : IFailureClassifier
     {
+        private readonly BuildLogProvider buildLogProvider;
+        
         public MavenBrokenPipeFailureClassifier(BuildLogProvider buildLogProvider)
         {
             this.buildLogProvider = buildLogProvider;
         }
-
-        private readonly BuildLogProvider buildLogProvider;
-
+        
         public async Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            var failedTasks = from r in context.Timeline.Records
-                                where r.Result == TaskResult.Failed
-                                where r.RecordType == "Task"
-                                where r.Task != null
-                                where r.Task.Name == "Maven"
-                                where r.Log != null
-                                select r;
+            var failedTasks = context.Timeline.Records
+                .Where(r => r.Result == TaskResult.Failed &&
+                            r.RecordType == "Task" &&
+                            r.Task?.Name == "Maven" &&
+                            r.Log != null);
 
             foreach (var failedTask in failedTasks)
             {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/PythonPipelineTestFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/PythonPipelineTestFailureClassifier.cs
@@ -1,26 +1,27 @@
+using System;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
-
     public class PythonPipelineTestFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            if (context.Build.Definition.Name.StartsWith("python - "))
+            if (context.Build.Definition.Name.StartsWith("python - ", StringComparison.InvariantCulture))
             {
                 var failedTasks = context.Timeline.Records
-                    .Where(r => r.Result == TaskResult.Failed &&
-                                r.RecordType == "Task" &&
-                                r.Name == "Run Tests");
+                    .Where(r => r.Result == TaskResult.Failed)
+                    .Where(r => r.RecordType == "Task")
+                    .Where(r => r.Name == "Run Tests");
 
                 foreach (var failedTask in failedTasks)
                 {
                     context.AddFailure(failedTask, "Test Failure");
                 }
             }
-            
+
             return Task.CompletedTask;
         }
     }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/PythonPipelineTestFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/PythonPipelineTestFailureClassifier.cs
@@ -1,33 +1,27 @@
-﻿using Azure.Sdk.Tools.PipelineWitness.Entities.AzurePipelines;
-using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
     public class PythonPipelineTestFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             if (context.Build.Definition.Name.StartsWith("python - "))
             {
-                var failedTasks = from r in context.Timeline.Records
-                                  where r.Result == TaskResult.Failed
-                                  where r.RecordType == "Task"
-                                  where r.Name == "Run Tests"
-                                  select r;
+                var failedTasks = context.Timeline.Records
+                    .Where(r => r.Result == TaskResult.Failed &&
+                                r.RecordType == "Task" &&
+                                r.Name == "Run Tests");
 
-                if (failedTasks.Count() > 0)
+                foreach (var failedTask in failedTasks)
                 {
-                    foreach (var failedTask in failedTasks)
-                    {
-                        context.AddFailure(failedTask, "Test Failure");
-                    }
+                    context.AddFailure(failedTask, "Test Failure");
                 }
             }
+            
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/TestResourcesDeploymentFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/TestResourcesDeploymentFailureClassifier.cs
@@ -1,28 +1,23 @@
-﻿using Microsoft.TeamFoundation.Build.WebApi;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using System.Linq;
+    using System.Threading.Tasks;
+
    public class TestResourcesDeploymentFailureClassifier : IFailureClassifier
     {
-        public async Task ClassifyAsync(FailureAnalyzerContext context)
+        public Task ClassifyAsync(FailureAnalyzerContext context)
         {
-            var failedTasks = from r in context.Timeline.Records
-                              where r.Name.StartsWith("Deploy test resources")
-                              where r.Result == TaskResult.Failed
-                              select r;
+            var failedTasks = context.Timeline.Records
+                .Where(r => r.Name.StartsWith("Deploy test resources") &&
+                            r.Result == TaskResult.Failed);
 
-            if (failedTasks.Count() > 0)
+            foreach (var failedTask in failedTasks)
             {
-                foreach (var failedTask in failedTasks)
-                {
-                    context.AddFailure(failedTask, "Test Resource Failure");
-                }
+                context.AddFailure(failedTask, "Test Resource Failure");
             }
+
+            return Task.CompletedTask;
         }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/TestResourcesDeploymentFailureClassifier.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/FailureAnalysis/TestResourcesDeploymentFailureClassifier.cs
@@ -1,16 +1,17 @@
+using System;
+using Microsoft.TeamFoundation.Build.WebApi;
+using System.Linq;
+using System.Threading.Tasks;
+
 namespace Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis
 {
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using System.Linq;
-    using System.Threading.Tasks;
-
-   public class TestResourcesDeploymentFailureClassifier : IFailureClassifier
+    public class TestResourcesDeploymentFailureClassifier : IFailureClassifier
     {
         public Task ClassifyAsync(FailureAnalyzerContext context)
         {
             var failedTasks = context.Timeline.Records
-                .Where(r => r.Name.StartsWith("Deploy test resources") &&
-                            r.Result == TaskResult.Failed);
+                .Where(r => r.Name.StartsWith("Deploy test resources", StringComparison.InvariantCulture))
+                .Where(r => r.Result == TaskResult.Failed);
 
             foreach (var failedTask in failedTasks)
             {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -1,23 +1,23 @@
+using System;
+using Azure.Identity;
+using Azure.Sdk.Tools.PipelineWitness.ApplicationInsights;
+using Azure.Sdk.Tools.PipelineWitness.Services;
+using Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.Azure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.TeamFoundation.Core.WebApi;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.TestResults.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+
 namespace Azure.Sdk.Tools.PipelineWitness
 {
-    using System;
-    using Azure.Identity;
-    using Azure.Sdk.Tools.PipelineWitness.ApplicationInsights;
-    using Azure.Sdk.Tools.PipelineWitness.Services;
-    using Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis;
-    using Azure.Security.KeyVault.Secrets;
-    using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.AspNetCore.Builder;
-    using Microsoft.Extensions.Azure;
-    using Microsoft.Extensions.Configuration;
-    using Microsoft.Extensions.DependencyInjection;
-    using Microsoft.Extensions.Hosting;
-    using Microsoft.TeamFoundation.Build.WebApi;
-    using Microsoft.TeamFoundation.Core.WebApi;
-    using Microsoft.VisualStudio.Services.Common;
-    using Microsoft.VisualStudio.Services.TestResults.WebApi;
-    using Microsoft.VisualStudio.Services.WebApi;
-
     public static class Startup
     {
         public static void Configure(WebApplicationBuilder builder)

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -1,23 +1,23 @@
-﻿using System;
-using Azure.Identity;
-using Azure.Sdk.Tools.PipelineWitness.ApplicationInsights;
-using Azure.Sdk.Tools.PipelineWitness.Services;
-using Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis;
-using Azure.Security.KeyVault.Secrets;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.AspNetCore.Builder;
-using Microsoft.Extensions.Azure;
-using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
-using Microsoft.Extensions.Hosting;
-using Microsoft.TeamFoundation.Build.WebApi;
-using Microsoft.TeamFoundation.Core.WebApi;
-using Microsoft.VisualStudio.Services.Common;
-using Microsoft.VisualStudio.Services.TestResults.WebApi;
-using Microsoft.VisualStudio.Services.WebApi;
-
 namespace Azure.Sdk.Tools.PipelineWitness
 {
+    using System;
+    using Azure.Identity;
+    using Azure.Sdk.Tools.PipelineWitness.ApplicationInsights;
+    using Azure.Sdk.Tools.PipelineWitness.Services;
+    using Azure.Sdk.Tools.PipelineWitness.Services.FailureAnalysis;
+    using Azure.Security.KeyVault.Secrets;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.AspNetCore.Builder;
+    using Microsoft.Extensions.Azure;
+    using Microsoft.Extensions.Configuration;
+    using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Hosting;
+    using Microsoft.TeamFoundation.Build.WebApi;
+    using Microsoft.TeamFoundation.Core.WebApi;
+    using Microsoft.VisualStudio.Services.Common;
+    using Microsoft.VisualStudio.Services.TestResults.WebApi;
+    using Microsoft.VisualStudio.Services.WebApi;
+
     public static class Startup
     {
         public static void Configure(WebApplicationBuilder builder)
@@ -30,12 +30,12 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddApplicationInsightsTelemetryProcessor<BlobNotFoundTelemetryProcessor>();
             builder.Services.AddTransient<ITelemetryInitializer, ApplicationVersionTelemetryInitializer>();
 
-            builder.Services.AddAzureClients(builder =>
+            builder.Services.AddAzureClients(clientFactoryBuilder =>
             {
-                builder.UseCredential(new DefaultAzureCredential());
-                builder.AddSecretClient(new Uri(settings.KeyVaultUri));
-                builder.AddBlobServiceClient(new Uri(settings.BlobStorageAccountUri));
-                builder.AddQueueServiceClient(new Uri(settings.QueueStorageAccountUri))
+                clientFactoryBuilder.UseCredential(new DefaultAzureCredential());
+                clientFactoryBuilder.AddSecretClient(new Uri(settings.KeyVaultUri));
+                clientFactoryBuilder.AddBlobServiceClient(new Uri(settings.BlobStorageAccountUri));
+                clientFactoryBuilder.AddQueueServiceClient(new Uri(settings.QueueStorageAccountUri))
                     .ConfigureOptions(o => o.MessageEncoding = Storage.Queues.QueueMessageEncoding.Base64);
             });
 
@@ -57,6 +57,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             builder.Services.AddSingleton<BlobUploadProcessor>();
             builder.Services.AddSingleton<BuildLogProvider>();
             builder.Services.AddSingleton<IFailureAnalyzer, FailureAnalyzer>();
+            builder.Services.AddSingleton<IFailureClassifier, AzurePowerShellModuleInstallationFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, AzuriteInstallFailureClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, CancelledTaskClassifier>();
             builder.Services.AddSingleton<IFailureClassifier, CosmosDbEmulatorStartFailureClassifier>();

--- a/tools/pipeline-witness/PipelineWitness.sln
+++ b/tools/pipeline-witness/PipelineWitness.sln
@@ -8,9 +8,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.PipelineWitness.Tests", "Azure.Sdk.Tools.PipelineWitness.Tests\Azure.Sdk.Tools.PipelineWitness.Tests.csproj", "{AE649A76-2DDA-4B45-A426-21425A0B988A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FD213B4A-A8B5-400D-ABD3-1D5B1551CE3C}"
-ProjectSection(SolutionItems) = preProject
-	.editorconfig = .editorconfig
-EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tools/pipeline-witness/PipelineWitness.sln
+++ b/tools/pipeline-witness/PipelineWitness.sln
@@ -1,13 +1,16 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30011.22
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32616.157
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.PipelineWitness", "Azure.Sdk.Tools.PipelineWitness\Azure.Sdk.Tools.PipelineWitness.csproj", "{32C6B030-8BED-4D1D-B007-07ABC3F314ED}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.PipelineWitness.Tests", "Azure.Sdk.Tools.PipelineWitness.Tests\Azure.Sdk.Tools.PipelineWitness.Tests.csproj", "{AE649A76-2DDA-4B45-A426-21425A0B988A}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FD213B4A-A8B5-400D-ABD3-1D5B1551CE3C}"
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A97D1389-26FD-483C-9188-A732056B798F}"
+ProjectSection(SolutionItems) = preProject
+	..\..\.editorconfig = ..\..\.editorconfig
+EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution


### PR DESCRIPTION
- Move using statements inside namespaces
- Replace LINQ statements with method chains
- Remove unused code
- Correct spelling
- Remove async from methods without await