### PR TITLE
Fix help and version

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -1,21 +1,20 @@
 {
-  "profiles": {
-    "Azure.Sdk.Tools.TestProxy": {
-      "commandName": "Project",
-      "commandLineArgs": "help",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Logging__LogLevel__Microsoft": "Information"
-      },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
-    }
-  },
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:5001/",
       "sslPort": 44362
+    }
+  },
+  "profiles": {
+    "Azure.Sdk.Tools.TestProxy": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "Logging__LogLevel__Microsoft": "Information"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
     }
   }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -1,20 +1,21 @@
 {
+  "profiles": {
+    "Azure.Sdk.Tools.TestProxy": {
+      "commandName": "Project",
+      "commandLineArgs": "help",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "Logging__LogLevel__Microsoft": "Information"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  },
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:5001/",
       "sslPort": 44362
-    }
-  },
-  "profiles": {
-    "Azure.Sdk.Tools.TestProxy": {
-      "commandName": "Project",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Logging__LogLevel__Microsoft": "Information"
-      },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
     }
   }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -71,6 +71,18 @@ namespace Azure.Sdk.Tools.TestProxy
 
         static void ExitWithError(IEnumerable<Error> errors)
         {
+
+            // ParseArguments lumps help/--help and version/--version into WithNotParsed
+            // but their type is VersionRequestedError and HelpRequestedError/HelpVerbRequestedError.
+            // If the user is requesting help or version, don't exit 1, just exit 0
+            if (errors.Count() == 1)
+            {
+                Error err = errors.First();
+                if ((err.Tag == ErrorType.HelpVerbRequestedError || err.Tag == ErrorType.HelpRequestedError || err.Tag == ErrorType.VersionRequestedError))
+                {
+                    Environment.Exit(0);
+                }
+            }
             Environment.Exit(1);
         }
 
@@ -97,7 +109,8 @@ namespace Azure.Sdk.Tools.TestProxy
             }
 
             // last but not least, the first argument is a verb, verify it's our verb
-            string[] array = { "start", "reset", "restore", "push" };
+            // version and help are default verbs and need to be in here
+            string[] array = { "start", "reset", "restore", "push", "version", "help" };
             if (!array.Contains(args[0]))
             {
                 // The odd looking formatting is to make this look like the same error


### PR DESCRIPTION
Couple things here:
1.  Just as `--help` and `--version` are default options, apparently `help `and `version `are default verbs. Add those to the verify verb array so they behave correctly.
2. `help`/`--help` and `version`/`--version`, parse as errors which is totally awesome, but not really. @benbp, this is why you were seeing exit code of 1, when running help and version. Before exiting with an exit code of 1, check to see what the error tag is. If there's only 1 error and its tag indicates a help or version request error, then exit 0 since that means the user only requested help or version. Note: ErrorType.HelpVerbRequestedError is the ErrorType you see with `help` but help used to be ErrorType.HelpRequestedError I added both in case they change this. `version` only has one ErrorType, ErrorType.VersionRequestedError.


Fixes #4407 