### PR TITLE
Ensure stable record entries

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -228,8 +228,11 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (mode != EntryRecordMode.DontRecord)
             {
-                session.Session.Entries.Add(entry);
-
+                lock(session.Session.Entries)
+                {
+                    session.Session.Entries.Add(entry);
+                }
+                
                 Interlocked.Increment(ref Startup.RequestsRecorded);
             }
 


### PR DESCRIPTION
@JoshLove-msft was able reliably repro this issue by running 100 concurrent requests for an individual recording. When stopping that recording, he didn't reliably find all of the expected entries in the recording.

This is due to the fact that List<> isn't thread safe, and we add to the list as part of handling a request during recording. Due to these requests stomping on each other, we'd end up dropping entries.

If we lock the entries prior to adding the session, we should avoid this behavior.

If _this_ doesn't address the issue, we'll need to swap to some concurrent structure for these items, which will be a bit more involved.