### PR TITLE
Remove duplicate PR API review revisions

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Models/ReviewRevisionModelList.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/ReviewRevisionModelList.cs
@@ -36,6 +36,11 @@ namespace APIViewWeb.Models
             }
         }
 
+        public void RemoveAll(System.Predicate<ReviewRevisionModel> match)
+        {
+            _list.RemoveAll(match);
+        }
+
         public void Clear()
         {
             _list.Clear();

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -298,9 +298,7 @@ namespace APIViewWeb.Repositories
                     //In case of brand new package, we don't have any baseline from automatic review. So it uses previous PR api review as baseline and
                     //below revision ID copy step makes duplicate revision IDs in such cases.
                     //We should ensure that no revision exists in review with previous revision ID before we update new revision
-                    var revisionsToRetain = review.Revisions.Where(r => r.RevisionId != prevRevisionId);
-                    review.Revisions.Clear();
-                    review.Revisions.AddRange(revisionsToRetain);
+                    review.Revisions.RemoveAll(r => r.RevisionId == prevRevisionId);
                     newRevision.RevisionId = prevRevisionId;
                 }
             }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -293,6 +293,14 @@ namespace APIViewWeb.Repositories
                     var prevRevisionId = review.Revisions.Last().RevisionId;
                     review = await GetBaseLineReview(codeFile.Language, codeFile.PackageName, pullRequestModel, true);
                     review.ReviewId = pullRequestModel.ReviewId;
+                    //Remove previous revisions with revision ID.
+                    //Currently revision ID is getting duplicated when a PR api review is created for a brand new package.
+                    //In case of brand new package, we don't have any baseline from automatic review. So it uses previous PR api review as baseline and
+                    //below revision ID copy step makes duplicate revision IDs in such cases.
+                    //We should ensure that no revision exists in review with previous revision ID before we update new revision
+                    var revisionsToRetain = review.Revisions.Where(r => r.RevisionId != prevRevisionId);
+                    review.Revisions.Clear();
+                    review.Revisions.AddRange(revisionsToRetain);
                     newRevision.RevisionId = prevRevisionId;
                 }
             }


### PR DESCRIPTION
PR API reviews generated from pull request for a brand-new package (package doesn't exists in repo) is creating duplicate revisions within review and this is causing an issue when reviewing such API reviews. This PR is removing any such duplicate revisions when a new request for that review comes as well as to avoid such duplicate revisions in the future.