### PR TITLE
[Perf] Pin versions of JS core packages

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -53,10 +53,20 @@ namespace Azure.Sdk.Tools.PerfAutomation
 
                 if (packageVersion != Program.PackageVersionSource)
                 {
-                    // TODO: Could change algo to "update deps, else update dev deps, else add to deps",
-                    //       but I think all our projects will only need deps added/updated.
-                    projectJson["dependencies"][packageName] = packageVersion;
-                    testUtilsProjectJson["dependencies"][packageName] = packageVersion;
+                    // TODO: Update common/config/rush/common-versions.json
+
+                    foreach (var packageJson in new JObject[] { projectJson, testUtilsProjectJson })
+                    {
+                        // Update devDependencies if exists, else upsert dependencies
+                        if (packageJson["devDependencies"]?[packageName] != null)
+                        {
+                            packageJson["devDependencies"][packageName] = packageVersion;
+                        }
+                        else
+                        {
+                            packageJson["dependencies"][packageName] = packageVersion;
+                        }
+                    }
                 }
             }
 

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -67,6 +67,8 @@ namespace Azure.Sdk.Tools.PerfAutomation
                         }
                         else
                         {
+                            // TODO: Consider only updating deps if they exist, rather than inserting
+                            // Some packages may need inserting, but some may only need updating.
                             packageJson["dependencies"][packageName] = packageVersion;
                         }
                     }

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -58,14 +58,14 @@ namespace Azure.Sdk.Tools.PerfAutomation
                 {
                     commonVersionsJson["preferredVersions"][packageName] = packageVersion;
 
-                    foreach (var packageJson in new JObject[] { projectJson/*, testUtilsProjectJson*/ })
+                    foreach (var packageJson in new JObject[] { projectJson, testUtilsProjectJson })
                     {
                         // Update devDependencies if exists, else upsert dependencies
                         if (packageJson["devDependencies"]?[packageName] != null)
                         {
                             packageJson["devDependencies"][packageName] = packageVersion;
                         }
-                        else // if (packageJson["dependencies"]?[packageName] != null)
+                        else if (packageJson["dependencies"]?[packageName] != null)
                         {
                             // TODO: Consider only updating deps if they exist, rather than inserting
                             // Some packages may need inserting, but some may only need updating.

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -65,7 +65,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
                         {
                             packageJson["devDependencies"][packageName] = packageVersion;
                         }
-                        else
+                        else if (packageJson["dependencies"]?[packageName] != null)
                         {
                             // TODO: Consider only updating deps if they exist, rather than inserting
                             // Some packages may need inserting, but some may only need updating.

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -82,7 +82,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
             File.Copy(testUtilsProjectFile, testUtilsProjectFile + ".bak", overwrite: true);
             File.WriteAllText(testUtilsProjectFile, testUtilsProjectJson.ToString() + Environment.NewLine);
 
-            await Util.RunAsync("node", $"{_rush} update", WorkingDirectory, outputBuilder: outputBuilder, errorBuilder: errorBuilder);
+            await Util.RunAsync("node", $"{_rush} update --full", WorkingDirectory, outputBuilder: outputBuilder, errorBuilder: errorBuilder);
 
             if (track1)
             {

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -60,16 +60,13 @@ namespace Azure.Sdk.Tools.PerfAutomation
 
                     foreach (var packageJson in new JObject[] { projectJson, testUtilsProjectJson })
                     {
-                        // Update devDependencies if exists, else upsert dependencies
-                        if (packageJson["devDependencies"]?[packageName] != null)
+                        foreach (var dependencyType in new string[] { "dependencies", "devDependencies" })
                         {
-                            packageJson["devDependencies"][packageName] = packageVersion;
-                        }
-                        else if (packageJson["dependencies"]?[packageName] != null)
-                        {
-                            // TODO: Consider only updating deps if they exist, rather than inserting
-                            // Some packages may need inserting, but some may only need updating.
-                            packageJson["dependencies"][packageName] = packageVersion;
+                            // Only update existing dependencies.  Not necessary to add dependencies not already present.
+                            if (packageJson[dependencyType]?[packageName] != null)
+                            {
+                                packageJson[dependencyType][packageName] = packageVersion;
+                            }
                         }
                     }
                 }

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -22,6 +22,9 @@ namespace Azure.Sdk.Tools.PerfAutomation
             var outputBuilder = new StringBuilder();
             var errorBuilder = new StringBuilder();
 
+            var commonVersionsFile = Path.Combine(WorkingDirectory, "common", "config", "rush", "common-versions.json");
+            var commonVersionsJson = JObject.Parse(File.ReadAllText(commonVersionsFile));
+
             var projectDirectory = Path.Combine(WorkingDirectory, project);
             var projectFile = Path.Combine(projectDirectory, "package.json");
             var projectJson = JObject.Parse(File.ReadAllText(projectFile));
@@ -53,7 +56,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
 
                 if (packageVersion != Program.PackageVersionSource)
                 {
-                    // TODO: Update common/config/rush/common-versions.json
+                    commonVersionsJson["preferredVersions"][packageName] = packageVersion;
 
                     foreach (var packageJson in new JObject[] { projectJson, testUtilsProjectJson })
                     {
@@ -69,6 +72,9 @@ namespace Azure.Sdk.Tools.PerfAutomation
                     }
                 }
             }
+
+            File.Copy(commonVersionsFile, commonVersionsFile + ".bak", overwrite: true);
+            File.WriteAllText(commonVersionsFile, commonVersionsJson.ToString() + Environment.NewLine);
 
             File.Copy(projectFile, projectFile + ".bak", overwrite: true);
             File.WriteAllText(projectFile, projectJson.ToString() + Environment.NewLine);
@@ -220,11 +226,13 @@ namespace Azure.Sdk.Tools.PerfAutomation
             File.Delete(Path.Combine(WorkingDirectory, "common", "config", "rush", "deploy.json"));
             Util.DeleteIfExists(Path.Combine(WorkingDirectory, "common", "deploy"));
 
+            var commonVersionsFile = Path.Combine(WorkingDirectory, "common", "config", "rush", "common-versions.json");
             var projectDirectory = Path.Combine(WorkingDirectory, project);
             var projectFile = Path.Combine(projectDirectory, "package.json");
             var testUtilsProjectFile = Path.Combine(WorkingDirectory, "sdk", "test-utils", "perf", "package.json");
 
             // Restore backups
+            File.Move(commonVersionsFile + ".bak", commonVersionsFile, overwrite: true);
             File.Move(projectFile + ".bak", projectFile, overwrite: true);
             File.Move(testUtilsProjectFile + ".bak", testUtilsProjectFile, overwrite: true);
 

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -50,6 +50,8 @@ namespace Azure.Sdk.Tools.PerfAutomation
 
                 if (packageVersion != Program.PackageVersionSource)
                 {
+                    // TODO: Stop checking devDependencies, since we only care about runtime deps
+                    // TODO: If dep does not already exist, add it instead of skipping
                     foreach (var dependencyType in new string[] { "dependencies", "devDependencies" })
                     {
                         if (projectJson[dependencyType]?[packageName] != null)

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -58,14 +58,14 @@ namespace Azure.Sdk.Tools.PerfAutomation
                 {
                     commonVersionsJson["preferredVersions"][packageName] = packageVersion;
 
-                    foreach (var packageJson in new JObject[] { projectJson, testUtilsProjectJson })
+                    foreach (var packageJson in new JObject[] { projectJson/*, testUtilsProjectJson*/ })
                     {
                         // Update devDependencies if exists, else upsert dependencies
                         if (packageJson["devDependencies"]?[packageName] != null)
                         {
                             packageJson["devDependencies"][packageName] = packageVersion;
                         }
-                        else if (packageJson["dependencies"]?[packageName] != null)
+                        else // if (packageJson["dependencies"]?[packageName] != null)
                         {
                             // TODO: Consider only updating deps if they exist, rather than inserting
                             // Some packages may need inserting, but some may only need updating.

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -150,6 +150,17 @@ Services:
       Project: sdk/storage/perf-tests/storage-blob
       PrimaryPackage: '@azure/storage-blob'
       PackageVersions:
+      # TODO: Get working with core-auth@1.3.2 and core-rest-pipeline@1.9.0
+      - '@azure/storage-blob': 12.11.0
+        '@azure/core-auth': 1.3.2
+        '@azure/core-http': 2.2.5
+        '@azure/core-lro': 2.2.4
+        '@azure/core-paging': 1.3.0
+        '@azure/core-rest-pipeline': 1.9.0
+        '@azure/core-tracing': 1.0.1
+        '@azure/core-util': 1.1.0
+        '@azure/abort-controller': 1.1.0
+        '@azure/logger': 1.0.3
       - '@azure/storage-blob': 12.11.0
         '@azure/core-auth': 1.4.0
         '@azure/core-http': 2.2.5

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -151,13 +151,13 @@ Services:
       PrimaryPackage: '@azure/storage-blob'
       PackageVersions:
       - '@azure/storage-blob': 12.11.0
-        '@azure/core-auth': 1.3.2
+        '@azure/core-auth': 1.4.0
         '@azure/core-http': 2.2.5
         '@azure/core-lro': 2.2.4
         '@azure/core-paging': 1.3.0
-        '@azure/core-rest-pipeline': 1.9.0
+        '@azure/core-rest-pipeline': 1.9.2
         '@azure/core-tracing': 1.0.1
-        '@azure/core-util': 1.0.0
+        '@azure/core-util': 1.1.0
         '@azure/abort-controller': 1.1.0
         '@azure/logger': 1.0.3
       - '@azure/storage-blob': source

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -148,6 +148,7 @@ Services:
       AdditionalArguments: *java-additional-arguments
     JS:
       Project: sdk/storage/perf-tests/storage-blob
+      PrimaryPackage: '@azure/storage-blob'
       PackageVersions:
       - '@azure/storage-blob': 12.11.0
         '@azure/core-auth': 1.3.2

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -149,9 +149,26 @@ Services:
     JS:
       Project: sdk/storage/perf-tests/storage-blob
       PackageVersions:
-      # TODO: Pin version of core to align with older version of storage.  Currently always uses source version of core.
       - '@azure/storage-blob': 12.11.0
+        '@azure/core-auth': 1.3.2
+        '@azure/core-http': 2.2.5
+        '@azure/core-lro': 2.2.4
+        '@azure/core-paging': 1.3.0
+        '@azure/core-rest-pipeline': 1.9.0
+        '@azure/core-tracing': 1.0.1
+        '@azure/core-util': 1.0.0
+        '@azure/abort-controller': 1.1.0
+        '@azure/logger': 1.0.3
       - '@azure/storage-blob': source
+        '@azure/core-auth': source
+        '@azure/core-http': source
+        '@azure/core-lro': source
+        '@azure/core-paging': source
+        '@azure/core-rest-pipeline': source
+        '@azure/core-tracing': source
+        '@azure/core-util': source
+        '@azure/abort-controller': source
+        '@azure/logger': source
     Python:
       Project: sdk/storage/azure-storage-blob
       PrimaryPackage: azure-storage-blob

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -151,16 +151,6 @@ Services:
       PrimaryPackage: '@azure/storage-blob'
       PackageVersions:
       - '@azure/storage-blob': 12.11.0
-        '@azure/core-auth': 1.4.0
-        '@azure/core-http': 2.2.5
-        '@azure/core-lro': 2.2.4
-        '@azure/core-paging': 1.3.0
-        '@azure/core-rest-pipeline': 1.9.2
-        '@azure/core-tracing': 1.0.1
-        '@azure/core-util': 1.1.0
-        '@azure/abort-controller': 1.1.0
-        '@azure/logger': 1.0.3
-      - '@azure/storage-blob': 12.11.0
         '@azure/core-auth': 1.3.2
         '@azure/core-http': 2.2.5
         '@azure/core-lro': 2.2.4

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -150,23 +150,22 @@ Services:
       Project: sdk/storage/perf-tests/storage-blob
       PrimaryPackage: '@azure/storage-blob'
       PackageVersions:
-      # TODO: Get working with core-auth@1.3.2 and core-rest-pipeline@1.9.0
-      - '@azure/storage-blob': 12.11.0
-        '@azure/core-auth': 1.3.2
-        '@azure/core-http': 2.2.5
-        '@azure/core-lro': 2.2.4
-        '@azure/core-paging': 1.3.0
-        '@azure/core-rest-pipeline': 1.9.0
-        '@azure/core-tracing': 1.0.1
-        '@azure/core-util': 1.1.0
-        '@azure/abort-controller': 1.1.0
-        '@azure/logger': 1.0.3
       - '@azure/storage-blob': 12.11.0
         '@azure/core-auth': 1.4.0
         '@azure/core-http': 2.2.5
         '@azure/core-lro': 2.2.4
         '@azure/core-paging': 1.3.0
         '@azure/core-rest-pipeline': 1.9.2
+        '@azure/core-tracing': 1.0.1
+        '@azure/core-util': 1.1.0
+        '@azure/abort-controller': 1.1.0
+        '@azure/logger': 1.0.3
+      - '@azure/storage-blob': 12.11.0
+        '@azure/core-auth': 1.3.2
+        '@azure/core-http': 2.2.5
+        '@azure/core-lro': 2.2.4
+        '@azure/core-paging': 1.3.0
+        '@azure/core-rest-pipeline': 1.9.0
         '@azure/core-tracing': 1.0.1
         '@azure/core-util': 1.1.0
         '@azure/abort-controller': 1.1.0


### PR DESCRIPTION
- Fixes #4131 

## Verification Build
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1854773&view=logs&j=e9a82041-32c4-5afc-7c62-6957ea0e4504&t=0431ff2a-151f-558c-7484-13e3a9e1b0ea&l=26

All package versions are aligned (except for outlier `core-tracing`), all source versions point to source tree.