### PR TITLE
Use CommandLineParser's --version

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitProcessHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitProcessHandlerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
 using Azure.Sdk.Tools.TestProxy.Store;
@@ -19,12 +19,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         // 2.37.0 is the min version of git required by the TestProxy
         // Windows git version strings
         [InlineData("git version 2.37.2.windows.2", false)]
-        [InlineData("git version 2.36.0.windows.2", true)]
+        [InlineData("git version 2.24.0.windows.2", true)]
         // Mac git version strings
         [InlineData("git version 2.37.1 (Apple Git-133)", false)]
         [InlineData("git version 1.37.1 (Apple Git-133)", true)]
         // Linux git version string
-        [InlineData("git version 2.37.0", false)]
+        [InlineData("git version 2.25.0", false)]
         // Check the actual version on the machine
         [InlineData(null, false)]
         public void CheckGitVersionTests(string gitTestVersionString, bool shouldThrow)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/DefaultOptions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/DefaultOptions.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 
 namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions
 {
@@ -12,8 +12,5 @@ namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions
 
         [Option('p', "storage-plugin", Default = "GitStore", HelpText = "The plugin for the selected storage, default is Git storage is GitStore. (Currently the only option)")]
         public string StoragePlugin { get; set; }
-
-        [Option('v', "version", Default = false, HelpText = "Flag. Output the TestProxy version.")]
-        public bool VersionFlag { get; set; }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -87,8 +87,6 @@ If you've already installed the tool, you can always check the installed version
 > test-proxy --version
 ```
 
-The `--version` option can also be invoked as part of a command and will display the version prior to running the command.
-
 ### Via Docker Image
 
 The Azure SDK Team maintains a public Azure Container Registry.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -57,9 +57,7 @@ namespace Azure.Sdk.Tools.TestProxy
         public static async Task Main(string[] args = null)
         {
             VerifyVerb(args);
-            // JRS - Temporarily disable this check because of https://github.com/Azure/azure-sdk-tools/issues/4116
-            // This throws and will exit
-            // new GitProcessHandler().VerifyGitMinVersion();
+            new GitProcessHandler().VerifyGitMinVersion();
             var parser = new Parser(settings =>
             {
                 settings.CaseSensitive = false;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -62,7 +62,6 @@ namespace Azure.Sdk.Tools.TestProxy
             // new GitProcessHandler().VerifyGitMinVersion();
             var parser = new Parser(settings =>
             {
-                settings.AutoVersion = false;
                 settings.CaseSensitive = false;
                 settings.HelpWriter = System.Console.Out;
                 settings.EnableDashDash = true;
@@ -121,13 +120,6 @@ namespace Azure.Sdk.Tools.TestProxy
         private static async Task Run(object commandObj)
         {
             DefaultOptions defaultOptions = (DefaultOptions)commandObj;
-            if (defaultOptions.VersionFlag)
-            {
-                var assembly = System.Reflection.Assembly.GetExecutingAssembly();
-                var semanticVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>().InformationalVersion;
-                var assemblyVersion = assembly.GetName().Version;
-                System.Console.WriteLine($"{assemblyVersion.Major}.{assemblyVersion.Minor}.{assemblyVersion.Build}-dev.{semanticVersion}");
-            }
 
             TargetLocation = resolveRepoLocation(defaultOptions.StorageLocation);
             Resolver = new StoreResolver();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -32,9 +32,10 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// </summary>
         class GitMinVersion
         {
-            // The minimum version of git supported is 2.37.0 due to cone/non-cone options for sparse-checkout
+            // As per https://github.com/Azure/azure-sdk-tools/issues/4146, the min version of git
+            // that supports what we need is 2.25.0.
             public static int Major = 2;
-            public static int Minor = 37;
+            public static int Minor = 25;
             public static int Patch = 0;
             public static string minVersionString = $"{Major}.{Minor}.{Patch}";
         }

--- a/tools/test-proxy/transition-scripts/README.md
+++ b/tools/test-proxy/transition-scripts/README.md
@@ -15,7 +15,7 @@ Before running the script, understand that **only services that have migrated to
 Running the script requires the following:
 
 - [x] The targeted library is already migrated to use the test-proxy.
-- [x] Git version `>2.32.1` needs to be on the machine and in the path. Git is used by the script and test-proxy.
+- [x] Git version `>2.25.0` needs to be on the machine and in the path. Git is used by the script and test-proxy.
 - [x] Test-proxy needs to be on the machine and in the path. Instructions for that are [here](https://github.com/Azure/azure-sdk-tools/blob/main/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md#installation). The script uses test-proxy's CLI commands.
 - [x] [Powershell Core](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell?view=powershell-7.2) at least version 7.
 


### PR DESCRIPTION
Previously, test proxy was printing out its own version string which was `1.0.0-dev.1.0.0-dev.20221007.1` which required us to have a version option on all of our commands because CommandLineParser's --version option was disabled. This change removes our version and uses CommandLineParser's default version, `Azure.Sdk.Tools.TestProxy 1.0.0-dev.20221011.1`, which differs from the previous version in that it outputs the binary name along with the version as well as the version, itself. I think the original version wasn't quite right anyways.

This also means that executing test-proxy --version will immediately return and --version cannot be executed as part of a command. I've updated the README to reflect this.

This is part of the fix for #4352

Enable the git version check and set the min git version to 2.25.0. Fixes #4146