### PR TITLE
Fix push tests by adding user.name and user.email to the commit

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/EnvironmentConditionalSkipTheory.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/EnvironmentConditionalSkipTheory.cs
@@ -17,7 +17,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
     {
         public EnvironmentConditionalSkipTheory()
         {
-            var token = Environment.GetEnvironmentVariable(GitStore.EnvironmentVariableName);
+            var token = Environment.GetEnvironmentVariable(GitStore.GIT_TOKEN_ENV_VAR);
             var inCI = Environment.GetEnvironmentVariable("TF_BUILD");
 
             // If we are in CI, we MUST have environment variable for PROXY_GIT_TOKEN populated.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -85,8 +85,6 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     GitHandler.Run($"branch {config.TagPrefix}", config);
                     GitHandler.Run($"checkout {config.TagPrefix}", config);
                     GitHandler.Run($"add -A .", config);
-                    // git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" commit -m
-                    //GitHandler.Run($"commit -m \"Automatic asset update from test-proxy.\"", config);
                     GitHandler.Run($"-c user.name=\"{gitUserName}\" -c user.email=\"{gitUserEmail}\" commit -m \"Automatic asset update from test-proxy.\"", config);
                     GitHandler.Run($"tag {generatedTagName}", config);
                     GitHandler.Run($"push origin {generatedTagName}", config);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -32,7 +32,11 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         public GitProcessHandler GitHandler = new GitProcessHandler();
         public string DefaultBranch = "main";
         public string FileName = "assets.json";
-        public static readonly string EnvironmentVariableName = "PROXY_GIT_TOKEN";
+        public static readonly string GIT_TOKEN_ENV_VAR = "GIT_TOKEN";
+        // Note: These are slightly different from the GIT_COMMITTER_NAME and GIT_COMMITTER_EMAIL
+        // variables that GIT recognizes, this is on purpose.
+        public static readonly string GIT_COMMIT_OWNER_ENV_VAR = "GIT_COMMIT_OWNER";
+        public static readonly string GIT_COMMIT_EMAIL_ENV_VAR = "GIT_COMMIT_EMAIL";
 
         public ConcurrentDictionary<string, string> Assets = new ConcurrentDictionary<string, string>();
 
@@ -76,10 +80,14 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             {
                 try
                 {
+                    string gitUserName = GetGitOwnerName(config);
+                    string gitUserEmail = GetGitOwnerEmail(config);
                     GitHandler.Run($"branch {config.TagPrefix}", config);
                     GitHandler.Run($"checkout {config.TagPrefix}", config);
                     GitHandler.Run($"add -A .", config);
-                    GitHandler.Run($"commit -m \"Automatic asset update from test-proxy.\"", config);
+                    // git -c user.name="azure-sdk" -c user.email="azuresdk@microsoft.com" commit -m
+                    //GitHandler.Run($"commit -m \"Automatic asset update from test-proxy.\"", config);
+                    GitHandler.Run($"-c user.name=\"{gitUserName}\" -c user.email=\"{gitUserEmail}\" commit -m \"Automatic asset update from test-proxy.\"", config);
                     GitHandler.Run($"tag {generatedTagName}", config);
                     GitHandler.Run($"push origin {generatedTagName}", config);
                 }
@@ -240,9 +248,43 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             }
         }
 
+        public string GetGitOwnerName(GitAssetsConfiguration config)
+        {
+            var ownerName = Environment.GetEnvironmentVariable(GIT_COMMIT_OWNER_ENV_VAR);
+            // If the owner wasn't set as part of the environment, check to see if there's
+            // a user.name set, if not 
+            if (string.IsNullOrWhiteSpace(ownerName))
+            {
+                ownerName = GitHandler.Run("config --get user.name", config).StdOut;
+                if (string.IsNullOrWhiteSpace(ownerName))
+                {
+                    // At this point we need to prompt the user
+                    ownerName = "";
+                }
+            }
+            return ownerName.Trim();
+        }
+
+        public string GetGitOwnerEmail(GitAssetsConfiguration config)
+        {
+            var ownerEmail = Environment.GetEnvironmentVariable(GIT_COMMIT_EMAIL_ENV_VAR);
+            // If the owner wasn't set as part of the environment, check to see if there's
+            // a user.name set, if not 
+            if (string.IsNullOrWhiteSpace(ownerEmail))
+            {
+                ownerEmail = GitHandler.Run("config --get user.email", config).StdOut;
+                if (string.IsNullOrWhiteSpace(ownerEmail))
+                {
+                    // At this point we need to prompt the user
+                    ownerEmail = "";
+                }
+            }
+            return ownerEmail.Trim();
+        }
+
         public static string GetCloneUrl(string assetsRepo)
         {
-            var gitToken = Environment.GetEnvironmentVariable(EnvironmentVariableName);
+            var gitToken = Environment.GetEnvironmentVariable(GIT_TOKEN_ENV_VAR);
 
             if (!string.IsNullOrWhiteSpace(gitToken)){
                 return $"https://{gitToken}@github.com/{assetsRepo}";
@@ -374,7 +416,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <returns>The default branch</returns>
         public async Task<string> GetDefaultBranch(GitAssetsConfiguration config)
         {
-            var token = Environment.GetEnvironmentVariable(EnvironmentVariableName);
+            var token = Environment.GetEnvironmentVariable(GIT_TOKEN_ENV_VAR);
 
             HttpRequestMessage msg = new HttpRequestMessage()
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -136,7 +136,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
             if (pendingChanges.Length > 0)
             {
-                _consoleWrapper.WriteLine("There are pending git chances, are you sure you want to reset? [Y|N]");
+                _consoleWrapper.WriteLine("There are pending git changes, are you sure you want to reset? [Y|N]");
                 while (true)
                 {
                     string response = _consoleWrapper.ReadLine();

--- a/tools/test-proxy/tests.yml
+++ b/tools/test-proxy/tests.yml
@@ -36,8 +36,10 @@ stages:
             DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
             DOTNET_CLI_TELEMETRY_OPTOUT: 1
             DOTNET_MULTILEVEL_LOOKUP: 0
-            PROXY_GIT_TOKEN: $(azuresdk-github-pat)
-        
+            GIT_TOKEN: $(azuresdk-github-pat)
+            GIT_COMMIT_OWNER: azure-sdk
+            GIT_COMMIT_EMAIL: azuresdk@microsoft.com
+
         - task: PublishTestResults@2
           condition: succeededOrFailed()
           inputs:
@@ -141,7 +143,7 @@ stages:
         - pwsh: |
             git clone https://github.com/$(REPO) $(CLONE_LOCATION) --depth 1
           displayName: Clone Repo
-        
+
         - template: /eng/pipelines/templates/steps/test-proxy-local-tool.yml
           parameters:
             runProxy: true


### PR DESCRIPTION
The push tests, when running on in automation, were failing because the commit message didn't have the user.name or user.email set when running on the lab machines. 
1. Change the token environment variable to GIT_TOKEN
2. Add GIT_COMMIT_OWNER and GIT_COMMIT_EMAIL as environment variables to the server in tests.yml
3. If neither of the environment variables in step 2 are set, check git for these values. If those aren't set, I'm probably going to have to prompt the user to enter them. That is still to be decided and part of this PR.

Right now, this PR is to unblock the failures that are happening when running **tools - test-proxy - tests** pipeline.