### PR TITLE
Support test proxy asset sync commands and tests with git ssh login

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -1,4 +1,5 @@
 using Azure.Sdk.Tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
 using System;
 using System.IO;
 using System.Text;
@@ -144,13 +145,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
         /// <summary>
         /// Used to define any set of file constructs we want. This enables us to roll a target environment to point various GitStore functionalities at.
-        /// 
+        ///
         /// Creates folder under the temp directory.
         /// </summary>
         /// <param name="assetsJsonContent">The content of the assets json, if any.</param>
         /// <param name="sampleFiles">A set of relative paths defining what the folder structure of the test folder. Paths should be relative to the root of the newly created temp folder.
         /// If one of the paths ends with assets.json, that path will receive the assetsJsonContent string, instead of defaulting to the root of the temp folder.</param>
-        /// <param name="ignoreEmptyAssetsJson">Normally passing string.Empty to assetsJsonContent argument will result in no assets.json being written. 
+        /// <param name="ignoreEmptyAssetsJson">Normally passing string.Empty to assetsJsonContent argument will result in no assets.json being written.
         /// Passing true to this argument will ensure that the file is still created without content.</param>
         /// <param name="isPushTest">Whether or not the scenario being run is a push test</param>
         /// <returns>The absolute path to the created folder.</returns>
@@ -175,7 +176,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 // Call InitIntegrationTag
                 InitIntegrationTag(assets, adjustedAssetsRepoTag);
 
-                // set the TagPrefix to the adjusted test branch 
+                // set the TagPrefix to the adjusted test branch
                 assets.TagPrefix = adjustedAssetsRepoTag;
                 localAssetsJsonContent = JsonSerializer.Serialize(assets);
             }
@@ -218,8 +219,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             }
 
-            // write a .git file into the root
-            WriteTestFile(String.Empty, Path.Combine(tmpPath, ".git"));
+            // initialize git repository into root
+            GitProcessHandler GitHandler = new GitProcessHandler();
+            GitHandler.Run($"init -q", tmpPath);
+            // set a dummy git remote, used for protocol detection
+            string gitCloneUrl = GitStore.GetCloneUrl("testrepo", Directory.GetCurrentDirectory());
+            GitHandler.Run($"remote add test {gitCloneUrl}", tmpPath);
 
             // write assets json if we were passed content
             if (!String.IsNullOrWhiteSpace(localAssetsJsonContent) || ignoreEmptyAssetsJson)
@@ -358,7 +363,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             {
                 Directory.CreateDirectory(tmpPath);
                 GitProcessHandler GitHandler = new GitProcessHandler();
-                string gitCloneUrl = GitStore.GetCloneUrl(assets.AssetsRepo);
+                string gitCloneUrl = GitStore.GetCloneUrl(assets.AssetsRepo, Directory.GetCurrentDirectory());
                 // Clone the original assets repo
                 GitHandler.Run($"clone {gitCloneUrl} .", tmpPath);
                 // Check to see if there's already a branch
@@ -412,7 +417,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             {
                 Directory.CreateDirectory(tmpPath);
                 GitProcessHandler GitHandler = new GitProcessHandler();
-                string gitCloneUrl = GitStore.GetCloneUrl(assets.AssetsRepo);
+                string gitCloneUrl = GitStore.GetCloneUrl(assets.AssetsRepo, Directory.GetCurrentDirectory());
                 GitHandler.Run($"clone {gitCloneUrl} .", tmpPath);
                 GitHandler.Run($"push origin --delete {assets.Tag}", tmpPath);
             }
@@ -453,7 +458,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         public static bool CheckExistenceOfTag(Assets assets, string workingDirectory)
         {
             GitProcessHandler GitHandler = new GitProcessHandler();
-            var cloneUrl = GitStore.GetCloneUrl(assets.AssetsRepo);
+            var cloneUrl = GitStore.GetCloneUrl(assets.AssetsRepo, Directory.GetCurrentDirectory());
             CommandResult result = GitHandler.Run($"ls-remote {cloneUrl} --tags {assets.Tag}", workingDirectory);
             return result.StdOut.Trim().Length > 0;
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Console/ConsoleWrapperTester.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Console/ConsoleWrapperTester.cs
@@ -38,6 +38,7 @@ namespace Azure.Sdk.Tools.TestProxy.Console
         }
         public string ReadLine()
         {
+            System.Console.WriteLine($"ReadLine response for test: '{_readLineResponse}'");
             return _readLineResponse;
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -107,6 +107,12 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <exception cref="GitProcessException">Throws GitProcessException on returnCode != 0 OR if an unexpected exception is thrown during invocation.</exception>
         public virtual CommandResult Run(string arguments, string workingDirectory)
         {
+            // Surface an easy to understand error when we shoot ourselves in the foot
+            if (arguments.StartsWith("git"))
+            {
+                throw new Exception("GitProcessHandler commands should not start with 'git'");
+            }
+
             ProcessStartInfo processStartInfo = CreateGitProcessInfo(workingDirectory);
             processStartInfo.Arguments = arguments;
 
@@ -192,6 +198,12 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <returns></returns>
         public virtual bool TryRun(string arguments, GitAssetsConfiguration config, out CommandResult result)
         {
+            // Surface an easy to understand error when we shoot ourselves in the foot
+            if (arguments.StartsWith("git"))
+            {
+                throw new Exception("GitProcessHandler commands should not start with 'git'");
+            }
+
             ProcessStartInfo processStartInfo = CreateGitProcessInfo(config.AssetsRepoLocation);
             processStartInfo.Arguments = arguments;
             var commandResult = new CommandResult();
@@ -271,9 +283,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         }
 
         /// <summary>
-        /// Verify that the version of git running on the machine is greater equal the git minimum version. 
+        /// Verify that the version of git running on the machine is greater equal the git minimum version.
         /// This is more for the people running the CLI/TestProxy locally than for lab machines which seem
-        /// to be running on the latest, released versions. The reason is that any git version less than 
+        /// to be running on the latest, released versions. The reason is that any git version less than
         /// 2.37.0 won't have the cone/no-cone options used by sparse-checkout.
         /// </summary>
         /// <exception cref="GitProcessException">Thrown by the internal call to Run.</exception>
@@ -326,7 +338,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             {
                 // In theory we shouldn't get here. If git isn't installed or on the path, the Run command should throw.
                 throw new GitVersionException($"Unable to determine the local git version from the returned version string '{localGitVersion}'. Please ensure that git is installed on the machine and has been added to the PATH.");
-            }    
+            }
         }
     }
 }


### PR DESCRIPTION
This update makes an attempt to discover if the user is using ssh-based authentication to github by looking at the url of the remote for the local repository. If the user is not in a repository, default to the https remote. We could consider adding a flag to override, but I think it's better to try to just handle it automatically rather than introduction an extra option. I think the number of people trying to run test proxy outside of a repo context AND using ssh is going to be rare.

I don't have a great idea for how to detect ssh based auth otherwise, aside from maybe checking if there's a credential store being used (but I don't think that guarantees it one way or the other). There are also options like `git push --dry-run` to see if one protocol or the other works, but that gets bundled in with cases where people just don't have push access at all.