### PR TITLE
Give the csv flexibility to onboard "not New" package to Docs.Ms

### DIFF
--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -35,3 +35,12 @@ function GetPackageKey($pkg) {
     }
     return $packageLookup
   }
+
+  fucntion GetDocsTocDisplayName($pkg) {
+    $displayName = $pkg.DisplayName
+    if ('deprecated' -eq $pkg.Support) {
+      LogWarning "The pkg $($pkg.Package) is deprecated. Add 'deprecated' besides of display name."
+      $diaplayName += " (deprecated)"
+    }
+    return $displayName
+  }

--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -41,7 +41,7 @@ function GetDocsTocDisplayName($pkg) {
   $displayName = $pkg.DisplayName
   if ('deprecated' -eq $pkg.Support) {
     LogWarning "The pkg $($pkg.Package) is deprecated. Add 'deprecated' besides of display name."
-    $diaplayName += " (deprecated)"
+    $displayName += " (deprecated)"
   }
   return $displayName
 }

--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -1,46 +1,47 @@
 function GetPackageKey($pkg) {
-    $pkgKey = $pkg.Package
-    $groupId = $null
-  
-    if ($pkg.PSObject.Members.Name -contains "GroupId") {
-      $groupId = $pkg.GroupId
-    }
-  
-    if ($groupId) {
-      $pkgKey = "${groupId}:${pkgKey}"
-    }
-  
-    return $pkgKey
-  }
-  
-  # Different language needs a different way to index the package. Build a map in convienice to lookup the package.
-  # E.g. <groupId>:<packageName> is the package key in java.
-  function GetPackageLookup($packageList) {
-    $packageLookup = @{}
-  
-    foreach ($pkg in $packageList) {
-      $pkgKey = GetPackageKey $pkg
-  
-      # We want to prefer updating non-hidden packages but if there is only
-      # a hidden entry then we will return that
-      if (!$packageLookup.ContainsKey($pkgKey) -or $packageLookup[$pkgKey].Hide -eq "true") {
-        $packageLookup[$pkgKey] = $pkg
-      }
-      else {
-        # Warn if there are more then one non-hidden package
-        if ($pkg.Hide -ne "true") {
-          Write-Host "Found more than one package entry for $($pkg.Package) selecting the first non-hidden one."
-        }
-      }
-    }
-    return $packageLookup
+  $pkgKey = $pkg.Package
+  $groupId = $null
+
+  if ($pkg.PSObject.Members.Name -contains "GroupId") {
+    $groupId = $pkg.GroupId
   }
 
-  fucntion GetDocsTocDisplayName($pkg) {
-    $displayName = $pkg.DisplayName
-    if ('deprecated' -eq $pkg.Support) {
-      LogWarning "The pkg $($pkg.Package) is deprecated. Add 'deprecated' besides of display name."
-      $diaplayName += " (deprecated)"
-    }
-    return $displayName
+  if ($groupId) {
+    $pkgKey = "${groupId}:${pkgKey}"
   }
+
+  return $pkgKey
+}
+  
+# Different language needs a different way to index the package. Build a map in convienice to lookup the package.
+# E.g. <groupId>:<packageName> is the package key in java.
+function GetPackageLookup($packageList) {
+  $packageLookup = @{}
+
+  foreach ($pkg in $packageList) {
+    $pkgKey = GetPackageKey $pkg
+
+    # We want to prefer updating non-hidden packages but if there is only
+    # a hidden entry then we will return that
+    if (!$packageLookup.ContainsKey($pkgKey) -or $packageLookup[$pkgKey].Hide -eq "true") {
+      $packageLookup[$pkgKey] = $pkg
+    }
+    else {
+      # Warn if there are more then one non-hidden package
+      if ($pkg.Hide -ne "true") {
+        Write-Host "Found more than one package entry for $($pkg.Package) selecting the first non-hidden one."
+      }
+    }
+  }
+  return $packageLookup
+}
+
+# For deprecated packages, add "(deprecated)" besides of display name.
+fucntion GetDocsTocDisplayName($pkg) {
+  $displayName = $pkg.DisplayName
+  if ('deprecated' -eq $pkg.Support) {
+    LogWarning "The pkg $($pkg.Package) is deprecated. Add 'deprecated' besides of display name."
+    $diaplayName += " (deprecated)"
+  }
+  return $displayName
+}

--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -37,7 +37,7 @@ function GetPackageLookup($packageList) {
 }
 
 # For deprecated packages, add "(deprecated)" besides of display name.
-fucntion GetDocsTocDisplayName($pkg) {
+function GetDocsTocDisplayName($pkg) {
   $displayName = $pkg.DisplayName
   if ('deprecated' -eq $pkg.Support) {
     LogWarning "The pkg $($pkg.Package) is deprecated. Add 'deprecated' besides of display name."

--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -40,7 +40,7 @@ function GetPackageLookup($packageList) {
 function GetDocsTocDisplayName($pkg) {
   $displayName = $pkg.DisplayName
   if ('deprecated' -eq $pkg.Support) {
-    LogWarning "The pkg $($pkg.Package) is deprecated. Add 'deprecated' besides of display name."
+    LogWarning "The pkg $($pkg.Package) is deprecated. Adding 'deprecated' beside the display name."
     $displayName += " (deprecated)"
   }
   return $displayName

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -81,7 +81,7 @@ function GetAdjustedReadmeContent($ReadmeContent, $PackageInfo, $PackageMetadata
   # The $PackageMetadata could be $null if there is no associated metadata entry
   # based on how the metadata CSV is filtered
   $service = $PackageInfo.ServiceDirectory.ToLower()
-  if ($PackageMetadata -and $PackageMetadata.MSDocService) {
+  if ($PackageMetadata -and $PackageMetadata.MSDocService -and 'placeholder' -ine $PackageMetadata.MSDocService) {
     # Use MSDocService in csv metadata to override the service directory
     # TODO: Use taxonomy for service name -- https://github.com/Azure/azure-sdk-tools/issues/1442
     $service = $PackageMetadata.MSDocService

--- a/eng/common/scripts/Update-DocsMsPackages.ps1
+++ b/eng/common/scripts/Update-DocsMsPackages.ps1
@@ -80,7 +80,7 @@ function GetDocsMetadataForMoniker($moniker) {
 }
 function GetDocsMetadata() {
   # Read metadata from CSV
-  $csvMetadata = (Get-CSVMetadata).Where({ $_.New -eq 'true' -and $_.Hide -ne 'true' })
+  $csvMetadata = (Get-CSVMetadata).Where({ ($_.New -eq 'true' -or $_.MSDocService -ne '') -and $_.Hide -ne 'true'})
 
   # Read metadata from docs repo
   $metadataByPackage = @{}

--- a/eng/common/scripts/common.ps1
+++ b/eng/common/scripts/common.ps1
@@ -15,6 +15,7 @@ $EngScriptsDir = Join-Path $EngDir "scripts"
 . (Join-Path $EngCommonScriptsDir Invoke-DevOpsAPI.ps1)
 . (Join-Path $EngCommonScriptsDir artifact-metadata-parsing.ps1)
 . (Join-Path $EngCommonScriptsDir "Helpers" git-helpers.ps1)
+. (Join-Path $EngCommonScriptsDir "Helpers" Package-Helpers.ps1)
 
 # Setting expected from common languages settings
 $Language = "Unknown"


### PR DESCRIPTION
**Problem**:
For package which is not "New" to csv, we have to use package.json to onboard the package. However, the best practice is to depend on csv file as many as possible. The PR change here is to add flexibility to use csv to onboard a new package.

**New onboard rule:**
1. If package sets "New" to true, then we will onboard the package.
2. If package sets some value to "MSDocService", then we will onboard the package. 
3. If nothing set for these two fields, then the package will not onboard to Docs.Ms.

**Pros:**
In this way, we can also push people to update `ms.service` as many as possible. If somehow we don't have the right `ms.service`, then we can use `placeholder` for temporary placement.

Testing onboarding logic:
1. Testing in Java, removed the `durabletask-azure-functions` in [package.json](https://github.com/azure-sdk/azure-docs-sdk-java/blob/main/package.json)
2. `durabletask-azure-functions` in csv is having `functions` in `MsDocService`, and `false` in `New`.
3. After docindex pipeline, the changes show up here: https://github.com/Azure/azure-docs-sdk-java/blob/daily/2022-12-15/package.json#L1054
<img width="544" alt="image" src="https://user-images.githubusercontent.com/48036328/208503572-d292b6a6-1eec-41f1-b112-b37e7d8307a6.png">

Testing on deprecated message:
1. .NET testing PR: https://github.com/Azure/azure-sdk-for-net/pull/33109
2. Testing on review site: https://review.learn.microsoft.com/en-us/dotnet/api/overview/azure/storage?view=azure-dotnet&branch=daily%2F2022-12-15-ci-succeeded
<img width="321" alt="image" src="https://user-images.githubusercontent.com/48036328/208749147-61c46ea3-5f58-489a-ac02-bd9e54ad6c55.png">
