### PR TITLE
Restore Paragraph Support in Comments

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadInnerPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_CommentThreadInnerPartial.cshtml
@@ -1,4 +1,4 @@
-﻿@using APIViewWeb.Models
+@using APIViewWeb.Models
 @model CommentModel
 
 <div id="@Model.CommentId" class="review-comment" data-comment-id="@Model.CommentId">
@@ -54,7 +54,51 @@
                 </div>
             </span>
             <textarea class="js-comment-raw d-none">@Model.Comment</textarea>
-            @Html.FormatAsMarkdown(@Model.Comment)
+            @if (Model.Comment.Contains("\r\n"))
+            {
+                var cmt = Model.Comment.Split("\r\n");
+                string codeBlockString = "";
+                bool codeBlock = false;
+                bool newLineAdded = true;
+                foreach (var line in cmt)
+                {
+                    @* Preserves code block formatting *@
+                    if (line.Contains("```"))
+                    {
+                        codeBlock = !codeBlock;
+                        codeBlockString += line + "\n";
+                        if (!codeBlock)
+                        {
+                            if (!newLineAdded)
+                            {
+                                <br />
+                            }
+                            @Html.FormatAsMarkdown(codeBlockString)
+                            codeBlockString = "";
+                            newLineAdded = true;
+                        }
+                    }
+                    else if (codeBlock)
+                    {
+                        codeBlockString += line + "\n";
+                    }
+                    @* Adds new lines where needed, otherwise breaks up parsing to be line by line *@
+                    else if (line.Equals("") && !newLineAdded)
+                    {
+                        <br />
+                        newLineAdded = true;
+                    }
+                    else if (!line.Equals(""))
+                    {
+                        @Html.FormatAsMarkdown(line)
+                        newLineAdded = false;
+                    }
+                }
+            }
+            else
+            {
+                @Html.FormatAsMarkdown(Model.Comment)
+            }
         </div>
     </div>
 </div>


### PR DESCRIPTION
Restore changes added in https://github.com/Azure/azure-sdk-tools/pull/4113/files, removed in error by https://github.com/Azure/azure-sdk-tools/pull/4091