### PR TITLE
Update `ubuntu-latest` images: set them to Ubuntu 22.04 XOR comment they are `latest` intentionally

### DIFF
--- a/.github/workflows/event.yml
+++ b/.github/workflows/event.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write # to read pull requests and write comments (azure/azure-sdk-actions)
       checks: read # to read check status (azure/azure-sdk-actions)
     name: Handle ${{ github.event_name }} ${{ github.event.action }} event
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # This image is intentionally set to "latest", and not to a specific version
     steps:
       - uses: azure/azure-sdk-actions@main
         with:

--- a/.github/workflows/label-to-project.yml
+++ b/.github/workflows/label-to-project.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check_issue_label:
     name: Check label on issue
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # This image is intentionally set to "latest", and not to a specific version
 
     steps:
       - uses: actions/checkout@v3

--- a/eng/pipelines/setup-tutorial-branch.yml
+++ b/eng/pipelines/setup-tutorial-branch.yml
@@ -44,7 +44,8 @@ variables:
 jobs:
 - job: SetupTutorialBranch
   pool:
-    vmImage: 'ubuntu-latest'
+    name: azsdk-pool-mms-ubuntu-2004-general
+    vmImage: MMSUbuntu22.04
   steps:
     - task: PowerShell@2
       displayName: 'Setup Tutorial Branch'

--- a/tools/js-sdk-release-tools/ci.yml
+++ b/tools/js-sdk-release-tools/ci.yml
@@ -46,7 +46,7 @@ stages:
         strategy:
           matrix:
             linux:
-              imageName: 'ubuntu-latest'
+              imageName: ubuntu-22.04 # This image is intentionally set to "latest", and not to a specific version
             mac:
               imageName: 'macos-latest'
             windows:

--- a/tools/js-sdk-release-tools/ci.yml
+++ b/tools/js-sdk-release-tools/ci.yml
@@ -46,7 +46,7 @@ stages:
         strategy:
           matrix:
             linux:
-              imageName: ubuntu-22.04 # This image is intentionally set to "latest", and not to a specific version
+              imageName: ubuntu-22.04
             mac:
               imageName: 'macos-latest'
             windows:

--- a/tools/mock-service-host/ci.yml
+++ b/tools/mock-service-host/ci.yml
@@ -43,7 +43,7 @@ stages:
         strategy:
           matrix:
             linux:
-              imageName: 'ubuntu-latest'
+              imageName: ubuntu-22.04
             mac:
               imageName: 'macos-latest'
             windows:

--- a/tools/sdk-testgen/ci.yml
+++ b/tools/sdk-testgen/ci.yml
@@ -26,7 +26,8 @@ pr:
       - tools/sdk-testgen
 
 pool:
-  vmImage: "ubuntu-latest"
+  name: azsdk-pool-mms-ubuntu-2204-general
+  vmImage: MMSUbuntu22.04
 
 variables:
   NugetSecurityAnalysisWarningLevel: "none"


### PR DESCRIPTION
This is a companion PR to:
- #4996

In this PR, I migrate occurrences of `ubuntu-latest` to Ubuntu 22.04 XOR I add a comment explaining they are intentionally set to `latest`.

I do not have enough context to guess which images should be updated - this is just my best guess. Thus I kindly ask reviewers to verify if my guess is correct.

This PR has revealed following issue:
- #5102