### PR TITLE
Add runtime assignment of SkipCheckingForChanges

### DIFF
--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -25,10 +25,21 @@ steps:
       echo "##vso[task.setvariable variable=HasChanges]$false"
       echo "No changes so skipping code push"
     }
+
+    # Conditions determined that SkipCheckingForChanges is 'false', set this
+    # as a variable which can be passed into the "Push Changes" step
+    echo "##vso[task.setvariable variable=SkipCheckingForChanges]false"
   displayName: Check for changes
   condition: and(succeeded(), eq(${{ parameters.SkipCheckingForChanges }}, false))
   workingDirectory: ${{ parameters.WorkingDirectory }}
   ignoreLASTEXITCODE: true
+
+- pwsh: |
+    # Checking for changes was skipped, set a variable which can be passed into
+    # the "Push Changes" step
+    Write-Host "##vso[task.setvariable variable=SkipCheckingForChanges]true"
+  condition: and(succeeded(), eq(${{ parameters.SkipCheckingForChanges }}, true))
+  displayName: Set SkipCheckingForChanges to true
 
 - pwsh: |
     # Remove the repo owner from the front of the repo name if it exists there
@@ -39,6 +50,7 @@ steps:
   condition: succeeded()
   workingDirectory: ${{ parameters.WorkingDirectory }}
 
+# $(SkipCheckingForChanges) is set in an earlier step
 - task: PowerShell@2
   displayName: Push changes
   condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
@@ -51,4 +63,4 @@ steps:
       -CommitMsg "${{ parameters.CommitMsg }}"
       -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.BaseRepoOwner }}/$(RepoNameWithoutOwner).git"
       -PushArgs "${{ parameters.PushArgs }}"
-      -SkipCommit $${{ parameters.SkipCheckingForChanges }}
+      -SkipCommit $$(SkipCheckingForChanges)


### PR DESCRIPTION
This change came from a failure in C++. We're representing `SkipCheckingForChanges` in `git-push-changes.yml` in a way that only accepts values of `true` or `false` specified at compile time for the template. 

With these changes we can now evaluate inputs of `true`, `false`, and `variable['VariableName']` to support scenarios where whether we should open a PR is evaluated at runtime. 

From searching other repositories, C++ is the only repo which uses `SkipCheckingForChanges` ... No other repos appear to use it according to my grep'ing of android, c, cpp, go, ios, java, js, net, and python repos. 