### PR TITLE
Add a time component to build blob paths

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/BlobUploadProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/BlobUploadProcessor.cs
@@ -24,6 +24,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
     using Microsoft.Extensions.Options;
     using Microsoft.TeamFoundation.Build.WebApi;
     using Microsoft.TeamFoundation.TestManagement.WebApi;
+    using Microsoft.VisualStudio.Services.Common;
     using Microsoft.VisualStudio.Services.TestResults.WebApi;
 
     using Newtonsoft.Json;
@@ -518,7 +519,8 @@ namespace Azure.Sdk.Tools.PipelineWitness
         {
             try
             {
-                var blobPath = $"{build.Project.Name}/{build.FinishTime:yyyy/MM/dd}/{build.Id}.jsonl";
+                long changeTime = ((DateTimeOffset)build.LastChangedDate).ToUnixTimeSeconds();
+                var blobPath = $"{build.Project.Name}/{build.FinishTime:yyyy/MM/dd}/{build.Id}-{changeTime}.jsonl";
                 var blobClient = this.buildsContainerClient.GetBlobClient(blobPath);
 
                 if (await blobClient.ExistsAsync())
@@ -821,7 +823,8 @@ namespace Azure.Sdk.Tools.PipelineWitness
         {
             try
             {
-                var blobPath = $"{build.Project.Name}/{testRun.CompletedDate:yyyy/MM/dd}/{testRun.Id}.jsonl";
+                long changeTime = ((DateTimeOffset)testRun.LastUpdatedDate).ToUnixTimeSeconds();
+                var blobPath = $"{build.Project.Name}/{testRun.CompletedDate:yyyy/MM/dd}/{testRun.Id}-{changeTime}.jsonl";
                 var blobClient = this.testRunsContainerClient.GetBlobClient(blobPath);
 
                 if (await blobClient.ExistsAsync())

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/BlobUploadProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/BlobUploadProcessor.cs
@@ -823,8 +823,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
         {
             try
             {
-                long changeTime = ((DateTimeOffset)testRun.LastUpdatedDate).ToUnixTimeSeconds();
-                var blobPath = $"{build.Project.Name}/{testRun.CompletedDate:yyyy/MM/dd}/{testRun.Id}-{changeTime}.jsonl";
+                var blobPath = $"{build.Project.Name}/{testRun.CompletedDate:yyyy/MM/dd}/{testRun.Id}.jsonl";
                 var blobClient = this.testRunsContainerClient.GetBlobClient(blobPath);
 
                 if (await blobClient.ExistsAsync())


### PR DESCRIPTION
Retries of builds in the same day weren't being exported to Kusto because their blob paths already existed.  This change makes the blob path unique to the retry by adding a date component to the build blob paths.

This may introduce duplicates for builds that are being processed during deployment. This is acceptable as duplicates should be expected in kusto and filtered out in-query