### PR TITLE
prepare pipeline job bug fix

### DIFF
--- a/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
     name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: MMSUbuntu20.04
   steps:
-    - template: install-pipeline-generation.yml
+    - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
     - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     # This covers our public repos.
     - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:

--- a/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
     name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: MMSUbuntu20.04
   steps:
-    - template: /eng/common/pipelines/templates/jobs/install-pipeline-generation.yml
+    - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
     - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     # This covers our public repos.
     - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:

--- a/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
@@ -23,7 +23,7 @@ jobs:
     name: azsdk-pool-mms-ubuntu-2004-general
     vmImage: MMSUbuntu20.04
   steps:
-    - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
+    - template: /eng/common/pipelines/templates/jobs/install-pipeline-generation.yml
     - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     # This covers our public repos.
     - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:


### PR DESCRIPTION
Was trying to set up live test pipeline for this [pr](https://github.com/Azure/azure-sdk-for-js/pull/24225). The prepare-pipeline job failed due to [not being able to find install-pipeline-generation.yml](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2056101&view=results). 