### PR TITLE
Use the new audience field

### DIFF
--- a/eng/common/scripts/Helpers/Metadata-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Metadata-Helpers.ps1
@@ -10,7 +10,7 @@ function Generate-AadToken ($TenantId, $ClientId, $ClientSecret)
         "grant_type" = "client_credentials"
         "client_id" = $ClientId
         "client_secret" = $ClientSecret
-        "resource" = "api://repos.opensource.microsoft.com/audience/7e04aa67"
+        "resource" = "api://2789159d-8d8b-4d13-b90b-ca29c1707afd"
     }
     Write-Host "Generating aad token..."
     $resp = Invoke-RestMethod $LoginAPIBaseURI -Method 'POST' -Headers $headers -Body $body


### PR DESCRIPTION
Use the new audience for service readme script.

For docs:
1. We use the APIs in release pipeline through Metadata-Helpers.ps1. (Fixed in this PR)
2. We use the API in docindex pipeline through Metadata-Helpers.ps1. (Fixed in this PR)

For notification:
1. We use the APIs from `NotificationCreator` through the `GitHubToAADConverter`

For pipeline owner extractor:
1. We use the APIs from `pipeline-owners-extractor` through the `GitHubToAADConverter`

Testing pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=1993950&view=results