### PR TITLE
(Hotfix) Adding resolution locking checkbox to usage sample comments

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_SampleCommentFormPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_SampleCommentFormPartial.cshtml
@@ -7,6 +7,8 @@
             <input name="usageSampleComment" value="true" hidden type="text" />
             <button type="submit" name="submit" value="Submit" class="comment-submit-button btn btn-outline-dark">Add Comment</button>
             <button type="button" name="cancel" value="Cancel" class="comment-cancel-button btn btn-outline-dark">Cancel</button>
+            <input type="checkbox" name="resolutionLock" checked class="custom-checkbox btn-outline-dark" />
+            <label for="resolutionLock" class="text-muted small"> Allow anyone to resolve conversation </label>
         </form>
     </div>
 </div>


### PR DESCRIPTION
Fixes usage sample comments believing they are locked without potential to toggle (checkbox beside creation button)