### PR TITLE
Ensure that a multi-value `Transfer-Encoding` header is properly checked

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -210,7 +210,7 @@ namespace Azure.Sdk.Tools.TestProxy
             //
             // The .NET http client is a bit weird about attaching the Content-Length header though. If you HAVE the .Content property defined, a Content-Length
             // header WILL be added. This is due to the fact that on send, the client considers a populated Client property as having a body, even if it's zero length.
-            if (incomingRequest.ContentLength == null && incomingRequest.Headers["Transfer-Encoding"] != "chunked")
+            if (incomingRequest.ContentLength == null && !incomingRequest.Headers["Transfer-Encoding"].Contains("chunked"))
             {
                 upstreamRequest.Content = null;
             }


### PR DESCRIPTION
See title.