### PR TITLE
[perf] Right-align numerical values in tables

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation.Tests/results/java.json
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation.Tests/results/java.json
@@ -1,24 +1,24 @@
 [
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T11:06:42.6786103+00:00",
-    "End": "2022-07-11T11:09:31.7284077+00:00",
+    "Start": "2022-07-31T07:11:22.3174712+00:00",
+    "End": "2022-07-31T07:14:04.7809235+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "downloadfileshare",
+    "LanguageTestName": "downloadblob",
     "Arguments": "--size 10240 --parallel 64 --warmup 15 --duration 15",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-blob": "12.18.0-beta.1",
-      "azure-storage-blob-cryptography": "12.17.0-beta.1",
-      "azure-storage-file-share": "12.13.1",
-      "azure-storage-file-datalake": "12.10.1",
-      "azure-core-http-netty": "1.12.2",
-      "azure-core-http-okhttp": "1.10.1",
-      "azure-core": "1.29.1",
-      "reactor-core": "3.4.17"
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -26,65 +26,65 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 6946.12,
+        "OperationsPerSecond": 11272,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 9040.56,
+        "OperationsPerSecond": 10188,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 11737.9,
+        "OperationsPerSecond": 10150,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 11873.52,
+        "OperationsPerSecond": 13973,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 11993.75,
+        "OperationsPerSecond": 14034,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 6946.12,
-    "OperationsPerSecondMean": 10318.37,
-    "OperationsPerSecondMedian": 11737.9,
-    "OperationsPerSecondMax": 11993.75
+    "OperationsPerSecondMin": 10150,
+    "OperationsPerSecondMean": 11923.4,
+    "OperationsPerSecondMedian": 11272,
+    "OperationsPerSecondMax": 14034
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T11:09:31.7285131+00:00",
-    "End": "2022-07-11T11:12:18.2920084+00:00",
+    "Start": "2022-07-31T07:14:04.7810427+00:00",
+    "End": "2022-07-31T07:16:49.654695+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "downloadfileshare",
+    "LanguageTestName": "downloadblob",
     "Arguments": "--size 10485760 --parallel 32 --warmup 15 --duration 15",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-blob": "12.18.0-beta.1",
-      "azure-storage-blob-cryptography": "12.17.0-beta.1",
-      "azure-storage-file-share": "12.13.1",
-      "azure-storage-file-datalake": "12.10.1",
-      "azure-core-http-netty": "1.12.2",
-      "azure-core-http-okhttp": "1.10.1",
-      "azure-core": "1.29.1",
-      "reactor-core": "3.4.17"
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -92,65 +92,131 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 160.55,
+        "OperationsPerSecond": 116.9,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 163.8,
+        "OperationsPerSecond": 88.66,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 165.95,
+        "OperationsPerSecond": 96,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 162.9,
+        "OperationsPerSecond": 95.63,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 163.95,
+        "OperationsPerSecond": 157,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 160.55,
-    "OperationsPerSecondMean": 163.43,
-    "OperationsPerSecondMedian": 163.8,
-    "OperationsPerSecondMax": 165.95
+    "OperationsPerSecondMin": 88.66,
+    "OperationsPerSecondMean": 110.83800000000001,
+    "OperationsPerSecondMedian": 96,
+    "OperationsPerSecondMax": 157
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T11:12:18.292034+00:00",
-    "End": "2022-07-11T11:23:13.8435441+00:00",
+    "Start": "2022-07-31T07:16:49.654718+00:00",
+    "End": "2022-07-31T07:19:39.4972102+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "downloadfileshare",
+    "LanguageTestName": "downloadblob",
+    "Arguments": "--size 10485760 --parallel 32 --sync --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 78.05,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 77.45,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 83.17,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 136.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 71.04,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 71.04,
+    "OperationsPerSecondMean": 89.22200000000001,
+    "OperationsPerSecondMedian": 78.05,
+    "OperationsPerSecondMax": 136.4
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-31T07:19:39.4972312+00:00",
+    "End": "2022-07-31T07:31:04.0098835+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "downloadblob",
     "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-blob": "12.18.0-beta.1",
-      "azure-storage-blob-cryptography": "12.17.0-beta.1",
-      "azure-storage-file-share": "12.13.1",
-      "azure-storage-file-datalake": "12.10.1",
-      "azure-core-http-netty": "1.12.2",
-      "azure-core-http-okhttp": "1.10.1",
-      "azure-core": "1.29.1",
-      "reactor-core": "3.4.17"
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -158,65 +224,65 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.11,
+        "OperationsPerSecond": 0.1132,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.09052,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 0.1222,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 0.05739,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.09102,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.08,
-    "OperationsPerSecondMean": 0.094,
-    "OperationsPerSecondMedian": 0.09,
-    "OperationsPerSecondMax": 0.11
+    "OperationsPerSecondMin": 0.05739,
+    "OperationsPerSecondMean": 0.09486599999999999,
+    "OperationsPerSecondMedian": 0.09102,
+    "OperationsPerSecondMax": 0.1222
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T11:23:13.8435611+00:00",
-    "End": "2022-07-11T11:36:44.9693509+00:00",
+    "Start": "2022-07-31T07:31:04.0099132+00:00",
+    "End": "2022-07-31T07:43:53.4199949+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "downloadfileshare",
+    "LanguageTestName": "downloadblob",
     "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-blob": "12.18.0-beta.1",
-      "azure-storage-blob-cryptography": "12.17.0-beta.1",
-      "azure-storage-file-share": "12.13.1",
-      "azure-storage-file-datalake": "12.10.1",
-      "azure-core-http-netty": "1.12.2",
-      "azure-core-http-okhttp": "1.10.1",
-      "azure-core": "1.29.1",
-      "reactor-core": "3.4.17"
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -224,131 +290,65 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 1.05,
+        "OperationsPerSecond": 0.4492,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 1.03,
+        "OperationsPerSecond": 0.732,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.99,
+        "OperationsPerSecond": 0.7449,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.97,
+        "OperationsPerSecond": 0.5345,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 1.04,
+        "OperationsPerSecond": 0.8216,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.97,
-    "OperationsPerSecondMean": 1.016,
-    "OperationsPerSecondMedian": 1.03,
-    "OperationsPerSecondMax": 1.05
+    "OperationsPerSecondMin": 0.4492,
+    "OperationsPerSecondMean": 0.65644,
+    "OperationsPerSecondMedian": 0.732,
+    "OperationsPerSecondMax": 0.8216
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T11:36:44.9694506+00:00",
-    "End": "2022-07-11T11:39:28.095958+00:00",
+    "Service": "storage-blob",
+    "Test": "download-file",
+    "Start": "2022-07-31T07:43:53.4200522+00:00",
+    "End": "2022-07-31T07:46:53.768522+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "uploadfileshare",
-    "Arguments": "--size 10240 --parallel 64 --warmup 15 --duration 15",
-    "PrimaryPackage": "azure-storage-file-share",
-    "PackageVersions": {
-      "azure-storage-blob": "12.18.0-beta.1",
-      "azure-storage-blob-cryptography": "12.17.0-beta.1",
-      "azure-storage-file-share": "12.13.1",
-      "azure-storage-file-datalake": "12.10.1",
-      "azure-core-http-netty": "1.12.2",
-      "azure-core-http-okhttp": "1.10.1",
-      "azure-core": "1.29.1",
-      "reactor-core": "3.4.17"
-    },
-    "SetupStandardOutput": "",
-    "SetupStandardError": "",
-    "SetupException": null,
-    "Iterations": [
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 11325.42,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 11288.46,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 11277.89,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 11663.26,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 11685.56,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      }
-    ],
-    "OperationsPerSecondMin": 11277.89,
-    "OperationsPerSecondMean": 11448.117999999999,
-    "OperationsPerSecondMedian": 11325.42,
-    "OperationsPerSecondMax": 11685.56
-  },
-  {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T11:39:28.0959733+00:00",
-    "End": "2022-07-11T11:42:13.1594268+00:00",
-    "Language": "java",
-    "LanguageVersion": "1.8.0_312",
-    "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "uploadfileshare",
+    "LanguageTestName": "downloadblobtofile",
     "Arguments": "--size 10485760 --parallel 32 --warmup 15 --duration 15",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-blob": "12.18.0-beta.1",
-      "azure-storage-blob-cryptography": "12.17.0-beta.1",
-      "azure-storage-file-share": "12.13.1",
-      "azure-storage-file-datalake": "12.10.1",
-      "azure-core-http-netty": "1.12.2",
-      "azure-core-http-okhttp": "1.10.1",
-      "azure-core": "1.29.1",
-      "reactor-core": "3.4.17"
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -356,65 +356,329 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 113.45,
+        "OperationsPerSecond": 68.96,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 108.07,
+        "OperationsPerSecond": 69.11,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 113.63,
+        "OperationsPerSecond": 61.14,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 112.04,
+        "OperationsPerSecond": 66.71,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 111.91,
+        "OperationsPerSecond": 67.1,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 108.07,
-    "OperationsPerSecondMean": 111.82000000000001,
-    "OperationsPerSecondMedian": 112.04,
-    "OperationsPerSecondMax": 113.63
+    "OperationsPerSecondMin": 61.14,
+    "OperationsPerSecondMean": 66.604,
+    "OperationsPerSecondMedian": 67.1,
+    "OperationsPerSecondMax": 69.11
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T11:42:13.1594397+00:00",
-    "End": "2022-07-11T11:53:47.5330646+00:00",
+    "Service": "storage-blob",
+    "Test": "download-file",
+    "Start": "2022-07-31T07:46:53.768536+00:00",
+    "End": "2022-07-31T07:49:44.4486886+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "uploadfileshare",
+    "LanguageTestName": "downloadblobtofile",
+    "Arguments": "--size 10485760 --parallel 32 --sync --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 65.81,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 62.82,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 70.09,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 70.44,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 69.63,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 62.82,
+    "OperationsPerSecondMean": 67.758,
+    "OperationsPerSecondMedian": 69.63,
+    "OperationsPerSecondMax": 70.44
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-31T07:49:44.4488887+00:00",
+    "End": "2022-07-31T07:52:23.4112692+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadblob",
+    "Arguments": "--size 10240 --parallel 64 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 5159,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 6762,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 10551,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 9800,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 8557,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 5159,
+    "OperationsPerSecondMean": 8165.8,
+    "OperationsPerSecondMedian": 8557,
+    "OperationsPerSecondMax": 10551
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-31T07:52:23.4114348+00:00",
+    "End": "2022-07-31T07:55:07.2491368+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadblob",
+    "Arguments": "--size 10485760 --parallel 32 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 144.1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 143.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 142.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 116.1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 119.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 116.1,
+    "OperationsPerSecondMean": 133.2,
+    "OperationsPerSecondMedian": 142.4,
+    "OperationsPerSecondMax": 144.1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-31T07:55:07.2491502+00:00",
+    "End": "2022-07-31T07:57:51.7832754+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadblob",
+    "Arguments": "--size 10485760 --parallel 32 --sync --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 124.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 143.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 124.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 123.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 143.8,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 123.9,
+    "OperationsPerSecondMean": 132.06,
+    "OperationsPerSecondMedian": 124.9,
+    "OperationsPerSecondMax": 143.8
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-31T07:57:51.7832907+00:00",
+    "End": "2022-07-31T08:08:28.6620817+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadblob",
     "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-blob": "12.18.0-beta.1",
-      "azure-storage-blob-cryptography": "12.17.0-beta.1",
-      "azure-storage-file-share": "12.13.1",
-      "azure-storage-file-datalake": "12.10.1",
-      "azure-core-http-netty": "1.12.2",
-      "azure-core-http-okhttp": "1.10.1",
-      "azure-core": "1.29.1",
-      "reactor-core": "3.4.17"
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -422,65 +686,65 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 0.3919,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 0.09851,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.11,
+        "OperationsPerSecond": 0.1015,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 0.09268,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.06,
+        "OperationsPerSecond": 0.331,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.06,
-    "OperationsPerSecondMean": 0.086,
-    "OperationsPerSecondMedian": 0.08,
-    "OperationsPerSecondMax": 0.11
+    "OperationsPerSecondMin": 0.09268,
+    "OperationsPerSecondMean": 0.203118,
+    "OperationsPerSecondMedian": 0.1015,
+    "OperationsPerSecondMax": 0.3919
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-11T11:53:47.5330939+00:00",
-    "End": "2022-07-11T12:07:43.0486291+00:00",
+    "Start": "2022-07-31T08:08:28.6620946+00:00",
+    "End": "2022-07-31T08:19:27.0031819+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "uploadfileshare",
+    "LanguageTestName": "uploadblob",
     "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-blob": "12.18.0-beta.1",
-      "azure-storage-blob-cryptography": "12.17.0-beta.1",
-      "azure-storage-file-share": "12.13.1",
-      "azure-storage-file-datalake": "12.10.1",
-      "azure-core-http-netty": "1.12.2",
-      "azure-core-http-okhttp": "1.10.1",
-      "azure-core": "1.29.1",
-      "reactor-core": "3.4.17"
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -488,122 +752,452 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.63,
+        "OperationsPerSecond": 1.148,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.72,
+        "OperationsPerSecond": 1.117,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.71,
+        "OperationsPerSecond": 1.316,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.81,
+        "OperationsPerSecond": 1.149,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.75,
+        "OperationsPerSecond": 1.394,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.63,
-    "OperationsPerSecondMean": 0.724,
-    "OperationsPerSecondMedian": 0.72,
-    "OperationsPerSecondMax": 0.81
+    "OperationsPerSecondMin": 1.117,
+    "OperationsPerSecondMean": 1.2247999999999999,
+    "OperationsPerSecondMedian": 1.149,
+    "OperationsPerSecondMax": 1.394
   },
   {
-    "Service": "storage-file-share",
-    "Test": "download",
-    "Start": "2022-07-11T12:09:23.0389189+00:00",
-    "End": "2022-07-11T12:12:15.5401167+00:00",
+    "Service": "storage-blob",
+    "Test": "upload-file",
+    "Start": "2022-07-31T08:19:27.0032135+00:00",
+    "End": "2022-07-31T08:22:10.0055083+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "downloadfileshare",
-    "Arguments": "--size 10240 --parallel 64 --warmup 15 --duration 15",
-    "PrimaryPackage": "azure-storage-file-share",
-    "PackageVersions": {
-      "azure-storage-blob": "source",
-      "azure-storage-blob-cryptography": "source",
-      "azure-storage-file-share": "source",
-      "azure-storage-file-datalake": "source",
-      "azure-core-http-netty": "source",
-      "azure-core-http-okhttp": "source",
-      "azure-core": "source",
-      "reactor-core": "source"
-    },
-    "SetupStandardOutput": "",
-    "SetupStandardError": "",
-    "SetupException": null,
-    "Iterations": [
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 11769.39,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 11405.63,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 11866.67,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 11483.99,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 11896.8,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      }
-    ],
-    "OperationsPerSecondMin": 11405.63,
-    "OperationsPerSecondMean": 11684.496,
-    "OperationsPerSecondMedian": 11769.39,
-    "OperationsPerSecondMax": 11896.8
-  },
-  {
-    "Service": "storage-file-share",
-    "Test": "download",
-    "Start": "2022-07-11T12:12:15.5402918+00:00",
-    "End": "2022-07-11T12:15:01.4191814+00:00",
-    "Language": "java",
-    "LanguageVersion": "1.8.0_312",
-    "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "downloadfileshare",
+    "LanguageTestName": "uploadfromfile",
     "Arguments": "--size 10485760 --parallel 32 --warmup 15 --duration 15",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 143.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 128.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 143.8,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 124.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 134.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 124.4,
+    "OperationsPerSecondMean": 134.9,
+    "OperationsPerSecondMedian": 134.5,
+    "OperationsPerSecondMax": 143.8
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload-file",
+    "Start": "2022-07-31T08:22:10.0055278+00:00",
+    "End": "2022-07-31T08:24:52.4141575+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadfromfile",
+    "Arguments": "--size 10485760 --parallel 32 --sync --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 144.1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 144.1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 138.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 134.6,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 143.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 134.6,
+    "OperationsPerSecondMean": 140.94,
+    "OperationsPerSecondMedian": 143.5,
+    "OperationsPerSecondMax": 144.1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-31T08:24:52.4143255+00:00",
+    "End": "2022-07-31T08:27:31.816601+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "listblobs",
+    "Arguments": "--count 5 --parallel 64 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 12472,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 12661,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 13044,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 12862,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 12790,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 12472,
+    "OperationsPerSecondMean": 12765.8,
+    "OperationsPerSecondMedian": 12790,
+    "OperationsPerSecondMax": 13044
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-31T08:27:31.8166124+00:00",
+    "End": "2022-07-31T08:30:16.6160839+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "listblobs",
+    "Arguments": "--count 500 --parallel 32 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 631.2,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 634.7,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 629.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 637.7,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 638.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 629.9,
+    "OperationsPerSecondMean": 634.4,
+    "OperationsPerSecondMedian": 634.7,
+    "OperationsPerSecondMax": 638.5
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-31T08:30:16.6160947+00:00",
+    "End": "2022-07-31T08:33:01.4919884+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "listblobs",
+    "Arguments": "--count 500 --parallel 32 --sync --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 629.6,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 636.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 642.8,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 633,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 640.8,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 629.6,
+    "OperationsPerSecondMean": 636.6200000000001,
+    "OperationsPerSecondMedian": 636.9,
+    "OperationsPerSecondMax": 642.8
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-31T08:33:01.4919978+00:00",
+    "End": "2022-07-31T08:44:50.6030641+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "listblobs",
+    "Arguments": "--count 50000 --parallel 32 --warmup 60 --duration 60",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.18.0",
+      "azure-storage-blob-cryptography": "12.17.0",
+      "azure-storage-file-share": "12.14.0",
+      "azure-storage-file-datalake": "12.11.0",
+      "azure-core-http-netty": "1.12.3",
+      "azure-core-http-okhttp": "1.11.0",
+      "azure-core": "1.30.0",
+      "reactor-core": "3.4.19"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 6.06,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 5.619,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 6.138,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 6.177,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 6.221,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 5.619,
+    "OperationsPerSecondMean": 6.043,
+    "OperationsPerSecondMedian": 6.138,
+    "OperationsPerSecondMax": 6.221
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-31T08:46:32.7579198+00:00",
+    "End": "2022-07-31T08:49:13.9007959+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "downloadblob",
+    "Arguments": "--size 10240 --parallel 64 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
       "azure-storage-blob": "source",
       "azure-storage-blob-cryptography": "source",
@@ -620,56 +1214,188 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 169.66,
+        "OperationsPerSecond": 13754,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 168.13,
+        "OperationsPerSecond": 14376,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 168.05,
+        "OperationsPerSecond": 14269,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 168.41,
+        "OperationsPerSecond": 13625,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 164.62,
+        "OperationsPerSecond": 13025,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 164.62,
-    "OperationsPerSecondMean": 167.774,
-    "OperationsPerSecondMedian": 168.13,
-    "OperationsPerSecondMax": 169.66
+    "OperationsPerSecondMin": 13025,
+    "OperationsPerSecondMean": 13809.8,
+    "OperationsPerSecondMedian": 13754,
+    "OperationsPerSecondMax": 14376
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T12:15:01.4193521+00:00",
-    "End": "2022-07-11T12:26:12.3704692+00:00",
+    "Start": "2022-07-31T08:49:13.9008142+00:00",
+    "End": "2022-07-31T08:52:02.2782802+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "downloadfileshare",
+    "LanguageTestName": "downloadblob",
+    "Arguments": "--size 10485760 --parallel 32 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 166.7,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 90.81,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 82.64,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 102.2,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 153.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 82.64,
+    "OperationsPerSecondMean": 119.13,
+    "OperationsPerSecondMedian": 102.2,
+    "OperationsPerSecondMax": 166.7
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-31T08:52:02.2784603+00:00",
+    "End": "2022-07-31T08:54:46.9909609+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "downloadblob",
+    "Arguments": "--size 10485760 --parallel 32 --sync --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 122,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 104.2,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 124.6,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 81.79,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 103.8,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 81.79,
+    "OperationsPerSecondMean": 107.27799999999999,
+    "OperationsPerSecondMedian": 104.2,
+    "OperationsPerSecondMax": 124.6
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-31T08:54:46.9911222+00:00",
+    "End": "2022-07-31T09:11:02.0345361+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "downloadblob",
     "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
       "azure-storage-blob": "source",
       "azure-storage-blob-cryptography": "source",
@@ -686,56 +1412,56 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.12,
+        "OperationsPerSecond": 0.1324,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 0.01083,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.1329,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 0.03711,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.11,
+        "OperationsPerSecond": 0.05503,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.09,
-    "OperationsPerSecondMean": 0.10400000000000001,
-    "OperationsPerSecondMedian": 0.1,
-    "OperationsPerSecondMax": 0.12
+    "OperationsPerSecondMin": 0.01083,
+    "OperationsPerSecondMean": 0.073654,
+    "OperationsPerSecondMedian": 0.05503,
+    "OperationsPerSecondMax": 0.1329
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T12:26:12.3704807+00:00",
-    "End": "2022-07-11T12:39:58.9892479+00:00",
+    "Start": "2022-07-31T09:11:02.0345444+00:00",
+    "End": "2022-07-31T09:23:25.4390162+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "downloadfileshare",
+    "LanguageTestName": "downloadblob",
     "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
       "azure-storage-blob": "source",
       "azure-storage-blob-cryptography": "source",
@@ -752,122 +1478,56 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 1.01,
+        "OperationsPerSecond": 0.483,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 1.05,
+        "OperationsPerSecond": 0.6735,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 1.07,
+        "OperationsPerSecond": 0.6518,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 1.08,
+        "OperationsPerSecond": 0.7678,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 1.02,
+        "OperationsPerSecond": 0.6859,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 1.01,
-    "OperationsPerSecondMean": 1.046,
-    "OperationsPerSecondMedian": 1.05,
-    "OperationsPerSecondMax": 1.08
+    "OperationsPerSecondMin": 0.483,
+    "OperationsPerSecondMean": 0.6524000000000001,
+    "OperationsPerSecondMedian": 0.6735,
+    "OperationsPerSecondMax": 0.7678
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T12:39:58.9892802+00:00",
-    "End": "2022-07-11T12:42:42.3807747+00:00",
+    "Service": "storage-blob",
+    "Test": "download-file",
+    "Start": "2022-07-31T09:23:25.4392066+00:00",
+    "End": "2022-07-31T09:26:08.4914376+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "uploadfileshare",
-    "Arguments": "--size 10240 --parallel 64 --warmup 15 --duration 15",
-    "PrimaryPackage": "azure-storage-file-share",
-    "PackageVersions": {
-      "azure-storage-blob": "source",
-      "azure-storage-blob-cryptography": "source",
-      "azure-storage-file-share": "source",
-      "azure-storage-file-datalake": "source",
-      "azure-core-http-netty": "source",
-      "azure-core-http-okhttp": "source",
-      "azure-core": "source",
-      "reactor-core": "source"
-    },
-    "SetupStandardOutput": "",
-    "SetupStandardError": "",
-    "SetupException": null,
-    "Iterations": [
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 12402.12,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 12148.21,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 12317.5,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 12345.69,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": null,
-        "OperationsPerSecond": 12295.64,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      }
-    ],
-    "OperationsPerSecondMin": 12148.21,
-    "OperationsPerSecondMean": 12301.832,
-    "OperationsPerSecondMedian": 12317.5,
-    "OperationsPerSecondMax": 12402.12
-  },
-  {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T12:42:42.3807864+00:00",
-    "End": "2022-07-11T12:45:27.0788249+00:00",
-    "Language": "java",
-    "LanguageVersion": "1.8.0_312",
-    "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "uploadfileshare",
+    "LanguageTestName": "downloadblobtofile",
     "Arguments": "--size 10485760 --parallel 32 --warmup 15 --duration 15",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
       "azure-storage-blob": "source",
       "azure-storage-blob-cryptography": "source",
@@ -884,56 +1544,56 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 143.88,
+        "OperationsPerSecond": 71.04,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 143.95,
+        "OperationsPerSecond": 68.27,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 143.79,
+        "OperationsPerSecond": 70.89,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 143.68,
+        "OperationsPerSecond": 69.1,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 143.77,
+        "OperationsPerSecond": 71.51,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 143.68,
-    "OperationsPerSecondMean": 143.814,
-    "OperationsPerSecondMedian": 143.79,
-    "OperationsPerSecondMax": 143.95
+    "OperationsPerSecondMin": 68.27,
+    "OperationsPerSecondMean": 70.16199999999999,
+    "OperationsPerSecondMedian": 70.89,
+    "OperationsPerSecondMax": 71.51
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T12:45:27.0788384+00:00",
-    "End": "2022-07-11T12:57:13.287026+00:00",
+    "Service": "storage-blob",
+    "Test": "download-file",
+    "Start": "2022-07-31T09:26:08.4914461+00:00",
+    "End": "2022-07-31T09:28:53.3523307+00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "uploadfileshare",
-    "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "LanguageTestName": "downloadblobtofile",
+    "Arguments": "--size 10485760 --parallel 32 --sync --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
       "azure-storage-blob": "source",
       "azure-storage-blob-cryptography": "source",
@@ -950,56 +1610,716 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 71.05,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.11,
+        "OperationsPerSecond": 69.65,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 69.51,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 67.27,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 71.26,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.08,
-    "OperationsPerSecondMean": 0.09400000000000001,
-    "OperationsPerSecondMedian": 0.1,
-    "OperationsPerSecondMax": 0.11
+    "OperationsPerSecondMin": 67.27,
+    "OperationsPerSecondMean": 69.74799999999999,
+    "OperationsPerSecondMedian": 69.65,
+    "OperationsPerSecondMax": 71.26
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-11T12:57:13.2870369+00:00",
+    "Start": "2022-07-31T09:28:53.3523577+00:00",
+    "End": "2022-07-31T09:31:32.1278198+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadblob",
+    "Arguments": "--size 10240 --parallel 64 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 9187,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 8874,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 9929,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 10062,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 9303,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 8874,
+    "OperationsPerSecondMean": 9471,
+    "OperationsPerSecondMedian": 9303,
+    "OperationsPerSecondMax": 10062
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-31T09:31:32.1278354+00:00",
+    "End": "2022-07-31T09:34:17.1979184+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadblob",
+    "Arguments": "--size 10485760 --parallel 32 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 95.01,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 129.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 143.1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 127.6,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 85.32,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 85.32,
+    "OperationsPerSecondMean": 116.06599999999999,
+    "OperationsPerSecondMedian": 127.6,
+    "OperationsPerSecondMax": 143.1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-31T09:34:17.1979293+00:00",
+    "End": "2022-07-31T09:37:04.1680617+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadblob",
+    "Arguments": "--size 10485760 --parallel 32 --sync --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 126.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 108.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 80.11,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 102.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 143.7,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 80.11,
+    "OperationsPerSecondMean": 112.38200000000002,
+    "OperationsPerSecondMedian": 108.3,
+    "OperationsPerSecondMax": 143.7
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-31T09:37:04.1680734+00:00",
+    "End": "2022-07-31T09:47:27.72615+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadblob",
+    "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 0.3125,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 0.3535,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 0.1829,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 0.1648,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 0.3121,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.1648,
+    "OperationsPerSecondMean": 0.26516,
+    "OperationsPerSecondMedian": 0.3121,
+    "OperationsPerSecondMax": 0.3535
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-31T09:47:27.7263369+00:00",
+    "End": "2022-07-31T09:58:45.630564+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadblob",
+    "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 0.7353,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 0.6771,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 1.057,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 0.7956,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 1.153,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.6771,
+    "OperationsPerSecondMean": 0.8835999999999998,
+    "OperationsPerSecondMedian": 0.7956,
+    "OperationsPerSecondMax": 1.153
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload-file",
+    "Start": "2022-07-31T09:58:45.6307555+00:00",
+    "End": "2022-07-31T10:01:32.0998845+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadfromfile",
+    "Arguments": "--size 10485760 --parallel 32 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 124.2,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 117.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 139.8,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 87.62,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 78.87,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 78.87,
+    "OperationsPerSecondMean": 109.598,
+    "OperationsPerSecondMedian": 117.5,
+    "OperationsPerSecondMax": 139.8
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload-file",
+    "Start": "2022-07-31T10:01:32.0998936+00:00",
+    "End": "2022-07-31T10:04:15.6888725+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "uploadfromfile",
+    "Arguments": "--size 10485760 --parallel 32 --sync --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 84.02,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 85.01,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 99.55,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 119.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 135.2,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 84.02,
+    "OperationsPerSecondMean": 104.61599999999999,
+    "OperationsPerSecondMedian": 99.55,
+    "OperationsPerSecondMax": 135.2
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-31T10:04:15.688904+00:00",
+    "End": "2022-07-31T10:06:56.16235+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "listblobs",
+    "Arguments": "--count 5 --parallel 64 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 10516,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 8028,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 7621,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 8148,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 8455,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 7621,
+    "OperationsPerSecondMean": 8553.6,
+    "OperationsPerSecondMedian": 8148,
+    "OperationsPerSecondMax": 10516
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-31T10:06:56.1623609+00:00",
+    "End": "2022-07-31T10:09:43.0738092+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "listblobs",
+    "Arguments": "--count 500 --parallel 32 --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 609.1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 468.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 616.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 611.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 619,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 468.3,
+    "OperationsPerSecondMean": 584.8399999999999,
+    "OperationsPerSecondMedian": 611.5,
+    "OperationsPerSecondMax": 619
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-31T10:09:43.0738197+00:00",
+    "End": "2022-07-31T10:12:27.907465+00:00",
+    "Language": "java",
+    "LanguageVersion": "1.8.0_312",
+    "Project": "sdk/storage/azure-storage-perf",
+    "LanguageTestName": "listblobs",
+    "Arguments": "--count 500 --parallel 32 --sync --warmup 15 --duration 15",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source",
+      "azure-storage-blob-cryptography": "source",
+      "azure-storage-file-share": "source",
+      "azure-storage-file-datalake": "source",
+      "azure-core-http-netty": "source",
+      "azure-core-http-okhttp": "source",
+      "azure-core": "source",
+      "reactor-core": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 600.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 590.2,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 581,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 650.6,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": null,
+        "OperationsPerSecond": 639.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 581,
+    "OperationsPerSecondMean": 612.3199999999999,
+    "OperationsPerSecondMedian": 600.4,
+    "OperationsPerSecondMax": 650.6
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-31T10:12:27.9074737+00:00",
     "End": "0001-01-01T00:00:00",
     "Language": "java",
     "LanguageVersion": "1.8.0_312",
     "Project": "sdk/storage/azure-storage-perf",
-    "LanguageTestName": "uploadfileshare",
-    "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "LanguageTestName": "listblobs",
+    "Arguments": "--count 50000 --parallel 32 --warmup 60 --duration 60",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
       "azure-storage-blob": "source",
       "azure-storage-blob-cryptography": "source",
@@ -1016,43 +2336,43 @@
     "Iterations": [
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.75,
+        "OperationsPerSecond": 5.811,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.86,
+        "OperationsPerSecond": 5.772,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.74,
+        "OperationsPerSecond": 5.493,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.8,
+        "OperationsPerSecond": 5.705,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": null,
-        "OperationsPerSecond": 0.89,
+        "OperationsPerSecond": 6.128,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.74,
-    "OperationsPerSecondMean": 0.8079999999999998,
-    "OperationsPerSecondMedian": 0.8,
-    "OperationsPerSecondMax": 0.89
+    "OperationsPerSecondMin": 5.493,
+    "OperationsPerSecondMean": 5.7818,
+    "OperationsPerSecondMedian": 5.772,
+    "OperationsPerSecondMax": 6.128
   }
 ]

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation.Tests/results/js.json
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation.Tests/results/js.json
@@ -1,17 +1,17 @@
 [
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T11:07:18.927965+00:00",
-    "End": "2022-07-11T11:09:01.5922958+00:00",
+    "Start": "2022-07-30T07:09:00.5287517+00:00",
+    "End": "2022-07-30T07:10:45.2364796+00:00",
     "Language": "js",
     "LanguageVersion": "14.19.0",
-    "Project": "sdk/storage/perf-tests/storage-file-share",
-    "LanguageTestName": "StorageFileShareDownloadTest",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobDownloadTest",
     "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "@azure/storage-file-share",
+    "PrimaryPackage": "@azure/storage-blob",
     "PackageVersions": {
-      "@azure/storage-file-share": "12.10.0"
+      "@azure/storage-blob": "12.11.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -19,137 +19,68 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.10.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-file-share@12.10.0/node_modules/@azure/storage-file-share"
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
         },
-        "OperationsPerSecond": 1836,
+        "OperationsPerSecond": 1962,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.10.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-file-share@12.10.0/node_modules/@azure/storage-file-share"
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
         },
-        "OperationsPerSecond": 1851.71,
+        "OperationsPerSecond": 2003,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.10.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-file-share@12.10.0/node_modules/@azure/storage-file-share"
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
         },
-        "OperationsPerSecond": 1852.97,
+        "OperationsPerSecond": 1959,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.10.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-file-share@12.10.0/node_modules/@azure/storage-file-share"
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
         },
-        "OperationsPerSecond": 1850.28,
+        "OperationsPerSecond": 1977,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.10.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-file-share@12.10.0/node_modules/@azure/storage-file-share"
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
         },
-        "OperationsPerSecond": 1857.43,
+        "OperationsPerSecond": 1991,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 1836,
-    "OperationsPerSecondMean": 1849.6779999999999,
-    "OperationsPerSecondMedian": 1851.71,
-    "OperationsPerSecondMax": 1857.43
+    "OperationsPerSecondMin": 1959,
+    "OperationsPerSecondMean": 1978.4,
+    "OperationsPerSecondMedian": 1977,
+    "OperationsPerSecondMax": 2003
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T11:09:01.5924066+00:00",
-    "End": "2022-07-11T11:10:44.2660447+00:00",
-    "Language": "js",
-    "LanguageVersion": "14.19.0",
-    "Project": "sdk/storage/perf-tests/storage-file-share",
-    "LanguageTestName": "StorageFileShareUploadTest",
-    "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "@azure/storage-file-share",
-    "PackageVersions": {
-      "@azure/storage-file-share": "12.10.0"
-    },
-    "SetupStandardOutput": "",
-    "SetupStandardError": "",
-    "SetupException": null,
-    "Iterations": [
-      {
-        "PackageVersions": {
-          "@azure/storage-file-share": "12.10.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-file-share@12.10.0/node_modules/@azure/storage-file-share"
-        },
-        "OperationsPerSecond": 1030.29,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "@azure/storage-file-share": "12.10.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-file-share@12.10.0/node_modules/@azure/storage-file-share"
-        },
-        "OperationsPerSecond": 1028.52,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "@azure/storage-file-share": "12.10.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-file-share@12.10.0/node_modules/@azure/storage-file-share"
-        },
-        "OperationsPerSecond": 1026.37,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "@azure/storage-file-share": "12.10.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-file-share@12.10.0/node_modules/@azure/storage-file-share"
-        },
-        "OperationsPerSecond": 1030.31,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "@azure/storage-file-share": "12.10.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-file-share@12.10.0/node_modules/@azure/storage-file-share"
-        },
-        "OperationsPerSecond": 1034.94,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      }
-    ],
-    "OperationsPerSecondMin": 1026.37,
-    "OperationsPerSecondMean": 1030.086,
-    "OperationsPerSecondMedian": 1030.29,
-    "OperationsPerSecondMax": 1034.94
-  },
-  {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T11:15:26.9090799+00:00",
-    "End": "2022-07-11T11:17:11.3311068+00:00",
+    "Start": "2022-07-30T07:10:45.2365825+00:00",
+    "End": "2022-07-30T07:13:06.6953738+00:00",
     "Language": "js",
     "LanguageVersion": "14.19.0",
-    "Project": "sdk/storage/perf-tests/storage-file-share",
-    "LanguageTestName": "StorageFileShareDownloadTest",
-    "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "@azure/storage-file-share",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobDownloadTest",
+    "Arguments": "--size 10485760 --parallel 32",
+    "PrimaryPackage": "@azure/storage-blob",
     "PackageVersions": {
-      "@azure/storage-file-share": "source"
+      "@azure/storage-blob": "12.11.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -157,68 +88,1793 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.11.0 -> /mnt/vss/_work/1/s/sdk/storage/storage-file-share"
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
         },
-        "OperationsPerSecond": 1858.92,
+        "OperationsPerSecond": 30.46,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.11.0 -> /mnt/vss/_work/1/s/sdk/storage/storage-file-share"
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
         },
-        "OperationsPerSecond": 1842.95,
+        "OperationsPerSecond": 54.74,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.11.0 -> /mnt/vss/_work/1/s/sdk/storage/storage-file-share"
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
         },
-        "OperationsPerSecond": 1856.38,
+        "OperationsPerSecond": 25.65,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.11.0 -> /mnt/vss/_work/1/s/sdk/storage/storage-file-share"
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
         },
-        "OperationsPerSecond": 1837.45,
+        "OperationsPerSecond": 21.29,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.11.0 -> /mnt/vss/_work/1/s/sdk/storage/storage-file-share"
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
         },
-        "OperationsPerSecond": 1860.57,
+        "OperationsPerSecond": 23.11,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 1837.45,
-    "OperationsPerSecondMean": 1851.2540000000001,
-    "OperationsPerSecondMedian": 1856.38,
-    "OperationsPerSecondMax": 1860.57
+    "OperationsPerSecondMin": 21.29,
+    "OperationsPerSecondMean": 31.05,
+    "OperationsPerSecondMedian": 25.65,
+    "OperationsPerSecondMax": 54.74
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T07:13:06.6953954+00:00",
+    "End": "2022-07-30T07:13:29.3821536+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobDownloadTest",
+    "Arguments": "--size 10485760 --parallel 32 --sync",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": -1,
+    "OperationsPerSecondMean": -1,
+    "OperationsPerSecondMedian": -1,
+    "OperationsPerSecondMax": -1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T07:13:29.3821666+00:00",
+    "End": "2022-07-30T07:26:14.1306082+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobDownloadTest",
+    "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.04227,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.09761,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.09439,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.09199,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.1025,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.04227,
+    "OperationsPerSecondMean": 0.085752,
+    "OperationsPerSecondMedian": 0.09439,
+    "OperationsPerSecondMax": 0.1025
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T07:26:14.1306161+00:00",
+    "End": "2022-07-30T07:42:09.5289315+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobDownloadTest",
+    "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.3555,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.2555,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.3256,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.2432,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.1881,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.1881,
+    "OperationsPerSecondMean": 0.27358,
+    "OperationsPerSecondMedian": 0.2555,
+    "OperationsPerSecondMax": 0.3555
+  },
+  {
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-11T11:17:11.3311388+00:00",
+    "Start": "2022-07-30T07:42:09.5289822+00:00",
+    "End": "2022-07-30T07:43:54.5275427+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobUploadTest",
+    "Arguments": "--size 10240 --parallel 64",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 1671,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 2081,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 2071,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 2077,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 2078,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 1671,
+    "OperationsPerSecondMean": 1995.6,
+    "OperationsPerSecondMedian": 2077,
+    "OperationsPerSecondMax": 2081
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T07:43:54.5275542+00:00",
+    "End": "2022-07-30T07:45:46.3107285+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobUploadTest",
+    "Arguments": "--size 10485760 --parallel 32",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 59.53,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 57.55,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 57.47,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 131.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 76.67,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 57.47,
+    "OperationsPerSecondMean": 76.504,
+    "OperationsPerSecondMedian": 59.53,
+    "OperationsPerSecondMax": 131.3
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T07:45:46.3108873+00:00",
+    "End": "2022-07-30T07:46:09.0398432+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobUploadTest",
+    "Arguments": "--size 10485760 --parallel 32 --sync",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": -1,
+    "OperationsPerSecondMean": -1,
+    "OperationsPerSecondMedian": -1,
+    "OperationsPerSecondMax": -1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T07:46:09.0398556+00:00",
+    "End": "2022-07-30T07:57:29.4482484+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobUploadTest",
+    "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.09707,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.1057,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.1157,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.1162,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.1329,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.09707,
+    "OperationsPerSecondMean": 0.113514,
+    "OperationsPerSecondMedian": 0.1157,
+    "OperationsPerSecondMax": 0.1329
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T07:57:29.4482583+00:00",
+    "End": "2022-07-30T08:26:49.183729+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobUploadTest",
+    "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.1942,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.4389,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.4707,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.2242,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.5001,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.1942,
+    "OperationsPerSecondMean": 0.36562,
+    "OperationsPerSecondMedian": 0.4389,
+    "OperationsPerSecondMax": 0.5001
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T08:26:49.1879476+00:00",
+    "End": "2022-07-30T08:28:42.2518815+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobListTest",
+    "Arguments": "--count 5 --parallel 64",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 941,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 951.1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 938.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 946.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 945.1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 938.3,
+    "OperationsPerSecondMean": 944.36,
+    "OperationsPerSecondMedian": 945.1,
+    "OperationsPerSecondMax": 951.1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T08:28:42.2518896+00:00",
+    "End": "2022-07-30T08:31:01.6860929+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobListTest",
+    "Arguments": "--count 500 --parallel 32",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 30.64,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 30.65,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 30.31,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 30.59,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 30.64,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 30.31,
+    "OperationsPerSecondMean": 30.565999999999995,
+    "OperationsPerSecondMedian": 30.64,
+    "OperationsPerSecondMax": 30.65
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T08:31:01.6861034+00:00",
+    "End": "2022-07-30T08:31:27.4438612+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobListTest",
+    "Arguments": "--count 500 --parallel 32 --sync",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": -1,
+    "OperationsPerSecondMean": -1,
+    "OperationsPerSecondMedian": -1,
+    "OperationsPerSecondMax": -1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T08:31:27.4438715+00:00",
+    "End": "2022-07-30T09:01:21.8998944+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobListTest",
+    "Arguments": "--count 50000 --parallel 32 --warmup 60 --duration 60",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "12.11.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.3241,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.3156,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.3277,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.3197,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.0 -> /mnt/vss/_work/1/s/common/temp/node_modules/.pnpm/@azure+storage-blob@12.11.0/node_modules/@azure/storage-blob"
+        },
+        "OperationsPerSecond": 0.3189,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.3156,
+    "OperationsPerSecondMean": 0.3212,
+    "OperationsPerSecondMedian": 0.3197,
+    "OperationsPerSecondMax": 0.3277
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T09:06:22.8643729+00:00",
+    "End": "2022-07-30T09:08:13.2554201+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobDownloadTest",
+    "Arguments": "--size 10240 --parallel 64",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 1404,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 1405,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 1441,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 1387,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 1388,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 1387,
+    "OperationsPerSecondMean": 1405,
+    "OperationsPerSecondMedian": 1404,
+    "OperationsPerSecondMax": 1441
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T09:08:13.2554323+00:00",
+    "End": "2022-07-30T09:10:11.6924224+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobDownloadTest",
+    "Arguments": "--size 10485760 --parallel 32",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 107.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 112.2,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 84.08,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 67.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 106.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 67.5,
+    "OperationsPerSecondMean": 95.556,
+    "OperationsPerSecondMedian": 106.5,
+    "OperationsPerSecondMax": 112.2
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T09:10:11.6924319+00:00",
+    "End": "2022-07-30T09:10:37.6291437+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobDownloadTest",
+    "Arguments": "--size 10485760 --parallel 32 --sync",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": -1,
+    "OperationsPerSecondMean": -1,
+    "OperationsPerSecondMedian": -1,
+    "OperationsPerSecondMax": -1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T09:10:37.6291585+00:00",
+    "End": "2022-07-30T09:26:13.8510809+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobDownloadTest",
+    "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.06055,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.00943,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.1039,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.09997,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.1052,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.00943,
+    "OperationsPerSecondMean": 0.07581000000000002,
+    "OperationsPerSecondMedian": 0.09997,
+    "OperationsPerSecondMax": 0.1052
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T09:26:13.8510905+00:00",
+    "End": "2022-07-30T09:42:10.0376978+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobDownloadTest",
+    "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.5866,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.4461,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.3755,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.3895,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.3733,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.3733,
+    "OperationsPerSecondMean": 0.4342,
+    "OperationsPerSecondMedian": 0.3895,
+    "OperationsPerSecondMax": 0.5866
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T09:42:10.0378912+00:00",
+    "End": "2022-07-30T09:44:01.5988171+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobUploadTest",
+    "Arguments": "--size 10240 --parallel 64",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 1481,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 1484,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 1499,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 1507,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 1490,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 1481,
+    "OperationsPerSecondMean": 1492.2,
+    "OperationsPerSecondMedian": 1490,
+    "OperationsPerSecondMax": 1507
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T09:44:01.5992639+00:00",
+    "End": "2022-07-30T09:46:02.6658372+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobUploadTest",
+    "Arguments": "--size 10485760 --parallel 32",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 126.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 138.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 138.8,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 131.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 120.2,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 120.2,
+    "OperationsPerSecondMean": 131.24,
+    "OperationsPerSecondMedian": 131.9,
+    "OperationsPerSecondMax": 138.8
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T09:46:02.6658436+00:00",
+    "End": "2022-07-30T09:46:28.8581437+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobUploadTest",
+    "Arguments": "--size 10485760 --parallel 32 --sync",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": -1,
+    "OperationsPerSecondMean": -1,
+    "OperationsPerSecondMedian": -1,
+    "OperationsPerSecondMax": -1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T09:46:28.8581554+00:00",
+    "End": "2022-07-30T09:59:21.1694156+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobUploadTest",
+    "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.02769,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.09511,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.02611,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.09231,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.1058,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.02611,
+    "OperationsPerSecondMean": 0.069404,
+    "OperationsPerSecondMedian": 0.09231,
+    "OperationsPerSecondMax": 0.1058
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T09:59:21.1694217+00:00",
+    "End": "2022-07-30T10:14:05.9633532+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobUploadTest",
+    "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.7044,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.339,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.1926,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.269,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 0.4261,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 0.1926,
+    "OperationsPerSecondMean": 0.38622000000000006,
+    "OperationsPerSecondMedian": 0.339,
+    "OperationsPerSecondMax": 0.7044
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T10:14:05.9635721+00:00",
+    "End": "2022-07-30T10:15:57.2733333+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobListTest",
+    "Arguments": "--count 5 --parallel 64",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 939.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 935.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 927.1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 931.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 948,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 927.1,
+    "OperationsPerSecondMean": 936.3,
+    "OperationsPerSecondMedian": 935.5,
+    "OperationsPerSecondMax": 948
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T10:15:57.2733413+00:00",
+    "End": "2022-07-30T10:18:12.5291835+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobListTest",
+    "Arguments": "--count 500 --parallel 32",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 30.97,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 30.58,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 30.68,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 30.72,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": 30.64,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 30.58,
+    "OperationsPerSecondMean": 30.717999999999996,
+    "OperationsPerSecondMedian": 30.68,
+    "OperationsPerSecondMax": 30.97
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T10:18:12.5291912+00:00",
+    "End": "2022-07-30T10:18:38.7223216+00:00",
+    "Language": "js",
+    "LanguageVersion": "14.19.0",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobListTest",
+    "Arguments": "--count 500 --parallel 32 --sync",
+    "PrimaryPackage": "@azure/storage-blob",
+    "PackageVersions": {
+      "@azure/storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": -1,
+    "OperationsPerSecondMean": -1,
+    "OperationsPerSecondMedian": -1,
+    "OperationsPerSecondMax": -1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T10:18:38.7223299+00:00",
     "End": "0001-01-01T00:00:00",
     "Language": "js",
     "LanguageVersion": "14.19.0",
-    "Project": "sdk/storage/perf-tests/storage-file-share",
-    "LanguageTestName": "StorageFileShareUploadTest",
-    "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "@azure/storage-file-share",
+    "Project": "sdk/storage/perf-tests/storage-blob",
+    "LanguageTestName": "StorageBlobListTest",
+    "Arguments": "--count 50000 --parallel 32 --warmup 60 --duration 60",
+    "PrimaryPackage": "@azure/storage-blob",
     "PackageVersions": {
-      "@azure/storage-file-share": "source"
+      "@azure/storage-blob": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -226,53 +1882,53 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.11.0 -> /mnt/vss/_work/1/s/sdk/storage/storage-file-share"
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
         },
-        "OperationsPerSecond": 1030.98,
+        "OperationsPerSecond": 0.3264,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.11.0 -> /mnt/vss/_work/1/s/sdk/storage/storage-file-share"
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
         },
-        "OperationsPerSecond": 1036.7,
+        "OperationsPerSecond": 0.3209,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.11.0 -> /mnt/vss/_work/1/s/sdk/storage/storage-file-share"
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
         },
-        "OperationsPerSecond": 1032.38,
+        "OperationsPerSecond": 0.323,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.11.0 -> /mnt/vss/_work/1/s/sdk/storage/storage-file-share"
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
         },
-        "OperationsPerSecond": 1036.78,
+        "OperationsPerSecond": 0.3223,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "@azure/storage-file-share": "12.11.0 -> /mnt/vss/_work/1/s/sdk/storage/storage-file-share"
+          "@azure/storage-blob": "12.11.1 -> /mnt/vss/_work/1/s/sdk/storage/storage-blob"
         },
-        "OperationsPerSecond": 1039.09,
+        "OperationsPerSecond": 0.3295,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 1030.98,
-    "OperationsPerSecondMean": 1035.1860000000001,
-    "OperationsPerSecondMedian": 1036.7,
-    "OperationsPerSecondMax": 1039.09
+    "OperationsPerSecondMin": 0.3209,
+    "OperationsPerSecondMean": 0.32442000000000004,
+    "OperationsPerSecondMedian": 0.323,
+    "OperationsPerSecondMax": 0.3295
   }
 ]

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation.Tests/results/net.json
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation.Tests/results/net.json
@@ -1,17 +1,17 @@
 [
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-08T11:05:51.6681681+00:00",
-    "End": "2022-07-08T11:07:13.798851+00:00",
+    "Start": "2022-07-30T07:05:38.9285954+00:00",
+    "End": "2022-07-30T07:06:56.932969+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "DownloadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "DownloadBlob",
     "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "12.10.0"
+      "Azure.Storage.Blobs": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -19,68 +19,68 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 14397.45,
+        "OperationsPerSecond": 13081,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 13524.26,
+        "OperationsPerSecond": 13882,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 14962.98,
+        "OperationsPerSecond": 14236,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 14998.55,
+        "OperationsPerSecond": 14115,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 13642.44,
+        "OperationsPerSecond": 14210,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 13524.26,
-    "OperationsPerSecondMean": 14305.136000000002,
-    "OperationsPerSecondMedian": 14397.45,
-    "OperationsPerSecondMax": 14998.55
+    "OperationsPerSecondMin": 13081,
+    "OperationsPerSecondMean": 13904.8,
+    "OperationsPerSecondMedian": 14115,
+    "OperationsPerSecondMax": 14236
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-08T11:07:13.798959+00:00",
-    "End": "2022-07-08T11:08:35.428707+00:00",
+    "Start": "2022-07-30T07:06:56.933124+00:00",
+    "End": "2022-07-30T07:08:15.0191023+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "DownloadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "DownloadBlob",
     "Arguments": "--size 10485760 --parallel 32",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "12.10.0"
+      "Azure.Storage.Blobs": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -88,16 +88,7 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
-        },
-        "OperationsPerSecond": 160.38,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
         "OperationsPerSecond": 166.8,
         "StandardOutput": "",
@@ -106,50 +97,128 @@
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 164.1,
+        "OperationsPerSecond": 169,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 161.43,
+        "OperationsPerSecond": 168.6,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 161.63,
+        "OperationsPerSecond": 166,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 166.6,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 160.38,
-    "OperationsPerSecondMean": 162.868,
-    "OperationsPerSecondMedian": 161.63,
-    "OperationsPerSecondMax": 166.8
+    "OperationsPerSecondMin": 166,
+    "OperationsPerSecondMean": 167.4,
+    "OperationsPerSecondMedian": 166.8,
+    "OperationsPerSecondMax": 169
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-08T11:08:35.4287375+00:00",
-    "End": "2022-07-08T11:19:35.8057829+00:00",
+    "Start": "2022-07-30T07:08:15.0191206+00:00",
+    "End": "2022-07-30T07:09:33.7290583+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "DownloadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "DownloadBlob",
+    "Arguments": "--size 10485760 --parallel 32 --sync",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "12.13.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 182.7,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 180.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 176.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 180.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 182.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 176.4,
+    "OperationsPerSecondMean": 180.42000000000002,
+    "OperationsPerSecondMedian": 180.3,
+    "OperationsPerSecondMax": 182.7
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T07:09:33.729071+00:00",
+    "End": "2022-07-30T07:19:50.8609034+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "DownloadBlob",
     "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "12.10.0"
+      "Azure.Storage.Blobs": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -157,68 +226,68 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 0.1609,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.11,
+        "OperationsPerSecond": 0.1516,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 0.141,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 0.1493,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.11,
+        "OperationsPerSecond": 0.194,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.1,
-    "OperationsPerSecondMean": 0.10400000000000001,
-    "OperationsPerSecondMedian": 0.1,
-    "OperationsPerSecondMax": 0.11
+    "OperationsPerSecondMin": 0.141,
+    "OperationsPerSecondMean": 0.15936,
+    "OperationsPerSecondMedian": 0.1516,
+    "OperationsPerSecondMax": 0.194
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-08T11:19:35.805801+00:00",
-    "End": "2022-07-08T11:30:43.2282515+00:00",
+    "Start": "2022-07-30T07:19:50.8609137+00:00",
+    "End": "2022-07-30T07:30:08.0200529+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "DownloadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "DownloadBlob",
     "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "12.10.0"
+      "Azure.Storage.Blobs": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -226,68 +295,68 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.85,
+        "OperationsPerSecond": 0.9603,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.83,
+        "OperationsPerSecond": 0.8789,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.86,
+        "OperationsPerSecond": 0.9217,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.81,
+        "OperationsPerSecond": 0.9722,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.88,
+        "OperationsPerSecond": 0.9555,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.81,
-    "OperationsPerSecondMean": 0.8460000000000001,
-    "OperationsPerSecondMedian": 0.85,
-    "OperationsPerSecondMax": 0.88
+    "OperationsPerSecondMin": 0.8789,
+    "OperationsPerSecondMean": 0.93772,
+    "OperationsPerSecondMedian": 0.9555,
+    "OperationsPerSecondMax": 0.9722
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-08T11:30:43.2283078+00:00",
-    "End": "2022-07-08T11:32:04.8091085+00:00",
+    "Start": "2022-07-30T07:30:08.0201077+00:00",
+    "End": "2022-07-30T07:31:25.3955676+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "UploadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "UploadBlob",
     "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "12.10.0"
+      "Azure.Storage.Blobs": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -295,68 +364,68 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 12541.48,
+        "OperationsPerSecond": 9580,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 12786.13,
+        "OperationsPerSecond": 12063,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 12867.9,
+        "OperationsPerSecond": 12161,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 13373.45,
+        "OperationsPerSecond": 11917,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 13425.91,
+        "OperationsPerSecond": 12010,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 12541.48,
-    "OperationsPerSecondMean": 12998.974000000002,
-    "OperationsPerSecondMedian": 12867.9,
-    "OperationsPerSecondMax": 13425.91
+    "OperationsPerSecondMin": 9580,
+    "OperationsPerSecondMean": 11546.2,
+    "OperationsPerSecondMedian": 12010,
+    "OperationsPerSecondMax": 12161
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-08T11:32:04.8091235+00:00",
-    "End": "2022-07-08T11:33:24.5217537+00:00",
+    "Start": "2022-07-30T07:31:25.3955813+00:00",
+    "End": "2022-07-30T07:32:42.813137+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "UploadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "UploadBlob",
     "Arguments": "--size 10485760 --parallel 32",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "12.10.0"
+      "Azure.Storage.Blobs": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -364,68 +433,137 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 76.91,
+        "OperationsPerSecond": 142.6,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 76.55,
+        "OperationsPerSecond": 142.6,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 78.76,
+        "OperationsPerSecond": 142.8,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 76.73,
+        "OperationsPerSecond": 127.2,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 80.93,
+        "OperationsPerSecond": 142.8,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 76.55,
-    "OperationsPerSecondMean": 77.976,
-    "OperationsPerSecondMedian": 76.91,
-    "OperationsPerSecondMax": 80.93
+    "OperationsPerSecondMin": 127.2,
+    "OperationsPerSecondMean": 139.6,
+    "OperationsPerSecondMedian": 142.6,
+    "OperationsPerSecondMax": 142.8
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-08T11:33:24.5217727+00:00",
-    "End": "2022-07-08T11:43:27.0633616+00:00",
+    "Start": "2022-07-30T07:32:42.8131462+00:00",
+    "End": "2022-07-30T07:34:00.2472101+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "UploadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "UploadBlob",
+    "Arguments": "--size 10485760 --parallel 32 --sync",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "12.13.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 142.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 142.8,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 142.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 142.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 142.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 142.4,
+    "OperationsPerSecondMean": 142.7,
+    "OperationsPerSecondMedian": 142.8,
+    "OperationsPerSecondMax": 142.9
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T07:34:00.2472213+00:00",
+    "End": "2022-07-30T07:44:02.5171402+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "UploadBlob",
     "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "12.10.0"
+      "Azure.Storage.Blobs": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -433,68 +571,68 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.3441,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.3552,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.3534,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.3522,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.3482,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.09,
-    "OperationsPerSecondMean": 0.09,
-    "OperationsPerSecondMedian": 0.09,
-    "OperationsPerSecondMax": 0.09
+    "OperationsPerSecondMin": 0.3441,
+    "OperationsPerSecondMean": 0.35062000000000004,
+    "OperationsPerSecondMedian": 0.3522,
+    "OperationsPerSecondMax": 0.3552
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-08T11:43:27.0633777+00:00",
-    "End": "2022-07-08T11:53:30.2018755+00:00",
+    "Start": "2022-07-30T07:44:02.5171486+00:00",
+    "End": "2022-07-30T07:54:04.8808603+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "UploadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "UploadBlob",
     "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "12.10.0"
+      "Azure.Storage.Blobs": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -502,68 +640,344 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.55,
+        "OperationsPerSecond": 1.394,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.64,
+        "OperationsPerSecond": 1.395,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.6,
+        "OperationsPerSecond": 1.394,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.64,
+        "OperationsPerSecond": 1.394,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.10.0+6b5e9e08afc63d6a5eb77587b79e8554668e1926"
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
         },
-        "OperationsPerSecond": 0.61,
+        "OperationsPerSecond": 1.395,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.55,
-    "OperationsPerSecondMean": 0.608,
-    "OperationsPerSecondMedian": 0.61,
-    "OperationsPerSecondMax": 0.64
+    "OperationsPerSecondMin": 1.394,
+    "OperationsPerSecondMean": 1.3943999999999999,
+    "OperationsPerSecondMedian": 1.394,
+    "OperationsPerSecondMax": 1.395
   },
   {
-    "Service": "storage-file-share",
-    "Test": "download",
-    "Start": "2022-07-08T11:54:07.4880898+00:00",
-    "End": "2022-07-08T11:55:29.4756342+00:00",
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T07:54:04.881384+00:00",
+    "End": "2022-07-30T07:55:22.4511004+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "DownloadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "GetBlobs",
+    "Arguments": "--count 5 --parallel 64",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "12.13.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 11505,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 11518,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 11325,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 11092,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 11478,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 11092,
+    "OperationsPerSecondMean": 11383.6,
+    "OperationsPerSecondMedian": 11478,
+    "OperationsPerSecondMax": 11518
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T07:55:22.451109+00:00",
+    "End": "2022-07-30T07:56:41.1156334+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "GetBlobs",
+    "Arguments": "--count 500 --parallel 32",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "12.13.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 273.6,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 275.2,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 273.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 274,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 280.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 273.5,
+    "OperationsPerSecondMean": 275.34,
+    "OperationsPerSecondMedian": 274,
+    "OperationsPerSecondMax": 280.4
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T07:56:41.1156429+00:00",
+    "End": "2022-07-30T07:57:33.3363229+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "GetBlobs",
+    "Arguments": "--count 500 --parallel 32 --sync",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "12.13.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": ""
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. System.Xml.XmlException: Unexpected end of file while parsing Name has occurred. Line 1, position 272348.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ParseQName(Boolean isQName, Int32 startOffset, Int32& colonPos)\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r, LoadOptions o)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.Xml.XmlException: Unexpected end of file while parsing Name has occurred. Line 1, position 272348.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ParseQName(Boolean isQName, Int32 startOffset, Int32& colonPos)\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r, LoadOptions o)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\n",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": ""
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "Unhandled exception. Unhandled exception. System.Xml.XmlException: Unexpected end of file while parsing Name has occurred. Line 1, position 130751.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ParseQName(Boolean isQName, Int32 startOffset, Int32& colonPos)\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r, LoadOptions o)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()System.Xml.XmlException: Unexpected end of file while parsing Name has occurred. Line 1, position 272348.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ParseQName(Boolean isQName, Int32 startOffset, Int32& colonPos)\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r, LoadOptions o)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\n\n",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": ""
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "Unhandled exception. System.Xml.XmlException: Root element is missing.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.ParseDocumentContent()\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\n",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": ""
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. System.NotSupportedException:  The ReadAsync method cannot be called when another read operation is pending.\n   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)\n   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at System.Net.Http.HttpConnection.Fill()\n   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.Read(Span`1 buffer)\n   at System.Net.Http.HttpBaseStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.CopyTo(Stream source, Stream destination, CancellationTokenSource cancellationTokenSource)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.LoggingPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.RedirectPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RedirectPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RetryPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipeline.Send(HttpMessage message, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.NotSupportedException:  The ReadAsync method cannot be called when another read operation is pending.\n   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)\n   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at System.Net.Http.HttpConnection.Fill()\n   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.Read(Span`1 buffer)\n   at System.Net.Http.HttpBaseStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.CopyTo(Stream source, Stream destination, CancellationTokenSource cancellationTokenSource)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.LoggingPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.RedirectPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RedirectPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RetryPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipeline.Send(HttpMessage message, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.NotSupportedException:  The ReadAsync method cannot be called when another read operation is pending.\n   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)\n   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at System.IO.Stream.Read(Span`1 buffer)\n   at System.Net.Http.HttpConnection.Read(Span`1 destination)\n   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.Read(Span`1 buffer)\n   at System.Net.Http.HttpBaseStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.CopyTo(Stream source, Stream destination, CancellationTokenSource cancellationTokenSource)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.LoggingPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.RedirectPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RedirectPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RetryPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipeline.Send(HttpMessage message, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.NotSupportedException:  The ReadAsync method cannot be called when another read operation is pending.\n   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)\n   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at System.Net.Http.HttpConnection.Fill()\n   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.Read(Span`1 buffer)\n   at System.Net.Http.HttpBaseStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.CopyTo(Stream source, Stream destination, CancellationTokenSource cancellationTokenSource)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.LoggingPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.RedirectPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RedirectPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async)\n   at Azure.Core.Pipeline.RetryPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline)\n   at Azure.Core.Pipeline.HttpPipeline.Send(HttpMessage message, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\n",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": ""
+        },
+        "OperationsPerSecond": 244.2,
+        "StandardOutput": "",
+        "StandardError": "Unhandled exception. Unhandled exception.Unhandled exception.  Unhandled exception.Unhandled exception. Unhandled exception.  Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. System.Xml.XmlException: Unexpected end of file has occurred. The following elements are not closed: Properties, Blob, Blobs, EnumerationResults. Line 1, position 65215.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ThrowUnclosedElements()\n   at System.Xml.XmlTextReaderImpl.ParseAttributes()\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.Xml.XmlException: Unexpected end of file has occurred. The following elements are not closed: Properties, Blob, Blobs, EnumerationResults. Line 1, position 65215.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ThrowUnclosedElements()\n   at System.Xml.XmlTextReaderImpl.ParseAttributes()\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.Xml.XmlException: Unexpected end of file has occurred. The following elements are not closed: Properties, Blob, Blobs, EnumerationResults. Line 1, position 65215.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ThrowUnclosedElements()\n   at System.Xml.XmlTextReaderImpl.ParseAttributes()\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.Xml.XmlException: Unexpected end of file has occurred. The following elements are not closed: Last-Modified, Properties, Blob, Blobs, EnumerationResults. Line 1, position 243676.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ThrowUnclosedElements()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.Xml.XmlException: Unexpected end of file while parsing Name has occurred. Line 1, position 130751.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ParseQName(Boolean isQName, Int32 startOffset, Int32& colonPos)\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.Xml.XmlException: Unexpected end of file has occurred. The following elements are not closed: Properties, Blob, Blobs, EnumerationResults. Line 1, position 65215.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ThrowUnclosedElements()\n   at System.Xml.XmlTextReaderImpl.ParseAttributes()\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.Xml.XmlException: Unexpected end of file has occurred. The following elements are not closed: Properties, Blob, Blobs, EnumerationResults. Line 1, position 65215.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ThrowUnclosedElements()\n   at System.Xml.XmlTextReaderImpl.ParseAttributes()\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken)\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task)\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext()\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\n",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": -1,
+    "OperationsPerSecondMean": 48.04,
+    "OperationsPerSecondMedian": -1,
+    "OperationsPerSecondMax": 244.2
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T07:57:33.3363357+00:00",
+    "End": "2022-07-30T08:08:15.0850789+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "GetBlobs",
+    "Arguments": "--count 50000 --parallel 32 --warmup 60 --duration 60",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "12.13.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 2.676,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 2.719,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 2.677,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 2.704,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.13.0+dd17f33e411562517144e4b6b16f5ea910e5c5ae"
+        },
+        "OperationsPerSecond": 2.702,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 2.676,
+    "OperationsPerSecondMean": 2.6955999999999998,
+    "OperationsPerSecondMedian": 2.702,
+    "OperationsPerSecondMax": 2.719
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T08:08:55.3009833+00:00",
+    "End": "2022-07-30T08:10:13.1236882+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "DownloadBlob",
     "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "source"
+      "Azure.Storage.Blobs": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -571,68 +985,68 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 16179.54,
+        "OperationsPerSecond": 14199,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 15209.52,
+        "OperationsPerSecond": 13944,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 16100.35,
+        "OperationsPerSecond": 14294,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 16153.63,
+        "OperationsPerSecond": 14513,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 16317.03,
+        "OperationsPerSecond": 14512,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 15209.52,
-    "OperationsPerSecondMean": 15992.014000000001,
-    "OperationsPerSecondMedian": 16153.63,
-    "OperationsPerSecondMax": 16317.03
+    "OperationsPerSecondMin": 13944,
+    "OperationsPerSecondMean": 14292.4,
+    "OperationsPerSecondMedian": 14294,
+    "OperationsPerSecondMax": 14513
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-08T11:55:29.4758041+00:00",
-    "End": "2022-07-08T11:56:51.1675109+00:00",
+    "Start": "2022-07-30T08:10:13.1236984+00:00",
+    "End": "2022-07-30T08:11:31.0886966+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "DownloadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "DownloadBlob",
     "Arguments": "--size 10485760 --parallel 32",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "source"
+      "Azure.Storage.Blobs": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -640,68 +1054,137 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 162.99,
+        "OperationsPerSecond": 166.2,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 165.65,
+        "OperationsPerSecond": 171,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 162.42,
+        "OperationsPerSecond": 171.4,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 162.95,
+        "OperationsPerSecond": 172.1,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 166.49,
+        "OperationsPerSecond": 168.4,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 162.42,
-    "OperationsPerSecondMean": 164.1,
-    "OperationsPerSecondMedian": 162.99,
-    "OperationsPerSecondMax": 166.49
+    "OperationsPerSecondMin": 166.2,
+    "OperationsPerSecondMean": 169.82,
+    "OperationsPerSecondMedian": 171,
+    "OperationsPerSecondMax": 172.1
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-08T11:56:51.1675245+00:00",
-    "End": "2022-07-08T12:07:51.1427047+00:00",
+    "Start": "2022-07-30T08:11:31.0887048+00:00",
+    "End": "2022-07-30T08:12:49.6981314+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "DownloadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "DownloadBlob",
+    "Arguments": "--size 10485760 --parallel 32 --sync",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 183.2,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 182.4,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 182.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 182.6,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 184.6,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 182.4,
+    "OperationsPerSecondMean": 183.06,
+    "OperationsPerSecondMedian": 182.6,
+    "OperationsPerSecondMax": 184.6
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-30T08:12:49.6981426+00:00",
+    "End": "2022-07-30T08:23:06.9668547+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "DownloadBlob",
     "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "source"
+      "Azure.Storage.Blobs": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -709,68 +1192,68 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 0.1694,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 0.1532,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.1,
+        "OperationsPerSecond": 0.1571,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.11,
+        "OperationsPerSecond": 0.2635,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.12,
+        "OperationsPerSecond": 0.1525,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.1,
-    "OperationsPerSecondMean": 0.10600000000000001,
-    "OperationsPerSecondMedian": 0.1,
-    "OperationsPerSecondMax": 0.12
+    "OperationsPerSecondMin": 0.1525,
+    "OperationsPerSecondMean": 0.17914000000000002,
+    "OperationsPerSecondMedian": 0.1571,
+    "OperationsPerSecondMax": 0.2635
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-08T12:07:51.1427148+00:00",
-    "End": "2022-07-08T12:18:56.1290412+00:00",
+    "Start": "2022-07-30T08:23:06.9668638+00:00",
+    "End": "2022-07-30T08:33:24.1286556+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "DownloadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "DownloadBlob",
     "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "source"
+      "Azure.Storage.Blobs": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -778,68 +1261,68 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.84,
+        "OperationsPerSecond": 0.9882,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.85,
+        "OperationsPerSecond": 0.9775,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.89,
+        "OperationsPerSecond": 0.9257,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.88,
+        "OperationsPerSecond": 0.8306,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.84,
+        "OperationsPerSecond": 0.9473,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.84,
-    "OperationsPerSecondMean": 0.86,
-    "OperationsPerSecondMedian": 0.85,
-    "OperationsPerSecondMax": 0.89
+    "OperationsPerSecondMin": 0.8306,
+    "OperationsPerSecondMean": 0.9338599999999999,
+    "OperationsPerSecondMedian": 0.9473,
+    "OperationsPerSecondMax": 0.9882
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-08T12:18:56.1290835+00:00",
-    "End": "2022-07-08T12:20:20.2433422+00:00",
+    "Start": "2022-07-30T08:33:24.1288415+00:00",
+    "End": "2022-07-30T08:34:43.5602591+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "UploadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "UploadBlob",
     "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "source"
+      "Azure.Storage.Blobs": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -847,68 +1330,68 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 15008.36,
+        "OperationsPerSecond": 11898,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 14669.41,
+        "OperationsPerSecond": 11834,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 14746.2,
+        "OperationsPerSecond": 9394,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 14854.8,
+        "OperationsPerSecond": 11791,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 14749.12,
+        "OperationsPerSecond": 12229,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 14669.41,
-    "OperationsPerSecondMean": 14805.578,
-    "OperationsPerSecondMedian": 14749.12,
-    "OperationsPerSecondMax": 15008.36
+    "OperationsPerSecondMin": 9394,
+    "OperationsPerSecondMean": 11429.2,
+    "OperationsPerSecondMedian": 11834,
+    "OperationsPerSecondMax": 12229
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-08T12:20:20.2433544+00:00",
-    "End": "2022-07-08T12:21:39.9039672+00:00",
+    "Start": "2022-07-30T08:34:43.5602756+00:00",
+    "End": "2022-07-30T08:36:01.027808+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "UploadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "UploadBlob",
     "Arguments": "--size 10485760 --parallel 32",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "source"
+      "Azure.Storage.Blobs": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -916,7 +1399,103 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 142.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 142.7,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 142.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 142.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 142.8,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 142.7,
+    "OperationsPerSecondMean": 142.84,
+    "OperationsPerSecondMedian": 142.9,
+    "OperationsPerSecondMax": 142.9
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "upload",
+    "Start": "2022-07-30T08:36:01.0278152+00:00",
+    "End": "2022-07-30T08:37:18.4934161+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "UploadBlob",
+    "Arguments": "--size 10485760 --parallel 32 --sync",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 142.9,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 143.3,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 142.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
         "OperationsPerSecond": 143,
         "StandardOutput": "",
@@ -925,59 +1504,32 @@
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
-        },
-        "OperationsPerSecond": 143.09,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
-        },
-        "OperationsPerSecond": 142.76,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
         "OperationsPerSecond": 143,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
-        },
-        "OperationsPerSecond": 142.59,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 142.59,
-    "OperationsPerSecondMean": 142.888,
+    "OperationsPerSecondMin": 142.5,
+    "OperationsPerSecondMean": 142.94,
     "OperationsPerSecondMedian": 143,
-    "OperationsPerSecondMax": 143.09
+    "OperationsPerSecondMax": 143.3
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-08T12:21:39.9039791+00:00",
-    "End": "2022-07-08T12:31:42.4820459+00:00",
+    "Start": "2022-07-30T08:37:18.4934268+00:00",
+    "End": "2022-07-30T08:47:20.707908+00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "UploadFile",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "UploadBlob",
     "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "source"
+      "Azure.Storage.Blobs": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -985,68 +1537,344 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.3452,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 0.3507,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.3492,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.3516,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.3515,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.08,
-    "OperationsPerSecondMean": 0.088,
-    "OperationsPerSecondMedian": 0.09,
-    "OperationsPerSecondMax": 0.09
+    "OperationsPerSecondMin": 0.3452,
+    "OperationsPerSecondMean": 0.34964,
+    "OperationsPerSecondMedian": 0.3507,
+    "OperationsPerSecondMax": 0.3516
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "upload",
-    "Start": "2022-07-08T12:31:42.4820552+00:00",
+    "Start": "2022-07-30T08:47:20.707916+00:00",
+    "End": "2022-07-30T08:57:23.1228342+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "UploadBlob",
+    "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 1.394,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 1.394,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 1.394,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 1.394,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 1.394,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 1.394,
+    "OperationsPerSecondMean": 1.394,
+    "OperationsPerSecondMedian": 1.394,
+    "OperationsPerSecondMax": 1.394
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T08:57:23.1233276+00:00",
+    "End": "2022-07-30T08:58:40.6932952+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "GetBlobs",
+    "Arguments": "--count 5 --parallel 64",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 11426,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 11485,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 11449,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 11448,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 11527,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 11426,
+    "OperationsPerSecondMean": 11467,
+    "OperationsPerSecondMedian": 11449,
+    "OperationsPerSecondMax": 11527
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T08:58:40.6933026+00:00",
+    "End": "2022-07-30T08:59:59.6777127+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "GetBlobs",
+    "Arguments": "--count 500 --parallel 32",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 275.7,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 271.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 276,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 275.5,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
+        },
+        "OperationsPerSecond": 272.8,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 271.5,
+    "OperationsPerSecondMean": 274.3,
+    "OperationsPerSecondMedian": 275.5,
+    "OperationsPerSecondMax": 276
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T08:59:59.677721+00:00",
+    "End": "2022-07-30T09:00:30.554258+00:00",
+    "Language": "net",
+    "LanguageVersion": "netcoreapp3.1",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "GetBlobs",
+    "Arguments": "--count 500 --parallel 32 --sync",
+    "PrimaryPackage": "Azure.Storage.Blobs",
+    "PackageVersions": {
+      "Azure.Storage.Blobs": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": ""
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "Unhandled exception. Unhandled exception. Unhandled exception. System.Xml.XmlException: Unexpected end of file has occurred. The following elements are not closed: Properties, Blob, Blobs, EnumerationResults. Line 1, position 65215.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ThrowUnclosedElements()\n   at System.Xml.XmlTextReaderImpl.ParseAttributes()\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()System.Xml.XmlException: Unexpected end of file has occurred. The following elements are not closed: Properties, Blob, Blobs, EnumerationResults. Line 1, position 65215.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ThrowUnclosedElements()\n   at System.Xml.XmlTextReaderImpl.ParseAttributes()\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\n\n",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": ""
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "Unhandled exception. System.Xml.XmlException: Root element is missing.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.ParseDocumentContent()\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\n",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": ""
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. System.Xml.XmlException: Root element is missing.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.ParseDocumentContent()\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.NotSupportedException:  The ReadAsync method cannot be called when another read operation is pending.\n   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)\n   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at System.Net.Http.HttpConnection.Fill()\n   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.Read(Span`1 buffer)\n   at System.Net.Http.HttpBaseStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.CopyTo(Stream source, Stream destination, CancellationTokenSource cancellationTokenSource) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 151\n   at Azure.Core.Pipeline.ResponseBodyPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 121\n   at Azure.Core.Pipeline.ResponseBodyPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 32\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.LoggingPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/LoggingPolicy.cs:line 44\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.RedirectPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RedirectPolicy.cs:line 33\n   at Azure.Core.Pipeline.RedirectPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RedirectPolicy.cs:line 175\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 61\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 94\n   at Azure.Core.Pipeline.RetryPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 38\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipeline.Send(HttpMessage message, CancellationToken cancellationToken) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs:line 189\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()System.NotSupportedException:  The ReadAsync method cannot be called when another read operation is pending.\n   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)\n   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at System.Net.Http.HttpConnection.Fill()\n   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.Read(Span`1 buffer)\n   at System.Net.Http.HttpBaseStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.CopyTo(Stream source, Stream destination, CancellationTokenSource cancellationTokenSource) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 151\n   at Azure.Core.Pipeline.ResponseBodyPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 121\n   at Azure.Core.Pipeline.ResponseBodyPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 32\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.LoggingPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/LoggingPolicy.cs:line 44\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.RedirectPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RedirectPolicy.cs:line 33\n   at Azure.Core.Pipeline.RedirectPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RedirectPolicy.cs:line 175\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 61\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 94\n   at Azure.Core.Pipeline.RetryPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 38\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipeline.Send(HttpMessage message, CancellationToken cancellationToken) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs:line 189\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\n\nSystem.NotSupportedException:  The ReadAsync method cannot be called when another read operation is pending.\n   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)\n   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at System.Net.Http.HttpConnection.Fill()\n   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.Read(Span`1 buffer)\n   at System.Net.Http.HttpBaseStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.CopyTo(Stream source, Stream destination, CancellationTokenSource cancellationTokenSource) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 151\n   at Azure.Core.Pipeline.ResponseBodyPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 121\n   at Azure.Core.Pipeline.ResponseBodyPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 32\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.LoggingPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/LoggingPolicy.cs:line 44\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.RedirectPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RedirectPolicy.cs:line 33\n   at Azure.Core.Pipeline.RedirectPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RedirectPolicy.cs:line 175\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 61\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 94\n   at Azure.Core.Pipeline.RetryPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 38\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipeline.Send(HttpMessage message, CancellationToken cancellationToken) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs:line 189\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\n",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": ""
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "Unhandled exception. System.NotSupportedException:  The ReadAsync method cannot be called when another read operation is pending.\n   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)\n   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at System.Net.Http.HttpConnection.Fill()\n   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.Read(Span`1 buffer)\n   at System.Net.Http.HttpBaseStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.CopyTo(Stream source, Stream destination, CancellationTokenSource cancellationTokenSource) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 151\n   at Azure.Core.Pipeline.ResponseBodyPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 121\n   at Azure.Core.Pipeline.ResponseBodyPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 32\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.LoggingPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/LoggingPolicy.cs:line 44\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.RedirectPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RedirectPolicy.cs:line 33\n   at Azure.Core.Pipeline.RedirectPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RedirectPolicy.cs:line 175\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 61\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 94\n   at Azure.Core.Pipeline.RetryPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 38\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipeline.Send(HttpMessage message, CancellationToken cancellationToken) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs:line 189\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n   at System.Threading.ThreadHelper.ThreadStart()\n",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "Azure.Storage.Blobs": ""
+        },
+        "OperationsPerSecond": -1,
+        "StandardOutput": "",
+        "StandardError": "Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. Unhandled exception. System.NotSupportedException:  The ReadAsync method cannot be called when another read operation is pending.\n   at System.Net.Security.SslStream.ReadAsyncInternal[TReadAdapter](TReadAdapter adapter, Memory`1 buffer)\n   at System.Net.Security.SslStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at System.Net.Http.HttpConnection.Fill()\n   at System.Net.Http.HttpConnection.ChunkedEncodingReadStream.Read(Span`1 buffer)\n   at System.Net.Http.HttpBaseStream.Read(Byte[] buffer, Int32 offset, Int32 count)\n   at Azure.Core.Pipeline.ResponseBodyPolicy.CopyTo(Stream source, Stream destination, CancellationTokenSource cancellationTokenSource) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 151\n   at Azure.Core.Pipeline.ResponseBodyPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 121\n   at Azure.Core.Pipeline.ResponseBodyPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/ResponseBodyPolicy.cs:line 32\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.LoggingPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/LoggingPolicy.cs:line 44\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.RedirectPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RedirectPolicy.cs:line 33\n   at Azure.Core.Pipeline.RedirectPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RedirectPolicy.cs:line 175\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 61\n   at Azure.Core.Pipeline.RetryPolicy.ProcessAsync(HttpMessage message, ReadOnlyMemory`1 pipeline, Boolean async) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 94\n   at Azure.Core.Pipeline.RetryPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/Internal/RetryPolicy.cs:line 38\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipelinePolicy.ProcessNext(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelinePolicy.cs:line 49\n   at Azure.Core.Pipeline.HttpPipelineSynchronousPolicy.Process(HttpMessage message, ReadOnlyMemory`1 pipeline) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipelineSynchronousPolicy.cs:line 37\n   at Azure.Core.Pipeline.HttpPipeline.Send(HttpMessage message, CancellationToken cancellationToken) in /_/sdk/core/Azure.Core/src/Pipeline/HttpPipeline.cs:line 189\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.Xml.XmlException: Unexpected end of file while parsing Name has occurred. Line 1, position 32447.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ParseQName(Boolean isQName, Int32 startOffset, Int32& colonPos)\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\nSystem.Xml.XmlException: Unexpected end of file while parsing Name has occurred. Line 1, position 16063.\n   at System.Xml.XmlTextReaderImpl.Throw(Exception e)\n   at System.Xml.XmlTextReaderImpl.Throw(String res, String arg)\n   at System.Xml.XmlTextReaderImpl.ParseQName(Boolean isQName, Int32 startOffset, Int32& colonPos)\n   at System.Xml.XmlTextReaderImpl.ParseElement()\n   at System.Xml.XmlTextReaderImpl.ParseElementContent()\n   at System.Xml.Linq.XContainer.ReadContentFrom(XmlReader r)\n   at System.Xml.Linq.XDocument.Load(XmlReader reader, LoadOptions options)\n   at System.Xml.Linq.XDocument.Load(Stream stream, LoadOptions options)\n   at Azure.Storage.Blobs.ContainerRestClient.ListBlobFlatSegment(String prefix, String marker, Nullable`1 maxresults, IEnumerable`1 include, Nullable`1 timeout, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Generated/ContainerRestClient.cs:line 1309\n   at Azure.Storage.Blobs.BlobContainerClient.GetBlobsInternal(String marker, BlobTraits traits, BlobStates states, String prefix, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/BlobContainerClient.cs:line 2599\n   at Azure.Storage.Blobs.Models.GetBlobsAsyncCollection.GetNextPageAsync(String continuationToken, Nullable`1 pageSizeHint, Boolean async, CancellationToken cancellationToken) in /_/sdk/storage/Azure.Storage.Blobs/src/Models/GetBlobsAsyncCollection.cs:line 71\n   at Azure.Core.Pipeline.TaskExtensions.EnsureCompleted[T](ValueTask`1 task) in /_/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs:line 53\n   at Azure.Storage.StorageCollectionEnumerator`1.StoragePageable.GetEnumerator()+MoveNext() in /_/sdk/storage/Azure.Storage.Common/src/Shared/StorageCollectionEnumerator.cs:line 103\n   at Azure.Storage.Blobs.Perf.Scenarios.GetBlobs.Run(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Scenarios/GetBlobs.cs:line 38\n   at Azure.Test.Perf.PerfTest`1.RunBatch(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfTest.cs:line 18\n   at Azure.Test.Perf.BatchPerfTest`1.RunAll(CancellationToken cancellationToken) in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/BatchPerfTest.cs:line 165\n   at Azure.Test.Perf.PerfProgram.<>c__DisplayClass20_1.<RunTestsAsync>b__2() in /mnt/vss/_work/1/s/common/Perf/Azure.Test.Perf/PerfProgram.cs:line 377\n   at System.Threading.ThreadHelper.ThreadStart_Context(Object state)\n   at System.Threading.ExecutionContext.RunInternal(ExecutionContext executionContext, ContextCallback callback, Object state)\n--- End of stack trace from previous location where exception was thrown ---\n   at System.Threading.ThreadHelper.ThreadStart()\n",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": -1,
+    "OperationsPerSecondMean": -1,
+    "OperationsPerSecondMedian": -1,
+    "OperationsPerSecondMax": -1
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-30T09:00:30.5542653+00:00",
     "End": "0001-01-01T00:00:00",
     "Language": "net",
     "LanguageVersion": "netcoreapp3.1",
-    "Project": "sdk/storage/Azure.Storage.Files.Shares/perf/Azure.Storage.Files.Shares.Perf/Azure.Storage.Files.Shares.Perf.csproj",
-    "LanguageTestName": "UploadFile",
-    "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "Azure.Storage.Files.Shares",
+    "Project": "sdk/storage/Azure.Storage.Blobs/perf/Azure.Storage.Blobs.Perf/Azure.Storage.Blobs.Perf.csproj",
+    "LanguageTestName": "GetBlobs",
+    "Arguments": "--count 50000 --parallel 32 --warmup 60 --duration 60",
+    "PrimaryPackage": "Azure.Storage.Blobs",
     "PackageVersions": {
-      "Azure.Storage.Files.Shares": "source"
+      "Azure.Storage.Blobs": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -1054,53 +1882,53 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.7,
+        "OperationsPerSecond": 2.708,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.69,
+        "OperationsPerSecond": 2.746,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.68,
+        "OperationsPerSecond": 2.706,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.68,
+        "OperationsPerSecond": 2.705,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "Azure.Storage.Files.Shares": "12.11.0-alpha.20220708.1+f9604b584eadeaa9dcd188056c0d63f449ed602d"
+          "Azure.Storage.Blobs": "12.14.0-alpha.20220730.1+ca51366a7e39fd256da50f7553518504d7c72b22"
         },
-        "OperationsPerSecond": 0.54,
+        "OperationsPerSecond": 2.705,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.54,
-    "OperationsPerSecondMean": 0.658,
-    "OperationsPerSecondMedian": 0.68,
-    "OperationsPerSecondMax": 0.7
+    "OperationsPerSecondMin": 2.705,
+    "OperationsPerSecondMean": 2.714,
+    "OperationsPerSecondMedian": 2.706,
+    "OperationsPerSecondMax": 2.746
   }
 ]

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation.Tests/results/python.json
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation.Tests/results/python.json
@@ -1,17 +1,17 @@
 [
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T11:03:47.4712877+00:00",
-    "End": "2022-07-11T11:05:12.8362394+00:00",
+    "Start": "2022-07-29T05:26:50.218959+00:00",
+    "End": "2022-07-29T05:27:43.586705+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
     "LanguageTestName": "DownloadTest",
     "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "12.8.0"
+      "azure-storage-blob": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -19,68 +19,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 412,
+        "OperationsPerSecond": 398.8,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 407.26,
+        "OperationsPerSecond": 399.3,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 411.76,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 417.36,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 411.94,
+        "OperationsPerSecond": 405.4,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 407.26,
-    "OperationsPerSecondMean": 412.064,
-    "OperationsPerSecondMedian": 411.94,
-    "OperationsPerSecondMax": 417.36
+    "OperationsPerSecondMin": 398.8,
+    "OperationsPerSecondMean": 401.1666666666667,
+    "OperationsPerSecondMedian": 399.3,
+    "OperationsPerSecondMax": 405.4
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T11:05:12.8363227+00:00",
-    "End": "2022-07-11T11:10:35.6061167+00:00",
+    "Start": "2022-07-29T05:27:43.5868033+00:00",
+    "End": "2022-07-29T05:28:35.4107803+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
     "LanguageTestName": "DownloadTest",
     "Arguments": "--size 10485760 --parallel 32",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "12.8.0"
+      "azure-storage-blob": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -88,68 +70,101 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 8.79,
+        "OperationsPerSecond": 45.51,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 8.49,
+        "OperationsPerSecond": 45.88,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 5.13,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 7.48,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 8.45,
+        "OperationsPerSecond": 45.38,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 5.13,
-    "OperationsPerSecondMean": 7.668000000000001,
-    "OperationsPerSecondMedian": 8.45,
-    "OperationsPerSecondMax": 8.79
+    "OperationsPerSecondMin": 45.38,
+    "OperationsPerSecondMean": 45.59,
+    "OperationsPerSecondMedian": 45.51,
+    "OperationsPerSecondMax": 45.88
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T11:10:35.6061397+00:00",
-    "End": "2022-07-11T11:23:03.5009751+00:00",
+    "Start": "2022-07-29T05:28:35.4107907+00:00",
+    "End": "2022-07-29T05:29:31.677821+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
+    "LanguageTestName": "DownloadTest",
+    "Arguments": "--size 10485760 --parallel 32 --sync",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "12.13.0"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
+        },
+        "OperationsPerSecond": 16.67,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
+        },
+        "OperationsPerSecond": 16.49,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
+        },
+        "OperationsPerSecond": 16.03,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 16.03,
+    "OperationsPerSecondMean": 16.396666666666665,
+    "OperationsPerSecondMedian": 16.49,
+    "OperationsPerSecondMax": 16.67
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-29T05:29:31.6778408+00:00",
+    "End": "2022-07-29T05:36:59.8168689+00:00",
+    "Language": "python",
+    "LanguageVersion": "3.7.12",
+    "Project": "sdk/storage/azure-storage-blob",
     "LanguageTestName": "DownloadTest",
     "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "12.8.0"
+      "azure-storage-blob": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -157,68 +172,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 0.1234,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 0.1271,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.08,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 0.08,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 0.1262,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.08,
-    "OperationsPerSecondMean": 0.08,
-    "OperationsPerSecondMedian": 0.08,
-    "OperationsPerSecondMax": 0.08
+    "OperationsPerSecondMin": 0.1234,
+    "OperationsPerSecondMean": 0.1255666666666667,
+    "OperationsPerSecondMedian": 0.1262,
+    "OperationsPerSecondMax": 0.1271
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T11:23:03.5009858+00:00",
-    "End": "2022-07-11T11:44:15.9816047+00:00",
+    "Start": "2022-07-29T05:36:59.8168777+00:00",
+    "End": "2022-07-29T05:44:49.4575594+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
     "LanguageTestName": "DownloadTest",
     "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "12.8.0"
+      "azure-storage-blob": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -226,68 +223,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.14,
+        "OperationsPerSecond": 0.3966,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.14,
+        "OperationsPerSecond": 0.4177,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.12,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 0.14,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 0.15,
+        "OperationsPerSecond": 0.4143,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.12,
-    "OperationsPerSecondMean": 0.138,
-    "OperationsPerSecondMedian": 0.14,
-    "OperationsPerSecondMax": 0.15
+    "OperationsPerSecondMin": 0.3966,
+    "OperationsPerSecondMean": 0.40953333333333336,
+    "OperationsPerSecondMedian": 0.4143,
+    "OperationsPerSecondMax": 0.4177
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T11:44:15.9816608+00:00",
-    "End": "2022-07-11T11:45:39.3045082+00:00",
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-29T05:44:49.4576526+00:00",
+    "End": "2022-07-29T05:45:41.6878258+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
-    "LanguageTestName": "UploadTest",
-    "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
+    "LanguageTestName": "ListBlobsTest",
+    "Arguments": "--count 5 --parallel 64",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "12.8.0"
+      "azure-storage-blob": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -295,68 +274,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 208.97,
+        "OperationsPerSecond": 259.2,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 212.57,
+        "OperationsPerSecond": 260.2,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 212.74,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 210.39,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 213.32,
+        "OperationsPerSecond": 260.6,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 208.97,
-    "OperationsPerSecondMean": 211.598,
-    "OperationsPerSecondMedian": 212.57,
-    "OperationsPerSecondMax": 213.32
+    "OperationsPerSecondMin": 259.2,
+    "OperationsPerSecondMean": 260,
+    "OperationsPerSecondMedian": 260.2,
+    "OperationsPerSecondMax": 260.6
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T11:45:39.3045207+00:00",
-    "End": "2022-07-11T11:50:22.0600598+00:00",
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-29T05:45:41.6878369+00:00",
+    "End": "2022-07-29T05:46:59.5544866+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
-    "LanguageTestName": "UploadTest",
-    "Arguments": "--size 10485760 --parallel 32",
-    "PrimaryPackage": "azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
+    "LanguageTestName": "ListBlobsTest",
+    "Arguments": "--count 500 --parallel 32",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "12.8.0"
+      "azure-storage-blob": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -364,68 +325,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 5.37,
+        "OperationsPerSecond": 8.733,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 5.42,
+        "OperationsPerSecond": 8.735,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 4.78,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 4.43,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 5.53,
+        "OperationsPerSecond": 8.745,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 4.43,
-    "OperationsPerSecondMean": 5.106,
-    "OperationsPerSecondMedian": 5.37,
-    "OperationsPerSecondMax": 5.53
+    "OperationsPerSecondMin": 8.733,
+    "OperationsPerSecondMean": 8.737666666666668,
+    "OperationsPerSecondMedian": 8.735,
+    "OperationsPerSecondMax": 8.745
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T11:50:22.060071+00:00",
-    "End": "2022-07-11T12:02:45.3563152+00:00",
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-29T05:46:59.554495+00:00",
+    "End": "2022-07-29T05:48:15.3340158+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
-    "LanguageTestName": "UploadTest",
-    "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
+    "LanguageTestName": "ListBlobsTest",
+    "Arguments": "--count 500 --parallel 32 --sync",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "12.8.0"
+      "azure-storage-blob": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -433,68 +376,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.06,
+        "OperationsPerSecond": 7.33,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.02,
+        "OperationsPerSecond": 7.557,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.04,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 0.02,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 0.06,
+        "OperationsPerSecond": 7.44,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.02,
-    "OperationsPerSecondMean": 0.039999999999999994,
-    "OperationsPerSecondMedian": 0.04,
-    "OperationsPerSecondMax": 0.06
+    "OperationsPerSecondMin": 7.33,
+    "OperationsPerSecondMean": 7.442333333333334,
+    "OperationsPerSecondMedian": 7.44,
+    "OperationsPerSecondMax": 7.557
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T12:02:45.3563407+00:00",
-    "End": "2022-07-11T12:24:58.5446399+00:00",
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-29T05:48:15.3340262+00:00",
+    "End": "2022-07-29T06:42:22.3023217+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
-    "LanguageTestName": "UploadTest",
-    "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
+    "LanguageTestName": "ListBlobsTest",
+    "Arguments": "--count 50000 --parallel 32 --warmup 60 --duration 60",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "12.8.0"
+      "azure-storage-blob": "12.13.0"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -502,68 +427,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.11,
+        "OperationsPerSecond": 0.0738,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.14,
+        "OperationsPerSecond": 0.07285,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
+          "azure-storage-blob": "azure-storage-blob==12.13.0"
         },
-        "OperationsPerSecond": 0.12,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 0.15,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "azure-storage-file-share==12.8.0"
-        },
-        "OperationsPerSecond": 0.14,
+        "OperationsPerSecond": 0.07235,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.11,
-    "OperationsPerSecondMean": 0.132,
-    "OperationsPerSecondMedian": 0.14,
-    "OperationsPerSecondMax": 0.15
+    "OperationsPerSecondMin": 0.07235,
+    "OperationsPerSecondMean": 0.073,
+    "OperationsPerSecondMedian": 0.07285,
+    "OperationsPerSecondMax": 0.0738
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T12:25:14.6295787+00:00",
-    "End": "2022-07-11T12:26:38.1234864+00:00",
+    "Start": "2022-07-29T06:42:37.2820143+00:00",
+    "End": "2022-07-29T06:43:27.5083823+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
     "LanguageTestName": "DownloadTest",
     "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "source"
+      "azure-storage-blob": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -571,68 +478,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 412.25,
+        "OperationsPerSecond": 399.4,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 416.78,
+        "OperationsPerSecond": 400.6,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 413.02,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 413.41,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 414.83,
+        "OperationsPerSecond": 402.3,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 412.25,
-    "OperationsPerSecondMean": 414.058,
-    "OperationsPerSecondMedian": 413.41,
-    "OperationsPerSecondMax": 416.78
+    "OperationsPerSecondMin": 399.4,
+    "OperationsPerSecondMean": 400.76666666666665,
+    "OperationsPerSecondMedian": 400.6,
+    "OperationsPerSecondMax": 402.3
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T12:26:38.1236442+00:00",
-    "End": "2022-07-11T12:31:25.2654019+00:00",
+    "Start": "2022-07-29T06:43:27.5083912+00:00",
+    "End": "2022-07-29T06:44:19.475843+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
     "LanguageTestName": "DownloadTest",
     "Arguments": "--size 10485760 --parallel 32",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "source"
+      "azure-storage-blob": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -640,68 +529,101 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 8.5,
+        "OperationsPerSecond": 45.83,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 8.32,
+        "OperationsPerSecond": 43.85,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 9.02,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 9.34,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 8.09,
+        "OperationsPerSecond": 44.32,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 8.09,
-    "OperationsPerSecondMean": 8.654,
-    "OperationsPerSecondMedian": 8.5,
-    "OperationsPerSecondMax": 9.34
+    "OperationsPerSecondMin": 43.85,
+    "OperationsPerSecondMean": 44.666666666666664,
+    "OperationsPerSecondMedian": 44.32,
+    "OperationsPerSecondMax": 45.83
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T12:31:25.2655652+00:00",
-    "End": "2022-07-11T12:44:44.3408194+00:00",
+    "Start": "2022-07-29T06:44:19.4758524+00:00",
+    "End": "2022-07-29T06:45:15.6461572+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
+    "LanguageTestName": "DownloadTest",
+    "Arguments": "--size 10485760 --parallel 32 --sync",
+    "PrimaryPackage": "azure-storage-blob",
+    "PackageVersions": {
+      "azure-storage-blob": "source"
+    },
+    "SetupStandardOutput": "",
+    "SetupStandardError": "",
+    "SetupException": null,
+    "Iterations": [
+      {
+        "PackageVersions": {
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
+        },
+        "OperationsPerSecond": 15.59,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
+        },
+        "OperationsPerSecond": 16.61,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      },
+      {
+        "PackageVersions": {
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
+        },
+        "OperationsPerSecond": 16.21,
+        "StandardOutput": "",
+        "StandardError": "",
+        "Exception": null
+      }
+    ],
+    "OperationsPerSecondMin": 15.59,
+    "OperationsPerSecondMean": 16.136666666666667,
+    "OperationsPerSecondMedian": 16.21,
+    "OperationsPerSecondMax": 16.61
+  },
+  {
+    "Service": "storage-blob",
+    "Test": "download",
+    "Start": "2022-07-29T06:45:15.6461684+00:00",
+    "End": "2022-07-29T06:52:42.499546+00:00",
+    "Language": "python",
+    "LanguageVersion": "3.7.12",
+    "Project": "sdk/storage/azure-storage-blob",
     "LanguageTestName": "DownloadTest",
     "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "source"
+      "azure-storage-blob": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -709,68 +631,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 0.1264,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.09,
+        "OperationsPerSecond": 0.1263,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.06,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 0.08,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 0.08,
+        "OperationsPerSecond": 0.1248,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.06,
-    "OperationsPerSecondMean": 0.078,
-    "OperationsPerSecondMedian": 0.08,
-    "OperationsPerSecondMax": 0.09
+    "OperationsPerSecondMin": 0.1248,
+    "OperationsPerSecondMean": 0.12583333333333335,
+    "OperationsPerSecondMedian": 0.1263,
+    "OperationsPerSecondMax": 0.1264
   },
   {
-    "Service": "storage-file-share",
+    "Service": "storage-blob",
     "Test": "download",
-    "Start": "2022-07-11T12:44:44.3408279+00:00",
-    "End": "2022-07-11T13:04:43.7579708+00:00",
+    "Start": "2022-07-29T06:52:42.4995541+00:00",
+    "End": "2022-07-29T06:59:53.0677152+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
     "LanguageTestName": "DownloadTest",
     "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "source"
+      "azure-storage-blob": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -778,68 +682,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.12,
+        "OperationsPerSecond": 0.3913,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.14,
+        "OperationsPerSecond": 0.3874,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.1,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 0.12,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 0.12,
+        "OperationsPerSecond": 0.3866,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.1,
-    "OperationsPerSecondMean": 0.12,
-    "OperationsPerSecondMedian": 0.12,
-    "OperationsPerSecondMax": 0.14
+    "OperationsPerSecondMin": 0.3866,
+    "OperationsPerSecondMean": 0.38843333333333335,
+    "OperationsPerSecondMedian": 0.3874,
+    "OperationsPerSecondMax": 0.3913
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T13:04:43.7579969+00:00",
-    "End": "2022-07-11T13:06:09.8279117+00:00",
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-29T06:59:53.0677425+00:00",
+    "End": "2022-07-29T07:00:43.6067879+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
-    "LanguageTestName": "UploadTest",
-    "Arguments": "--size 10240 --parallel 64",
-    "PrimaryPackage": "azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
+    "LanguageTestName": "ListBlobsTest",
+    "Arguments": "--count 5 --parallel 64",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "source"
+      "azure-storage-blob": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -847,68 +733,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 210.36,
+        "OperationsPerSecond": 256.7,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 209.21,
+        "OperationsPerSecond": 259.8,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 114.88,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 115.75,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 213.38,
+        "OperationsPerSecond": 257.5,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 114.88,
-    "OperationsPerSecondMean": 172.716,
-    "OperationsPerSecondMedian": 209.21,
-    "OperationsPerSecondMax": 213.38
+    "OperationsPerSecondMin": 256.7,
+    "OperationsPerSecondMean": 258,
+    "OperationsPerSecondMedian": 257.5,
+    "OperationsPerSecondMax": 259.8
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T13:06:09.8279236+00:00",
-    "End": "2022-07-11T13:09:37.9783845+00:00",
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-29T07:00:43.6069495+00:00",
+    "End": "2022-07-29T07:02:01.82108+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
-    "LanguageTestName": "UploadTest",
-    "Arguments": "--size 10485760 --parallel 32",
-    "PrimaryPackage": "azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
+    "LanguageTestName": "ListBlobsTest",
+    "Arguments": "--count 500 --parallel 32",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "source"
+      "azure-storage-blob": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -916,68 +784,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 4.65,
+        "OperationsPerSecond": 8.698,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 5.29,
+        "OperationsPerSecond": 8.723,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 14.18,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 7.47,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 13.87,
+        "OperationsPerSecond": 8.747,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 4.65,
-    "OperationsPerSecondMean": 9.092,
-    "OperationsPerSecondMedian": 7.47,
-    "OperationsPerSecondMax": 14.18
+    "OperationsPerSecondMin": 8.698,
+    "OperationsPerSecondMean": 8.722666666666667,
+    "OperationsPerSecondMedian": 8.723,
+    "OperationsPerSecondMax": 8.747
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T13:09:37.9783952+00:00",
-    "End": "2022-07-11T13:21:21.0385136+00:00",
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-29T07:02:01.8210894+00:00",
+    "End": "2022-07-29T07:03:17.0943083+00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
-    "LanguageTestName": "UploadTest",
-    "Arguments": "--size 1073741824 --parallel 1 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
+    "LanguageTestName": "ListBlobsTest",
+    "Arguments": "--count 500 --parallel 32 --sync",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "source"
+      "azure-storage-blob": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -985,68 +835,50 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.06,
+        "OperationsPerSecond": 7.356,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.07,
+        "OperationsPerSecond": 7.287,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.07,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 0.07,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 0.07,
+        "OperationsPerSecond": 7.434,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.06,
-    "OperationsPerSecondMean": 0.068,
-    "OperationsPerSecondMedian": 0.07,
-    "OperationsPerSecondMax": 0.07
+    "OperationsPerSecondMin": 7.287,
+    "OperationsPerSecondMean": 7.359000000000001,
+    "OperationsPerSecondMedian": 7.356,
+    "OperationsPerSecondMax": 7.434
   },
   {
-    "Service": "storage-file-share",
-    "Test": "upload",
-    "Start": "2022-07-11T13:21:21.0385221+00:00",
+    "Service": "storage-blob",
+    "Test": "list-blobs",
+    "Start": "2022-07-29T07:03:17.0943168+00:00",
     "End": "0001-01-01T00:00:00",
     "Language": "python",
     "LanguageVersion": "3.7.12",
-    "Project": "sdk/storage/azure-storage-file-share",
-    "LanguageTestName": "UploadTest",
-    "Arguments": "--size 1073741824 --parallel 8 --warmup 60 --duration 60",
-    "PrimaryPackage": "azure-storage-file-share",
+    "Project": "sdk/storage/azure-storage-blob",
+    "LanguageTestName": "ListBlobsTest",
+    "Arguments": "--count 50000 --parallel 32 --warmup 60 --duration 60",
+    "PrimaryPackage": "azure-storage-blob",
     "PackageVersions": {
-      "azure-storage-file-share": "source"
+      "azure-storage-blob": "source"
     },
     "SetupStandardOutput": "",
     "SetupStandardError": "",
@@ -1054,53 +886,35 @@
     "Iterations": [
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.13,
+        "OperationsPerSecond": 0.07055,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.13,
+        "OperationsPerSecond": 0.06952,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       },
       {
         "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
+          "azure-storage-blob": "-e git+https://github.com/Azure/azure-sdk-for-python@4429048d442d463d732d54b965bd3db119e3fa44#egg=azure_storage_blob&subdirectory=sdk/storage/azure-storage-blob"
         },
-        "OperationsPerSecond": 0.12,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 0.15,
-        "StandardOutput": "",
-        "StandardError": "",
-        "Exception": null
-      },
-      {
-        "PackageVersions": {
-          "azure-storage-file-share": "-e git+https://github.com/Azure/azure-sdk-for-python@78020f658a4c2e3f7e919e2a50d1845bf3651c0e#egg=azure_storage_file_share&subdirectory=sdk/storage/azure-storage-file-share"
-        },
-        "OperationsPerSecond": 0.13,
+        "OperationsPerSecond": 0.06965,
         "StandardOutput": "",
         "StandardError": "",
         "Exception": null
       }
     ],
-    "OperationsPerSecondMin": 0.12,
-    "OperationsPerSecondMean": 0.132,
-    "OperationsPerSecondMedian": 0.13,
-    "OperationsPerSecondMax": 0.15
+    "OperationsPerSecondMin": 0.06952,
+    "OperationsPerSecondMean": 0.06990666666666667,
+    "OperationsPerSecondMedian": 0.06965,
+    "OperationsPerSecondMax": 0.07055
   }
 ]

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Program.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Program.cs
@@ -554,7 +554,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
 
                     var operationsPerSecondStrings = operationsPerSecond(resultSummary)
                         .Select(o => $"{NumberFormatter.Format(o.operationsPerSecond, 4, groupSeparator: outputFormat != OutputFormat.Csv)}");
-                    var operationsPerSecondDifferencesStrings = operationsPerSecondDifferences(resultSummary).Select(o => $"{o * 100:N2}%");
+                    var operationsPerSecondDifferencesStrings = operationsPerSecondDifferences(resultSummary).Select(o => $"{o * 100:N1}%");
 
                     var values = operationsPerSecondStrings.Take(1).Concat(operationsPerSecondStrings.Skip(1)
                         .Zip(operationsPerSecondDifferencesStrings, (f, s) => new[] { f, s }).SelectMany(f => f));

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/TableGenerator.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/TableGenerator.cs
@@ -70,7 +70,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
 
                     // Right-align numbers and percentages, left-align everything else
                     if (double.TryParse(cell, out var _) ||
-                        (cell.EndsWith('%') && double.TryParse(cell.Substring(0, cell.Length - 1), out var _)))
+                        (cell != null && cell.EndsWith('%') && double.TryParse(cell.Substring(0, cell.Length - 1), out var _)))
                     {
                         sb.AppendFormat($" {{0,{columnWidths[i]}}} ", cell);
                     }

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/TableGenerator.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/TableGenerator.cs
@@ -67,7 +67,17 @@ namespace Azure.Sdk.Tools.PerfAutomation
                 for (var i = 0; i < columnWidths.Count; i++)
                 {
                     var cell = (row.Count > i) ? row[i] : null;
-                    sb.AppendFormat($" {{0,-{columnWidths[i]}}} ", cell);
+
+                    // Right-align numbers and percentages, left-align everything else
+                    if (double.TryParse(cell, out var _) ||
+                        (cell.EndsWith('%') && double.TryParse(cell.Substring(0, cell.Length - 1), out var _)))
+                    {
+                        sb.AppendFormat($" {{0,{columnWidths[i]}}} ", cell);
+                    }
+                    else
+                    {
+                        sb.AppendFormat($" {{0,-{columnWidths[i]}}} ", cell);
+                    }
                     sb.Append('|');
                 }
                 sb.AppendLine();


### PR DESCRIPTION
- Change percentages from two to one decimal place, since our results are not stable enough to justify two decimals
- Update sample results to 4 significant figures
- Fixes #3703

## Before
```
|----------|----------------------------------------------------------|---------|---------|---------|
| Test     | Arguments                                                | 12.10.0 | source  | %Change |
|----------|----------------------------------------------------------|---------|---------|---------|
| download | --size 10240 --parallel 64                               | 14,999  | 16,317  | 8.79%   |
| download | --size 10485760 --parallel 32                            | 166.8   | 166.5   | -0.19%  |
| download | --size 1073741824 --parallel 1 --warmup 60 --duration 60 | 0.1100  | 0.1200  | 9.09%   |
| download | --size 1073741824 --parallel 8 --warmup 60 --duration 60 | 0.8800  | 0.8900  | 1.14%   |
|----------|----------------------------------------------------------|---------|---------|---------|
| upload   | --size 10240 --parallel 64                               | 13,426  | 15,008  | 11.79%  |
| upload   | --size 10485760 --parallel 32                            | 80.93   | 143.1   | 76.81%  |
| upload   | --size 1073741824 --parallel 1 --warmup 60 --duration 60 | 0.09000 | 0.09000 | 0.00%   |
| upload   | --size 1073741824 --parallel 8 --warmup 60 --duration 60 | 0.6400  | 0.7000  | 9.38%   |
|----------|----------------------------------------------------------|---------|---------|---------|
```

## After
```
|----------|----------------------------------------------------------|---------|---------|---------|
| Test     | Arguments                                                | 12.10.0 | source  | %Change |
|----------|----------------------------------------------------------|---------|---------|---------|
| download | --size 10240 --parallel 64                               |  14,999 |  16,317 |    8.8% |
| download | --size 10485760 --parallel 32                            |   166.8 |   166.5 |   -0.2% |
| download | --size 1073741824 --parallel 1 --warmup 60 --duration 60 |  0.1100 |  0.1200 |    9.1% |
| download | --size 1073741824 --parallel 8 --warmup 60 --duration 60 |  0.8800 |  0.8900 |    1.1% |
|----------|----------------------------------------------------------|---------|---------|---------|
| upload   | --size 10240 --parallel 64                               |  13,426 |  15,008 |   11.8% |
| upload   | --size 10485760 --parallel 32                            |   80.93 |   143.1 |   76.8% |
| upload   | --size 1073741824 --parallel 1 --warmup 60 --duration 60 | 0.09000 | 0.09000 |    0.0% |
| upload   | --size 1073741824 --parallel 8 --warmup 60 --duration 60 |  0.6400 |  0.7000 |    9.4% |
|----------|----------------------------------------------------------|---------|---------|---------|
```