### PR TITLE
Bump globals.yml .NET SDK version from 3.1.405 to 6.x + assorted changes

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-azure-function.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-azure-function.yml
@@ -12,6 +12,7 @@ stages:
       jobs:
       - job: BuildPackage
         pool:
+          name: azsdk-pool-mms-ubuntu-2004-general
           vmImage: MMSUbuntu20.04
         steps:
           - task: UseDotNet@2

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-azure-function.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-azure-function.yml
@@ -17,7 +17,7 @@ stages:
           - task: UseDotNet@2
             displayName: Tools
             inputs:
-              version: '3.1.201'
+              version: '6.x'
           - pwsh: |
               dotnet build tools/${{ parameters.ToolName }} --configuration Release
             displayName: Build

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-azure-function.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-azure-function.yml
@@ -12,7 +12,7 @@ stages:
       jobs:
       - job: BuildPackage
         pool:
-          vmImage: ubuntu-18.04
+          vmImage: MMSUbuntu20.04
         steps:
           - task: UseDotNet@2
             displayName: Tools

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-azure-webapp.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-azure-webapp.yml
@@ -22,7 +22,7 @@ stages:
           - task: UseDotNet@2
             displayName: Tools
             inputs:
-              version: '6.0.x'
+              version: '6.x'
           - pwsh: |
               dotnet build tools/${{ parameters.ToolName }} --configuration Release
             displayName: Build

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -90,9 +90,9 @@ stages:
           - pwsh: |
               if (!(Test-Path -PathType container "$(Build.ArtifactStagingDirectory)/packages")) {
                 New-Item -ItemType Directory -Path "$(Build.ArtifactStagingDirectory)/packages"
-                Write-Host "Created $(Build.ArtifactStagingDirectory)/packages directory"
+                Write-Host "Created directory $(Build.ArtifactStagingDirectory)/packages"
               } else {
-                Write-Host "Directory $(Build.ArtifactStagingDirectory)/packages already existed. Nothing to do."
+                Write-Host "Directory $(Build.ArtifactStagingDirectory)/packages already exists. Nothing to do."
               }
             displayName: Create directory for packages to publish if absent
 

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -83,6 +83,19 @@ stages:
               BuildMatrix: ${{ parameters.StandaloneExeMatrix }}
               TargetDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
 
+          # This step creates "$(Build.ArtifactStagingDirectory)/packages" directory if it doesn't exist.
+          # This step is necessary since migration to net6.0. This is because since net6.0, 
+          # in case the "Build and Package" above would not output any packages to this directory, 
+          # the "Publish to packages artifact" step below would fail on missing directory.
+          - pwsh: |
+              if (!(Test-Path -PathType container "$(Build.ArtifactStagingDirectory)/packages")) {
+                New-Item -ItemType Directory -Path "$(Build.ArtifactStagingDirectory)/packages"
+                Write-Host "Created $(Build.ArtifactStagingDirectory)/packages directory"
+              } else {
+                Write-Host "Directory $(Build.ArtifactStagingDirectory)/packages already existed. Nothing to do."
+              }
+            displayName: Create directory for packages to publish if absent
+
           - publish: $(Build.ArtifactStagingDirectory)/packages
             displayName: Publish to packages artifact
             artifact: packages

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,6 +1,6 @@
 variables:
   OfficialBuildId: $(Build.BuildNumber)
   skipComponentGovernanceDetection: true
-  DotNetCoreVersion: '3.1.405'
+  DotNetCoreVersion: '6.0.403'
   NotificationsCreatorVersion: '1.0.0-dev.20221011.1'
   PipelineOwnersExtractorVersion: '1.0.0-dev.20221011.1'

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,6 +1,6 @@
 variables:
   OfficialBuildId: $(Build.BuildNumber)
   skipComponentGovernanceDetection: true
-  DotNetCoreVersion: '6.0.403'
+  DotNetCoreVersion: '6.x'
   NotificationsCreatorVersion: '1.0.0-dev.20221011.1'
   PipelineOwnersExtractorVersion: '1.0.0-dev.20221011.1'

--- a/src/dotnet/Azure.ClientSdk.Analyzers/ci.yml
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/ci.yml
@@ -25,7 +25,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: src/dotnet/Azure.ClientSdk.Analyzers
-    # As of 12/11/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403

--- a/tools/CreateRuleFabricBot/ci.yml
+++ b/tools/CreateRuleFabricBot/ci.yml
@@ -25,7 +25,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/CreateRuleFabricBot
-    # As of 12/10/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403

--- a/tools/apiview/parsers/swagger-api-parser/ci.yml
+++ b/tools/apiview/parsers/swagger-api-parser/ci.yml
@@ -26,7 +26,3 @@ extends:
   parameters:
     PackageDirectory: $(Build.SourcesDirectory)/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser
     TestDirectory: $(Build.SourcesDirectory)/tools/apiview/parsers/swagger-api-parser/SwaggerApiParserTest
-    # As of 12/11/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403

--- a/tools/code-owners-parser/ci.yml
+++ b/tools/code-owners-parser/ci.yml
@@ -26,10 +26,6 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/code-owners-parser
-    # As of 12/11/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403
     # As of 12/11/2022 temporarily disabling TestPostSteps because the
     # get-codeowners.ps1 script uses the codeowners-parser NuGet package
     # which has net5.0, not net6.0, which causes it to fail. 

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues.Tests/Azure.Sdk.Tools.GitHubIssues.Tests.csproj
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues.Tests/Azure.Sdk.Tools.GitHubIssues.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
@@ -12,7 +12,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.0.0" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.3" />
     <PackageReference Include="Octokit" Version="0.48.0" />
     <PackageReference Include="Polly" Version="7.2.1" />
     <PackageReference Include="RateLimiter" Version="2.1.0" />

--- a/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
+++ b/tools/github-issues/Azure.Sdk.Tools.GitHubIssues/Azure.Sdk.Tools.GitHubIssues.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
     <!-- Do not warn about using assemblies without a strong name signature-->
     <NoWarn>$(NoWarn);8002</NoWarn>

--- a/tools/http-fault-injector/ci.yml
+++ b/tools/http-fault-injector/ci.yml
@@ -25,7 +25,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/http-fault-injector
-    # As of 12/11/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403    

--- a/tools/identity-resolution/ci.yml
+++ b/tools/identity-resolution/ci.yml
@@ -25,7 +25,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/identity-resolution
-    # As of 12/11/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403

--- a/tools/notification-configuration/ci.yml
+++ b/tools/notification-configuration/ci.yml
@@ -29,7 +29,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/notification-configuration
-    # As of 12/11/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403

--- a/tools/pipeline-generator/ci.yml
+++ b/tools/pipeline-generator/ci.yml
@@ -25,7 +25,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/pipeline-generator
-    # As of 12/10/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403

--- a/tools/snippet-generator/ci.yml
+++ b/tools/snippet-generator/ci.yml
@@ -25,7 +25,3 @@ extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/snippet-generator
-    # As of 12/11/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403

--- a/tools/stress-cluster/cluster/kubernetes/generator/ci.yml
+++ b/tools/stress-cluster/cluster/kubernetes/generator/ci.yml
@@ -19,7 +19,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/stress-cluster/cluster/kubernetes/generator
-    # As of 12/11/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403

--- a/tools/version-guard/ci.yml
+++ b/tools/version-guard/ci.yml
@@ -25,7 +25,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/version-guard
-    # As of 12/10/2022 this is a temporary override until the globally-set
-    # SDK is set to net6.0. For details, please see:
-    # https://github.com/Azure/azure-sdk-tools/pull/4916
-    DotNetCoreVersion: 6.0.403


### PR DESCRIPTION
## Context

Updating .NET SDK version from `3.1.405` to `6.x` for our pipelines because:

- `.NET Core 3.1` support [is ending on December 13, 2022](https://dotnet.microsoft.com/en-us/download/dotnet), hence we want to move to a supported SDK. See also #4934.
- As `.NET Core 3.1` support is ending, [it got removed from latest Ubuntu images](https://github.com/Azure/azure-sdk-tools/issues/4888#issuecomment-1342033218), and in some places we we didn't pin the Ubuntu image, thus resulting in us using the latest image, thus leading to issues, like #4888.
- To address #4888 we need to move `PipelineGenerator` to .NET 6, which we do in PR #4915. But for the PR #4915 to successfully build, this PR needs to be merged first, as explained in https://github.com/Azure/azure-sdk-tools/pull/4915#issuecomment-1342167140.
- Updated `GitHubIssues` `TargetFramework` as it wasn't included in update made in PR #4937.

I chose `6.x` because this is the version installed on the image we use, as explained in https://github.com/Azure/azure-sdk-tools/pull/4915#issue-1483843025. 

Note: Alternatively, I could have used `6.0.403`, because it is a string that is present in `releases / sdk / version` in the [releases.json](https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/6.0/releases.json), as explained in [UseDotNet@2 task doc](https://learn.microsoft.com/en-gb/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines&viewFallbackFrom=azure-devops). For more, see https://github.com/Azure/azure-sdk-tools/pull/4915#issuecomment-1342167140.

## Changes made

- Primarily, the .NET SDK version in `globals.yml`, which is picked by our `archetype` files;
- Also changed `archetype-sdk-tool-azure-function.yml` to use `net6.x` and does few other assorted changes. 
    - Updated used image from Ubuntu 18.04, 1ES-hosted Ubuntu 20.04.
- Got rid of temporary project-specific .NET overrides.
- In `GitHubIssues`, updated `Microsoft.NET.Sdk.Functions` from `3.0.9` to `4.1.3`, as the old version depended on obsolete .NET SDK version.
- In `archetype-sdk-tool-dotnet.yml`, ensured the directory from which packages are to be published always exists, even if it wasn't created by previous steps because they didn't create any packages. This is the case e.g. for `identity-resolution - ci` which caused it to fail after the update of .NET version. This appears to be a behavior change introduced in .NET 6 or earlier. Unfortunately, there is no "directory exists" expression: the doc doesn't mention it, and relevant issues or feature requests only propose workarounds: [azure-devops-docs #1877](https://github.com/MicrosoftDocs/azure-devops-docs/issues/1877?) and [developer community 366095](https://developercommunity.visualstudio.com/t/add-an-exists-on-task-custom-condition/366095).

Note I **did not** update `CheckEnforcer` and `WebhookRouter` as they are scheduled for deletion per https://github.com/Azure/azure-sdk-tools/pull/4937#pullrequestreview-1214475397. PRs doing that: 
- #4963
- #4966

## 