### PR TITLE
Move internal wiki page "Subscribe to Notifications" next to tools/notification-configuration

### DIFF
--- a/tools/notification-configuration/README.md
+++ b/tools/notification-configuration/README.md
@@ -1,6 +1,6 @@
 # About
 
-This directory contains sources for tools implementing the
+This directory contains sources of tools implementing the
 "Subscribe to AzureDevOps notifications through CODEOWNERS file" feature.
 
 To learn more about it, including links to relevant ADO pipelines, please see

--- a/tools/notification-configuration/README.md
+++ b/tools/notification-configuration/README.md
@@ -1,0 +1,7 @@
+# About
+
+This directory contains sources for tools implementing the
+"Subscribe to AzureDevOps notifications through CODEOWNERS file" feature.
+
+To learn more about it, including links to relevant ADO pipelines, please see
+the [feature wiki documentation](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/63/Subscribe-to-Notifications).

--- a/tools/notification-configuration/notification-configuration.sln
+++ b/tools/notification-configuration/notification-configuration.sln
@@ -14,6 +14,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EBC153AF-0244-4DFB-8084-E6C0ACAA5CF3}"
 	ProjectSection(SolutionItems) = preProject
 		ci.yml = ci.yml
+		README.md = README.md
 	EndProjectSection
 EndProject
 Global


### PR DESCRIPTION
This PR adds a README.md file to `tools/notification-configuration`.

This README most notably just points to the wiki article describing the feature that is implemented by the sources in the directory to which the README was added, i.e.:
https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/63/Subscribe-to-Notifications

As accompanying change to this PR, I made several updates to the doc hyperlinked from the README. [You can find the full diff of my wiki changes here](https://dev.azure.com/azure-sdk/internal/_git/internal.wiki?path=/Engineering-System/Testing-Guidelines/Subscribe-to-Notifications.md&version=GBwikiMaster&_a=compare&oversion=GC35202cb5a14fcf5a8a49c82795dd25c6b6babfdf&mversion=GCbf3ad8946b4544958d67a5429849ef9b28de1f73).

![image](https://user-images.githubusercontent.com/4429827/204747185-d69d8d9b-21a6-489d-b558-e79bc13262d0.png)
