### PR TITLE
Bump kubernetes client version and addons version for stress watcher

### DIFF
--- a/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/Chart.lock
+++ b/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 2.1.4
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.1.20
-digest: sha256:174a2f4b768cb47718d4b3d5a506330aa781abb31803fbeaeba3b7eef87a9f38
-generated: "2022-07-25T18:54:24.3081785-04:00"
+  version: 0.2.0
+digest: sha256:f9f4b6fa01e634fe3842ed1d257a2618483b1f8972ed85b97fb9abf641c8084a
+generated: "2022-11-15T20:35:48.4869487-05:00"

--- a/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/Chart.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/Chart.yaml
@@ -29,5 +29,5 @@ dependencies:
   repository: https://charts.chaos-mesh.org
   condition: deploy.chaosmesh
 - name: stress-test-addons
-  version: 0.1.20
+  version: ~0.2.0
   repository: "@stress-test-charts"

--- a/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/templates/stresswatcher.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/templates/stresswatcher.yaml
@@ -1,4 +1,4 @@
-{{ $ctx := fromYaml (include "stress-test-addons.util.mergeStressContext" (list . "watcher" )) }}
+{{ $ctx := fromYaml (include "stress-test-addons.util.mergeStressContext" (list . (dict "Scenario" "watcher") )) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/tools/stress-cluster/services/Stress.Watcher/src/JobEventHandler.cs
+++ b/tools/stress-cluster/services/Stress.Watcher/src/JobEventHandler.cs
@@ -54,7 +54,8 @@ namespace Stress.Watcher
             {
                 try
                 {
-                    var listTask = Client.ListJobForAllNamespacesWithHttpMessagesAsync(
+                    Logger.Information("Starting job watch");
+                    var listTask = Client.BatchV1.ListJobForAllNamespacesWithHttpMessagesAsync(
                         allowWatchBookmarks: true,
                         watch: true,
                         resourceVersion: resourceVersion,
@@ -62,9 +63,9 @@ namespace Stress.Watcher
                     );
                     var tcs = new TaskCompletionSource();
                     using var watcher = listTask.Watch<V1Job, V1JobList>(
-                        (type, pod) => {
-                            resourceVersion = pod.ResourceVersion();
-                            HandleJobEvent(type, pod);
+                        (type, job) => {
+                            resourceVersion = job.ResourceVersion();
+                            HandleJobEvent(type, job);
                         },
                         (err) =>
                         {

--- a/tools/stress-cluster/services/Stress.Watcher/src/Stress.Watcher.csproj
+++ b/tools/stress-cluster/services/Stress.Watcher/src/Stress.Watcher.csproj
@@ -8,7 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
-    <PackageReference Include="KubernetesClient" Version="6.0.1" />
+    <PackageReference Include="KubernetesClient" Version="9.0.38" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />
     <PackageReference Include="Azure.Identity" Version="1.5.0" />

--- a/tools/stress-cluster/services/Stress.Watcher/tests/Stress.Watcher.Tests.csproj
+++ b/tools/stress-cluster/services/Stress.Watcher/tests/Stress.Watcher.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="fluentassertions" Version="6.1.0" />
-    <PackageReference Include="KubernetesClient" Version="6.0.1" />
+    <PackageReference Include="KubernetesClient" Version="9.0.38" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
Potentially fixes some issues with the watcher and http connections/re-connections. The latest version of the client has better handling for keepalive issues.

This also fixes build/deploy of the chart, which needed to be updated to the latest addons.