### PR TITLE
Disable target framework check

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
@@ -8,6 +8,7 @@
     <ToolCommandName>test-proxy</ToolCommandName>
     <LangVersion>preview</LangVersion>
     <InformationalVersion>$(OfficialBuildId)</InformationalVersion>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">


### PR DESCRIPTION
[See build failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1981636&view=results).

Need to speak with .NET folks before removing .NET 5 support, and need an eng/common update out the door. Need builds green again 👍 