### PR TITLE
Add pool definition to prepare-pipelines.yml set to Ubuntu 20.04, and wrap the steps in a job

### DIFF
--- a/eng/common/pipelines/templates/steps/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/steps/prepare-pipelines.yml
@@ -17,171 +17,176 @@ parameters:
     type: boolean
     default: false
 
-steps:
-  - template: install-pipeline-generation.yml
-  - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
-  # This covers our public repos.
-  - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project public
-        --prefix ${{parameters.Prefix}}
-        --devopspath "\${{parameters.Prefix}}"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention ci
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --set-managed-variables
-        --debug
-        ${{parameters.CIConventionOptions}}
-      displayName: Create CI Pipelines for Public Repository
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}
-        --devopspath "\${{parameters.Prefix}}"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention up
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --set-managed-variables
-        --debug
-        ${{parameters.UPConventionOptions}}
-      displayName: Create UP Pipelines for Public Repository
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}
-        --devopspath "\${{parameters.Prefix}}"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention tests
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --set-managed-variables
-        --debug
-        ${{parameters.TestsConventionOptions}}
-      displayName: Create Live Test Pipelines for Public Repository
-      condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}
-        --devopspath "\${{parameters.Prefix}}"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention testsweekly
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --set-managed-variables
-        --debug
-        ${{parameters.TestsConventionOptions}}
-      displayName: Create Weekly (Multi-Cloud) Live Test Pipelines for Public Repository
-      condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}
-        --devopspath "\${{parameters.Prefix}}"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention upweekly
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --set-managed-variables
-        --debug
-        ${{parameters.UPConventionOptions}}
-      displayName: Create Weekly (Multi-Cloud) Unified Test Pipelines for Public Repository
-      condition: and(succeeded(), eq(${{parameters.GenerateUnifiedWeekly}},true))
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+jobs:
+- job: PreparePipelines
+  pool:
+    name: azsdk-pool-mms-ubuntu-2004-general
+    vmImage: MMSUbuntu20.04
+  steps:
+    - template: install-pipeline-generation.yml
+    - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+    # This covers our public repos.
+    - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project public
+          --prefix ${{parameters.Prefix}}
+          --devopspath "\${{parameters.Prefix}}"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention ci
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --set-managed-variables
+          --debug
+          ${{parameters.CIConventionOptions}}
+        displayName: Create CI Pipelines for Public Repository
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}
+          --devopspath "\${{parameters.Prefix}}"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention up
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --set-managed-variables
+          --debug
+          ${{parameters.UPConventionOptions}}
+        displayName: Create UP Pipelines for Public Repository
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}
+          --devopspath "\${{parameters.Prefix}}"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention tests
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --set-managed-variables
+          --debug
+          ${{parameters.TestsConventionOptions}}
+        displayName: Create Live Test Pipelines for Public Repository
+        condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}
+          --devopspath "\${{parameters.Prefix}}"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention testsweekly
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --set-managed-variables
+          --debug
+          ${{parameters.TestsConventionOptions}}
+        displayName: Create Weekly (Multi-Cloud) Live Test Pipelines for Public Repository
+        condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}
+          --devopspath "\${{parameters.Prefix}}"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention upweekly
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --set-managed-variables
+          --debug
+          ${{parameters.UPConventionOptions}}
+        displayName: Create Weekly (Multi-Cloud) Unified Test Pipelines for Public Repository
+        condition: and(succeeded(), eq(${{parameters.GenerateUnifiedWeekly}},true))
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 
 
-  # This covers our -pr repositories.
-  - ${{ if endsWith(parameters.Repository, '-pr')}}:
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}-pr
-        --devopspath "\${{parameters.Prefix}}\pr"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention ci
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --set-managed-variables
-        --debug
-        --no-schedule
-        ${{parameters.CIConventionOptions}}
-      displayName: Create CI Pipelines for Private Repository
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}-pr
-        --devopspath "\${{parameters.Prefix}}\pr"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention up
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --set-managed-variables
-        --debug
-        --no-schedule
-        ${{parameters.UPConventionOptions}}
-      displayName: Create UP Pipelines for Private Repository
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-    - script: >
-        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
-        --organization https://dev.azure.com/azure-sdk
-        --project internal
-        --prefix ${{parameters.Prefix}}-pr
-        --devopspath "\${{parameters.Prefix}}\pr"
-        --path $(System.DefaultWorkingDirectory)/sdk
-        --endpoint Azure
-        --repository ${{parameters.Repository}}
-        --convention tests
-        --agentpool Hosted
-        --branch refs/heads/$(DefaultBranch)
-        --patvar PATVAR
-        --set-managed-variables
-        --debug
-        --no-schedule
-        ${{parameters.TestsConventionOptions}}
-      displayName: Create Live Test Pipelines for Private Repository
-      condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
-      env:
-        PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+    # This covers our -pr repositories.
+    - ${{ if endsWith(parameters.Repository, '-pr')}}:
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}-pr
+          --devopspath "\${{parameters.Prefix}}\pr"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention ci
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --set-managed-variables
+          --debug
+          --no-schedule
+          ${{parameters.CIConventionOptions}}
+        displayName: Create CI Pipelines for Private Repository
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}-pr
+          --devopspath "\${{parameters.Prefix}}\pr"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention up
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --set-managed-variables
+          --debug
+          --no-schedule
+          ${{parameters.UPConventionOptions}}
+        displayName: Create UP Pipelines for Private Repository
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+      - script: >
+          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator
+          --organization https://dev.azure.com/azure-sdk
+          --project internal
+          --prefix ${{parameters.Prefix}}-pr
+          --devopspath "\${{parameters.Prefix}}\pr"
+          --path $(System.DefaultWorkingDirectory)/sdk
+          --endpoint Azure
+          --repository ${{parameters.Repository}}
+          --convention tests
+          --agentpool Hosted
+          --branch refs/heads/$(DefaultBranch)
+          --patvar PATVAR
+          --set-managed-variables
+          --debug
+          --no-schedule
+          ${{parameters.TestsConventionOptions}}
+        displayName: Create Live Test Pipelines for Private Repository
+        condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
+        env:
+          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)


### PR DESCRIPTION
This PR, in tandem with PR #4915, addresses https://github.com/Azure/azure-sdk-tools/issues/4888 by doing the following:

- It wraps the [steps](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/steps?view=azure-pipelines) definition in [jobs/job](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/jobs-job?view=azure-pipelines) definition, so that [pool](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/pool?view=azure-pipelines) definition can be added. The `job` is named `PreparePipelines`, mimicking the name `GeneratePipelines` [as seen in pipeline-generation.yml](https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/pipeline-generation.yml#LL33C8-L33C25).
- It adds the `pool` definition with value copy-pasted from [pipeline-generation.yml](https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/pipeline-generation.yml#L34-L36), which points to the [ubuntu 20.04 1ES hosted pool](https://dev.azure.com/azure-sdk/internal/_settings/agentqueues?queueId=128&view=jobs):
```
pool:
  name: azsdk-pool-mms-ubuntu-2004-general
  vmImage: MMSUbuntu20.04
```

By setting the image to `MMSUbuntu20.04`, which has `net6.0` installed, and ensuring the tool used by the pipeline, `PipelineGenerator`, is using `net6.0`, we ensure the pipeline will work as expected.  
For more detailed analysis on why this combination of `PipelineGenerator` SDK version and pool images, see https://github.com/Azure/azure-sdk-tools/pull/4915#issue-1483843025.

### Testing

I am not going to merge this PR until I test if it is going to work in expected way. I will do so by submitting PRs against some target `azure-sdk-for-*` repos, changing their derived `prepare-pipelines.yml`. I will provide an update here once done with these tests. Note that the file updates made by these test PRs will be transient, as they will be overridden by changes made by this PR once fully deployed, as explained by the [Common Engineering System doc](https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/common_engsys.md#updating).

UPDATE 12/8/2022 9:24 PM PST: indeed, wrapping the steps into a job and setting the pool makes the pipeline pass, as evidenced by [this build on azure-sdk-for-java](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2044120&view=results), from [my branch](https://github.com/Azure/azure-sdk-for-java/compare/main...users/kojamroz/iss_4880_pool_test).

