### PR TITLE
need to remove ENV for source compile

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Cpp.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Cpp.cs
@@ -29,7 +29,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
             string project, string languageVersion, string primaryPackage, IDictionary<string, string> packageVersions)
         {
             var buildDirectory = Path.Combine(WorkingDirectory, _buildDirectory);
-            
+
             Util.DeleteIfExists(buildDirectory);
             Directory.CreateDirectory(buildDirectory);
 

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Cpp.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Cpp.cs
@@ -29,7 +29,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
             string project, string languageVersion, string primaryPackage, IDictionary<string, string> packageVersions)
         {
             var buildDirectory = Path.Combine(WorkingDirectory, _buildDirectory);
-
+            
             Util.DeleteIfExists(buildDirectory);
             Directory.CreateDirectory(buildDirectory);
 
@@ -138,6 +138,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
                 // we don't need to make any updates we want the latest version
                 if (String.Compare(packageVersion, "source", true) == 0)
                 {
+                    Environment.SetEnvironmentVariable(envName, null);
                     continue;
                 }
                 bool found = false;


### PR DESCRIPTION
since the presence of the ENV triggers the build against the vcpkg published version needs to be removed when we build against source