### PR TITLE
Improved Java reference docs in APIView

### DIFF
--- a/src/java/apiview-java-processor/pom.xml
+++ b/src/java/apiview-java-processor/pom.xml
@@ -53,6 +53,11 @@
       <version>4.0.0</version> <!-- {x-version-update;org.mockito:mockito-core;external_dependency} -->
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+          <version>2.6</version>
+      </dependency>
   </dependencies>
 
   <build>

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -70,6 +70,8 @@ import java.util.stream.Collector;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.lang.StringEscapeUtils;
+
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.attemptToFindJavadocComment;
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPackageName;
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.isInterfaceType;
@@ -1388,11 +1390,15 @@ public class JavaASTAnalyser implements Analyser {
             // we want to wrap our javadocs so that they are easier to read, so we wrap at 120 chars
             final String wrappedString = MiscUtils.wrap(line, 120);
             Arrays.stream(SPLIT_NEWLINE.split(wrappedString)).forEach(line2 -> {
+                if (line2.contains("&")) {
+                    line2 = StringEscapeUtils.unescapeHtml(line2);
+                }
                 addToken(makeWhitespace());
                 addToken(new Token(COMMENT, line2));
                 addNewLine();
             });
         });
+        addToken(makeWhitespace());
         addToken(new Token(DOCUMENTATION_RANGE_END));
     }
 


### PR DESCRIPTION
The indentation error and HTML escape characters have been rectified. The padding around the first line in each text section was deemed an APIView bug and an issue has been created to address it.
Fixes #3769 
**Indentation Before/After:**
<img width="915" alt="Screen Shot 2022-08-02 at 12 10 14 PM" src="https://user-images.githubusercontent.com/87786853/182266355-8a6b386d-968b-4e12-9ff4-12cc85a355cb.png">
<img width="874" alt="Screen Shot 2022-08-02 at 12 13 29 PM" src="https://user-images.githubusercontent.com/87786853/182266370-455935de-7f5d-4a55-87a7-98eb893f7fd0.png">
**HTML escape characters Before/After:**
<img width="1005" alt="Screen Shot 2022-08-02 at 12 07 15 PM" src="https://user-images.githubusercontent.com/87786853/182266452-37b0030a-f6b4-44a7-92f2-4ea5b4a49419.png">
<img width="978" alt="Screen Shot 2022-08-02 at 12 16 24 PM" src="https://user-images.githubusercontent.com/87786853/182266464-f40f0382-1891-4bd5-a5c7-8656f708bfda.png">

