### PR TITLE
Shorten the internal assets SHA

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/ShortHashGeneratorTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/ShortHashGeneratorTests.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Azure.Sdk.Tools.TestProxy.Common;
+using Xunit;
+
+namespace Azure.Sdk.Tools.TestProxy.Tests
+{
+    public class ShortHashGeneratorTests
+    {
+
+        [Theory]
+        [InlineData("sdk/t/assets.json", "sdk/t/assets.json", true)]
+        [InlineData("1", "1", true)]
+        [InlineData("11", "12", false)]
+        [InlineData("sdk/communication/azure-communication-tables/assets.json", "sdk/communication/azure-communication-tableś/assets.json", false)]
+        [InlineData("sdk/communication/assets.json", "sdk/ommunication/assets.json", false)]
+        public void TestShortHashGenerator(string inputString1, string inputString2, bool shouldMatch)
+        {
+            String shortHash1 = ShortHashGenerator.GenerateShortHash(inputString1);
+            String shortHash2 = ShortHashGenerator.GenerateShortHash(inputString2);
+            if (shouldMatch)
+            {
+                Assert.Equal(shortHash1, shortHash2);
+            }
+            else
+            {
+                Assert.NotEqual(shortHash1, shortHash2);
+            }
+        }
+
+        [Theory]
+        [InlineData("sdk/t/assets.json", 1)]
+        [InlineData("1", 5)]
+        [InlineData("11", 10)]
+        [InlineData("sdk/communication/azure-communication-tables/assets.json", 20)]
+        [InlineData("abcdeghijklmnop", 27)]
+        public void TestShortHashGeneratorDifferentLength(string inputString1, int hashLen)
+        {
+            String shortHash1 = ShortHashGenerator.GenerateShortHash(inputString1, hashLen);
+            Assert.Equal(shortHash1.Length, hashLen);
+        }
+
+        [Theory]
+        [InlineData("sdk/t/assets.json", 0)]
+        [InlineData("sdk/t/assets.json", 29)]
+
+        public void TestShortHashGeneratorInvalidRequestedLength(string inputString1, int hashLen)
+        {
+            Action action = () => ShortHashGenerator.GenerateShortHash(inputString1, hashLen);
+            ArgumentException argumentException = Assert.Throws<ArgumentException>(action);
+            Assert.Equal("returnHashLength must be > 1 and <= 28", argumentException.Message);
+        }
+
+        [Theory]
+        [InlineData("sdk/t/assets.json", 28)]
+        public void TestShortHashGeneratorShorterReturnLength(string inputString1, int hashLen)
+        {
+            Action action = () => ShortHashGenerator.GenerateShortHash(inputString1, hashLen);
+            ArgumentException argumentException = Assert.Throws<ArgumentException>(action);
+            Assert.StartsWith($"GenerateShortHash of {inputString1} does not produce a return string", argumentException.Message);
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ShortHashGenerator.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ShortHashGenerator.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Azure.Sdk.Tools.TestProxy.Common
+{
+    public class ShortHashGenerator
+    {
+        /// <summary>
+        /// Given a string, UTF8 encode it and create the hash using SHA1. Convert the resulting string to Base64
+        /// and return a string consisting of only letters or digits of the requested length (default is 10). 
+        /// This isn't supposed to be perfect, it's supposed to be good enough. The primary usage of this is to 
+        /// shorten the local paths of the AssetsRepoLocation
+        /// </summary>
+        /// <param name="inputString">The string to generate the short hash from.</param>
+        /// <param name="returnHashLength">The length of the returned hash, default is 10</param>
+        /// <returns></returns>
+        public static string GenerateShortHash(string inputString, int returnHashLength=10)
+        {
+            // 28 is the max length base64 string, chances are it'll be shorter once the non-lettersOrDigits are
+            // stripped away but ensure that the user isn't trying to get something longer than what could
+            // possibly be produced
+            if (returnHashLength < 1 || returnHashLength > 28)
+            {
+                throw new ArgumentException($"returnHashLength must be > 1 and <= 28");
+            }
+
+            byte[] hash = SHA1.Create().ComputeHash(Encoding.UTF8.GetBytes(inputString));
+            // Converting the hash to Hex will produce 40 character which is quite a bit longer than we actually want to add to
+            // the path. Converting the hash to Base64 produces 28 characters, which is still too long, and also has the potential
+            // to have non-alphanumeric characters which wouldn't be okay in a directory name. Take the Base64 string, grab only
+            // letters and digits and then, only grab the first 10 characters. This should be reasonably unique for the scenarios
+            // in which we're using it.
+            string returnString = String.Concat(Convert.ToBase64String(hash).ToCharArray().Where(char.IsLetterOrDigit).Take(returnHashLength));
+
+            int strLen = returnString.Length;
+            // Take won't throw, if the count is greater than the number of items in the string it'll return the entire string.
+            // If an input string is unable to produce a short hash if the requested length ensure the input string and it's
+            // resulting value/length are reported clearly and correctly.
+            if (strLen < returnHashLength)
+            {
+                throw new ArgumentException($"GenerateShortHash of {inputString} does not produce a return string of the required return hash length. Return value: {returnString}, returnHashLength: {returnHashLength}");
+            }
+
+            return returnString;
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using Azure.Sdk.Tools.TestProxy.Common;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
@@ -71,13 +72,8 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             // AssetsRepo will be something like Azure/azure-sdk-assets-integration and
             // AssetsJsonRelativeLocation will be something like sdk/<service>/assets.json
             string assetsRepoPlusJsonRelPathLoc = AssetsRepo + AssetsJsonRelativeLocation;
-            var hash = SHA1.Create().ComputeHash(Encoding.UTF8.GetBytes(assetsRepoPlusJsonRelPathLoc));
-            // Converting the hash to Hex will produce 40 character which is quite a bit longer than we actually want to add to
-            // the path. Converting the hash to Base64 produces 28 characters, which is still too long, and also has the potential
-            // to have non-alphanumeric characters which wouldn't be okay in a directory name. Take the Base64 string, grab only
-            // letters and digits and then, only grab the first 10 characters. This should be reasonably unique for the scenarios
-            // in which we're using it.
-            string shortHashString = string.Concat(Convert.ToBase64String(hash).ToCharArray().Where(char.IsLetterOrDigit).Take(10));
+
+            string shortHashString = ShortHashGenerator.GenerateShortHash(assetsRepoPlusJsonRelPathLoc);
 
             var location = Path.Join(assetsStore, shortHashString);
             if (!Directory.Exists(location))


### PR DESCRIPTION
Right now, pulling the assets locally will result in a pretty long path. This was partially the result of using the AssetsRepo (which is something like Azure/azure-sdk-assets converted to Azure-azure-sdk-assets) and the hex string from the hash computed from the AssetsJsonRelativeLocation (which is something like sdk/<service>/assets.json). Unfortunately, the hex string from the hash ends up being 40 characters. Converted the same hash to base64 still produces a character string that's 28 characters, which is too long. It can also produce non-alphanumeric characters which won't be okay for a directory name. 

We needed something "good enough" to make things unique to prevent on disk collisions when pulling assets but also reproducible, the same inputs need to generate the same string. Taking the base64 string and the first 10 letters or digits should be good enough for this purpose.

The latest commit had a change that moved the short hash code into its own class and added a test suite for it. Also added was the ability to change the hash length with the default being 10.