### PR TITLE
Update docs/trusting-cert-per-language for Mac

### DIFF
--- a/tools/test-proxy/documentation/test-proxy/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/test-proxy/trusting-cert-per-language.md
@@ -45,7 +45,7 @@ Also note that taken to trust this cert will _also apply to installing the dotne
 
 On a Mac(OS X), If port 5000 is the problem, you need to check the 'AirPlay' sharing feature in settings or kill port process. [see here](https://github.com/Azure/azure-sdk-tools/pull/3739#issuecomment-1207217025)
 
-Make sure you don't have customized proxy settings in .bash or .zshrc file, otherwise any test that tries to connect to local proxy may hang forever.
+Make sure you don't have customized proxy settings as environment variables in .bashrc or .zshrc file, otherwise any test that tries to connect to local proxy may hang forever.
 
 ```
 # DO NOT have settings like below unless it's set to localhost 5000

--- a/tools/test-proxy/documentation/test-proxy/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/test-proxy/trusting-cert-per-language.md
@@ -45,6 +45,17 @@ Also note that taken to trust this cert will _also apply to installing the dotne
 
 On a Mac(OS X), If port 5000 is the problem, you need to check the 'AirPlay' sharing feature in settings or kill port process. [see here](https://github.com/Azure/azure-sdk-tools/pull/3739#issuecomment-1207217025)
 
+Make sure you don't have customized proxy settings in .bash or .zshrc file, otherwise any test that tries to connect to local proxy may hang forever.
+
+```
+# DO NOT have settings like below unless it's set to localhost 5000
+export http_proxy="xxx"
+export https_proxy="xxx"
+
+# Not necessary but also works
+export http_proty="http://localhost:5000/"
+```
+
 ## Go
 
 [Reference This Document](https://forfuncsake.github.io/post/2017/08/trust-extra-ca-cert-in-go-app/) for a walkthrough on how to add the certificate to the `trusted pool`.

--- a/tools/test-proxy/documentation/test-proxy/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/test-proxy/trusting-cert-per-language.md
@@ -53,7 +53,7 @@ export http_proxy="xxx"
 export https_proxy="xxx"
 
 # Not necessary but also works
-export http_proty="http://localhost:5000/"
+export http_proxy="http://localhost:5000/"
 ```
 
 ## Go

--- a/tools/test-proxy/documentation/test-proxy/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/test-proxy/trusting-cert-per-language.md
@@ -45,16 +45,7 @@ Also note that taken to trust this cert will _also apply to installing the dotne
 
 On a Mac(OS X), If port 5000 is the problem, you need to check the 'AirPlay' sharing feature in settings or kill port process. [see here](https://github.com/Azure/azure-sdk-tools/pull/3739#issuecomment-1207217025)
 
-Make sure you don't have customized proxy settings as environment variables in .bashrc or .zshrc file, otherwise any test that tries to connect to local proxy may hang forever.
-
-```
-# DO NOT have settings like below unless it's set to localhost 5000
-export http_proxy="xxx"
-export https_proxy="xxx"
-
-# Not necessary but also works
-export http_proxy="http://localhost:5000/"
-```
+Double-check your proxy settings like HTTP_PROXY, HTTPS_PROXY or any other settings may have network impact in .bashrc or .zshrc file, improper proxy settings may result in tests hanging forever when trying to connect to local proxy.
 
 ## Go
 


### PR DESCRIPTION
I had issue setting up my mac, and found out that I have customized proxy environment vars in my .zshrc file, update the doc  for troubleshooting