### PR TITLE
Update Readmes for TestProxy CLI

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -175,9 +175,9 @@ $env:ASPNETCORE_URLS="http://*3331;https://*:8881"  // set custom ports for both
 
 #### Input arguments
 
-When starting the test proxy there are Verbs, as shown in the test-proxy --help output above. For the start  verb, there can be additional command arguments that need to get passed to **Host.CreateDefaultBuilder** 'as is'. The way this is done is through the use of `--` or dashdash as it's referred to. If `--` is on the command line, everything after will be treated as arguments that will be passed into this Host call.
+When starting the test proxy there are Verbs, as shown in the test-proxy --help output above. For the `start` verb, there can be additional command arguments that need to get passed to **Host.CreateDefaultBuilder** 'as is'. The way this is done is through the use of `--` or dashdash as it's referred to. If `--` is on the command line, everything after will be treated as arguments that will be passed into this Host call.
 
-For example, you can use command line argument `--urls` to bind to a non-default host and port. This configuration will override the environment configuration. To bind to localhost http 5000, provide the argument `-- --urls http://localhost:9000`. Note that `--`, space, then the `--urls http://localhost:9000`.
+For example, you can use command line argument `--urls` to bind to a non-default host and port. This configuration will override the environment configuration. To bind to localhost http 9000, provide the argument `-- --urls http://localhost:9000`. Note that `--`, space, then the `--urls http://localhost:9000`.
 
 ```powershell
 test-proxy -- --urls "http://localhost:9000;https://localhost:9001"

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -87,6 +87,8 @@ If you've already installed the tool, you can always check the installed version
 > test-proxy --version
 ```
 
+The `--version` option can also be invoked as part of a command and will display the version prior to running the command.
+
 ### Via Docker Image
 
 The Azure SDK Team maintains a public Azure Container Registry.
@@ -126,7 +128,6 @@ The test-proxy executable fulfills one of two primary purposes:
 
 This is surfaced by only showing options for the default commands. Each individual command has its own argument set that can be detailed by invoking `test-proxy <command> --help`.
 
-
 ```text
 />test-proxy --help
 Azure.Sdk.Tools.TestProxy 1.0.0-dev.20220926.1
@@ -150,7 +151,7 @@ c Microsoft Corporation. All rights reserved.
 
 The test-proxy resolves the storage location via:
 
-1. Command Line argument `storage-location`
+1. Command Line argument `--storage-location` or the abbreviation `-l`
 2. Environment variable TEST_PROXY_FOLDER
 3. If neither are present, the working directory from which the server is invoked.
 
@@ -174,10 +175,12 @@ $env:ASPNETCORE_URLS="http://*3331;https://*:8881"  // set custom ports for both
 
 #### Input arguments
 
-Use command line argument `--urls` to bind to a non-default host and port. This configuration will override the environment configuration.  For example, to only bind to localhost http 5000, provide the argument `--urls http://localhost:9000`.
+When starting the test proxy there are Verbs, as shown in the test-proxy --help output above. For the start  verb, there can be additional command arguments that need to get passed to **Host.CreateDefaultBuilder** 'as is'. The way this is done is through the use of `--` or dashdash as it's referred to. If `--` is on the command line, everything after will be treated as arguments that will be passed into this Host call.
+
+For example, you can use command line argument `--urls` to bind to a non-default host and port. This configuration will override the environment configuration. To bind to localhost http 5000, provide the argument `-- --urls http://localhost:9000`. Note that `--`, space, then the `--urls http://localhost:9000`.
 
 ```powershell
-test-proxy --urls "http://localhost:9000;https://localhost:9001"
+test-proxy -- --urls "http://localhost:9000;https://localhost:9001"
 ```
 
 ## Environment Variables
@@ -249,7 +252,7 @@ The implementation is language specific, but what you want to do is:
 2. Make the following changes to every outgoing request
     1. Place original request scheme + hostname in header `x-recording-upstream-base-uri`
        - Example header setting: `x-recording-upstream-base-uri: "https://fakeazsdktestaccount.table.core.windows.net"`
-    2. Replace request <scheme:hostname> with Proxy Server <scheme:hostname>. (currently https://localhost:5001 or http://localhost:5000)
+    2. Replace request <scheme:hostname> with Proxy Server <scheme:hostname>. (currently `https://localhost:5001` or `http://localhost:5000`)
        - Example transformation: `https://fakeazsdktestaccount.table.core.windows.net/Tables` -> `http://localhost:5001/Tables`.
     3. Add header `"x-recording-id": <x-recording-id>` from startup step
     4. Add header `"x-recording-mode": "record"`
@@ -293,7 +296,7 @@ This will **finalize** your recording by:
 
 In the above example notice that there is an optional body. This is extremely useful when your tests have an element of "randomness" to them. A great example of non-secret randomness would be a `tablename` provided during `tables storage` tests. It is extremely common for a given azure-sdk test framework to generate a name like `u324bca`. Unfortunately, randomness can lead to difficulties during `playback`. The URI, headers, and body of a request must match _exactly_ with a recording entry.
 
-Given that reccordings are _not traditionally accessible_ to the client code, there is no way to "retrieve" what those random non-secret values WERE. Without that capability, one must sanitize _everything_ that could be possibly random.
+Given that recordings are _not traditionally accessible_ to the client code, there is no way to "retrieve" what those random non-secret values WERE. Without that capability, one must sanitize _everything_ that could be possibly random.
 
 An alternative is this `variable` concept. During a final POST to `/Record/Stop`, set the `Content-Type` header and make the `body` of the request a simple JSON map. The test-proxy will pass back these values in the `body` of `/Playback/Start`.
 
@@ -518,11 +521,11 @@ Example:
 
 ```jsonc
 // POST to URI: https://localhost:5001/Admin/SetRecordingOptions
-// body is a json dictionary, the value of HandleRedirects can be multiple representation of "true" 
+// body is a json dictionary, the value of HandleRedirects can be multiple representation of "true"
 {
     "HandleRedirects": true
 }
-// ...or 
+// ...or
 {
     "HandleRedirects": 1
 }
@@ -531,7 +534,7 @@ Example:
 {
     "HandleRedirects": false
 }
-// ...or 
+// ...or
 {
     "HandleRedirects": "false"
 }
@@ -547,7 +550,7 @@ In normal running, the test-proxy actually sets the Host header automatically. I
 
 ## Testing
 
-This project uses `xunit` as the test framework. This is the most popular .NET test solution [according to this twitter poll](https://twitter.com/shahedC/status/1131337874903896065?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1131337874903896065%7Ctwgr%5E%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fwakeupandcode.com%2Funit-testing-in-asp-net-core%2F) and it's also what the majority of the test projects in the `Azure/azure-sdk-tools` repo utilize as well.
+This project uses `Xunit` as the test framework. This is the most popular .NET test solution [according to this twitter poll](https://twitter.com/shahedC/status/1131337874903896065?ref_src=twsrc%5Etfw%7Ctwcamp%5Etweetembed%7Ctwterm%5E1131337874903896065%7Ctwgr%5E%7Ctwcon%5Es1_c10&ref_url=https%3A%2F%2Fwakeupandcode.com%2Funit-testing-in-asp-net-core%2F) and it's also what the majority of the test projects in the `Azure/azure-sdk-tools` repo utilize as well.
 
 ## SSL Support
 

--- a/tools/test-proxy/documentation/asset-sync/README.md
+++ b/tools/test-proxy/documentation/asset-sync/README.md
@@ -50,7 +50,7 @@ Interactions with the external assets repository are accessible when the proxy i
 |---|---|
 | `/Playback/Restore` | Retrieve files from external git repo as targeted in the Tag from assets.json |
 | `/Playback/Reset` | Discard pending changes and reset to the original Tag from targeted assets.json. |
-| `/Record/Push` | Push changes if they are pending for files described by targeted assets.json. Updates the Tag in assets.json the new tag generated from the push operation. |
+| `/Record/Push` | Push changes if they are pending for files described by targeted assets.json. Updates the Tag in assets.json to match the new tag generated from the push operation. |
 
 ## test-proxy CLI commands
 
@@ -60,7 +60,7 @@ The test-proxy also offers interactions with the external assets repository as a
 
 #### Restore
 
-Restore will pull the assets at the Tag, from the AssetsRepo referenced by the targeted assets.json
+A restore operation is merely a test-proxy-encapsulated `clone or pull` operation. A given `asets.json` provides the target `Tag` and `AssetsRepo`.
 
 ```bash
 > test-proxy restore --assets-json-path <assetsJsonPath>
@@ -68,9 +68,11 @@ Restore will pull the assets at the Tag, from the AssetsRepo referenced by the t
 
 #### Reset
 
-Reset will reset the assets back to the Tag, from the AssetsRepo referenced by the targeted assets.json. Reset would be used if the assets were already restored, modified (maybe re-recorded while library development was done), and then needed to be reset back to their original files. If there are pending changes, the user will be prompted to overwrite. If there are no pending changes, then reset is no-op, otherwise, the following prompt will be displayed.
+Reset discards local changes to a targeted assets.json files and resets the local copy of the files back to the version targeted by the given assets.json Tag.  Reset would be used if the assets were already restored, modified (maybe re-recorded while library development was done), and then needed to be reset back to their original files. If there are pending changes, the user will be prompted to overwrite. If there are no pending changes, then reset is no-op, otherwise, the following prompt will be displayed.
 `There are pending git changes, are you sure you want to reset? [Y|N]`
-Selecting N will leave things as they are, selecting Y will restore the assets back to their original files referenced by the Tag, from the AssetsRepo referenced by the targeted assets.json file.
+
+- Selecting `N` will leave things as they are.
+- Selecting `Y` will discard pending changes and reset the locally cloned assets to the Tag within the targeted `assets.json`.
 
 ```bash
 > test-proxy reset --assets-json-path <assetsJsonPath>

--- a/tools/test-proxy/documentation/asset-sync/README.md
+++ b/tools/test-proxy/documentation/asset-sync/README.md
@@ -1,4 +1,4 @@
-## Asset Sync (Retrieve External Test Recordings)
+# Asset Sync (Retrieve External Test Recordings)
 
 The `test-proxy` optionally offers integration with other git repositories for **storing** and **retrieving** recordings. This enables the proxy to work against repositories that do not emplace their test recordings directly alongside their test implementations.
 
@@ -14,7 +14,7 @@ This header will contain a value of where the test framework "expects" the recor
 
 The combination of the the `assets.json` context and this relative path will allow the test-proxy to restore a set of recordings to a path, then _load_ the recording from that newly gathered data. The path to the recording file within the external assets repo can be _predictably_ calculated and retrieved given just the location of the `assets.json` within the code repo, the requested file name during playback or record start, and the properties within the assets.json itself. The diagram above has colors to show how the paths are used in context.
 
-### The `assets.json` and how it enables external recordings
+## The `assets.json` and how it enables external recordings
 
 An `assets.json` contains _targeting_ information for use by the test-proxy when restoring (or updating) recordings "below" a specific path.
 
@@ -25,49 +25,61 @@ An `assets.json` takes the form:
 ```jsonc
 {
   "AssetsRepo": "Azure/azure-sdk-assets-integration",
-  "AssetsRepoPrefixPath": "python/recordings/",
-  "AssetsRepoBranch": "auto/test",
-  "SHA": "786b4f3d380d9c36c91f5f146ce4a7661ffee3b9"
+  "AssetsRepoPrefixPath": "python",
+  "TagPrefix": "python/core",
+  "Tag": "python/core<Guid>"
 }
 ```
 
 | Property | Description |
 |---|---|
 | AssetsRepo | The full name of the external github repo storing the data. EG: `Azure/azure-sdk-assets` |
-| AssetsRepoPrefixPath | The assets repository may want to place the content under a specific path in the assets repo. Populate this property with that path. EG: `python/recordings`. |
-| AssetsRepoBranch | The branch within the assets repo that your updated recordings will be pushed to. |
-| SHA | The reference SHA the recordings that should be restored from the assets repository. |
+| AssetsRepoPrefixPath | The assets repository may want to place the content under a specific path in the assets repo. The default is the language that the assets belong to. EG: `python`, `net`, `java` etc. |
+| TagPrefix | `<Language>/<ServiceDirectory>` or `<Language>/<ServiceDirectory>/<Library>` or deeper if things are nested in such a manner. |
+| Tag | Initially empty until after the first push at which point the tag will be the `<TagPrefix><Guid>` |
 
 Comments within the assets.json are allowed and _maintained_ by the tooling. Feel free to leave notes to yourself. They will not be eliminated.
 
 As one can see in the example image above, the test-proxy does the heavy lifting for push and pull of files to and from the assets repository.
 
-### Restore, push, reset when proxy is waiting for requests
+## Restore, push, reset when proxy is waiting for requests
 
 Interactions with the external assets repository are accessible when the proxy is actively serving requests. These are available through routes:
 
 | Route | Description |
 |---|---|
-| `/Playback/Restore` | Retrieve files from external git repo as targeted in the SHA from assets.json |
-| `/Playback/Reset` | Discard pending changes and reset to the original SHA from targeted assets.json. |
-| `/Record/Push` | Push changes if they are pending for files described by targeted assets.json. |
+| `/Playback/Restore` | Retrieve files from external git repo as targeted in the Tag from assets.json |
+| `/Playback/Reset` | Discard pending changes and reset to the original Tag from targeted assets.json. |
+| `/Record/Push` | Push changes if they are pending for files described by targeted assets.json. Updates the Tag in assets.json the new tag generated from the push operation. |
 
-### Restore, push, reset as a CLI app
+## test-proxy CLI commands
 
-The test-proxy also offers interactions with the external assets repository as a CLI app. What this means is that one could invoke
+The test-proxy also offers interactions with the external assets repository as a CLI. Invoking `test-proxy --help` will show the available list of commands. `test-proxy <command> --help` will show the help and options for an individual command. The options for a given command are all `--<option>`, for example, `--assets-json-path`, but each option has an abbreviation shown in the help, those are a single dash. For example the abbreviation for `--assets-json-path` is `-a`.
+
+### The following CLI commands are available for manipulation of assets
+
+#### Restore
+
+Restore will pull the assets at the Tag, from the AssetsRepo referenced by the targeted assets.json
 
 ```bash
-> test-proxy --command restore --asetsJsonPath <assetsJsonPath>
+> test-proxy restore --assets-json-path <assetsJsonPath>
 ```
 
-to pull the necessary recordings files down for a targeted assets.json. The following commands are available.
+#### Reset
+
+Reset will reset the assets back to the Tag, from the AssetsRepo referenced by the targeted assets.json. Reset would be used if the assets were already restored, modified (maybe re-recorded while library development was done), and then needed to be reset back to their original files. If there are pending changes, the user will be prompted to overwrite. If there are no pending changes, then reset is no-op, otherwise, the following prompt will be displayed.
+`There are pending git changes, are you sure you want to reset? [Y|N]`
+Selecting N will leave things as they are, selecting Y will restore the assets back to their original files referenced by the Tag, from the AssetsRepo referenced by the targeted assets.json file.
 
 ```bash
-> test-proxy --command reset --asetsJsonPath <assetsJsonPath>
-> test-proxy --command restore --asetsJsonPath <assetsJsonPath>
-> test-proxy --command push --asetsJsonPath <assetsJsonPath>
+> test-proxy reset --assets-json-path <assetsJsonPath>
 ```
 
-When a `push` activity is completed, the `SHA` value within the targeted `assets.json` will be UPDATED with the new reference to the external assets repository.
+#### Push
 
-As a user, ensure that this new SHA is commit alongside your code changes.
+After assets have been restored and then modified (re-recorded etc.) a push will update the assets in the AssetsRepo. After the push completes, the `Tag` within the targeted assets.json will be updated with the new Tag. The updated asset.json will need to be committed into the language repository along with the code changes.
+
+```bash
+> test-proxy restore --assets-json-path <assetsJsonPath>
+```


### PR DESCRIPTION
Update the Azure.Sdk.Tools.TestProxy/README.md and documentation/asset-sync/README.md to accurately reflect the CLI commands and start arguments. 