### PR TITLE
CADL manual API review additional changes

### DIFF
--- a/eng/pipelines/apiview-review-gen-cadl.yml
+++ b/eng/pipelines/apiview-review-gen-cadl.yml
@@ -44,8 +44,8 @@ jobs:
     condition: eq(variables['APIViewURL'], '')
 
   - pwsh: |
-      npm install -g @cadl-lang/compiler
-      npm install -g @azure-tools/cadl-apiview
+      npm install -g @cadl-lang/compiler@0.37.0
+      npm install -g @azure-tools/cadl-apiview@0.3.0
       npm list -g
     displayName: "Install npm packages"
 

--- a/eng/pipelines/apiview-review-gen-cadl.yml
+++ b/eng/pipelines/apiview-review-gen-cadl.yml
@@ -44,8 +44,9 @@ jobs:
     condition: eq(variables['APIViewURL'], '')
 
   - pwsh: |
-      npm install -g @cadl-lang/compiler  
+      npm install -g @cadl-lang/compiler
       npm install -g @azure-tools/cadl-apiview
+      npm list -g
     displayName: "Install npm packages"
 
   - task: Powershell@2

--- a/eng/pipelines/apiview-review-gen-cadl.yml
+++ b/eng/pipelines/apiview-review-gen-cadl.yml
@@ -44,8 +44,7 @@ jobs:
     condition: eq(variables['APIViewURL'], '')
 
   - pwsh: |
-      npm install -g cadl
-      npm install -g @cadl-lang/compiler
+      npm install -g @cadl-lang/compiler  
       npm install -g @azure-tools/cadl-apiview
     displayName: "Install npm packages"
 

--- a/eng/scripts/Create-Apiview-Token-Cadl.ps1
+++ b/eng/scripts/Create-Apiview-Token-Cadl.ps1
@@ -14,7 +14,10 @@ $sparseCheckoutFile = ".git/info/sparse-checkout"
 
 function Sparse-Checkout($branchName, $packagePath)
 {
-    Remove-Item $sparseCheckoutFile -Force
+    if (Test-Path $sparseCheckoutFile)
+    {
+        Remove-Item $sparseCheckoutFile -Force
+    }    
     git sparse-checkout init --cone
     git sparse-checkout set $packagePath
     git checkout $BranchName
@@ -59,6 +62,10 @@ if ($revs)
         $GitRepoName = $r.SourceRepoName
         $branchName = $r.SourceBranchName
 
+        if ($packagePath.StartsWith("/"))
+        {
+            $packagePath = $packagePath.Substring(1)
+        }
         Write-Host "Generating API review for Review ID: '$($reviewId), Revision ID: '$($revisionId)"
         Write-Host "URL to Repo: '$($GitRepoName), Branch name: '$($branchName), Package Path: '$($packagePath)"
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/CadlLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CadlLanguageService.cs
@@ -45,7 +45,7 @@ namespace APIViewWeb
 
         public override bool GeneratePipelineRunParams(ReviewGenPipelineParamModel param)
         {
-            var filePath = param.FileName.ToLower();
+            var filePath = param.FileName;
             // Verify cadl source file path is a GitHub URL to cadl package root 
             if (filePath == null || !filePath.StartsWith("https://github.com/"))
                 return false;

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -717,6 +717,11 @@ namespace APIViewWeb.Managers
                 review.RunAnalysis,
                 language);
 
+            // Set revision name using file name in case input is a URL(Input is either fielstream or URL)
+            if (fileStream == null)
+            {
+                revision.Name = Path.GetFileName(name);
+            }
             revision.Files.Add(codeFile);
             revision.Author = user.GetGitHubLogin();
             revision.Label = label;

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml
@@ -31,12 +31,21 @@
                             </button>
                         </div>
                         <div class="modal-body">
-                            <div class="form-group">
-                                <div class="custom-file">
-                                    <input name="upload" type="file" class="custom-file-input">
-                                    <label for="upload" class="custom-file-label">Select file to add</label>
+                            @if (Model.Review.Language != "Cadl")
+                            {
+                                <div class="form-group">
+                                    <div class="custom-file">
+                                        <input name="upload" type="file" class="custom-file-input">
+                                        <label for="upload" class="custom-file-label">Select file to add</label>
+                                    </div>
                                 </div>
-                            </div>
+                            }
+                            else
+                            {
+                                <div class="form-group package-selector">
+                                    <input asp-for="FilePath" class="form-control" type="text" placeholder="Enter URL to package root source. For e.g. URL to CADL file">
+                                </div>
+                            }
                             <div>
                                 <input asp-for="Label" class="form-control" type="text" placeholder="Enter an optional revision label">
                             </div>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml.cs
@@ -26,6 +26,9 @@ namespace APIViewWeb.Pages.Assemblies
         [FromForm]
         public string Label { get; set; }
 
+        [FromForm]
+        public string FilePath { get; set; }
+
         public async Task<IActionResult> OnGetAsync(string id)
         {
             TempData["Page"] = "revisions";
@@ -46,6 +49,10 @@ namespace APIViewWeb.Pages.Assemblies
             {
                 var openReadStream = upload.OpenReadStream();
                 await _manager.AddRevisionAsync(User, id, upload.FileName, Label, openReadStream);
+            }
+            else
+            {
+                await _manager.AddRevisionAsync(User, id, FilePath, Label, null);
             }
 
             return RedirectToPage();


### PR DESCRIPTION
1. Fix script to check git info path before removing it.
2. Remove path separator from sparse checkout path if it is present
3. Update review name using package root path for CADL review
4. Show URL path input field when creating revision on CADL review.
