### PR TITLE
Fix GZip handling for requests

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/request_response_with_gzipped_content.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/request_response_with_gzipped_content.json
@@ -1,0 +1,48 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeazsdktestaccount.table.core.windows.net/Tables",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "34",
+        "Content-Type": "application/json",
+        "Content-Encoding": "gzip",
+        "DataServiceVersion": "3.0",
+        "Date": "Tue, 18 May 2021 23:27:42 GMT",
+        "User-Agent": "azsdk-python-data-tables/12.0.0b7 Python/3.8.6 (Windows-10-10.0.19041-SP0)",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-date": "Tue, 18 May 2021 23:27:42 GMT",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "{\u0022TableName\u0022:    \u0022listtable09bf2a3d\u0022}",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json",
+        "Content-Encoding": "gzip",
+        "Date": "Tue, 18 May 2021 23:27:43 GMT",
+        "Retry-After": "10",
+        "Location": "https://fakeazsdktestaccount.table.core.windows.net/Tables(\u0027listtable09bf2a3d\u0027)",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-request-id": "d2270777-c002-0072-313d-4ce19f000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeazsdktestaccount.table.core.windows.net/$metadata#Tables/@Element",
+        "TableName": "listtable09bf2a3d",
+        "connectionString":  null
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/GZipUtilities.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/GZipUtilities.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http.Headers;
+using Microsoft.AspNetCore.Http;
+
+namespace Azure.Sdk.Tools.TestProxy.Common
+{
+    /// <summary>
+    /// Utility methods to compress and decompress content to/from GZip.
+    /// </summary>
+    public static class GZipUtilities
+    {
+        private const string Gzip = "gzip";
+        private const string ContentEncoding = "Content-Encoding";
+
+        public static byte[] CompressBody(byte[] incomingBody, IDictionary<string, string[]> headers)
+        {
+            if (headers.TryGetValue(ContentEncoding, out var values) && values.Contains(Gzip))
+            {
+                return CompressBodyCore(incomingBody);
+            }
+
+            return incomingBody;
+        }
+
+        public static byte[] CompressBody(byte[] incomingBody, IHeaderDictionary headers)
+        {
+            if (headers.TryGetValue(ContentEncoding, out var values) && values.Contains(Gzip))
+            {
+                return CompressBodyCore(incomingBody);
+            }
+
+            return incomingBody;
+        }
+
+        public static byte[] CompressBodyCore(byte[] body)
+        {
+            using (var uncompressedStream = new MemoryStream(body))
+            using (var resultStream = new MemoryStream())
+            {
+                using (var compressedStream = new GZipStream(resultStream, CompressionMode.Compress))
+                {
+                    uncompressedStream.CopyTo(compressedStream);
+                }
+
+                return resultStream.ToArray();
+            }
+        }
+
+        public static byte[] DecompressBody(MemoryStream incomingBody, HttpContentHeaders headers)
+        {
+            if (headers.TryGetValues(ContentEncoding, out var values) && values.Contains(Gzip))
+            {
+                return DecompressBodyCore(incomingBody);
+            }
+
+            return incomingBody.ToArray();
+        }
+
+        public static byte[] DecompressBody(byte[] incomingBody, IHeaderDictionary headers)
+        {
+            if (headers.TryGetValue(ContentEncoding, out var values) && values.Contains(Gzip))
+            {
+                return DecompressBodyCore(new MemoryStream(incomingBody));
+            }
+
+            return incomingBody;
+        }
+
+        private static byte[] DecompressBodyCore(MemoryStream stream)
+        {
+            using var uncompressedStream = new GZipStream(stream, CompressionMode.Decompress);
+            using var resultStream = new MemoryStream();
+            uncompressedStream.CopyTo(resultStream);
+            return resultStream.ToArray();
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -10,7 +10,6 @@
   "profiles": {
     "Azure.Sdk.Tools.TestProxy": {
       "commandName": "Project",
-      "commandLineArgs": "--help",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "Logging__LogLevel__Microsoft": "Information"

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -200,7 +200,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             var entry = await CreateEntryAsync(incomingRequest).ConfigureAwait(false);
 
-            var upstreamRequest = CreateUpstreamRequest(incomingRequest, entry.Request.Body);
+            var upstreamRequest = CreateUpstreamRequest(incomingRequest);
 
             HttpResponseMessage upstreamResponse = null;
 
@@ -218,7 +218,7 @@ namespace Azure.Sdk.Tools.TestProxy
             // HEAD requests do NOT have a body regardless of the value of the Content-Length header
             if (incomingRequest.Method.ToUpperInvariant() != "HEAD")
             {
-                body = DecompressBody((MemoryStream)await upstreamResponse.Content.ReadAsStreamAsync().ConfigureAwait(false), upstreamResponse.Content.Headers);
+                body = GZipUtilities.DecompressBody((MemoryStream)await upstreamResponse.Content.ReadAsStreamAsync().ConfigureAwait(false), upstreamResponse.Content.Headers);
             }
 
             entry.Response.Body = body.Length == 0 ? null : body;
@@ -250,7 +250,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (entry.Response.Body?.Length > 0)
             {
-                var bodyData = CompressBody(entry.Response.Body, entry.Response.Headers);
+                var bodyData = GZipUtilities.CompressBody(entry.Response.Body, entry.Response.Headers);
                 outgoingResponse.ContentLength = bodyData.Length;
                 await outgoingResponse.Body.WriteAsync(bodyData).ConfigureAwait(false);
             }
@@ -290,51 +290,12 @@ namespace Azure.Sdk.Tools.TestProxy
             return mode;
         }
 
-        private byte[] CompressBody(byte[] incomingBody, SortedDictionary<string, string[]> headers)
-        {
-            if (headers.TryGetValue("Content-Encoding", out var values))
-            {
-                if (values.Contains("gzip"))
-                {
-                    using (var uncompressedStream = new MemoryStream(incomingBody))
-                    using (var resultStream = new MemoryStream())
-                    {
-                        using (var compressedStream = new GZipStream(resultStream, CompressionMode.Compress))
-                        {
-                            uncompressedStream.CopyTo(compressedStream);
-                        }
-                        return resultStream.ToArray();
-                    }
-                }
-            }
-
-            return incomingBody;
-        }
-
-        private byte[] DecompressBody(MemoryStream incomingBody, HttpContentHeaders headers)
-        {
-            if (headers.TryGetValues("Content-Encoding", out var values))
-            {
-                if (values.Contains("gzip"))
-                {
-                    using (var uncompressedStream = new GZipStream(incomingBody, CompressionMode.Decompress))
-                    using (var resultStream = new MemoryStream())
-                    {
-                        uncompressedStream.CopyTo(resultStream);
-                        return resultStream.ToArray();
-                    }
-                }
-            }
-
-            return incomingBody.ToArray();
-        }
-
-        public HttpRequestMessage CreateUpstreamRequest(HttpRequest incomingRequest, byte[] incomingBody)
+        public HttpRequestMessage CreateUpstreamRequest(HttpRequest incomingRequest)
         {
             var upstreamRequest = new HttpRequestMessage();
             upstreamRequest.RequestUri = GetRequestUri(incomingRequest);
             upstreamRequest.Method = new HttpMethod(incomingRequest.Method);
-            upstreamRequest.Content = new ReadOnlyMemoryContent(incomingBody);
+            upstreamRequest.Content = new StreamContent(incomingRequest.Body);
 
             foreach (var header in incomingRequest.Headers)
             {
@@ -484,7 +445,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (match.Response.Body?.Length > 0)
             {
-                var bodyData = CompressBody(match.Response.Body, match.Response.Headers);
+                var bodyData = GZipUtilities.CompressBody(match.Response.Body, match.Response.Headers);
 
                 outgoingResponse.ContentLength = bodyData.Length;
 
@@ -506,7 +467,9 @@ namespace Azure.Sdk.Tools.TestProxy
                 }
             }
 
-            entry.Request.Body = await ReadAllBytes(request.Body).ConfigureAwait(false);
+            byte[] bytes = await ReadAllBytes(request.Body).ConfigureAwait(false);
+
+            entry.Request.Body = GZipUtilities.DecompressBody(bytes, request.Headers);
             return entry;
         }
 


### PR DESCRIPTION
@JoshLove-msft went out of his way to contribute a bugfix via #4165 

However, given the fact that this _probably_ breaks recordings where `gzip` is present...we'll need to re-record tests. We will do that in each corresponding auto-created branch from _this_ PR.

- [ ] eng/common test branch created
- [ ] update test recordings (on _all_ relevant repos)
- [ ] once green is had on all the repos, merge the PRs


