### PR TITLE
Control Parallel Git Invocation

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -113,12 +114,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 Arguments = arguments
             };
 
-            if (!AssetTasks.TryGetValue(workingDirectory, out var queue))
-            {
-                // only add a new task queue if it doesn't exist
-                // if it does exist, just use the old one so that pending tasks will still be able to complete
-                queue = AssetTasks.GetOrAdd(workingDirectory, new TaskQueue());
-            }
+            var queue = AssetTasks.GetOrAdd(workingDirectory, new TaskQueue());
 
             queue.Enqueue(() =>
             {
@@ -173,10 +169,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             processStartInfo.Arguments = arguments;
             var commandResult = new CommandResult();
 
-            if (!AssetTasks.TryGetValue(config.AssetsRepoLocation, out var queue))
-            {
-                queue = AssetTasks.GetOrAdd(config.AssetsRepoLocation, new TaskQueue());
-            }
+            var queue = AssetTasks.GetOrAdd(config.AssetsRepoLocation, new TaskQueue());
 
             queue.Enqueue(() =>
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/TaskQueue.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/TaskQueue.cs
@@ -1,0 +1,76 @@
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+
+namespace Azure.Sdk.Tools.TestProxy.Store
+{
+    /// <summary>
+    /// This class is used to control access to a directory. Within the GitProcessHandler, a queue is used per targeted git directory. This ensures
+    /// that multiple Async requests hitting the asset store functionality will NEVER be able to stomp on each other.
+    /// </summary>
+    public class TaskQueue
+    {
+        private SemaphoreSlim semaphore;
+
+        public TaskQueue()
+        {
+            semaphore = new SemaphoreSlim(1);
+        }
+
+        /// <summary>
+        /// Used to await the running of a single block of code. Returns a value of type T.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="incomingTask"></param>
+        /// <returns></returns>
+        public async Task<T> EnqueueAsync<T>(Func<Task<T>> incomingTask)
+        {
+            await semaphore.WaitAsync();
+            try
+            {
+                return await incomingTask();
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Used to await the running of a single block of code. No incoming arguments, no return types.
+        /// </summary>
+        /// <param name="incomingTask"></param>
+        /// <returns></returns>
+        public async Task EnqueueAsync(Func<Task> incomingTask)
+        {
+            await semaphore.WaitAsync();
+
+            try
+            {
+                await incomingTask();
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+
+        /// <summary>
+        /// Used to invoke a block of code. No incoming arguments, no output arguments.
+        /// </summary>
+        /// <param name="incomingTask"></param>
+        public void Enqueue(Action incomingTask)
+        {
+            semaphore.Wait();
+
+            try
+            {
+                incomingTask();
+            }
+            finally
+            {
+                semaphore.Release();
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR ensures that we will ever run git commands in **serial** against a given working directory. Controlling per directory means that concurrent tests from various service areas will still be able to work alongside each other.

@benbp what do you think about this? I like that it is _entirely_ atomic to the class. When we move this guy to a common core, this functionality should definitely merge IMO.

