### PR TITLE
Helm template for deploy script

### DIFF
--- a/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
+++ b/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
@@ -26,6 +26,9 @@ param(
     # Override remote stress-test-addons with local on-disk addons for development
     [System.IO.FileInfo]$LocalAddonsPath,
 
+    # Renders chart templates locally without deployment
+    [Parameter(Mandatory=$False)][switch]$Template,
+
     # Matrix generation parameters
     [Parameter(Mandatory=$False)][string]$MatrixFileName,
     [Parameter(Mandatory=$False)][string]$MatrixSelection,

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -301,8 +301,9 @@ function DeployStressPackage(
     Write-Host "Installing or upgrading stress test $($pkg.ReleaseName) from $($pkg.Directory)"
 
     $generatedConfigPath = Join-Path $pkg.Directory generatedValues.yaml
-    $subCommand = $Template ? "template" : "upgrade --install"
-    $helmCommandArg = "helm", $subCommand, $pkg.ReleaseName, $pkg.Directory, "-n", $pkg.Namespace, "--set", "stress-test-addons.env=$environment", "--values", $generatedConfigPath
+    $subCommand = $Template ? "template" : "upgrade"
+    $installFlag = $Template ? "" : "--install"
+    $helmCommandArg = "helm", $subCommand, $pkg.ReleaseName, $pkg.Directory, "-n", $pkg.Namespace, $installFlag, "--set", "stress-test-addons.env=$environment", "--values", $generatedConfigPath
 
     $result = (Run @helmCommandArg) 2>&1 | Write-Host
 

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -300,8 +300,9 @@ function DeployStressPackage(
 
     Write-Host "Installing or upgrading stress test $($pkg.ReleaseName) from $($pkg.Directory)"
 
-    $helmCommandArg = "helm", ($Template ? "template":"upgrade"), $pkg.ReleaseName, $pkg.Directory, "-n", $pkg.Namespace,
-                        ($Template ? "":"--install"), "--set", "stress-test-addons.env=$environment", "--values", (Join-Path $pkg.Directory generatedValues.yaml)
+    $generatedConfigPath = Join-Path $pkg.Directory generatedValues.yaml
+    $subCommand = $Template ? "template" : "upgrade --install"
+    $helmCommandArg = "helm", $subCommand, $pkg.ReleaseName, $pkg.Directory, "-n", $pkg.Namespace, "--set", "stress-test-addons.env=$environment", "--values", $generatedConfigPath
 
     $result = (Run @helmCommandArg) 2>&1 | Write-Host
 

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -97,6 +97,7 @@ function DeployStressTests(
         return $true
     })]
     [System.IO.FileInfo]$LocalAddonsPath,
+    [Parameter(Mandatory=$False)][switch]$Template,
     [Parameter(Mandatory=$False)][string]$MatrixFileName,
     [Parameter(Mandatory=$False)][string]$MatrixSelection = "sparse",
     [Parameter(Mandatory=$False)][string]$MatrixDisplayNameFilter,
@@ -298,11 +299,11 @@ function DeployStressPackage(
     }
 
     Write-Host "Installing or upgrading stress test $($pkg.ReleaseName) from $($pkg.Directory)"
-    $result = (Run helm upgrade $pkg.ReleaseName $pkg.Directory `
-                -n $pkg.Namespace `
-                --install `
-                --set stress-test-addons.env=$environment `
-                --values (Join-Path $pkg.Directory generatedValues.yaml)) 2>&1
+
+    $helmCommandArg = "helm", ($Template ? "template":"upgrade"), $pkg.ReleaseName, $pkg.Directory, "-n", $pkg.Namespace,
+                        ($Template ? "":"--install"), "--set", "stress-test-addons.env=$environment", "--values", (Join-Path $pkg.Directory generatedValues.yaml)
+
+    $result = (Run @helmCommandArg) 2>&1 | Write-Host
 
     if ($LASTEXITCODE) {
         # Error: UPGRADE FAILED: create: failed to create: Secret "sh.helm.release.v1.stress-test.v3" is invalid: data: Too long: must have at most 1048576 bytes
@@ -324,12 +325,13 @@ function DeployStressPackage(
     # Helm 3 stores release information in kubernetes secrets. The only way to add extra labels around
     # specific releases (thereby enabling filtering on `helm list`) is to label the underlying secret resources.
     # There is not currently support for setting these labels via the helm cli.
-    $helmReleaseConfig = RunOrExitOnFailure kubectl get secrets `
+    if(!$Template) {
+        $helmReleaseConfig = RunOrExitOnFailure kubectl get secrets `
                                                 -n $pkg.Namespace `
                                                 -l "status=deployed,name=$($pkg.ReleaseName)" `
                                                 -o jsonpath='{.items[0].metadata.name}'
-
-    Run kubectl label secret -n $pkg.Namespace --overwrite $helmReleaseConfig deployId=$deployId
+        Run kubectl label secret -n $pkg.Namespace --overwrite $helmReleaseConfig deployId=$deployId
+    }
 }
 
 function CheckDependencies()


### PR DESCRIPTION
Adding in feature for stress deployment script to do a dry run and generate helm templates locally without deploying