### PR TITLE
Allow type aliases with `typing.NewType`

### DIFF
--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 0.3.4 (2022-08-11)
 Fixed issue so that APIView is still generated even if pylint parsing fails.
 Fixed issue where diagnostics could be duplicated on functions with the same name.
+Fixed issue where `typing.NewType` aliases were not displayed in APIView.
 
 ## Version 0.3.3 (2022-08-03)
 Fixed issue in module order to get consistent order

--- a/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
@@ -4,8 +4,11 @@
 # license information.
 # --------------------------------------------------------------------------
 
+from typing import NewType
 from apistub.nodes import ClassNode
 from apistubgentest.models import (
+    AliasNewType,
+    AliasUnion,
     FakeTypedDict,
     FakeObject,
     GenericStack,
@@ -195,5 +198,23 @@ class TestClassParsing:
         actuals = _render_lines(_tokenize(class_node))
         expected = [
             "class GenericStack(Generic[T]):"
+        ]
+        _check_all(actuals, expected, obj)
+
+    def test_new_type_alias(self):
+        obj = AliasNewType
+        class_node = ClassNode(name=obj.__name__, namespace=obj.__name__, parent_node=None, obj=obj, pkg_root_namespace=self.pkg_namespace)
+        actuals = _render_lines(_tokenize(class_node))
+        expected = [
+            "class AliasNewType(Dict[str, str]):"
+        ]
+        _check_all(actuals, expected, obj)        
+
+    def test_union_alias(self):
+        obj = AliasUnion
+        class_node = ClassNode(name=obj.__name__, namespace=obj.__name__, parent_node=None, obj=obj, pkg_root_namespace=self.pkg_namespace)
+        actuals = _render_lines(_tokenize(class_node))
+        expected = [
+            "class AliasUnion(Union[str, int, bool]):"
         ]
         _check_all(actuals, expected, obj)        

--- a/packages/python-packages/apistubgentest/apistubgentest/models/__init__.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/__init__.py
@@ -8,6 +8,8 @@
 
 # pylint: disable=wrong-import-position
 from ._models import (
+    AliasNewType,
+    AliasUnion,
     DocstringClass,
     FakeError,
     FakeObject,
@@ -34,6 +36,8 @@ from ._dataclasses import (
 )
 
 __all__ = (
+    "AliasNewType",
+    "AliasUnion",
     "DataClassSimple",
     "DataClassWithFields",
     "DataClassDynamic",

--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -11,7 +11,7 @@ from azure.core import CaseInsensitiveEnumMeta
 from collections.abc import Sequence
 from enum import Enum, EnumMeta
 import functools
-from typing import Any, overload, TypedDict, Union, Optional, Generic, TypeVar
+from typing import Any, overload, Dict, TypedDict, Union, Optional, Generic, TypeVar, NewType, TypeAlias
 
 from ._mixin import MixinWithOverloads
 
@@ -267,3 +267,6 @@ class GenericStack(Generic[T]):
     def empty(self) -> bool:
         return not self.items
 
+AliasUnion = NewType('AliasUnion', Union[str, int, bool])
+
+AliasNewType = NewType('AliasNewType', Dict[str, str])


### PR DESCRIPTION
Fix #3138.