### PR TITLE
Review assignment/requesting 

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Client/src/review.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/review.ts
@@ -383,6 +383,40 @@ $(() => {
       }
     });
   });
+  
+  /* BUTTON FOR REQUEST REVIEW (CHANGES BETWEEN REQUEST ALL AND REQUEST SELECTED IN THE REQUEST APPROVAL SECTION)
+  --------------------------------------------------------------------------------------------------------------------------------------------------------*/
+  $('.selectDropdownForRequest').on("click", function () {
+    var reviewers = document.getElementsByName('reviewers');
+    var button = document.getElementById('submitReviewRequest') as HTMLInputElement | null;
+    var anyChecked = false;
+
+    if (button == null) return; // Case to remove null warnings
+    button.disabled = false;
+
+    for (var i = 0; i < reviewers.length; i++) {
+      var element = reviewers[i] as HTMLInputElement | null;
+      if (element?.checked) {
+        anyChecked = true;
+        button.innerText = "Request Selected";
+        button.onclick = function () { document.getElementById("submitRequestForReview")?.click(); };
+        break;
+      }
+    }
+
+    if (!anyChecked) {
+      button.innerText = "Request All";
+      button.onclick = function () {
+        var reviewers = document.getElementsByName('reviewers');
+        // Select all, submit
+        reviewers.forEach(f => {
+          var e = f as HTMLInputElement | null;
+          if(e != null) e.checked = true;
+          document.getElementById("submitRequestForReview")?.click();
+        });
+      };
+    }
+  });
 
   /* COLLAPSIBLE CODE LINES (EXPAND AND COLLAPSE FEATURE)
   --------------------------------------------------------------------------------------------------------------------------------------------------------*/

--- a/src/dotnet/APIView/APIViewWeb/Models/ReviewModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/ReviewModel.cs
@@ -122,5 +122,12 @@ namespace APIViewWeb
         public string ServiceName { get; set; }
 
         public string PackageDisplayName { get; set; }
+
+        // Approvers requested for review and when (for hiding older reviews)
+        public HashSet<string> requestedReviewers { get; set; } = null;
+
+        public DateTime approvalRequestedOn;
+
+        public DateTime approvalDate;
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Models/ReviewModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/ReviewModel.cs
@@ -124,10 +124,10 @@ namespace APIViewWeb
         public string PackageDisplayName { get; set; }
 
         // Approvers requested for review and when (for hiding older reviews)
-        public HashSet<string> requestedReviewers { get; set; } = null;
+        public HashSet<string> RequestedReviewers { get; set; } = null;
 
-        public DateTime approvalRequestedOn;
+        public DateTime ApprovalRequestedOn;
 
-        public DateTime approvalDate;
+        public DateTime ApprovalDate;
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml
@@ -1,0 +1,142 @@
+﻿@page "RequestedReviews"
+@model APIViewWeb.Pages.Assemblies.RequestedReviews
+@using APIViewWeb.Helpers
+@using APIViewWeb.Models
+@{
+    ViewData["Title"] = "Requested Reviews";
+    var userPreference = PageModelHelpers.GetUserPreference(Model._preferenceCache, User.GetGitHubLogin()) ?? new UserPreferenceModel();
+    ViewData["UserPreference"] = userPreference;
+}
+<div class="mx-5 row">
+    <div class="col-md-12" id="reviews-filter-partial">
+        <div class="mt-3 row">
+            <div class="col-12 p-0 border rounded table-responsive shadow-sm">
+                <table id="reviews-table" class="table table-sm table-hover m-0" style="width:100%">
+                    <thead>
+                        <tr>
+                            <th scope="col" class="pl-4">Name</th>
+                            <th scope="col" class="border-left pl-3">Author</th>
+                            <th scope="col" class="border-left pl-3">Last Updated</th>
+                            <th scope="col" class="border-left pl-3">Type</th>
+                            <th scope="col" class="border-left pl-3">Approval Requested</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @if (Model.ActiveReviews.Any())
+                        {
+                            @foreach (var review in Model.ActiveReviews)
+                            {
+                                var truncationIndex = @Math.Min(@review.DisplayName.Length, 100);
+                                <tr class="package-data-row">
+                                    <td class="align-middle pl-4 pt-0 pb-0">
+                                        @if (review.Language != null)
+                                        {
+                                            string iconClassName = "icon-" + review.GetLanguageCssSafeName();
+                                            @if (!string.IsNullOrEmpty(review.LanguageVariant) && review.LanguageVariant.ToLower() != "default")
+                                            {
+                                                iconClassName += "-" + @review.LanguageVariant.ToLower();
+                                            }
+                                            <span role="img" class="mx-1 icon icon-language @iconClassName" aria-label="@review.Language @review.LanguageVariant"></span>
+                                        }
+                                        <a class="review-name align-middle" asp-page="./Review" asp-route-id="@review.ReviewId">@review.DisplayName.Substring(0, @truncationIndex)</a>
+                                        @if (review.IsApproved == true)
+                                        {
+                                            <i class="fas fa-check-circle text-success ml-2"></i>
+                                        }
+                                    </td>
+                                    <td class="align-middle border-left pl-3">
+                                        <a username="@review.Author">@review.Author</a>
+                                    </td>
+                                    <td class="align-middle border-left pl-3">
+                                        <span data-placement="left" data-toggle="tooltip" title="@review.LastUpdated" date="@review.LastUpdated.ToLocalTime()"></span>
+                                    </td>
+                                    <td class="align-middle border-left pl-3">
+                                        <span>@review.FilterType.ToString()</span>
+                                    </td>
+                                    <td class="align-middle border-left pl-3">
+                                        <span data-placement="left" data-toggle="tooltip" title="@review.LastUpdated" date="@review.approvalRequestedOn.ToLocalTime()"></span>
+                                    </td>
+                                </tr>
+                            }
+                        }
+                        else 
+                        {
+                            <tr class="package-data-row"> 
+                                <td colspan="5">No reviews require approval</td>
+                            </tr>
+                    
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+        <div class="mt-3 row">
+            <div class="col-12 p-0 border rounded table-responsive shadow-sm">
+                <table id="reviews-table" class="table table-sm table-hover m-0" style="width:100%">
+                    <thead>
+                        <tr>
+                            <th scope="col" class="pl-4">Name</th>
+                            <th scope="col" class="border-left pl-3">Author</th>
+                            <th scope="col" class="border-left pl-3">Last Updated</th>
+                            <th scope="col" class="border-left pl-3">Type</th>
+                            <th scope="col" class="border-left pl-3">Approved last</th>
+                            <th scope="col" class="border-left pl-3">Approved by</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        @if (Model.ApprovedReviews.Any())
+                        {
+                            @foreach (var review in Model.ApprovedReviews)
+                            {
+                                var truncationIndex = @Math.Min(@review.DisplayName.Length, 100);
+                                <tr class="package-data-row">
+                                    <td class="align-middle pl-4 pt-0 pb-0">
+                                        @if (review.Language != null)
+                                        {
+                                            string iconClassName = "icon-" + review.GetLanguageCssSafeName();
+                                            @if (!string.IsNullOrEmpty(review.LanguageVariant) && review.LanguageVariant.ToLower() != "default")
+                                            {
+                                                iconClassName += "-" + @review.LanguageVariant.ToLower();
+                                            }
+                                            <span role="img" class="mx-1 icon icon-language @iconClassName" aria-label="@review.Language @review.LanguageVariant"></span>
+                                        }
+                                        <a class="review-name align-middle" asp-page="./Review" asp-route-id="@review.ReviewId">@review.DisplayName.Substring(0, @truncationIndex)</a>
+                                        @if (review.IsApproved == true)
+                                        {
+                                            <i class="fas fa-check-circle text-success ml-2"></i>
+                                        }
+                                    </td>
+                                    <td class="align-middle border-left pl-3">
+                                        <a username="@review.Author">@review.Author</a>
+                                    </td>
+                                    <td class="align-middle border-left pl-3">
+                                        <span data-placement="left" data-toggle="tooltip" title="@review.LastUpdated" date="@review.LastUpdated.ToLocalTime()"></span>
+                                    </td>
+                                    <td class="align-middle border-left pl-3">
+                                        <span>@review.FilterType.ToString()</span>
+                                    </td>
+                                    <td class="align-middle border-left pl-3">
+                                        <span data-placement="left" data-toggle="tooltip" title="@review.LastUpdated" date="@review.approvalDate.ToLocalTime()"></span>
+                                    </td>
+                                    <td class="align-middle border-left pl-3">
+                                        <span>
+                                            @foreach(var approver in review.Revisions.First().Approvers) {
+                                                 <a username="@approver"> @approver </a>
+                                            }
+                                        </span>
+                                    </td>
+                                </tr>
+                            }
+                        }
+                        else 
+                        {
+                            <tr class="package-data-row">
+                                <td colspan="6">No reviews have been recently approved</td>
+                            </tr>
+                        }
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml
@@ -10,6 +10,7 @@
 <div class="mx-5 row">
     <div class="col-md-12" id="reviews-filter-partial">
         <div class="mt-3 row">
+            <h3>Pending Reviews</h3>
             <div class="col-12 p-0 border rounded table-responsive shadow-sm">
                 <table id="reviews-table" class="table table-sm table-hover m-0" style="width:100%">
                     <thead>
@@ -62,7 +63,7 @@
                         else 
                         {
                             <tr class="package-data-row"> 
-                                <td colspan="5">No reviews require approval</td>
+                                <td colspan="5">No new reviews require approval.</td>
                             </tr>
                     
                         }
@@ -71,6 +72,7 @@
             </div>
         </div>
         <div class="mt-3 row">
+            <h3>Recently-Approved Reviews</h3>
             <div class="col-12 p-0 border rounded table-responsive shadow-sm">
                 <table id="reviews-table" class="table table-sm table-hover m-0" style="width:100%">
                     <thead>
@@ -131,7 +133,7 @@
                         else 
                         {
                             <tr class="package-data-row">
-                                <td colspan="6">No reviews have been recently approved</td>
+                                <td colspan="6">No reviews have been recently approved.</td>
                             </tr>
                         }
                     </tbody>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml
@@ -5,7 +5,7 @@
 @{
     ViewData["Title"] = "Requested Reviews";
     var userPreference = PageModelHelpers.GetUserPreference(Model._preferenceCache, User.GetGitHubLogin()) ?? new UserPreferenceModel();
-    ViewData["UserPreference"] = userPreference;
+    TempData["UserPreference"] = userPreference;
 }
 <div class="mx-5 row">
     <div class="col-md-12" id="reviews-filter-partial">
@@ -55,7 +55,7 @@
                                         <span>@review.FilterType.ToString()</span>
                                     </td>
                                     <td class="align-middle border-left pl-3">
-                                        <span data-placement="left" data-toggle="tooltip" title="@review.LastUpdated" date="@review.approvalRequestedOn.ToLocalTime()"></span>
+                                        <span data-placement="left" data-toggle="tooltip" title="@review.LastUpdated" date="@review.ApprovalRequestedOn.ToLocalTime()"></span>
                                     </td>
                                 </tr>
                             }
@@ -118,7 +118,7 @@
                                         <span>@review.FilterType.ToString()</span>
                                     </td>
                                     <td class="align-middle border-left pl-3">
-                                        <span data-placement="left" data-toggle="tooltip" title="@review.LastUpdated" date="@review.approvalDate.ToLocalTime()"></span>
+                                        <span data-placement="left" data-toggle="tooltip" title="@review.LastUpdated" date="@review.ApprovalDate.ToLocalTime()"></span>
                                     </td>
                                     <td class="align-middle border-left pl-3">
                                         <span>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using ApiView;
+using APIViewWeb.Models;
+using APIViewWeb.Repositories;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.VisualStudio.Services.Common;
+using Octokit;
+
+namespace APIViewWeb.Pages.Assemblies
+{
+    public class RequestedReviews: PageModel
+    {
+        private readonly ReviewManager _manager;
+        public readonly UserPreferenceCache _preferenceCache;
+        public IEnumerable<ReviewModel> ActiveReviews { get; set; } = new List<ReviewModel>();
+        public IEnumerable<ReviewModel> ApprovedReviews { get; set; } = new List<ReviewModel>();
+
+        public RequestedReviews(ReviewManager manager, UserPreferenceCache cache)
+        {
+            _manager = manager;
+            _preferenceCache = cache;
+        }
+
+        public async Task<IActionResult> OnGetAsync()
+        {
+            var fullResult = (await _manager.GetReviewsAsync(false, "All")).Where(r => r.requestedReviewers != null).Where(r => r.requestedReviewers.Contains(User.GetGitHubLogin()));
+            ActiveReviews = fullResult.Where(r => r.IsApproved == false).OrderByDescending(r => r.approvalRequestedOn);
+            // Remove all approvals over a week old
+            ApprovedReviews = fullResult.Where(r => r.IsApproved == true).Where(r => r.approvalDate >= DateTime.Now.AddDays(-7)).OrderByDescending(r => r.approvalDate); 
+            return Page();
+        }
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml.cs
@@ -30,7 +30,7 @@ namespace APIViewWeb.Pages.Assemblies
             var fullResult = (await _manager.GetReviewsAsync(false, "All")).Where(r => r.RequestedReviewers != null).Where(r => r.RequestedReviewers.Contains(User.GetGitHubLogin()));
             ActiveReviews = fullResult.Where(r => r.IsApproved == false).OrderByDescending(r => r.ApprovalRequestedOn);
             // Remove all approvals over a week old
-            ApprovedReviews = fullResult.Where(r => r.IsApproved == true).Where(r => r.ApprovalDate >= DateTime.Now.AddDays(-7)).OrderByDescending(r => r.ApprovalDate); 
+            ApprovedReviews = fullResult.Where(r => r.IsApproved == true).Where(r => r.ApprovalDate != null).Where(r => r.ApprovalDate >= DateTime.Now.AddDays(-7)).OrderByDescending(r => r.ApprovalDate); 
             return Page();
         }
     }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml.cs
@@ -27,10 +27,10 @@ namespace APIViewWeb.Pages.Assemblies
 
         public async Task<IActionResult> OnGetAsync()
         {
-            var fullResult = (await _manager.GetReviewsAsync(false, "All")).Where(r => r.requestedReviewers != null).Where(r => r.requestedReviewers.Contains(User.GetGitHubLogin()));
-            ActiveReviews = fullResult.Where(r => r.IsApproved == false).OrderByDescending(r => r.approvalRequestedOn);
+            var fullResult = (await _manager.GetReviewsAsync(false, "All")).Where(r => r.RequestedReviewers != null).Where(r => r.RequestedReviewers.Contains(User.GetGitHubLogin()));
+            ActiveReviews = fullResult.Where(r => r.IsApproved == false).OrderByDescending(r => r.ApprovalRequestedOn);
             // Remove all approvals over a week old
-            ApprovedReviews = fullResult.Where(r => r.IsApproved == true).Where(r => r.approvalDate >= DateTime.Now.AddDays(-7)).OrderByDescending(r => r.approvalDate); 
+            ApprovedReviews = fullResult.Where(r => r.IsApproved == true).Where(r => r.ApprovalDate >= DateTime.Now.AddDays(-7)).OrderByDescending(r => r.ApprovalDate); 
             return Page();
         }
     }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -102,7 +102,7 @@
                 @{
                     var popOverContent = $"<b>{Model.ActiveConversations}</b> active revision threads.<br><b>{Model.UsageSampleConversations}</b> active usage sample threads.<br><b>{Model.TotalActiveConversations}</b> total active threads.<br>"
                     + $"<b>Current Revision:</b> <em>{@Model.Revision.DisplayName}</em>";
-                                                @if (Model.DiffRevisionId != null)
+                    @if (Model.DiffRevisionId != null)
                     {
                         popOverContent += $"<br><b>Current Diff:</b> <em>{@Model.DiffRevision?.DisplayName}</em>";
                     }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -106,14 +106,14 @@
                     {
                         popOverContent += $"<br><b>Current Diff:</b> <em>{@Model.DiffRevision?.DisplayName}</em>";
                     }
-                                                <div class="btn-group btn-group-sm shadow-sm" aria-label="Page Information">
-                                                    <button type="button" class="btn btn-info" id="jump-to-first-comment">
-                                                        <i class="far fa-comment-alt"></i>
-                                                    </button>
-                                                    <button type="button" class="btn btn-info" data-placement="bottom" data-trigger="focus" data-toggle="popover" data-html="true" data-title="Page Info" data-content="@popOverContent">
-                                                        <span class="badge badge-light">@Model.ActiveConversations / @Model.TotalActiveConversations</span>
-                                                    </button>
-                                                </div>
+                    <div class="btn-group btn-group-sm shadow-sm" aria-label="Page Information">
+                        <button type="button" class="btn btn-info" id="jump-to-first-comment">
+                            <i class="far fa-comment-alt"></i>
+                        </button>
+                        <button type="button" class="btn btn-info" data-placement="bottom" data-trigger="focus" data-toggle="popover" data-html="true" data-title="Page Info" data-content="@popOverContent">
+                            <span class="badge badge-light">@Model.ActiveConversations / @Model.TotalActiveConversations</span>
+                        </button>
+                    </div>
                 }
             </div>
             <div class="my-1">

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -30,7 +30,48 @@
                 <br>
                 <small class="text-muted">@Model.Review.PackageDisplayName</small>
             </p>
-            <div class="my-1">
+
+            <div class="dropdown d-inline-block my-1">
+                <a class="btn btn-light btn-sm border shadow-sm dropdown-toggle" href="#" role="button" data-toggle="dropdown">
+                    <i class="fa-solid fa-flag"></i>&nbsp;&nbsp;Request Approval
+                </a>
+                <div class="dropdown-menu dropdown-menu-right">
+                    <span class="dropdown-header">
+                        Select users to request for review
+                    </span>
+                    <span class="dropdown modal-dialog-scrollable">
+                        <form asp-resource="@Model.Review" asp-page-handler="RequestReviewers" method="post"
+                            class ="selectpicker show-tick show-menu-arrow " data-style="btn-light btn-sm border" data-selected-text-format="value" 
+                            data-live-search="true" data-size="10" data-width="100%" data-container="body" id="revisions-bootstraps-select" data-tick-icon="fa-solid fa-check">
+
+                            @foreach (var approver in Model.approvers) 
+                            {
+                                @* TODO: Sort by approver language/filter to approvers who work in Review's langauge *@
+                                <span class="checkbox dropdown-item-text">
+                                    <label>
+                                        @if (Model.Review.requestedReviewers != null && Model.Review.requestedReviewers.Contains(approver))
+                                        {
+                                            <input type="checkbox" name="reviewers" value="@approver" checked>
+                                        }
+                                        else 
+                                        {
+                                            <input type="checkbox" name="reviewers" value="@approver">
+                                        }
+                                        &nbsp;&nbsp;<img username="@approver" class="comment-icon align-self-start mr-2" height="28" width="28" />
+                                        @approver
+                                    </label>
+                                </span>
+                            }
+
+                            <span class="dropdown-item-text">
+                                <button class="btn btn-sm btn-light shadow-sm" id="submitReviewRequest" type="submit">Request</button>&nbsp;&nbsp;
+                                <button class="btn btn-sm btn-light shadow-sm" onclick="var r = document.getElementsByName('reviewers'); r.forEach((e) => e.checked = true); document.getElementById('submitReviewRequest').click();">Request all</button>
+                            </span>
+                        </form>
+                    </span>
+                </div>
+            </div>
+            <div class="my-1 ml-2">
                 @if (Model.Revision.Approvers.Count > 0)
                 {
                     var approvers = String.Join(", ", Model.Revision.Approvers);

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -52,7 +52,7 @@
                                     @* TODO: Sort by approver language/filter to approvers who work in Review's langauge *@
                                     <span class="checkbox dropdown-item-text">
                                         <label>
-                                            @if (Model.Review.requestedReviewers != null && Model.Review.requestedReviewers.Contains(approver))
+                                            @if (Model.Review.RequestedReviewers != null && Model.Review.RequestedReviewers.Contains(approver))
                                             {
                                                 <input type="checkbox" class="selectDropdownForRequest" name="reviewers" value="@approver" checked>
                                                 anyChecked = true;

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -42,30 +42,41 @@
                     <span class="dropdown modal-dialog-scrollable">
                         <form asp-resource="@Model.Review" asp-page-handler="RequestReviewers" method="post"
                             class ="selectpicker show-tick show-menu-arrow " data-style="btn-light btn-sm border" data-selected-text-format="value" 
-                            data-live-search="true" data-size="10" data-width="100%" data-container="body" id="revisions-bootstraps-select" data-tick-icon="fa-solid fa-check">
-
-                            @foreach (var approver in Model.approvers) 
-                            {
-                                @* TODO: Sort by approver language/filter to approvers who work in Review's langauge *@
-                                <span class="checkbox dropdown-item-text">
-                                    <label>
-                                        @if (Model.Review.requestedReviewers != null && Model.Review.requestedReviewers.Contains(approver))
-                                        {
-                                            <input type="checkbox" name="reviewers" value="@approver" checked>
-                                        }
-                                        else 
-                                        {
-                                            <input type="checkbox" name="reviewers" value="@approver">
-                                        }
-                                        &nbsp;&nbsp;<img username="@approver" class="comment-icon align-self-start mr-2" height="28" width="28" />
-                                        @approver
-                                    </label>
-                                </span>
+                            data-live-search="true" data-size="10" data-width="100%" data-container="body" data-tick-icon="fa-solid fa-check">
+                            @{
+                                var anyChecked = false;
                             }
-
+                            <div style="max-height:400px;width:max-content;overflow-y:auto">
+                                @foreach (var approver in Model.approvers) 
+                                {
+                                    @* TODO: Sort by approver language/filter to approvers who work in Review's langauge *@
+                                    <span class="checkbox dropdown-item-text">
+                                        <label>
+                                            @if (Model.Review.requestedReviewers != null && Model.Review.requestedReviewers.Contains(approver))
+                                            {
+                                                <input type="checkbox" class="selectDropdownForRequest" name="reviewers" value="@approver" checked>
+                                                anyChecked = true;
+                                            }
+                                            else 
+                                            {
+                                                <input type="checkbox" class="selectDropdownForRequest"  name="reviewers" value="@approver">
+                                            }
+                                            &nbsp;&nbsp;<img username="@approver" class="comment-icon align-self-start mr-2" height="28" width="28" />
+                                            @approver
+                                        </label>
+                                    </span>
+                                }
+                            </div>
                             <span class="dropdown-item-text">
-                                <button class="btn btn-sm btn-light shadow-sm" id="submitReviewRequest" type="submit">Request</button>&nbsp;&nbsp;
-                                <button class="btn btn-sm btn-light shadow-sm" onclick="var r = document.getElementsByName('reviewers'); r.forEach((e) => e.checked = true); document.getElementById('submitReviewRequest').click();">Request all</button>
+                                @if (anyChecked)
+                                {
+                                    <button class="btn btn-sm btn-light shadow-sm" id="submitReviewRequest" onclick="document.getElementById('submitRequestForReview').click()" disabled>Request Selected</button>
+                                }
+                                else 
+                                {
+                                    <button class="btn btn-sm btn-light shadow-sm" id="submitReviewRequest" onclick="var r = document.getElementsByName('reviewers'); r.forEach((e) => e.checked = true); document.getElementById('submitRequestForReview').click();">Request All</button>
+                                }                                
+                                <button type="submit" id="submitRequestForReview" hidden></button>
                             </span>
                         </form>
                     </span>
@@ -91,18 +102,18 @@
                 @{
                     var popOverContent = $"<b>{Model.ActiveConversations}</b> active revision threads.<br><b>{Model.UsageSampleConversations}</b> active usage sample threads.<br><b>{Model.TotalActiveConversations}</b> total active threads.<br>"
                     + $"<b>Current Revision:</b> <em>{@Model.Revision.DisplayName}</em>";
-                    @if (Model.DiffRevisionId != null)
+                                                @if (Model.DiffRevisionId != null)
                     {
                         popOverContent += $"<br><b>Current Diff:</b> <em>{@Model.DiffRevision?.DisplayName}</em>";
                     }
-                    <div class="btn-group btn-group-sm shadow-sm" aria-label="Page Information">
-                        <button type="button" class="btn btn-info" id="jump-to-first-comment">
-                            <i class="far fa-comment-alt"></i>
-                        </button>
-                        <button type="button" class="btn btn-info" data-placement="bottom" data-trigger="focus" data-toggle="popover" data-html="true" data-title="Page Info" data-content="@popOverContent">
-                            <span class="badge badge-light">@Model.ActiveConversations / @Model.TotalActiveConversations</span>
-                        </button>
-                    </div>
+                                                <div class="btn-group btn-group-sm shadow-sm" aria-label="Page Information">
+                                                    <button type="button" class="btn btn-info" id="jump-to-first-comment">
+                                                        <i class="far fa-comment-alt"></i>
+                                                    </button>
+                                                    <button type="button" class="btn btn-info" data-placement="bottom" data-trigger="focus" data-toggle="popover" data-html="true" data-title="Page Info" data-content="@popOverContent">
+                                                        <span class="badge badge-light">@Model.ActiveConversations / @Model.TotalActiveConversations</span>
+                                                    </button>
+                                                </div>
                 }
             </div>
             <div class="my-1">

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
@@ -176,7 +176,7 @@ namespace APIViewWeb.Pages.Assemblies
         public async Task<ActionResult> OnPostRequestReviewersAsync(string id, HashSet<string> reviewers)
         {
             // TODO: Email Notifications for those requested
-            _manager.RequestApproversAsync(User, id, reviewers);
+            await _manager.RequestApproversAsync(User, id, reviewers);
             return RedirectToPage(new { id = id });
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
@@ -11,6 +11,7 @@ using APIViewWeb.Models;
 using APIViewWeb.Repositories;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.Extensions.Configuration;
 
 namespace APIViewWeb.Pages.Assemblies
 {
@@ -29,18 +30,22 @@ namespace APIViewWeb.Pages.Assemblies
 
         public readonly UserPreferenceCache _preferenceCache;
 
+        private readonly IConfiguration _configuration;
+
         public ReviewPageModel(
             ReviewManager manager,
             BlobCodeFileRepository codeFileRepository,
             CommentsManager commentsManager,
             NotificationManager notificationManager,
-            UserPreferenceCache preferenceCache)
+            UserPreferenceCache preferenceCache,
+            IConfiguration configuration)
         {
             _manager = manager;
             _codeFileRepository = codeFileRepository;
             _commentsManager = commentsManager;
             _notificationManager = notificationManager;
             _preferenceCache = preferenceCache;
+            _configuration = configuration;
 
         }
 
@@ -71,6 +76,8 @@ namespace APIViewWeb.Pages.Assemblies
         public bool ShowDiffOnly { get; set; }
 
         public IEnumerable<ReviewModel> ReviewsForPackage { get; set; } = new List<ReviewModel>();
+
+        public readonly HashSet<string> approvers = new HashSet<string>();
 
         public async Task<IActionResult> OnGetAsync(string id, string revisionId = null)
         {
@@ -121,6 +128,16 @@ namespace APIViewWeb.Pages.Assemblies
             UsageSampleConversations = Comments.Threads.Count(t => t.Comments.First().IsUsageSampleComment);
             var filterPreference = _preferenceCache.GetFilterType(User.GetGitHubLogin(), Review.FilterType);
             ReviewsForPackage = await _manager.GetReviewsAsync(Review.ServiceName, Review.PackageDisplayName, filterPreference);
+
+            var approverConfig = _configuration["approvers"];
+            if (!string.IsNullOrEmpty(approverConfig))
+            {
+                foreach (var username in approverConfig.Split(","))
+                {
+                    approvers.Add(username);
+                }
+            }
+
             return Page();
         }
 
@@ -154,6 +171,12 @@ namespace APIViewWeb.Pages.Assemblies
         public async Task<IActionResult> OnPostToggleApprovalAsync(string id, string revisionId)
         {
             await _manager.ToggleApprovalAsync(User, id, revisionId);
+            return RedirectToPage(new { id = id });
+        }
+        public async Task<ActionResult> OnPostRequestReviewersAsync(string id, HashSet<string> reviewers)
+        {
+            // TODO: Email Notifications for those requested
+            _manager.RequestApproversAsync(User, id, reviewers);
             return RedirectToPage(new { id = id });
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_Layout.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_Layout.cshtml
@@ -60,9 +60,14 @@
                 <div class="navbar-collapse collapse">
                     <ul class="navbar-nav mr-auto">
                         @if (User.Identity.IsAuthenticated) {
-                        <li class="nav-item">
-                            <a class="nav-link" asp-area="" asp-page="/Assemblies/Index">Reviews</a>
-                        </li>
+                            <li class="nav-item">
+                                <a class="nav-link" asp-area="" asp-page="/Assemblies/Index">Reviews</a>
+                            </li>
+                            <li class="nav-item">
+                                <span asp-resource="@Model" asp-requirement="@ApproverRequirement.Instance">
+                                    <a class="nav-link" asp-area="" asp-page="RequestedReviews">Requested Reviews</a>
+                                </span>
+                            </li>
                         }
                     </ul>
                     <ul class="navbar-nav ml-auto">

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -408,6 +408,7 @@ namespace APIViewWeb.Repositories
             {
                 //Approve revision
                 revision.Approvers.Add(userId);
+                review.approvalDate = DateTime.Now;
             }
             await _reviewsRepository.UpsertReviewAsync(review);
         }
@@ -770,6 +771,14 @@ namespace APIViewWeb.Repositories
             await _devopsArtifactRepository.RunPipeline($"tools - generate-{language}-apireview", 
                 reviewParamString, 
                 _originalsRepository.GetContainerUrl());
+        }
+
+        public async void RequestApproversAsync(ClaimsPrincipal User, string ReviewId, HashSet<string> reviewers)
+        {
+            var review = await GetReviewAsync(User, ReviewId);
+            review.requestedReviewers = reviewers;
+            review.approvalRequestedOn = DateTime.Now;
+            await _reviewsRepository.UpsertReviewAsync(review);
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -408,7 +408,7 @@ namespace APIViewWeb.Repositories
             {
                 //Approve revision
                 revision.Approvers.Add(userId);
-                review.approvalDate = DateTime.Now;
+                review.ApprovalDate = DateTime.Now;
             }
             await _reviewsRepository.UpsertReviewAsync(review);
         }
@@ -776,8 +776,8 @@ namespace APIViewWeb.Repositories
         public async Task RequestApproversAsync(ClaimsPrincipal User, string ReviewId, HashSet<string> reviewers)
         {
             var review = await GetReviewAsync(User, ReviewId);
-            review.requestedReviewers = reviewers;
-            review.approvalRequestedOn = DateTime.Now;
+            review.RequestedReviewers = reviewers;
+            review.ApprovalRequestedOn = DateTime.Now;
             await _reviewsRepository.UpsertReviewAsync(review);
         }
     }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -773,7 +773,7 @@ namespace APIViewWeb.Repositories
                 _originalsRepository.GetContainerUrl());
         }
 
-        public async void RequestApproversAsync(ClaimsPrincipal User, string ReviewId, HashSet<string> reviewers)
+        public async Task RequestApproversAsync(ClaimsPrincipal User, string ReviewId, HashSet<string> reviewers)
         {
             var review = await GetReviewAsync(User, ReviewId);
             review.requestedReviewers = reviewers;


### PR DESCRIPTION
Resolves #2281

This adds a dropdown as follows to each review created:
![image](https://user-images.githubusercontent.com/28514942/192398091-aae7f4b5-9acd-4cd1-ab85-a8631b1d4e6a.png)

You can either check the boxes of each user you want to select, or hit request all and request every listed approver. This will be improved to just be language-specific approvers after #4164. Email notifications to approvers should also come once this issue is resolved.

One a request is submitted, the reviewers get a page as follows:
![image](https://user-images.githubusercontent.com/28514942/192398225-a9c69fb8-bdb0-4be2-88e7-5805f02db52d.png)

The top table in unapproved reviews, sorted by newest first, and the bottom is approved reviews, sorted by most recently approved. The bottom table is limited to 1 week since approval was given.  

Additional note, once the user profile system is there, the IConfiguration could also be removed once again from Reviews.cshtml.cs and replaced with a different method to get approvers from the profiles. 