### PR TITLE
Allow multiple leading / on path

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -125,9 +125,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 context.Request.Headers[header.Key] = header.Value;
             }
 
-            context.Request.Headers["x-recording-upstream-base-uri"] = entry.RequestUri;
-
             var uri = new Uri(entry.RequestUri);
+
+            context.Request.Headers["x-recording-upstream-base-uri"] = new UriBuilder(uri.Scheme, uri.Host, uri.Port).Uri.ToString();
             context.Request.Host = new HostString(uri.Authority);
             context.Request.QueryString = new QueryString(uri.Query);
             context.Request.Path = uri.AbsolutePath;


### PR DESCRIPTION
Resolves #4557
Repro Azure/azure-sdk-for-js/pull/23655


It's technically allowed. It was our _methodology_ of creating the URI that was actually breaking.

By limiting this logic to only apply in this _specific_ situation, I believe we should be able to safely use this string concatenation.

@mikeharder for discussion. @hallipr for FYI. @timovv lmk when the repro is updated with the fix for base uri. Should just turn green with this change.

EDIT after Timo's update:

![image](https://user-images.githubusercontent.com/45376673/199120656-00f2a047-edb1-42f5-9f64-bc1952a636e3.png)
