### PR TITLE
Fix 50x errors while loading page links

### DIFF
--- a/eng/common/scripts/Verify-Links.ps1
+++ b/eng/common/scripts/Verify-Links.ps1
@@ -43,7 +43,7 @@
 
   .PARAMETER outputCacheFile
   Path to a file that the script will output all the validated links after running all checks.
-  
+
   .PARAMETER requestTimeoutSec
   The number of seconds before we timeout when sending an individual web request. Default is 15 seconds.
 
@@ -332,7 +332,7 @@ function GetLinks([System.Uri]$pageUri)
 {
   if ($pageUri.Scheme.StartsWith("http")) {
     try {
-      $response = Invoke-WebRequest -Uri $pageUri -UserAgent $userAgent -TimeoutSec $requestTimeoutSec
+      $response = Invoke-WebRequest -Uri $pageUri -UserAgent $userAgent -TimeoutSec $requestTimeoutSec -MaximumRetryCount 3
       $content = $response.Content
 
       if ($pageUri.ToString().EndsWith(".md")) {
@@ -341,7 +341,7 @@ function GetLinks([System.Uri]$pageUri)
     }
     catch {
       $statusCode = $_.Exception.Response.StatusCode.value__
-      Write-Error "Invalid page [$statusCode] $pageUri"
+      LogError "Invalid page [$statusCode] $pageUri"
     }
   }
   elseif ($pageUri.IsFile -and (Test-Path $pageUri.LocalPath)) {
@@ -363,7 +363,7 @@ function GetLinks([System.Uri]$pageUri)
     }
   }
   else {
-    Write-Error "Don't know how to process uri $pageUri"
+    LogError "Don't know how to process uri $pageUri"
   }
 
   $links = ParseLinks $pageUri $content
@@ -396,12 +396,12 @@ if ($inputCacheFile)
   $cacheContent = ""
   if ($inputCacheFile.StartsWith("http")) {
     try {
-      $response = Invoke-WebRequest -Uri $inputCacheFile -TimeoutSec $requestTimeoutSec
+      $response = Invoke-WebRequest -Uri $inputCacheFile -TimeoutSec $requestTimeoutSec -MaximumRetryCount 3
       $cacheContent = $response.Content
     }
     catch {
       $statusCode = $_.Exception.Response.StatusCode.value__
-      Write-Error "Failed to read cache file from  page [$statusCode] $inputCacheFile"
+      LogError "Failed to read cache file from  page [$statusCode] $inputCacheFile"
     }
   }
   elseif (Test-Path $inputCacheFile) {


### PR DESCRIPTION
We have hit a few 50x errors while pulling a page to get links and that has caused the rest of the link checking to terminate early. To fix that we switching to LogError which will output an error in devops instead of Write-Error which terminates immediately. We also add some retry count to the page retrieval and cache file retrieval to help with these transitent 50x issues.