### PR TITLE
Adding deeper nested check of chunked transfer-encoding

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -210,9 +210,12 @@ namespace Azure.Sdk.Tools.TestProxy
             //
             // The .NET http client is a bit weird about attaching the Content-Length header though. If you HAVE the .Content property defined, a Content-Length
             // header WILL be added. This is due to the fact that on send, the client considers a populated Client property as having a body, even if it's zero length.
-            if (incomingRequest.ContentLength == null && !incomingRequest.Headers["Transfer-Encoding"].Contains("chunked"))
+            if (incomingRequest.ContentLength == null)
             {
-                upstreamRequest.Content = null;
+                if(!incomingRequest.Headers["Transfer-Encoding"].ToString().Split(' ').Select(x => x.Trim()).Contains("chunked"))
+                {
+                    upstreamRequest.Content = null;
+                }
             }
 
             if (HandleRedirects)


### PR DESCRIPTION
This is due to the fact that comma separated `Transfer-Encoding` values EG: `gzip, chunked` are _not_ split into multiple StringValues entries. We have to split them ourselves.