### PR TITLE
Handle helm version modifiers in stress test min version check

### DIFF
--- a/eng/common/scripts/stress-testing/find-all-stress-packages.ps1
+++ b/eng/common/scripts/stress-testing/find-all-stress-packages.ps1
@@ -86,7 +86,8 @@ function MatchesAnnotations([hashtable]$chart, [hashtable]$filters) {
 function VerifyAddonsVersion([hashtable]$chart, [string]$chartFile) {
     foreach ($dependency in $chart.dependencies) {
         if ($dependency.name -eq "stress-test-addons" -and
-            $dependency.version -lt "0.2.0") {
+            $dependency.version -like '0.1.*' -or
+            $dependency.version -like '^0.1.*') {
             throw "The stress-test-addons version in use for '$chartFile' is $($dependency.version), please use versions >= 0.2.0"
         }
     }


### PR DESCRIPTION
This handles versions like `~0.1.21` appropriately.

Fixes #4590