### PR TITLE
Explicit Error Message for Mismatch BEGIN and END Aliases

### DIFF
--- a/packages/java-packages/codesnippet-maven-plugin/CHANGELOG.md
+++ b/packages/java-packages/codesnippet-maven-plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.8 (Unreleased)
+## 1.0.0-beta.8 (2022-08-09)
 
 ### Features Added
 

--- a/packages/java-packages/codesnippet-maven-plugin/CHANGELOG.md
+++ b/packages/java-packages/codesnippet-maven-plugin/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## 1.0.0-beta.8 (Unreleased)
+
+### Features Added
+
+- Added verbose exception indicating mismatch BEGIN and END codesnippet aliases to aid in troubleshooting snippet injection failures.
+
 ## 1.0.0-beta.7 (2022-04-13)
 
 ### Bugs Fixed

--- a/packages/java-packages/codesnippet-maven-plugin/README.md
+++ b/packages/java-packages/codesnippet-maven-plugin/README.md
@@ -12,7 +12,7 @@ First, reference the plugin in your maven project's `pom.xml` file.
 <plugin>
   <groupId>com.azure.tools</groupId>
   <artifactId>codesnippet-maven-plugin</artifactId>
-  <version>1.0.0-beta.1</version>
+  <version>1.0.0-beta.8</version>
   <configuration>
     <codesnippetGlob>**/src/samples/java/**/*.java</codesnippetGlob>
     <codesnippetRootDirectory>${project.basedir}/src/samples/java</codesnippetRootDirectory>

--- a/packages/java-packages/codesnippet-maven-plugin/pom.xml
+++ b/packages/java-packages/codesnippet-maven-plugin/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.azure.tools</groupId>
   <artifactId>codesnippet-maven-plugin</artifactId>
-  <version>1.0.0-beta.7</version>
+  <version>1.0.0-beta.8</version>
   <packaging>maven-plugin</packaging>
 
   <name>Codesnippet Maven Plugin</name>

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetDictionary.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetDictionary.java
@@ -13,9 +13,28 @@ import java.util.Map;
  */
 public final class SnippetDictionary {
     private final Map<String, List<String>> snippetDictionary = new HashMap<>();
+    private final List<String> missingBeginTag = new ArrayList<>();
 
     public boolean isActive() {
         return !snippetDictionary.isEmpty();
+    }
+
+    /**
+     * Gets all codesnippet aliases that are missing a corresponding end tag, aka all begin tags missing an end tag.
+     *
+     * @return All codesnippet aliases that are missing an end tag.
+     */
+    public List<String> getMissingEndTags() {
+        return new ArrayList<>(snippetDictionary.keySet());
+    }
+
+    /**
+     * Gets all codesnippet aliases that are missing a corresponding begin tag, aka all end tags missing a begin tag.
+     *
+     * @return All codesnippet aliases that are missing a begin tag.
+     */
+    public List<String> getMissingBeginTags() {
+        return missingBeginTag;
     }
 
     public void beginSnippet(String key) {
@@ -31,9 +50,18 @@ public final class SnippetDictionary {
     }
 
     public List<String> finalizeSnippet(String key) {
-        List<String> value = this.snippetDictionary.get(key);
-        this.snippetDictionary.remove(key);
+        List<String> value = null;
 
+        // Check the dictionary for containing the key.
+        if (snippetDictionary.containsKey(key)) {
+            // If it does contain the key return the codesnippet for the key.
+            value = snippetDictionary.remove(key);
+        } else {
+            // Otherwise add the codesnippet to the list of keys that have missing begin tags.
+            missingBeginTag.add(key);
+        }
+
+        // Return no matter what, if begin tags are missing an exception will be thrown later.
         return value;
     }
 }

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
@@ -57,13 +57,13 @@ public final class SnippetReplacer {
 
     /**
      * The "verification" operation encapsulated by this function is as follows.
-     *
+     * <p>
      * 1. Scan under the target direction for all discovered code snippet DEFINITIONS 2. Examine all snippet CALLS,
      * finding where updates are needed. 3. Report all discovered snippets in need of update as well as all bad snippet
      * calls
-     *
+     * <p>
      * A "bad snippet call" is simply calling for a snippet whose ID has no definition.
-     *
+     * <p>
      * See {@link #updateCodesnippets(RootAndGlob, List, RootAndGlob, boolean, RootAndGlob, List, boolean, int, boolean, Log)}
      * for details on actually defining and calling snippets.
      */
@@ -405,6 +405,8 @@ public final class SnippetReplacer {
     static Map<String, Codesnippet> getAllSnippets(List<Path> snippetSources)
         throws IOException, MojoExecutionException {
         Map<String, List<Codesnippet>> codesnippets = new HashMap<>();
+        Map<String, List<String>> missingBeginTag = new HashMap<>();
+        Map<String, List<String>> missingEndTag = new HashMap<>();
 
         for (Path samplePath : snippetSources) {
             List<String> fileContent = Files.readAllLines(samplePath, StandardCharsets.UTF_8);
@@ -432,9 +434,17 @@ public final class SnippetReplacer {
                     snippetReader.processLine(line);
                 }
             }
+
+            if (!snippetReader.getMissingEndTags().isEmpty()) {
+                missingEndTag.put(samplePath.toString(), snippetReader.getMissingEndTags());
+            }
+
+            if (!snippetReader.getMissingBeginTags().isEmpty()) {
+                missingBeginTag.put(samplePath.toString(), snippetReader.getMissingBeginTags());
+            }
         }
 
-        String potentialErrorMessage = createDuplicateCodesnippetErrorMessage(codesnippets);
+        String potentialErrorMessage = createInvalidSnippetsErrorMessage(codesnippets, missingEndTag, missingBeginTag);
         if (!potentialErrorMessage.isEmpty()) {
             throw new MojoExecutionException(potentialErrorMessage);
         }
@@ -443,7 +453,8 @@ public final class SnippetReplacer {
             .collect(Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().get(0)));
     }
 
-    private static String createDuplicateCodesnippetErrorMessage(Map<String, List<Codesnippet>> codesnippets) {
+    private static String createInvalidSnippetsErrorMessage(Map<String, List<Codesnippet>> codesnippets,
+        Map<String, List<String>> missingEndTags, Map<String, List<String>> missingBeginTags) {
         StringBuilder errorMessage = new StringBuilder();
 
         for (Map.Entry<String, List<Codesnippet>> codesnippetsById : codesnippets.entrySet()) {
@@ -465,6 +476,32 @@ public final class SnippetReplacer {
             for (Codesnippet codesnippet : codesnippetsById.getValue()) {
                 errorMessage.append("--> ").append(codesnippet.getDefinitionLocation())
                     .append(System.lineSeparator());
+            }
+
+            errorMessage.append(System.lineSeparator());
+        }
+
+        for (Map.Entry<String, List<String>> missingEndTag : missingEndTags.entrySet()) {
+            errorMessage.append("The following codesnippet aliases in file' ")
+                .append(missingEndTag.getKey())
+                .append("' didn't have a matching END alias:")
+                .append(System.lineSeparator());
+
+            for (String alias : missingEndTag.getValue()) {
+                errorMessage.append(" - ").append(alias).append(System.lineSeparator());
+            }
+
+            errorMessage.append(System.lineSeparator());
+        }
+
+        for (Map.Entry<String, List<String>> missingBeginTag : missingBeginTags.entrySet()) {
+            errorMessage.append("The following codesnippet aliases in file' ")
+                .append(missingBeginTag.getKey())
+                .append("' didn't have a matching BEGIN alias:")
+                .append(System.lineSeparator());
+
+            for (String alias : missingBeginTag.getValue()) {
+                errorMessage.append(" - ").append(alias).append(System.lineSeparator());
             }
 
             errorMessage.append(System.lineSeparator());

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
@@ -495,7 +495,7 @@ public final class SnippetReplacer {
         }
 
         for (Map.Entry<String, List<String>> missingBeginTag : missingBeginTags.entrySet()) {
-            errorMessage.append("The following codesnippet aliases in file' ")
+            errorMessage.append("The following codesnippet aliases in file '")
                 .append(missingBeginTag.getKey())
                 .append("' didn't have a matching BEGIN alias:")
                 .append(System.lineSeparator());


### PR DESCRIPTION
Adds an explicit error message when codesnippet aliases have mismatch BEGIN and END tags.