### PR TITLE
Include NullableResponse<T> as an accepted response type

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0015Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0015Tests.cs
@@ -44,6 +44,8 @@ namespace RandomNamespace
         [InlineData("public Response<int> ClientMethodAsync() { return default; }")]
         [InlineData("public Response<int[]> ClientMethodAsync() { return default; }")]
         [InlineData("public Task<Response<int[]>> ClientMethodAsync() { return default; }")]
+        [InlineData("public NullableResponse<int[]> ClientMethodAsync() { return default; }")]
+        [InlineData("public Task<NullableResponse<int[]>> ClientMethodAsync() { return default; }")]
         [InlineData("public Response ClientMethodAsync() { return default; }")]
         [InlineData("public SomeClient ClientMethod() { return default; }")]
         public async Task AZC0015NotProducedForValidReturnTypes(string usage)

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
@@ -16,7 +16,7 @@ namespace Azure.ClientSdk.Analyzers.Tests
     {
         private static readonly ReferenceAssemblies DefaultReferenceAssemblies =
             ReferenceAssemblies.Default.AddPackages(ImmutableArray.Create(
-                new PackageIdentity("Azure.Core", "1.21.0"),
+                new PackageIdentity("Azure.Core", "1.26.0"),
                 new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "1.1.0"),
                 new PackageIdentity("System.Text.Json", "4.6.0"),
                 new PackageIdentity("Newtonsoft.Json", "12.0.3"),

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerVerifier.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerVerifier.cs
@@ -17,7 +17,7 @@ namespace Azure.ClientSdk.Analyzers.Tests
     {
         private static readonly ReferenceAssemblies DefaultReferenceAssemblies =
             ReferenceAssemblies.Default.AddPackages(ImmutableArray.Create(
-                new PackageIdentity("Azure.Core", "1.21.0"),
+                new PackageIdentity("Azure.Core", "1.26.0"),
                 new PackageIdentity("Microsoft.Bcl.AsyncInterfaces", "1.1.0"),
                 new PackageIdentity("System.Text.Json", "4.6.0"),
                 new PackageIdentity("Newtonsoft.Json", "12.0.3"),

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -100,6 +100,7 @@ namespace Azure.ClientSdk.Analyzers
             }
 
             if (IsOrImplements(unwrappedType, "Response") ||
+                IsOrImplements(unwrappedType, "NullableResponse") ||
                 IsOrImplements(unwrappedType, "Operation") ||
                 IsOrImplements(originalType, "Pageable") ||
                 IsOrImplements(originalType, "AsyncPageable") ||


### PR DESCRIPTION
fixes #4444

This should pass checks once Azure.Core 1.26.0 ships.