### PR TITLE
Remove unnecessary checkout: none that causes conflicts with sparse checkout declarations

### DIFF
--- a/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+++ b/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
@@ -34,7 +34,6 @@ parameters:
     default: ''
 steps:
   - ${{ if eq(length(parameters.PackageInfoLocations), 0) }}:
-    - checkout: none
     - pwsh: |
         Write-Host "Skipping DocsMS Update because package list was empty."
       displayName: Skip DocsMS Update


### PR DESCRIPTION
This was causing `checkout: none` to appear twice in release pipeline yaml, which caused someone to add `SkipDefaultCheckout` to the sparse checkout parameters in order to avoid the conflict. However, this meant that we were then doing full clones in some places.
