### PR TITLE
Enable Breadcrumbs In Test-Proxy Store

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/BreadcrumbTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/BreadcrumbTests.cs
@@ -1,0 +1,65 @@
+using Azure.Sdk.Tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Models;
+using Azure.Sdk.Tools.TestProxy.Sanitizers;
+using Azure.Sdk.Tools.TestProxy.Store;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Azure.Sdk.Tools.TestProxy.Tests
+{
+    public class BreadCrumbtests
+    {
+        GitStore _defaultStore = new GitStore();
+
+        [Theory]
+        [InlineData("sdk", "tables", "assets.json")]
+        [InlineData("assets.json")]
+        public async Task TestbreadcrumbLine(params string[] args)
+        {
+            var folderStructure = new string[]
+            {
+                Path.Combine(args)
+            };
+            var inputJson = @"{
+              ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
+              ""AssetsRepoPrefixPath"": ""pull/scenarios"",
+              ""AssetsRepoId"": """",
+              ""TagPrefix"": ""main"",
+              ""Tag"": ""language/tables_bb2223""
+            }";
+
+            Assets assets = System.Text.Json.JsonSerializer.Deserialize<Assets>(inputJson);
+            var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure);
+            var pathToAssets = Path.Join(testFolder, Path.Combine(args));
+
+            try
+            {
+                var parsedConfig = await _defaultStore.ParseConfigurationFile(pathToAssets);
+                var breadcrumbLine = new BreadcrumbLine(parsedConfig);
+
+                Assert.Equal(parsedConfig.Tag, breadcrumbLine.Tag);
+                Assert.Equal(parsedConfig.AssetsJsonRelativeLocation, breadcrumbLine.PathToAssetsJson);
+                Assert.Equal(parsedConfig.AssetRepoShortHash, breadcrumbLine.ShortHash);
+
+                // now tostring the line, then reparse it.
+                var reparsedLine = new BreadcrumbLine(breadcrumbLine.ToString());
+
+                Assert.Equal(breadcrumbLine.Tag, reparsedLine.Tag);
+                Assert.Equal(breadcrumbLine.ShortHash, reparsedLine.ShortHash);
+                Assert.Equal(breadcrumbLine.PathToAssetsJson.Replace("\\", "/"), reparsedLine.PathToAssetsJson);
+            }
+            finally
+            {
+                DirectoryHelper.DeleteGitDirectory(testFolder);
+            }
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
@@ -428,6 +428,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 Assert.Equal(fakeSha, configuration.Tag);
                 var newConfiguration = await _defaultStore.ParseConfigurationFile(testFolder);
                 Assert.Equal(fakeSha, newConfiguration.Tag);
+
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { Path.Combine(testFolder, "assets.json") });
             }
             finally
             {
@@ -470,6 +472,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
                 var result = _defaultStore.ResolveCheckoutPaths(configuration);
                 Assert.Equal(expectedResult, result);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { configLocation });
             }
             finally
             {
@@ -487,12 +490,15 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 var creationTime = File.GetLastWriteTime(pathToAssets);
 
                 var configuration = await _defaultStore.ParseConfigurationFile(testFolder);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { pathToAssets });
                 await _defaultStore.UpdateAssetsJson(configuration.Tag, configuration);
                 var postUpdateLastWrite = File.GetLastWriteTime(pathToAssets);
 
                 Assert.Equal(creationTime, postUpdateLastWrite);
                 var newConfiguration = await _defaultStore.ParseConfigurationFile(testFolder);
                 Assert.Equal(configuration.Tag, newConfiguration.Tag);
+
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { pathToAssets });
             }
             finally
             {
@@ -520,6 +526,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
                 Assert.NotEqual(contentBeforeUpdate, contentAfterUpdate);
                 Assert.Equal(contentBeforeUpdate.Replace(originalSHA, fakeSha), contentAfterUpdate);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { pathToAssets });
             }
             finally
             {
@@ -566,11 +573,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             try
             {
                 var jsonFileLocation = Path.Join(testFolder, "sdk/tables", GitStoretests.AssetsJson);
-
                 var parsedConfiguration = await _defaultStore.ParseConfigurationFile(jsonFileLocation);
+
                 await _defaultStore.Restore(jsonFileLocation);
 
                 var result = await _defaultStore.GetPath(jsonFileLocation);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
 
                 Assert.True(File.Exists(Path.Combine(result, "sdk", "tables", "azure-data-tables", "tests", "recordings", "test_retry.pyTestStorageRetrytest_retry_on_server_error.json")));
             }
@@ -580,21 +588,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             }
         }
 
-
-        [Fact(Skip ="Skipping because we don't have an integration test suite working yet.")]
-        public async Task GitCallHonorsLocalCredential()
+        public async Task BreadcrumbContainsMultipleAssetRefs()
         {
-            var testFolder = TestHelpers.DescribeTestFolder(DefaultAssets, basicFolderStructure);
-            try
-            {
-                var config = await _defaultStore.ParseConfigurationFile(testFolder);
-
-                var workDone = _defaultStore.InitializeAssetsRepo(config);
-            }
-            finally
-            {
-                DirectoryHelper.DeleteGitDirectory(testFolder);
-            }
+            throw new NotImplementedException("scbedd to implement prior to checkin");
         }
 
         [Fact(Skip = "Skipping due to integration tests not figured out yet.")]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -100,6 +100,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 // Ensure that the targeted tag is present on the repo
                 TestHelpers.CheckExistenceOfTag(updatedAssets, localFilePath);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {
@@ -181,6 +182,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 // Ensure that the targeted tag is present on the repo
                 TestHelpers.CheckExistenceOfTag(updatedAssets, localFilePath);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {
@@ -273,6 +275,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 // Ensure that the targeted tag is present on the repo
                 TestHelpers.CheckExistenceOfTag(updatedAssets, localFilePath);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {
@@ -354,6 +357,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 // Ensure that the targeted tag is present on the repo
                 TestHelpers.CheckExistenceOfTag(updatedAssets, localFilePath);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {
@@ -480,6 +484,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath2, "file1.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath2, "file2.txt", 3));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath2, "file6.txt", 1));
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
 
             }
             finally
@@ -557,6 +562,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 // Ensure that the targeted tag is present on the repo
                 TestHelpers.CheckExistenceOfTag(updatedAssets, assetRepoRoot);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationResetTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationResetTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -92,6 +92,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 1));
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {
@@ -157,6 +158,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 2));
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
 
             }
             finally
@@ -232,6 +234,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
 
             }
             finally
@@ -306,6 +309,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file5.txt", 1));
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
 
             }
             finally
@@ -394,6 +398,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file5.txt", 1));
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -75,6 +75,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 1));
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             } 
             finally
             {
@@ -130,6 +131,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {
@@ -186,6 +188,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file5.txt", 1));
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {
@@ -240,6 +243,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // this is the first time this Gitstore has seen this assets.json. This allows
                 // us to simulate a re-entrant command on an already initialized repo.
                 await additionalStore.Restore(jsonFileLocation);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {
@@ -279,6 +283,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
 
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {
@@ -317,6 +322,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                     await _defaultStore.Restore(jsonFileLocation);
                 });
                 Assert.Contains(httpException, assertion.Message);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }
             finally
             {
@@ -354,6 +360,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 var result = (await _defaultStore.ParseConfigurationFile(pathToAssets)).AssetsRepoLocation;
 
                 Assert.Equal(result, recordingHandler.ContextDirectory);
+                TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { pathToAssets });
             }
             finally
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -354,6 +354,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var breadCrumbFile = Path.Join(assetsStorePath, ".breadcrumb");
             var targetKey = configuration.AssetsJsonRelativeLocation.Replace("\\", "/");
 
+            Assert.True(File.Exists(breadCrumbFile));
+
             var contents = File.ReadAllLines(breadCrumbFile).Select(x => new BreadcrumbLine(x)).ToDictionary(x => x.PathToAssetsJson, x => x);
 
             Assert.True(contents.ContainsKey(targetKey));

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
@@ -44,6 +44,22 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         { 
             get { return ResolveAssetRepoLocation(); }
         }
+        
+        /// <summary>
+        /// Used to access the hash that each assets repo will be stored under within the assets store.
+        /// </summary>
+        public string AssetRepoShortHash
+        {
+            get
+            {
+                // Combine the AssetsRepo and AssetsJsonRelativeLocation and grab the hash of that.
+                // AssetsRepo will be something like Azure/azure-sdk-assets-integration and
+                // AssetsJsonRelativeLocation will be something like sdk/<service>/assets.json
+                string assetsRepoPlusJsonRelPathLoc = AssetsRepo + AssetsJsonRelativeLocation;
+
+                return ShortHashGenerator.GenerateShortHash(assetsRepoPlusJsonRelPathLoc);
+            }
+        }
 
         /// <summary>
         /// Used to resolve the location of the "assets" store location. This is the folder CONTAINING other cloned repos. No git data will be restored or staged directly within this folder.
@@ -68,14 +84,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         {
             var assetsStore = ResolveAssetsStoreLocation();
 
-            // Combine the AssetsRepo and AssetsJsonRelativeLocation and grab the hash of that.
-            // AssetsRepo will be something like Azure/azure-sdk-assets-integration and
-            // AssetsJsonRelativeLocation will be something like sdk/<service>/assets.json
-            string assetsRepoPlusJsonRelPathLoc = AssetsRepo + AssetsJsonRelativeLocation;
-
-            string shortHashString = ShortHashGenerator.GenerateShortHash(assetsRepoPlusJsonRelPathLoc);
-
-            var location = Path.Join(assetsStore, shortHashString);
+            var location = Path.Join(assetsStore, AssetRepoShortHash);
             if (!Directory.Exists(location))
             {
                 Directory.CreateDirectory(location);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -40,6 +40,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         public static readonly string GIT_COMMIT_OWNER_ENV_VAR = "GIT_COMMIT_OWNER";
         public static readonly string GIT_COMMIT_EMAIL_ENV_VAR = "GIT_COMMIT_EMAIL";
 
+        public GitStoreBreadcrumb BreadCrumb = new GitStoreBreadcrumb();
+
+
         public ConcurrentDictionary<string, string> Assets = new ConcurrentDictionary<string, string>();
 
         public GitStore()
@@ -72,6 +75,11 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             }
 
             return config.AssetsRepoLocation;
+        }
+
+        public async Task UpdateBreadCrumb(string pathToAssetsJson)
+        {
+            var config = await ParseConfigurationFile(pathToAssetsJson);
         }
 
         /// <summary>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStoreBreadcrumb.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStoreBreadcrumb.cs
@@ -1,0 +1,84 @@
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
+
+namespace Azure.Sdk.Tools.TestProxy.Store
+{
+
+    public class BreadcrumbLine
+    {
+        public string PathToAssetsJson;
+        public string ShortHash;
+        public string Tag;
+
+        public BreadcrumbLine(string line)
+        {
+            // split the line here. assign values
+            var values = line.Split(";;").Select(x => x.Trim()).Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+
+            // we should have exactly 3 values.
+            if (values.Count() != 3)
+            {
+                throw new HttpException(HttpStatusCode.BadRequest, $"Unable to parse breadcrumb line \"{line}\".");
+            }
+
+            PathToAssetsJson = values[0];
+            ShortHash = values[1];
+            Tag = values[2];
+        }
+
+        /// <summary>
+        /// Converts a configuration to the breadcrumb presentation.
+        /// </summary>
+        /// <param name="config"></param>
+        public BreadcrumbLine(GitAssetsConfiguration config)
+        {
+            PathToAssetsJson = config.AssetsJsonRelativeLocation;
+            ShortHash = config.AssetRepoShortHash;
+            Tag = config.Tag;
+        }
+
+        /// <summary>
+        /// Contract is AssetsJsonRelative;;ShortHash;;TargetTag
+        /// </summary>
+        /// <returns></returns>
+        public override string ToString()
+        {
+            return $"{PathToAssetsJson.Replace("\\", "/")};;{ShortHash};;{Tag}";
+        }
+    }
+
+    public class GitStoreBreadcrumb
+    {
+        TaskQueue BreadCrumbWorker = new TaskQueue();
+
+        public GitStoreBreadcrumb() { }
+
+        public void Update(GitAssetsConfiguration configuration)
+        {
+            var breadcrumbFile = Path.Join(configuration.ResolveAssetsStoreLocation(), ".breadcrumb");
+            var targetKey = configuration.AssetsJsonRelativeLocation.Replace("\\", "/");
+
+            BreadCrumbWorker.Enqueue(() =>
+            {
+                IEnumerable<string> linesForWriting = null;
+
+                if (!File.Exists(breadcrumbFile))
+                {
+                    linesForWriting = new List<string>() { new BreadcrumbLine(configuration).ToString() };
+                }
+                else
+                {
+                    var lines = File.ReadAllLines(breadcrumbFile).Select(x => new BreadcrumbLine(x)).ToDictionary(x => x.PathToAssetsJson, x => x);
+                    lines[targetKey] = new BreadcrumbLine(configuration);
+                    linesForWriting = lines.Values.Select(x => x.ToString());
+                }
+                
+                File.WriteAllLines(breadcrumbFile, linesForWriting, System.Text.Encoding.UTF8);
+            });
+        }
+    }
+
+}


### PR DESCRIPTION
To properly update the transition script for `docker` and `podman`, I want to get rid of the `temp` directory. The `temp` directory was a necessary evil because we didn't surface breadcrumbs yet.

By enabling this, I am able to make the docker support for the transition script without being especially hacky.