### PR TITLE
Detect API changes using pre-generated code file by CI approach

### DIFF
--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -18,7 +18,6 @@ Param (
   [string] $TargetBranch = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/")
 )
 
-Set-StrictMode -version 3
 . (Join-Path $PSScriptRoot common.ps1)
 
 # Submit API review request and return status whether current revision is approved or pending or failed to create review

--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -18,6 +18,7 @@ Param (
   [string] $TargetBranch = ("origin/${env:SYSTEM_PULLREQUEST_TARGETBRANCH}" -replace "refs/heads/")
 )
 
+Set-StrictMode -version 3
 . (Join-Path $PSScriptRoot common.ps1)
 
 # Submit API review request and return status whether current revision is approved or pending or failed to create review

--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -27,6 +27,7 @@ function Submit-Request($filePath, $packageName)
     if (!$repoName) {
         $repoName = "azure/azure-sdk-for-$LanguageShort"
     }
+    $reviewFileName = "$($packageName)_$($LanguageShort).json"
     $query = [System.Web.HttpUtility]::ParseQueryString('')
     $query.Add('artifactName', $ArtifactName)
     $query.Add('buildId', $BuildId)
@@ -35,6 +36,12 @@ function Submit-Request($filePath, $packageName)
     $query.Add('repoName', $repoName)
     $query.Add('pullRequestNumber', $PullRequestNumber)
     $query.Add('packageName', $packageName)
+    $query.Add('language', $LanguageShort)
+    $reviewFileFullName = Join-Path -Path $ArtifactPath $packageName $reviewFileName
+    if (Test-Path $reviewFileFullName)
+    {
+        $query.Add('codeFile', $reviewFileName)
+    }
     $uri = [System.UriBuilder]$APIViewUri
     $uri.query = $query.toString()
     Write-Host "Request URI: $($uri.Uri.OriginalString)"

--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -88,7 +88,6 @@ function Log-Input-Params()
     Write-Host "Language: $($Language)"
     Write-Host "Commit SHA: $($CommitSha)"
     Write-Host "Repo Name: $($RepoFullName)"
-    Write-Host "Package Name: $($PackageName)"
 }
 
 Log-Input-Params

--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -73,7 +73,7 @@ function Should-Process-Package($pkgPath, $packageName)
     # Get package info from json file created before updating version to daily dev
     $pkgInfo = Get-Content $pkgPropPath | ConvertFrom-Json
     $packagePath = $pkgInfo.DirectoryPath
-    $modifiedFiles  = Get-ChangedFiles -DiffPath "$packagePath/*" -DiffFilterType ''
+    $modifiedFiles  = @(Get-ChangedFiles -DiffPath "$packagePath/*" -DiffFilterType '')
     $filteredFileCount = $modifiedFiles.Count
     Write-Host "Number of modified files for package: $filteredFileCount"
     return ($filteredFileCount -gt 0 -and $pkgInfo.IsNewSdk)


### PR DESCRIPTION
Create API review from pull request using code file created by CI. APIView will use this approach instead of converting artifact to code file within server if review file name is passed as a parameter.