### PR TITLE
Test-Proxy Integration updates

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -93,12 +93,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             if (string.IsNullOrEmpty(additionalEntryModeHeader))
             {
-                var fullPath = testRecordingHandler.GetRecordingPath(targetFile);
+                var fullPath = await testRecordingHandler.GetRecordingPath(targetFile);
                 Assert.True(File.Exists(fullPath));
             }
             else
             {
-                var fullPath = testRecordingHandler.GetRecordingPath(targetFile);
+                var fullPath = await testRecordingHandler.GetRecordingPath(targetFile);
                 Assert.False(File.Exists(fullPath));
             }
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -191,11 +191,11 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void TestResetTargetsRecordingOnly()
+        public async Task TestResetTargetsRecordingOnly()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
-            testRecordingHandler.StartRecording("recordingings/cool.json", httpContext.Response);
+            await testRecordingHandler.StartRecordingAsync("recordingings/cool.json", httpContext.Response);
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
 
 
@@ -215,11 +215,11 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void TestResetTargetsSessionOnly()
+        public async Task TestResetTargetsSessionOnly()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
-            testRecordingHandler.StartRecording("recordingings/cool.json", httpContext.Response);
+            await testRecordingHandler.StartRecordingAsync("recordingings/cool.json", httpContext.Response);
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
 
             testRecordingHandler.Sanitizers.Clear();
@@ -241,11 +241,11 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void TestResetExtensionsFailsWithActiveSessions()
+        public async Task TestResetExtensionsFailsWithActiveSessions()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
-            testRecordingHandler.StartRecording("recordingings/cool.json", httpContext.Response);
+            await testRecordingHandler.StartRecordingAsync("recordingings/cool.json", httpContext.Response);
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
 
             var assertion = Assert.Throws<HttpException>(
@@ -318,7 +318,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void TestWriteAbsoluteRecording()
+        public async Task TestWriteAbsoluteRecording()
         {
             var tmpPath = Path.GetTempPath();
             var currentPath = Directory.GetCurrentDirectory();
@@ -326,7 +326,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var pathToRecording = Path.Combine(currentPath, "recordings/oauth_request_new.json");
             var recordingHandler = new RecordingHandler(tmpPath);
 
-            recordingHandler.StartRecording(pathToRecording, httpContext.Response);
+            await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
             recordingHandler.StopRecording(sessionId);
 
@@ -341,7 +341,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void TestWriteRelativeRecording()
+        public async Task TestWriteRelativeRecording()
         {
             var currentPath = Directory.GetCurrentDirectory();
             var httpContext = new DefaultHttpContext();
@@ -349,7 +349,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var recordingHandler = new RecordingHandler(currentPath);
             var fullPathToRecording = Path.Combine(currentPath, pathToRecording) + ".json";
 
-            recordingHandler.StartRecording(pathToRecording, httpContext.Response);
+            await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
             recordingHandler.StopRecording(sessionId);
 
@@ -378,7 +378,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             var fullPathToRecording = Path.Combine(currentPath, pathToRecording) + ".json";
 
-            recordingHandler.StartRecording(pathToRecording, httpContext.Response);
+            await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
 
             CreateRecordModeRequest(httpContext, "request-body");
@@ -418,7 +418,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             var fullPathToRecording = Path.Combine(currentPath, pathToRecording) + ".json";
 
-            recordingHandler.StartRecording(pathToRecording, httpContext.Response);
+            await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
 
             CreateRecordModeRequest(httpContext, "request-response");
@@ -466,7 +466,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 RedirectlessClient = mockClient
             };
 
-            recordingHandler.StartRecording(pathToRecording, httpContext.Response);
+            await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
 
             CreateRecordModeRequest(httpContext, new StringValues(values));
@@ -521,7 +521,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void TestStopRecordingWithVariables()
+        public async Task TestStopRecordingWithVariables()
         {
             var tmpPath = Path.GetTempPath();
             var startHttpContext = new DefaultHttpContext();
@@ -533,7 +533,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             var endHttpContext = new DefaultHttpContext();
 
-            recordingHandler.StartRecording(pathToRecording, startHttpContext.Response);
+            await recordingHandler.StartRecordingAsync(pathToRecording, startHttpContext.Response);
             var sessionId = startHttpContext.Response.Headers["x-recording-id"].ToString();
 
             recordingHandler.StopRecording(sessionId, variables: new SortedDictionary<string, string>(dict));
@@ -548,14 +548,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void TestStopRecordingWithoutVariables()
+        public async Task TestStopRecordingWithoutVariables()
         {
             var tmpPath = Path.GetTempPath();
             var httpContext = new DefaultHttpContext();
             var pathToRecording = "recordings/oauth_request_new.json";
             var recordingHandler = new RecordingHandler(tmpPath);
 
-            recordingHandler.StartRecording(pathToRecording, httpContext.Response);
+            await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
             recordingHandler.StopRecording(sessionId, variables: new SortedDictionary<string, string>());
 
@@ -565,14 +565,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void TestStopRecordingNullVariables()
+        public async Task TestStopRecordingNullVariables()
         {
             var tmpPath = Path.GetTempPath();
             var httpContext = new DefaultHttpContext();
             var pathToRecording = "recordings/oauth_request_new.json";
             var recordingHandler = new RecordingHandler(tmpPath);
 
-            recordingHandler.StartRecording(pathToRecording, httpContext.Response);
+            await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
             recordingHandler.StopRecording(sessionId, variables: null);
 
@@ -663,12 +663,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [Theory]
         [InlineData("awesomehost.com")]
         [InlineData("")]
-        public void TestRecordMaintainsUpstreamOverrideHostHeader(string upstreamHostHeaderValue)
+        public async Task TestRecordMaintainsUpstreamOverrideHostHeader(string upstreamHostHeaderValue)
         {
             var httpContext = new DefaultHttpContext();
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
 
-            testRecordingHandler.StartRecording("hello.json", httpContext.Response);
+            await testRecordingHandler.StartRecordingAsync("hello.json", httpContext.Response);
 
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
 
@@ -871,7 +871,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [InlineData("{{\"Transport\": {{\"Certificates\": [ {{ \"PemValue\": \"{0}\", \"PemKey\": \"{1}\" }}, {{ \"PemValue\": \"{0}\", \"PemKey\": \"{1}\" }}]}}}}")]
         [InlineData("{{\"Transport\": {{\"Certificates\": [ {{ \"PemValue\": \"{0}\", \"PemKey\": \"{1}\" }}]}}}}")]
         [InlineData("{{\"Transport\": {{\"Certificates\": []}}}}")]
-        public void TestSetRecordingOptionsValidTransportRecordingLevel(string body)
+        public async Task TestSetRecordingOptionsValidTransportRecordingLevel(string body)
         {
             var pemKey = TestHelpers.GetValueFromCertificateFile("test_pem_key").Replace(Environment.NewLine, "");
             var pemValue = TestHelpers.GetValueFromCertificateFile("test_pem_value").Replace(Environment.NewLine, "");
@@ -880,7 +880,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);
 
             HttpContext context = new DefaultHttpContext();
-            testRecordingHandler.StartRecording("TestSetRecordingOptionsInValidTransportRecordingLevel.json", context.Response);
+            await testRecordingHandler.StartRecordingAsync("TestSetRecordingOptionsInValidTransportRecordingLevel.json", context.Response);
             var recordingId = context.Response.Headers["x-recording-id"].ToString();
 
             testRecordingHandler.SetRecordingOptions(inputBody, recordingId);
@@ -910,7 +910,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [InlineData("{{\"Transport\": {{\"Certificates\": [ {{ \"PemValue\": \"badvalue\", \"PemKey\": \"{1}\" }}]}}}}")]
         [InlineData("{{\"Transport\": {{\"Certificates\": [ {{ \"PemValue\": \"badvalue\" }}]}}}}")]
         [InlineData("{{\"Transport\": {{\"Certificates\": [ {{ \"PemKey\": \"{1}\" }}]}}}}")]
-        public void TestSetRecordingOptionsInvalidTransportRecordingLevel(string body)
+        public async Task TestSetRecordingOptionsInvalidTransportRecordingLevel(string body)
         {
             var pemKey = TestHelpers.GetValueFromCertificateFile("test_pem_key").Replace(Environment.NewLine, "");
             var pemValue = TestHelpers.GetValueFromCertificateFile("test_pem_value").Replace(Environment.NewLine, "");
@@ -919,7 +919,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var inputBody = System.Text.Json.JsonSerializer.Deserialize<Dictionary<string, object>>(inputObj, SerializerOptions);
 
             HttpContext context = new DefaultHttpContext();
-            testRecordingHandler.StartRecording("TestSetRecordingOptionsInValidTransportRecordingLevel.json", context.Response);
+            await testRecordingHandler.StartRecordingAsync("TestSetRecordingOptionsInValidTransportRecordingLevel.json", context.Response);
             var recordingId = context.Response.Headers["x-recording-id"].ToString();
 
             var assertion = Assert.Throws<HttpException>(

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpRequestInteractions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpRequestInteractions.cs
@@ -31,6 +31,18 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
             if(document != null)
             {
+                return GetBodyKey(document, key, allowNulls: allowNulls);
+            }
+            
+            return value;
+        }
+
+        public static string GetBodyKey(JsonDocument document, string key, bool allowNulls = false)
+        {
+            string value = null;
+
+            if (document != null)
+            {
                 var recordingFile = GetProp(key, document.RootElement);
 
                 if (recordingFile.Value.ValueKind != JsonValueKind.Undefined)
@@ -45,7 +57,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                     }
                 }
             }
-            
+
             return value;
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
@@ -29,16 +29,19 @@ namespace Azure.Sdk.Tools.TestProxy
         [HttpPost]
         public async Task Start()
         {
-            string file = await HttpRequestInteractions.GetBodyKey(Request, "x-recording-file", true);
-            string recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", true);
+            var body = await HttpRequestInteractions.GetBody(Request);
+
+            string file = HttpRequestInteractions.GetBodyKey(body, "x-recording-file", allowNulls: true);
+            string assetsJson = HttpRequestInteractions.GetBodyKey(body, "x-recording-assets-file", allowNulls: true);
+            string recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
 
             if (String.IsNullOrEmpty(file) && !String.IsNullOrEmpty(recordingId))
             {
-                await _recordingHandler.StartPlaybackAsync(recordingId, Response, RecordingType.InMemory);
+                await _recordingHandler.StartPlaybackAsync(recordingId, Response, RecordingType.InMemory, assetsJson);
             }
             else if(!String.IsNullOrEmpty(file))
             {
-                await _recordingHandler.StartPlaybackAsync(file, Response, RecordingType.FilePersisted);
+                await _recordingHandler.StartPlaybackAsync(file, Response, RecordingType.FilePersisted, assetsJson);
             }
             else
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
@@ -28,9 +28,12 @@ namespace Azure.Sdk.Tools.TestProxy
         [HttpPost]
         public async Task Start()
         {
-            string file = await HttpRequestInteractions.GetBodyKey(Request, "x-recording-file", allowNulls: true);
+            var body = await HttpRequestInteractions.GetBody(Request);
 
-            _recordingHandler.StartRecording(file, Response);
+            string file = HttpRequestInteractions.GetBodyKey(body, "x-recording-file", allowNulls: true);
+            string assetsJson = HttpRequestInteractions.GetBodyKey(body, "x-recording-assets-file", allowNulls: true);
+
+            await _recordingHandler.StartRecordingAsync(file, Response, assetsJson);
         }
 
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -138,33 +138,46 @@ namespace Azure.Sdk.Tools.TestProxy
                 }
                 else
                 {
-                    var targetPath = GetRecordingPath(recordingSession.Path);
-
                     // Create directories above file if they don't already exist
-                    var directory = Path.GetDirectoryName(targetPath);
+                    var directory = Path.GetDirectoryName(recordingSession.Path);
                     if (!String.IsNullOrEmpty(directory))
                     {
                         Directory.CreateDirectory(directory);
                     }
 
-                    using var stream = System.IO.File.Create(targetPath);
+                    using var stream = System.IO.File.Create(recordingSession.Path);
                     var options = new JsonWriterOptions { Indented = true };
                     var writer = new Utf8JsonWriter(stream, options);
                     recordingSession.Session.Serialize(writer);
                     writer.Flush();
                     stream.Write(Encoding.UTF8.GetBytes(Environment.NewLine));
-
                 }
             }
         }
 
-        public void StartRecording(string sessionId, HttpResponse outgoingResponse)
+        /// <summary>
+        /// Entrypoint handling an an optional parameter assets.json. If present, a restore option either MUST run or MAY run depending on if we're running in playback or adding new recordings.
+        /// </summary>
+        /// <param name="assetsJson">The absolute path to the targeted assets.json.</param>
+        /// <param name="forceCheckout">If this is set to true, a restore MUST be run. Otherwise, we just need to ensure that the current assets SHA is selected.</param>
+        /// <returns></returns>
+        private async Task RestoreAssetsJson(string assetsJson = null, bool forceCheckout = false)
+        {
+            if (!string.IsNullOrWhiteSpace(assetsJson))
+            {
+                await this.Store.Restore(assetsJson);
+            }
+        }
+
+        public async Task StartRecordingAsync(string sessionId, HttpResponse outgoingResponse, string assetsJson = null)
         {
             var id = Guid.NewGuid().ToString();
 
+            await RestoreAssetsJson(assetsJson, false);
+
             var session = new ModifiableRecordSession(new RecordSession())
             {
-                Path = sessionId ?? String.Empty,
+                Path = !string.IsNullOrWhiteSpace(sessionId) ? GetRecordingPath(sessionId, assetsJson) : String.Empty,
                 Client = null
             };
 
@@ -361,7 +374,7 @@ namespace Azure.Sdk.Tools.TestProxy
         #endregion
 
         #region playback functionality
-        public async Task StartPlaybackAsync(string sessionId, HttpResponse outgoingResponse, RecordingType mode = RecordingType.FilePersisted)
+        public async Task StartPlaybackAsync(string sessionId, HttpResponse outgoingResponse, RecordingType mode = RecordingType.FilePersisted, string assetsPath = null)
         {
             var id = Guid.NewGuid().ToString();
             ModifiableRecordSession session;
@@ -376,7 +389,9 @@ namespace Azure.Sdk.Tools.TestProxy
             }
             else
             {
-                var path = GetRecordingPath(sessionId);
+                await RestoreAssetsJson(assetsPath, true);
+
+                var path = GetRecordingPath(sessionId, assetsPath);
 
                 if (!File.Exists(path))
                 {
@@ -892,7 +907,7 @@ namespace Azure.Sdk.Tools.TestProxy
             }
         }
 
-        public string GetRecordingPath(string file)
+        public string GetRecordingPath(string file, string assetsPath = null)
         {
             var normalizedFileName = file.Replace('\\', '/');
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -917,7 +917,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             var path = file;
 
-            // if an assets.json iis provided, we have a bit of work to do here.
+            // if an assets.json is provided, we have a bit of work to do here.
             if (!string.IsNullOrWhiteSpace(assetsPath))
             {
                 var contextDirectory = await Store.GetPath(assetsPath);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -18,9 +18,11 @@ using System.Reflection;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Azure.Sdk.Tools.TestProxy.Store;
 using Azure.Sdk.Tools.TestProxy.Console;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Azure.Sdk.Tools.TestProxy
 {
+    [ExcludeFromCodeCoverage]
     public sealed class Startup
     {
         internal static int RequestsRecorded;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -47,7 +47,18 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             GitHandler = processHandler;
         }
 
-        #region push, reset, restore, and other asset repo implementations 
+        #region push, reset, restore, and other asset repo implementations
+        /// <summary>
+        /// Given a config, locate the cloned assets.
+        /// </summary>
+        /// <param name="pathToAssetsJson"></param>
+        /// <returns></returns>
+        public async Task<string> GetPath(string pathToAssetsJson)
+        {
+            var config = await ParseConfigurationFile(pathToAssetsJson);
+            return config.RepoRoot;
+        }
+
         /// <summary>
         /// Pushes a set of changed files to the assets repo. Honors configuration of assets.json passed into it.
         /// </summary>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -56,7 +56,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         public async Task<string> GetPath(string pathToAssetsJson)
         {
             var config = await ParseConfigurationFile(pathToAssetsJson);
-            return config.RepoRoot;
+            return config.AssetsRepoLocation;
         }
 
         /// <summary>
@@ -515,7 +515,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             return new DirectoryEvaluation()
             {
                 AssetsJsonPresent = File.Exists(assetsJsonLocation),
-                IsGitRoot = File.Exists(gitLocation),
+                IsGitRoot = File.Exists(gitLocation) || Directory.Exists(gitLocation),
                 IsRoot = new DirectoryInfo(directoryPath).Parent == null
             };
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsStore.cs
@@ -23,5 +23,12 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// </summary>
         /// <param name="pathToAssetsJson"></param>
         public abstract Task Reset(string pathToAssetsJson);
+
+        /// <summary>
+        /// Given a configuration, return the path on disk to the root of the cloned repo.
+        /// </summary>
+        /// <param name="pathToAssetsJson"></param>
+        /// <returns></returns>
+        public abstract Task<string> GetPath(string pathToAssetsJson);
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
@@ -8,19 +8,21 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 {
     public class NullStore : IAssetsStore
     {
-        public Task Push(string assetsJsonPath) { return null; }
+        public Task Push(string pathToAssetsJson) { return null; }
 
-        public Task Restore(string assetsJsonPath) { return null; }
+        public Task Restore(string pathToAssetsJson) { return null; }
 
-        public Task Reset(string assetsJsonPath) { return null; }
+        public Task Reset(string assetsJspathToAssetsJsononPath) { return null; }
 
-        public AssetsConfiguration ParseConfigurationFile(string assetsJsonPath)
+        public AssetsConfiguration ParseConfigurationFile(string pathToAssetsJson)
         {
-            if (!File.Exists(assetsJsonPath)) {
-                throw new HttpException(HttpStatusCode.BadRequest, $"The provided assets json path of \"{assetsJsonPath}\" does not exist.");
+            if (!File.Exists(pathToAssetsJson)) {
+                throw new HttpException(HttpStatusCode.BadRequest, $"The provided assets json path of \"{pathToAssetsJson}\" does not exist.");
             }
 
             return new AssetsConfiguration();
         }
+
+        public Task<string> GetPath(string pathToAssetsJson) { return null; }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Vendored/LightweightPkcs8Decoder.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Vendored/LightweightPkcs8Decoder.cs
@@ -1,9 +1,9 @@
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
-
 
 namespace Azure.Sdk.Tools.TestProxy.Vendored
 {
@@ -21,6 +21,7 @@ namespace Azure.Sdk.Tools.TestProxy.Vendored
     ///
     /// This code is able to decode RSA keys (without any attributes) from well formed PKCS#8 blobs.
     /// </summary>
+    [ExcludeFromCodeCoverage]
     internal static partial class LightweightPkcs8Decoder
     {
         private static readonly byte[] s_derIntegerZero = { 0x02, 0x01, 0x00 };

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Vendored/PemReader.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Vendored/PemReader.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Reflection;
 using System.Security.Cryptography;
@@ -19,6 +20,7 @@ namespace Azure.Sdk.Tools.TestProxy.Vendored
     /// The <c>PemEncoding</c> class takes advantage of other implementation changes in net5.0 and,
     /// based on conversations with the .NET team, runtime changes.
     /// </remarks>
+    [ExcludeFromCodeCoverage]
     internal static partial class PemReader
     {
         // The following implementation was based on PemEncoding and reviewed by @bartonjs on the .NET / cryptography team.


### PR DESCRIPTION
@JimSuplizio for FYI.

Related to #4056

This PR is intended to cover the gap between `planning` and `execution` for the asset sync shims.

I am working through .NET and Python tests to ensure we cover our bases.

Currently:


- [x] Makes the path to a recording determined at `Record/Start` or `Playback/Start`
- [x] Adds comprehension of new body key `x-recording-assets-file` that will be parsed from the two `/Start` routes. When present, we will auto restore your recordings.
- [x] Keeps track of cloned assets
- [x] This works with the integration code over in [this python branch](https://github.com/Azure/azure-sdk-for-python/tree/feature/integrate-assetsync).

We may want to adjust the efficiency of the check for whether or not an assets.json is restored to save the server disk querying.