### PR TITLE
Use long type for semver to handle version number edge cases

### DIFF
--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -14,16 +14,16 @@ Note: A builtin Powershell version of SemVer exists in 'System.Management.Automa
 #>
 
 class AzureEngSemanticVersion : IComparable {
-  [int] $Major
-  [int] $Minor
-  [int] $Patch
+  [long] $Major
+  [long] $Minor
+  [long] $Patch
   [string] $PrereleaseLabelSeparator
   [string] $PrereleaseLabel
   [string] $PrereleaseNumberSeparator
   [string] $BuildNumberSeparator
   # BuildNumber is string to preserve zero-padding where applicable
   [string] $BuildNumber
-  [int] $PrereleaseNumber
+  [long] $PrereleaseNumber
   [bool] $IsPrerelease
   [string] $VersionType
   [string] $RawVersion
@@ -63,9 +63,9 @@ class AzureEngSemanticVersion : IComparable {
     {
       $this.IsSemVerFormat = $true
       $this.RawVersion = $versionString
-      $this.Major = [int]$matches.Major
-      $this.Minor = [int]$matches.Minor
-      $this.Patch = [int]$matches.Patch
+      $this.Major = [long]$matches.Major
+      $this.Minor = [long]$matches.Minor
+      $this.Patch = [long]$matches.Patch
 
       # If Language exists and is set to python setup the python conventions.
       $parseLanguage = (Get-Variable -Name "Language" -ValueOnly -ErrorAction "Ignore")
@@ -96,7 +96,7 @@ class AzureEngSemanticVersion : IComparable {
       {
         $this.PrereleaseLabel = $matches["prelabel"]
         $this.PrereleaseLabelSeparator = $matches["presep"]
-        $this.PrereleaseNumber = [int]$matches["prenumber"]
+        $this.PrereleaseNumber = [long]$matches["prenumber"]
         $this.PrereleaseNumberSeparator = $matches["prenumsep"]
         $this.IsPrerelease = $true
         $this.VersionType = "Beta"
@@ -205,7 +205,7 @@ class AzureEngSemanticVersion : IComparable {
     $ret = $this.PrereleaseNumber.CompareTo($other.PrereleaseNumber)
     if ($ret) { return $ret }
 
-    return ([int] $this.BuildNumber).CompareTo([int] $other.BuildNumber)
+    return ([long] $this.BuildNumber).CompareTo([long] $other.BuildNumber)
   }
 
   static [string[]] SortVersionStrings([string[]] $versionStrings)

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -31,16 +31,16 @@ function ToSemVer($version){
 
             # some older packages don't have a prenumber, should handle this
             if($matches["prenumber"]){
-                $prenumber = [int]$matches["prenumber"]
+                $prenumber = [long]$matches["prenumber"]
             }
 
             $isPre = $true;
         }
 
         New-Object PSObject -Property @{
-            Major = [int]$matches['major']
-            Minor = [int]$matches['minor']
-            Patch = [int]$matches['patch']
+            Major = [long]$matches['major']
+            Minor = [long]$matches['minor']
+            Patch = [long]$matches['patch']
             PrereleaseLabel = $prelabel
             PrereleaseNumber = $prenumber
             IsPrerelease = $isPre


### PR DESCRIPTION
Fixes #3793. If the devops pipeline version increment used to generate a version number is >= 10, we exceed the max int32 size.