### PR TITLE
[Cadl APIView] Show Aliases in their own category within navigation

### DIFF
--- a/tools/apiview/emitters/cadl-apiview/CHANGELOG.md
+++ b/tools/apiview/emitters/cadl-apiview/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## Version 0.3.2 (12-20-2022)
+Changed structure of APIView navigation so that aliases appear under a separate "Alias" section, instead of
+  within the existing "Models" section. Will likely result in a non-API-related diff with prior APIView versions.
+
 ## Version 0.3.1 (12-9-2022)
 Support Cadl scalars.
 

--- a/tools/apiview/emitters/cadl-apiview/package.json
+++ b/tools/apiview/emitters/cadl-apiview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/cadl-apiview",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "author": "Microsoft Corporation",
   "description": "Cadl library for emitting APIView token files from Cadl specifications",
   "homepage": "https://github.com/Azure/azure-sdk-tools",

--- a/tools/apiview/emitters/cadl-apiview/src/apiview.ts
+++ b/tools/apiview/emitters/cadl-apiview/src/apiview.ts
@@ -828,6 +828,10 @@ export class ApiView {
       this.tokenize(node);
       this.blankLines(1);
     }
+    for (const node of model.aliases.values()) {
+        this.tokenize(node);
+        this.blankLines(1);
+    }  
     this.endGroup();
     this.newline();
     this.namespaceStack.pop();

--- a/tools/apiview/emitters/cadl-apiview/src/namespace-model.ts
+++ b/tools/apiview/emitters/cadl-apiview/src/namespace-model.ts
@@ -47,7 +47,6 @@ export class NamespaceModel {
   >();
   models = new Map<
     string,
-    | AliasStatementNode
     | ModelStatementNode
     | ModelExpressionNode
     | IntersectionExpressionNode
@@ -57,6 +56,7 @@ export class NamespaceModel {
     | UnionStatementNode
     | UnionExpressionNode
   >();
+  aliases = new Map<string, AliasStatementNode>;
   augmentDecorators = new Array<AugmentDecoratorStatementNode>();
 
   constructor(name: string, ns: Namespace, program: Program) {
@@ -99,8 +99,10 @@ export class NamespaceModel {
     for (const [scalarName, sc] of ns.scalars) {
       this.models.set(scalarName, sc.node);
     }
+
+    // Gather aliases
     for (const alias of findNodes(SyntaxKind.AliasStatement, program, ns)) {
-      this.models.set(alias.id.sv, alias);
+      this.aliases.set(alias.id.sv, alias);
     }
 
     // collect augment decorators
@@ -109,9 +111,10 @@ export class NamespaceModel {
     }
 
     // sort operations and models
-    this.operations = new Map([...this.operations].sort(caseInsenstiveSort));
-    this.resources = new Map([...this.resources].sort(caseInsenstiveSort));
-    this.models = new Map([...this.models].sort(caseInsenstiveSort));
+    this.operations = new Map([...this.operations].sort(caseInsensitiveSort));
+    this.resources = new Map([...this.resources].sort(caseInsensitiveSort));
+    this.models = new Map([...this.models].sort(caseInsensitiveSort));
+    this.aliases = new Map([...this.aliases].sort(caseInsensitiveSort));
   }
 
   /**
@@ -270,7 +273,7 @@ export function generateId(obj: BaseNode | NamespaceModel | undefined): string |
   }
 }
 
-function caseInsenstiveSort(a: [string, any], b: [string, any]): number {
+function caseInsensitiveSort(a: [string, any], b: [string, any]): number {
   const aLower = a[0].toLowerCase();
   const bLower = b[0].toLowerCase();
   return aLower > bLower ? 1 : (aLower < bLower ? -1 : 0);

--- a/tools/apiview/emitters/cadl-apiview/src/navigation.ts
+++ b/tools/apiview/emitters/cadl-apiview/src/navigation.ts
@@ -12,7 +12,7 @@ import {
   UnionExpressionNode,
   UnionStatementNode,
 } from "@cadl-lang/compiler";
-import { NamespaceStack } from "./apiview.js";
+import { ApiView, NamespaceStack } from "./apiview.js";
 import { NamespaceModel } from "./namespace-model.js";
 
 export class ApiViewNavigation {
@@ -55,6 +55,10 @@ export class ApiViewNavigation {
         for (const node of objNode.models.values()) {
           modelItems.push(new ApiViewNavigation(node, stack));
         }
+        const aliasItems = new Array<ApiViewNavigation>();
+        for (const node of objNode.aliases.values()) {
+            aliasItems.push(new ApiViewNavigation(node, stack));
+        }
         this.ChildItems = [];
         if (operationItems.length) {
           this.ChildItems.push({ Text: "Operations", ChildItems: operationItems, Tags: { TypeKind: ApiViewNavigationKind.Method }, NavigationId: "" });
@@ -64,6 +68,9 @@ export class ApiViewNavigation {
         }
         if (modelItems.length) {
           this.ChildItems.push({ Text: "Models", ChildItems: modelItems, Tags: { TypeKind: ApiViewNavigationKind.Class }, NavigationId: "" });
+        }
+        if (aliasItems.length) {
+            this.ChildItems.push({ Text: "Aliases", ChildItems: aliasItems, Tags: { TypeKind: ApiViewNavigationKind.Class }, NavigationId: "" });
         }
         break;
       case SyntaxKind.ModelStatement:

--- a/tools/apiview/emitters/cadl-apiview/src/version.ts
+++ b/tools/apiview/emitters/cadl-apiview/src/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "0.3.1";
+export const LIB_VERSION = "0.3.2";


### PR DESCRIPTION
Fixes #4977.

Example for OpenAI Inference:
https://apiviewstaging.azurewebsites.net/Assemblies/Review/05b84c030c904b208aa0eefbe5a8b55f