### PR TITLE
Update Ubuntu images in `eng/common` to Ubuntu 22.04

### DIFF
--- a/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
+++ b/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
@@ -27,10 +27,10 @@ parameters:
   default: []
 - name: Pool
   type: string
-  default: azsdk-pool-mms-ubuntu-2004-general
+  default: azsdk-pool-mms-ubuntu-2204-general
 - name: OsVmImage
   type: string
-  default: MMSUbuntu20.04
+  default: MMSUbuntu22.04
 # This parameter is only necessary if there are multiple invocations of this template within the SAME STAGE.
 # When that occurs, provide a name other than the default value.
 - name: GenerateJobName

--- a/eng/common/pipelines/templates/jobs/perf.yml
+++ b/eng/common/pipelines/templates/jobs/perf.yml
@@ -4,10 +4,10 @@ parameters:
   default: 'Perf'
 - name: LinuxPool
   type: string
-  default: 'azsdk-pool-mms-ubuntu-2004-perf'
+  default: azsdk-pool-mms-ubuntu-2204-perf
 - name: LinuxVmImage
   type: string
-  default: 'MMSUbuntu20.04'
+  default: MMSUbuntu22.04
 - name: WindowsPool
   type: string
   default: 'azsdk-pool-mms-win-2019-perf'

--- a/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
@@ -20,8 +20,8 @@ parameters:
 jobs:
 - job: PreparePipelines
   pool:
-    name: azsdk-pool-mms-ubuntu-2004-general
-    vmImage: MMSUbuntu20.04
+    name: azsdk-pool-mms-ubuntu-2204-general
+    vmImage: MMSUbuntu22.04
   steps:
     - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
     - template: /eng/common/pipelines/templates/steps/set-default-branch.yml


### PR DESCRIPTION
This is a companion PR to:
- #4996

In this PR, I migrate all occurrences of Ubuntu to `22.04` in the directory `eng/common`, but excluding `eng/commons/scripts/job-matrix`, as this it will be handled by:
- #4995