### PR TITLE
Hotfix `test-proxy` executable in dockerfile

### DIFF
--- a/tools/test-proxy/docker/dockerfile
+++ b/tools/test-proxy/docker/dockerfile
@@ -39,6 +39,7 @@ RUN \
     && sed -i -e 's|dotnet dev-certs|dotnet /dotnet-dev-certs/dotnet-dev-certs.dll|' $CERT_FOLDER/$CERT_IMPORT_SH \
     # Run script to import certificate
     && chmod +x $CERT_FOLDER/$CERT_IMPORT_SH \
+    && chmod +x /proxyserver/test-proxy \
     && $CERT_FOLDER/$CERT_IMPORT_SH \
     && rm $CERT_FOLDER/$CERT_IMPORT_SH \
     && mkdir -p /srv/testproxy


### PR DESCRIPTION
When locally testing, I was building and running on WSL.
The published images are built on Ubuntu.

Unbeknownst to me, due to my test platform, the `test-proxy` shell script that I add to the container will execute. However, when invoking the container built on ubuntu, it fails as we never properly `chmod`-ed the test-proxy shim.

This PR takes care of that.