### PR TITLE
Improvements around aliased types

### DIFF
--- a/src/go/cmd/api_view.go
+++ b/src/go/cmd/api_view.go
@@ -5,7 +5,7 @@ package cmd
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -19,7 +19,7 @@ func CreateAPIView(pkgDir, outputDir string) error {
 	}
 	filename := filepath.Join(outputDir, review.Name+".json")
 	file, _ := json.MarshalIndent(review, "", " ")
-	err = ioutil.WriteFile(filename, file, 0644)
+	err = os.WriteFile(filename, file, 0644)
 	if err != nil {
 		return err
 	}

--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -5,7 +5,6 @@ package cmd
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -23,7 +22,7 @@ func TestFuncDecl(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	file, err := ioutil.ReadFile("./output/testfuncdecl.json")
+	file, err := os.ReadFile("./output/testfuncdecl.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,7 +50,7 @@ func TestInterface(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	file, err := ioutil.ReadFile("./output/testinterface.json")
+	file, err := os.ReadFile("./output/testinterface.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -79,7 +78,7 @@ func TestStruct(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	file, err := ioutil.ReadFile("./output/teststruct.json")
+	file, err := os.ReadFile("./output/teststruct.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -107,7 +106,7 @@ func TestConst(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	file, err := ioutil.ReadFile("./output/testconst.json")
+	file, err := os.ReadFile("./output/testconst.json")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/go/cmd/content.go
+++ b/src/go/cmd/content.go
@@ -323,6 +323,26 @@ func (c *content) filterDeclarations(typ string, decls map[string]Declaration, t
 	return results
 }
 
+// findMethods takes the name of the receiver and looks for Funcs that are methods on that receiver.
+func (c *content) findMethods(s string) map[string]Func {
+	methods := map[string]Func{}
+	for key, fn := range c.Funcs {
+		name := fn.Name()
+		if unicode.IsLower(rune(name[0])) {
+			continue
+		}
+		_, n := getReceiver(key)
+		if before, _, found := strings.Cut(n, "["); found {
+			// ignore type parameters when matching receivers to types
+			n = before
+		}
+		if s == n || "*"+s == n {
+			methods[key] = fn
+		}
+	}
+	return methods
+}
+
 // searchForMethods takes the name of the receiver and looks for Funcs that are methods on that receiver.
 func (c *content) searchForMethods(s string, tokenList *[]Token) {
 	methods := map[string]Func{}

--- a/src/go/cmd/content.go
+++ b/src/go/cmd/content.go
@@ -345,28 +345,16 @@ func (c *content) findMethods(s string) map[string]Func {
 
 // searchForMethods takes the name of the receiver and looks for Funcs that are methods on that receiver.
 func (c *content) searchForMethods(s string, tokenList *[]Token) {
-	methods := map[string]Func{}
+	methods := c.findMethods(s)
 	methodNames := []string{}
-	for key, fn := range c.Funcs {
-		name := fn.Name()
-		if unicode.IsLower(rune(name[0])) {
-			continue
-		}
-		_, n := getReceiver(key)
-		if before, _, found := strings.Cut(n, "["); found {
-			// ignore type parameters when matching receivers to types
-			n = before
-		}
-		if s == n || "*"+s == n {
-			methods[key] = fn
-			methodNames = append(methodNames, key)
-			delete(c.Funcs, key)
-		}
+	for key := range methods {
+		methodNames = append(methodNames, key)
 	}
 	sort.Strings(methodNames)
 	for _, name := range methodNames {
 		fn := methods[name]
 		*tokenList = append(*tokenList, fn.MakeTokens()...)
+		delete(c.Funcs, name)
 	}
 }
 

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -144,18 +144,24 @@ func NewModule(dir string) (*Module, error) {
 						continue
 					}
 					fieldTypeName := unwrapStructFieldTypeName(field)
+					if fieldTypeName == "" {
+						// we can ignore this field
+						continue
+					}
 
-					if fieldTypeName != "" {
-						// ensure that our package exports this type
-						if _, ok := p.typeAliases[fieldTypeName]; !ok {
-							if t != nil {
-								p.diagnostics = append(p.diagnostics, Diagnostic{
-									Level:    DiagnosticLevelError,
-									TargetID: t.ID(),
-									Text:     "missing alias for nested type " + fieldTypeName,
-								})
-							}
-						}
+					// ensure that our package exports this type
+					if _, ok := p.typeAliases[fieldTypeName]; ok {
+						// found an alias
+						continue
+					}
+
+					// no alias, add a diagnostic
+					if t != nil {
+						p.diagnostics = append(p.diagnostics, Diagnostic{
+							Level:    DiagnosticLevelError,
+							TargetID: t.ID(),
+							Text:     "missing alias for nested type " + fieldTypeName,
+						})
 					}
 				}
 			}

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -139,6 +139,10 @@ func NewModule(dir string) (*Module, error) {
 				// ensure that all struct field types that are structs are also aliased from this package
 				for _, field := range aliasedStruct.Fields.List {
 					// FieldName *FieldType
+					if field.Names != nil && !field.Names[0].IsExported() {
+						// field isn't exported so skip it
+						continue
+					}
 					fieldTypeName := unwrapStructFieldTypeName(field)
 
 					if fieldTypeName != "" {

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -176,6 +176,8 @@ func unwrapStructFieldTypeName(field *ast.Field) string {
 	var ident *ast.Ident
 	if se, ok := field.Type.(*ast.StarExpr); ok {
 		ident, _ = se.X.(*ast.Ident)
+	} else if at, ok := field.Type.(*ast.ArrayType); ok {
+		ident, _ = at.Elt.(*ast.Ident)
 	} else {
 		ident, _ = field.Type.(*ast.Ident)
 	}

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -48,6 +48,11 @@ func NewModule(dir string) (*Module, error) {
 	m := Module{Name: filepath.Base(dir), packages: map[string]*Pkg{}}
 
 	baseImportPath := path.Dir(mf.Module.Mod.Path) + "/"
+	if baseImportPath == "./" {
+		// this is a relative path in the tests, so remove this prefix.
+		// if not, then the package name added below won't match the imported packages.
+		baseImportPath = ""
+	}
 	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
 		if d.IsDir() {
 			if !indexTestdata && strings.Contains(path, "testdata") {
@@ -139,7 +144,7 @@ func NewModule(dir string) (*Module, error) {
 						p.diagnostics = append(p.diagnostics, Diagnostic{
 							Level:    DiagnosticLevelError,
 							TargetID: t.ID(),
-							Text:     "missing alias for nested type " + fieldTypeName,
+							Text:     missingAliasFor + fieldTypeName,
 						})
 					}
 				case *ast.Ident:

--- a/src/go/cmd/pkg.go
+++ b/src/go/cmd/pkg.go
@@ -9,7 +9,6 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -200,7 +199,7 @@ func (pkg Pkg) getText(start token.Pos, end token.Pos) string {
 	p := pkg.fs.Position(start)
 	// check if the file has been loaded, if not then load it
 	if _, ok := pkg.files[p.Filename]; !ok {
-		b, err := ioutil.ReadFile(p.Filename)
+		b, err := os.ReadFile(p.Filename)
 		if err != nil {
 			panic(err)
 		}

--- a/src/go/cmd/pkg.go
+++ b/src/go/cmd/pkg.go
@@ -18,6 +18,7 @@ import (
 // diagnostic messages
 const (
 	aliasFor               = "Alias for "
+	missingAliasFor        = "missing alias for nested type "
 	embedsUnexportedStruct = "Anonymously embeds unexported struct "
 	sealedInterface        = "Applications can't implement this interface"
 )

--- a/src/go/cmd/testdata/test_alias_diagnostics/go.mod
+++ b/src/go/cmd/testdata/test_alias_diagnostics/go.mod
@@ -1,0 +1,3 @@
+module test_alias_diagnostics
+
+go 1.18

--- a/src/go/cmd/testdata/test_alias_diagnostics/internal/internal.go
+++ b/src/go/cmd/testdata/test_alias_diagnostics/internal/internal.go
@@ -1,0 +1,20 @@
+package internal
+
+type Widget struct {
+	OK             bool
+	Value          WidgetValue
+	MissingScalar  WidgetProperties
+	MissingScalarP *WidgetPropertiesP
+	MissingSlice   []WidgetThings
+	MissingSliceP  []*WidgetThingsP
+}
+
+type WidgetProperties struct{}
+
+type WidgetPropertiesP struct{}
+
+type WidgetThings struct{}
+
+type WidgetThingsP struct{}
+
+type WidgetValue struct{}

--- a/src/go/cmd/testdata/test_alias_diagnostics/test.go
+++ b/src/go/cmd/testdata/test_alias_diagnostics/test.go
@@ -1,0 +1,9 @@
+package test_alias_diagnostics
+
+import (
+	"test_alias_diagnostics/internal"
+)
+
+type Widget = internal.Widget
+
+type WidgetValue = internal.WidgetValue

--- a/src/go/cmd/token_makers.go
+++ b/src/go/cmd/token_makers.go
@@ -184,6 +184,17 @@ func (f Func) ID() string {
 	return f.id
 }
 
+func (f Func) ForAlias(pkg string) Func {
+	clone := f
+	// replace everything to the left of - with the new package name
+	i := strings.Index(clone.id, "-")
+	if i < 0 {
+		panic("missing sig separator in id")
+	}
+	clone.id = pkg + clone.id[i:]
+	return clone
+}
+
 func (f Func) MakeTokens() []Token {
 	list := &[]Token{}
 	if f.embedded {


### PR DESCRIPTION
Issue a diagnostic error if an exported, aliased type contains nested
types that aren't exported from the same package.
Include methods for aliased types in the source package.
Removed references to ioutil as it's been deprecated.