### PR TITLE
Fetch only review requested API reviews for logged in user

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -27,10 +27,10 @@ namespace APIViewWeb.Pages.Assemblies
 
         public async Task<IActionResult> OnGetAsync()
         {
-            var fullResult = (await _manager.GetReviewsAsync(false, "All")).Where(r => r.RequestedReviewers != null).Where(r => r.RequestedReviewers.Contains(User.GetGitHubLogin()));
-            ActiveReviews = fullResult.Where(r => r.IsApproved == false).OrderByDescending(r => r.ApprovalRequestedOn);
+            var requestedReviews = await _manager.GetRequestedReviews(User.GetGitHubLogin());
+            ActiveReviews = requestedReviews.Where(r => r.IsApproved == false).OrderByDescending(r => r.ApprovalRequestedOn);
             // Remove all approvals over a week old
-            ApprovedReviews = fullResult.Where(r => r.IsApproved == true).Where(r => r.ApprovalDate != null).Where(r => r.ApprovalDate >= DateTime.Now.AddDays(-7)).OrderByDescending(r => r.ApprovalDate); 
+            ApprovedReviews = requestedReviews.Where(r => r.IsApproved == true).Where(r => r.ApprovalDate != null).Where(r => r.ApprovalDate >= DateTime.Now.AddDays(-7)).OrderByDescending(r => r.ApprovalDate);
             return Page();
         }
     }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CommentsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CommentsManager.cs
@@ -42,7 +42,9 @@ namespace APIViewWeb
 
             TaggableUsers = new HashSet<GithubUser>();
 
-            LoadTaggableUsers();
+            //Disable this to avoid exception when loading reviews for now.
+            // Fetch users as a background task and populate it in cache.
+            //LoadTaggableUsers();
         }
 
         public async void LoadTaggableUsers()

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -6,9 +6,9 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using APIViewWeb.Repositories;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
+
 
 namespace APIViewWeb
 {
@@ -114,6 +114,21 @@ namespace APIViewWeb
                 reviews.AddRange(result.Resource);
             }
             return reviews.OrderBy(r => r.Name).ThenByDescending(r => r.LastUpdated);
+        }
+
+        public async Task<IEnumerable<ReviewModel>> GetRequestedReviews(string userName)
+        {
+            var query = $"SELECT * FROM Reviews r WHERE IS_DEFINED(r.RequestedReviewers) AND ARRAY_CONTAINS(r.RequestedReviewers, @userName)";
+            var allReviews = new List<ReviewModel>();
+            var queryDefinition = new QueryDefinition(query).WithParameter("@userName", userName);
+            var itemQueryIterator = _reviewsContainer.GetItemQueryIterator<ReviewModel>(queryDefinition);
+            while (itemQueryIterator.HasMoreResults)
+            {
+                var result = await itemQueryIterator.ReadNextAsync();
+                allReviews.AddRange(result.Resource);
+            }
+
+            return allReviews.OrderByDescending(r => r.LastUpdated);
         }
 
         public async Task<IEnumerable<string>> GetReviewFirstLevelPropertiesAsync(string propertyName)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -94,6 +94,11 @@ namespace APIViewWeb.Repositories
         public async Task<IEnumerable<string>> GetReviewPropertiesAsync(string propertyName)
         {
             return await _reviewsRepository.GetReviewFirstLevelPropertiesAsync(propertyName);
+        }
+
+        public async Task<IEnumerable<ReviewModel>> GetRequestedReviews(string userName)
+        {
+            return await _reviewsRepository.GetRequestedReviews(userName);
         }
 
         public async Task<(IEnumerable<ReviewModel> Reviews, int TotalCount, int TotalPages, int CurrentPage, int? PreviousPage, int? NextPage)> GetPagedReviewsAsync(


### PR DESCRIPTION
Added new cosmos query to fetch only review requested API reviews from cosmos DB to avoid fetching all and filtering in app side.

I have also commented loading GitHub users to avoid issue in loading some reviews due to GitHub exception. I will submit another PR to load these user details as background task and cache it,