### PR TITLE
Transition script not throwing error properly

### DIFF
--- a/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
+++ b/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
@@ -269,7 +269,7 @@ Function Invoke-ProxyCommand {
 
     if(-not $token -or -not $committer -or -not $email){
       Write-Error ("When running this transition script in `"docker`" or `"podman`" mode, " `
-        + "the environment variables GIT_TOKEN, GIT_COMMIT_OWNER, GIT_COMMIT_EMAIL must be set to reflect the appropriate user. ")
+        + "the environment variables GIT_TOKEN, GIT_COMMIT_OWNER, and GIT_COMMIT_EMAIL must be set to reflect the appropriate user. ")
         exit(1)
     }
 

--- a/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
+++ b/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
@@ -268,8 +268,9 @@ Function Invoke-ProxyCommand {
     }
 
     if(-not $token -or -not $committer -or -not $email){
-      Write-Error "When running this transition script in `"docker`" or `"podman`" mode, " `
-        + "the environment variables GIT_TOKEN, GIT_COMMIT_OWNER, GIT_COMMIT_EMAIL must be set to reflect the appropriate user. "
+      Write-Error ("When running this transition script in `"docker`" or `"podman`" mode, " `
+        + "the environment variables GIT_TOKEN, GIT_COMMIT_OWNER, GIT_COMMIT_EMAIL must be set to reflect the appropriate user. ")
+        exit(1)
     }
 
     $targetImage = if ($env:TRANSITION_SCRIPT_DOCKER_TAG) { $env:TRANSITION_SCRIPT_DOCKER_TAG } else { "azsdkengsys.azurecr.io/engsys/test-proxy:latest" }


### PR DESCRIPTION
It _should_ be yelling at you for not having your environment variables set. Instead it's throwing 

```
A positional parameter cannot be found that accepts argument '+'.
```

This PR fixes the reason. Resolves #4724 