### PR TITLE
Adding one restore test that checks for expected exceptions

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -224,9 +224,6 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 await _defaultStore.Restore(jsonFileLocation);
 
-                // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
-                // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
-                // will be a forward one as expected by git but on Windows this won't result in a usable path.
                 string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
 
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -193,9 +193,6 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             }
         }
 
-
-        // Scenario4
-        // NONEXISTENT or INVALID tag
         [EnvironmentConditionalSkipTheory]
         [InlineData(
         @"{


### PR DESCRIPTION
During integration I sometimes see _nothing_ and I'm trying to figure out the scenarios that cause that.