### PR TITLE
Process dependencies only when it's not empty

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs
@@ -86,10 +86,13 @@ namespace APIViewWeb
                                     dependency.Attribute("id").Value,
                                         dependency.Attribute("version").Value)));
                     // filter duplicates and sort
-                    dependencies = dependencies
+                    if (dependencies.Any())
+                    {
+                        dependencies = dependencies
                         .GroupBy(d => d.Name)
                         .Select(d => d.First())
                         .OrderBy(d => d.Name).ToList();
+                    }
                 }
 
                 var assemblySymbol = CompilationFactory.GetCompilation(dllStream, docStream);


### PR DESCRIPTION
Fixes exception found in APIView app insights that blocks creating automatic API reviews in case of few packages.

System.InvalidOperationException:
   at System.Linq.ThrowHelper.ThrowNoElementsException (System.Linq, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at System.Linq.Enumerable.First (System.Linq, Version=4.2.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a)
   at APIViewWeb.CSharpLanguageService.GetCodeFileAsync (APIViewWeb, Version=1.0.0.0, Culture=neutral, PublicKeyToken=7a84984c17ca6b7d: D:\a\_work\1\s\src\dotnet\APIView\APIViewWeb\Languages\CSharpLanguageService.cs:107)
