### PR TITLE
[check-enforcer] Remove unused dependency Azure.Storage.Blobs

### DIFF
--- a/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
+++ b/tools/check-enforcer/Azure.Sdk.Tools.CheckEnforcer/Azure.Sdk.Tools.CheckEnforcer.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Azure.Identity" Version="1.2.3" />
     <PackageReference Include="Azure.Security.KeyVault.Keys" Version="4.1.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.1.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.EventHubs" Version="4.1.1" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />


### PR DESCRIPTION
I didn't see any references to `Azure.Storage.Blobs` in the code, and it seems to build fine without this dependency, so I think it can be removed.