### PR TITLE
Adding paragraph support in comments

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
@@ -1081,6 +1081,10 @@ mark {
     color: #6A737D;
 }
 
+.review-comment pre {
+    background-color: var(--bg-light-hover);
+}
+
 .review-thread-reply {
     background-color: var(--bg-light);
     border-radius: 0 0 3px 3px;

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
@@ -33,10 +33,10 @@
                                             <input type="hidden" name="commentId" value="@comment.CommentId" />
                                             <button type="submit" class="btn btn-light btn-xs btn-upvote" title="@string.Join(", ", comment.Upvotes)" active-if="@comment.Upvotes.Contains(User.GetGitHubLogin())">
                                                 @{
-                                                        <span active-if="@comment.Upvotes.Any()">👍</span>
+                                                    <span active-if="@comment.Upvotes.Any()">👍</span>
                                                     if (comment.Upvotes.Any())
                                                     {
-                                                            <small class="mr-1">@comment.Upvotes.Count</small>
+                                                        <small class="mr-1">@comment.Upvotes.Count</small>
                                                     }
                                                 }
                                             </button>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
@@ -33,10 +33,10 @@
                                             <input type="hidden" name="commentId" value="@comment.CommentId" />
                                             <button type="submit" class="btn btn-light btn-xs btn-upvote" title="@string.Join(", ", comment.Upvotes)" active-if="@comment.Upvotes.Contains(User.GetGitHubLogin())">
                                                 @{
-                                                    <span active-if="@comment.Upvotes.Any()">👍</span>
+                                                        <span active-if="@comment.Upvotes.Any()">👍</span>
                                                     if (comment.Upvotes.Any())
                                                     {
-                                                        <small class="mr-1">@comment.Upvotes.Count</small>
+                                                            <small class="mr-1">@comment.Upvotes.Count</small>
                                                     }
                                                 }
                                             </button>
@@ -71,7 +71,43 @@
                                         </div>
                                     </span>
                                     <textarea class="js-comment-raw d-none">@comment.Comment</textarea>
-                                    @Html.FormatAsMarkdown(@comment.Comment)
+                                    
+                                    @if (comment.Comment.Contains("\r\n")) 
+                                    {
+                                        var cmt = comment.Comment.Split("\r\n");
+                                        string codeBlockString = "";
+                                        bool codeBlock = false;
+                                        foreach (var line in cmt){
+                                            @* Preserves code block formatting *@
+                                            if (line.Contains("```")) {
+                                                codeBlock = !codeBlock;
+                                                codeBlockString += line + "\n";
+                                                if (!codeBlock)
+                                                {
+                                                    <br />
+                                                    @Html.FormatAsMarkdown(codeBlockString)
+                                                    codeBlockString = "";
+                                                }
+                                            }
+                                            else if (codeBlock)
+                                            {
+                                                codeBlockString += line + "\n";
+                                            }
+                                            @* Adds new lines where needed, otherwise breaks up parsing to be line by line *@
+                                            else if (line.Equals(""))
+                                            {
+                                                <br />
+                                            } 
+                                            else
+                                            {
+                                                @Html.FormatAsMarkdown(line)
+                                            }
+                                        }
+                                    }
+                                    else 
+                                    {
+                                        @Html.FormatAsMarkdown(comment.Comment)
+                                    }
                                 </div>
                             </div>
                         </div>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadPartial.cshtml
@@ -77,6 +77,7 @@
                                         var cmt = comment.Comment.Split("\r\n");
                                         string codeBlockString = "";
                                         bool codeBlock = false;
+                                        bool newLineAdded = true;
                                         foreach (var line in cmt){
                                             @* Preserves code block formatting *@
                                             if (line.Contains("```")) {
@@ -84,9 +85,13 @@
                                                 codeBlockString += line + "\n";
                                                 if (!codeBlock)
                                                 {
-                                                    <br />
+                                                    if (!newLineAdded) 
+                                                    {
+                                                        <br />
+                                                    }
                                                     @Html.FormatAsMarkdown(codeBlockString)
                                                     codeBlockString = "";
+                                                    newLineAdded = true;
                                                 }
                                             }
                                             else if (codeBlock)
@@ -94,13 +99,15 @@
                                                 codeBlockString += line + "\n";
                                             }
                                             @* Adds new lines where needed, otherwise breaks up parsing to be line by line *@
-                                            else if (line.Equals(""))
+                                            else if (line.Equals("") && !newLineAdded)
                                             {
                                                 <br />
+                                                newLineAdded = true;
                                             } 
-                                            else
+                                            else if (!line.Equals(""))
                                             {
                                                 @Html.FormatAsMarkdown(line)
+                                                newLineAdded = false;
                                             }
                                         }
                                     }


### PR DESCRIPTION
This updates the comment parser to be line-by-line, including parsing code blocks, so that newlines are not squashed by the inbuilt method. This resolves #4030.

Before:
![image](https://user-images.githubusercontent.com/28514942/189774815-b79b2f77-f969-4c82-87cb-21be0db9153f.png)

After:
![image](https://user-images.githubusercontent.com/28514942/189774835-98fdd583-1a99-4b2f-bdff-6e15571fab99.png)

#### The markdown used is as follows:

Here we have a comment that spans several lines.
This should be on a new line. 
\```
// This is a java code block
System.out.println("Hello, world!");

int i = 0;
\```
And a continued comment.

Now an additional paragraph, to test all cases I am aware of.

#### Which is formatted to:

Here we have a comment that spans several lines.
This should be on a new line. 
```
// This is a java code block
System.out.println("Hello, world!");

int i = 0;
```
And a continued comment.

Now an additional paragraph, to test all cases I am aware of.
