### PR TITLE
Store updated code file in cache

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/SwaggerLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/SwaggerLanguageService.cs
@@ -14,7 +14,7 @@ namespace APIViewWeb
 
         public override string Extension { get; } = ".swagger";
 
-        public override string VersionString { get; } = "1.0.0";
+        public override string VersionString { get; } = "0";
 
         public override string ProcessName => throw new NotImplementedException();
 
@@ -30,6 +30,10 @@ namespace APIViewWeb
         public override string GetProcessorArguments(string originalName, string tempDirectory, string jsonPath)
         {
             throw new NotImplementedException();
+        }
+        public override bool CanUpdate(string versionString)
+        {
+            return false;
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/BlobCodeFileRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/BlobCodeFileRepository.cs
@@ -72,6 +72,11 @@ namespace APIViewWeb
             memoryStream.Position = 0;
             await GetBlobClient(revisionId, codeFileId, out var key).UploadAsync(memoryStream, overwrite: true);
             _cache.Remove(key);
+
+            var renderedCodeFile = new RenderedCodeFile(codeFile);
+            _cache.CreateEntry(key)
+            .SetSlidingExpiration(TimeSpan.FromMinutes(10))
+            .SetValue(renderedCodeFile);
         }
 
         public async Task DeleteCodeFileAsync(string revisionId, string codeFileId)


### PR DESCRIPTION
Updated code file is not refreshed in cache so this causes unnecessary blob fetch.