### PR TITLE
Add notification for azd failures

### DIFF
--- a/eng/pipelines/notifications.yml
+++ b/eng/pipelines/notifications.yml
@@ -16,20 +16,20 @@ stages:
       # Running all entries simultaneously causes "Service Unavailable" errors
       maxParallel: 2
       matrix:
-        # NET:
-        #   PathPrefix: 'net'
-        # Python:
-        #   PathPrefix: 'python'
-        # JS:
-        #   PathPrefix: 'js'
-        # Java:
-        #   PathPrefix: 'java'
-        # C:
-        #   PathPrefix: 'c'
-        # CPP:
-        #   PathPrefix: 'cpp'
-        # Go:
-        #   PathPrefix: 'go'
+        NET:
+          PathPrefix: 'net'
+        Python:
+          PathPrefix: 'python'
+        JS:
+          PathPrefix: 'js'
+        Java:
+          PathPrefix: 'java'
+        C:
+          PathPrefix: 'c'
+        CPP:
+          PathPrefix: 'cpp'
+        Go:
+          PathPrefix: 'go'
         AzDev:
           PathPrefix: 'azure-accelerators'
 

--- a/eng/pipelines/notifications.yml
+++ b/eng/pipelines/notifications.yml
@@ -16,20 +16,22 @@ stages:
       # Running all entries simultaneously causes "Service Unavailable" errors
       maxParallel: 2
       matrix:
-        NET:
-          PathPrefix: 'net'
-        Python:
-          PathPrefix: 'python'
-        JS:
-          PathPrefix: 'js'
-        Java:
-          PathPrefix: 'java'
-        C:
-          PathPrefix: 'c'
-        CPP:
-          PathPrefix: 'cpp'
-        Go:
-          PathPrefix: 'go'
+        # NET:
+        #   PathPrefix: 'net'
+        # Python:
+        #   PathPrefix: 'python'
+        # JS:
+        #   PathPrefix: 'js'
+        # Java:
+        #   PathPrefix: 'java'
+        # C:
+        #   PathPrefix: 'c'
+        # CPP:
+        #   PathPrefix: 'cpp'
+        # Go:
+        #   PathPrefix: 'go'
+        AzDev:
+          PathPrefix: 'azure-dev'
 
     pool:
       name: azsdk-pool-mms-ubuntu-2004-general

--- a/eng/pipelines/notifications.yml
+++ b/eng/pipelines/notifications.yml
@@ -31,7 +31,7 @@ stages:
         Go:
           PathPrefix: 'go'
         AzDev:
-          PathPrefix: 'azure-accelerators'
+          PathPrefix: 'azure-dev'
 
     pool:
       name: azsdk-pool-mms-ubuntu-2004-general

--- a/eng/pipelines/notifications.yml
+++ b/eng/pipelines/notifications.yml
@@ -31,7 +31,7 @@ stages:
         # Go:
         #   PathPrefix: 'go'
         AzDev:
-          PathPrefix: 'azure-dev'
+          PathPrefix: 'azure-accelerators'
 
     pool:
       name: azsdk-pool-mms-ubuntu-2004-general


### PR DESCRIPTION
Adds notification configurations for azd pipelines. 

Example successful pipeline run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1821283&view=logs&j=bc477995-0c4a-574b-536f-2e0d94a7118e&t=330da002-0be6-5a2c-2b14-ef5f270c12c9&l=191