### PR TITLE
Assorted set of minor refactorings for logic related to CODEOWNERS processing

### DIFF
--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/ConsoleOutput.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/ConsoleOutput.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 
 namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests
@@ -8,8 +8,8 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests
     /// </summary>
     public class ConsoleOutput : IDisposable
     {
-        private StringWriter stringWriter;
-        private TextWriter originalOutput;
+        private readonly StringWriter stringWriter;
+        private readonly TextWriter originalOutput;
 
         /// <summary>
         /// The constructor is where we take in the console output and output to string writer.
@@ -25,7 +25,7 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests
         /// Writes the text representation of a string builder to the string.
         /// </summary>
         /// <returns>The string from console output.</returns>
-        public string GetOuput()
+        public string GetOutput()
         {
             return this.stringWriter.ToString();
         }

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/MainTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/MainTests.cs
@@ -11,7 +11,7 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests
     [TestFixture]
     public class MainTests
     {
-        private const string CodeOwnerFilePath = "CODEOWNERS";
+        private const string CodeOwnersFilePath = "CODEOWNERS";
 
         private static readonly object[] sourceLists =
         {
@@ -29,7 +29,7 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests
         {
             using (var consoleOutput = new ConsoleOutput())
             {
-                Program.Main(CodeOwnerFilePath, targetDirectory, includeUserAliasesOnly);
+                Program.Main(CodeOwnersFilePath, targetDirectory, includeUserAliasesOnly);
                 var output = consoleOutput.GetOutput();
                 TestExpectResult(expectedReturn, output);
                 consoleOutput.Dispose();

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/MainTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/MainTests.cs
@@ -11,9 +11,9 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests
     [TestFixture]
     public class MainTests
     {
-        private const string codeOwnerFilePath = "CODEOWNERS";
+        private const string CodeOwnerFilePath = "CODEOWNERS";
 
-        private static readonly object[] _sourceLists =
+        private static readonly object[] sourceLists =
         {
             new object[] {"sdk", false, new List<string> { "person1", "person2" } },
             new object[] { "/sdk", false, new List<string> { "person1", "person2" } },
@@ -24,14 +24,13 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests
             new object[] { "/sd", true, new List<string>() }
         };
 
-        [TestCaseSource("_sourceLists")]
-        public void TestOnNormalOuput(string targetDirectory, bool includeUserAliasesOnly, List<string> expectedReturn)
+        [TestCaseSource(nameof(sourceLists))]
+        public void TestOnNormalOutput(string targetDirectory, bool includeUserAliasesOnly, List<string> expectedReturn)
         {
-            
             using (var consoleOutput = new ConsoleOutput())
             {
-                Program.Main(codeOwnerFilePath, targetDirectory, includeUserAliasesOnly);
-                var output = consoleOutput.GetOuput();
+                Program.Main(CodeOwnerFilePath, targetDirectory, includeUserAliasesOnly);
+                var output = consoleOutput.GetOutput();
                 TestExpectResult(expectedReturn, output);
                 consoleOutput.Dispose();
             }
@@ -45,10 +44,10 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests
             Assert.AreEqual(1, Program.Main(codeOwnerPath, "sdk"));
         }
 
-        private void TestExpectResult(List<string> expectReturn, string output)
+        private static void TestExpectResult(List<string> expectReturn, string output)
         {
             CodeOwnerEntry codeOwnerEntry = JsonSerializer.Deserialize<CodeOwnerEntry>(output);
-            List<string> actualReturn = codeOwnerEntry.Owners;
+            List<string> actualReturn = codeOwnerEntry!.Owners;
             Assert.AreEqual(expectReturn.Count, actualReturn.Count);
             for (int i = 0; i < actualReturn.Count; i++)
             {

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners/Program.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text.Json;
 using Azure.Sdk.Tools.CodeOwnersParser;
 
@@ -7,10 +7,10 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners
     /// <summary>
     /// The tool command to retrieve code owners.
     /// </summary>
-    public class Program
+    public static class Program
     {
         /// <summary>
-        /// Retrieves codeowners information for specific section of the repo
+        /// Retrieves CODEOWNERS information for specific section of the repo
         /// </summary>
         /// <param name="codeOwnerFilePath">The path of CODEOWNERS file in repo</param>
         /// <param name="targetDirectory">The directory whose information is to be retrieved</param>

--- a/tools/code-owners-parser/CodeOwnersParser.sln
+++ b/tools/code-owners-parser/CodeOwnersParser.sln
@@ -7,7 +7,13 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CodeOwnersP
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.RetrieveCodeOwners", "Azure.Sdk.Tools.RetrieveCodeOwners\Azure.Sdk.Tools.RetrieveCodeOwners.csproj", "{FE65F92D-C71B-4E38-A4B2-3089EA7C5FEC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Sdk.Tools.RetrieveCodeOwners.Tests", "Azure.Sdk.Tools.RetrieveCodeOwners.Tests\Azure.Sdk.Tools.RetrieveCodeOwners.Tests.csproj", "{798B8CAC-68FC-49FD-A0F6-51C0DC4A4D1D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.RetrieveCodeOwners.Tests", "Azure.Sdk.Tools.RetrieveCodeOwners.Tests\Azure.Sdk.Tools.RetrieveCodeOwners.Tests.csproj", "{798B8CAC-68FC-49FD-A0F6-51C0DC4A4D1D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{EF585CCA-55F8-44EB-921A-30996CBAFC49}"
+	ProjectSection(SolutionItems) = preProject
+		ci.yml = ci.yml
+		..\..\eng\common\scripts\get-codeowners.ps1 = ..\..\eng\common\scripts\get-codeowners.ps1
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/tools/code-owners-parser/CodeOwnersParser.sln.DotSettings
+++ b/tools/code-owners-parser/CodeOwnersParser.sln.DotSettings
@@ -1,0 +1,4 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PR/@EntryIndexedValue">PR</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=azconfig/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=CODEOWNERS/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/tools/code-owners-parser/CodeOwnersParser/CodeOwnerEntry.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/CodeOwnerEntry.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Net.Http;
 
 namespace Azure.Sdk.Tools.CodeOwnersParser
 {

--- a/tools/code-owners-parser/CodeOwnersParser/CodeOwnersFile.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/CodeOwnersFile.cs
@@ -1,4 +1,3 @@
-﻿using OutputColorizer;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -9,20 +8,15 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
     {
         public static List<CodeOwnerEntry> ParseFile(string filePathOrUrl)
         {
-            string content;
-            content = FileHelpers.GetFileContents(filePathOrUrl);
-
+            string content = FileHelpers.GetFileContents(filePathOrUrl);
             return ParseContent(content);
         }
 
         public static List<CodeOwnerEntry> ParseContent(string fileContent)
         {
             List<CodeOwnerEntry> entries = new List<CodeOwnerEntry>();
-            string line;
-
 
             // An entry ends when we get to a path (a real path or a commented dummy path)
-
             using (StringReader sr = new StringReader(fileContent))
             {
                 CodeOwnerEntry entry = new CodeOwnerEntry();
@@ -30,7 +24,7 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
                 // we are going to read line by line until we find a line that is not a comment OR that is using the placeholder entry inside the comment.
                 // while we are trying to find the folder entry, we parse all comment lines to extract the labels from it.
                 // when we find the path or placeholder, we add the completed entry and create a new one.
-                while ((line = sr.ReadLine()) != null)
+                while (sr.ReadLine() is { } line)
                 {
                     line = NormalizeLine(line);
 
@@ -93,14 +87,9 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
         }
 
         private static string NormalizeLine(string line)
-        {
-            if (string.IsNullOrEmpty(line))
-            {
-                return line;
-            }
-
-            // Remove tabs and trim extra whitespace
-            return line.Replace('\t', ' ').Trim();
-        }
+            => !string.IsNullOrEmpty(line)
+                // Remove tabs and trim extra whitespace
+                ? line.Replace('\t', ' ').Trim()
+                : line;
     }
 }

--- a/tools/code-owners-parser/CodeOwnersParser/FileHelpers.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/FileHelpers.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Net.Http;
 

--- a/tools/identity-resolution/Services/GitHubService.cs
+++ b/tools/identity-resolution/Services/GitHubService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
@@ -14,8 +14,10 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
     /// </summary>
     public class GitHubService
     {
-        private static HttpClient httpClient = new HttpClient();
-        private static ConcurrentDictionary<string, List<CodeOwnerEntry>> codeownersFileCache = new ConcurrentDictionary<string, List<CodeOwnerEntry>>();
+        private static readonly HttpClient httpClient = new HttpClient();
+
+        private static readonly ConcurrentDictionary<string, List<CodeOwnerEntry>>
+            codeownersFileCache = new ConcurrentDictionary<string, List<CodeOwnerEntry>>();
 
         private readonly ILogger<GitHubService> logger;
 

--- a/tools/notification-configuration/notification-configuration.sln.DotSettings
+++ b/tools/notification-configuration/notification-configuration.sln.DotSettings
@@ -1,0 +1,3 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PR/@EntryIndexedValue">PR</s:String>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=CODEOWNERS/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
In preparation for making changes for #2770 I submit this PR with a set of assorted refactorings on `tools/code-owners-parser/CodeOwnersParser.sln` and `tools/notification-configuration/notification-configuration.sln`. 

Here is what I did on both of these solutions:

- Applied various refactorings suggested by [ReSharper](https://www.jetbrains.com/resharper/); this includes, but is not limited to: simplifying code, adding missing `readonly` attributes, fixing member capitalization [to match official convention](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/capitalization-conventions) (which also matches the convention used by majority of the codebase), and removing unused `using` statements and fixing typos.
- Added some of the highlighted words and abbreviations to ReSharper dictionary files, in `*.sln.DotSettings`.
- Renamed `Azure.Sdk.Tools.RetrieveCodeOwners.Tests.MainTests.CodeOwnerFilePath` to `CodeOwnersFilePath`.
- Added relevant files to `CodeOwnersParser.sln`.