### PR TITLE
Hide EditorBrowsableNever members by default

### DIFF
--- a/src/dotnet/APIView/APIView/CodeFileHtmlRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileHtmlRenderer.cs
@@ -21,7 +21,7 @@ namespace ApiView
         public static CodeFileHtmlRenderer Normal { get; } = new CodeFileHtmlRenderer(false);
         public static CodeFileHtmlRenderer ReadOnly { get; } = new CodeFileHtmlRenderer(true);
 
-        protected override void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedToken)
+        protected override void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedToken, bool isHiddenApiToken)
         {
             if (token.Value == null)
             {
@@ -53,6 +53,11 @@ namespace ApiView
             if (isDeprecatedToken)
             {
                 elementClass += " deprecated";
+            }
+
+            if (isHiddenApiToken)
+            {
+                elementClass += " hidden-api";
             }
 
             string href = null;

--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -34,6 +34,7 @@ namespace ApiView
             var stringBuilder = new StringBuilder();
             string currentId = null;
             bool isDocumentationRange = false;
+            bool isHiddenApiRange = false;
             bool isDeprecatedToken = false;
             bool isSkipDiffRange = false;
             Stack<SectionType> nodesInProcess = new Stack<SectionType>();
@@ -56,7 +57,7 @@ namespace ApiView
                 {
                     case CodeFileTokenKind.Newline:
                         int ? sectionKey = (nodesInProcess.Count > 0 && section == null) ? sections.Count: null;
-                        CodeLine codeLine = new CodeLine(stringBuilder.ToString(), currentId, String.Empty, ++lineNumber, sectionKey, isDocumentation: isDocumentationRange);
+                        CodeLine codeLine = new CodeLine(stringBuilder.ToString(), currentId, String.Empty, ++lineNumber, sectionKey, isDocumentation: isDocumentationRange, isHiddenApi: isHiddenApiRange);
                         if (leafSectionPlaceHolderNumber != 0)
                         {
                             lineNumber += leafSectionPlaceHolderNumber - 1;
@@ -102,6 +103,14 @@ namespace ApiView
                     case CodeFileTokenKind.DocumentRangeEnd:
                         CloseDocumentationRange(stringBuilder);
                         isDocumentationRange = false;
+                        break;
+
+                    case CodeFileTokenKind.HiddenApiRangeStart:
+                        isHiddenApiRange = true;
+                        break;
+
+                    case CodeFileTokenKind.HiddenApiRangeEnd:
+                        isHiddenApiRange = false;
                         break;
 
                     case CodeFileTokenKind.DeprecatedRangeStart:

--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -34,7 +34,7 @@ namespace ApiView
             var stringBuilder = new StringBuilder();
             string currentId = null;
             bool isDocumentationRange = false;
-            bool isHiddenApiRange = false;
+            bool isHiddenApiToken = false;
             bool isDeprecatedToken = false;
             bool isSkipDiffRange = false;
             Stack<SectionType> nodesInProcess = new Stack<SectionType>();
@@ -57,7 +57,7 @@ namespace ApiView
                 {
                     case CodeFileTokenKind.Newline:
                         int ? sectionKey = (nodesInProcess.Count > 0 && section == null) ? sections.Count: null;
-                        CodeLine codeLine = new CodeLine(stringBuilder.ToString(), currentId, String.Empty, ++lineNumber, sectionKey, isDocumentation: isDocumentationRange, isHiddenApi: isHiddenApiRange);
+                        CodeLine codeLine = new CodeLine(stringBuilder.ToString(), currentId, String.Empty, ++lineNumber, sectionKey, isDocumentation: isDocumentationRange, isHiddenApi: isHiddenApiToken);
                         if (leafSectionPlaceHolderNumber != 0)
                         {
                             lineNumber += leafSectionPlaceHolderNumber - 1;
@@ -106,11 +106,11 @@ namespace ApiView
                         break;
 
                     case CodeFileTokenKind.HiddenApiRangeStart:
-                        isHiddenApiRange = true;
+                        isHiddenApiToken = true;
                         break;
 
                     case CodeFileTokenKind.HiddenApiRangeEnd:
-                        isHiddenApiRange = false;
+                        isHiddenApiToken = false;
                         break;
 
                     case CodeFileTokenKind.DeprecatedRangeStart:
@@ -132,7 +132,7 @@ namespace ApiView
                     case CodeFileTokenKind.FoldableSectionHeading:
                         nodesInProcess.Push(SectionType.Heading);
                         currentId = (token.DefinitionId != null) ? token.DefinitionId : currentId;
-                        RenderToken(token, stringBuilder, isDeprecatedToken);
+                        RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
                         break;
 
                     case CodeFileTokenKind.FoldableSectionContentStart:
@@ -173,14 +173,14 @@ namespace ApiView
                         {
                             stringBuilder.Append($"<thead><tr>");
                             stringBuilder.Append($"<th height=\"30\" scope=\"col\">");
-                            RenderToken(token, stringBuilder, isDeprecatedToken);
+                            RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
                             stringBuilder.Append("</th>");
                             tableColumnCount.Curr++;
                         }
                         else if (tableColumnCount.Curr == tableColumnCount.Count - 1)
                         {
                             stringBuilder.Append($"<th height=\"30\" scope=\"col\">");
-                            RenderToken(token, stringBuilder, isDeprecatedToken);
+                            RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
                             stringBuilder.Append("</th>");
                             stringBuilder.Append("</tr></thead><tbody>");
                             tableColumnCount.Curr = 0;
@@ -188,7 +188,7 @@ namespace ApiView
                         else
                         {
                             stringBuilder.Append($"<th height=\"30\" scope=\"col\">");
-                            RenderToken(token, stringBuilder, isDeprecatedToken);
+                            RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
                             stringBuilder.Append("</th>");
                             tableColumnCount.Curr++;
                         }
@@ -243,13 +243,13 @@ namespace ApiView
 
                     default:
                         currentId = (token.DefinitionId != null) ? token.DefinitionId : currentId;
-                        RenderToken(token, stringBuilder, isDeprecatedToken);
+                        RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
                         break;
                 }
             }
         }
 
-        protected virtual void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedToken)
+        protected virtual void RenderToken(CodeFileToken token, StringBuilder stringBuilder, bool isDeprecatedToken, bool isHiddenApiToken)
         {
             if (token.Value != null)
             {

--- a/src/dotnet/APIView/APIView/CodeLine.cs
+++ b/src/dotnet/APIView/APIView/CodeLine.cs
@@ -13,8 +13,9 @@ namespace ApiView
         public int Indent { get; }
         public bool IsDocumentation { get; }
         public TreeNode<CodeLine> NodeRef { get; }
+        public bool IsHiddenApi { get; }
 
-        public CodeLine(string html, string id, string lineClass, int? lineNumber = null, int? sectionKey = null, int indent = 0, bool isDocumentation = false, TreeNode<CodeLine> nodeRef = null)
+        public CodeLine(string html, string id, string lineClass, int? lineNumber = null, int? sectionKey = null, int indent = 0, bool isDocumentation = false, TreeNode<CodeLine> nodeRef = null, bool isHiddenApi = false)
         {
             this.DisplayString = html;
             this.ElementId = id;
@@ -24,9 +25,10 @@ namespace ApiView
             this.Indent = indent;
             this.IsDocumentation = isDocumentation;
             this.NodeRef = nodeRef;
+            this.IsHiddenApi = isHiddenApi;
         }
 
-        public CodeLine(CodeLine codeLine, string html = null, string id = null, string lineClass = null, int? lineNumber = null, int? sectionKey = null, int indent = 0, bool isDocumentation = false, TreeNode<CodeLine> nodeRef = null)
+        public CodeLine(CodeLine codeLine, string html = null, string id = null, string lineClass = null, int? lineNumber = null, int? sectionKey = null, int indent = 0, bool isDocumentation = false, TreeNode<CodeLine> nodeRef = null, bool isHiddenApi = false)
         {
             this.DisplayString = html ?? codeLine.DisplayString;
             this.ElementId = id ?? codeLine.ElementId;
@@ -36,6 +38,7 @@ namespace ApiView
             this.Indent = (indent != 0)? indent : codeLine.Indent;
             this.IsDocumentation = (isDocumentation != false)? isDocumentation : codeLine.IsDocumentation;
             this.NodeRef = nodeRef ?? codeLine.NodeRef;
+            this.IsHiddenApi = isHiddenApi;
         }
 
         public override string ToString()
@@ -45,7 +48,7 @@ namespace ApiView
 
         public bool Equals(CodeLine other)
         {
-            return DisplayString == other.DisplayString && ElementId == other.ElementId;
+            return DisplayString == other.DisplayString && ElementId == other.ElementId && other.IsHiddenApi == IsHiddenApi;
         }
     }
 }

--- a/src/dotnet/APIView/APIView/Model/CodeFileTokenKind.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFileTokenKind.cs
@@ -33,6 +33,8 @@ namespace APIView
         TableCellEnd = 26,
         LeafSectionPlaceholder = 27,
         ExternalLinkStart = 28,
-        ExternalLinkEnd = 29
+        ExternalLinkEnd = 29,
+        HiddenApiRangeStart = 30,
+        HiddenApiRangeEnd = 31
     }
 }

--- a/src/dotnet/APIView/APIView/Model/NavigationItem.cs
+++ b/src/dotnet/APIView/APIView/Model/NavigationItem.cs
@@ -13,6 +13,8 @@ namespace APIView
 
         public Dictionary<string, string> Tags { get; set; } = new Dictionary<string, string>(0);
 
+        public bool IsHiddenApi { get; set; }
+
         public override string ToString() => Text;
     }
 }

--- a/src/dotnet/APIView/APIViewUnitTests/ExactFormatting/Attributes.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ExactFormatting/Attributes.cs
@@ -24,11 +24,11 @@ namespace A {
         [IteratorStateMachine(typeof(Class))]
         [PrivateAttribute]
         [AsyncStateMachine(typeof(Class))]
+        [EditorBrowsable(EditorBrowsableState.Never)]
         /*-*/[Public(1)]
         [Public("s")]
         [Public("s", Property = "a")]
         [Public(null, Property = null)]
-        [EditorBrowsable(EditorBrowsableState.Never)]
         [Array(new[] {1, 2, 3})]
         public void M1()/*-*/{/*-*/;/*-*/}/*-*/
     }

--- a/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
@@ -756,14 +756,9 @@ code {
 .deprecated {
     text-decoration: line-through;
 }
-
-.hidden-api .code-inner {
+.hidden-api {
   color: var(--text-color-muted) !important;
   font-style: italic;
-  span, a {
-    color: var(--text-color-muted) !important;
-    font-style: italic;
-  }
 }
 
 .file-code-icon {

--- a/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/site.scss
@@ -757,6 +757,15 @@ code {
     text-decoration: line-through;
 }
 
+.hidden-api .code-inner {
+  color: var(--text-color-muted) !important;
+  font-style: italic;
+  span, a {
+    color: var(--text-color-muted) !important;
+    font-style: italic;
+  }
+}
+
 .file-code-icon {
     filter: var(--icon-color-filter);
 }

--- a/src/dotnet/APIView/APIViewWeb/Client/src/helpers.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/helpers.ts
@@ -2,7 +2,8 @@
 export function updatePageSettings(callBack) {
   var hideLineNumbers = $("#hide-line-numbers").prop("checked");
   var hideLeftNavigation = $("#hide-left-navigation").prop("checked");
-  var uri = location.origin + `/userprofile/updatereviewpagesettings?hideLineNumbers=${hideLineNumbers}&hideLeftNavigation=${hideLeftNavigation}`;
+  var showHiddenApis = $("#show-hidden-api-checkbox").prop("checked");
+  var uri = location.origin + `/userprofile/updatereviewpagesettings?hideLineNumbers=${hideLineNumbers}&hideLeftNavigation=${hideLeftNavigation}&showHiddenApis=${showHiddenApis}`;
     
   $.ajax({
     type: "PUT",

--- a/src/dotnet/APIView/APIViewWeb/Client/src/review.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/review.ts
@@ -345,7 +345,9 @@ $(() => {
   });
 
   $(SHOW_HIDDEN_CHECKBOX).on("click", e => {
-    $(SEL_HIDDEN_CLASS).toggleClass("d-none");
+    updatePageSettings(function() {
+      $(SEL_HIDDEN_CLASS).toggleClass("d-none");
+    });
   });
 
   $(SHOW_HIDDEN_HREF).on("click", e => {

--- a/src/dotnet/APIView/APIViewWeb/Client/src/review.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/review.ts
@@ -9,14 +9,21 @@ $(() => {
   const SHOW_DIFFONLY_CHECKBOX = ".show-diffonly-checkbox";
   const SHOW_DIFFONLY_HREF = ".show-diffonly";
   const TOGGLE_DOCUMENTATION = ".line-toggle-documentation-button";
+  const SEL_HIDDEN_CLASS = ".hidden-api-toggleable";
+  const SHOW_HIDDEN_CHECK_COMPONENT = "#show-hidden-api-component";
+  const SHOW_HIDDEN_CHECKBOX = "#show-hidden-api-checkbox";
+  const SHOW_HIDDEN_HREF = ".show-hidden-api";
 
-  hideCheckboxIfNoDocs();
+  hideCheckboxesIfNotApplicable();
 
   /* FUNCTIONS
   --------------------------------------------------------------------------------------------------------------------------------------------------------*/
-  function hideCheckboxIfNoDocs() {
+  function hideCheckboxesIfNotApplicable() {
     if ($(SEL_DOC_CLASS).length == 0) {
       $(SHOW_DOC_CHECK_COMPONENT).hide();
+    }
+    if ($(SEL_HIDDEN_CLASS).length == 0) {
+      $(SHOW_HIDDEN_CHECK_COMPONENT).hide();
     }
   }
 
@@ -337,6 +344,14 @@ $(() => {
     $(SHOW_DOC_CHECKBOX)[0].click();
   });
 
+  $(SHOW_HIDDEN_CHECKBOX).on("click", e => {
+    $(SEL_HIDDEN_CLASS).toggleClass("d-none");
+  });
+
+  $(SHOW_HIDDEN_HREF).on("click", e => {
+      $(SHOW_HIDDEN_CHECKBOX)[0].click();
+  });
+  
   $(SHOW_DIFFONLY_CHECKBOX).on("click", e => {
     $(SHOW_DIFFONLY_HREF)[0].click();
   });

--- a/src/dotnet/APIView/APIViewWeb/Controllers/UserProfileController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/UserProfileController.cs
@@ -18,12 +18,13 @@ namespace APIViewWeb.Controllers
         }
 
         [HttpPut]
-        public ActionResult UpdateReviewPageSettings(bool? hideLineNumbers = null, bool? hideLeftNavigation = null)
+        public ActionResult UpdateReviewPageSettings(bool? hideLineNumbers = null, bool? hideLeftNavigation = null, bool? showHiddenApis = null)
         {
             _userPreferenceCache.UpdateUserPreference(new UserPreferenceModel()
             {
                 HideLeftNavigation = hideLeftNavigation,
                 HideLineNumbers = hideLineNumbers,
+                ShowHiddenApis = showHiddenApis
             }, User);
             return Ok();
         }
@@ -35,7 +36,7 @@ namespace APIViewWeb.Controllers
             UserPreferenceModel preference = await _userPreferenceCache.GetUserPreferences(User);
 
             preference.Theme = theme;
-            
+
             HashSet<string> Languages = new HashSet<string>(languages);
             preference.ApprovedLanguages = Languages;
 

--- a/src/dotnet/APIView/APIViewWeb/Helpers/AutoMapperProfiles.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/AutoMapperProfiles.cs
@@ -16,7 +16,9 @@ namespace APIViewWeb.Helpers
                 .ForMember(dest => dest.Status, opt => opt.MapFrom((src, dest) => src._status != null ? src._status : dest._status))
                 .ForMember(dest => dest.HideLineNumbers, opt => opt.MapFrom((src, dest) => src._hideLineNumbers != null ? src._hideLineNumbers : dest._hideLineNumbers))
                 .ForMember(dest => dest.HideLeftNavigation, opt => opt.MapFrom((src, dest) => src._hideLeftNavigation != null ? src._hideLeftNavigation : dest._hideLeftNavigation))
-                .ForMember(dest => dest.Theme, opt => opt.MapFrom((src, dest) => src._theme != null ? src._theme : dest._theme));
+                .ForMember(dest => dest.Theme, opt => opt.MapFrom((src, dest) => src._theme != null ? src._theme : dest._theme))
+                .ForMember(dest => dest.ShowHiddenApis, opt => opt.MapFrom((src, dest) => src._showHiddenApis != null ? src._showHiddenApis : dest._showHiddenApis));
+
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Helpers/PageModelHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/PageModelHelpers.cs
@@ -10,5 +10,15 @@ namespace APIViewWeb.Helpers
         {
             return preferenceCache.GetUserPreferences(User).Result;
         }
+
+        public static string GetHiddenApiClass(UserPreferenceModel userPreference)
+        {
+            var hiddenApiClass = " hidden-api hidden-api-toggleable";
+            if (userPreference.ShowHiddenApis != true)
+            {
+                hiddenApiClass += " d-none";
+            }
+            return hiddenApiClass;
+        }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Models/UserPreferenceModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/UserPreferenceModel.cs
@@ -1,4 +1,4 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using CsvHelper.Configuration.Attributes;
 using Newtonsoft.Json;
 
@@ -13,6 +13,7 @@ namespace APIViewWeb.Models
         internal IEnumerable<string> _status;
         internal bool? _hideLineNumbers;
         internal bool? _hideLeftNavigation;
+        internal bool? _showHiddenApis;
         internal string _theme;
 
         public string UserName { get; set; }
@@ -64,6 +65,12 @@ namespace APIViewWeb.Models
         public string Theme {
             get => _theme ?? "light-theme";
             set => _theme = value;
+        }
+
+        [Name("ShowHiddenApis")]
+        public bool? ShowHiddenApis {
+            get => _showHiddenApis ?? false;
+            set => _showHiddenApis = value;
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -198,7 +198,14 @@
                     </span>
                     <span class="dropdown-item checkbox" id="show-hidden-api-component">
                         <label>
-                            <input type="checkbox" id="show-hidden-api-checkbox">
+                            @if (userPreference.ShowHiddenApis == true)
+                            {
+                                <input type="checkbox" id="show-hidden-api-checkbox" checked>
+                            }
+                            else
+                            {
+                                <input type="checkbox" id="show-hidden-api-checkbox" >
+                            }
                             &nbsp;Show Hidden APIs
                         </label>
                     </span>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -196,6 +196,12 @@
                             <label>&nbsp;Show Documentation</label>
                         </a>
                     </span>
+                    <span class="dropdown-item checkbox" id="show-hidden-api-component">
+                        <label>
+                            <input type="checkbox" id="show-hidden-api-checkbox">
+                            &nbsp;Show Hidden APIs
+                        </label>
+                    </span>
                     <span class="dropdown-item checkbox">
                         <label>
                             @if (userPreference.HideLineNumbers == true)

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -59,10 +59,16 @@
         codeLineDisplay = "hidden-row";
     }
 
-    // Hidden APIs are always shown if we are in Diff mode and there are changes.
+    var userPreference = TempData["UserPreference"] as UserPreferenceModel ?? new UserPreferenceModel();
+
+    // Always show hidden APIs if we are in Diff mode and there are changes.
     if (Model.CodeLine.IsHiddenApi && Model.Kind == DiffLineKind.Unchanged)
     {
-        hiddenApiRow += " hidden-api-toggleable d-none";
+        hiddenApiRow += " hidden-api-toggleable";
+        if (userPreference.ShowHiddenApis != true)
+        {
+            hiddenApiRow += " d-none";
+        }
     }
 
     if (Regex.IsMatch(codeLineClass, @".*lvl_[0-9]+_parent.*"))
@@ -76,7 +82,6 @@
         lineClass += " code-delta";
         isHeadingWithDelta = true;
     }
-    var userPreference = TempData["UserPreference"] as UserPreferenceModel ?? new UserPreferenceModel();
     var rowClass = RemoveMultipleSpaces($"code-line {headingClass} {codeLineClass} {lineClass} {codeLineDisplay} {documentationRow} {hiddenApiRow}");
     var cellContent = String.Empty;
     for (int i = 0; i < Model.CodeLine.Indent; i++)

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -4,6 +4,8 @@
 @using System.Text.RegularExpressions
 @using APIViewWeb.Models;
 @using System.Text
+@using APIViewWeb.Helpers
+@using Microsoft.AspNetCore.Mvc.TagHelpers
 @model APIViewWeb.Models.CodeLineModel
 @functions
 {
@@ -64,11 +66,7 @@
     // Always show hidden APIs if we are in Diff mode and there are changes.
     if (Model.CodeLine.IsHiddenApi && Model.Kind == DiffLineKind.Unchanged)
     {
-        hiddenApiRow += " hidden-api-toggleable";
-        if (userPreference.ShowHiddenApis != true)
-        {
-            hiddenApiRow += " d-none";
-        }
+        hiddenApiRow += PageModelHelpers.GetHiddenApiClass(userPreference);
     }
 
     if (Regex.IsMatch(codeLineClass, @".*lvl_[0-9]+_parent.*"))
@@ -227,13 +225,18 @@
     var errorDiags = Model.Diagnostics.Where(d => d.Level == APIView.CodeDiagnosticLevel.Default || d.Level == APIView.CodeDiagnosticLevel.Error);
     var warningDiags = Model.Diagnostics.Where(d => d.Level == APIView.CodeDiagnosticLevel.Warning);
     var infoDiags = Model.Diagnostics.Where(d => d.Level == APIView.CodeDiagnosticLevel.Info);
-    <tr class="code-diagnostics" data-line-id="@Model.CodeLine.ElementId">
+    var diagnosticsClass = "code-diagnostics";
+    if (Model.CodeLine.IsHiddenApi)
+    {
+        diagnosticsClass += PageModelHelpers.GetHiddenApiClass(userPreference);
+    }
+    <tr class="@diagnosticsClass" data-line-id="@Model.CodeLine.ElementId">
         <partial name="_DiagnosticsPartial" model="@errorDiags" />
     </tr>
-    <tr class="code-diagnostics" data-line-id="@Model.CodeLine.ElementId">
+    <tr class="@diagnosticsClass" data-line-id="@Model.CodeLine.ElementId">
         <partial name="_DiagnosticsPartial" model="@warningDiags" />
     </tr>
-    <tr class="code-diagnostics" data-line-id="@Model.CodeLine.ElementId">
+    <tr class="@diagnosticsClass" data-line-id="@Model.CodeLine.ElementId">
         <partial name="_DiagnosticsPartial" model="@infoDiags" />
     </tr>
 }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -59,13 +59,10 @@
         codeLineDisplay = "hidden-row";
     }
 
-    if (Model.CodeLine.IsHiddenApi)
+    // Hidden APIs are always shown if we are in Diff mode and there are changes.
+    if (Model.CodeLine.IsHiddenApi && Model.Kind == DiffLineKind.Unchanged)
     {
-        hiddenApiRow = "hidden-api";
-        if (Model.Kind == DiffLineKind.Unchanged)
-        {
-            hiddenApiRow += " hidden-api-toggleable d-none";
-        }
+        hiddenApiRow += " hidden-api-toggleable d-none";
     }
 
     if (Regex.IsMatch(codeLineClass, @".*lvl_[0-9]+_parent.*"))
@@ -212,7 +209,7 @@
             {
                 indentOrDelta = "<svg height='23' width='23'></svg>";
             }
-            <div class="code-inner">@Html.Raw(indentOrDelta)@Html.Raw(cellContent)@Html.Raw(collapseMenu)</div>
+            <div class="code-inner" data-toggle="tooltip">@Html.Raw(indentOrDelta)@Html.Raw(cellContent)@Html.Raw(collapseMenu)</div>
         }
     </td>
 </tr>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -214,7 +214,7 @@
             {
                 indentOrDelta = "<svg height='23' width='23'></svg>";
             }
-            <div class="code-inner" data-toggle="tooltip">@Html.Raw(indentOrDelta)@Html.Raw(cellContent)@Html.Raw(collapseMenu)</div>
+            <div class="code-inner">@Html.Raw(indentOrDelta)@Html.Raw(cellContent)@Html.Raw(collapseMenu)</div>
         }
     </td>
 </tr>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -26,6 +26,7 @@
     bool isHeadingWithDelta = false;
     string headingClass = String.Empty;
     string documentationRow = String.Empty;
+    string hiddenApiRow = String.Empty;
     string codeLineDisplay = String.Empty;
     string codeLineClass = (!String.IsNullOrWhiteSpace(Model.CodeLine.LineClass)) ? Model.CodeLine.LineClass.Trim() : String.Empty;
     int? sectionKey = Model.DiffSectionId ?? Model.CodeLine.SectionKey;
@@ -58,6 +59,15 @@
         codeLineDisplay = "hidden-row";
     }
 
+    if (Model.CodeLine.IsHiddenApi)
+    {
+        hiddenApiRow = "hidden-api";
+        if (Model.Kind == DiffLineKind.Unchanged)
+        {
+            hiddenApiRow += " hidden-api-toggleable d-none";
+        }
+    }
+
     if (Regex.IsMatch(codeLineClass, @".*lvl_[0-9]+_parent.*"))
     {
         isSubSectionHeading = true;
@@ -70,7 +80,7 @@
         isHeadingWithDelta = true;
     }
     var userPreference = TempData["UserPreference"] as UserPreferenceModel ?? new UserPreferenceModel();
-    var rowClass = RemoveMultipleSpaces($"code-line {headingClass} {codeLineClass} {lineClass} {codeLineDisplay} {documentationRow}");
+    var rowClass = RemoveMultipleSpaces($"code-line {headingClass} {codeLineClass} {lineClass} {codeLineDisplay} {documentationRow} {hiddenApiRow}");
     var cellContent = String.Empty;
     for (int i = 0; i < Model.CodeLine.Indent; i++)
     {

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/Navigation.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/Navigation.cshtml
@@ -1,14 +1,23 @@
-﻿@model IEnumerable<APIView.NavigationItem>
+﻿@using APIViewWeb.Models
+@using Microsoft.AspNetCore.Mvc.TagHelpers
+@using APIViewWeb.Helpers
+@model IEnumerable<APIView.NavigationItem>
 @{
     bool hasSections = ViewBag.HasSections;
     bool isChildNavigation = ViewBag.IsChildNavigation ?? false;
     string navListGroupClass = (hasSections && isChildNavigation) ? "nav-list-group nav-list-collapsed" : "nav-list-group";
+    var userPreference = TempData["UserPreference"] as UserPreferenceModel;
 }
 
 <ul class="nav-list-children">
         @foreach (var item in Model)
         {
-            <li class="@navListGroupClass @(item.IsHiddenApi ? " hidden-api-toggleable d-none" : "")">
+            var elementNavListClass = navListGroupClass;
+            if (item.IsHiddenApi)
+            {
+                elementNavListClass += PageModelHelpers.GetHiddenApiClass(userPreference);
+            }
+            <li class="@elementNavListClass">
                 <span class="nav-list-toggle @(item.ChildItems.Any() ? "":"invisible")"></span>
 
                 @if (item.Tags != null && item.Tags.ContainsKey("TypeKind"))

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/Navigation.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/Navigation.cshtml
@@ -8,7 +8,7 @@
 <ul class="nav-list-children">
         @foreach (var item in Model)
         {
-            <li class="@navListGroupClass">
+            <li class="@navListGroupClass @(item.IsHiddenApi ? " hidden-api-toggleable d-none" : "")">
                 <span class="nav-list-toggle @(item.ChildItems.Any() ? "":"invisible")"></span>
 
                 @if (item.Tags != null && item.Tags.ContainsKey("TypeKind"))


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-tools/issues/3900

- EditorBrowsable attribute is itself now always hidden
- Members attributed with this are hidden by default
- There is a checkbox to show the hidden members - the checkbox is only visible if review contains hidden API elements.
- Value is added to user preferences (just like show left nav, hide line numbers, etc) which is valid for current session - it does not get written to Cosmos like the more permanent settings such as preferred language
- When diffing, if there is a change in any hidden members they are shown
- Hidden members are italicized and grayed out
- Namespaces with only hidden types are also hidden
- Navigation items that correspond to hidden namespaces or types are hidden


EBN applied to constructor:
<img width="849" alt="image" src="https://user-images.githubusercontent.com/54595583/199898756-6cda7303-8dc1-4dd2-a91d-41d9db08ad7b.png">

Show Hidden APIs checkbox:
<img width="170" alt="image" src="https://user-images.githubusercontent.com/54595583/199863447-8738ac45-0d94-4795-a70b-911c8200cd2d.png">

Entire namespace and type is hidden:
<img width="491" alt="image" src="https://user-images.githubusercontent.com/54595583/199863388-e488fd6b-9405-4bee-a384-f7d02e11560c.png">

Some hidden and some non-hidden APIs when Show Hidden is checked:
<img width="706" alt="image" src="https://user-images.githubusercontent.com/54595583/199866382-2815ec00-6c36-4743-9a41-9aa6ffe70512.png">

