### PR TITLE
Update PipelineGenerator target framework from netcoreapp3.1 to net6.0

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pipeline-generator</ToolCommandName>

--- a/tools/pipeline-generator/ci.yml
+++ b/tools/pipeline-generator/ci.yml
@@ -25,4 +25,4 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/pipeline-generator
-    DotNetCoreVersion: 6.0.405
+    DotNetCoreVersion: 6.0.403

--- a/tools/pipeline-generator/ci.yml
+++ b/tools/pipeline-generator/ci.yml
@@ -25,4 +25,6 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/pipeline-generator
+    # As of 12/10/2022 this is a temporary override until the globally-set
+    # SDK is set to net6.0. For details, please see:
     DotNetCoreVersion: 6.0.403

--- a/tools/pipeline-generator/ci.yml
+++ b/tools/pipeline-generator/ci.yml
@@ -27,4 +27,5 @@ extends:
     ToolDirectory: tools/pipeline-generator
     # As of 12/10/2022 this is a temporary override until the globally-set
     # SDK is set to net6.0. For details, please see:
+    # https://github.com/Azure/azure-sdk-tools/pull/4916
     DotNetCoreVersion: 6.0.403

--- a/tools/pipeline-generator/ci.yml
+++ b/tools/pipeline-generator/ci.yml
@@ -25,3 +25,4 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/pipeline-generator
+    DotNetCoreVersion: 6.0.405


### PR DESCRIPTION
This PR, in tandem with PR #4930, addresses #4888 by updating the `PipelineGenerator` tool target framework from `netcoreapp3.1` to `net60` ([version reference](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#latest-versions)). The `net60` SDK is supported both by the Ubuntu pool image we are pinning too, `20.04` (see analysis below), as well as should future-proof us at list until November 12, 2024, as this is when [net6.0 support ends](https://dotnet.microsoft.com/en-us/download/dotnet).

This PR also contributes to solving #4934 and #4935, together with PR #4937.

## Why the version bump, and will it work?

I have identified two pipeline kinds calling into the `PipelineGenerator` tool:

1. The [azure-sdk / internal / Pipelines / automation / automation - pipeline-generation](https://dev.azure.com/azure-sdk/internal/_build?definitionId=773&_a=summary) pipeline, using [azure-sdk-tools / pipeline-generation.yml](https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/pipeline-generation.yml).
2. The `azure-sdk / internal / Pipelines / <lang> / prepare-pipelines / prepare-pipelines` pipelines, for each applicable value of `<lang>`, e.g.: [azure-sdk / internal / Pipelines / net / prepare-pipelines / prepare-pipelines](https://dev.azure.com/azure-sdk/internal/_build?definitionId=2179&_a=summary). These pipelines are ultimately deriving its source from [azure-sdk-tools / prepare-pipelines.yml](https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/pipelines/templates/steps/prepare-pipelines.yml).

The `.yml` file used in 1. case is using [the following pool](https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/pipeline-generation.yml#L34-L36):
```
pool:
  name: azsdk-pool-mms-ubuntu-2004-general
  vmImage: MMSUbuntu20.04
```

### Re case 1 - pipeline-generation.yml

According to [1ES hosted pools doc on MMS images (Microsoft-internal)](https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-hosted-azure-devops-pools/createpoolimage#use-mms-image) this image has [.NET Core 6.0.403 SDK](https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md#net-core-sdk) installed, hence the pipeline should work after the update. 

### Re case 2 - prepare-pipelines.yml

The image for these pipelines is set to `ubuntu-latest`, as explained in #4888. It has `net6.0` installed, as explained in https://github.com/Azure/azure-sdk-tools/issues/4888#issuecomment-1342033218.