### PR TITLE
Fix race condition in RecordingHandler when there are concurrent requests

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -228,7 +228,10 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (mode != EntryRecordMode.DontRecord)
             {
-                session.Session.Entries.Add(entry);
+                lock (session.Session.Entries)
+                {
+                    session.Session.Entries.Add(entry);
+                }
 
                 Interlocked.Increment(ref Startup.RequestsRecorded);
             }


### PR DESCRIPTION
Adds a lock around the critical section that modifies the entries list. 