### PR TITLE
Add Azure.Monitor to the allowlist of .NET namespaces

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
@@ -20,7 +20,7 @@ namespace RandomNamespace
 
             var diagnostic = Verifier.Diagnostic("AZC0001")
                 .WithMessage("Namespace 'RandomNamespace' shouldn't contain public types. Use one of the following pre-approved namespace groups (https://azure.github.io/azure-sdk/registered_namespaces.html):" +
-                             " Azure.AI, Azure.Analytics, Azure.Communication, Azure.Core.Expressions, Azure.Data, Azure.DigitalTwins, Azure.IoT, Azure.Learn, Azure.Media, Azure.Management, Azure.Messaging, Azure.ResourceManager, Azure.Search, Azure.Security, Azure.Storage, Azure.Template, Azure.Identity, Microsoft.Extensions.Azure")
+                             " Azure.AI, Azure.Analytics, Azure.Communication, Azure.Core.Expressions, Azure.Data, Azure.DigitalTwins, Azure.Identity, Azure.IoT, Azure.Learn, Azure.Management, Azure.Media, Azure.Messaging, Azure.Monitor, Azure.ResourceManager, Azure.Search, Azure.Security, Azure.Storage, Azure.Template, Microsoft.Extensions.Azure")
                 .WithSpan(2, 11, 2, 26);
 
             await Verifier.VerifyAnalyzerAsync(code, diagnostic);

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
@@ -18,17 +18,18 @@ namespace Azure.ClientSdk.Analyzers
             "Azure.Core.Expressions",
             "Azure.Data",
             "Azure.DigitalTwins",
+            "Azure.Identity",
             "Azure.IoT",
             "Azure.Learn",
-            "Azure.Media",
             "Azure.Management",
+            "Azure.Media",
             "Azure.Messaging",
-            "Azure.ResourceManager",   
+            "Azure.Monitor",
+            "Azure.ResourceManager",
             "Azure.Search",
             "Azure.Security",
             "Azure.Storage",
             "Azure.Template",
-            "Azure.Identity",
             "Microsoft.Extensions.Azure"
         };
 


### PR DESCRIPTION
Add the missing `Azure.Monitor` namespace, which is being used by both the Azure Monitor Query and Azure Monitor Ingestion libraries. It's already listed at https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-namespace-naming. This PR also alphabetizes the namespace lists.