### PR TITLE
Properly Handling `AssetsRepoPrefixPath` when autoretrieving a recording file

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -63,6 +63,12 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         public async Task<string> GetPath(string pathToAssetsJson)
         {
             var config = await ParseConfigurationFile(pathToAssetsJson);
+
+            if (!string.IsNullOrWhiteSpace(config.AssetsRepoPrefixPath))
+            {
+                return Path.Combine(config.AssetsRepoLocation, config.AssetsRepoPrefixPath);
+            }
+
             return config.AssetsRepoLocation;
         }
 


### PR DESCRIPTION
Without this bugfix, our autorestore was totally broken where a prefix path is used.