### PR TITLE
[Do Not Merge] Modify Storage perf tests to include name only listing

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -210,9 +210,13 @@ Services:
     Arguments: &storage-blob-counts
     - --count 1 --warmup 0 --duration 1
     - --count 5 --parallel 64
+    - --count 5 --parallel 64 --name-only
     - --count 500 --parallel 32
+    - --count 500 --parallel 32 --name-only
     - --count 500 --parallel 32 --sync
+    - --count 500 --parallel 32 --sync --name-only
     - --count 50000 --parallel 32 --warmup 60 --duration 60
+    - --count 50000 --parallel 32 --warmup 60 --duration 60 --name-only
     TestNames:
       Net: GetBlobs
       Java: listblobs


### PR DESCRIPTION
Modifying the Storage blob listing perf tests to include the `--name-only` argument for testing Python `list_blob_names` feature.

This is a temporary change and will not be merged.