### PR TITLE
[stress testing] Improve scenario matrix edge case handling

### DIFF
--- a/eng/common/scripts/stress-testing/generate-scenario-matrix.ps1
+++ b/eng/common/scripts/stress-testing/generate-scenario-matrix.ps1
@@ -39,12 +39,16 @@ function GenerateScenarioMatrix(
         $scenariosMatrix += $entry
     }
 
-    $valuesYaml = Get-Content -Raw (Join-Path (Split-Path $matrixFilePath) 'values.yaml')
-    $values = $valuesYaml | ConvertFrom-Yaml -Ordered
-    if (!$values) {$values = @{}}
+    $valuesConfig = Join-Path (Split-Path $matrixFilePath) 'values.yaml'
+    $values = [ordered]@{}
+    if (Test-Path $valuesConfig) {
+        $valuesYaml = Get-Content -Raw $valuesConfig
+        $values = $valuesYaml | ConvertFrom-Yaml -Ordered
+        if (!$values) {$values = @{}}
 
-    if ($values.ContainsKey('Scenarios')) {
-        throw "Please use matrix generation for stress test scenarios."
+        if ($values.ContainsKey('Scenarios')) {
+            throw "Please use matrix generation for stress test scenarios."
+        }
     }
 
     $values.scenarios = $scenariosMatrix

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -248,7 +248,7 @@ function DeployStressPackage(
                 }
             }
         }
-        $genVal.scenarios = foreach ($scenario in $genVal.scenarios) {
+        $genVal.scenarios = @( foreach ($scenario in $genVal.scenarios) {
             $dockerPath = Join-Path $pkg.Directory $scenario.image
             if ("image" -notin $scenario) {
                 $dockerPath = $dockerFilePath
@@ -257,7 +257,7 @@ function DeployStressPackage(
                 $scenario.imageTag = $imageTag
             }
             $scenario
-        }
+        } )
 
         $genVal | ConvertTo-Yaml | Out-File -FilePath $genValFile
     }


### PR DESCRIPTION
1. Handle case where the matrix produces a single length array. Powershell by default will return the array item type (object) instead of an array, which messes things up the generated values file.
2. Handle case where there is no values.yaml file defined.
