### PR TITLE
Migrate Tests.CI.BuildTasks.csproj and Tests.CI.Common.csproj to net6.0

### DIFF
--- a/src/dotnet/Mgmt.CI.BuildTools/CI/CI.BuildTasks/Tests/CI.BuildTasks.Tests/Tests.CI.BuildTasks.csproj
+++ b/src/dotnet/Mgmt.CI.BuildTools/CI/CI.BuildTasks/Tests/CI.BuildTasks.Tests/Tests.CI.BuildTasks.csproj
@@ -9,7 +9,7 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <PropertyGroup>
-		<TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+		<TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
 	</PropertyGroup>
   <ItemGroup>

--- a/src/dotnet/Mgmt.CI.BuildTools/CI/CI.BuildTasks/Tests/CI.BuildTasks.Tests/Tests.CI.BuildTasks.csproj
+++ b/src/dotnet/Mgmt.CI.BuildTools/CI/CI.BuildTasks/Tests/CI.BuildTasks.Tests/Tests.CI.BuildTasks.csproj
@@ -4,6 +4,7 @@
     <Description>Tests for MS.Az.NetSdk.Build.Tasks msbuild build tasks tests</Description>
     <AssemblyTitle>MS.Az.NetSdk.Build.Tasks Tests</AssemblyTitle>
     <AssemblyName>Build.Tasks.Tests</AssemblyName>
+    <RuntimeIdentifier>win10-x64</RuntimeIdentifier>
 
     <!-- Skip test projects until tests can be fixed -->
     <IsTestProject>false</IsTestProject>

--- a/src/dotnet/Mgmt.CI.BuildTools/CI/CI.Common/Tests/Tests.CI.Common.csproj
+++ b/src/dotnet/Mgmt.CI.BuildTools/CI/CI.Common/Tests/Tests.CI.Common.csproj
@@ -10,7 +10,7 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
This PR is a follow-up to:
- #4937

it contributes to addressing:
- #4934

Here I migrate some more projects from `netcoreapp2.1` to `net6.0`.

I also quenched the error (escalated from warning):

> MSB3270: There was a mismatch between the processor architecture of the project being built "MSIL" and the processor architecture of the reference (...) AMD64"

by forcing the relevant tests project to be win10-x64 too.