### PR TITLE
[Perf automation] Remove Eventhubs Python v5.9 from passes

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -517,8 +517,6 @@ Services:
       PrimaryPackage: azure-eventhub
       PackageVersions:
       - azure-core: 1.26.1
-        azure-eventhub: 5.9.0
-      - azure-core: 1.26.1
         azure-eventhub: 5.10.0
       - azure-core: 1.26.1
         azure-eventhub: 5.10.1


### PR DESCRIPTION
This is no longer necessary and should reduce the runtime a little.