### PR TITLE
Add extra parameters for .net readme path

### DIFF
--- a/eng/common/scripts/Update-DocsMsToc.ps1
+++ b/eng/common/scripts/Update-DocsMsToc.ps1
@@ -30,7 +30,7 @@ depending on the requirements for the domain
 Output location for unified reference yml file
 
 .PARAMETER ReadmeFolderRoot
-The readme folder root path. E.g. docs-ref-services in Java, JS, Python, api/overview/azure
+The readme folder root path, use default value here for backward compability. E.g. docs-ref-services in Java, JS, Python, api/overview/azure
 
 .PARAMETER PackageSourceOverride
 The package source override is the devops public feeds which each language published their SDK to.
@@ -44,7 +44,7 @@ param(
   [string] $OutputLocation,
 
   [Parameter(Mandatory = $false)]
-  [string] $ReadmeFolderRoot,
+  [string] $ReadmeFolderRoot = 'docs-ref-services',
 
   [Parameter(Mandatory = $false)]
   [string] $PackageSourceOverride
@@ -217,14 +217,9 @@ foreach ($service in $serviceNameList) {
   }
 
   $serviceReadmeBaseName = $service.ToLower().Replace(' ', '-').Replace('/', '-')
-  # This is the common readme path for Java/Python/Js
-  $serviceHref = "~/docs-ref-services/{moniker}/$serviceReadmeBaseName.md"
-  if ($ReadmeFolderRoot) {
-    $serviceHref = "~/$ReadmeFolderRoot/{moniker}/$serviceReadmeBaseName.md"
-  }
   $serviceTocEntry = [PSCustomObject]@{
     name            = $service;
-    href            = $serviceHref
+    href            = "~/$ReadmeFolderRoot/{moniker}/$serviceReadmeBaseName.md"
     landingPageType = 'Service'
     items           = @($packageItems)
   }

--- a/eng/common/scripts/Update-DocsMsToc.ps1
+++ b/eng/common/scripts/Update-DocsMsToc.ps1
@@ -31,9 +31,6 @@ Output location for unified reference yml file
 
 .PARAMETER ReadmeFolderRoot
 The readme folder root path, use default value here for backward compability. E.g. docs-ref-services in Java, JS, Python, api/overview/azure
-
-.PARAMETER PackageSourceOverride
-The package source override is the devops public feeds which each language published their SDK to.
 #>
 
 param(
@@ -44,10 +41,7 @@ param(
   [string] $OutputLocation,
 
   [Parameter(Mandatory = $false)]
-  [string] $ReadmeFolderRoot = 'docs-ref-services',
-
-  [Parameter(Mandatory = $false)]
-  [string] $PackageSourceOverride
+  [string] $ReadmeFolderRoot = 'docs-ref-services'
 )
 . $PSScriptRoot/common.ps1
 . $PSScriptRoot/Helpers/PSModule-Helpers.ps1
@@ -259,7 +253,7 @@ if ($otherPackages) {
           break
         }
 
-        if ($matchingNode -and ($matchingNode[0].PSObject.Members.Name -contains "items")) {
+        if ($matchingNode) {
           $currentNode = $matchingNode[0].items
         }
         else {

--- a/eng/common/scripts/Update-DocsMsToc.ps1
+++ b/eng/common/scripts/Update-DocsMsToc.ps1
@@ -29,6 +29,11 @@ depending on the requirements for the domain
 .PARAMETER OutputLocation
 Output location for unified reference yml file
 
+.PARAMETER ReadmeFolderRoot
+The readme folder root path. E.g. docs-ref-services in Java, JS, Python, api/overview/azure
+
+.PARAMETER PackageSourceOverride
+The package source override is the devops public feeds which each language published their SDK to.
 #>
 
 param(
@@ -36,7 +41,13 @@ param(
   [string] $DocRepoLocation,
 
   [Parameter(Mandatory = $true)]
-  [string] $OutputLocation
+  [string] $OutputLocation,
+
+  [Parameter(Mandatory = $false)]
+  [string] $ReadmeFolderRoot,
+
+  [Parameter(Mandatory = $false)]
+  [string] $PackageSourceOverride
 )
 . $PSScriptRoot/common.ps1
 . $PSScriptRoot/Helpers/PSModule-Helpers.ps1
@@ -206,9 +217,14 @@ foreach ($service in $serviceNameList) {
   }
 
   $serviceReadmeBaseName = $service.ToLower().Replace(' ', '-').Replace('/', '-')
+  # This is the common readme path for Java/Python/Js
+  $serviceHref = "~/docs-ref-services/{moniker}/$serviceReadmeBaseName.md"
+  if ($ReadmeFolderRoot) {
+    $serviceHref = "~/$ReadmeFolderRoot/{moniker}/$serviceReadmeBaseName.md"
+  }
   $serviceTocEntry = [PSCustomObject]@{
     name            = $service;
-    href            = "~/docs-ref-services/{moniker}/$serviceReadmeBaseName.md"
+    href            = $serviceHref
     landingPageType = 'Service'
     items           = @($packageItems)
   }
@@ -248,7 +264,7 @@ if ($otherPackages) {
           break
         }
 
-        if ($matchingNode) {
+        if ($matchingNode -and ($matchingNode[0].PSObject.Members.Name -contains "items")) {
           $currentNode = $matchingNode[0].items
         }
         else {


### PR DESCRIPTION
Docs toc linked to the readme information for Overview page.

.NET uses different readme path than other languages. 
.NET: `api/overview/azure`. Ref [link](https://github.com/Azure/azure-docs-sdk-dotnet/tree/main/api/overview/azure)
Java/Python/JS: `docs-ref-services`. Ref [link](https://github.com/Azure/azure-docs-sdk-java/tree/main/docs-ref-services)
To have the flexibility of using different path for .NET Toc, we add one more parameter in common script. As the common script currently run in prod, so we default to what we had before.