### PR TITLE
Add optional TestResourcesDirectory override parameter

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -22,6 +22,9 @@ param (
     [string] $ServiceDirectory,
 
     [Parameter()]
+    [string] $TestResourcesDirectory,
+
+    [Parameter()]
     [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
     [string] $TestApplicationId,
 
@@ -351,6 +354,14 @@ try {
     # Enumerate test resources to deploy. Fail if none found.
     $repositoryRoot = "$PSScriptRoot/../../.." | Resolve-Path
     $root = [System.IO.Path]::Combine($repositoryRoot, "sdk", $ServiceDirectory) | Resolve-Path
+    if ($TestResourcesDirectory) {
+        $root = $TestResourcesDirectory | Resolve-Path
+        # Add an explicit check below in case ErrorActionPreference is overridden and Resolve-Path doesn't stop execution
+        if (!$root) {
+            throw "TestResourcesDirectory '$TestResourcesDirectory' does not exist."
+        }
+        Write-Verbose "Overriding test resources search directory to '$root'"
+    }
     $templateFiles = @()
 
     "$ResourceType-resources.json", "$ResourceType-resources.bicep" | ForEach-Object {
@@ -809,7 +820,13 @@ group that will be created.
 .PARAMETER ServiceDirectory
 A directory under 'sdk' in the repository root - optionally with subdirectories
 specified - in which to discover ARM templates named 'test-resources.json' and
-Bicep templates named 'test-resources.bicep'. This can also be an absolute path
+Bicep templates named 'test-resources.bicep'. This can be an absolute path
+or specify parent directories. ServiceDirectory is also used for resource and
+environment variable naming.
+
+.PARAMETER TestResourcesDirectory
+An override directory in which to discover ARM templates named 'test-resources.json' and
+Bicep templates named 'test-resources.bicep'. This can be an absolute path
 or specify parent directories.
 
 .PARAMETER TestApplicationId


### PR DESCRIPTION
Resolves #4450

This adds an optional `TestResourcesDirectory` parameter to `New-TestResources.ps1` to enable searching for templates outside the immediate service directory (the specific scenario in mind is a sub-project directory).

There are a couple benefits and drawbacks to the approach I took here:

- In this PR, the resource and environment variable naming is still determined by the service directory. This means that no test code needs to be changed to handle new environment variable prefixes.
- A drawback of ^^ is parallel local testing of multiple sub-projects within the same service directory will cause resource and environment variable naming conflicts, unless `-BaseName` is also passed in. 
- The above drawback could be partially addressed by determining resource naming based on `TestResourcesDirectory` but keeping the environment variable behavior. That way you could deploy in multiple shell sessions without env var overlap. However, this will require people to run `Update-TestResources.ps1` and `Remove-TestResources.ps1` with a `TestResourcesDirectory` parameter as well in order for us to discover the resource group name consistently. I think it is better to prioritize keeping the update/remove scripts simple and require `-BaseName` for parallel local testing of sub-projects.
