### PR TITLE
Stress deployment namespace bug fix

### DIFF
--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -41,7 +41,11 @@ function Login([string]$subscription, [string]$clusterGroup, [switch]$pushImages
     $clusterName = ($cluster | ConvertFrom-Json).name
 
     $kubeContext = (RunOrExitOnFailure kubectl config view -o json) | ConvertFrom-Json
-    $defaultNamespace = $kubeContext.contexts.Where({ $_.name -eq $clusterName }).context.namespace
+    $context = $kubeContext.contexts.Where({ $_.name -eq $clusterName }).context
+    defaultNamespace = $null
+    if ($context.psobject.properties.name -match 'namespace') {
+        $defaultNamespace = $context.namespace
+    }
 
     RunOrExitOnFailure az aks get-credentials `
         -n "$clusterName" `


### PR DESCRIPTION
This solved the bug where it shows "does not have property namespace" error if the user's context doesn't have default namespace