### PR TITLE
Add Parser version in Python APIView code file

### DIFF
--- a/packages/python-packages/api-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/api-stub-generator/apistub/_apiview.py
@@ -42,7 +42,7 @@ class ApiView:
     def __init__(self, *, pkg_name="", namespace = "", metadata_map=None, source_url=None):
         self.name = pkg_name
         self.version = 0
-        self.version_string = ""
+        self.version_string = VERSION
         self.language = "Python"
         self.tokens = []
         self.navigation = []


### PR DESCRIPTION
Python parser needs to set parser version in code file so offline generated code file can be tagged using correct version number so auto upgrade will upgrade these reviews as well when parser is changed. This is part of the work to generate API code file outside APIView server.

Fixes #3627