### PR TITLE
Add a min proxy version check to generate-assets-json.ps1

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -73,7 +73,12 @@ There is a walkthrough through the process below in the [how do I use the test p
 > dotnet tool install azure.sdk.tools.testproxy --global --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json --version 1.0.0-dev*
 ```
 
-This feed is available in [the public azure-sdk project.](https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk)
+To uninstall an existing test-proxy
+```powershell
+> dotnet tool uninstall --global azure.sdk.tools.testproxy
+```
+
+The test-proxy is also available from the [azure-sdk-for-net public feed](https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net)
 
 After successful installation, run the tool:
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -57,7 +57,6 @@ namespace Azure.Sdk.Tools.TestProxy
         public static async Task Main(string[] args = null)
         {
             VerifyVerb(args);
-            new GitProcessHandler().VerifyGitMinVersion();
             var parser = new Parser(settings =>
             {
                 settings.CaseSensitive = false;
@@ -117,6 +116,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
         private static async Task Run(object commandObj)
         {
+            new GitProcessHandler().VerifyGitMinVersion();
             DefaultOptions defaultOptions = (DefaultOptions)commandObj;
 
             TargetLocation = resolveRepoLocation(defaultOptions.StorageLocation);


### PR DESCRIPTION
1. Add a min test-proxy version check to generate-assets-json.ps1
2. Moved the git version check from Main into Run method in Startup.cs. The reason for this was that when running test-proxy --version it was spitting out the stdout from the git --version check. The check was in the wrong place. We shouldn't check the git version until we've successfully ensured that the command has been parsed and is valid.
3. Minor tweaks to test-proxy's README.md. Add the uninstall command and updated the link to the dev feed. 

Fixes #4352 