### PR TITLE
Add --tags to git fetch

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -248,7 +248,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             {
                 // Always retrieve latest as we don't know when the last time we fetched from origin was. If we're lucky, this is a
                 // no-op. However, we are only paying this price _once_ per startup of the server (as we cache assets.json status remember!).
-                GitHandler.Run("fetch origin", config);
+                GitHandler.Run("fetch --tags origin", config);
                 // Set non-cone mode otherwise path filters will not work in git >= 2.37.0
                 // See https://github.blog/2022-06-27-highlights-from-git-2-37/#tidbits
                 GitHandler.Run($"sparse-checkout set --no-cone {checkoutPaths}", config);


### PR DESCRIPTION
The test scenario isn't being added with this PR as it'll take a bit of time. The scenario is this:
1. Restore into the default .assets directory from an existing tag.
2. Push another tag from somewhere else
3. Try to restore that tag into the default .assets directory from step 1. <-- this step will fail

The problem is that restore does a git fetch origin which won't pull new tags. The fix is just to change it to git fetch --tags origin which will get the tags.