### PR TITLE
Hotfix for #4382

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/UserProfileController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/UserProfileController.cs
@@ -24,10 +24,10 @@ namespace APIViewWeb.Controllers
             UserPreferenceModel preference = await _userPreferenceCache.GetUserPreferences(User);
 
             preference.Theme = theme;
-
-            HashSet<string> Languages = new HashSet<string>(languages);
-            preference.Language = Languages;
             
+            HashSet<string> Languages = new HashSet<string>(languages);
+            preference.ApprovedLanguages = Languages;
+
             if(profile.UserName == null)
             {
                 await _userProfileManager.createUserProfileAsync(User, email, Languages, preference);

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -30,7 +30,7 @@
                                 var anyChecked = false;
                             }
                             <div style="max-height:400px;width:max-content;overflow-y:auto">
-                                @foreach (var approver in Model.approvers) 
+                                @foreach (var approver in Model.PreferredApprovers)
                                 {
                                     <span class="checkbox dropdown-item-text">
                                         <label>
@@ -111,7 +111,7 @@
                         }
                         else
                         {
-                            @if (Model.ActiveConversations > 0 && Model.approvers.Contains(User.GetGitHubLogin()))
+                            @if (Model.ActiveConversations > 0 && Model.PreferredApprovers.Contains(User.GetGitHubLogin()))
                             {
                                 <button type="button" class="btn btn-sm shadow-sm btn-success ml-2" data-toggle="modal" data-target="#approveModel">
                                     <i class="far fa-thumbs-up" aria-hidden="true"></i>&nbsp;&nbsp;Approve
@@ -141,7 +141,7 @@
                             }
                             else
                             {
-                                @if (Model.approvers.Contains(User.GetGitHubLogin()))
+                                @if (Model.PreferredApprovers.Contains(User.GetGitHubLogin()))
                                 {
                                     <button type="submit" class="btn btn-sm shadow-sm btn-success ml-2">
                                         <i class="far fa-thumbs-up" aria-hidden="true"></i>&nbsp;&nbsp;Approve

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
@@ -86,7 +86,7 @@ namespace APIViewWeb.Pages.Assemblies
 
         public IEnumerable<ReviewModel> ReviewsForPackage { get; set; } = new List<ReviewModel>();
 
-        public readonly HashSet<string> approvers = new HashSet<string>();
+        public readonly HashSet<string> PreferredApprovers = new HashSet<string>();
 
         public async Task<IActionResult> OnGetAsync(string id, string revisionId = null)
         {
@@ -156,18 +156,18 @@ namespace APIViewWeb.Pages.Assemblies
                             userCache.ApprovedLanguages = langs;
                             _preferenceCache.UpdateUserPreference(userCache, User);
                         }
-                        if (langs.Contains(Review.Language))
+                        if (langs.Contains(Review.Language) || !langs.Any())
                         {
-                            approvers.Add(username);
+                            PreferredApprovers.Add(username);
                         }
                     }
                     else
                     {
                         UserProfileModel user = await _userProfileRepository.tryGetUserProfileAsync(username);
                         var langs = user.Languages;
-                        if (langs.Contains(Review.Language))
+                        if (langs.Contains(Review.Language) || !langs.Any())
                         {
-                            approvers.Add(username);
+                            PreferredApprovers.Add(username);
                         }
                     }
                 }


### PR DESCRIPTION
Fixes a few minor nits with PR #4382, listed below.

- Corrected cache to update ApprovedLanguages rather than languages. (Languages being the language filter for reviews, ApprovedLanguages being the preferred approval languages)
- Changed `approvers` to `PreferredApprovers` to avoid confusion with existing `Approvers` list (People you can request/approve vs those who have approved)
- Default behavior if no languages selected changed from never showing to always showing (old behavior) 

Functionality unchanged otherwise 