### PR TITLE
Fix deserialization of Transport config

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -58,6 +58,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
         private NullLoggerFactory _nullLogger = new NullLoggerFactory();
 
+        public JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
+        {
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            AllowTrailingCommas = true,
+        };
+
         [Flags]
         enum CheckSkips
         {
@@ -826,7 +832,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var certValue = TestHelpers.GetValueFromCertificateFile("test_public-key-only_pem").Replace(Environment.NewLine, "");
             var inputObj = string.Format("{{\"Transport\": {{\"TLSValidationCert\": \"{0}\"}}}}", certValue);
             var testRecordingHandler = new RecordingHandler(Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString()));
-            var inputBody = JsonConvert.DeserializeObject<Dictionary<string, object>>(inputObj);
+            var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);
 
             testRecordingHandler.SetRecordingOptions(inputBody, null);
         }
@@ -839,7 +845,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var pemValue = TestHelpers.GetValueFromCertificateFile("test_pem_value").Replace(Environment.NewLine, "");
             var inputObj = string.Format("{{\"Transport\": {{\"TLSValidationCert\": \"{0}\", \"Certificates\": [ {{ \"PemValue\": \"{1}\", \"PemKey\": \"{2}\" }}]}}}}", certValue, pemValue, pemKey);
             var testRecordingHandler = new RecordingHandler(Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString()));
-            var inputBody = JsonConvert.DeserializeObject<Dictionary<string, object>>(inputObj);
+            var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);
 
             testRecordingHandler.SetRecordingOptions(inputBody, null);
         }
@@ -853,7 +859,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var pemKey = TestHelpers.GetValueFromCertificateFile("test_pem_key").Replace(Environment.NewLine, "");
             var pemValue = TestHelpers.GetValueFromCertificateFile("test_pem_value").Replace(Environment.NewLine, "");
             var inputObj = string.Format(body, pemValue, pemKey);
-            var inputBody = JsonConvert.DeserializeObject<Dictionary<string, object>>(inputObj);
+            var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);
 
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             testRecordingHandler.SetRecordingOptions(inputBody, null);
@@ -869,7 +875,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var pemValue = TestHelpers.GetValueFromCertificateFile("test_pem_value").Replace(Environment.NewLine, "");
             var testRecordingHandler = new RecordingHandler(Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString()));
             var inputObj = string.Format(body, pemValue, pemKey);
-            var inputBody = JsonConvert.DeserializeObject<Dictionary<string, object>>(inputObj);
+            var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);
 
             HttpContext context = new DefaultHttpContext();
             testRecordingHandler.StartRecording("TestSetRecordingOptionsInValidTransportRecordingLevel.json", context.Response);
@@ -889,7 +895,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var pemValue = TestHelpers.GetValueFromCertificateFile("test_pem_value").Replace(Environment.NewLine, "");
             var testRecordingHandler = new RecordingHandler(Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString()));
             var inputObj = string.Format(body, pemValue, pemKey);
-            var inputBody = JsonConvert.DeserializeObject<Dictionary<string, object>>(inputObj);
+            var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);
 
             var assertion = Assert.Throws<HttpException>(
                () => testRecordingHandler.SetRecordingOptions(inputBody)
@@ -908,7 +914,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var pemValue = TestHelpers.GetValueFromCertificateFile("test_pem_value").Replace(Environment.NewLine, "");
             var testRecordingHandler = new RecordingHandler(Path.Join(Path.GetTempPath(), Guid.NewGuid().ToString()));
             var inputObj = string.Format(body, pemValue, pemKey);
-            var inputBody = JsonConvert.DeserializeObject<Dictionary<string, object>>(inputObj);
+            var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);
 
             HttpContext context = new DefaultHttpContext();
             testRecordingHandler.StartRecording("TestSetRecordingOptionsInValidTransportRecordingLevel.json", context.Response);
@@ -929,7 +935,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var inputObj = string.Format("{{\"Transport\": {{\"TLSValidationCert\": \"hello-there\", \"Certificates\": [ {{ \"PemValue\": \"{0}\", \"PemKey\": \"{1}\" }}]}}}}", pemValue, pemKey);
 
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            var inputBody = JsonConvert.DeserializeObject<Dictionary<string, object>>(inputObj);
+            var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);
 
             var assertion = Assert.Throws<HttpException>(
                () => testRecordingHandler.SetRecordingOptions(inputBody)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -117,9 +117,9 @@ namespace Azure.Sdk.Tools.TestProxy
                 recordingSession.Session.Sanitize(sanitizer);
             }
 
-            if(variables != null)
+            if (variables != null)
             {
-                foreach(var kvp in variables)
+                foreach (var kvp in variables)
                 {
                     recordingSession.Session.Variables[kvp.Key] = kvp.Value;
                 }
@@ -338,7 +338,7 @@ namespace Azure.Sdk.Tools.TestProxy
                         continue;
                     }
 
-                    if(!upstreamRequest.Content.Headers.TryAddWithoutValidation(header.Key, values))
+                    if (!upstreamRequest.Content.Headers.TryAddWithoutValidation(header.Key, values))
                     {
                         throw new HttpException(
                             HttpStatusCode.BadRequest,
@@ -347,7 +347,7 @@ namespace Azure.Sdk.Tools.TestProxy
                     }
                 }
 
-                if(header.Key == "x-recording-upstream-host-header")
+                if (header.Key == "x-recording-upstream-host-header")
                 {
                     upstreamRequest.Headers.Host = header.Value;
                 }
@@ -562,7 +562,15 @@ namespace Azure.Sdk.Tools.TestProxy
                     {
                         try
                         {
-                            var transportObject = ((JObject)transportConventions).ToString();
+                            string transportObject;
+                            if (transportConventions is JsonElement je)
+                            {
+                                transportObject = je.ToString();
+                            }
+                            else
+                            {
+                                throw new Exception("'Transport' object was not a JsonElement");
+                            }
 
                             var serializerOptions = new JsonSerializerOptions
                             {
@@ -602,7 +610,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 var base64Data = settings.TLSValidationCert[fields.Base64Data];
                 return new X509Certificate2(Encoding.ASCII.GetBytes(base64Data));
             }
-            catch(Exception e)
+            catch (Exception e)
             {
                 throw new HttpException(HttpStatusCode.BadRequest, $"Unable to instantiate a valid cert from the value provided in Transport settings key \"TLSValidationCert\". Value: \"{settings.TLSValidationCert}\". Message: \"{e.Message}\".");
             }
@@ -632,7 +640,7 @@ namespace Azure.Sdk.Tools.TestProxy
                     }
                 }
             }
-            
+
             if (customizations.TLSValidationCert != null && !insecure)
             {
                 var ledgerCert = GetValidationCert(customizations);
@@ -809,7 +817,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
                     sb.Append($"There are a total of {countTotal} active sessions. Remove these sessions before hitting Admin/Reset." + Environment.NewLine);
 
-                    if(countPlayback > 0)
+                    if (countPlayback > 0)
                     {
                         sb.Append("Active Playback Sessions: [");
                         lock (PlaybackSessions)
@@ -839,7 +847,7 @@ namespace Azure.Sdk.Tools.TestProxy
                         sb.Append("]. ");
                     }
 
-                    throw new HttpException(HttpStatusCode.BadRequest, sb.ToString());               
+                    throw new HttpException(HttpStatusCode.BadRequest, sb.ToString());
                 }
                 Sanitizers = new List<RecordedTestSanitizer>
                 {
@@ -913,7 +921,7 @@ namespace Azure.Sdk.Tools.TestProxy
             // to give us some amount of safety, but note that we explicitly disable escaping in that combination.
             var rawTarget = request.HttpContext.Features.Get<IHttpRequestFeature>().RawTarget;
             var hostValue = GetHeader(request, "x-recording-upstream-base-uri");
-            
+
             // There is an ongoing issue where some libraries send a URL with two leading // after the hostname.
             // This will just handle the error explicitly rather than letting it slip through and cause random issues during record/playback sessions.
             if (rawTarget.StartsWith("//"))


### PR DESCRIPTION
I hit this issue while trying to use the new Transport customization feature from a real client. Apparently, the object in the `dictionary<string, object>` is actually a `JsonElement` (System.Text.Json) rather than a `JObject` (NewtonSoft).