### PR TITLE
Fix codesnippet-maven-plugin Bug with Full Class Codesnippets

### DIFF
--- a/packages/java-packages/codesnippet-maven-plugin/CHANGELOG.md
+++ b/packages/java-packages/codesnippet-maven-plugin/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release History
 
-## 1.0.0-beta.8 (2022-08-17)
+## 1.0.0-beta.8 (2022-08-18)
 
 ### Features Added
 

--- a/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/main/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacer.java
@@ -541,6 +541,8 @@ public final class SnippetReplacer {
                     modifiedStrings.add(snippetLine);
                 }
             }
+        } else {
+            return snippetText;
         }
 
         return modifiedStrings;

--- a/packages/java-packages/codesnippet-maven-plugin/src/test/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacerTests.java
+++ b/packages/java-packages/codesnippet-maven-plugin/src/test/java/com/azure/tools/codesnippetplugin/implementation/SnippetReplacerTests.java
@@ -174,4 +174,19 @@ public class SnippetReplacerTests {
         assertTrue(errors.isEmpty());
         assertEquals(expectedString, new String(Files.readAllBytes(codeForReplacement), StandardCharsets.UTF_8));
     }
+
+    @Test
+    public void fullClassCodesnippet() throws Exception {
+        Path snippetSourceFile = getPathToResource("full_class_parse.txt");
+        Path codeForReplacement = getPathToResource("full_class_readme_insertion_before.txt");
+        Path expectedOutCome = getPathToResource("full_class_readme_insertion_after.txt");
+        String expectedString = new String(Files.readAllBytes(expectedOutCome), StandardCharsets.UTF_8);
+
+        Map<String, Codesnippet> foundSnippets = SnippetReplacer.getAllSnippets(
+            new ArrayList<>(Collections.singletonList(snippetSourceFile.toAbsolutePath())));
+        List<CodesnippetError> errors = SnippetReplacer.updateReadmeCodesnippets(codeForReplacement, foundSnippets);
+
+        assertTrue(errors.isEmpty());
+        assertEquals(expectedString, new String(Files.readAllBytes(codeForReplacement), StandardCharsets.UTF_8));
+    }
 }

--- a/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/basic_readme_insertion_before.txt
+++ b/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/basic_readme_insertion_before.txt
@@ -6,7 +6,7 @@ Once you have the value of the connection string you can create the configuratio
 ConfigurationClient configurationClient = new ConfigurationClientBuilder()
     .connectionString(connectionString)
     .buildClient();
-    Some other crap
+    Some other stuff
 ```
 
 or

--- a/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/full_class_parse.txt
+++ b/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/full_class_parse.txt
@@ -1,0 +1,56 @@
+
+// BEGIN: full-class-readme-sample
+/**
+ * This class contains code samples for generating javadocs through doclets for {@link ConfigurationClient}
+ */
+public final class ConfigurationClientJavaDocCodeSnippets {
+
+    private String key1 = "key1";
+    private String key2 = "key2";
+    private String value1 = "val1";
+    private String value2 = "val2";
+
+    /**
+     * Generates code sample for creating a {@link ConfigurationClient}
+     *
+     * @return An instance of {@link ConfigurationClient}
+     * @throws IllegalStateException If configuration credentials cannot be created.
+     */
+    public ConfigurationClient createAsyncConfigurationClientWithPipeline() {
+
+    /**
+     * Generates code sample for creating a {@link ConfigurationClient}
+     *
+     * @return An instance of {@link ConfigurationClient}
+     * @throws IllegalStateException If configuration credentials cannot be created
+     */
+    public ConfigurationClient createSyncConfigurationClient() {
+        String connectionString = getConnectionString();
+        ConfigurationClient configurationClient = new ConfigurationClientBuilder()
+            .connectionString(connectionString)
+            .buildClient();
+        return configurationClient;
+    }
+
+    /**
+     * Generates code sample for using {@link ConfigurationClient#addConfigurationSetting(String, String, String)}
+     */
+    public void addConfigurationSetting() {
+        ConfigurationClient configurationClient = createSyncConfigurationClient();
+        ConfigurationSetting result = configurationClient
+            .addConfigurationSetting("prodDBConnection", "westUS", "db_connection");
+        System.out.printf("Key: %s, Label: %s, Value: %s", result.getKey(), result.getLabel(), result.getValue());
+    }
+
+    public void encodedHtmlWorks(){
+        // A supplier that fetches the first page of data from source/service
+        Supplier<Mono<PagedResponse<Integer>>> firstPageRetriever = () -> getFirstPage();
+
+        // A function that fetches subsequent pages of data from source/service given a continuation token
+        Function<String, Mono<PagedResponse<Integer>>> nextPageRetriever =
+            continuationToken -> getNextPage(continuationToken);
+
+        PagedFlux<Integer> pagedFlux = new PagedFlux<>(firstPageRetriever, nextPageRetriever);
+    }
+}
+// END: full-class-readme-sample

--- a/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/full_class_readme_insertion_after.txt
+++ b/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/full_class_readme_insertion_after.txt
@@ -1,0 +1,59 @@
+##### Configuration Client Examples
+
+The following is a bunch of examples:
+
+```java full-class-readme-sample
+/**
+ * This class contains code samples for generating javadocs through doclets for {@link ConfigurationClient}
+ */
+public final class ConfigurationClientJavaDocCodeSnippets {
+
+    private String key1 = "key1";
+    private String key2 = "key2";
+    private String value1 = "val1";
+    private String value2 = "val2";
+
+    /**
+     * Generates code sample for creating a {@link ConfigurationClient}
+     *
+     * @return An instance of {@link ConfigurationClient}
+     * @throws IllegalStateException If configuration credentials cannot be created.
+     */
+    public ConfigurationClient createAsyncConfigurationClientWithPipeline() {
+
+    /**
+     * Generates code sample for creating a {@link ConfigurationClient}
+     *
+     * @return An instance of {@link ConfigurationClient}
+     * @throws IllegalStateException If configuration credentials cannot be created
+     */
+    public ConfigurationClient createSyncConfigurationClient() {
+        String connectionString = getConnectionString();
+        ConfigurationClient configurationClient = new ConfigurationClientBuilder()
+            .connectionString(connectionString)
+            .buildClient();
+        return configurationClient;
+    }
+
+    /**
+     * Generates code sample for using {@link ConfigurationClient#addConfigurationSetting(String, String, String)}
+     */
+    public void addConfigurationSetting() {
+        ConfigurationClient configurationClient = createSyncConfigurationClient();
+        ConfigurationSetting result = configurationClient
+            .addConfigurationSetting("prodDBConnection", "westUS", "db_connection");
+        System.out.printf("Key: %s, Label: %s, Value: %s", result.getKey(), result.getLabel(), result.getValue());
+    }
+
+    public void encodedHtmlWorks(){
+        // A supplier that fetches the first page of data from source/service
+        Supplier<Mono<PagedResponse<Integer>>> firstPageRetriever = () -> getFirstPage();
+
+        // A function that fetches subsequent pages of data from source/service given a continuation token
+        Function<String, Mono<PagedResponse<Integer>>> nextPageRetriever =
+            continuationToken -> getNextPage(continuationToken);
+
+        PagedFlux<Integer> pagedFlux = new PagedFlux<>(firstPageRetriever, nextPageRetriever);
+    }
+}
+```

--- a/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/full_class_readme_insertion_before.txt
+++ b/packages/java-packages/codesnippet-maven-plugin/src/test/resources/project-to-test/full_class_readme_insertion_before.txt
@@ -1,0 +1,10 @@
+##### Configuration Client Examples
+
+The following is a bunch of examples:
+
+```java full-class-readme-sample
+ConfigurationClient configurationClient = new ConfigurationClientBuilder()
+    .connectionString(connectionString)
+    .buildClient();
+    Some other stuff
+```


### PR DESCRIPTION
Fixes an issue where non-indented codesnippets wouldn't be injected properly into READMEs.