### PR TITLE
Add automation for updating github branch protection required status checks

### DIFF
--- a/eng/scripts/Github-Project-Helpers.ps1
+++ b/eng/scripts/Github-Project-Helpers.ps1
@@ -51,3 +51,93 @@ function Remove-GithubIssueFromProject([string]$projectId, [string]$projectItemI
 
   return $projectDeletedItemId
 }
+
+function Get-BranchProtectionChecks([string]$org = "Azure", [string]$repo, [string]$branch = "main")
+{
+  $resp = gh api -H "Accept: application/vnd.github+json" /repos/$org/$repo/branches/$branch/protection/required_status_checks
+  if ($LASTEXITCODE) {
+      exit $LASTEXITCODE
+  }
+  return $resp | ConvertFrom-Json -AsHashtable -Depth 100
+}
+
+function Remove-BranchProtectionCheck()
+{
+  [CmdletBinding(SupportsShouldProcess)]
+  param(
+    [string]$org = "Azure",
+    [string]$repo,
+    [string]$branch = "main",
+    [string]$ruleName
+  )
+  $ErrorActionPreference = 'Stop'
+
+  $rules = Get-BranchProtectionChecks -org $org -repo $repo -branch $branch
+  $dateTag = Get-Date -Format "yyyyMMdd.hhmmss"
+  $backupFile = "$org.$repo.$branch.required-checks.$dateTag.json"
+  Write-Host "Backing up original rules to $backupFile"
+  $rules | ConvertTo-Json -Depth 100 | Out-File -WhatIf:$false $backupFile
+
+  $rules.checks = [array]($rules.checks | Where-Object { $_.context -ne $ruleName })
+  # Deprecated, but update for parity just in case
+  $rules.contexts = [array]($rules.contexts | Where-Object { $_ -ne $ruleName })
+  if (!$rules.checks) {
+      $rules.checks = @()
+  }
+  if (!$rules.contexts) {
+      $rules.contexts = @()
+  }
+
+  Write-Host "Removing check '$ruleName'"
+  Write-Host "New rules: $($rules.checks | ConvertTo-Json -Compress)"
+  $body = $rules | ConvertTo-Json -Depth 100 -Compress
+  if($PSCmdlet.ShouldProcess("Remove check $ruleName for ${branch}?")) {
+    $_ = $body | gh api -X PATCH -H "Accept: application/vnd.github+json" /repos/$org/$repo/branches/$branch/protection/required_status_checks --input -
+    if ($LASTEXITCODE) {
+      exit $LASTEXITCODE
+    }
+  }
+}
+
+function Add-BranchProtectionCheck()
+{
+  [CmdletBinding(SupportsShouldProcess)]
+  param(
+    [string]$org = "Azure",
+    [string]$repo,
+    [string]$branch = "main",
+    [string]$ruleName
+  )
+  $ErrorActionPreference = 'Stop'
+
+  $rules = Get-BranchProtectionChecks -org $org -repo $repo -branch $branch
+  $rules.checks = [array]($rules.checks | Where-Object { $_.context -ne $ruleName -and !$_.app_id })
+  # Deprecated, but update for parity just in case
+  $rules.contexts = [array]($rules.contexts | Where-Object { $_ -ne $ruleName })
+  if (!$rules.checks) {
+      $rules.checks = @()
+  }
+  if (!$rules.contexts) {
+      $rules.contexts = @()
+  }
+
+  if ($rules.checks.context -notcontains $ruleName) {
+   # For now, support "any source" only for required check source
+   # Setting the `app_id` field to -1 results in "any source" being set for the check
+   $rules.checks = $rules.checks + @( @{ context = $ruleName ; app_id = -1 } )
+   # Deprecated, but update for parity just in case
+   $rules.contexts = $rules.contexts + $ruleName
+  } else {
+    Write-Host "Rule $ruleName already exists for $branch"
+    return
+  }
+
+  Write-Host "New rules: $($rules.checks | ConvertTo-Json -Compress)"
+  $body = $rules | ConvertTo-Json -Depth 100 -Compress
+  if($PSCmdlet.ShouldProcess("Add rule $ruleName for ${branch}?")) {
+    $_ = $body | gh api -X PATCH -H "Accept: application/vnd.github+json" /repos/$org/$repo/branches/$branch/protection/required_status_checks --input -
+    if ($LASTEXITCODE) {
+      exit $LASTEXITCODE
+    }
+  }
+}


### PR DESCRIPTION
This is something we're having to do a bit more of lately, so I decided to automate it. The code favors "any source" for our required status checks.

The only unknown is I'm not sure how this will behave when the extra 2fa for admin changes is expired, since I currently have it set. I will do a test update tomorrow.

Example run:

```
$ Add-BranchProtectionCheck -org Azure -repo "azure-sdk-tools" -ruleName "license/cla" -WhatIf
Backing up original rules to Azure.azure-sdk-tools.main.required-checks.20221018.011815.json
New rules: [{"context":"https://aka.ms/azsdk/checkenforcer","app_id":null},{"context":"license/cla","app_id":-1}]
What if: Performing the operation "Add-BranchProtectionCheck" on target "Add rule license/cla for main?".

$ Remove-BranchProtectionCheck -org Azure -repo "azure-sdk-tools" -ruleName "license/cla"
Backing up original rules to Azure.azure-sdk-tools.main.required-checks.20221018.011909.json
Removing check 'license/cla'
New rules: {"context":"https://aka.ms/azsdk/checkenforcer","app_id":null}

$ Add-BranchProtectionCheck -org Azure -repo "azure-sdk-tools" -ruleName "license/cla"
Backing up original rules to Azure.azure-sdk-tools.main.required-checks.20221018.012226.json
New rules: [{"context":"https://aka.ms/azsdk/checkenforcer","app_id":null},{"context":"license/cla","app_id":-1}]
```
