### PR TITLE
Docs: filename typo in eng/common/testproxy

### DIFF
--- a/tools/test-proxy/documentation/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/trusting-cert-per-language.md
@@ -21,7 +21,7 @@ dotnet dev-certs https --clean --import eng/common/testproxy/dotnet-devcert.pfx 
 dotnet dev-certs https --trust
 ```
 
-On a ubuntu-flavored distro of linux, feel free to re-use the import mechanism in the local file `eng/common/testproxy/import-dev-cert.sh`. Prior to using locally, ensure $CERT_FOLDER environment variable is set to the local directory containing the script. Otherwise it won't be able to access necessary files!
+On a ubuntu-flavored distro of linux, feel free to re-use the import mechanism in the local file `eng/common/testproxy/apply-dev-cert.sh`. Prior to using locally, ensure $CERT_FOLDER environment variable is set to the local directory containing the script. Otherwise it won't be able to access necessary files!
 
 Also note that taken to trust this cert will _also apply to installing the dotnet tool directly_. The test-proxy tool will consume the certificate just the same as the docker container does.
 


### PR DESCRIPTION
eng/common/testproxy/import-dev-cert.sh ->
eng/common/testproxy/apply-dev-cert.sh