### PR TITLE
Return 401 error code if org info is not available for PR owner

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -49,9 +49,9 @@ namespace APIViewWeb.Controllers
                 var reviewUrl = await _pullRequestManager.DetectApiChanges(buildId, artifactName, filePath, commitSha, repoName, packageName, pullRequestNumber, this.Request.Host.ToUriComponent(), codeFileName: codeFile, baselineCodeFileName: baselineCodeFile, commentOnPR: commentOnPR, language: language);
                 return !string.IsNullOrEmpty(reviewUrl) ? StatusCode(statusCode: StatusCodes.Status201Created, reviewUrl) : StatusCode(statusCode: StatusCodes.Status208AlreadyReported);
             }
-            catch (AuthorizationFailedException authEx)
+            catch (AuthorizationFailedException)
             {
-                return StatusCode(StatusCodes.Status401Unauthorized, authEx);
+                return StatusCode(StatusCodes.Status401Unauthorized);
             }
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -41,8 +41,18 @@ namespace APIViewWeb.Controllers
             {
                 return StatusCode(StatusCodes.Status400BadRequest);
             }
-            var reviewUrl = await _pullRequestManager.DetectApiChanges(buildId, artifactName, filePath, commitSha, repoName, packageName, pullRequestNumber, this.Request.Host.ToUriComponent(), codeFileName: codeFile, baselineCodeFileName: baselineCodeFile, commentOnPR: commentOnPR, language: language);
-            return !string.IsNullOrEmpty(reviewUrl) ? StatusCode(statusCode: StatusCodes.Status201Created, reviewUrl) : StatusCode(statusCode: StatusCodes.Status208AlreadyReported);
+
+            //Handle only authorization exception and send 401 as status code.
+            //All other exception should not be handled so we will have required info in app insights.
+            try
+            {
+                var reviewUrl = await _pullRequestManager.DetectApiChanges(buildId, artifactName, filePath, commitSha, repoName, packageName, pullRequestNumber, this.Request.Host.ToUriComponent(), codeFileName: codeFile, baselineCodeFileName: baselineCodeFile, commentOnPR: commentOnPR, language: language);
+                return !string.IsNullOrEmpty(reviewUrl) ? StatusCode(statusCode: StatusCodes.Status201Created, reviewUrl) : StatusCode(statusCode: StatusCodes.Status208AlreadyReported);
+            }
+            catch (AuthorizationFailedException authEx)
+            {
+                return StatusCode(StatusCodes.Status401Unauthorized, authEx);
+            }
         }
 
         private bool ValidateInputParams()


### PR DESCRIPTION
APIView returns 500 server error even when authorization fails for API detect change request comes from PR pipeline. This PR is to  return 401 in case of auth failure so SDK automation can handle it.