### PR TITLE
Add more than one APIKey support

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Filters/ApiKeyAuthorizeAsyncFilter.cs
+++ b/src/dotnet/APIView/APIViewWeb/Filters/ApiKeyAuthorizeAsyncFilter.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.AspNetCore.Mvc;
@@ -15,14 +15,14 @@ namespace APIViewWeb.Filters
     {
         private static string _apiKeyHeader = "ApiKey";
         private string _azure_sdk_bot = "azure-sdk";
-        private string _apiKeyValue;
+        private HashSet<string> _apiKeyValues = new HashSet<string>();
 
         public ApiKeyAuthorizeAsyncFilter(IConfiguration configuration)
         {
             var apiKey = configuration[_apiKeyHeader];
             if (!string.IsNullOrEmpty(apiKey))
             {
-                _apiKeyValue = apiKey;
+                _apiKeyValues.UnionWith(apiKey.Split(","));
             }
         }
 
@@ -32,7 +32,7 @@ namespace APIViewWeb.Filters
         {
             var request = context.HttpContext.Request;
             var hasApiKeyHeader = request.Headers.TryGetValue(_apiKeyHeader, out var apiKeyValue);
-            if (hasApiKeyHeader && apiKeyValue == _apiKeyValue)
+            if (hasApiKeyHeader && _apiKeyValues.Contains(apiKeyValue))
             {
                 //Adding claim as github login type to keep it uniform across the checks
                 var user = new Claim("urn:github:login", _azure_sdk_bot);


### PR DESCRIPTION
Add support for multiple API Key to use REST API by other teams as well. Communication calling team require this change to integrate with APIView.