### PR TITLE
Remove IP address information from telemetry

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Filters/TelemetryIpAddressFilter.cs
+++ b/src/dotnet/APIView/APIViewWeb/Filters/TelemetryIpAddressFilter.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.ApplicationInsights.Channel;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.DataContracts;
+
+namespace APIViewWeb.Filters
+{
+    public class TelemetryIpAddressFilter : ITelemetryProcessor
+    {
+        private ITelemetryProcessor Next { get; set; }
+
+        public TelemetryIpAddressFilter(ITelemetryProcessor next)
+        {
+            this.Next = next;
+        }
+
+        public void Process(ITelemetry item)
+        {
+            if(item.Context?.Location?.Ip != null)
+            {
+                item.Context.Location.Ip = null;
+            }
+
+            this.Next.Process(item);
+        }
+    }
+}
+
+
+

--- a/src/dotnet/APIView/APIViewWeb/Filters/TelemetryIpAddressFilter.cs
+++ b/src/dotnet/APIView/APIViewWeb/Filters/TelemetryIpAddressFilter.cs
@@ -12,19 +12,15 @@ namespace APIViewWeb.Filters
         public TelemetryIpAddressFilter(ITelemetryProcessor next)
         {
             _next = next;
-
         }
 
         public void Process(ITelemetry item)
         {
             if (item.Context?.Location?.Ip != null)
-
             {
                 item.Context.Location.Ip = null;
             }
-
             _next.Process(item);
-
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Filters/TelemetryIpAddressFilter.cs
+++ b/src/dotnet/APIView/APIViewWeb/Filters/TelemetryIpAddressFilter.cs
@@ -6,21 +6,25 @@ namespace APIViewWeb.Filters
 {
     public class TelemetryIpAddressFilter : ITelemetryProcessor
     {
-        private ITelemetryProcessor Next { get; set; }
+        private readonly ITelemetryProcessor _next;
+
 
         public TelemetryIpAddressFilter(ITelemetryProcessor next)
         {
-            this.Next = next;
+            _next = next;
+
         }
 
         public void Process(ITelemetry item)
         {
-            if(item.Context?.Location?.Ip != null)
+            if (item.Context?.Location?.Ip != null)
+
             {
                 item.Context.Location.Ip = null;
             }
 
-            this.Next.Process(item);
+            _next.Process(item);
+
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -21,6 +21,7 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Options;
 using System.Threading.Tasks;
 using APIViewWeb.HostedServices;
+using APIViewWeb.Filters;
 
 namespace APIViewWeb
 {
@@ -48,6 +49,7 @@ namespace APIViewWeb
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddApplicationInsightsTelemetry();
+            services.AddApplicationInsightsTelemetryProcessor<TelemetryIpAddressFilter>();
 
             services.Configure<CookiePolicyOptions>(options =>
             {


### PR DESCRIPTION
Remove IP address from app insights telemetry to disable collecting Geo info.

Fixes #3139 