### PR TITLE
APIvIew - Go package name for internal package

### DIFF
--- a/src/go/cmd/api_view.go
+++ b/src/go/cmd/api_view.go
@@ -80,6 +80,6 @@ func createReview(pkgDir string) (PackageReview, error) {
 		Name:        m.Name,
 		Navigation:  nav,
 		Tokens:      *tokenList,
-		PackageName: m.Name,
+		PackageName: m.PackageName,
 	}, nil
 }

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -28,6 +28,7 @@ var sdkDirName = "sdk"
 // Module collects the data required to describe an Azure SDK module's public API.
 type Module struct {
 	Name string
+	// PackageName is the name of the APIView review for this module
 	PackageName string
 
 	// packages maps import paths to packages

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -46,12 +46,12 @@ func NewModule(dir string) (*Module, error) {
 	packageName := ""
 	if before, after, found := strings.Cut(dir, fmt.Sprintf("%s%c", sdkDirName, filepath.Separator)); found {
 		sdkRoot = filepath.Join(before, sdkDirName)
-		fmt.Printf("Package path: %s\n", after)
 		if filepath.Base(after) == "internal" {
 			packageName = after
 		} else {
 			packageName = filepath.Base(after)
-		}		
+		}
+		fmt.Printf("Package Name: %s\n", packageName)
 	}
 	m := Module{Name: filepath.Base(dir), PackageName: packageName, packages: map[string]*Pkg{}}
 

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -28,6 +28,7 @@ var sdkDirName = "sdk"
 // Module collects the data required to describe an Azure SDK module's public API.
 type Module struct {
 	Name string
+	PackageName string
 
 	// packages maps import paths to packages
 	packages map[string]*Pkg
@@ -42,10 +43,17 @@ func NewModule(dir string) (*Module, error) {
 	// sdkRoot is the path on disk to the sdk folder e.g. /home/user/me/azure-sdk-for-go/sdk.
 	// Used to find definitions of types imported from other Azure SDK modules.
 	sdkRoot := ""
-	if before, _, found := strings.Cut(dir, fmt.Sprintf("%s%c", sdkDirName, filepath.Separator)); found {
+	packageName := ""
+	if before, after, found := strings.Cut(dir, fmt.Sprintf("%s%c", sdkDirName, filepath.Separator)); found {
 		sdkRoot = filepath.Join(before, sdkDirName)
+		fmt.Printf("Package path: %s\n", after)
+		if filepath.Base(after) == "internal" {
+			packageName = after
+		} else {
+			packageName = filepath.Base(after)
+		}		
 	}
-	m := Module{Name: filepath.Base(dir), packages: map[string]*Pkg{}}
+	m := Module{Name: filepath.Base(dir), PackageName: packageName, packages: map[string]*Pkg{}}
 
 	baseImportPath := path.Dir(mf.Module.Mod.Path) + "/"
 	if baseImportPath == "./" {


### PR DESCRIPTION
Crete package name using relative path after `sdk` for internal package and set package name using base module name for non internal package.