### PR TITLE
Only add DeleteAfter tag to resource groups in terminal state

### DIFF
--- a/eng/scripts/live-test-resource-cleanup.ps1
+++ b/eng/scripts/live-test-resource-cleanup.ps1
@@ -269,6 +269,17 @@ function FindOrCreateDeleteAfterTag {
     [object]$ResourceGroup
   )
 
+  if (!$ResourceGroup) {
+      return
+  }
+
+  # Possible states are Canceled, Deleting, Failed, InProgress, Succeeded
+  # https://learn.microsoft.com/dotnet/api/microsoft.azure.management.websites.models.provisioningstate
+  if ($ResourceGroup.ProvisioningState -in @('Deleting', 'InProgress')) {
+      Write-Host "Skipping tag query/update for group '$($ResourceGroup.ResourceGroupName)' as it is in '$($ResourceGroup.ProvisioningState)' state"
+      return
+  }
+
   $deleteAfter = GetTag $ResourceGroup "DeleteAfter"
   if (!$deleteAfter -or !($deleteAfter -as [datetime])) {
     $deleteAfter = [datetime]::UtcNow.AddHours($DeleteAfterHours)


### PR DESCRIPTION
This fixes an issue where we fail trying to update groups that are already being deleted, e.g. [here](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1895128&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=2ae92968-c003-547a-10d9-00fa5e34d21d&l=99).