### PR TITLE
[Perf] Removed passes from EH Python perf tests

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -517,11 +517,7 @@ Services:
       PrimaryPackage: azure-eventhub
       PackageVersions:
       - azure-core: 1.26.0
-        azure-eventhub: 5.9.0
-      - azure-core: 1.26.0
         azure-eventhub: 5.10.0
-      - azure-core: 1.26.0
-        azure-eventhub: 5.10.1
       - azure-core: source
         azure-eventhub: source
   Tests:
@@ -549,10 +545,10 @@ Services:
     - --event-size 1024 --max-batch-size 100 --preload 1000000 --uamqp-transport
     - --event-size 1024 --max-batch-size 100 --preload 1000000 --transport-type 1
     - --event-size 1024 --max-batch-size 100 --preload 1000000 --transport-type 1 --uamqp-transport
-    - --event-size 1024 --max-batch-size 100 --preload 1000000 --sync --warmup 30
-    - --event-size 1024 --max-batch-size 100 --preload 1000000 --uamqp-transport --sync --warmup 30
-    - --event-size 1024 --max-batch-size 100 --preload 1000000 --transport-type 1 --sync --warmup 30
-    - --event-size 1024 --max-batch-size 100 --preload 1000000 --transport-type 1 --uamqp-transport --sync --warmup 30
+    - --event-size 1024 --max-batch-size 100 --preload 1000000 --sync
+    - --event-size 1024 --max-batch-size 100 --preload 1000000 --uamqp-transport --sync
+    - --event-size 1024 --max-batch-size 100 --preload 1000000 --transport-type 1 --sync
+    - --event-size 1024 --max-batch-size 100 --preload 1000000 --transport-type 1 --uamqp-transport --sync
     TestNames:
       Python: ProcessEventsBatchTest
 


### PR DESCRIPTION
We no longer need the comparison going back to v5.9, so in order to lower the test run time we're streamlining to just comparisons with v5.10.0.
Also the slow start up issue should now be resolved, making the long 30 second warmup redundant.