### PR TITLE
Improve diagnostic output + refactor handling of packages-to-be-published directory in `archetype-sdk-tool-dotnet.yml`

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -52,7 +52,8 @@ variables:
       value: -warnaserror
   # A path to directory to contain the output of "dotnet pack" call,
   # to be consumed as input by "publish" task.
-  - packagesToPublishDir: $(Build.ArtifactStagingDirectory)/packages
+  - name: packagesToPublishDir
+    value: $(Build.ArtifactStagingDirectory)/packages
 
 stages:
   - stage: BuildTestAndPackage

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -93,6 +93,8 @@ stages:
                 Write-Host "Created directory $(Build.ArtifactStagingDirectory)/packages"
               } else {
                 Write-Host "Directory $(Build.ArtifactStagingDirectory)/packages already exists. Nothing to do."
+                Write-Host" Directory contents:"
+                Get-ChildItem $(Build.ArtifactStagingDirectory)/packages | ForEach-Object { Write-Host $_ }
               }
             displayName: Create directory for packages to publish if absent
 

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -90,10 +90,10 @@ stages:
           - pwsh: |
               if (!(Test-Path -PathType container "$(Build.ArtifactStagingDirectory)/packages")) {
                 New-Item -ItemType Directory -Path "$(Build.ArtifactStagingDirectory)/packages"
-                Write-Host "Created directory $(Build.ArtifactStagingDirectory)/packages"
+                Write-Host "Created directory ""$(Build.ArtifactStagingDirectory)/packages"""
               } else {
-                Write-Host "Directory $(Build.ArtifactStagingDirectory)/packages already exists. Nothing to do."
-                Write-Host "Directory $(Build.ArtifactStagingDirectory)/packages contents:"
+                Write-Host "Directory ""$(Build.ArtifactStagingDirectory)/packages"" already exists. Nothing to do."
+                Write-Host "Directory ""$(Build.ArtifactStagingDirectory)/packages"" contents:"
                 Get-ChildItem $(Build.ArtifactStagingDirectory)/packages | ForEach-Object { Write-Host $_ }
               }
             displayName: Create directory for packages to publish if absent

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -93,7 +93,7 @@ stages:
                 Write-Host "Created directory $(Build.ArtifactStagingDirectory)/packages"
               } else {
                 Write-Host "Directory $(Build.ArtifactStagingDirectory)/packages already exists. Nothing to do."
-                Write-Host "Directory contents:"
+                Write-Host "Directory $(Build.ArtifactStagingDirectory)/packages contents:"
                 Get-ChildItem $(Build.ArtifactStagingDirectory)/packages | ForEach-Object { Write-Host $_ }
               }
             displayName: Create directory for packages to publish if absent

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -50,6 +50,9 @@ variables:
       value: ''
     ${{ if not(parameters.NoWarn) }}:
       value: -warnaserror
+  # A path to directory to contain the output of "dotnet pack" call,
+  # to be consumed as input by "publish" task.
+  - packagesToPublishDir: $(Build.ArtifactStagingDirectory)/packages
 
 stages:
   - stage: BuildTestAndPackage
@@ -69,7 +72,7 @@ stages:
             inputs:
               version: '${{ coalesce( parameters.DotNetCoreVersion, variables.DotNetCoreVersion) }}'
 
-          - script: 'dotnet pack /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory)/packages $(Warn) -c Release'
+          - script: 'dotnet pack /p:ArtifactsPackagesDir=$(packagesToPublishDir) $(Warn) -c Release'
             displayName: 'Build and Package'
             workingDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
             env:
@@ -83,22 +86,22 @@ stages:
               BuildMatrix: ${{ parameters.StandaloneExeMatrix }}
               TargetDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
 
-          # This step creates "$(Build.ArtifactStagingDirectory)/packages" directory if it doesn't exist.
+          # This step creates "$(packagesToPublishDir)" directory if it doesn't exist.
           # This step is necessary since migration to net6.0. This is because since net6.0, 
           # in case the "Build and Package" above would not output any packages to this directory, 
           # the "Publish to packages artifact" step below would fail on missing directory.
           - pwsh: |
-              if (!(Test-Path -PathType container "$(Build.ArtifactStagingDirectory)/packages")) {
-                New-Item -ItemType Directory -Path "$(Build.ArtifactStagingDirectory)/packages"
-                Write-Host "Created directory ""$(Build.ArtifactStagingDirectory)/packages"""
+              if (!(Test-Path -PathType container "$(packagesToPublishDir)")) {
+                New-Item -ItemType Directory -Path "$(packagesToPublishDir)"
+                Write-Host "Created directory ""$(packagesToPublishDir)"""
               } else {
-                Write-Host "Directory ""$(Build.ArtifactStagingDirectory)/packages"" already exists. Nothing to do."
-                Write-Host "Directory ""$(Build.ArtifactStagingDirectory)/packages"" contents:"
-                Get-ChildItem $(Build.ArtifactStagingDirectory)/packages | ForEach-Object { Write-Host $_ }
+                Write-Host "Directory ""$(packagesToPublishDir)"" already exists. Nothing to do."
+                Write-Host "Directory ""$(packagesToPublishDir)"" contents:"
+                Get-ChildItem $(packagesToPublishDir) | ForEach-Object { Write-Host $_ }
               }
-            displayName: Create directory for packages to publish if absent
+            displayName: Create XOR list contents of directory of packages to publish
 
-          - publish: $(Build.ArtifactStagingDirectory)/packages
+          - publish: $(packagesToPublishDir)
             displayName: Publish to packages artifact
             artifact: packages
             condition: succeededOrFailed()

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -93,7 +93,7 @@ stages:
                 Write-Host "Created directory $(Build.ArtifactStagingDirectory)/packages"
               } else {
                 Write-Host "Directory $(Build.ArtifactStagingDirectory)/packages already exists. Nothing to do."
-                Write-Host" Directory contents:"
+                Write-Host "Directory contents:"
                 Get-ChildItem $(Build.ArtifactStagingDirectory)/packages | ForEach-Object { Write-Host $_ }
               }
             displayName: Create directory for packages to publish if absent

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -18,8 +18,9 @@ parameters:
 
 steps:
   - pwsh: |
-      mkdir -p "$(Build.ArtifactStagingDirectory)/binaries"
-    displayName: Create destination directory
+      New-Item -ItemType Directory -Path "$(Build.ArtifactStagingDirectory)/binaries"
+      Write-Host "Created directory ""$(Build.ArtifactStagingDirectory)/binaries"""
+    displayName: Create .NET standalone packs destination directory
 
   - ${{ each target in parameters.BuildMatrix }}:
     - pwsh: |

--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -18,7 +18,7 @@ parameters:
 
 steps:
   - pwsh: |
-      New-Item -ItemType Directory -Path "$(Build.ArtifactStagingDirectory)/binaries"
+      New-Item -ItemType Directory -Path "$(Build.ArtifactStagingDirectory)/binaries" -Force
       Write-Host "Created directory ""$(Build.ArtifactStagingDirectory)/binaries"""
     displayName: Create .NET standalone packs destination directory
 


### PR DESCRIPTION
This PR addresses following comment:
- https://github.com/Azure/azure-sdk-tools/pull/4916#discussion_r1049896767

### Changes made

- added variable to deduplicate `$(Build.ArtifactStagingDirectory)/packages`;
- now listing contents of `$(Build.ArtifactStagingDirectory)/packages`;
- made improvements to task message and name;
- also improved the name and diagnostic output of `Create destination directory` task, coming from [produce-net-standalone-packs.yml](https://github.com/Azure/azure-sdk-tools/pull/5007/files#diff-79ac80271b4abca08d08ecc17c0ade284347c8a119af78c01889600d30b264fa), as it was too vague and misleading.

### Testing done

Tested by making a build from this PR branch and observing it behaved correctly:
- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2069738&view=logs&j=6d7966cd-0423-5022-78e0-a1ae4dd99f62&t=bddaeae6-38f3-5452-e64d-884acb9e7471
- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2069738&view=logs&j=6d7966cd-0423-5022-78e0-a1ae4dd99f62&t=15333f4d-654b-5473-4de1-6eb96caccf39