### PR TITLE
Create a missing .sln file for notification-configuration tool

### DIFF
--- a/tools/notification-configuration/ci.proj
+++ b/tools/notification-configuration/ci.proj
@@ -1,5 +1,0 @@
-<Project Sdk="Microsoft.Build.Traversal">
-  <ItemGroup>
-    <ProjectReference Include="**\*.csproj" />
-  </ItemGroup>
-</Project>

--- a/tools/notification-configuration/notification-configuration.sln
+++ b/tools/notification-configuration/notification-configuration.sln
@@ -13,7 +13,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "identity-resolution", "..\i
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EBC153AF-0244-4DFB-8084-E6C0ACAA5CF3}"
 	ProjectSection(SolutionItems) = preProject
-		ci.proj = ci.proj
 		ci.yml = ci.yml
 	EndProjectSection
 EndProject

--- a/tools/notification-configuration/notification-configuration.sln
+++ b/tools/notification-configuration/notification-configuration.sln
@@ -11,6 +11,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CodeOwnersP
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "identity-resolution", "..\identity-resolution\identity-resolution.csproj", "{9805B503-5469-412C-9A0C-F09F504F0ED8}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EBC153AF-0244-4DFB-8084-E6C0ACAA5CF3}"
+	ProjectSection(SolutionItems) = preProject
+		ci.proj = ci.proj
+		ci.yml = ci.yml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/tools/notification-configuration/notification-configuration.sln
+++ b/tools/notification-configuration/notification-configuration.sln
@@ -1,0 +1,43 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.5.33103.201
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.GithubCodeownerSubscriber", "github-codeowner-subscriber\Azure.Sdk.Tools.GithubCodeownerSubscriber.csproj", "{0198E848-DEF4-4241-BD7C-A7793239AA62}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.NotificationConfiguration", "notification-creator\Azure.Sdk.Tools.NotificationConfiguration.csproj", "{5759063D-A7B3-4D36-ACF4-5595C2789D27}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CodeOwnersParser", "..\code-owners-parser\CodeOwnersParser\Azure.Sdk.Tools.CodeOwnersParser.csproj", "{A9826C8B-85DF-48DB-8A05-40FB04833C42}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "identity-resolution", "..\identity-resolution\identity-resolution.csproj", "{9805B503-5469-412C-9A0C-F09F504F0ED8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0198E848-DEF4-4241-BD7C-A7793239AA62}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0198E848-DEF4-4241-BD7C-A7793239AA62}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0198E848-DEF4-4241-BD7C-A7793239AA62}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0198E848-DEF4-4241-BD7C-A7793239AA62}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5759063D-A7B3-4D36-ACF4-5595C2789D27}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5759063D-A7B3-4D36-ACF4-5595C2789D27}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5759063D-A7B3-4D36-ACF4-5595C2789D27}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5759063D-A7B3-4D36-ACF4-5595C2789D27}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A9826C8B-85DF-48DB-8A05-40FB04833C42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A9826C8B-85DF-48DB-8A05-40FB04833C42}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A9826C8B-85DF-48DB-8A05-40FB04833C42}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A9826C8B-85DF-48DB-8A05-40FB04833C42}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9805B503-5469-412C-9A0C-F09F504F0ED8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9805B503-5469-412C-9A0C-F09F504F0ED8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9805B503-5469-412C-9A0C-F09F504F0ED8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9805B503-5469-412C-9A0C-F09F504F0ED8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {1B352588-04B2-4983-B0F6-A559065D99EC}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This PR makes it easy to open in Visual Studio the `.csproj` files that are descendants of `tools/notification-configuration` path, by adding a `.sln` file containing minimum set of projects required to do a successful build.

I created the `.sln` file by doing the following in VS:
- new project -> blank solution; named it `notification-configuration` and placed in the dir `tools\notification-configuration`
- added `tools\notification-configuration\github-codeowner-subscriber\Azure.Sdk.Tools.GithubCodeownerSubscriber.csproj`  
- added `tools\notification-configuration\notification-creator\Azure.Sdk.Tools.NotificationConfiguration.csproj`
- added the two other required projects to make the build succeed;
- added `ci.yml` as solution file.

I also deleted `ci.proj` to avoid the `MSBUILD : error MSB1011: Specify which project or solution file to use because this folder contains more than one project or solution file.` error.