### PR TITLE
Use deterministic shortname for stress test BaseName

### DIFF
--- a/tools/stress-cluster/chaos/examples/network-stress-example/Chart.lock
+++ b/tools/stress-cluster/chaos/examples/network-stress-example/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.19
-digest: sha256:617c5c463a27a54f01743c718921a2f668d11b7769958ff9d418627256dec3fa
-generated: "2022-06-30T15:10:48.0418404-04:00"
+  version: 0.1.20
+digest: sha256:174a2f4b768cb47718d4b3d5a506330aa781abb31803fbeaeba3b7eef87a9f38
+generated: "2022-07-25T18:54:24.3081785-04:00"

--- a/tools/stress-cluster/chaos/examples/network-stress-example/Chart.yaml
+++ b/tools/stress-cluster/chaos/examples/network-stress-example/Chart.yaml
@@ -10,5 +10,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.19
+  version: 0.1.20
   repository: "@stress-test-charts"

--- a/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/Chart.yaml
+++ b/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/Chart.yaml
@@ -1,0 +1,14 @@
+apiVersion: v2
+name: network-scenario-example
+description: An example stress test chart with network chaos
+version: 0.1.1
+appVersion: v0.1
+annotations:
+  stressTest: 'true'  # enable auto-discovery of this test via `find-all-stress-packages.ps1`
+  example: 'true'  # enable auto-discovery filtering `find-all-stress-packages.ps1 -filters @{example='true'}`
+  namespace: 'examples'
+
+dependencies:
+- name: stress-test-addons
+  version: 0.1.20
+  repository: "@stress-test-charts"

--- a/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/Dockerfile
+++ b/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/Dockerfile
@@ -1,0 +1,7 @@
+FROM mcr.microsoft.com/cbl-mariner/base/core:1.0
+# Included packages: https://github.com/microsoft/CBL-Mariner/blob/1.0/SPECS/core-packages/core-packages.spec
+
+ADD ./poll.sh /poll.sh
+RUN chmod +x /poll.sh
+
+CMD bash /poll.sh

--- a/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/poll.sh
+++ b/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/poll.sh
@@ -1,0 +1,16 @@
+set -x
+
+if test -f "$ENV_FILE"; then
+    echo "env file located at $ENV_FILE:"
+    ls -al $ENV_FILE
+else
+    echo "ENV FILE NOT FOUND"
+fi
+
+while true;
+    # Azure AKS default outbound rules do not allow ICMP,
+    # so use wget in place of ping for deployment simplicity
+    echo "SCENARIO_NAME: $SCENARIO_NAME"
+    do wget -T1 -t1 --spider http://$SCENARIO_NAME.bing.com
+    sleep 5
+done

--- a/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/templates/network_loss.yaml
+++ b/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/templates/network_loss.yaml
@@ -1,0 +1,22 @@
+{{- include "stress-test-addons.chaos-wrapper.tpl" (list . "stress.network-chaos") -}}
+{{- define "stress.network-chaos" -}}
+apiVersion: chaos-mesh.org/v1alpha1
+kind: NetworkChaos
+
+spec:
+  action: loss
+  direction: to
+  externalTargets:
+    - {{ .Stress.Scenario }}.bing.com
+  mode: one
+  selector:
+    labelSelectors:
+      # .Stress.BaseName is a unique id that can be used for azure resource naming and correlation
+      testInstance: {{ .Stress.BaseName }}
+      chaos: "true"
+    namespaces:
+      - {{ .Release.Namespace }}
+  loss:
+    loss: "100"
+    correlation: "100"
+{{- end -}}

--- a/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/templates/testjob.yaml
+++ b/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/templates/testjob.yaml
@@ -1,0 +1,18 @@
+{{- include "stress-test-addons.env-job-template.from-pod" (list . "stress.network-example") -}}
+{{- define "stress.network-example" -}}
+metadata:
+  labels:
+    # .Stress.BaseName is a unique id that can be used for azure resource naming and correlation
+    testInstance: {{ .Stress.BaseName }}
+    testName: packet-loss
+    chaos: "true"
+spec:
+  nodeSelector:
+    sku: 'default'
+  containers:
+    - name: network-example
+      command: ["bash", "poll.sh"]
+      imagePullPolicy: Always
+      image: {{ .Values.image }}
+      {{- include "stress-test-addons.container-env" . | nindent 6 }}
+{{- end -}}

--- a/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/values.yaml
+++ b/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/values.yaml
@@ -1,0 +1,4 @@
+scenarios:
+  - maps
+  - images
+  - videos

--- a/tools/stress-cluster/chaos/examples/stress-debug-share-example/Chart.lock
+++ b/tools/stress-cluster/chaos/examples/stress-debug-share-example/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.19
-digest: sha256:617c5c463a27a54f01743c718921a2f668d11b7769958ff9d418627256dec3fa
-generated: "2022-06-30T15:10:41.0984217-04:00"
+  version: 0.1.20
+digest: sha256:174a2f4b768cb47718d4b3d5a506330aa781abb31803fbeaeba3b7eef87a9f38
+generated: "2022-07-25T18:54:17.4896935-04:00"

--- a/tools/stress-cluster/chaos/examples/stress-debug-share-example/Chart.yaml
+++ b/tools/stress-cluster/chaos/examples/stress-debug-share-example/Chart.yaml
@@ -10,5 +10,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.19
+  version: 0.1.20
   repository: "@stress-test-charts"

--- a/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.lock
+++ b/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.19
-digest: sha256:617c5c463a27a54f01743c718921a2f668d11b7769958ff9d418627256dec3fa
-generated: "2022-06-30T15:10:30.8276449-04:00"
+  version: 0.1.20
+digest: sha256:174a2f4b768cb47718d4b3d5a506330aa781abb31803fbeaeba3b7eef87a9f38
+generated: "2022-07-25T18:53:54.6113438-04:00"

--- a/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.yaml
+++ b/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.yaml
@@ -10,5 +10,5 @@ annotations:
 
 dependencies:
 - name: stress-test-addons
-  version: 0.1.19
+  version: 0.1.20
   repository: "@stress-test-charts"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/CHANGELOG.md
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release History
 
+## 0.1.20 (2022-07-25)
+
+### Features Added
+
+### Breaking Changes
+
+### Bugs Fixed
+
+Fixed a bug introduced in 0.1.18 with `{{ .Stress.BaseName }}` not being deterministic. This meant that chaos policies using `{{ .Stress.BaseName }}` to block DNS entries did not use the same string value as the test template resources. The new BaseName is generated via a sha1 hash of the resource group name (which includes the scenario name, release name and release revision), truncated to length 5, and prefixed with a `s` character for maximum azure resource naming compatibility.
+
+### Other Changes
+
 ## 0.1.19 (2022-06-30)
 
 ### Features Added

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: stress-test-addons
 description: Baseline resources and templates for stress testing clusters
 
-version: 0.1.19
+version: 0.1.20
 appVersion: v0.1

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/index.yaml
@@ -3,6 +3,15 @@ entries:
   stress-test-addons:
   - apiVersion: v2
     appVersion: v0.1
+    created: "2022-07-25T18:49:51.1630068-04:00"
+    description: Baseline resources and templates for stress testing clusters
+    digest: a9f896b09084c2ce2f2b361cf944c5b13473ea2f343e395482fdf4ff0c53f0f7
+    name: stress-test-addons
+    urls:
+    - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.20.tgz
+    version: 0.1.20
+  - apiVersion: v2
+    appVersion: v0.1
     created: "2022-06-30T15:09:19.3110544-04:00"
     description: Baseline resources and templates for stress testing clusters
     digest: b8248b376dba388aec32a77ec5ba8fd76b59b7fa0916c83b924466bc77280af4
@@ -145,4 +154,4 @@ entries:
     urls:
     - https://stresstestcharts.blob.core.windows.net/helm/stress-test-addons-0.1.2.tgz
     version: 0.1.2
-generated: "2022-06-30T15:09:19.3033354-04:00"
+generated: "2022-07-25T18:49:51.1548109-04:00"

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_container_env.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_container_env.tpl
@@ -14,6 +14,8 @@ env:
     value: /mnt/share/$(POD_NAMESPACE)/$(POD_NAME)/
   - name: DEBUG_SHARE_ROOT
     value: /mnt/share/
+  - name: SCENARIO_NAME
+    value: {{ .Stress.Scenario }}
 volumeMounts:
   - name: test-env-{{ lower .Stress.Scenario }}-{{ .Release.Name }}-{{ .Release.Revision }}
     mountPath: /mnt/outputs

--- a/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_util.tpl
+++ b/tools/stress-cluster/cluster/kubernetes/stress-test-addons/templates/_util.tpl
@@ -36,8 +36,8 @@ See https://github.com/Masterminds/sprig/tree/master/docs for template function 
 {{- $_global := index . 0 -}}
 {{- $_scenario := index . 1 -}}
 {{- $resourceGroupName := lower (print $_global.Release.Namespace "-" $_scenario "-" $_global.Release.Name "-" $_global.Release.Revision) -}}
-{{- /* Use lowercase alpha characters for maximum azure resource naming compatibility */ -}}
-{{- $uniqueTestId := lower (randAlpha 6) -}}
+{{- /* Use lowercase alphanumeric characters beginning with a letter for maximum azure resource naming compatibility */ -}}
+{{- $uniqueTestId := lower (print "s" (trunc 5 (sha1sum $resourceGroupName) ) ) -}}
 {{- /* Create add Stress context to top level keys of global context */}}
 {{- $_stress := dict "Scenario" $_scenario "ResourceGroupName" $resourceGroupName "BaseName" $uniqueTestId -}}
 {{- $_instance := deepCopy ($_global | merge (dict "Stress" $_stress )) -}}


### PR DESCRIPTION
Resolves #3743

The current basename approach is causing issues with chaos policies correlating to test jobs, because the random shortnames generated for the BaseName property used in the templates does not match up on subsequent invocations.

- Use deterministic shortname for stress BaseName
- Add network stress example with scenarios and basename targeting
