### PR TITLE
handle apiview devops throttle

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -64,7 +64,7 @@ namespace APIViewWeb.Repositories
             int count = 0;
             while (downloadResp.StatusCode == HttpStatusCode.TooManyRequests && count < 5)
             {
-                var retryAfter = downloadResp.Headers.GetValues("Retry-After").FirstOrDefault() ?? "60";
+                var retryAfter = downloadResp.Headers.RetryAfter?.ToString() ?? "60";
                 await Task.Delay(int.Parse(retryAfter) * 1000);
                 downloadResp = await _devopsClient.GetAsync(request);
                 count++;

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -251,7 +251,7 @@ namespace APIViewWeb.Repositories
                 {
                     foreach (var file in revision.Files)
                     {
-                        if (!file.HasOriginal || !languageService.IsSupportedFile(file.FileName) || !languageService.CanUpdate(file.VersionString))
+                        if (!file.HasOriginal || !languageService.CanUpdate(file.VersionString))
                         {
                             continue;
                         }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -326,7 +326,7 @@ namespace APIViewWeb.Repositories
             if (languageService != null && languageService.IsReviewGenByPipeline)
             {
                 // Run offline review gen for review and reviewCodeFileModel
-                GenerateReviewOffline(review, revision.RevisionId, codeFile.ReviewFileId, name);
+                await GenerateReviewOffline(review, revision.RevisionId, codeFile.ReviewFileId, name);
             }
 
             // auto subscribe revision creation user
@@ -795,7 +795,7 @@ namespace APIViewWeb.Repositories
                 }
             }
         }
-        private void GenerateReviewOffline(ReviewModel review, string revisionId, string fileId, string fileName)
+        private async Task GenerateReviewOffline(ReviewModel review, string revisionId, string fileId, string fileName)
         {
             var param = new ReviewGenPipelineParamModel()
             {
@@ -807,7 +807,7 @@ namespace APIViewWeb.Repositories
             var paramList = new List<ReviewGenPipelineParamModel>();
             paramList.Add(param);
             var languageService = _languageServices.Single(s => s.Name == review.Language);
-            RunReviewGenPipeline(paramList, languageService.Name);
+            await RunReviewGenPipeline(paramList, languageService.Name);
         }
 
         public async Task UpdateReviewCodeFiles(string repoName, string buildId, string artifact, string project)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/ReviewManager.cs
@@ -207,48 +207,77 @@ namespace APIViewWeb.Repositories
             return review;
         }
 
-        private async Task UpdateReviewAsync(ReviewModel review)
+        private async Task UpdateReviewOffline(ReviewModel review)
         {
+            var paramList = new List<ReviewGenPipelineParamModel>();
+            var languageService = GetLanguageService(review.Language);
             foreach (var revision in review.Revisions.Reverse())
             {
                 foreach (var file in revision.Files)
                 {
-                    if (!file.HasOriginal)
+                    //Don't include current revision if file is not required to be updated.
+                    // E.g. json token file is uploaded for a language, specific revision was already upgraded.
+                    if (!file.HasOriginal || file.FileName == null || !languageService.IsSupportedFile(file.FileName) || !languageService.CanUpdate(file.VersionString))
                     {
                         continue;
                     }
-
-                    try
+                    paramList.Add(new ReviewGenPipelineParamModel()
                     {
-                        var fileOriginal = await _originalsRepository.GetOriginalAsync(file.ReviewFileId);
-                        var languageService = GetLanguageService(file.Language);
-                        if (languageService == null)
-                            continue;
+                        FileID = file.ReviewFileId,
+                        ReviewID = review.ReviewId,
+                        RevisionID = revision.RevisionId,
+                        FileName = Path.GetFileName(file.FileName)
+                    });
+                }
+            }
+            await RunReviewGenPipeline(paramList, languageService.Name);
+        }
 
-                        // file.Name property has been repurposed to store package name and version string
-                        // This is causing issue when updating review using latest parser since it expects Name field as file name
-                        // We have added a new property FileName which is only set for new reviews
-                        // All older reviews needs to be handled by checking review name field
-                        var fileName = file.FileName ?? (Path.HasExtension(review.Name) ? review.Name : file.Name);
-                        if (languageService.IsReviewGenByPipeline)
+        private async Task UpdateReviewAsync(ReviewModel review)
+        {
+            var languageService = GetLanguageService(review.Language);
+            if (languageService == null)
+                return;
+
+            if (languageService.IsReviewGenByPipeline)
+            {
+                // Wait 30 seconds before running next review gen using pipeline to reduce queueing pipeline jobs
+                await Task.Delay(30000);
+                await UpdateReviewOffline(review);
+            }
+            else
+            {
+                foreach (var revision in review.Revisions.Reverse())
+                {
+                    foreach (var file in revision.Files)
+                    {
+                        if (!file.HasOriginal || !languageService.IsSupportedFile(file.FileName) || !languageService.CanUpdate(file.VersionString))
                         {
-                            GenerateReviewOffline(review, revision.RevisionId, file.ReviewFileId, fileName);
+                            continue;
                         }
-                        else
+
+                        try
                         {
+                            var fileOriginal = await _originalsRepository.GetOriginalAsync(file.ReviewFileId);
+                            // file.Name property has been repurposed to store package name and version string
+                            // This is causing issue when updating review using latest parser since it expects Name field as file name
+                            // We have added a new property FileName which is only set for new reviews
+                            // All older reviews needs to be handled by checking review name field
+                            var fileName = file.FileName ?? (Path.HasExtension(review.Name) ? review.Name : file.Name);
                             var codeFile = await languageService.GetCodeFileAsync(fileName, fileOriginal, review.RunAnalysis);
                             await _codeFileRepository.UpsertCodeFileAsync(revision.RevisionId, file.ReviewFileId, codeFile);
                             // update only version string
                             file.VersionString = codeFile.VersionString;
                             await _reviewsRepository.UpsertReviewAsync(review);
-                        }                        
+                        }
+                        catch (Exception ex)
+                        {
+                            _telemetryClient.TrackTrace("Failed to update review " + review.ReviewId);
+                            _telemetryClient.TrackException(ex);
+                        }
                     }
-                    catch (Exception ex) {
-                        _telemetryClient.TrackTrace("Failed to update review " + review.ReviewId);
-                        _telemetryClient.TrackException(ex);
-                    }                    
                 }
-            }            
+            }
         }
 
         public async Task AddRevisionAsync(
@@ -816,7 +845,7 @@ namespace APIViewWeb.Repositories
                 }
             }
         }
-        private async void RunReviewGenPipeline(List<ReviewGenPipelineParamModel> reviewGenParams, string language)
+        private async Task RunReviewGenPipeline(List<ReviewGenPipelineParamModel> reviewGenParams, string language)
         {
             var jsonSerializerOptions = new JsonSerializerOptions()
             {


### PR DESCRIPTION
1. Run upgrade review pipeline once for all revisions instead of a pipeline run per revision.
2. Add 30 seconds before running upgrade pipeline to avoid queueing too many jobs
3. Add delay if devops return 429 with RetryAfter instead of success status when downloading artifact from devops after pipeline is completed.
