### PR TITLE
Fix minor issue getting stress secret labels with quoting and error handling

### DIFF
--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -315,10 +315,10 @@ function DeployStressPackage(
     # Helm 3 stores release information in kubernetes secrets. The only way to add extra labels around
     # specific releases (thereby enabling filtering on `helm list`) is to label the underlying secret resources.
     # There is not currently support for setting these labels via the helm cli.
-    $helmReleaseConfig = kubectl get secrets `
-        -n $pkg.Namespace `
-        -l status=deployed,name=$($pkg.ReleaseName) `
-        -o jsonpath='{.items[0].metadata.name}'
+    $helmReleaseConfig = RunOrExitOnFailure kubectl get secrets `
+                                                -n $pkg.Namespace `
+                                                -l "status=deployed,name=$($pkg.ReleaseName)" `
+                                                -o jsonpath='{.items[0].metadata.name}'
 
     Run kubectl label secret -n $pkg.Namespace --overwrite $helmReleaseConfig deployId=$deployId
 }


### PR DESCRIPTION
In some environments, the lack of quoting is causing `$pkg.ReleaseName` to not resolve, resulting in a bad secret query.

```
Error from server (BadRequest): Unable to find "/v1, Resource=secrets" that match label 
selector "status=deployed,name=$($pkg.ReleaseName)", field selector "": unable to parse 
requirement: values[0][name]: Invalid value: "$": a valid label must be an empty string or 
consist of alphanumeric characters, '-', '_' or '.', and must start and end with an 
alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for 
validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?')
error executing jsonpath "{.items[0].metadata.name}": Error executing template: array index out of bounds: index 0, length 0. Printing more information for debugging the template:
        template was:
                {.items[0].metadata.name}
        object given to jsonpath engine was:
                map[string]interface {}{"apiVersion":"v1", "items":[]interface {}{}, "kind":"List", "metadata":map[string]interface {}{"resourceVersion":""}}
```