### PR TITLE
Improve test proxy install command

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -70,7 +70,7 @@ There is a walkthrough through the process below in the [how do I use the test p
 2. Install test-proxy
 
 ```powershell
-> dotnet tool install azure.sdk.tools.testproxy --global --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json --version 1.0.0-dev*
+dotnet tool update azure.sdk.tools.testproxy --global --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json --version "1.0.0-dev*"
 ```
 
 To uninstall an existing test-proxy


### PR DESCRIPTION
This updates the install command to be more flexible:

1. Removing the leading `>` so that you can click the copy button on the code snippet and have a runnable command on paste.
2. Changing `install` to `update` so that the command works even if you already have an older version. `update` still works if you don't have it installed.
3. Surrounding the version glob in quotes since some shells will try to do expansion on them.