### PR TITLE
Prevent broken state on cancelled push

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -91,10 +91,11 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             {
                 try
                 {
+                    string branchGuid = Guid.NewGuid().ToString().Substring(0, 8);
                     string gitUserName = GetGitOwnerName(config);
                     string gitUserEmail = GetGitOwnerEmail(config);
-                    GitHandler.Run($"branch {config.TagPrefix}", config);
-                    GitHandler.Run($"checkout {config.TagPrefix}", config);
+                    GitHandler.Run($"branch {branchGuid}", config);
+                    GitHandler.Run($"checkout {branchGuid}", config);
                     GitHandler.Run($"add -A .", config);
                     GitHandler.Run($"-c user.name=\"{gitUserName}\" -c user.email=\"{gitUserEmail}\" commit -m \"Automatic asset update from test-proxy.\"", config);
                     // Get the first 10 digits of the commit SHA. The generatedTagName will be the


### PR DESCRIPTION
Resolves #4118

We always checkout a new branch just before pushing it to the new tag. This new branch is always the same name. This means that if something goes wrong between creating the branch to hold the changeset and pushing the new tag, we'll be in a stuck state that can't even be fixed by a `reset` because the branch will already exist. `git branch <branchname>` will continually fail, we already created a branch of that name!

We can avoid a weird broken state if we create a new one each time we try to push.

If we're _already_ in the middle of the push, we'll already be on another branch, and it'll just checkout a new one with all the information still present, and the tag push will succeed.