### PR TITLE
Update swagger review gen pipeline to use variables

### DIFF
--- a/eng/pipelines/apiview-review-gen-swagger.yml
+++ b/eng/pipelines/apiview-review-gen-swagger.yml
@@ -6,17 +6,6 @@ pool:
   name: azsdk-pool-mms-win-2019-general
   vmImage: MMS2019
 
-parameters:
-  - name: Reviews
-    type: string
-    default: '[{"ReviewID":"<reviewid>","RevisionID":"<revisionId>","FileID":"<fileid>","FileName":"<fileName>"}]'
-  - name: APIViewURL
-    type: string
-    default: 'https://apiview.dev' 
-  - name: StorageContainerUrl
-    type: string
-    default: ''
-
 variables:
   SwaggerParserInstallPath: $(Pipeline.Workspace)/SwaggerApiParser
 
@@ -49,8 +38,8 @@ jobs:
 
   - template: /eng/pipelines/templates/steps/apiview-review-gen.yml
     parameters:
-      Reviews: ${{ parameters.Reviews }}
-      APIViewURL: ${{ parameters.APIViewURL }}
-      StorageContainerUrl: ${{ parameters.StorageContainerUrl }}
+      Reviews: $(Reviews)
+      APIViewURL: $(APIViewURL)
+      StorageContainerUrl: $(StorageContainerUrl)
       ApiviewGenScript: './Create-Apiview-Token-Swagger.ps1'
       ParserPath: $(SwaggerParserInstallPath)/SwaggerApiParser


### PR DESCRIPTION
Azure Devops .Net client doesn't allow to pass run time parameters and parameters passed to pipeline run are set as variables. So this PR is read inputs to API review gen as variables.