### PR TITLE
Avoid loading documentation unless explicitly asked by user

### DIFF
--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -13,11 +13,11 @@ namespace ApiView
     {
         public static CodeFileRenderer Instance = new CodeFileRenderer();
 
-        public RenderResult Render(CodeFile file, bool enableSkipDiff = false)
+        public RenderResult Render(CodeFile file, bool showDocumentation = false, bool enableSkipDiff = false)
         {
             var codeLines = new List<CodeLine>();
             var sections = new Dictionary<int,TreeNode<CodeLine>>();
-            Render(codeLines, file.Tokens, enableSkipDiff, sections);
+            Render(codeLines, file.Tokens, showDocumentation, enableSkipDiff, sections);
             return new RenderResult(codeLines.ToArray(), sections);
         }
 
@@ -25,11 +25,11 @@ namespace ApiView
         {
             var codeLines = new List<CodeLine>();
             var sections = new Dictionary<int, TreeNode<CodeLine>>();
-            Render(codeLines, tokens, false, sections);
+            Render(codeLines, tokens, false, false, sections);
             return codeLines.ToArray();
         }
 
-        private void Render(List<CodeLine> list, IEnumerable<CodeFileToken> node, bool enableSkipDiff, Dictionary<int,TreeNode<CodeLine>> sections)
+        private void Render(List<CodeLine> list, IEnumerable<CodeFileToken> node, bool showDocumentation, bool enableSkipDiff, Dictionary<int,TreeNode<CodeLine>> sections)
         {
             var stringBuilder = new StringBuilder();
             string currentId = null;
@@ -49,7 +49,10 @@ namespace ApiView
                 if (enableSkipDiff && isSkipDiffRange && token.Kind != CodeFileTokenKind.SkipDiffRangeEnd)
                     continue;
 
-                switch(token.Kind)
+                if (!showDocumentation && isDocumentationRange && token.Kind != CodeFileTokenKind.DocumentRangeEnd)
+                    continue;
+
+                switch (token.Kind)
                 {
                     case CodeFileTokenKind.Newline:
                         int ? sectionKey = (nodesInProcess.Count > 0 && section == null) ? sections.Count: null;

--- a/src/dotnet/APIView/APIViewWeb/Client/src/review.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/review.ts
@@ -4,7 +4,7 @@ import { updatePageSettings } from "./helpers";
 $(() => {  
   const SEL_DOC_CLASS = ".documentation";
   const SHOW_DOC_CHECK_COMPONENT = "#show-documentation-component";
-  const SHOW_DOC_CHECKBOX = "#show-doc-checkbox";
+  const SHOW_DOC_CHECKBOX = ".show-doc-checkbox";
   const SHOW_DOC_HREF = ".show-document";
   const SHOW_DIFFONLY_CHECKBOX = ".show-diffonly-checkbox";
   const SHOW_DIFFONLY_HREF = ".show-diffonly";
@@ -294,7 +294,8 @@ $(() => {
   /* TOGGLE PAGE OPTIONS
   --------------------------------------------------------------------------------------------------------------------------------------------------------*/
   $(SHOW_DOC_CHECKBOX).on("click", e => {
-    if((e.target as HTMLInputElement).checked) {
+    $(SHOW_DOC_HREF)[0].click();
+    /*if((e.target as HTMLInputElement).checked) {
       // show all documentation
       $(".code-line-documentation").removeClass('hidden-row');
       $(TOGGLE_DOCUMENTATION).children('i').removeClass("fa-square-plus");
@@ -308,7 +309,7 @@ $(() => {
       $(TOGGLE_DOCUMENTATION).children('i').addClass("fa-square-plus");
       $(TOGGLE_DOCUMENTATION).children('i').css("color", "darkcyan");
       $(TOGGLE_DOCUMENTATION).children('svg').addClass("invisible");
-    }
+    }*/
   });
 
   $(SHOW_DOC_HREF).on("click", e => {

--- a/src/dotnet/APIView/APIViewWeb/Models/RenderedCodeFile.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/RenderedCodeFile.cs
@@ -24,8 +24,14 @@ namespace APIViewWeb.Models
         public CodeFile CodeFile { get; }
         public RenderResult RenderResult { get; private set; }
 
-        public CodeLine[] Render()
+        public CodeLine[] Render(bool showDocumentation)
         {
+            //Always render when documentation is requested to avoid cach thrashing
+            if (showDocumentation)
+            {
+                return CodeFileHtmlRenderer.Normal.Render(CodeFile, showDocumentation: true).CodeLines;
+            }
+
             if (_rendered == null)
             {
                 RenderResult = CodeFileHtmlRenderer.Normal.Render(CodeFile);
@@ -35,8 +41,13 @@ namespace APIViewWeb.Models
             return _rendered;
         }
 
-        public CodeLine[] RenderReadOnly()
+        public CodeLine[] RenderReadOnly(bool showDocumentation)
         {
+            if (showDocumentation)
+            {
+                return CodeFileHtmlRenderer.ReadOnly.Render(CodeFile, showDocumentation: true).CodeLines;
+            }
+
             if (_renderedReadOnly == null)
             {
                 RenderResult = CodeFileHtmlRenderer.ReadOnly.Render(CodeFile);
@@ -46,11 +57,11 @@ namespace APIViewWeb.Models
             return _renderedReadOnly;
         }
 
-        internal CodeLine[] RenderText(bool skipDiff = false)
+        internal CodeLine[] RenderText(bool showDocumentation, bool skipDiff = false)
         {
-            if (skipDiff)
+            if (showDocumentation || skipDiff)
             {
-                RenderResult = CodeFileRenderer.Instance.Render(CodeFile, enableSkipDiff: skipDiff);
+                RenderResult = CodeFileRenderer.Instance.Render(CodeFile, showDocumentation: showDocumentation, enableSkipDiff: skipDiff);
                 return RenderResult.CodeLines;
             }
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -148,8 +148,8 @@
                         </label>
                     </span>
                     <span class="dropdown-item" id="show-documentation-component">
-                        <input type="checkbox" id="show-doc-checkbox">
-                        <a class="text-dark show-document">
+                        <input asp-for="@Model.ShowDocumentation" class="show-doc-checkbox">
+                        <a class="text-dark show-document" asp-all-route-data=@Model.GetRoutingData(diffRevisionId: Model.DiffRevisionId, showDocumentation: !Model.ShowDocumentation, showDiffOnly: Model.ShowDiffOnly, revisionId: Model.Revision.RevisionId)>
                             <label>&nbsp;Show Documentation</label>
                         </a>
                     </span>
@@ -269,7 +269,8 @@
                         var optionName = revision.IsApproved ? $"{@revision.DisplayName} {@approvedBadge}" : @revision.DisplayName;
                         var urlValue = @Url.ActionLink("Review", "Assemblies", new {
                             id = @Model.Review.ReviewId,
-                            revisionId = @revision.RevisionId
+                            revisionId = @revision.RevisionId,
+                            doc = @Model.ShowDocumentation
                         });
                         if (@revision.DisplayName == @Model.Revision.DisplayName)
                         {
@@ -292,6 +293,7 @@
                             id = @Model.Review.ReviewId,
                             revisionId = @Model.Revision.RevisionId,
                             diffRevisionId = @Model.DiffRevisionId,
+                            doc = @Model.ShowDocumentation,
                             diffOnly = @Model.ShowDiffOnly
                         });
                         <label class="mb-0 ml-1"><a href="@urlValue"><small>Diff With:</small></a></label>
@@ -302,6 +304,7 @@
                             id = @Model.Review.ReviewId,
                             revisionId = @Model.Revision.RevisionId,
                             diffRevisionId = @Model.PreviousRevisions.Last().RevisionId,
+                            doc = @Model.ShowDocumentation,
                             diffOnly = @Model.ShowDiffOnly
                         });
                         <label class="mb-0 ml-1"><a href="@urlValue"><small>Diff:</small></a></label>
@@ -319,7 +322,8 @@
                                 id = @Model.Review.ReviewId,
                                 diffRevisionId = @revision.RevisionId,
                                 diffOnly = @Model.ShowDiffOnly,
-                                revisionId = @Model.Revision.RevisionId
+                                revisionId = @Model.Revision.RevisionId,
+                                doc = @Model.ShowDocumentation
                             });
                             if (@Model.DiffRevisionId != null)
                             {

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
@@ -67,6 +67,10 @@ namespace APIViewWeb.Pages.Assemblies
         [BindProperty(SupportsGet = true)]
         public string DiffRevisionId { get; set; }
 
+        // Flag to decide whether to  include documentation
+        [BindProperty(Name = "doc", SupportsGet = true)]
+        public bool ShowDocumentation { get; set; }
+
         [BindProperty(Name = "diffOnly", SupportsGet = true)]
         public bool ShowDiffOnly { get; set; }
 
@@ -91,7 +95,7 @@ namespace APIViewWeb.Pages.Assemblies
             CodeFile = renderedCodeFile.CodeFile;
 
             var fileDiagnostics = CodeFile.Diagnostics ?? Array.Empty<CodeDiagnostic>();
-            var fileHtmlLines = renderedCodeFile.Render();
+            var fileHtmlLines = renderedCodeFile.Render(ShowDocumentation);
 
             if (DiffRevisionId != null)
             {
@@ -99,9 +103,9 @@ namespace APIViewWeb.Pages.Assemblies
 
                 var previousRevisionFile = await _codeFileRepository.GetCodeFileAsync(DiffRevision);
 
-                var previousHtmlLines = previousRevisionFile.RenderReadOnly();
-                var previousRevisionTextLines = previousRevisionFile.RenderText();
-                var fileTextLines = renderedCodeFile.RenderText();
+                var previousHtmlLines = previousRevisionFile.RenderReadOnly(ShowDocumentation);
+                var previousRevisionTextLines = previousRevisionFile.RenderText(ShowDocumentation);
+                var fileTextLines = renderedCodeFile.RenderText(ShowDocumentation);
 
                 var diffLines = InlineDiff.Compute(
                     previousRevisionTextLines,
@@ -167,11 +171,12 @@ namespace APIViewWeb.Pages.Assemblies
             return new EmptyResult();
         }
 
-        public Dictionary<string, string> GetRoutingData(string diffRevisionId = null, bool? showDiffOnly = null, string revisionId = null)
+        public Dictionary<string, string> GetRoutingData(string diffRevisionId = null, bool? showDiffOnly = null, bool? showDocumentation = null, string revisionId = null)
         {
             var routingData = new Dictionary<string, string>();
             routingData["revisionId"] = revisionId;
             routingData["diffRevisionId"] = diffRevisionId;
+            routingData["doc"] = (showDocumentation ?? false).ToString();
             routingData["diffOnly"] = (showDiffOnly ?? false).ToString();
             return routingData;
         }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/PullRequestManager.cs
@@ -316,8 +316,8 @@ namespace APIViewWeb.Repositories
         private async Task GetFormattedDiff(RenderedCodeFile renderedCodeFile, ReviewRevisionModel lastRevision, StringBuilder stringBuilder)
         {
             RenderedCodeFile autoReview = await _codeFileRepository.GetCodeFileAsync(lastRevision, false);
-            var autoReviewTextFile = autoReview.RenderText(skipDiff: true);
-            var prCodeTextFile = renderedCodeFile.RenderText(skipDiff: true);
+            var autoReviewTextFile = autoReview.RenderText(false, skipDiff: true);
+            var prCodeTextFile = renderedCodeFile.RenderText(false, skipDiff: true);
             var diffLines = InlineDiff.Compute(autoReviewTextFile, prCodeTextFile, autoReviewTextFile, prCodeTextFile);
             if (diffLines == null || diffLines.Length == 0 || diffLines.Count(l=>l.Kind != DiffLineKind.Unchanged) > 10)
             {

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -435,8 +435,8 @@ namespace APIViewWeb.Repositories
         {
             //This will compare and check if new code file content is same as revision in parameter
             var lastRevisionFile = await _codeFileRepository.GetCodeFileAsync(revision, false);
-            var lastRevisionTextLines = lastRevisionFile.RenderText(skipDiff: true);
-            var fileTextLines = renderedCodeFile.RenderText(skipDiff: true);
+            var lastRevisionTextLines = lastRevisionFile.RenderText(false, skipDiff: true);
+            var fileTextLines = renderedCodeFile.RenderText(false,skipDiff: true);
             return lastRevisionTextLines.SequenceEqual(fileTextLines);
         }
 


### PR DESCRIPTION
Changes included:

1. Process documentation tokens only if `Show Documentation` checkbox is selected
2. Pass `Show Documentation` value in calls
3. Retain UI side individual doc expand/collapse feature

This change will allow us to load review faster without documentation. We still need to evaluate performance issue when docs are visible.