### PR TITLE
`Test-Proxy` shouldn't add `Content-Length:0` if one exists

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -304,12 +304,7 @@ namespace Azure.Sdk.Tools.TestProxy
             var upstreamRequest = new HttpRequestMessage();
             upstreamRequest.RequestUri = GetRequestUri(incomingRequest);
             upstreamRequest.Method = new HttpMethod(incomingRequest.Method);
-            upstreamRequest.Method = new HttpMethod(incomingRequest.Method);
-
-            if (incomingBody != null)
-            {
-                upstreamRequest.Content = new ReadOnlyMemoryContent(incomingBody);
-            }
+            upstreamRequest.Content = new ReadOnlyMemoryContent(incomingBody);
 
             foreach (var header in incomingRequest.Headers)
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -210,8 +210,7 @@ namespace Azure.Sdk.Tools.TestProxy
             //
             // The .NET http client is a bit weird about attaching the Content-Length header though. If you HAVE the .Content property defined, a Content-Length
             // header WILL be added. This is due to the fact that on send, the client considers a populated Client property as having a body, even if it's zero length.
-            incomingRequest.Headers.TryGetValue("transfer-encoding", out var transferEncoding);
-            if (incomingRequest.ContentLength == null && transferEncoding != "chunked")
+            if (incomingRequest.ContentLength == null && incomingRequest.Headers["TransferEncoding"] != "chunked")
             {
                 upstreamRequest.Content = null;
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -206,7 +206,7 @@ namespace Azure.Sdk.Tools.TestProxy
             // If an incoming request...
             //    ...has a Content-Length 0 header, and no body. We should send along the Content-Length: 0 header with the upstreamrequest.
             //    ...has no Content-Length header, and no body. We _should not_ send along the Content-Length: 0 header.
-            //    ...has no Content-Length header, a 0 length body, but a TransferEncoding header with value "chunked"
+            //    ...has no Content-Length header, a 0 length body, but a TransferEncoding header with value "chunked". We _should_ allow the Content-Length to stick around.
             //
             // The .NET http client is a bit weird about attaching the Content-Length header though. If you HAVE the .Content property defined, a Content-Length
             // header WILL be added. This is due to the fact that on send, the client considers a populated Client property as having a body, even if it's zero length.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -212,17 +212,11 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (HandleRedirects)
             {
-                var client = session.Client ?? RedirectableClient;
-
-                var defaultHeaders = client.DefaultRequestHeaders;
-
-                upstreamResponse = await (client).SendAsync(upstreamRequest).ConfigureAwait(false);
+                upstreamResponse = await (session.Client ?? RedirectableClient).SendAsync(upstreamRequest).ConfigureAwait(false);
             }
             else
             {
-                var client = session.Client ?? RedirectlessClient;
-
-                upstreamResponse = await (client).SendAsync(upstreamRequest).ConfigureAwait(false);
+                upstreamResponse = await (session.Client ?? RedirectlessClient).SendAsync(upstreamRequest).ConfigureAwait(false);
             }
 
             byte[] body = Array.Empty<byte>();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -210,7 +210,7 @@ namespace Azure.Sdk.Tools.TestProxy
             //
             // The .NET http client is a bit weird about attaching the Content-Length header though. If you HAVE the .Content property defined, a Content-Length
             // header WILL be added. This is due to the fact that on send, the client considers a populated Client property as having a body, even if it's zero length.
-            if (incomingRequest.ContentLength == null && incomingRequest.Headers["TransferEncoding"] != "chunked")
+            if (incomingRequest.ContentLength == null && incomingRequest.Headers["Transfer-Encoding"] != "chunked")
             {
                 upstreamRequest.Content = null;
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Core;
+using Azure.Core;
 using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
 using Azure.Sdk.Tools.TestProxy.Sanitizers;
@@ -206,7 +206,7 @@ namespace Azure.Sdk.Tools.TestProxy
             // If an incoming request...
             //    ...has a Content-Length 0 header, and no body. We should send along the Content-Length: 0 header with the upstreamrequest.
             //    ...has no Content-Length header, and no body. We _should not_ send along the Content-Length: 0 header.
-            //    ...has no Content-Length header, a 0 length body, but a TransferEncoding header with value "chunked". We _should_ allow the Content-Length to stick around.
+            //    ...has no Content-Length header, a 0 length body, but a TransferEncoding header with value "chunked". We _should_ allow any other Content headers to stick around.
             //
             // The .NET http client is a bit weird about attaching the Content-Length header though. If you HAVE the .Content property defined, a Content-Length
             // header WILL be added. This is due to the fact that on send, the client considers a populated Client property as having a body, even if it's zero length.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -205,7 +205,7 @@ namespace Azure.Sdk.Tools.TestProxy
             // already initialized and ready to be customized is definitely the efficient way to go.
             // 
             // To properly account for that, we need to _null out_ the Content property to actually allow the .NET httpclient to send without the added header.
-            if (!incomingRequest.Headers.ContainsKey("Content-Length"))
+            if (incomingRequest.ContentLength == null && incomingRequest.ContentType == null)
             {
                 upstreamRequest.Content = null;
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -211,7 +211,7 @@ namespace Azure.Sdk.Tools.TestProxy
             // The .NET http client is a bit weird about attaching the Content-Length header though. If you HAVE the .Content property defined, a Content-Length
             // header WILL be added. This is due to the fact that on send, the client considers a populated Client property as having a body, even if it's zero length.
             incomingRequest.Headers.TryGetValue("transfer-encoding", out var transferEncoding);
-            if (incomingRequest.ContentLength == null && transferEncoding.Count > 0 && transferEncoding != "chunked")
+            if (incomingRequest.ContentLength == null && transferEncoding != "chunked")
             {
                 upstreamRequest.Content = null;
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -304,7 +304,12 @@ namespace Azure.Sdk.Tools.TestProxy
             var upstreamRequest = new HttpRequestMessage();
             upstreamRequest.RequestUri = GetRequestUri(incomingRequest);
             upstreamRequest.Method = new HttpMethod(incomingRequest.Method);
-            upstreamRequest.Content = new ReadOnlyMemoryContent(incomingBody);
+            upstreamRequest.Method = new HttpMethod(incomingRequest.Method);
+
+            if (incomingBody != null)
+            {
+                upstreamRequest.Content = new ReadOnlyMemoryContent(incomingBody);
+            }
 
             foreach (var header in incomingRequest.Headers)
             {


### PR DESCRIPTION
@mikeharder I definitely want your opinion here. I probably should be doing this a bit safer.

@timovv your little test scenario repro test was **god tier** here. Thank you so so much for the easy repeatability. (they pass after this code change).