### PR TITLE
Update Ubuntu images in `tools/sdk-generation-pipeline` to Ubuntu 22.04

### DIFF
--- a/tools/sdk-generation-pipeline/.github/workflows/ci.yml
+++ b/tools/sdk-generation-pipeline/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [ "main" ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tools/sdk-generation-pipeline/Dockerfile
+++ b/tools/sdk-generation-pipeline/Dockerfile
@@ -31,7 +31,7 @@ RUN apt install python3-pip -y && apt install python3-venv -y && pip3 install --
 RUN add-apt-repository ppa:deadsnakes/ppa -y && apt-get install python3.10 -y && apt-get install python3.10-venv -y
 
 # install powershell
-RUN wget -q https://packages.microsoft.com/config/ubuntu/20.04/packages-microsoft-prod.deb
+RUN wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb
 RUN dpkg -i packages-microsoft-prod.deb
 RUN apt-get update && apt-get install -y powershell
 RUN rm packages-microsoft-prod.deb

--- a/tools/sdk-generation-pipeline/ci.yml
+++ b/tools/sdk-generation-pipeline/ci.yml
@@ -42,8 +42,8 @@ variables:
     value: $(Build.ArtifactStagingDirectory)
 
 pool:
-  name: "azsdk-pool-mms-ubuntu-2004-general"
-  vmImage: "MMSUbuntu20.04"
+  name: azsdk-pool-mms-ubuntu-2204-general
+  vmImage: MMSUbuntu22.04
   
 stages:
   - stage: Build

--- a/tools/sdk-generation-pipeline/documents/task-engine/README.md
+++ b/tools/sdk-generation-pipeline/documents/task-engine/README.md
@@ -20,7 +20,7 @@ SDK Automation is launched in azure pipeline. It runs tasks in the following ste
 
 ### CodegenToSdkConfig
 This is type of file `./codegen_to_sdk_config.json` in sdk repo.
-The running environment of these scripts would be expected to be __Ubuntu 20.04__ on Azure Pipeline. This may change in the future. All the running script should be executable.
+The running environment of these scripts would be expected to be __Ubuntu 22.04__ on Azure Pipeline. This may change in the future. All the running script should be executable.
 The working folder of all the scripts is the __root folder of sdk repo__.
 
 #### CodegenToSdkConfig Example

--- a/tools/sdk-generation-pipeline/sdk-generation-pipeline.yml
+++ b/tools/sdk-generation-pipeline/sdk-generation-pipeline.yml
@@ -82,8 +82,8 @@ stages:
     jobs:
       - job: SdkGeneration
         pool:
-          name: azsdk-pool-mms-ubuntu-2004-general
-          vmImage: MMSUbuntu20.04
+          name: azsdk-pool-mms-ubuntu-2204-general
+          vmImage: MMSUbuntu22.04
         timeoutInMinutes: 180
         displayName: ${{ parameters.sdkToGenerate }}-${{ parameters.serviceType }}-${{ parameters.service }}
         steps:


### PR DESCRIPTION
This is a companion PR to:
- #4996

In this PR, I migrate all occurrences of Ubuntu to `22.04` in the directory `tools/sdk-generation-pipeline`.

This PR is part of work on:
- #5178

This PR requires review by @dw511214992, notably because of this comment:
- https://github.com/Azure/azure-sdk-tools/pull/4996#discussion_r1052977794

@dw511214992 could you let me know what else needs to be done so that we can migrate `tools/sdk-generation-pipeline` to Ubuntu 22.04? For example, how to migrate the docker image? Could I assist somehow with this? Note we want to do this migration to avoid issues like #4888 and get all the usual benefits on staying up to date with the newest image.

Also please note this PR currently causes [the build to fail on Go integration tests](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2069511&view=logs&j=46f7c609-157b-5ecf-ad71-5099ca1c8979&t=d8ca8b56-f5e3-544d-457e-eba43fd35a30). I would appreciate any assistance with fixing this failure.