### PR TITLE
Update `archetype-sdk-tool-dotnet.yml` to use `global.json` via `install-net.yaml`

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -63,11 +63,7 @@ stages:
         displayName: Build and Package
 
         steps:
-          - task: UseDotNet@2
-            condition: eq(${{ parameters.SkipDotNetInstall }}, false)
-            displayName: 'Use .NET Core sdk ${{ coalesce( parameters.DotNetCoreVersion, variables.DotNetCoreVersion) }}'
-            inputs:
-              version: '${{ coalesce( parameters.DotNetCoreVersion, variables.DotNetCoreVersion) }}'
+          - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
           - script: 'dotnet pack /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory)/packages $(Warn) -c Release'
             displayName: 'Build and Package'

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -1,0 +1,21 @@
+# As of 12/20/2022 this is work in progress.
+# Please see:
+# https://github.com/Azure/azure-sdk-tools/issues/5009
+# and linked PRs.
+parameters:
+  # Use this parameter if you want to override the .NET SDK set by global.json
+  - name: DotNetCoreVersion
+    type: string
+    default: ''
+
+steps:
+  # https://learn.microsoft.com/en-us/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines
+  - task: UseDotNet@2
+    condition: eq(parameters.DotNetCoreVersion, '')
+    displayName: "Use .NET SDK ${{ coalesce( parameters.DotNetCoreVersion, 'from global.json') }}"
+    retryCountOnTaskFailure: 3
+    inputs:
+      ${{ if eq(parameters.DotNetCoreVersion, '') }}:
+        useGlobalJson: true
+      ${{ else }}:
+        version: ${{ parameters.DotNetCoreVersion }}

--- a/global.json
+++ b/global.json
@@ -1,5 +1,9 @@
 {
   "msbuild-sdks": {
     "Microsoft.Build.Traversal": "1.0.45"
+  },
+  "sdk": {
+    "version": "6.0.403",
+    "rollForward": "feature"
   }
 }


### PR DESCRIPTION
This PR contributes to:

- #5009 

### Changes made

- Added .NET SDK version to `global.json`
- Added initial version of `install-net.yml`
  - It supports `DotNetCoreVersion` param but not `SkipDotInstallNet` as we no longer use the latter
- Made `archetype-sdk-tool-dotnet.yml` call into `install-net.yml` instead of installing SDK in-line

### Testing done

TODO / Pending
