### PR TITLE
Create API review using modules in consistent order

### DIFF
--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
-## Version 0.3.2 (Unreleased)
+## Version 0.3.3 (2022-08-03)
+Fixed issue in module order to get consistent order
+
+## Version 0.3.2 (2022-07-19)
 Fixed issue where comments would appear incorrectly on overloaded functions.
 Fixed issue where inherited overloads would not appear in APIView.
 

--- a/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/api-stub-generator/apistub/_stub_generator.py
@@ -186,7 +186,7 @@ class StubGenerator:
                 modules.extend(["{0}.{1}".format(module_name, x) for x in sub_modules])
 
         logging.debug("Modules in package: {}".format(modules))
-        return modules
+        return sorted(modules)
 
 
     def _generate_tokens(self, pkg_root_path, package_name, namespace, *, source_url):

--- a/packages/python-packages/api-stub-generator/apistub/_version.py
+++ b/packages/python-packages/api-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.3.2"
+VERSION = "0.3.3"


### PR DESCRIPTION
APIView code file created on Ubuntu and Windows machine has modules listed in code file in different order even though same version of Python and APIStubGen parser used. So order of module names is not guaranteed. This PR is to sort module name before we parse individual modules to ensure it is listed in correct sort order.