### PR TITLE
Update Python parser version and Python version to match version used…

### DIFF
--- a/.azure-pipelines/apiview.yml
+++ b/.azure-pipelines/apiview.yml
@@ -30,7 +30,7 @@ pr:
 
 variables:
   DotNetRuntimeVersion: '3.1.x'
-  PythonVersion: '3.10.2'
+  PythonVersion: '3.10.5'
   WebClientProjectDirectory: 'src/dotnet/APIView/APIViewWeb/Client'
   WebProjectPath: 'src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj'
   TestProjectPath: 'src/dotnet/APIView/**/*Tests.csproj'

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -17,7 +17,7 @@ namespace APIViewWeb
     {
         public override string Name { get; } = "Python";
         public override string Extension { get; } = ".whl";
-        public override string VersionString { get; } = "0.3.2";
+        public override string VersionString { get; } = "0.3.3";
 
         private readonly string _pythonExecutablePath;
         public override string ProcessName => _pythonExecutablePath;


### PR DESCRIPTION
api-stub-generator is fixed to generate review with module names in consistent order. Currently order is dependent on the platform. This PR is to update python parser version to 0.3.3 so all existing reviews will get upgraded. It also changes Python version to match the version used by CI.