### PR TITLE
Fix misleading step name in az module install

### DIFF
--- a/eng/common/TestResources/setup-environments.yml
+++ b/eng/common/TestResources/setup-environments.yml
@@ -21,7 +21,7 @@ steps:
     condition: contains(variables['OSVmImage'], 'mac')
 
   - task: Powershell@2
-    displayName: Register Dogfood environment
+    displayName: Setup Az Modules and Dogfood Environment
     inputs:
       targetType: inline
       pwsh: true


### PR DESCRIPTION
The name of this step is misleading and needed renaming.