### PR TITLE
Increase Java Perf Pipeline Build Parallelization

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
@@ -38,8 +38,8 @@ namespace Azure.Sdk.Tools.PerfAutomation
             var result = await Util.RunAsync(
                 "mvn",
                 "clean install -T 2C -am" +
-                " -Denforcer.skip=true -DskipTests=true -Dmaven.test.skip=true -Dmaven.javadoc.skip=true " +
-                " -Dcodesnippet.skip=true -Dspotbugs.skip=true -Dcheckstyle.skip=true -Drevapi.skip=true" +
+                " -Denforcer.skip=true -DskipTests=true -Dmaven.javadoc.skip=true -Dcodesnippet.skip=true " +
+                " -Dspotbugs.skip=true -Dcheckstyle.skip=true -Drevapi.skip=true" +
                 $" --no-transfer-progress --pl {project}",
                 WorkingDirectory,
                 environmentVariables: _buildEnvironment

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
@@ -38,7 +38,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
             var result = await Util.RunAsync(
                 "mvn",
                 "clean install -T 2C -am" +
-                " -Denforcer.skip=true -DskipTests=true -Dmaven.test.skip = true -Dmaven.javadoc.skip=true " +
+                " -Denforcer.skip=true -DskipTests=true -Dmaven.test.skip=true -Dmaven.javadoc.skip=true " +
                 " -Dcodesnippet.skip=true -Dspotbugs.skip=true -Dcheckstyle.skip=true -Drevapi.skip=true" +
                 $" --no-transfer-progress --pl {project}",
                 WorkingDirectory,

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
@@ -37,9 +37,9 @@ namespace Azure.Sdk.Tools.PerfAutomation
 
             var result = await Util.RunAsync(
                 "mvn",
-                "clean install -T1C -am" +
-                " -Denforcer.skip=true -DskipTests=true -Dmaven.javadoc.skip=true -Dcodesnippet.skip=true " +
-                " -Dspotbugs.skip=true -Dcheckstyle.skip=true -Drevapi.skip=true" +
+                "clean install -T 2C -am" +
+                " -Denforcer.skip=true -DskipTests=true -Dmaven.test.skip = true -Dmaven.javadoc.skip=true " +
+                " -Dcodesnippet.skip=true -Dspotbugs.skip=true -Dcheckstyle.skip=true -Drevapi.skip=true" +
                 $" --no-transfer-progress --pl {project}",
                 WorkingDirectory,
                 environmentVariables: _buildEnvironment


### PR DESCRIPTION
~~Skip compiling tests in Java performance pipelines as the test JARs will never be used.~~

Updated to only increase build parallelization as it turned out the from source runs did require the test compile.