### PR TITLE
Repair Test-Proxy public CI

### DIFF
--- a/eng/pipelines/publish-docker-image.yml
+++ b/eng/pipelines/publish-docker-image.yml
@@ -47,12 +47,6 @@ jobs:
             displayName: "Run prep script"
 
         - task: Docker@2
-          displayName: Login to ACR
-          inputs:
-            command: login
-            containerRegistry: ${{ parameters.ContainerRegistry }}
-
-        - task: Docker@2
           displayName: Build ${{ config.name }}:${{ parameters.ImageTag }}
           inputs:
             command: build


### PR DESCRIPTION
The original change that added this code turned out to be unnecessary, but I left it in for cohesion.

Now I realize _why_ I left it out to begin with. We cannot have a docker login on a part of the build that runs on `public`. It'll just fail, rightfully so.

[Manually queued proxy build showing the issue is fixed.](https://dev.azure.com/azure-sdk/public/_build/results?buildId=1822286&view=results)