### PR TITLE
[Asset sync] Handle additional git remote format

### DIFF
--- a/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
+++ b/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
@@ -194,7 +194,7 @@ Function Get-Repo-Language {
   # will match what is below. If the regular expression needs to be updated the following
   # link below will go to a regex playground
   # https://regex101.com/r/2uvYDF/1
-  $lang = $remotes[0] | ForEach-Object { if ($_ -match "azure-sdk-for-(?<lang>[^\-\.\/]+)") {
+  $lang = $remotes[0] | ForEach-Object { if ($_ -match "azure-sdk-for-(?<lang>[^\-\.\/ ]+)") {
       #Return the named language match
       return $Matches["lang"]
     }

--- a/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
+++ b/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
@@ -188,12 +188,13 @@ Function Get-Repo-Language {
   # origin git@github.com:Azure/azure-sdk-for-python-pr.git (fetch)
   # fork git@github.com:UserName/azure-sdk-for-python (fetch)
   # azure-sdk https://github.com/azure-sdk/azure-sdk-for-net.git (fetch)
+  # origin  https://github.com/Azure/azure-sdk-for-python/ (fetch)
   # ForEach-Object splits the string on whitespace so each of the above strings is actually
   # 3 different strings. The first and last pieces won't match anything, the middle string
   # will match what is below. If the regular expression needs to be updated the following
   # link below will go to a regex playground
-  # https://regex101.com/r/btVW5A/1
-  $lang = $remotes[0] | ForEach-Object { if ($_ -match "azure-sdk-for-(?<lang>[^\-\.]+)") {
+  # https://regex101.com/r/2uvYDF/1
+  $lang = $remotes[0] | ForEach-Object { if ($_ -match "azure-sdk-for-(?<lang>[^\-\.\/]+)") {
       #Return the named language match
       return $Matches["lang"]
     }

--- a/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
+++ b/tools/test-proxy/scripts/transition-scripts/generate-assets-json.ps1
@@ -193,7 +193,7 @@ Function Get-Repo-Language {
   # 3 different strings. The first and last pieces won't match anything, the middle string
   # will match what is below. If the regular expression needs to be updated the following
   # link below will go to a regex playground
-  # https://regex101.com/r/2uvYDF/1
+  # https://regex101.com/r/auOnAr/1
   $lang = $remotes[0] | ForEach-Object { if ($_ -match "azure-sdk-for-(?<lang>[^\-\.\/ ]+)") {
       #Return the named language match
       return $Matches["lang"]


### PR DESCRIPTION
@xiangyan99 was running the `generate-assets-json.ps1` script earlier today and got the following error message:
```
The language, python/ (fetch), does not have an entry in the LangRecordingDirs dictionary.
```
This was because the language repo parsing method couldn't correctly parse the format of Xiang's `git remote -v` output:
```
PS D:\Github\azure-sdk-for-python\sdk\search\azure-search-documents> git remote -v
origin  https://github.com/Azure/azure-sdk-for-python/ (fetch)
origin  https://github.com/Azure/azure-sdk-for-python/ (push)
```
This fixes that by adding `/` as a terminating character for parsing the language string.

Resolves https://github.com/Azure/azure-sdk-tools/issues/4748

@scbedd