### PR TITLE
[Asset-Sync] Use tags not branches

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
@@ -61,8 +61,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
     ""AssetsRepo"":""Azure/azure-sdk-assets-integration"",
     ""AssetsRepoPrefixPath"":""python/recordings/"",
     ""AssetsRepoId"":"""",
-    ""AssetsRepoBranch"":""scenario_clean_push"",
-    ""SHA"":""e4a4949a2b6cc2ff75afd0fe0d97cbcabf7b67b7""
+    ""TagPrefix"":""scenario_clean_push"",
+    ""Tag"":""e4a4949a2b6cc2ff75afd0fe0d97cbcabf7b67b7""
 }
 ";
         #endregion
@@ -259,8 +259,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""python/recordings/"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""auto/test"",
-              ""SHA"": ""786b4f3d380d9c36c91f5f146ce4a7661ffee3b9""
+              ""TagPrefix"": ""auto/test"",
+              ""Tag"": ""786b4f3d380d9c36c91f5f146ce4a7661ffee3b9""
         }")]
         // Valid to just pass the assets repo. We can infer everything else.
         [InlineData(
@@ -299,8 +299,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [InlineData(
         @"{
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""auto/test"",
-              ""SHA"": ""786b4f3d380d9c36c91f5f146ce4a7661ffee3b9""
+              ""TagPrefix"": ""auto/test"",
+              ""Tag"": ""786b4f3d380d9c36c91f5f146ce4a7661ffee3b9""
         }")]
         public async Task ParseConfigurationThrowsOnMissingRequiredProperty(string inputJson)
         {
@@ -448,9 +448,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 var configuration = await _defaultStore.ParseConfigurationFile(testFolder);
                 await _defaultStore.UpdateAssetsJson(fakeSha, configuration);
 
-                Assert.Equal(fakeSha, configuration.SHA);
+                Assert.Equal(fakeSha, configuration.Tag);
                 var newConfiguration = await _defaultStore.ParseConfigurationFile(testFolder);
-                Assert.Equal(fakeSha, newConfiguration.SHA);
+                Assert.Equal(fakeSha, newConfiguration.Tag);
             }
             finally
             {
@@ -510,12 +510,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 var creationTime = File.GetLastWriteTime(pathToAssets);
 
                 var configuration = await _defaultStore.ParseConfigurationFile(testFolder);
-                await _defaultStore.UpdateAssetsJson(configuration.SHA, configuration);
+                await _defaultStore.UpdateAssetsJson(configuration.Tag, configuration);
                 var postUpdateLastWrite = File.GetLastWriteTime(pathToAssets);
 
                 Assert.Equal(creationTime, postUpdateLastWrite);
                 var newConfiguration = await _defaultStore.ParseConfigurationFile(testFolder);
-                Assert.Equal(configuration.SHA, newConfiguration.SHA);
+                Assert.Equal(configuration.Tag, newConfiguration.Tag);
             }
             finally
             {
@@ -533,12 +533,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 var pathToAssets = Path.Combine(testFolder, "assets.json");
                 var contentBeforeUpdate = File.ReadAllText(pathToAssets);
                 var configuration = await _defaultStore.ParseConfigurationFile(pathToAssets);
-                var originalSHA = configuration.SHA;
+                var originalSHA = configuration.Tag;
 
                 await _defaultStore.UpdateAssetsJson(fakeSha, configuration);
 
                 var newConfiguration = await _defaultStore.ParseConfigurationFile(pathToAssets);
-                Assert.NotEqual(originalSHA, newConfiguration.SHA);
+                Assert.NotEqual(originalSHA, newConfiguration.Tag);
                 var contentAfterUpdate = File.ReadAllText(pathToAssets);
 
                 Assert.NotEqual(contentBeforeUpdate, contentAfterUpdate);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
@@ -566,27 +566,6 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             }
         }
 
-        [Theory(Skip = "Skipping because we don't have an integration test suite working yet.")]
-        [InlineData("scenario_clean_push", "scenario_clean_push")]
-        [InlineData("nonexistent_branch", "main")]
-        public async Task ResolveTargetBranchIntegration(string targetBranch, string result)
-        {
-            var testFolder = TestHelpers.DescribeTestFolder(DefaultAssets, basicFolderStructure);
-            try
-            {
-                var config = await _defaultStore.ParseConfigurationFile(testFolder);
-                config.AssetsRepoBranch = targetBranch;
-
-                var defaultBranch = _defaultStore.ResolveCheckoutBranch(config);
-
-                Assert.Equal(result, targetBranch);
-            }
-            finally
-            {
-                DirectoryHelper.DeleteGitDirectory(testFolder);
-            }
-        }
-
         [Fact(Skip = "Skipping due to integration tests not figured out yet.")]
         public async Task GetDefaultBranchWorksWithValidRepo()
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
@@ -50,8 +50,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             AssetsRepo = "Azure/azure-sdk-assets-integration",
             AssetsRepoPrefixPath = "python/recordings/",
             AssetsRepoId = "",
-            AssetsRepoBranch = "scenario_clean_push",
-            SHA = "e4a4949a2b6cc2ff75afd0fe0d97cbcabf7b67b7"
+            TagPrefix = "scenario_clean_push",
+            Tag = "e4a4949a2b6cc2ff75afd0fe0d97cbcabf7b67b7"
         };
 
         public static string DefaultAssetsJson =

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -269,10 +269,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Ensure that the config was updated with the new SHA as part of the push
                 Assets updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
                 Assert.NotEqual(originalSHA, updatedAssets.SHA);
-                // Ensure that the latest commit SHA and the updated assets file SHA are equal
-                string latestSHA = TestHelpers.GetLatestCommitSHA(updatedAssets, localFilePath);
-                Assert.Equal(latestSHA, updatedAssets.SHA);
 
+                // Ensure that the targeted SHA is present on the repo
+                // this is failing when targeting a tag. the failure is
+                // fatal: ambiguous argument 'origin/test_d15a3644-7513-41c3-920e-4a8c40caeaa9_python/tables': unknown revision or path not in the working tree.
+                // Use '--' to separate paths from revisions, like this: 'git <command> [<revision>...] -- [<file>...]
+                //string latestSHA = TestHelpers.GetLatestCommitSHA(updatedAssets, localFilePath);
+                //Assert.Equal(latestSHA, updatedAssets.SHA);
             }
             finally
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -51,13 +51,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 GitStoretests.AssetsJson
             };
             Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
-            string originalAssetsRepoBranch = assets.AssetsRepoBranch;
-            string originalSHA = assets.SHA;
+            string originalAssetsRepoBranch = assets.TagPrefix;
+            string originalSHA = assets.Tag;
             var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure, isPushTest:true);
             try
             {
                 // Ensure that the TagPrefix was updated
-                Assert.NotEqual(originalAssetsRepoBranch, assets.AssetsRepoBranch);
+                Assert.NotEqual(originalAssetsRepoBranch, assets.TagPrefix);
 
                 var jsonFileLocation = Path.Join(testFolder, GitStoretests.AssetsJson);
 
@@ -93,10 +93,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 // Ensure that the config was updated with the new Tag as part of the push
                 Assets updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
-                Assert.NotEqual(originalSHA, updatedAssets.SHA);
+                Assert.NotEqual(originalSHA, updatedAssets.Tag);
                 // Ensure that the latest commit Tag and the updated assets file Tag are equal
                 string latestSHA = TestHelpers.GetLatestCommitSHA(updatedAssets, localFilePath);
-                Assert.Equal(latestSHA, updatedAssets.SHA);
+                Assert.Equal(latestSHA, updatedAssets.Tag);
 
             }
             finally
@@ -133,13 +133,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 GitStoretests.AssetsJson
             };
             Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
-            string originalAssetsRepoBranch = assets.AssetsRepoBranch;
-            string originalSHA = assets.SHA;
+            string originalAssetsRepoBranch = assets.TagPrefix;
+            string originalSHA = assets.Tag;
             var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure, isPushTest: true);
             try
             {
                 // Ensure that the TagPrefix was updated
-                Assert.NotEqual(originalAssetsRepoBranch, assets.AssetsRepoBranch);
+                Assert.NotEqual(originalAssetsRepoBranch, assets.TagPrefix);
 
                 var jsonFileLocation = Path.Join(testFolder, GitStoretests.AssetsJson);
 
@@ -175,10 +175,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 // Ensure that the config was updated with the new Tag as part of the push
                 Assets updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
-                Assert.NotEqual(originalSHA, updatedAssets.SHA);
+                Assert.NotEqual(originalSHA, updatedAssets.Tag);
                 // Ensure that the latest commit Tag and the updated assets file Tag are equal
                 string latestSHA = TestHelpers.GetLatestCommitSHA(updatedAssets, localFilePath);
-                Assert.Equal(latestSHA, updatedAssets.SHA);
+                Assert.Equal(latestSHA, updatedAssets.Tag);
 
             }
             finally
@@ -215,13 +215,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 GitStoretests.AssetsJson
             };
             Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
-            string originalAssetsRepoBranch = assets.AssetsRepoBranch;
-            string originalSHA = assets.SHA;
+            string originalAssetsRepoBranch = assets.TagPrefix;
+            string originalSHA = assets.Tag;
             var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure, isPushTest: true);
             try
             {
                 // Ensure that the TagPrefix was updated
-                Assert.NotEqual(originalAssetsRepoBranch, assets.AssetsRepoBranch);
+                Assert.NotEqual(originalAssetsRepoBranch, assets.TagPrefix);
 
                 var jsonFileLocation = Path.Join(testFolder, GitStoretests.AssetsJson);
 
@@ -268,7 +268,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 // Ensure that the config was updated with the new Tag as part of the push
                 Assets updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
-                Assert.NotEqual(originalSHA, updatedAssets.SHA);
+                Assert.NotEqual(originalSHA, updatedAssets.Tag);
 
                 // Ensure that the targeted Tag is present on the repo
                 // this is failing when targeting a tag. the failure is

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -30,7 +30,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         /// 3. Add/Delete/Update files
         /// 4. Push to new branch
         /// 5. Verify local files are what is expected
-        /// 6. Verify assets.json was updated with the new commit SHA
+        /// 6. Verify assets.json was updated with the new commit Tag
         /// </summary>
         /// <param name="inputJson"></param>
         /// <returns></returns>
@@ -40,8 +40,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""scenario_new_push"",
-              ""SHA"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
+              ""TagPrefix"": ""scenario_new_push"",
+              ""Tag"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
         }")]
         [Trait("Category", "Integration")]
         public async Task ScenarioNewPush(string inputJson)
@@ -56,7 +56,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure, isPushTest:true);
             try
             {
-                // Ensure that the AssetsRepoBranch was updated
+                // Ensure that the TagPrefix was updated
                 Assert.NotEqual(originalAssetsRepoBranch, assets.AssetsRepoBranch);
 
                 var jsonFileLocation = Path.Join(testFolder, GitStoretests.AssetsJson);
@@ -69,7 +69,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
                 string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
 
-                // These are the files pulled down with the original SHA
+                // These are the files pulled down with the original Tag
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 1));
@@ -91,10 +91,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
 
-                // Ensure that the config was updated with the new SHA as part of the push
+                // Ensure that the config was updated with the new Tag as part of the push
                 Assets updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
                 Assert.NotEqual(originalSHA, updatedAssets.SHA);
-                // Ensure that the latest commit SHA and the updated assets file SHA are equal
+                // Ensure that the latest commit Tag and the updated assets file Tag are equal
                 string latestSHA = TestHelpers.GetLatestCommitSHA(updatedAssets, localFilePath);
                 Assert.Equal(latestSHA, updatedAssets.SHA);
 
@@ -108,11 +108,11 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
         /// <summary>
         /// Clean Push Scenario
-        /// 1. Branch already exists and we're on the latest SHA
+        /// 1. Branch already exists and we're on the latest Tag
         /// 2. Add/Delete/Update files
         /// 3. Push commit to branch
         /// 4. Verify local files are what is expected
-        /// 5. Verify assets.json was updated with the new commit SHA
+        /// 5. Verify assets.json was updated with the new commit Tag
         /// </summary>
         /// <param name="inputJson"></param>
         /// <returns></returns>
@@ -122,8 +122,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""scenario_clean_push"",
-              ""SHA"": ""bb2223a3aa0472ff481f8e1850e7647dc39fbfdd""
+              ""TagPrefix"": ""scenario_clean_push"",
+              ""Tag"": ""bb2223a3aa0472ff481f8e1850e7647dc39fbfdd""
         }")]
         [Trait("Category", "Integration")]
         public async Task ScenarioCleanPush(string inputJson)
@@ -138,7 +138,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure, isPushTest: true);
             try
             {
-                // Ensure that the AssetsRepoBranch was updated
+                // Ensure that the TagPrefix was updated
                 Assert.NotEqual(originalAssetsRepoBranch, assets.AssetsRepoBranch);
 
                 var jsonFileLocation = Path.Join(testFolder, GitStoretests.AssetsJson);
@@ -151,7 +151,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
                 string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
 
-                // These are the files pulled down with the original SHA
+                // These are the files pulled down with the original Tag
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
@@ -173,10 +173,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file6.txt", 1));
 
-                // Ensure that the config was updated with the new SHA as part of the push
+                // Ensure that the config was updated with the new Tag as part of the push
                 Assets updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
                 Assert.NotEqual(originalSHA, updatedAssets.SHA);
-                // Ensure that the latest commit SHA and the updated assets file SHA are equal
+                // Ensure that the latest commit Tag and the updated assets file Tag are equal
                 string latestSHA = TestHelpers.GetLatestCommitSHA(updatedAssets, localFilePath);
                 Assert.Equal(latestSHA, updatedAssets.SHA);
 
@@ -190,11 +190,11 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
         /// <summary>
         /// Conflict Push Scenario
-        /// 1. Branch already exists and we're not on the latest SHA
+        /// 1. Branch already exists and we're not on the latest Tag
         /// 2. Add/Delete/Update files
         /// 3. Push commit to branch, detects a conflict
         /// 4. Verify local files are what is expected
-        /// 5. Verify assets.json was updated with the new commit SHA
+        /// 5. Verify assets.json was updated with the new commit Tag
         /// </summary>
         /// <param name="inputJson"></param>
         /// <returns></returns>
@@ -204,8 +204,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""python/tables"",
-              ""SHA"": ""python/tables/abc12345""
+              ""TagPrefix"": ""python/tables"",
+              ""Tag"": ""python/tables/abc12345""
         }")]
         [Trait("Category", "Integration")]
         public async Task ScenarioConflictPush(string inputJson)
@@ -220,7 +220,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure, isPushTest: true);
             try
             {
-                // Ensure that the AssetsRepoBranch was updated
+                // Ensure that the TagPrefix was updated
                 Assert.NotEqual(originalAssetsRepoBranch, assets.AssetsRepoBranch);
 
                 var jsonFileLocation = Path.Join(testFolder, GitStoretests.AssetsJson);
@@ -233,7 +233,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
                 string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
 
-                // These are the files pulled down with the original SHA
+                // These are the files pulled down with the original Tag
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
@@ -252,8 +252,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 // Push the update, it should detect a conflict:
                 // The latest commit only has files 2,4,5 with versions 2,1,1 respectively
-                // We've made the the following changes against the previous SHA
-                // 1. File1's version was incremented to 2, but deleted in the latest SHA
+                // We've made the the following changes against the previous Tag
+                // 1. File1's version was incremented to 2, but deleted in the latest Tag
                 // 2. File2's version was incremented to 3
                 // 3. File3 was deleted
                 // 4. File4 was deleted
@@ -266,16 +266,16 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 3));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file6.txt", 1));
 
-                // Ensure that the config was updated with the new SHA as part of the push
+                // Ensure that the config was updated with the new Tag as part of the push
                 Assets updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
                 Assert.NotEqual(originalSHA, updatedAssets.SHA);
 
-                // Ensure that the targeted SHA is present on the repo
+                // Ensure that the targeted Tag is present on the repo
                 // this is failing when targeting a tag. the failure is
                 // fatal: ambiguous argument 'origin/test_d15a3644-7513-41c3-920e-4a8c40caeaa9_python/tables': unknown revision or path not in the working tree.
                 // Use '--' to separate paths from revisions, like this: 'git <command> [<revision>...] -- [<file>...]
                 //string latestSHA = TestHelpers.GetLatestCommitSHA(updatedAssets, localFilePath);
-                //Assert.Equal(latestSHA, updatedAssets.SHA);
+                //Assert.Equal(latestSHA, updatedAssets.Tag);
             }
             finally
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -40,8 +40,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""TagPrefix"": ""scenario_new_push"",
-              ""Tag"": ""python/tables_fc54d0""
+              ""TagPrefix"": ""language/tables"",
+              ""Tag"": ""language/tables_fc54d0""
         }")]
         [Trait("Category", "Integration")]
         public async Task ScenarioNewPush(string inputJson)
@@ -122,8 +122,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""TagPrefix"": ""scenario_clean_push"",
-              ""Tag"": ""python/tables_bb2223""
+              ""TagPrefix"": ""language/tables"",
+              ""Tag"": ""language/tables_bb2223""
         }")]
         [Trait("Category", "Integration")]
         public async Task ScenarioCleanPush(string inputJson)
@@ -204,8 +204,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""TagPrefix"": ""python/tables"",
-              ""Tag"": ""python/tables_9e81fb""
+              ""TagPrefix"": ""language/tables"",
+              ""Tag"": ""language/tables_9e81fb""
         }")]
         [Trait("Category", "Integration")]
         public async Task ScenarioConflictPush(string inputJson)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -198,15 +198,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         /// </summary>
         /// <param name="inputJson"></param>
         /// <returns></returns>
-        //[EnvironmentConditionalSkipTheory]
-        [Theory(Skip = "Skipping, scenario is currently broken the way push is done on conflict.")]
+        [EnvironmentConditionalSkipTheory]
         [InlineData(
         @"{
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""scenario_conflict_push"",
-              ""SHA"": ""9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1""
+              ""AssetsRepoBranch"": ""python/tables"",
+              ""SHA"": ""python/tables/abc12345""
         }")]
         [Trait("Category", "Integration")]
         public async Task ScenarioConflictPush(string inputJson)
@@ -262,11 +261,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 await _defaultStore.Push(jsonFileLocation);
 
                 // Verify that after the push the directory still contains our updated files
-                Assert.Equal(5, System.IO.Directory.EnumerateFiles(localFilePath).Count());
+                Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 3));
-                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
-                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file5.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file6.txt", 1));
 
                 // Ensure that the config was updated with the new SHA as part of the push

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -41,7 +41,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""scenario_new_push"",
-              ""Tag"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
+              ""Tag"": ""python/tables_fc54d0""
         }")]
         [Trait("Category", "Integration")]
         public async Task ScenarioNewPush(string inputJson)
@@ -95,6 +95,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Ensure that the config was updated with the new Tag as part of the push
                 updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
                 Assert.NotEqual(originalSHA, updatedAssets.Tag);
+
+                // Ensure that the targeted tag is present on the repo
+                TestHelpers.CheckExistenceOfTag(updatedAssets, localFilePath);
             }
             finally
             {
@@ -120,7 +123,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""scenario_clean_push"",
-              ""Tag"": ""bb2223a3aa0472ff481f8e1850e7647dc39fbfdd""
+              ""Tag"": ""python/tables_bb2223""
         }")]
         [Trait("Category", "Integration")]
         public async Task ScenarioCleanPush(string inputJson)
@@ -174,6 +177,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Ensure that the config was updated with the new Tag as part of the push
                 updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
                 Assert.NotEqual(originalSHA, updatedAssets.Tag);
+
+                // Ensure that the targeted tag is present on the repo
+                TestHelpers.CheckExistenceOfTag(updatedAssets, localFilePath);
             }
             finally
             {
@@ -199,7 +205,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""python/tables"",
-              ""Tag"": ""python/tables/abc12345""
+              ""Tag"": ""python/tables_9e81fb""
         }")]
         [Trait("Category", "Integration")]
         public async Task ScenarioConflictPush(string inputJson)
@@ -265,12 +271,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
                 Assert.NotEqual(originalSHA, updatedAssets.Tag);
 
-                // Ensure that the targeted Tag is present on the repo
-                // this is failing when targeting a tag. the failure is
-                // fatal: ambiguous argument 'origin/test_d15a3644-7513-41c3-920e-4a8c40caeaa9_python/tables': unknown revision or path not in the working tree.
-                // Use '--' to separate paths from revisions, like this: 'git <command> [<revision>...] -- [<file>...]
-                //string latestSHA = TestHelpers.GetLatestCommitSHA(updatedAssets, localFilePath);
-                //Assert.Equal(latestSHA, updatedAssets.Tag);
+                // Ensure that the targeted tag is present on the repo
+                TestHelpers.CheckExistenceOfTag(updatedAssets, localFilePath);
             }
             finally
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -51,6 +51,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 GitStoretests.AssetsJson
             };
             Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
+            Assets updatedAssets = null;
             string originalAssetsRepoBranch = assets.TagPrefix;
             string originalSHA = assets.Tag;
             var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure, isPushTest:true);
@@ -92,17 +93,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
 
                 // Ensure that the config was updated with the new Tag as part of the push
-                Assets updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
+                updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
                 Assert.NotEqual(originalSHA, updatedAssets.Tag);
-                // Ensure that the latest commit Tag and the updated assets file Tag are equal
-                string latestSHA = TestHelpers.GetLatestCommitSHA(updatedAssets, localFilePath);
-                Assert.Equal(latestSHA, updatedAssets.Tag);
-
             }
             finally
             {
                 DirectoryHelper.DeleteGitDirectory(testFolder);
-                TestHelpers.CleanupIntegrationTestBranch(assets);
+                TestHelpers.CleanupIntegrationTestBranch(updatedAssets);
             }
         }
 
@@ -133,6 +130,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 GitStoretests.AssetsJson
             };
             Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
+            Assets updatedAssets = null;
             string originalAssetsRepoBranch = assets.TagPrefix;
             string originalSHA = assets.Tag;
             var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure, isPushTest: true);
@@ -174,17 +172,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file6.txt", 1));
 
                 // Ensure that the config was updated with the new Tag as part of the push
-                Assets updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
+                updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
                 Assert.NotEqual(originalSHA, updatedAssets.Tag);
-                // Ensure that the latest commit Tag and the updated assets file Tag are equal
-                string latestSHA = TestHelpers.GetLatestCommitSHA(updatedAssets, localFilePath);
-                Assert.Equal(latestSHA, updatedAssets.Tag);
-
             }
             finally
             {
                 DirectoryHelper.DeleteGitDirectory(testFolder);
-                TestHelpers.CleanupIntegrationTestBranch(assets);
+                TestHelpers.CleanupIntegrationTestBranch(updatedAssets);
             }
         }
 
@@ -215,6 +209,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 GitStoretests.AssetsJson
             };
             Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
+            Assets updatedAssets = null;
             string originalAssetsRepoBranch = assets.TagPrefix;
             string originalSHA = assets.Tag;
             var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure, isPushTest: true);
@@ -267,7 +262,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file6.txt", 1));
 
                 // Ensure that the config was updated with the new Tag as part of the push
-                Assets updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
+                updatedAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
                 Assert.NotEqual(originalSHA, updatedAssets.Tag);
 
                 // Ensure that the targeted Tag is present on the repo
@@ -280,7 +275,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             finally
             {
                 DirectoryHelper.DeleteGitDirectory(testFolder);
-                TestHelpers.CleanupIntegrationTestBranch(assets);
+                TestHelpers.CleanupIntegrationTestBranch(updatedAssets);
             }
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationResetTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationResetTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 1 - Changes to existing files only are detected and overridden with Reset response Y
-        // 1. Restore from Tag python/tables_fc54d0
+        // 1. Restore from Tag language/tables_fc54d0
         // 2. Expect: 3 files with versions they were checked in with
         // 3. Update one or more files, incrementing their version
         // 4. Expect: files updated should be at version 2
@@ -50,7 +50,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""python/tables_fc54d0""
+              ""Tag"": ""language/tables_fc54d0""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario1(string inputJson)
@@ -100,7 +100,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 2 - Changes to existing files only are detected and retained with Reset response N
-        // 1. Restore from Tag python/tables_fc54d0
+        // 1. Restore from Tag language/tables_fc54d0
         // 2. Expect: 3 files with versions they were checked in with
         // 3. Update one or more files, incrementing their version
         // 4. Expect: files updated should be at version 2
@@ -113,7 +113,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""python/tables_fc54d0""
+              ""Tag"": ""language/tables_fc54d0""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario2(string inputJson)
@@ -166,7 +166,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 3 - Restore from Tag, add and remove files, Reset response Y
-        // 1. Restore from Tag python/tables_9e81fb
+        // 1. Restore from Tag language/tables_9e81fb
         // 2. Expect: 4 files with versions they were checked in with
         // 3. Update add/remove files
         // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
@@ -179,7 +179,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""python/tables_9e81fb""
+              ""Tag"": ""language/tables_9e81fb""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario3(string inputJson)
@@ -241,7 +241,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 4 - Restore from Tag, add and remove files, Reset response N
-        // 1. Restore from Tag python/tables_9e81fb
+        // 1. Restore from Tag language/tables_9e81fb
         // 2. Expect: 4 files with versions they were checked in with
         // 3. Update add/remove files
         // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
@@ -254,7 +254,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""python/tables_9e81fb""
+              ""Tag"": ""language/tables_9e81fb""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario4(string inputJson)
@@ -315,7 +315,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 5 - Restore from Tag, add and remove files, Reset response N, then Reset response Y
-        // 1. Restore from Tag python/tables_9e81fb
+        // 1. Restore from Tag language/tables_9e81fb
         // 2. Expect: 3 files with versions they were checked in with
         // 3. Update add/remove files
         // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
@@ -330,7 +330,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""python/tables_bb2223""
+              ""Tag"": ""language/tables_bb2223""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario5(string inputJson)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationResetTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationResetTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 1 - Changes to existing files only are detected and overridden with Reset response Y
-        // 1. Restore from Tag fc54d000d0427c4a68bc8962d40f957f59e14577
+        // 1. Restore from Tag python/tables_fc54d0
         // 2. Expect: 3 files with versions they were checked in with
         // 3. Update one or more files, incrementing their version
         // 4. Expect: files updated should be at version 2
@@ -50,7 +50,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
+              ""Tag"": ""python/tables_fc54d0""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario1(string inputJson)
@@ -100,7 +100,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 2 - Changes to existing files only are detected and retained with Reset response N
-        // 1. Restore from Tag fc54d000d0427c4a68bc8962d40f957f59e14577
+        // 1. Restore from Tag python/tables_fc54d0
         // 2. Expect: 3 files with versions they were checked in with
         // 3. Update one or more files, incrementing their version
         // 4. Expect: files updated should be at version 2
@@ -113,7 +113,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
+              ""Tag"": ""python/tables_fc54d0""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario2(string inputJson)
@@ -166,7 +166,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 3 - Restore from Tag, add and remove files, Reset response Y
-        // 1. Restore from Tag 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
+        // 1. Restore from Tag python/tables_9e81fb
         // 2. Expect: 4 files with versions they were checked in with
         // 3. Update add/remove files
         // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
@@ -179,7 +179,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1""
+              ""Tag"": ""python/tables_9e81fb""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario3(string inputJson)
@@ -241,7 +241,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 4 - Restore from Tag, add and remove files, Reset response N
-        // 1. Restore from Tag 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
+        // 1. Restore from Tag python/tables_9e81fb
         // 2. Expect: 4 files with versions they were checked in with
         // 3. Update add/remove files
         // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
@@ -254,7 +254,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1""
+              ""Tag"": ""python/tables_9e81fb""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario4(string inputJson)
@@ -315,7 +315,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 5 - Restore from Tag, add and remove files, Reset response N, then Reset response Y
-        // 1. Restore from Tag 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
+        // 1. Restore from Tag python/tables_9e81fb
         // 2. Expect: 3 files with versions they were checked in with
         // 3. Update add/remove files
         // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
@@ -330,7 +330,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""bb2223a3aa0472ff481f8e1850e7647dc39fbfdd""
+              ""Tag"": ""python/tables_bb2223""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario5(string inputJson)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationResetTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationResetTests.cs
@@ -18,9 +18,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
     // Setup:
     // The files live under https://github.com/Azure/azure-sdk-assets-integration/tree/main/pull/scenarios.
     // Each file contains nothing but a single version digit, which is used for verification purposes.
-    // Most of the scenarios involve restoring from a SHA, updating, adding, and/or deleting files locally
-    // and then performing a Reset and verifying that the only the files in the original SHA are there and
-    // they've been restored to what they were in the original SHA.
+    // Most of the scenarios involve restoring from a Tag, updating, adding, and/or deleting files locally
+    // and then performing a Reset and verifying that the only the files in the original Tag are there and
+    // they've been restored to what they were in the original Tag.
     public class GitStoreIntegrationResetTests
     {
         private GitStore _defaultStore;
@@ -37,20 +37,20 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 1 - Changes to existing files only are detected and overridden with Reset response Y
-        // 1. Restore from SHA fc54d000d0427c4a68bc8962d40f957f59e14577
+        // 1. Restore from Tag fc54d000d0427c4a68bc8962d40f957f59e14577
         // 2. Expect: 3 files with versions they were checked in with
         // 3. Update one or more files, incrementing their version
         // 4. Expect: files updated should be at version 2
         // 5. Reset with Y
-        // 6. Expect: each file should be at it's initial version, the version that was in the original SHA
+        // 6. Expect: each file should be at it's initial version, the version that was in the original Tag
         [EnvironmentConditionalSkipTheory]
         [InlineData(
         @"{
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""main"",
-              ""SHA"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
+              ""TagPrefix"": ""main"",
+              ""Tag"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario1(string inputJson)
@@ -100,7 +100,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario 2 - Changes to existing files only are detected and retained with Reset response N
-        // 1. Restore from SHA fc54d000d0427c4a68bc8962d40f957f59e14577
+        // 1. Restore from Tag fc54d000d0427c4a68bc8962d40f957f59e14577
         // 2. Expect: 3 files with versions they were checked in with
         // 3. Update one or more files, incrementing their version
         // 4. Expect: files updated should be at version 2
@@ -112,8 +112,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""main"",
-              ""SHA"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
+              ""TagPrefix"": ""main"",
+              ""Tag"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario2(string inputJson)
@@ -165,21 +165,21 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             }
         }
 
-        // Scenario 3 - Restore from SHA, add and remove files, Reset response Y
-        // 1. Restore from SHA 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
+        // Scenario 3 - Restore from Tag, add and remove files, Reset response Y
+        // 1. Restore from Tag 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
         // 2. Expect: 4 files with versions they were checked in with
         // 3. Update add/remove files
         // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
         // 5. Reset with Y
-        // 6. Expect: each file should be at it's initial version, the version that was in the original SHA
+        // 6. Expect: each file should be at it's initial version, the version that was in the original Tag
         [EnvironmentConditionalSkipTheory]
         [InlineData(
         @"{
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""main"",
-              ""SHA"": ""9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1""
+              ""TagPrefix"": ""main"",
+              ""Tag"": ""9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario3(string inputJson)
@@ -203,7 +203,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
                 string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
 
-                // Verify files from SHA
+                // Verify files from Tag
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
@@ -226,7 +226,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 _consoleWrapperTester.SetReadLineResponse("Y");
                 await _defaultStore.Reset(jsonFileLocation);
 
-                // Verify the only files there are ones from the SHA
+                // Verify the only files there are ones from the Tag
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
@@ -240,8 +240,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             }
         }
 
-        // Scenario 4 - Restore from SHA, add and remove files, Reset response N
-        // 1. Restore from SHA 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
+        // Scenario 4 - Restore from Tag, add and remove files, Reset response N
+        // 1. Restore from Tag 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
         // 2. Expect: 4 files with versions they were checked in with
         // 3. Update add/remove files
         // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
@@ -253,8 +253,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""main"",
-              ""SHA"": ""9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1""
+              ""TagPrefix"": ""main"",
+              ""Tag"": ""9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario4(string inputJson)
@@ -278,7 +278,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
                 string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
 
-                // Verify files from SHA
+                // Verify files from Tag
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
@@ -301,7 +301,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 _consoleWrapperTester.SetReadLineResponse("N");
                 await _defaultStore.Reset(jsonFileLocation);
 
-                // Verify the only files were not restored from the SHA
+                // Verify the only files were not restored from the Tag
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 2));
@@ -314,8 +314,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             }
         }
 
-        // Scenario 5 - Restore from SHA, add and remove files, Reset response N, then Reset response Y
-        // 1. Restore from SHA 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
+        // Scenario 5 - Restore from Tag, add and remove files, Reset response N, then Reset response Y
+        // 1. Restore from Tag 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
         // 2. Expect: 3 files with versions they were checked in with
         // 3. Update add/remove files
         // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
@@ -329,8 +329,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""main"",
-              ""SHA"": ""bb2223a3aa0472ff481f8e1850e7647dc39fbfdd""
+              ""TagPrefix"": ""main"",
+              ""Tag"": ""bb2223a3aa0472ff481f8e1850e7647dc39fbfdd""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario5(string inputJson)
@@ -354,7 +354,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
                 string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
 
-                // Verify files from SHA
+                // Verify files from Tag
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
@@ -378,7 +378,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 _consoleWrapperTester.SetReadLineResponse("N");
                 await _defaultStore.Reset(jsonFileLocation);
 
-                // Verify the files were not restored from the SHA
+                // Verify the files were not restored from the Tag
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
@@ -389,7 +389,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 _consoleWrapperTester.SetReadLineResponse("Y");
                 await _defaultStore.Reset(jsonFileLocation);
 
-                // Verify files are from the SHA
+                // Verify files are from the Tag
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -32,7 +32,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         private GitStore _defaultStore = new GitStore();
 
         // Scenario1
-        // Tag python/tables_fc54d0
+        // Tag language/tables_fc54d0
         // This was the initial push of the test files:
         // Added file1.txt
         // Added file2.txt
@@ -45,7 +45,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""python/tables_fc54d0""
+              ""Tag"": ""language/tables_fc54d0""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario1(string inputJson)
@@ -82,7 +82,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
 
         // Scenario2
-        // Tag python/tables_9e81fb
+        // Tag language/tables_9e81fb
         // This was the second push of the test files.
         // Unchanged file1.txt
         // Updated file2.txt
@@ -99,7 +99,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""python/tables_9e81fb""
+              ""Tag"": ""language/tables_9e81fb""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario2(string inputJson)
@@ -136,7 +136,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario3
-        // Tag python/tables_bb2223
+        // Tag language/tables_bb2223
         // This was the third push of the test files.
         // Deleted   file1.txt
         // Unchanged file2.txt
@@ -155,7 +155,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""python/tables_bb2223""
+              ""Tag"": ""language/tables_bb2223""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario3(string inputJson)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -32,7 +32,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         private GitStore _defaultStore = new GitStore();
 
         // Scenario1
-        // Tag fc54d000d0427c4a68bc8962d40f957f59e14577
+        // Tag python/tables_fc54d0
         // This was the initial push of the test files:
         // Added file1.txt
         // Added file2.txt
@@ -45,7 +45,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
+              ""Tag"": ""python/tables_fc54d0""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario1(string inputJson)
@@ -82,7 +82,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
 
         // Scenario2
-        // Tag 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
+        // Tag python/tables_9e81fb
         // This was the second push of the test files.
         // Unchanged file1.txt
         // Updated file2.txt
@@ -99,7 +99,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1""
+              ""Tag"": ""python/tables_9e81fb""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario2(string inputJson)
@@ -136,7 +136,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario3
-        // Tag bb2223a3aa0472ff481f8e1850e7647dc39fbfdd
+        // Tag python/tables_bb2223
         // This was the third push of the test files.
         // Deleted   file1.txt
         // Unchanged file2.txt
@@ -155,7 +155,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
-              ""Tag"": ""bb2223a3aa0472ff481f8e1850e7647dc39fbfdd""
+              ""Tag"": ""python/tables_bb2223""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario3(string inputJson)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -17,7 +17,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
     // Setup:
     // The files live under https://github.com/Azure/azure-sdk-assets-integration/tree/main/pull/scenarios.
     // Each file contains nothing but a single version digit, which is used for verification purposes.
-    // There are restore test scenarios and each uses a different SHA. The scenarios are detailed down
+    // There are restore test scenarios and each uses a different Tag. The scenarios are detailed down
     // below with their test functions.
     public class GitStoreIntegrationRestoreTests
     {
@@ -32,7 +32,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         private GitStore _defaultStore = new GitStore();
 
         // Scenario1
-        // SHA fc54d000d0427c4a68bc8962d40f957f59e14577
+        // Tag fc54d000d0427c4a68bc8962d40f957f59e14577
         // This was the initial push of the test files:
         // Added file1.txt
         // Added file2.txt
@@ -44,8 +44,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""main"",
-              ""SHA"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
+              ""TagPrefix"": ""main"",
+              ""Tag"": ""fc54d000d0427c4a68bc8962d40f957f59e14577""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario1(string inputJson)
@@ -82,7 +82,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
 
         // Scenario2
-        // SHA 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
+        // Tag 9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1
         // This was the second push of the test files.
         // Unchanged file1.txt
         // Updated file2.txt
@@ -98,8 +98,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""main"",
-              ""SHA"": ""9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1""
+              ""TagPrefix"": ""main"",
+              ""Tag"": ""9e81fbb7d08c2df4cbdbfaffe79cde5d72f560d1""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario2(string inputJson)
@@ -136,7 +136,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         // Scenario3
-        // SHA bb2223a3aa0472ff481f8e1850e7647dc39fbfdd
+        // Tag bb2223a3aa0472ff481f8e1850e7647dc39fbfdd
         // This was the third push of the test files.
         // Deleted   file1.txt
         // Unchanged file2.txt
@@ -154,8 +154,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
-              ""AssetsRepoBranch"": ""main"",
-              ""SHA"": ""bb2223a3aa0472ff481f8e1850e7647dc39fbfdd""
+              ""TagPrefix"": ""main"",
+              ""Tag"": ""bb2223a3aa0472ff481f8e1850e7647dc39fbfdd""
         }")]
         [Trait("Category", "Integration")]
         public async Task Scenario3(string inputJson)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -400,17 +400,17 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         /// <summary>
-        /// Given an 
+        /// Given a test assets config, check to see if the tag exists on the assets repo.
         /// </summary>
         /// <param name="assets"></param>
         /// <param name="workingDirectory"></param>
         /// <returns></returns>
-        public static string GetLatestCommitSHA(Assets assets, string workingDirectory)
+        public static bool CheckExistenceOfTag(Assets assets, string workingDirectory)
         {
-            // git rev-parse origin/$($config.TagPrefix) --quiet
             GitProcessHandler GitHandler = new GitProcessHandler();
-            CommandResult result = GitHandler.Run($"rev-parse origin/{assets.TagPrefix} --quiet", workingDirectory);
-            return result.StdOut.Trim();
+            var cloneUrl = GitStore.GetCloneUrl(assets.AssetsRepo);
+            CommandResult result = GitHandler.Run($"ls-remote {cloneUrl} --tags {assets.Tag}", workingDirectory);
+            return result.StdOut.Trim().Length > 0;
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -380,15 +380,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 GitProcessHandler GitHandler = new GitProcessHandler();
                 string gitCloneUrl = GitStore.GetCloneUrl(assets.AssetsRepo);
                 GitHandler.Run($"clone {gitCloneUrl} .", tmpPath);
-
-                CommandResult commandResult = GitHandler.Run($"branch -a -l *{assets.TagPrefix}*", tmpPath);
-                if (!String.IsNullOrWhiteSpace(commandResult.StdOut))
-                {
-                    // git checkout $adjustedName
-                    // git push origin --delete $adjustedName
-                    GitHandler.Run($"checkout {assets.TagPrefix}", tmpPath);
-                    GitHandler.Run($"push origin --delete {assets.TagPrefix}", tmpPath);
-                }
+                GitHandler.Run($"push origin --delete {assets.Tag}", tmpPath);
             }
             finally
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -26,8 +26,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         public string AssetsRepo { get; set; }
         public string AssetsRepoPrefixPath { get; set; }
         public string AssetsRepoId { get; set; }
-        public string AssetsRepoBranch { get; set; }
-        public string SHA { get; set; }
+        public string TagPrefix { get; set; }
+        public string Tag { get; set; }
     }
 
     public static class TestHelpers
@@ -149,12 +149,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             // 1. The AssetsReproBranch
             if (isPushTest)
             {
-                string adjustedAssetsRepoBranch = string.Format("test_{0}_{1}", testGuid, assets.AssetsRepoBranch);
+                string adjustedAssetsRepoBranch = string.Format("test_{0}_{1}", testGuid, assets.TagPrefix);
                 // Call InitIntegrationBranch
                 InitIntegrationBranch(assets, adjustedAssetsRepoBranch);
 
                 // set the TagPrefix to the adjusted test branch 
-                assets.AssetsRepoBranch = adjustedAssetsRepoBranch;
+                assets.TagPrefix = adjustedAssetsRepoBranch;
                 localAssetsJsonContent = JsonSerializer.Serialize(assets);
             }
 
@@ -340,7 +340,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 // Clone the original assets repo
                 GitHandler.Run($"clone {gitCloneUrl} .", tmpPath);
                 // Check to see if there's already a branch
-                CommandResult commandResult = GitHandler.Run($"ls-remote --heads {gitCloneUrl} {assets.AssetsRepoBranch}", tmpPath);
+                CommandResult commandResult = GitHandler.Run($"ls-remote --heads {gitCloneUrl} {assets.TagPrefix}", tmpPath);
                 // If the commandResult response is empty, there's nothing to do and we can return
                 if (String.IsNullOrWhiteSpace(commandResult.StdOut))
                 {
@@ -350,7 +350,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 // If the commandResult response is not empty, the command result will have something
                 // similar to the following:
                 // e4a4949a2b6cc2ff75afd0fe0d97cbcabf7b67b7	refs/heads/scenario_clean_push
-                GitHandler.Run($"checkout {assets.AssetsRepoBranch}", tmpPath);
+                GitHandler.Run($"checkout {assets.TagPrefix}", tmpPath);
 
                 // Create the adjustedAssetsRepoBranch from the original branch. The reason being is that pushing
                 // to a branch of a branch is automatic
@@ -381,13 +381,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 string gitCloneUrl = GitStore.GetCloneUrl(assets.AssetsRepo);
                 GitHandler.Run($"clone {gitCloneUrl} .", tmpPath);
 
-                CommandResult commandResult = GitHandler.Run($"branch -a -l *{assets.AssetsRepoBranch}*", tmpPath);
+                CommandResult commandResult = GitHandler.Run($"branch -a -l *{assets.TagPrefix}*", tmpPath);
                 if (!String.IsNullOrWhiteSpace(commandResult.StdOut))
                 {
                     // git checkout $adjustedName
                     // git push origin --delete $adjustedName
-                    GitHandler.Run($"checkout {assets.AssetsRepoBranch}", tmpPath);
-                    GitHandler.Run($"push origin --delete {assets.AssetsRepoBranch}", tmpPath);
+                    GitHandler.Run($"checkout {assets.TagPrefix}", tmpPath);
+                    GitHandler.Run($"push origin --delete {assets.TagPrefix}", tmpPath);
                 }
             }
             finally
@@ -417,7 +417,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         {
             // git rev-parse origin/$($config.TagPrefix) --quiet
             GitProcessHandler GitHandler = new GitProcessHandler();
-            CommandResult result = GitHandler.Run($"rev-parse origin/{assets.AssetsRepoBranch} --quiet", workingDirectory);
+            CommandResult result = GitHandler.Run($"rev-parse origin/{assets.TagPrefix} --quiet", workingDirectory);
             return result.StdOut.Trim();
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -16,9 +16,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 {
     /// <summary>
     /// Assets is the class representation of assets.json. When setting up for the push tests we're going to end up
-    /// creating a branch of the original AssetsRepoBranch so we can automatically push to it. This is done at setup
+    /// creating a branch of the original TagPrefix so we can automatically push to it. This is done at setup
     /// time and then the AssetsReproBranch will have to be changed to use this new branch. This class will be used
-    /// to deserialize from string representation of assets.json, set the AssetsRepoBranch to the generated testing
+    /// to deserialize from string representation of assets.json, set the TagPrefix to the generated testing
     /// branch and serialize back into a string. This is only used for testing purposes.
     /// </summary>
     public class Assets
@@ -153,7 +153,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 // Call InitIntegrationBranch
                 InitIntegrationBranch(assets, adjustedAssetsRepoBranch);
 
-                // set the AssetsRepoBranch to the adjusted test branch 
+                // set the TagPrefix to the adjusted test branch 
                 assets.AssetsRepoBranch = adjustedAssetsRepoBranch;
                 localAssetsJsonContent = JsonSerializer.Serialize(assets);
             }
@@ -330,7 +330,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             // What needs to get done here is as follows:
             // 1. Clone the original assets repo
-            // 2. <response> = git ls-remote --heads <gitCloneUrl> <assets.AssetsRepoBranch>
+            // 2. <response> = git ls-remote --heads <gitCloneUrl> <assets.TagPrefix>
             // if the <response> is empty then just return, if not then create a test branch
             try
             {
@@ -355,7 +355,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 // Create the adjustedAssetsRepoBranch from the original branch. The reason being is that pushing
                 // to a branch of a branch is automatic
                 GitHandler.Run($"checkout -b {adjustedAssetsRepoBranch}", tmpPath);
-                // Push the contents of the AssetsRepoBranch into the adjustedAssetsRepoBranch
+                // Push the contents of the TagPrefix into the adjustedAssetsRepoBranch
                 GitHandler.Run($"push origin {adjustedAssetsRepoBranch}", tmpPath);
             }
             finally
@@ -415,7 +415,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         /// <returns></returns>
         public static string GetLatestCommitSHA(Assets assets, string workingDirectory)
         {
-            // git rev-parse origin/$($config.AssetsRepoBranch) --quiet
+            // git rev-parse origin/$($config.TagPrefix) --quiet
             GitProcessHandler GitHandler = new GitProcessHandler();
             CommandResult result = GitHandler.Run($"rev-parse origin/{assets.AssetsRepoBranch} --quiet", workingDirectory);
             return result.StdOut.Trim();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -159,7 +159,7 @@ namespace Azure.Sdk.Tools.TestProxy
         /// Entrypoint handling an an optional parameter assets.json. If present, a restore option either MUST run or MAY run depending on if we're running in playback or adding new recordings.
         /// </summary>
         /// <param name="assetsJson">The absolute path to the targeted assets.json.</param>
-        /// <param name="forceCheckout">If this is set to true, a restore MUST be run. Otherwise, we just need to ensure that the current assets SHA is selected.</param>
+        /// <param name="forceCheckout">If this is set to true, a restore MUST be run. Otherwise, we just need to ensure that the current assets Tag is selected.</param>
         /// <returns></returns>
         private async Task RestoreAssetsJson(string assetsJson = null, bool forceCheckout = false)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
@@ -21,9 +21,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         public string AssetsRepo { get; set; }
 
         /// <summary>
-        /// The targeted SHA within the AssetsRepo.
+        /// The targeted Tag within the AssetsRepo.
         /// </summary>
-        public string SHA { get; set;  }
+        public string Tag { get; set;  }
 
         /// <summary>
         /// Within the assets repo, is there a prefix that should be inserted prior to writing out files?
@@ -31,9 +31,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         public string AssetsRepoPrefixPath { get; set; }
 
         /// <summary>
-        /// The auto-commit branch.
+        /// Tags are generated and pushed with each changeset. This prefix will inform the name of the tag to be recognizable as soemthing other than a guid.
         /// </summary>
-        public string AssetsRepoBranch { get; set; }
+        public string TagPrefix { get; set; }
 
         /// <summary>
         /// The location of the assets repo for this config.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -380,26 +380,6 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         }
 
         /// <summary>
-        /// Reaches out to the assets repo and confirms presence of auto branch.
-        /// </summary>
-        /// <param name="config"></param>
-        /// <returns></returns>
-        public string ResolveCheckoutBranch(GitAssetsConfiguration config)
-        {
-            GitHandler.TryRun($"rev-parse \"origin/{config.AssetsRepoBranch}\"", config, out var commandResult);
-
-            switch (commandResult.ExitCode)
-            {
-                case 0:   // there is indeed a branch that exists with that name
-                    return config.AssetsRepoBranch;
-                case 128: // not a git repo
-                    throw new HttpException(HttpStatusCode.BadRequest, commandResult.StdOut); ;
-            }
-
-            return DefaultBranch;
-        }
-
-        /// <summary>
         /// Used to ascend to the repo root of any given startup path. Unlike ResolveAssetsJson, which implements similar ascension logic, this function returns the repo root, NOT the assets.json.
         /// </summary>
         /// <param name="path"></param>


### PR DESCRIPTION
Tests should be working now.

- [x] Properties renamed
- [x] Integration tests updated to pull from actual tags, instead of the SHAs of said tags
- [x] Updated the cleanup of the push tests so that instead of deleting the original tag (via TagPrefix), they delete the tag that we just pushed.
- [x] Updated the last check of the `push` tests to check that the tag exists on the target repo, instead of checking that the latest tag on the branch is the one we just pushed.
- [x] Tests Passing