### PR TITLE
Add full clone fallback to sparse checkout

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -113,7 +113,7 @@ steps:
 
           try {
             # Enable global override if there are sparse checkout issues
-            if ('$(DisableSparseCheckout)' -ne 'true') {
+            if ('$(SkipSparseCheckout)' -ne 'true') {
               try {
                 SparseCheckout $paths $repo
               } catch {

--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -25,7 +25,6 @@ steps:
       script: |
         function Clone([Hashtable]$repository)
         {
-          Write-Warning "Sparse checkout failed, falling back to full clone"
           if (Test-Path .git) {
             Write-Warning "Deleting existing git repository"
             Write-Host "Remove-Item -Force -Recurse ./*"
@@ -34,6 +33,9 @@ steps:
 
           Write-Host "git clone https://github.com/$($repository.Name) ."
           git clone https://github.com/$($repository.Name) .
+          if ($LASTEXITCODE) {
+            exit $LASTEXITCODE
+          }
           Write-Host "git -c advice.detachedHead=false checkout $($repository.Commitish)"
           # This will use the default branch if repo.Commitish is empty
           git -c advice.detachedHead=false checkout $($repository.Commitish)
@@ -44,65 +46,56 @@ steps:
 
         function SparseCheckout([Array]$paths, [Hashtable]$repository)
         {
-            $dir = $repository.WorkingDirectory
-            if (!$dir) {
-              $dir = "./$($repository.Name)"
-            }
-            New-Item $dir -ItemType Directory -Force
-            Push-Location $dir
+          if (Test-Path .git/info/sparse-checkout) {
+            $hasInitialized = $true
+            Write-Host "Repository $($repository.Name) has already been initialized. Skipping this step."
+          } else {
+            Write-Host "Repository $($repository.Name) is being initialized."
 
-            if (Test-Path .git/info/sparse-checkout) {
-              $hasInitialized = $true
-              Write-Host "Repository $($repository.Name) has already been initialized. Skipping this step."
-            } else {
-              Write-Host "Repository $($repository.Name) is being initialized."
-
-              Write-Host "git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) ."
-              git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) .
-              if ($LASTEXITCODE) {
-                return (Clone $repository && Pop-Location)
-              }
-
-              Write-Host "git sparse-checkout init"
-              git sparse-checkout init
-              if ($LASTEXITCODE) {
-                return (Clone $repository && Pop-Location)
-              }
-
-              # Set non-cone mode otherwise path filters will not work in git >= 2.37.0
-              # See https://github.blog/2022-06-27-highlights-from-git-2-37/#tidbits
-              Write-Host "git sparse-checkout set --no-cone '/*' '!/*/' '/eng'"
-              git sparse-checkout set --no-cone '/*' '!/*/' '/eng'
-              if ($LASTEXITCODE) {
-                return (Clone $repository && Pop-Location)
-              }
-            }
-
-            # Prevent wildcard expansion in Invoke-Expression (e.g. for checkout path '/*')
-            $quotedPaths = $paths | ForEach-Object { "'$_'" }
-            $gitsparsecmd = "git sparse-checkout add $quotedPaths"
-            Write-Host $gitsparsecmd
-            Invoke-Expression -Command $gitsparsecmd
+            Write-Host "git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) ."
+            git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) .
             if ($LASTEXITCODE) {
-              return (Clone $repository && Pop-Location)
+              throw
             }
 
-            Write-Host "Set sparse checkout paths to:"
-            Get-Content .git/info/sparse-checkout
-
-            # sparse-checkout commands after initial checkout will auto-checkout again
-            if (!$hasInitialized) {
-              Write-Host "git -c advice.detachedHead=false checkout $($repository.Commitish)"
-              # This will use the default branch if repo.Commitish is empty
-              git -c advice.detachedHead=false checkout $($repository.Commitish)
-              if ($LASTEXITCODE) {
-                return (Clone $repository && Pop-Location)
-              }
-            } else {
-              Write-Host "Skipping checkout as repo has already been initialized"
+            Write-Host "git sparse-checkout init"
+            git sparse-checkout init
+            if ($LASTEXITCODE) {
+              throw
             }
 
-            Pop-Location
+            # Set non-cone mode otherwise path filters will not work in git >= 2.37.0
+            # See https://github.blog/2022-06-27-highlights-from-git-2-37/#tidbits
+            Write-Host "git sparse-checkout set --no-cone '/*' '!/*/' '/eng'"
+            git sparse-checkout set --no-cone '/*' '!/*/' '/eng'
+            if ($LASTEXITCODE) {
+              throw
+            }
+          }
+
+          # Prevent wildcard expansion in Invoke-Expression (e.g. for checkout path '/*')
+          $quotedPaths = $paths | ForEach-Object { "'$_'" }
+          $gitsparsecmd = "git sparse-checkout add $quotedPaths"
+          Write-Host $gitsparsecmd
+          Invoke-Expression -Command $gitsparsecmd
+          if ($LASTEXITCODE) {
+            throw
+          }
+
+          Write-Host "Set sparse checkout paths to:"
+          Get-Content .git/info/sparse-checkout
+
+          # sparse-checkout commands after initial checkout will auto-checkout again
+          if (!$hasInitialized) {
+            Write-Host "git -c advice.detachedHead=false checkout $($repository.Commitish)"
+            # This will use the default branch if repo.Commitish is empty
+            git -c advice.detachedHead=false checkout $($repository.Commitish)
+            if ($LASTEXITCODE) {
+              throw
+            }
+          } else {
+            Write-Host "Skipping checkout as repo has already been initialized"
+          }
         }
 
         # Paths may be sourced as a yaml object literal OR a dynamically generated variable json string.
@@ -111,7 +104,30 @@ steps:
         # Replace windows backslash paths, as Azure Pipelines default directories are sometimes formatted like 'D:\a\1\s'
         $repositories = '${{ convertToJson(parameters.Repositories) }}' -replace '\\', '/' | ConvertFrom-Json -AsHashtable
         foreach ($repo in $Repositories) {
-          SparseCheckout $paths $repo
+          $dir = $repo.WorkingDirectory
+          if (!$dir) {
+            $dir = "./$($repo.Name)"
+          }
+          New-Item $dir -ItemType Directory -Force
+          Push-Location $dir
+
+          try {
+            # Enable global override if there are sparse checkout issues
+            if ('$(DisableSparseCheckout)' -ne 'true') {
+              try {
+                SparseCheckout $paths $repo
+              } catch {
+                # Fallback to full clone if sparse checkout is not working properly
+                Write-Warning "Sparse checkout failed, falling back to full clone"
+                Clone $repo
+              }
+            } else {
+              Write-Warning "Sparse checkout disabled, performing full clone"
+              Clone $repo
+            }
+          } finally {
+            Pop-Location
+          }
         }
       pwsh: true
       workingDirectory: $(System.DefaultWorkingDirectory)

--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -23,6 +23,25 @@ steps:
       # Define this inline, because of the chicken/egg problem with loading a script when nothing
       # has been checked out yet.
       script: |
+        function Clone([Hashtable]$repository)
+        {
+          Write-Warning "Sparse checkout failed, falling back to full clone"
+          if (Test-Path .git) {
+            Write-Warning "Deleting existing git repository"
+            Write-Host "Remove-Item -Force -Recurse ./*"
+            Remove-Item -Force -Recurse ./*
+          }
+
+          Write-Host "git clone https://github.com/$($repository.Name) ."
+          git clone https://github.com/$($repository.Name) .
+          Write-Host "git -c advice.detachedHead=false checkout $($repository.Commitish)"
+          # This will use the default branch if repo.Commitish is empty
+          git -c advice.detachedHead=false checkout $($repository.Commitish)
+          if ($LASTEXITCODE) {
+            exit $LASTEXITCODE
+          }
+        }
+
         function SparseCheckout([Array]$paths, [Hashtable]$repository)
         {
             $dir = $repository.WorkingDirectory
@@ -40,14 +59,23 @@ steps:
 
               Write-Host "git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) ."
               git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) .
+              if ($LASTEXITCODE) {
+                return (Clone $repository && Pop-Location)
+              }
 
               Write-Host "git sparse-checkout init"
               git sparse-checkout init
+              if ($LASTEXITCODE) {
+                return (Clone $repository && Pop-Location)
+              }
 
               # Set non-cone mode otherwise path filters will not work in git >= 2.37.0
               # See https://github.blog/2022-06-27-highlights-from-git-2-37/#tidbits
               Write-Host "git sparse-checkout set --no-cone '/*' '!/*/' '/eng'"
               git sparse-checkout set --no-cone '/*' '!/*/' '/eng'
+              if ($LASTEXITCODE) {
+                return (Clone $repository && Pop-Location)
+              }
             }
 
             # Prevent wildcard expansion in Invoke-Expression (e.g. for checkout path '/*')
@@ -55,6 +83,9 @@ steps:
             $gitsparsecmd = "git sparse-checkout add $quotedPaths"
             Write-Host $gitsparsecmd
             Invoke-Expression -Command $gitsparsecmd
+            if ($LASTEXITCODE) {
+              return (Clone $repository && Pop-Location)
+            }
 
             Write-Host "Set sparse checkout paths to:"
             Get-Content .git/info/sparse-checkout
@@ -64,6 +95,9 @@ steps:
               Write-Host "git -c advice.detachedHead=false checkout $($repository.Commitish)"
               # This will use the default branch if repo.Commitish is empty
               git -c advice.detachedHead=false checkout $($repository.Commitish)
+              if ($LASTEXITCODE) {
+                return (Clone $repository && Pop-Location)
+              }
             } else {
               Write-Host "Skipping checkout as repo has already been initialized"
             }


### PR DESCRIPTION
We sometimes have issues with the sparse checkout pipeline step. When it breaks, it breaks almost all pipelines. This change adds a failsafe to clone the full repository normally when sparse checkout fails.

For example, this recent failure highlighted the need for more resiliency with this core step:
https://github.com/Azure/azure-sdk-tools/pull/3606.
