### PR TITLE
Address Failing `test-proxy-local-tool` install

### DIFF
--- a/eng/pipelines/templates/steps/test-proxy-local-tool.yml
+++ b/eng/pipelines/templates/steps/test-proxy-local-tool.yml
@@ -9,7 +9,7 @@ steps:
       dotnet tool install --tool-path $(Build.BinariesDirectory)/test-proxy `
         --prerelease `
         --add-source $(Build.ArtifactStagingDirectory) `
-        azure.sdk.tools.testproxy
+        test-proxy
     displayName: "Install test-proxy from local file"
     workingDirectory: $(Build.SourcesDirectory)/tools/test-proxy
 


### PR DESCRIPTION
I went on vacation last wednesday, which is when the failure began.

This should address the failing build / livetest pipeline.

Next update of `eng/common/testproxy/target_version.txt` will _also_ need to change how the package is installed under `eng/common/testproxy/test-proxy-tool.yml`.


