### PR TITLE
Fix stress watcher to delete test resources on job deletion events

### DIFF
--- a/tools/stress-cluster/services/Stress.Watcher/src/JobEventHandler.cs
+++ b/tools/stress-cluster/services/Stress.Watcher/src/JobEventHandler.cs
@@ -97,12 +97,12 @@ namespace Stress.Watcher
             }
         }
 
-        public void HandleJobEvent(WatchEventType type, V1Job job)
+        public void HandleJobEvent(WatchEventType eventType, V1Job job)
         {
             using (LogContext.PushProperty("namespace", job.Namespace()))
             using (LogContext.PushProperty("job", job.Name()))
             {
-                DeleteResources(job).ContinueWith(t =>
+                DeleteResources(job, eventType).ContinueWith(t =>
                 {
                     if (t.Exception != null)
                     {
@@ -112,9 +112,9 @@ namespace Stress.Watcher
             }
         }
 
-        public async Task DeleteResources(V1Job job)
+        public async Task DeleteResources(V1Job job, WatchEventType eventType)
         {
-            if (!ShouldDeleteResources(job))
+            if (!ShouldDeleteResources(job, eventType))
             {
                 return;
             }
@@ -141,7 +141,7 @@ namespace Stress.Watcher
             Logger.Information($"Deleted resources for group {rgName}");
         }
 
-        public bool ShouldDeleteResources(V1Job job)
+        public bool ShouldDeleteResources(V1Job job, WatchEventType eventType)
         {
             if (!string.IsNullOrEmpty(Namespace) && Namespace != job.Namespace())
             {
@@ -160,6 +160,12 @@ namespace Stress.Watcher
             {
                 Logger.Debug($"No deploy init container found, skipping resource deletion.");
                 return false;
+            }
+
+            // Handle helm uninstall, helm upgrade, namespace deletion, job deletion, etc.
+            if (eventType == WatchEventType.Deleted)
+            {
+                return true;
             }
 
             /*


### PR DESCRIPTION
@liukun-msft this should fix the issue you have been seeing with resources not being deleted on uninstall/upgrade.