### PR TITLE
[Python APIView] Fix issue with duplicated diagnostics

### DIFF
--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.3.4 (Unreleased)
 Fixed issue so that APIView is still generated even if pylint parsing fails.
+Fixed issue where diagnostics could be duplicated on functions with the same name.
 
 ## Version 0.3.3 (2022-08-03)
 Fixed issue in module order to get consistent order

--- a/packages/python-packages/api-stub-generator/apistub/_diagnostic.py
+++ b/packages/python-packages/api-stub-generator/apistub/_diagnostic.py
@@ -21,9 +21,10 @@ class Diagnostic:
     id_counter = 1
 
     def __init__(self, *, obj: "PylintError", target_id: str):
-        self.diagnostic_id = "AZ_PY_{}".format(Diagnostic.id_counter)
+        diagnostic_number = Diagnostic.id_counter
+        self.diagnostic_id = f"AZ_PY_{diagnostic_number}"
         Diagnostic.id_counter += 1
-        self.text = f"({self.diagnostic_id}) {obj.message} [{obj.symbol}]"
+        self.text = f"{obj.message} [{obj.symbol}]"
         self.help_link_uri = obj.help_link
         self.target_id = target_id
         self.level = obj.level

--- a/packages/python-packages/api-stub-generator/apistub/_diagnostic.py
+++ b/packages/python-packages/api-stub-generator/apistub/_diagnostic.py
@@ -23,7 +23,7 @@ class Diagnostic:
     def __init__(self, *, obj: "PylintError", target_id: str):
         self.diagnostic_id = "AZ_PY_{}".format(Diagnostic.id_counter)
         Diagnostic.id_counter += 1
-        self.text = f"{obj.message} [{obj.symbol}]"
+        self.text = f"({self.diagnostic_id}) {obj.message} [{obj.symbol}]"
         self.help_link_uri = obj.help_link
         self.target_id = target_id
         self.level = obj.level

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_function_node.py
@@ -65,7 +65,7 @@ class FunctionNode(NodeEntityBase):
         Regenerate the namespace_id for functions to account for overloads, which
         have the same name.
         """
-        lines = [f"{self.name}("]
+        lines = [f"{self.full_name}("]
         for arg in self.args.values():
             lines.append(f"{arg.argname}:{arg.argtype},")
         for arg in self.kwargs.values():

--- a/packages/python-packages/api-stub-generator/apiview_reqs.txt
+++ b/packages/python-packages/api-stub-generator/apiview_reqs.txt
@@ -1,2 +1,2 @@
 ./
-pylint-guidelines-checker==0.0.5
+pylint-guidelines-checker==0.0.7


### PR DESCRIPTION
Fixes #3712.

Example:
https://apiview.dev/Assemblies/Review/bb9acfe54154462fb036f502819d90c3

Rev 0 represents the original behavior.
Rev 1 represents the fix.

Note: this _will_ cause a diff between 0.3.3 because it changes how the line id is calculated for these inherited methods. 