### PR TITLE
Consistent path handling

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/BreadcrumbTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/BreadcrumbTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 var breadcrumbLine = new BreadcrumbLine(parsedConfig);
 
                 Assert.Equal(parsedConfig.Tag, breadcrumbLine.Tag);
-                Assert.Equal(parsedConfig.AssetsJsonRelativeLocation.ToString(), breadcrumbLine.PathToAssetsJson);
+                Assert.Equal(parsedConfig.AssetsJsonRelativeLocation, breadcrumbLine.PathToAssetsJson);
                 Assert.Equal(parsedConfig.AssetRepoShortHash, breadcrumbLine.ShortHash);
 
                 // now tostring the line, then reparse it.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/BreadcrumbTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/BreadcrumbTests.cs
@@ -47,7 +47,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 var breadcrumbLine = new BreadcrumbLine(parsedConfig);
 
                 Assert.Equal(parsedConfig.Tag, breadcrumbLine.Tag);
-                Assert.Equal(parsedConfig.AssetsJsonRelativeLocation, breadcrumbLine.PathToAssetsJson);
+                Assert.Equal(parsedConfig.AssetsJsonRelativeLocation.ToString(), breadcrumbLine.PathToAssetsJson);
                 Assert.Equal(parsedConfig.AssetRepoShortHash, breadcrumbLine.ShortHash);
 
                 // now tostring the line, then reparse it.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
@@ -344,8 +344,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 var jsonFileLocation = Path.Join(testFolder, targetRelPath, AssetsJson);
 
                 var parsedConfiguration = await _defaultStore.ParseConfigurationFile(jsonFileLocation);
-                Assert.Equal(Path.Join(targetRelPath, AssetsJson), parsedConfiguration.AssetsJsonRelativeLocation);
-                Assert.Equal(jsonFileLocation, parsedConfiguration.AssetsJsonLocation);
+                Assert.Equal(Path.Join(targetRelPath, AssetsJson), parsedConfiguration.AssetsJsonRelativeLocation.ToString());
+                Assert.Equal(jsonFileLocation, parsedConfiguration.AssetsJsonLocation.ToString());
             }
             finally
             {
@@ -610,7 +610,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             try
             {
                 var assetStore = (await _defaultStore.ParseConfigurationFile(Path.Join(testFolder, target1))).ResolveAssetsStoreLocation();
-                var breadCrumbFile = Path.Join(assetStore, ".breadcrumb");
+                var breadCrumbFile = Path.Join(assetStore.ToString(), ".breadcrumb");
 
                 // run 3 restore operations
                 foreach (var assetsJson in folderStructure)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
@@ -8,6 +8,7 @@ using Xunit;
 using System.Text.Json;
 using System.Linq;
 using System.ComponentModel;
+using Azure.Sdk.tools.TestProxy.Common;
 
 namespace Azure.Sdk.Tools.TestProxy.Tests
 {
@@ -341,10 +342,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var testFolder = TestHelpers.DescribeTestFolder(DefaultAssets, folderStructure);
             try
             {
-                var jsonFileLocation = Path.Join(testFolder, targetRelPath, AssetsJson);
+                var jsonFileLocation = new NormalizedString(Path.Join(testFolder, targetRelPath, AssetsJson));
 
                 var parsedConfiguration = await _defaultStore.ParseConfigurationFile(jsonFileLocation);
-                Assert.Equal(Path.Join(targetRelPath, AssetsJson), parsedConfiguration.AssetsJsonRelativeLocation.ToString());
+                Assert.Equal(new NormalizedString(Path.Join(targetRelPath, AssetsJson)), parsedConfiguration.AssetsJsonRelativeLocation.ToString());
                 Assert.Equal(jsonFileLocation, parsedConfiguration.AssetsJsonLocation.ToString());
             }
             finally
@@ -450,15 +451,15 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var testFolder = TestHelpers.DescribeTestFolder(DefaultAssets, expectedPaths);
             try
             {
-                string configLocation;
+                NormalizedString configLocation;
 
                 if (assetsJsonPath == "assets.json")
                 {
-                    configLocation = testFolder;
+                    configLocation = new NormalizedString(testFolder);
                 }
                 else
                 {
-                    configLocation = Path.Join(testFolder, assetsJsonPath);
+                    configLocation = new NormalizedString(Path.Join(testFolder, assetsJsonPath));
                 }
 
                 var configuration = await _defaultStore.ParseConfigurationFile(configLocation);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationPushTests.cs
@@ -70,7 +70,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 // These are the files pulled down with the original Tag
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
@@ -152,7 +152,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 // These are the files pulled down with the original Tag
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
@@ -234,7 +234,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 // These are the files pulled down with the original Tag
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
@@ -327,7 +327,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 // These are the files pulled down with the original Tag
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
@@ -416,7 +416,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 // These are the files pulled down with the original Tag
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
@@ -433,7 +433,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath2 = Path.GetFullPath(Path.Combine(parsedConfiguration2.AssetsRepoLocation, parsedConfiguration2.AssetsRepoPrefixPath));
+                string localFilePath2 = Path.GetFullPath(Path.Combine(parsedConfiguration2.AssetsRepoLocation.ToString(), parsedConfiguration2.AssetsRepoPrefixPath.ToString()));
 
                 // These are the files pulled down with the original Tag
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath2).Count());

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationResetTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationResetTests.cs
@@ -71,7 +71,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
@@ -136,7 +136,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
@@ -203,7 +203,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 // Verify files from Tag
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
@@ -279,7 +279,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 // Verify files from Tag
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
@@ -356,7 +356,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 // Verify files from Tag
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -69,7 +69,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
@@ -124,7 +124,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
@@ -182,7 +182,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
                 // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
                 // will be a forward one as expected by git but on Windows this won't result in a usable path.
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
@@ -286,7 +286,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
 
                 await _defaultStore.Restore(jsonFileLocation);
 
-                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation, parsedConfiguration.AssetsRepoPrefixPath));
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
 
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 await TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
@@ -362,7 +362,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             {
                 await recordingHandler.Restore(pathToAssets);
 
-                var result = (await _defaultStore.ParseConfigurationFile(pathToAssets)).AssetsRepoLocation;
+                var result = (await _defaultStore.ParseConfigurationFile(pathToAssets)).AssetsRepoLocation.ToString();
 
                 Assert.Equal(result, recordingHandler.ContextDirectory);
                 await TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { pathToAssets });

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -355,8 +355,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         public static void CheckBreadcrumbAgainstAssetsConfig(GitAssetsConfiguration configuration)
         {
             var assetsStorePath = configuration.ResolveAssetsStoreLocation();
-            var breadCrumbFile = Path.Join(assetsStorePath, ".breadcrumb");
-            var targetKey = configuration.AssetsJsonRelativeLocation.Replace("\\", "/");
+            var breadCrumbFile = Path.Join(assetsStorePath.ToString(), ".breadcrumb");
+            var targetKey = configuration.AssetsJsonRelativeLocation.ToString();
 
             Assert.True(File.Exists(breadCrumbFile));
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/NormalizedString.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/NormalizedString.cs
@@ -1,0 +1,20 @@
+namespace Azure.Sdk.tools.TestProxy.Common {
+    public class NormalizedString {
+        private string value;
+
+        public NormalizedString(string s){
+            if (s == null)
+            {
+                value = null;
+            }
+            else
+            {
+                value = s.Replace("\\", "/");
+            }
+        }
+
+        public override string ToString(){
+            return value;
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/NormalizedString.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/NormalizedString.cs
@@ -13,6 +13,16 @@ namespace Azure.Sdk.tools.TestProxy.Common {
             }
         }
 
+        public static implicit operator string(NormalizedString s)
+        {
+            return s.ToString();
+        }
+
+        public static explicit operator NormalizedString(string s)
+        {
+            return new NormalizedString(s);
+        }
+
         public override string ToString(){
             return value;
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/AssetsConfiguration.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/AssetsConfiguration.cs
@@ -1,4 +1,5 @@
 using System.Text.Json.Serialization;
+using Azure.Sdk.tools.TestProxy.Common;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
@@ -13,18 +14,18 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// Useful for sparse checkout operations.
         /// </summary>
         [JsonIgnore]
-        public virtual string AssetsJsonRelativeLocation { get; set; }
+        public virtual NormalizedString AssetsJsonRelativeLocation { get; set; }
 
         /// <summary>
         /// Contains the absolute path to the assets.json.
         /// </summary>
         [JsonIgnore]
-        public virtual string AssetsJsonLocation { get; set; }
+        public virtual NormalizedString AssetsJsonLocation { get; set; }
 
         /// <summary>
         /// Contains the absolute path to the root of the repo. Outside of a git repo, will return disk root.
         /// </summary>
         [JsonIgnore]
-        public virtual string RepoRoot { get; set; }
+        public virtual NormalizedString RepoRoot { get; set; }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
@@ -1,13 +1,35 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Azure.Sdk.tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Common;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
+
+    public class NormalizedStringConverter : JsonConverter<NormalizedString>
+    {
+        public override NormalizedString Read(
+            ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            using (var jsonDoc = JsonDocument.ParseValue(ref reader))
+            {
+                return new NormalizedString(reader.GetString());
+            }
+        }
+
+        public override void Write(
+            Utf8JsonWriter writer, NormalizedString value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value);
+        }
+    }
+
     /// <summary>
     /// This class is used to represent any assets.json configuration. An assets.json configuration contains all the necessary configuration needed to restore an asset to the local storage directory of the test-proxy.
     /// </summary>
@@ -31,6 +53,8 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <summary>
         /// Within the assets repo, is there a prefix that should be inserted prior to writing out files?
         /// </summary>
+
+        [JsonConverter(typeof(NormalizedStringConverter))]
         public NormalizedString AssetsRepoPrefixPath { get; set; }
 
         /// <summary>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitAssetsConfiguration.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
 using System.Text;
+using Azure.Sdk.tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Common;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
@@ -30,7 +31,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <summary>
         /// Within the assets repo, is there a prefix that should be inserted prior to writing out files?
         /// </summary>
-        public string AssetsRepoPrefixPath { get; set; }
+        public NormalizedString AssetsRepoPrefixPath { get; set; }
 
         /// <summary>
         /// Tags are generated and pushed with each changeset. This prefix will inform the name of the tag to be recognizable as soemthing other than a guid.
@@ -40,7 +41,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <summary>
         /// The location of the assets repo for this config.
         /// </summary>
-        public string AssetsRepoLocation
+        public NormalizedString AssetsRepoLocation
         { 
             get { return ResolveAssetRepoLocation(); }
         }
@@ -65,32 +66,32 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// Used to resolve the location of the "assets" store location. This is the folder CONTAINING other cloned repos. No git data will be restored or staged directly within this folder.
         /// </summary>
         /// <returns></returns>
-        public string ResolveAssetsStoreLocation()
+        public NormalizedString ResolveAssetsStoreLocation()
         {
-            var location = Environment.GetEnvironmentVariable("PROXY_ASSETS_FOLDER") ?? Path.Join(RepoRoot, ".assets");
+            var location = Environment.GetEnvironmentVariable("PROXY_ASSETS_FOLDER") ?? Path.Join(RepoRoot.ToString(), ".assets");
             if (!Directory.Exists(location))
             {
                 Directory.CreateDirectory(location);
             }
 
-            return location;
+            return new NormalizedString(location);
         }
 
         /// <summary>
         /// Resolves the location of the actual folder containing a cloned repository WITHIN the asset store. Git data will be stored directly within this directory.
         /// </summary>
         /// <returns></returns>
-        public string ResolveAssetRepoLocation()
+        public NormalizedString ResolveAssetRepoLocation()
         {
             var assetsStore = ResolveAssetsStoreLocation();
 
-            var location = Path.Join(assetsStore, AssetRepoShortHash);
+            var location = Path.Join(assetsStore.ToString(), AssetRepoShortHash);
             if (!Directory.Exists(location))
             {
                 Directory.CreateDirectory(location);
             }
 
-            return location;
+            return new NormalizedString(location);
         }
 
         /// <summary>
@@ -100,7 +101,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <returns></returns>
         public bool IsAssetsRepoInitialized(bool autoCreate = true)
         {
-            var location = Path.Join(ResolveAssetRepoLocation(), ".git");
+            var location = Path.Join(ResolveAssetRepoLocation().ToString(), ".git");
 
             return Directory.Exists(location);
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -95,7 +95,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <exception cref="GitProcessException">Throws GitProcessException on returnCode != 0 OR if an unexpected exception is thrown during invocation.</exception>
         public virtual CommandResult Run(string arguments, GitAssetsConfiguration config)
         {
-            return Run(arguments, config.AssetsRepoLocation);
+            return Run(arguments, config.AssetsRepoLocation.ToString());
         }
 
         /// <summary>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -421,7 +421,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <exception cref="NotImplementedException"></exception>
         public string ResolveCheckoutPaths(GitAssetsConfiguration config)
         {
-            var combinedPath = Path.Join(config.AssetsRepoPrefixPath.ToString() ?? String.Empty, config.AssetsJsonRelativeLocation.ToString()).Replace("\\", "/");
+            var combinedPath = new NormalizedString(Path.Join(config.AssetsRepoPrefixPath ?? String.Empty, config.AssetsJsonRelativeLocation)).ToString();
 
             if (combinedPath.ToLower() == AssetsJsonFileName)
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -14,6 +14,7 @@ using Azure.Sdk.Tools.TestProxy.Console;
 using System.Collections.Concurrent;
 using System.Reflection.Metadata;
 using System.Text.RegularExpressions;
+using Azure.Sdk.tools.TestProxy.Common;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {
@@ -69,12 +70,12 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         {
             var config = await ParseConfigurationFile(pathToAssetsJson);
 
-            if (!string.IsNullOrWhiteSpace(config.AssetsRepoPrefixPath))
+            if (!string.IsNullOrWhiteSpace(config.AssetsRepoPrefixPath.ToString()))
             {
-                return Path.Combine(config.AssetsRepoLocation, config.AssetsRepoPrefixPath);
+                return Path.Combine(config.AssetsRepoLocation.ToString(), config.AssetsRepoPrefixPath.ToString());
             }
 
-            return config.AssetsRepoLocation;
+            return config.AssetsRepoLocation.ToString();
         }
 
         /// <summary>
@@ -100,7 +101,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     GitHandler.Run($"-c user.name=\"{gitUserName}\" -c user.email=\"{gitUserEmail}\" commit -m \"Automatic asset update from test-proxy.\"", config);
                     // Get the first 10 digits of the commit SHA. The generatedTagName will be the
                     // config.TagPrefix_<SHA>
-                    if (GitHandler.TryRun("rev-parse --short=10 HEAD", config.AssetsRepoLocation, out CommandResult SHAResult))
+                    if (GitHandler.TryRun("rev-parse --short=10 HEAD", config.AssetsRepoLocation.ToString(), out CommandResult SHAResult))
                     {
                         var newSHA = SHAResult.StdOut.Trim();
                         generatedTagName += $"_{newSHA}";
@@ -137,7 +138,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             CheckoutRepoAtConfig(config);
             await BreadCrumb.Update(config);
 
-            return config.AssetsRepoLocation;
+            return config.AssetsRepoLocation.ToString();
         }
 
         /// <summary>
@@ -222,7 +223,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <returns></returns>
         public string[] DetectPendingChanges(GitAssetsConfiguration config)
         {
-            if (!GitHandler.TryRun("status --porcelain", config.AssetsRepoLocation, out var diffResult))
+            if (!GitHandler.TryRun("status --porcelain", config.AssetsRepoLocation.ToString(), out var diffResult))
             {
                 throw GenerateInvokeException(diffResult);
             }
@@ -244,7 +245,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <param name="config"></param>
         public void CheckoutRepoAtConfig(GitAssetsConfiguration config)
         {
-            if (Assets.TryGetValue(config.AssetsJsonRelativeLocation, out var value) && value == config.Tag)
+            if (Assets.TryGetValue(config.AssetsJsonRelativeLocation.ToString(), out var value) && value == config.Tag)
             {
                 return;
             }
@@ -276,7 +277,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 // the second argument, the value, is the value we want to set the json elative location to
                 // the third argument is a function argument that resolves what to do in the "update" case. If the key already exists
                 // update the tag to what we just checked out.
-                Assets.AddOrUpdate(config.AssetsJsonRelativeLocation, config.Tag, (key, oldValue) => config.Tag);
+                Assets.AddOrUpdate(config.AssetsJsonRelativeLocation.ToString(), config.Tag, (key, oldValue) => config.Tag);
             }
             catch(GitProcessException e)
             {
@@ -364,7 +365,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
         public bool IsAssetsRepoInitialized(GitAssetsConfiguration config)
         {
-            if (Assets.ContainsKey(config.AssetsJsonRelativeLocation))
+            if (Assets.ContainsKey(config.AssetsJsonRelativeLocation.ToString()))
             {
                 return true;
             }
@@ -386,8 +387,8 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
             if (forceInit)
             {
-                DirectoryHelper.DeleteGitDirectory(assetRepo);
-                Directory.CreateDirectory(assetRepo);
+                DirectoryHelper.DeleteGitDirectory(assetRepo.ToString());
+                Directory.CreateDirectory(assetRepo.ToString());
                 initialized = false;
             }
 
@@ -396,7 +397,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 try
                 {
                     // The -c core.longpaths=true is basically for Windows and is a noop for other platforms
-                    var cloneUrl = GetCloneUrl(config.AssetsRepo, config.RepoRoot);
+                    var cloneUrl = GetCloneUrl(config.AssetsRepo, config.RepoRoot.ToString());
                     GitHandler.Run($"clone -c core.longpaths=true --no-checkout --filter=tree:0 {cloneUrl} .", config);
                     GitHandler.Run($"sparse-checkout init", config);
                 }
@@ -420,7 +421,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <exception cref="NotImplementedException"></exception>
         public string ResolveCheckoutPaths(GitAssetsConfiguration config)
         {
-            var combinedPath = Path.Join(config.AssetsRepoPrefixPath ?? String.Empty, config.AssetsJsonRelativeLocation).Replace("\\", "/");
+            var combinedPath = Path.Join(config.AssetsRepoPrefixPath.ToString() ?? String.Empty, config.AssetsJsonRelativeLocation.ToString()).Replace("\\", "/");
 
             if (combinedPath.ToLower() == AssetsJsonFileName)
             {
@@ -466,9 +467,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
                 var repoRoot = AscendToRepoRoot(pathToAssets);
 
-                assetConfig.AssetsJsonLocation = pathToAssets;
-                assetConfig.AssetsJsonRelativeLocation = Path.GetRelativePath(repoRoot, pathToAssets);
-                assetConfig.RepoRoot = repoRoot;
+                assetConfig.AssetsJsonLocation = new NormalizedString(pathToAssets);
+                assetConfig.AssetsJsonRelativeLocation = new NormalizedString(Path.GetRelativePath(repoRoot, pathToAssets));
+                assetConfig.RepoRoot = new NormalizedString(repoRoot);
                 assetConfig.AssetsFileName = AssetsJsonFileName;
 
                 return assetConfig;
@@ -612,8 +613,8 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 // any comments left in the assets.json though maintaining attribute ordering is also nice. To do this, we read all the file content, then
                 // simply replace the existing Tag value with the new one, then write the content back to the json file.
 
-                var currentSHA = (await ParseConfigurationFile(config.AssetsJsonLocation)).Tag;
-                var content = await File.ReadAllTextAsync(config.AssetsJsonLocation);
+                var currentSHA = (await ParseConfigurationFile(config.AssetsJsonLocation.ToString())).Tag;
+                var content = await File.ReadAllTextAsync(config.AssetsJsonLocation.ToString());
                 if (String.IsNullOrWhiteSpace(currentSHA))
                 {
                     string pattern = @"""Tag"":\s*""\s*""";
@@ -623,7 +624,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 {
                     content = content.Replace(currentSHA, newSha);
                 }
-                File.WriteAllText(config.AssetsJsonLocation, content);
+                File.WriteAllText(config.AssetsJsonLocation.ToString(), content);
             }
         }
         #endregion

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStoreBreadcrumb.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStoreBreadcrumb.cs
@@ -42,7 +42,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <param name="config"></param>
         public BreadcrumbLine(GitAssetsConfiguration config)
         {
-            PathToAssetsJson = config.AssetsJsonRelativeLocation;
+            PathToAssetsJson = config.AssetsJsonRelativeLocation.ToString();
             ShortHash = config.AssetRepoShortHash;
             Tag = config.Tag;
         }
@@ -77,8 +77,8 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <returns></returns>
         public async Task Update(GitAssetsConfiguration configuration)
         {
-            var breadcrumbFile = Path.Join(configuration.ResolveAssetsStoreLocation(), ".breadcrumb");
-            var targetKey = configuration.AssetsJsonRelativeLocation.Replace("\\", "/");
+            var breadcrumbFile = Path.Join(configuration.ResolveAssetsStoreLocation().ToString(), ".breadcrumb");
+            var targetKey = configuration.AssetsJsonRelativeLocation.ToString();
 
             await BreadCrumbWorker.EnqueueAsync(async () =>
             {


### PR DESCRIPTION
This PR **forces** every string going through our configuration structure to maintain linux-style path separators.

I'm really tired of wonky bugs being caused by inconsistent `\` vs `/`.

Resolves #4568