### PR TITLE
Update perf-automation to `net6.0`; get rid of remaining, now no-op, overrides of `DotNetCoreVersion`

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -1,9 +1,9 @@
 ﻿Languages:
   Net:
     DefaultVersions:
-    - net6.0
+    - netcoreapp3.1
     OptionalVersions:
-    - net7.0
+    - net6.0
 
   Java:
     DefaultVersions:

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -1,9 +1,9 @@
 ﻿Languages:
   Net:
     DefaultVersions:
-    - netcoreapp3.1
-    OptionalVersions:
     - net6.0
+    OptionalVersions:
+    - net7.0
 
   Java:
     DefaultVersions:

--- a/tools/perf-automation/ci.yml
+++ b/tools/perf-automation/ci.yml
@@ -25,4 +25,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/perf-automation
-    DotNetCoreVersion: "6.x"

--- a/tools/pipeline-owners-extractor/ci.yml
+++ b/tools/pipeline-owners-extractor/ci.yml
@@ -25,4 +25,3 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/pipeline-owners-extractor
-    DotNetCoreVersion: 6.x

--- a/tools/stress-cluster/services/Stress.Watcher/ci.yml
+++ b/tools/stress-cluster/services/Stress.Watcher/ci.yml
@@ -25,5 +25,4 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/stress-cluster/services/Stress.Watcher
-    DotNetCoreVersion: "6.0.x"
     NoWarn: true

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -25,7 +25,6 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/test-proxy
-    DotNetCoreVersion: "6.x"
     DockerTagPrefix: '1.0.0-dev.'
     DockerDeployments:
     - name: test_proxy_linux


### PR DESCRIPTION
This PR:

- contributes to addressing #4888;
- migrates `perf-automation` to `net6.0`, per https://github.com/Azure/azure-sdk-tools/issues/4888#issuecomment-1356639653;
- removes obsolete `DotNetCoreVersion` overrides, which no longer make sense since the default .NET version was changed to `6.x` in #4916. For full list of relevant PRs doing .NET version migration, see https://github.com/Azure/azure-sdk-tools/issues/4888#issuecomment-1356639653.