### PR TITLE
Solved formatting issue in Java API view

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -1398,7 +1398,6 @@ public class JavaASTAnalyser implements Analyser {
                 addNewLine();
             });
         });
-        addToken(makeWhitespace());
         addToken(new Token(DOCUMENTATION_RANGE_END));
     }
 


### PR DESCRIPTION
fixes #4052 

Issue introduced with #3806 - I'm assuming that this issue was fixed twice, and it ended up giving a negative indentation twice, causing the documentation to be indented one level below the code it documents.

Before fix:
![image](https://user-images.githubusercontent.com/47310940/193729037-f1754d72-6a46-406c-a9ce-d2bc431bd820.png)

After fix:
![image](https://user-images.githubusercontent.com/47310940/193729054-160c6c7a-3bf5-41bf-9a43-cd50933d339c.png)
