### PR TITLE
[Test-Proxy] Add Optional Specificity to the TLSValidationCert

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -927,6 +927,21 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             Assert.Contains("Unable to instantiate a new X509 certificate from the provided value and key.", assertion.Message);
         }
 
+
+        [Fact]
+        public void TestSetRecordingOptionsTransportWithTLSCert()
+        {
+            var certValue = TestHelpers.GetValueFromCertificateFile("test_public-key-only_pem").Replace(Environment.NewLine, "");
+            var pemKey = TestHelpers.GetValueFromCertificateFile("test_pem_key").Replace(Environment.NewLine, "");
+            var pemValue = TestHelpers.GetValueFromCertificateFile("test_pem_value").Replace(Environment.NewLine, "");
+            var inputObj = string.Format("{{\"Transport\": {{\"TLSValidationCert\": \"{0}\", \"Certificates\": [ {{ \"PemValue\": \"{1}\", \"PemKey\": \"{2}\" }}]}}}}", certValue, pemValue, pemKey);
+
+            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
+            var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);
+
+            testRecordingHandler.SetRecordingOptions(inputBody);
+        }
+
         [Fact]
         public void TestSetRecordingOptionsInValidTransportWithTLSCert()
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -934,7 +934,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var certValue = TestHelpers.GetValueFromCertificateFile("test_public-key-only_pem").Replace(Environment.NewLine, "");
             var pemKey = TestHelpers.GetValueFromCertificateFile("test_pem_key").Replace(Environment.NewLine, "");
             var pemValue = TestHelpers.GetValueFromCertificateFile("test_pem_value").Replace(Environment.NewLine, "");
-            var inputObj = string.Format("{{\"Transport\": {{\"TLSValidationCert\": \"{0}\", \"Certificates\": [ {{ \"PemValue\": \"{1}\", \"PemKey\": \"{2}\" }}]}}}}", certValue, pemValue, pemKey);
+            var inputObj = string.Format("{{\"Transport\": {{\"TLSValidationCert\": \"{0}\", \"TLSValidationCertHost\":\"azure.blobs.windows.net\", \"Certificates\": [ {{ \"PemValue\": \"{1}\", \"PemKey\": \"{2}\" }}]}}}}", certValue, pemValue, pemKey);
 
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/TransportCustomizations.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/TransportCustomizations.cs
@@ -22,6 +22,12 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         public string TLSValidationCert { get; set; }
 
         /// <summary>
+        /// When providing a TLS Validation Cert, that validation cert will often only apply to a single hostname. Providing this hostname as an argument ensures
+        /// that this TLSValidationCert will only be utilized when attempting to reach out to the value contained in TLSValidationCertHost.
+        /// </summary>
+        public string TSLValidationCertHost { get; set; }
+
+        /// <summary>
         /// Each certificate pair contained within this list should be added to the clientHandler for the server or an individual recording.
         /// </summary>
         public List<PemPair> Certificates { get; set; }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -493,6 +493,9 @@ The test-proxy offers further customization beyond that offered by sanitizers, m
       ],
       // used specifically so that an SSL connection presenting a non-standard certificate can still be validated
       "TLSValidationCert": "<public key portion of TLS cert>",
+      // if not provided, the TLS Validation validation callbacks will be used for all targeted hosts
+      // if provided, only requests to the hostname contained herein will be validated against the cert present in TLSValidationCert
+      "TLSValidationCertHost": "<hostname for the targeted resource associated with TLS Cert>",
    }
 }
 ```

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -656,12 +656,24 @@ namespace Azure.Sdk.Tools.TestProxy
 
                 clientHandler.ServerCertificateCustomValidationCallback = (HttpRequestMessage httpRequestMessage, X509Certificate2 cert, X509Chain x509Chain, SslPolicyErrors sslPolicyErrors) =>
                 {
-                    bool isChainValid = certificateChain.Build(cert);
-                    if (!isChainValid) return false;
-                    var isCertSignedByTheTlsCert = certificateChain.ChainElements.Cast<X509ChainElement>()
-                        .Any(x => x.Certificate.Thumbprint == ledgerCert.Thumbprint);
+                    if (!string.IsNullOrWhiteSpace(customizations.TSLValidationCertHost) && httpRequestMessage.RequestUri.Host != customizations.TSLValidationCertHost)
+                    {
+                        if (sslPolicyErrors == SslPolicyErrors.None)
+                        {
+                            return true;
+                        }
 
-                    return isCertSignedByTheTlsCert;
+                        return false;
+                    }
+                    else
+                    {
+                        bool isChainValid = certificateChain.Build(cert);
+                        if (!isChainValid) return false;
+                        var isCertSignedByTheTlsCert = certificateChain.ChainElements.Cast<X509ChainElement>()
+                            .Any(x => x.Certificate.Thumbprint == ledgerCert.Thumbprint);
+
+                        return isCertSignedByTheTlsCert;
+                    }
                 };
             }
             else if (insecure)


### PR DESCRIPTION
@lynshi @mccoyp 

Users can now say:

> apply this for this hostname only.

And a standard server validation callback will be used otherwise.

Example updates to your unit tests: 
![image](https://user-images.githubusercontent.com/45376673/183782072-c6aa5d71-62d3-4598-90d8-b18d9432a4c5.png)

Am facing a new issue when recording though. It doesn't look like we're getting a valid key back.

The value we're getting is `----BEGIN CERTIFICATE KEY-----\n` and that's it 👍 

Specifically, this is the setting from [the second `SetRecordingOptions()` ](https://github.com/lynshi/azure-sdk-for-python/blob/50ffaf746bf05c11ef6924c4c5c126fbbc0de60b/sdk/confidentialledger/azure-confidentialledger/tests/test_confidential_ledger_client.py#L83)

I will push the test changes directly to your branch after the new version of the proxy is published and follow-up on the new error.

