### PR TITLE
Updating how Test-Proxy shells out, adding tests for long running add operations

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -285,9 +285,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         /// <summary>
-        /// 1. Restore from a tag that has minimal existing files and a long destination path.
-        /// 2. Add a _bunch_ of files.
-        /// 3. Push.
+        /// 1. Restore from a tag that has minimal existing files and a long destination path
+        /// 2. Add a _bunch_ of files
+        /// 3. Push
         /// 4. Verify local files are what is expected
         /// 5. Verify assets.json was updated with the new commit Tag
         /// </summary>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -437,5 +437,3 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
     }
 }
-    }
-}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -372,11 +372,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         /// <param name="inputJson"></param>
         /// <returns></returns>
         [EnvironmentConditionalSkipTheory]
-        [InlineData(1000, 0.15)] // 1000 0.15 MB files
-        [InlineData(150, 0.25)]  // 150  0.25 MB files
-        [InlineData(100, 0.50)]  // 100  0.5 MB files
-        [InlineData(10, 1.50)]   // 10   1.5 MB files
-        [InlineData(1, 1024)]    // 11   1 GB file
+        [InlineData(1000, 0.15)] // 1000 0.15MB files
+        [InlineData(150, 0.25)]  // 150  0.25MB files
+        [InlineData(100, 0.50)]  // 100  0.5MB files
+        [InlineData(10, 90)]     // 10   90MB files
         [Trait("Category", "Integration")]
         public async Task LargePushPerformance(int numberOfFiles, double fileSize)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -285,30 +285,31 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         }
 
         /// <summary>
-        /// 1. Restore from the third tag in pull/scenarios
-        /// 2. Add/Delete/Update files
-        /// 3. Push to new branch
+        /// 1. Restore from a tag that has minimal existing files and a long destination path.
+        /// 2. Add a _bunch_ of files.
+        /// 3. Push.
         /// 4. Verify local files are what is expected
         /// 5. Verify assets.json was updated with the new commit Tag
         /// </summary>
         /// <param name="inputJson"></param>
         /// <returns></returns>
         [EnvironmentConditionalSkipTheory]
-        [InlineData(
-        @"{
-              ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
-              ""AssetsRepoPrefixPath"": ""python"",
-              ""TagPrefix"": ""python/tables"",
-              ""Tag"": ""python/tables4f724f0c""
-        }")]
+        [InlineData(150, 0.25)]
+        [InlineData(100, 0.50)]
+        [InlineData(10, 1.50)]
         [Trait("Category", "Integration")]
-        public async Task LargePushPerformance(string inputJson)
+        public async Task LargePushPerformance(int numberOfFiles, double fileSize)
         {
             var folderStructure = new string[]
             {
                 GitStoretests.AssetsJson
             };
-            Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
+            Assets assets = JsonSerializer.Deserialize<Assets>(@"{
+              ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
+              ""AssetsRepoPrefixPath"": ""python"",
+              ""TagPrefix"": ""python/tables"",
+              ""Tag"": ""python/tables4f724f0c""
+            }");
             Assets updatedAssets = null;
             List<string> testFiles = new List<string>();
             string originalTagPrefix = assets.TagPrefix;
@@ -328,17 +329,16 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 var assetRepoRoot = await _defaultStore.GetPath(jsonFileLocation);
                 var deepPath = Path.Join(assetRepoRoot, "sdk", "tables", "azure-data-tables", "tests", "recordings");
 
-
-                // generate 150 ~250KB files.
-                for (var i = 0; i < 150; i++)
+                // generate a bunch of files
+                for (var i = 0; i < numberOfFiles; i++)
                 {
-                    testFiles.Add(TestHelpers.GenerateRandomFile(0.25, deepPath));
+                    testFiles.Add(TestHelpers.GenerateRandomFile(fileSize, deepPath));
                 }
                 
                 await _defaultStore.Push(jsonFileLocation);
 
                 // Verify that after the push the directory still contains our updated files
-                Assert.Equal(153, System.IO.Directory.EnumerateFiles(deepPath).Count());
+                Assert.Equal(3 + testFiles.Count, System.IO.Directory.EnumerateFiles(deepPath).Count());
                 foreach (var path in testFiles)
                 {
                     Assert.True(File.Exists(path));

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -1,14 +1,11 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Store;
-using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
 using Xunit;
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -372,9 +372,11 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
         /// <param name="inputJson"></param>
         /// <returns></returns>
         [EnvironmentConditionalSkipTheory]
-        [InlineData(150, 0.25)]
-        [InlineData(100, 0.50)]
-        [InlineData(10, 1.50)]
+        [InlineData(1000, 0.15)] // 1000 0.15 MB files
+        [InlineData(150, 0.25)]  // 150  0.25 MB files
+        [InlineData(100, 0.50)]  // 100  0.5 MB files
+        [InlineData(10, 1.50)]   // 10   1.5 MB files
+        [InlineData(1, 1024)]    // 11   1 GB file
         [Trait("Category", "Integration")]
         public async Task LargePushPerformance(int numberOfFiles, double fileSize)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -61,22 +61,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             byte[] data = new byte[blockSize];
             Random rng = new Random();
 
-            try
+            using (FileStream stream = File.OpenWrite(fileName))
             {
-                using (FileStream stream = File.OpenWrite(fileName))
+                for (int i = 0; i < sizeInMb * blocksPerMb; i++)
                 {
-                    for (int i = 0; i < sizeInMb * blocksPerMb; i++)
-                    {
-                        rng.NextBytes(data);
-                        stream.Write(data, 0, data.Length);
-                    }
+                    rng.NextBytes(data);
+                    stream.Write(data, 0, data.Length);
                 }
             }
-            catch(Exception e)
-            {
-                return e.ToString();
-            }
-            
 
             return fileName;
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Sdk.Tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Common;
 using System;
 using System.IO;
 using System.Text;
@@ -49,6 +49,41 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             writer.Flush();
             stream.Position = 0;
             return stream;
+        }
+
+        public static string GenerateRandomFile(double sizeInMb, string destinationFolder)
+        {
+            if (!Directory.Exists(destinationFolder))
+            {
+                throw new Exception($"To generate a new test file, the destination folder {destinationFolder} must exist.");
+            }
+
+            var fileName = Path.Join(destinationFolder, $"{Guid.NewGuid()}.txt");
+
+            const int blockSize = 1024 * 8;
+            const int blocksPerMb = (1024 * 1024) / blockSize;
+
+            byte[] data = new byte[blockSize];
+            Random rng = new Random();
+
+            try
+            {
+                using (FileStream stream = File.OpenWrite(fileName))
+                {
+                    for (int i = 0; i < sizeInMb * blocksPerMb; i++)
+                    {
+                        rng.NextBytes(data);
+                        stream.Write(data, 0, data.Length);
+                    }
+                }
+            }
+            catch(Exception e)
+            {
+                return e.ToString();
+            }
+            
+
+            return fileName;
         }
 
         public static ModifiableRecordSession LoadRecordSession(string path)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -3,14 +3,9 @@ using System;
 using System.IO;
 using System.Text;
 using System.Text.Json;
-using Azure.Core;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using Azure.Sdk.Tools.TestProxy.Store;
-using System.Diagnostics;
-using Moq;
-using Microsoft.Build.Tasks;
 
 namespace Azure.Sdk.Tools.TestProxy.Tests
 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -159,8 +159,8 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                         DebugLogger.LogDebug($"ExitCode: {process.ExitCode}");
 
                         result.ExitCode = process.ExitCode;
-                        result.StdErr = string.Join(Environment.NewLine, stdOut);
-                        result.StdOut = string.Join(Environment.NewLine, stdError);
+                        result.StdErr = string.Join(Environment.NewLine, stdError);
+                        result.StdOut = string.Join(Environment.NewLine, stdOut);
 
                         if (result.ExitCode != 0)
                         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -122,6 +122,16 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 {
                     DebugLogger.LogInformation($"git {arguments}");
                     var process = Process.Start(processStartInfo);
+
+                    process.OutputDataReceived += new DataReceivedEventHandler((sender, e) =>
+                    {
+                        // Prepend line numbers to each line of the output.
+                        if (!String.IsNullOrEmpty(e.Data))
+                        {
+                            System.Console.WriteLine(e.Data);
+                        }
+                    });
+
                     string stdOut = process.StandardOutput.ReadToEnd();
                     string stdErr = process.StandardError.ReadToEnd();
                     process.WaitForExit();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -121,26 +121,51 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 try
                 {
                     DebugLogger.LogInformation($"git {arguments}");
-                    var process = Process.Start(processStartInfo);
 
-                    string stdOut = process.StandardOutput.ReadToEnd();
-                    string stdErr = process.StandardError.ReadToEnd();
-                    process.WaitForExit();
+                    var output = new List<string>();
+                    var error = new List<string>();
 
-                    int returnCode = process.ExitCode;
-
-                    DebugLogger.LogDebug($"StdOut: {stdOut}");
-                    DebugLogger.LogDebug($"StdErr: {stdErr}");
-                    DebugLogger.LogDebug($"ExitCode: {process.ExitCode}");
-
-
-                    result.ExitCode = process.ExitCode;
-                    result.StdErr = stdErr;
-                    result.StdOut = stdOut;
-
-                    if (result.ExitCode != 0)
+                    using (var process = new Process())
                     {
-                        throw new GitProcessException(result);
+                        process.StartInfo = processStartInfo;
+
+                        process.OutputDataReceived += (s, e) =>
+                        {
+                            lock (output)
+                            {
+                                output.Add(e.Data);
+                            }
+                        };
+
+                        process.ErrorDataReceived += (s, e) =>
+                        {
+                            lock (error)
+                            {
+                                error.Add(e.Data);
+                            }
+                        };
+
+                        process.Start();
+                        process.BeginErrorReadLine();
+                        process.BeginOutputReadLine();
+                        process.WaitForExit();
+
+                        int returnCode = process.ExitCode;
+                        var stdOut = string.Join(Environment.NewLine, output);
+                        var stdError = string.Join(Environment.NewLine, error);
+
+                        DebugLogger.LogDebug($"StdOut: {stdOut}");
+                        DebugLogger.LogDebug($"StdErr: {stdError}");
+                        DebugLogger.LogDebug($"ExitCode: {process.ExitCode}");
+
+                        result.ExitCode = process.ExitCode;
+                        result.StdErr = string.Join(Environment.NewLine, stdOut);
+                        result.StdOut = string.Join(Environment.NewLine, stdError);
+
+                        if (result.ExitCode != 0)
+                        {
+                            throw new GitProcessException(result);
+                        }
                     }
                 }
                 catch (Exception e)
@@ -177,24 +202,50 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 try
                 {
                     DebugLogger.LogInformation($"git {arguments}");
-                    var process = Process.Start(processStartInfo);
-                    string stdOut = process.StandardOutput.ReadToEnd();
-                    string stdErr = process.StandardError.ReadToEnd();
-                    process.WaitForExit();
+                    var output = new List<string>();
+                    var error = new List<string>();
 
-                    int returnCode = process.ExitCode;
-
-                    DebugLogger.LogDebug($"StdOut: {stdOut}");
-                    DebugLogger.LogDebug($"StdErr: {stdErr}");
-                    DebugLogger.LogDebug($"ExitCode: {process.ExitCode}");
-
-                    commandResult = new CommandResult()
+                    using (var process = new Process())
                     {
-                        ExitCode = process.ExitCode,
-                        StdErr = stdErr,
-                        StdOut = stdOut,
-                        Arguments = arguments
-                    };
+                        process.StartInfo = processStartInfo;
+
+                        process.OutputDataReceived += (s, e) =>
+                        {
+                            lock (output)
+                            {
+                                output.Add(e.Data);
+                            }
+                        };
+
+                        process.ErrorDataReceived += (s, e) =>
+                        {
+                            lock (error)
+                            {
+                                error.Add(e.Data);
+                            }
+                        };
+
+                        process.Start();
+                        process.BeginErrorReadLine();
+                        process.BeginOutputReadLine();
+                        process.WaitForExit();
+
+                        int returnCode = process.ExitCode;
+                        var stdOut = string.Join(Environment.NewLine, output);
+                        var stdError = string.Join(Environment.NewLine, error);
+
+                        DebugLogger.LogDebug($"StdOut: {stdOut}");
+                        DebugLogger.LogDebug($"StdErr: {stdError}");
+                        DebugLogger.LogDebug($"ExitCode: {process.ExitCode}");
+
+                        commandResult = new CommandResult()
+                        {
+                            ExitCode = process.ExitCode,
+                            StdErr = stdError,
+                            StdOut = stdOut,
+                            Arguments = arguments
+                        };
+                    }
                 }
                 catch (Exception e)
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -123,15 +123,6 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     DebugLogger.LogInformation($"git {arguments}");
                     var process = Process.Start(processStartInfo);
 
-                    process.OutputDataReceived += new DataReceivedEventHandler((sender, e) =>
-                    {
-                        // Prepend line numbers to each line of the output.
-                        if (!String.IsNullOrEmpty(e.Data))
-                        {
-                            System.Console.WriteLine(e.Data);
-                        }
-                    });
-
                     string stdOut = process.StandardOutput.ReadToEnd();
                     string stdErr = process.StandardError.ReadToEnd();
                     process.WaitForExit();


### PR DESCRIPTION
- Bunch of small files
- Couple of large files

This is an attempt at repro-ing the issue #4286

I've got a working solution that I really like the look of. We shouldn't ever get in a deadlock situation now, and the LargePushPerf tests are passing locally for the worst case scenario (1000 files of ~150KB random bytes each)
