### PR TITLE
Update `<TargetFramework>netstandard2.0` to `net6.0` in `Azure.ClientSdk.Analyzers` and `CodeOwnersParser`

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <BuildOutputTargetFolder>analyzers/dotnet/cs/</BuildOutputTargetFolder>
     <VersionPrefix>0.1.1</VersionPrefix>
     <LangVersion>8</LangVersion>

--- a/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
+++ b/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Contributes to:

- #4888 

By updating all projects whose `TargetFramework` was `nestandard2.0` to `net6.0`.

Notably it does leftover update to `CodeOwnersParser`, which was missed by this PR:

- #4937

Note that this PR might require a follow-up package update, same as it was done b this PR:

- #4988

For a list of all PRs doing migration to `net6.0`, see this comment:
- https://github.com/Azure/azure-sdk-tools/issues/4888#issuecomment-1356639653

## Tests done

- `APIView` build, the only tool iun `azure-sdk-tools` that depends on `Azure.ClientSdk.Analyzers`:
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2083442&view=results