### PR TITLE
Produce Standalone .NET Executables

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -30,6 +30,9 @@ parameters:
   - name: ManifestDeployment
     type: object
     default: []
+  - name: StandaloneExeMatrix
+    type: object
+    default: []
 
 variables:
   - template: ../variables/globals.yml
@@ -63,6 +66,12 @@ stages:
               DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
               DOTNET_CLI_TELEMETRY_OPTOUT: 1
               DOTNET_MULTILEVEL_LOOKUP: 0
+
+          - template: /eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+            parameters:
+              StagingDirectory: $(Build.ArtifactStagingDirectory)
+              BuildMatrix: ${{ parameters.StandaloneExeMatrix }}
+              TargetDirectory: $(Build.SourcesDirectory)/${{parameters.ToolDirectory}}
 
           - publish: $(Build.ArtifactStagingDirectory)
             displayName: Publish package to run artifacts

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -51,6 +51,7 @@ stages:
 
     jobs:
       - job: BuildAndPackage
+        displayName: Build and Package
 
         steps:
           - task: UseDotNet@2

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -20,7 +20,7 @@ steps:
   - ${{ each target in parameters.BuildMatrix }}:
     - pwsh: |
         $toolName = Split-Path -Leaf "${{ parameters.TargetDirectory }}"
-        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$(toolName)-{{ target.rid }}"
+        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$toolName-{{ target.rid }}"
         $sourcePath = "${{ parameters.TargetDirectory }}/{{ target.rid }}"
 
         dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained $(Warn) --output ${{ parameters.TargetDirectory }}/{{ target.rid }}

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -19,8 +19,7 @@ parameters:
 steps:
   - ${{ each target in parameters.BuildMatrix }}:
     - pwsh: |
-        $toolName = Split-Path -Leaf "${{ parameters.TargetDirectory }}"
-        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$toolName-{{ target.rid }}"
+        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$((Split-Path -Leaf "${{ parameters.TargetDirectory }}"))-{{ target.rid }}"
         $sourcePath = "${{ parameters.TargetDirectory }}/{{ target.rid }}"
 
         dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained --output ${{ parameters.TargetDirectory }}/{{ target.rid }}

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -20,12 +20,9 @@ steps:
   - ${{ each target in parameters.BuildMatrix }}:
     - pwsh: |
         $toolName = Split-Path -Leaf "${{ parameters.TargetDirectory }}"
-        Write-Host "##vso[task.setvariable variable=PUBLISHING_TOOL_NAME]$toolName"
-      displayName: Calculate artifact name from target directory
-
-    - pwsh: |
-        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$(PUBLISHING_TOOL_NAME)-{{ target.rid }}"
+        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$(toolName)-{{ target.rid }}"
         $sourcePath = "${{ parameters.TargetDirectory }}/{{ target.rid }}"
+
         dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained $(Warn) --output ${{ parameters.TargetDirectory }}/{{ target.rid }}
 
         # windows? produce a zip, otherwise tar.gz

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -19,7 +19,7 @@ parameters:
 steps:
   - ${{ each target in parameters.BuildMatrix }}:
     - pwsh: |
-        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$((Split-Path -Leaf "${{ parameters.TargetDirectory }}"))-${{ target.rid }}"
+        $destinationPathSegment = "$(Build.ArtifactStagingDirectory)/$((Split-Path -Leaf "${{ parameters.TargetDirectory }}"))-${{ target.rid }}"
         $sourcePath = "${{ parameters.TargetDirectory }}/${{ target.rid }}"
 
         dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained --output ${{ parameters.TargetDirectory }}/${{ target.rid }}

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -34,8 +34,6 @@ steps:
 
         # clean up the uncompressed artifact directory
         Remove-Item -Recurse -Force -Path $sourcePath
-
-        Get-ChildItem -Recurse -Path $(Build.ArtifactStagingDirectory)
       displayName: 'Produce Executable for ${{ target.rid }}'
       workingDirectory: "${{ parameters.TargetDirectory }}"
       env:

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -19,10 +19,10 @@ parameters:
 steps:
   - ${{ each target in parameters.BuildMatrix }}:
     - pwsh: |
-        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$((Split-Path -Leaf "${{ parameters.TargetDirectory }}"))-{{ target.rid }}"
-        $sourcePath = "${{ parameters.TargetDirectory }}/{{ target.rid }}"
+        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$((Split-Path -Leaf "${{ parameters.TargetDirectory }}"))-${{ target.rid }}"
+        $sourcePath = "${{ parameters.TargetDirectory }}/${{ target.rid }}"
 
-        dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained --output ${{ parameters.TargetDirectory }}/{{ target.rid }}
+        dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained --output ${{ parameters.TargetDirectory }}/${{ target.rid }}
 
         # windows? produce a zip, otherwise tar.gz
         if ("${{ target.rid }}".StartsWith("win")){

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -26,10 +26,10 @@ steps:
 
         # windows? produce a zip, otherwise tar.gz
         if ("${{ target.rid }}".StartsWith("win")){
-          Compress-Archive -Path "$(sourcePath)/*" -DestinationPath "$(destinationPathSegment).zip"
+          Compress-Archive -Path "$($sourcePath)/*" -DestinationPath "$(destinationPathSegment).zip"
         }
         else {
-          tar -cvzf "$(destinationPathSegment).tar.gz" "$(sourcePath)"
+          tar -cvzf "$(destinationPathSegment).tar.gz" "$sourcePath"
         }
 
         # clean up the uncompressed artifact directory

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -23,7 +23,7 @@ steps:
         $destinationPathSegment = "${{ parameters.TargetDirectory }}/$toolName-{{ target.rid }}"
         $sourcePath = "${{ parameters.TargetDirectory }}/{{ target.rid }}"
 
-        dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained $(Warn) --output ${{ parameters.TargetDirectory }}/{{ target.rid }}
+        dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained --output ${{ parameters.TargetDirectory }}/{{ target.rid }}
 
         # windows? produce a zip, otherwise tar.gz
         if ("${{ target.rid }}".StartsWith("win")){

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -33,7 +33,7 @@ steps:
         }
 
         # clean up the uncompressed artifact directory
-        Remove-Item "$($sourcePath)"
+        Remove-Item -Recurse -Force "$($sourcePath)" -Confirm
       displayName: 'Produce Executable for ${{ target.rid }}'
       workingDirectory: "${{ parameters.TargetDirectory }}"
       env:

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -33,7 +33,7 @@ steps:
         }
 
         # clean up the uncompressed artifact directory
-        Remove-Item -Recurse -Force "$($sourcePath)" -Confirm
+        Remove-Item -Recurse -Force "$($sourcePath)" -Confirm $false
       displayName: 'Produce Executable for ${{ target.rid }}'
       workingDirectory: "${{ parameters.TargetDirectory }}"
       env:

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -33,7 +33,7 @@ steps:
         }
 
         # clean up the uncompressed artifact directory
-        Remove-Item -Recurse -Force "$($sourcePath)" -Confirm $false
+        Remove-Item -Recurse -Force -Path $sourcePath
       displayName: 'Produce Executable for ${{ target.rid }}'
       workingDirectory: "${{ parameters.TargetDirectory }}"
       env:

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -22,7 +22,13 @@ steps:
         $destinationPathSegment = "$(Build.ArtifactStagingDirectory)/$((Split-Path -Leaf "${{ parameters.TargetDirectory }}"))-standalone-${{ target.rid }}"
         $sourcePath = "${{ parameters.TargetDirectory }}/${{ target.rid }}"
 
+        Write-Host "dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained --output ${{ parameters.TargetDirectory }}/${{ target.rid }}"
         dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained --output ${{ parameters.TargetDirectory }}/${{ target.rid }}
+
+        if ($LASTEXITCODE -ne 0) {
+          Write-Error "dotnet publish failed with exit code $LASTEXITCODE."
+          exit $LASTEXITCODE
+        }
 
         # windows? produce a zip, otherwise tar.gz
         if ("${{ target.rid }}".StartsWith("win")){

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -16,7 +16,7 @@ parameters:
 steps:
   - ${{ each target in parameters.BuildMatrix }}:
     - script: |
-        dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) $(Warn)
+        dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained $(Warn) --output ${{ parameters.TargetDirectory }}/{{ target.rid }}
       displayName: 'Produce Executable for ${{ target.rid }}'
       workingDirectory: "${{ parameters.TargetDirectory }}"
       env:

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -1,8 +1,6 @@
 parameters:
   - name: TargetDirectory
     type: string
-  - name: ToolName
-    type: string
   - name: StagingDirectory
     type: string
     default: $(Build.ArtifactStagingDirectory)
@@ -21,14 +19,21 @@ parameters:
 steps:
   - ${{ each target in parameters.BuildMatrix }}:
     - pwsh: |
+        $toolName = Split-Path -Leaf "${{ parameters.TargetDirectory }}"
+        Write-Host "##vso[task.setvariable variable=PUBLISHING_TOOL_NAME]$toolName"
+      displayName: Calculate artifact name from target directory
+
+    - pwsh: |
+        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$(TOOL_NAME)-{{ target.rid }}"
+        $sourcePath = "${{ parameters.TargetDirectory }}/{{ target.rid }}"
         dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained $(Warn) --output ${{ parameters.TargetDirectory }}/{{ target.rid }}
 
         # windows? produce a zip, otherwise tar.gz
         if ("${{ target.rid }}".StartsWith("win")){
-          Compress-Archive -Path ${{ parameters.TargetDirectory }}/{{ target.rid }}/* -DestinationPath "${{ parameters.TargetDirectory }}/{{ target.rid }}.zip"
+          Compress-Archive -Path "$(sourcePath)/*" -DestinationPath "$(destinationPathSegment).zip"
         }
         else {
-          tar -cvzf "${{ parameters.TargetDirectory }}/{{ target.rid }}.tar.gz" "${{ parameters.TargetDirectory }}/{{ target.rid }}"
+          tar -cvzf "$(destinationPathSegment).tar.gz" "$(sourcePath)"
         }
 
         # clean up the uncompressed artifact directory

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -24,7 +24,7 @@ steps:
       displayName: Calculate artifact name from target directory
 
     - pwsh: |
-        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$(TOOL_NAME)-{{ target.rid }}"
+        $destinationPathSegment = "${{ parameters.TargetDirectory }}/$(PUBLISHING_TOOL_NAME)-{{ target.rid }}"
         $sourcePath = "${{ parameters.TargetDirectory }}/{{ target.rid }}"
         dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained $(Warn) --output ${{ parameters.TargetDirectory }}/{{ target.rid }}
 
@@ -37,7 +37,7 @@ steps:
         }
 
         # clean up the uncompressed artifact directory
-        Remove-Item "${{ parameters.TargetDirectory }}/{{ target.rid }}"
+        Remove-Item "$(sourcePath)"
       displayName: 'Produce Executable for ${{ target.rid }}'
       workingDirectory: "${{ parameters.TargetDirectory }}"
       env:

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -1,0 +1,27 @@
+parameters:
+  - name: TargetDirectory
+    type: string
+  - name: StagingDirectory
+    type: string
+    default: $(Build.ArtifactStagingDirectory)
+  - name: BuildMatrix
+    type: object
+    default: []
+
+# A `BuildMatrix` is merely a list of possible targeted platforms. .NET 6 can build for any target from any other target.
+# - rid: win-x64
+#   rid: linux-x64
+#   rid: osx-x64
+
+steps:
+  - ${{ each target in parameters.BuildMatrix }}:
+    - script: |
+        dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) $(Warn) -c Release
+      displayName: 'Produce Executable for ${{ target.rid }}'
+      workingDirectory: "${{ parameters.TargetDirectory }}"
+      env:
+        DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+        DOTNET_CLI_TELEMETRY_OPTOUT: 1
+        DOTNET_MULTILEVEL_LOOKUP: 0
+
+

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -34,6 +34,8 @@ steps:
 
         # clean up the uncompressed artifact directory
         Remove-Item -Recurse -Force -Path $sourcePath
+
+        Get-ChildItem -Recurse -Path $(Build.ArtifactStagingDirectory)
       displayName: 'Produce Executable for ${{ target.rid }}'
       workingDirectory: "${{ parameters.TargetDirectory }}"
       env:

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -16,7 +16,7 @@ parameters:
 steps:
   - ${{ each target in parameters.BuildMatrix }}:
     - script: |
-        dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) $(Warn) -c Release
+        dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) $(Warn)
       displayName: 'Produce Executable for ${{ target.rid }}'
       workingDirectory: "${{ parameters.TargetDirectory }}"
       env:

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -33,7 +33,7 @@ steps:
         }
 
         # clean up the uncompressed artifact directory
-        Remove-Item "$(sourcePath)"
+        Remove-Item "$($sourcePath)"
       displayName: 'Produce Executable for ${{ target.rid }}'
       workingDirectory: "${{ parameters.TargetDirectory }}"
       env:

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -19,7 +19,7 @@ parameters:
 steps:
   - ${{ each target in parameters.BuildMatrix }}:
     - pwsh: |
-        $destinationPathSegment = "$(Build.ArtifactStagingDirectory)/$((Split-Path -Leaf "${{ parameters.TargetDirectory }}"))-${{ target.rid }}"
+        $destinationPathSegment = "$(Build.ArtifactStagingDirectory)/$((Split-Path -Leaf "${{ parameters.TargetDirectory }}"))-standalone-${{ target.rid }}"
         $sourcePath = "${{ parameters.TargetDirectory }}/${{ target.rid }}"
 
         dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained --output ${{ parameters.TargetDirectory }}/${{ target.rid }}

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -26,10 +26,10 @@ steps:
 
         # windows? produce a zip, otherwise tar.gz
         if ("${{ target.rid }}".StartsWith("win")){
-          Compress-Archive -Path "$($sourcePath)/*" -DestinationPath "$(destinationPathSegment).zip"
+          Compress-Archive -Path "$($sourcePath)/*" -DestinationPath "$($destinationPathSegment).zip"
         }
         else {
-          tar -cvzf "$(destinationPathSegment).tar.gz" "$sourcePath"
+          tar -cvzf "$($destinationPathSegment).tar.gz" "$sourcePath"
         }
 
         # clean up the uncompressed artifact directory

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -1,6 +1,8 @@
 parameters:
   - name: TargetDirectory
     type: string
+  - name: ToolName
+    type: string
   - name: StagingDirectory
     type: string
     default: $(Build.ArtifactStagingDirectory)
@@ -9,14 +11,28 @@ parameters:
     default: []
 
 # A `BuildMatrix` is merely a list of possible targeted platforms. .NET 6 can build for any target from any other target.
-# - rid: win-x64
-#   rid: linux-x64
-#   rid: osx-x64
+  # - rid: win-x64
+  #   framework: net6.0
+  # - rid: linux-x64
+  #   framework: net6.0
+  # - rid: osx-x64
+  #   framework: net6.0
 
 steps:
   - ${{ each target in parameters.BuildMatrix }}:
-    - script: |
+    - pwsh: |
         dotnet publish -f ${{ target.framework }} -c Release -r ${{ target.rid }} --self-contained $(Warn) --output ${{ parameters.TargetDirectory }}/{{ target.rid }}
+
+        # windows? produce a zip, otherwise tar.gz
+        if ("${{ target.rid }}".StartsWith("win")){
+          Compress-Archive -Path ${{ parameters.TargetDirectory }}/{{ target.rid }}/* -DestinationPath "${{ parameters.TargetDirectory }}/{{ target.rid }}.zip"
+        }
+        else {
+          tar -cvzf "${{ parameters.TargetDirectory }}/{{ target.rid }}.tar.gz" "${{ parameters.TargetDirectory }}/{{ target.rid }}"
+        }
+
+        # clean up the uncompressed artifact directory
+        Remove-Item "${{ parameters.TargetDirectory }}/{{ target.rid }}"
       displayName: 'Produce Executable for ${{ target.rid }}'
       workingDirectory: "${{ parameters.TargetDirectory }}"
       env:

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFrameworks>net6.0;net5.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;AZC0001;AZC0012;CA1724;CA1801;CA1812;CA1822;SA1028</NoWarn>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
@@ -9,6 +9,7 @@
     <LangVersion>preview</LangVersion>
     <InformationalVersion>$(OfficialBuildId)</InformationalVersion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <AssemblyName>test-proxy</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -55,6 +55,8 @@ extends:
       framework: net6.0
     - rid: linux-x64
       framework: net6.0
+    - rid: linux-arm64
+      framework: net6.0
     - rid: osx-x64
       framework: net6.0
     - rid: osx.12-arm64

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -59,6 +59,6 @@ extends:
       framework: net6.0
     - rid: osx-x64
       framework: net6.0
-    - rid: osx.12-arm64
+    - rid: osx-arm64
       framework: net6.0
       

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -53,7 +53,7 @@ extends:
     StandaloneExeMatrix:
     - rid: win-x64
       framework: net6.0
-    # - rid: linux-x64
-    #   framework: net6.0
-    # - rid: osx-x64
-    #   framework: net6.0
+    - rid: linux-x64
+      framework: net6.0
+    - rid: osx-x64
+      framework: net6.0

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -59,6 +59,4 @@ extends:
       framework: net6.0
     - rid: osx-x64
       framework: net6.0
-    - rid: osx-arm64
-      framework: net6.0
       

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -57,3 +57,6 @@ extends:
       framework: net6.0
     - rid: osx-x64
       framework: net6.0
+    - rid: osx.12-arm64
+      framework: net6.0
+      

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -50,3 +50,10 @@ extends:
       dockerRepo: 'engsys/test-proxy'
       stableTags:
       - 'latest'
+    StandaloneExeMatrix:
+    - rid: win-x64
+      framework: net6.0
+    # - rid: linux-x64
+    #   framework: net6.0
+    # - rid: osx-x64
+    #   framework: net6.0


### PR DESCRIPTION
Adding additional capability to archetype-dotnet-tool.

I still need to do work in `azure-sdk-build-tools` to handle the addition of these new artifacts. I want to upload them to git release that was created in the remote template.

@timovv @billwert I still have orchestration work to do, but I can merge this and ensure that you have test clients for all your platforms.
