### PR TITLE
Refactor pipeline-generator to use CommandLineParser

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
@@ -7,16 +7,17 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pipeline-generator</ToolCommandName>
 
-    <VersionPrefix>1.0.2</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
 
     <AssemblyName>Azure.Sdk.Tools.PipelineGenerator</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.3.4" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
+
     <PackageReference Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="16.170.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
     <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.170.0" />

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/CommandParserOptions/DefaultOptions.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/CommandParserOptions/DefaultOptions.cs
@@ -1,0 +1,34 @@
+using CommandLine;
+
+namespace PipelineGenerator.CommandParserOptions
+{
+    public class DefaultOptions
+    {
+        private string _organization = "";
+
+        [Option('o', "organization", Required = false, Default = "azure-sdk", HelpText = "Azure DevOps organization name. Default: azure-sdk")]
+        public string Organization
+        {
+            get { return _organization; }
+            set {
+                if (_organization.StartsWith("https://dev.azure.com/"))
+                {
+                    _organization = value;
+                }
+                else
+                {
+                    _organization = "https://dev.azure.com/" + value;
+                }
+            }
+        }
+
+        [Option('p', "project", Required = false, Default = "internal", HelpText = "Azure DevOps project name. Default: internal")]
+        public string Project { get; set; }
+
+        [Option('t', "patvar", Required = false, HelpText = "Environment variable name containing a Personal Access Token.")]
+        public string Patvar { get; set; }
+
+        [Option("whatif", Required = false, HelpText = "Dry Run changes")]
+        public bool WhatIf { get; set; }
+    }
+}

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/CommandParserOptions/GenerateOptions.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/CommandParserOptions/GenerateOptions.cs
@@ -1,0 +1,54 @@
+using CommandLine;
+using System.Collections.Generic;
+
+namespace PipelineGenerator.CommandParserOptions
+{
+    [Verb("generate", HelpText = "Generate Azure Pipelines from config files")]
+    public class GenerateOptions : DefaultOptions
+    {
+        [Option('x', "prefix", Required = true, HelpText = "The prefix to append to the pipeline name")]
+        public string Prefix { get; set; }
+
+        [Option("path", Required = true, HelpText = "The directory from which to scan for components")]
+        public string Path { get; set; }
+
+        [Option('d', "devopspath", Required = false, HelpText = "The DevOps directory for created pipelines")]
+        public string DevOpsPath { get; set; }
+
+        [Option('e', "endpoint", Required = false, Default = "Azure", HelpText = "Name of the service endpoint to configure repositories with. Default: Azure")]
+        public string Endpoint { get; set; }
+
+        [Option('r', "repository", Required = true, HelpText = "Name of the GitHub repo in the form [org]/[repo]")]
+        public string Repository { get; set; }
+
+        [Option('b', "branch", Required = false, Default = "refs/heads/main", HelpText = "Default: refs/heads/main")]
+        public string Branch { get; set; }
+
+        [Option('a', "agentpool", Required = false, Default = "Hosted", HelpText = "Name of the agent pool to use when pool isn't specified. Default: hosted")]
+        public string Agentpool { get; set; }
+
+        [Option('c', "convention", Required = true, HelpText = "The convention to build pipelines for: [ci|up|upweekly|tests|testsweekly]")]
+        public string Convention { get; set; }
+
+        [Option('v', "variablegroups", Required = true, HelpText = "Variable groups to link, separated by a space, e.g. --variablegroups 1 9 64")]
+        public IEnumerable<int> VariableGroups { get; set; }
+
+        [Option("open", Required = false, HelpText = "Open a browser window to the definitions that are created")]
+        public bool Open { get; set; }
+
+        [Option("destroy", Required = false, HelpText = "Use this switch to delete the pipelines instead (DANGER!)")]
+        public bool Destroy { get; set; }
+
+        [Option("debug", Required = false, HelpText = "Turn on debug level logging")]
+        public bool Debug { get; set; }
+
+        [Option("no-schedule", Required = false, HelpText = "Skip creating any scheduled triggers")]
+        public bool NoSchedule { get; set; }
+
+        [Option("set-managed-variables", Required = false, HelpText = "Set managed meta.* variable values")]
+        public bool SetManagedVariables { get; set; }
+
+        [Option("overwrite-triggers", Required = false, HelpText = "Overwrite existing pipeline triggers (triggers may be manually modified, use with caution)")]
+        public bool OverwriteTriggers { get; set; }
+    }
+}

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Conventions/PipelineConvention.cs
@@ -163,9 +163,9 @@ namespace PipelineGenerator.Conventions
         private async Task<BuildDefinition> CreateDefinitionAsync(string definitionName, SdkComponent component, CancellationToken cancellationToken)
         {
             var serviceEndpoint = await Context.GetServiceEndpointAsync(cancellationToken);
-            
+
             var repository = Context.Repository;
-            
+
             var buildRepository = new BuildRepository
             {
                 DefaultBranch = Context.Branch,
@@ -175,7 +175,7 @@ namespace PipelineGenerator.Conventions
                 Url = new Uri($"https://github.com/{repository}.git"),
                 Properties = { ["connectedServiceId"] = serviceEndpoint.Id.ToString() }
             };
-            
+
             var projectReference = await Context.GetProjectReferenceAsync(cancellationToken);
             var agentPoolQueue = await Context.GetAgentPoolQueue(cancellationToken);
             var normalizedRelativeYamlPath = component.RelativeYamlPath.Replace("\\", "/");

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
@@ -35,7 +35,7 @@ namespace PipelineGenerator
             string repository,
             string branch,
             string agentPool,
-            string[] variableGroups,
+            int[] variableGroups,
             string devOpsPath,
             string prefix,
             bool whatIf,
@@ -51,7 +51,7 @@ namespace PipelineGenerator
             this.Repository = repository;
             this.Branch = branch;
             this.agentPool = agentPool;
-            this.variableGroups = ParseIntArray(variableGroups);
+            this.variableGroups = variableGroups;
             this.devOpsPath = devOpsPath;
             this.Prefix = prefix;
             this.WhatIf = whatIf;
@@ -69,9 +69,6 @@ namespace PipelineGenerator
         public bool SetManagedVariables { get; set; }
         public int[] VariableGroups => this.variableGroups;
         public string DevOpsPath => string.IsNullOrEmpty(this.devOpsPath) ? Prefix : this.devOpsPath;
-
-        private int[] ParseIntArray(string[] strs)
-            => strs.Select(str => int.Parse(str)).ToArray();
 
         private VssConnection cachedConnection;
 
@@ -135,7 +132,7 @@ namespace PipelineGenerator
 
         private ServiceEndpointHttpClient cachedServiceEndpointClient;
 
-        private async Task<ServiceEndpointHttpClient> GetServiceEndpointClientAsync(CancellationToken cancellationToken)
+        public async Task<ServiceEndpointHttpClient> GetServiceEndpointClientAsync(CancellationToken cancellationToken)
         {
             if (cachedServiceEndpointClient == null)
             {


### PR DESCRIPTION
I'm extending pipeline-generator to enable scenarios detailed in #2572. To do this, pipeline-generator will have multiple sub-commands:

```
pipeline-generator generate   # Current functionality, generate/sync pipelines from yaml files
pipeline-generator bootstrap  # (new) Create or update service principals and service connections for pipeline usage
pipeline-generator onboard    # (new) Set up keyvaults and/or access policies for new teams onboarding to Bring Your Own Subscription
```

As part of adding sub-command support, this PR updates the project to use CommandLineParser in line with our other C# CLI projects. I have also set up defaults for a lot of the common values to make local invocation much more concise, for example:

```
pipeline-generator generate --path /home/ben/sdk/azure-sdk-for-go/sdk -x go -d "\go" -r Azure/azure-sdk-for-go -c up -v 64 --set-managed-variables
```

After merge and tool release, I will put up a separate PR that includes the yaml config changes to call the tool correctly alongside the version bump.
