### PR TITLE
Update docker files to have `git` available

### DIFF
--- a/tools/test-proxy/docker/dockerfile
+++ b/tools/test-proxy/docker/dockerfile
@@ -21,7 +21,6 @@ ENV \
     Logging__LogLevel__Default=Information \
     Logging__LogLevel__Microsoft=Information
 
-
 # dotnet-dev-certs tool is not included in aspnet image, so manually copy from sdk image
 COPY --from=build /usr/share/dotnet/sdk/6.0.102/DotnetTools/dotnet-dev-certs/6.0.2-servicing.22064.12/tools/net6.0/any/ /dotnet-dev-certs
 
@@ -29,8 +28,7 @@ COPY --from=build /usr/share/dotnet/sdk/6.0.102/DotnetTools/dotnet-dev-certs/6.0
 COPY docker_build/$CERT_IMPORT_SH docker_build/dotnet-devcert.pfx docker_build/dotnet-devcert.crt $CERT_FOLDER/
 
 RUN \
-    # Install bash and certutil
-    apk add --no-cache bash nss-tools \
+    && apk add --no-cache bash nss-tools git \
     # Fix line endings
     && sed -i -e 's/\r$//' $CERT_FOLDER/$CERT_IMPORT_SH \
     # Use copied dotnet-dev-certs tool

--- a/tools/test-proxy/docker/dockerfile
+++ b/tools/test-proxy/docker/dockerfile
@@ -28,7 +28,7 @@ COPY --from=build /usr/share/dotnet/sdk/6.0.102/DotnetTools/dotnet-dev-certs/6.0
 COPY docker_build/$CERT_IMPORT_SH docker_build/dotnet-devcert.pfx docker_build/dotnet-devcert.crt $CERT_FOLDER/
 
 RUN \
-    && apk add --no-cache bash nss-tools git \
+    apk add --no-cache bash nss-tools git \
     # Fix line endings
     && sed -i -e 's/\r$//' $CERT_FOLDER/$CERT_IMPORT_SH \
     # Use copied dotnet-dev-certs tool

--- a/tools/test-proxy/docker/dockerfile-win
+++ b/tools/test-proxy/docker/dockerfile-win
@@ -2,6 +2,11 @@ FROM mcr.microsoft.com/dotnet/sdk:6.0.101-nanoserver-1809 AS build_env
 
 # copy the code
 COPY docker_build/Azure.Sdk.Tools.TestProxy/ /proxyservercode
+COPY windows-git-install.ps1 /tempcode/
+
+RUN pwsh /tempcode/windows-git-install.ps1
+
+RUN pwsh -c "gci -R /git"
 
 # publish the package
 RUN cd /proxyservercode && dotnet publish -c Release -o /proxyserver -f net6.0
@@ -40,8 +45,9 @@ ADD docker_build/dotnet-devcert.pfx certwork
 # we still need to import this certificate to ensure it's available to all users. there is _something_ gnarly going on that purely having the cert 
 # available through the environment variables is causing some inconsistent weirdness.    
 COPY --from=build_env ["C:/Program Files/dotnet/sdk/6.0.101/DotnetTools/dotnet-dev-certs/6.0.1-servicing.21567.14/tools/net6.0/any/", "C:/dotnet-dev-certs/"]
+COPY --from=build_env ["C:/git", "C:/git"]
 
-RUN dotnet /dotnet-dev-certs/dotnet-dev-certs.dll https --clean --import /certwork/dotnet-devcert.pfx -p "password"
+RUN setx /M PATH "C:\git\cmd;%PATH%" && dotnet /dotnet-dev-certs/dotnet-dev-certs.dll https --clean --import /certwork/dotnet-devcert.pfx -p "password"
 
 WORKDIR /proxyserver
 ADD host-patcher.cmd .

--- a/tools/test-proxy/docker/dockerfile-win
+++ b/tools/test-proxy/docker/dockerfile-win
@@ -6,8 +6,6 @@ COPY windows-git-install.ps1 /tempcode/
 
 RUN pwsh /tempcode/windows-git-install.ps1
 
-RUN pwsh -c "gci -R /git"
-
 # publish the package
 RUN cd /proxyservercode && dotnet publish -c Release -o /proxyserver -f net6.0
 

--- a/tools/test-proxy/docker/windows-git-install.ps1
+++ b/tools/test-proxy/docker/windows-git-install.ps1
@@ -1,0 +1,3 @@
+mkdir -p /git
+Invoke-RestMethod -Uri "https://github.com/git-for-windows/git/releases/download/v2.37.3.windows.1/MinGit-2.37.3-64-bit.zip" -OutFile "/git/git.zip"
+Expand-Archive "/git/git.zip" -DestinationPath "/git/" -Force && Remove-Item "/git/git.zip"


### PR DESCRIPTION
So that the `gitstore` has something to operate against.

Verified presence of git by changing ENTRYPOINT to `git --version` locally before submitting.

Resolves #4139 