### PR TITLE
Support Relative AssetsJson Paths

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -8,6 +8,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Azure.Sdk.Tools.TestProxy.Common;
 using Xunit;
+using System.Text.Json;
+using Azure.Sdk.Tools.TestProxy.Store;
 
 namespace Azure.Sdk.Tools.TestProxy.Tests
 {
@@ -247,6 +249,98 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             request.Body = new MemoryStream(GZipUtilities.CompressBody(BinaryData.FromStream(request.Body).ToArray(), request.Headers));
             HttpResponse response = new DefaultHttpContext().Response;
             await testRecordingHandler.HandlePlaybackRequest(recordingId, request, response);
+        }
+
+
+        [Theory]
+        [InlineData(
+        @"{
+              ""AssetsRepo"": ""Azure/azure-sdk-assets"",
+              ""AssetsRepoPrefixPath"": """",
+              ""AssetsRepoId"": """",
+              ""TagPrefix"": ""python/tables"",
+              ""Tag"": ""python/tables_0f2a2fa5""
+        }")]
+        [Trait("Category", "Integration")]
+        public async Task TestPlaybackWithRelativeAssetsJsonPath(string inputJson)
+        {
+            var folderStructure = new string[]
+            {
+                Path.Join("sdk", "tables", GitStoretests.AssetsJson)
+            };
+
+            Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
+            var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure);
+
+            try
+            {
+                RecordingHandler testRecordingHandler = new RecordingHandler(testFolder, new GitStore());
+                var httpContext = new DefaultHttpContext();
+                var recordingPath = "sdk/tables/azure-data-tables/tests/recordings/test_challenge_auth.pyTestTableChallengeAuthtest_challenge_auth_supported_version.json";
+                var body = "{\"x-recording-file\":\"" + recordingPath + "\", \"x-recording-assets-file\": \"sdk/tables/assets.json\"}";
+                httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
+                httpContext.Request.ContentLength = httpContext.Request.Body.Length;
+
+                var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
+                {
+                    ControllerContext = new ControllerContext()
+                    {
+                        HttpContext = httpContext
+                    }
+                };
+                await controller.Start();
+            }
+            finally
+            {
+                DirectoryHelper.DeleteGitDirectory(testFolder);
+            }
+        }
+
+        [Theory]
+        [InlineData(
+        @"{
+              ""AssetsRepo"": ""Azure/azure-sdk-assets"",
+              ""AssetsRepoPrefixPath"": """",
+              ""AssetsRepoId"": """",
+              ""TagPrefix"": ""python/tables"",
+              ""Tag"": ""python/tables_0f2a2fa5""
+        }")]
+        [Trait("Category", "Integration")]
+        public async Task TestPlaybackWithAbsoluteAssetsJsonPath(string inputJson)
+        {
+            var assetsJsonRelativePath = Path.Join("sdk", "tables", GitStoretests.AssetsJson);
+
+            var folderStructure = new string[]
+            {
+                assetsJsonRelativePath
+            };
+
+            Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
+            var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure);
+            var pathToAssetsJson = Path.Join(testFolder, assetsJsonRelativePath).Replace("\\", "/");
+
+            try
+            {
+                RecordingHandler testRecordingHandler = new RecordingHandler(testFolder, new GitStore());
+                var httpContext = new DefaultHttpContext();
+                var recordingPath = "sdk/tables/azure-data-tables/tests/recordings/test_challenge_auth.pyTestTableChallengeAuthtest_challenge_auth_supported_version.json";
+                var body = "{\"x-recording-file\":\"" + recordingPath + "\", \"x-recording-assets-file\": \"" + pathToAssetsJson + "\"}";
+                httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
+                httpContext.Request.ContentLength = httpContext.Request.Body.Length;
+
+                var controller = new Playback(testRecordingHandler, new NullLoggerFactory())
+                {
+                    ControllerContext = new ControllerContext()
+                    {
+                        HttpContext = httpContext
+                    }
+                };
+                await controller.Start();
+            }
+            finally
+            {
+                DirectoryHelper.DeleteGitDirectory(testFolder);
+            }
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
@@ -32,8 +32,10 @@ namespace Azure.Sdk.Tools.TestProxy
             var body = await HttpRequestInteractions.GetBody(Request);
 
             string file = HttpRequestInteractions.GetBodyKey(body, "x-recording-file", allowNulls: true);
-            string assetsJson = HttpRequestInteractions.GetBodyKey(body, "x-recording-assets-file", allowNulls: true);
             string recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
+            var assetsJson = RecordingHandler.GetAssetsJsonLocation(
+                HttpRequestInteractions.GetBodyKey(body, "x-recording-assets-file", allowNulls: true),
+                _recordingHandler.ContextDirectory);
 
             if (String.IsNullOrEmpty(file) && !String.IsNullOrEmpty(recordingId))
             {
@@ -63,7 +65,7 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             await DebugLogger.LogRequestDetailsAsync(_logger, Request);
 
-            var pathToAssets = StoreResolver.ParseAssetsJsonBody(options);
+            var pathToAssets = RecordingHandler.GetAssetsJsonLocation(StoreResolver.ParseAssetsJsonBody(options), _recordingHandler.ContextDirectory);
 
             await _recordingHandler.Store.Reset(pathToAssets);
         }
@@ -73,7 +75,7 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             await DebugLogger.LogRequestDetailsAsync(_logger, Request);
 
-            var pathToAssets = StoreResolver.ParseAssetsJsonBody(options);
+            var pathToAssets = RecordingHandler.GetAssetsJsonLocation(StoreResolver.ParseAssetsJsonBody(options), _recordingHandler.ContextDirectory);
 
             await _recordingHandler.Restore(pathToAssets);
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
@@ -6,6 +6,7 @@ using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
 using Azure.Sdk.Tools.TestProxy.Store;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading.Tasks;
@@ -31,7 +32,10 @@ namespace Azure.Sdk.Tools.TestProxy
             var body = await HttpRequestInteractions.GetBody(Request);
 
             string file = HttpRequestInteractions.GetBodyKey(body, "x-recording-file", allowNulls: true);
-            string assetsJson = HttpRequestInteractions.GetBodyKey(body, "x-recording-assets-file", allowNulls: true);
+
+            var assetsJson = RecordingHandler.GetAssetsJsonLocation(
+                HttpRequestInteractions.GetBodyKey(body, "x-recording-assets-file", allowNulls: true),
+                _recordingHandler.ContextDirectory);
 
             await _recordingHandler.StartRecordingAsync(file, Response, assetsJson);
         }
@@ -41,7 +45,9 @@ namespace Azure.Sdk.Tools.TestProxy
         public async Task Push([FromBody()] IDictionary<string, object> options = null)
         {
             await DebugLogger.LogRequestDetailsAsync(_logger, Request);
-            var pathToAssets = StoreResolver.ParseAssetsJsonBody(options);
+
+            var pathToAssets = RecordingHandler.GetAssetsJsonLocation(StoreResolver.ParseAssetsJsonBody(options), _recordingHandler.ContextDirectory);
+
             await _recordingHandler.Store.Push(pathToAssets);
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -8,18 +8,14 @@ using Azure.Sdk.Tools.TestProxy.Vendored;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
-using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
-using System.IO.Compression;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Net.Security;
-using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
@@ -479,6 +475,23 @@ namespace Azure.Sdk.Tools.TestProxy
         #endregion
 
         #region SetRecordingOptions and store functionality
+        public static string GetAssetsJsonLocation(string pathToAssetsJson, string contextDirectory)
+        {
+            if (pathToAssetsJson == null)
+            {
+                return null;
+            }
+
+            var path = pathToAssetsJson;
+
+            if (!Path.IsPathFullyQualified(pathToAssetsJson))
+            {
+                path = Path.Join(contextDirectory, pathToAssetsJson);
+            }
+
+            return path;
+        }
+
         public async Task Restore(string pathToAssetsJson)
         {
             var resultingPath = await Store.Restore(pathToAssetsJson);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -96,11 +96,11 @@ namespace Azure.Sdk.Tools.TestProxy
                     break;
                 case ResetOptions resetOptions:
                     assetsJson = RecordingHandler.GetAssetsJsonLocation(resetOptions.AssetsJsonPath, TargetLocation);
-                    await DefaultStore.Reset(resetOptions.AssetsJsonPath);
+                    await DefaultStore.Reset(assetsJson);
                     break;
                 case RestoreOptions restoreOptions:
                     assetsJson = RecordingHandler.GetAssetsJsonLocation(restoreOptions.AssetsJsonPath, TargetLocation);
-                    await DefaultStore.Restore(restoreOptions.AssetsJsonPath);
+                    await DefaultStore.Restore(assetsJson);
                     break;
                 default:
                     throw new ArgumentException("Invalid verb. The only supported verbs are start, push, reset and restore.");

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -91,12 +91,15 @@ namespace Azure.Sdk.Tools.TestProxy
                     StartServer(startOptions);
                     break;
                 case PushOptions pushOptions:
-                    await DefaultStore.Push(pushOptions.AssetsJsonPath);
+                    var assetsJson = RecordingHandler.GetAssetsJsonLocation(pushOptions.AssetsJsonPath, TargetLocation);
+                    await DefaultStore.Push(assetsJson);
                     break;
                 case ResetOptions resetOptions:
+                    assetsJson = RecordingHandler.GetAssetsJsonLocation(resetOptions.AssetsJsonPath, TargetLocation);
                     await DefaultStore.Reset(resetOptions.AssetsJsonPath);
                     break;
                 case RestoreOptions restoreOptions:
+                    assetsJson = RecordingHandler.GetAssetsJsonLocation(restoreOptions.AssetsJsonPath, TargetLocation);
                     await DefaultStore.Restore(restoreOptions.AssetsJsonPath);
                     break;
                 default:


### PR DESCRIPTION
Effectively, use the current `context` directory as the "root" if we receive an assets.json that isn't fully qualified.

EG:

Absolute Reference:
```json
"x-recording-assets-file": "C:/repo/sdk-for-python/sdk/tables/assets.json"
```

versus:

Relative Reference:
`<test proxy started in C:/repo/sdk-for-python>`
```json
"x-recording-assets-file": "sdk/tables/assets.json"
```

We're doing this so that folks can run the docker _with a command_ that passes in the relative path to their assets.json (so that writing can actually happen).