### PR TITLE
Enable .NET merge main to live

### DIFF
--- a/eng/pipelines/merge-docs-main-to-live.yml
+++ b/eng/pipelines/merge-docs-main-to-live.yml
@@ -6,6 +6,9 @@ parameters:
 - name: DocsRepos
   type: object
   default:
+    - RepoName: azure-docs-sdk-dotnet
+      RepoOwner: Azure
+      AllowlistPath: docsms-allowlist/dotnet-allowlist.txt
     - RepoName: azure-docs-sdk-java
       RepoOwner: Azure
       AllowlistPath: docsms-allowlist/java-allowlist.txt


### PR DESCRIPTION
This is the PR to enable merge main to live for .NET.
The pre-requisite PR in dotnet repo has been merged.
https://github.com/Azure/azure-docs-sdk-dotnet/blob/main/docsms-allowlist/dotnet-allowlist.txt

Testing pipeline with whatif: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2007538&view=results