### PR TITLE
Add load-testing to list of valid sample slugs

### DIFF
--- a/eng/common/scripts/Test-SampleMetadata.ps1
+++ b/eng/common/scripts/Test-SampleMetadata.ps1
@@ -227,6 +227,7 @@ begin {
         "azure-live-ondemand-streaming",
         "azure-live-video-analytics",
         "azure-load-balancer",
+        "azure-load-testing",
         "azure-log-analytics",
         "azure-logic-apps",
         "azure-machine-learning",


### PR DESCRIPTION
`azure-load-testing` is an approved product slug in https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=main#product but is not present in the SampleMetadata.ps1 file. Adding it here as pipelines are failing due to this