### PR TITLE
Add glob-based support for wildcards in `CODEOWNERS` file parser (disabled, behind a feature flag)

### DIFF
--- a/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/Azure.Sdk.Tools.CodeOwnersParser.Tests.csproj
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/Azure.Sdk.Tools.CodeOwnersParser.Tests.csproj
@@ -2,26 +2,22 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
+    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.2.1" />
     <PackageReference Include="NUnit.Analyzers" Version="3.3.0" />
     <PackageReference Include="coverlet.collector" Version="3.1.2" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Azure.Sdk.Tools.RetrieveCodeOwners\Azure.Sdk.Tools.RetrieveCodeOwners.csproj" />
+    <ProjectReference Include="..\CodeOwnersParser\Azure.Sdk.Tools.CodeOwnersParser.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="CODEOWNERS">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
 </Project>

--- a/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs
@@ -78,13 +78,21 @@ public class CodeOwnersFileTests
         new(       "*10" ,   "a/b/cxy/d" , "/**/*x*/" ,  false , true  ),
         new(        "1*" ,           "a" , "*"        ,  false , true  ),
         new(        "2*" ,         "a/b" , "a/*"      ,  false , true  ),
-        new(        "3*" ,       "x/a/b" , "a/*"      ,  false , false ),
-        new(        "4*" ,         "a/b" , "a/*/*"    ,  false , false ),
-        new(        "5*" ,     "a/b/c/d" , "a/*/*/d"  ,  false , true  ),
-        new(        "6*" ,   "a/b/x/c/d" , "a/*/*/d"  ,  false , false ),
-        new(        "7*" ,   "a/b/x/c/d" , "a/**/*/d" ,  false , true  ),
+        // There is discrepancy between GitHub CODEOWNERS behavior [1] and .gitignore behavior here
+        // CODEOWNERS will not match this path, while .gitignore will
+        // [1] The "docs/*" example in https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+        // [2] Confirmed empirically. The .gitignore will match "a/*" to "a/b" and thus ignore everything.
+        new(        "3*" ,       "a/b/c" , "a/*"      ,  false , true  ),
+        new(        "4*" ,       "x/a/b" , "a/*"      ,  false , false ),
+        new(       "1*/" ,         "a/b" , "a/*/"     ,  false , false ),
+        new(       "2*/" ,        "a/b/" , "a/*/"     ,  false , true  ),
+        new(       "3*/" ,       "a/b/c" , "a/*/"     ,  false , true  ),
+        new(      "1*/*" ,         "a/b" , "a/*/*"    ,  false , false ),
+        new(      "2*/*" ,     "a/b/c/d" , "a/*/*/d"  ,  false , true  ),
+        new(      "3*/*" ,   "a/b/x/c/d" , "a/*/*/d"  ,  false , false ),
+        new(     "1**/*" ,   "a/b/x/c/d" , "a/**/*/d" ,  false , true  ),
         new(        "*1" ,         "a/b" , "*/b"      ,  false , true  ),
-        new(        "*2" ,         "a/b" , "*/*/b"    ,  false , false ),
+        new(      "*/*1" ,         "a/b" , "*/*/b"    ,  false , false ),
         new(       "1**" ,           "a" , "a/**"     ,  false , false ),
         new(       "2**" ,          "a/" , "a/**"     ,  false , true  ),
         new(       "3**" ,         "a/b" , "a/**"     ,  false , true  ),
@@ -103,7 +111,7 @@ public class CodeOwnersFileTests
         // New parser should return false, but returns true due to https://github.com/dotnet/runtime/issues/80076
         // TODO globbug1 actually covers-up problem with the parser, where it converts "*" to "**/*".
         new(  "globbug1" ,         "a/b" , "*"        ,  false , true  ),
-        new(  "globbug2" ,         "a/b" , "a/*"      ,  false , true  )
+        new(  "globbug2" ,      "a/b/c/" , "a/*/"     ,  false , true  )
         // @formatter:on
     };
 

--- a/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs
@@ -1,0 +1,160 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.FileSystemGlobbing;
+using NUnit.Framework;
+
+namespace Azure.Sdk.Tools.CodeOwnersParser.Tests;
+
+[TestFixture]
+public class CodeOwnersFileTests
+{
+    /// <summary>
+    /// A battery of test cases specifying behavior of new logic matching target
+    /// path to CODEOWNERS entries , and comparing it to existing, legacy logic.
+    ///
+    /// The logic that has changed lives in CodeOwnersFile.FindOwnersForClosestMatch.
+    ///
+    /// The new logic supports matching against wildcards, while the old one doesn't.
+    ///
+    /// In the test case table below, any discrepancy between legacy and new
+    /// parser expected matches that doesn't pertain to wildcard matching denotes
+    /// a potential backward compatibility and/or existing defect in the legacy parser.
+    /// 
+    /// For further details, please see:
+    /// https://github.com/Azure/azure-sdk-tools/issues/2770
+    /// </summary>
+    private static readonly TestCase[] testCases =
+    {
+        // @formatter:off
+        //       TestCase:        Path:                 Expected match:
+        //           Name,        Target , Codeown.   , Legacy , New
+        new(         "1" ,           "a" , "a"        ,   true , true  ),
+        new(         "2" ,           "a" , "a/"       ,   true , false ), // New parser doesn't match as codeowners path expects directory, but it is unclear if target is directory, or not.
+        new(         "3" ,         "a/b" , "a/b"      ,   true , true  ),
+        new(         "4" ,         "a/b" , "/a/b"     ,   true , true  ),
+        new(         "5" ,         "a/b" , "a/b/"     ,   true , false ), // New parser doesn't match as codeowners path expects directory, but it is unclear if target is directory, or not.
+        new(         "6" ,        "/a/b" , "a/b"      ,   true , true  ),
+        new(         "7" ,        "/a/b" , "/a/b"     ,   true , true  ),
+        new(         "8" ,        "/a/b" , "a/b/"     ,   true , false ), // New parser doesn't match as codeowners path expects directory, but it is unclear if target is directory, or not.
+        new(         "9" ,        "a/b/" , "a/b"      ,   true , true  ),
+        new(        "10" ,        "a/b/" , "/a/b"     ,   true , true  ),
+        new(        "11" ,        "a/b/" , "a/b/"     ,   true , true  ),
+        new(        "12" ,       "/a/b/" , "a/b"      ,   true , true  ),
+        new(        "13" ,       "/a/b/" , "/a/b"     ,   true , true  ),
+        new(        "14" ,       "/a/b/" , "a/b/"     ,   true , true  ),
+        new(        "15" ,       "/a/b/" , "/a/b/"    ,   true , true  ),
+        new(        "16" ,      "/a/b/c" , "a/b"      ,   true , true  ),
+        new(        "17" ,      "/a/b/c" , "/a/b"     ,   true , true  ),
+        new(        "18" ,      "/a/b/c" , "a/b/"     ,   true , true  ),
+        new(        "19" ,    "/a/b/c/d" , "/a/b/"    ,   true , true  ),
+        new(    "casing" ,         "ABC" , "abc"      ,   true , false ), // New parser doesn't match as it is case-sensitive, per codeowners spec
+        new(  "chained1" ,       "a/b/c" , "a"        ,   true , true  ),
+        new(  "chained2" ,       "a/b/c" , "b"        ,  false , true  ), // New parser matches per codeowners and .gitignore spec
+        new(  "chained3" ,       "a/b/c" , "b/"       ,  false , true  ), // New parser matches per codeowners and .gitignore spec
+        new(  "chained4" ,       "a/b/c" , "c"        ,  false , true  ), // New parser matches per codeowners and .gitignore spec
+        new(  "chained5" ,       "a/b/c" , "c/"       ,  false , false ),
+        new(  "chained6" ,     "a/b/c/d" , "c/"       ,  false , true  ), // New parser matches per codeowners and .gitignore spec
+        new(  "chained7" ,   "a/b/c/d/e" , "c/"       ,  false , true  ), // New parser matches per codeowners and .gitignore spec
+        new(  "chained8" ,       "a/b/c" , "b/c"      ,  false , false ), // TODO need to verify if CODEOWNERS actually follows this rule of "middle slashes prevent path relativity" from .gitignore, or not.
+        new(  "chained9" ,           "a" , "a/b/c"    ,  false , false ),
+        new( "chained10" ,           "c" , "a/b/c"    ,  false , false ),
+        // Cases not supported by the new parser.
+        new(   "unsupp1" ,          "!a" , "!a"       ,   true , false ),
+        new(   "unsupp2" ,           "b" , "!a"       ,  false , false ),
+        new(   "unsupp3" ,        "a[b"  , "a[b"      ,   true , false ),
+        new(   "unsupp4" ,        "a]b"  , "a]b"      ,   true , false ),
+        new(   "unsupp5" ,        "a?b"  , "a?b"      ,   true , false ),
+        new(   "unsupp6" ,        "axb"  , "a?b"      ,  false , false ),
+        // The cases below test for wildcard support by the new parser. Legacy parser skips over wildcards.
+        new(       "**1" ,           "a" , "**/a"     ,  false , true  ), 
+        new(       "**2" ,           "a" , "**/b/a"   ,  false , false ), 
+        new(       "**3" ,           "a" , "**/a/b"   ,  false , false ), 
+        new(       "**4" ,           "a" , "/**/a"    ,  false , true  ),
+        new(       "**5" ,         "a/b" , "a/**/b"   ,  false , true  ),
+        new(       "**6" ,       "a/x/b" , "a/**/b"   ,  false , true  ),
+        new(       "**7" ,       "a/y/b" , "a/**/b"   ,  false , true  ),
+        new(       "**8" ,     "a/x/y/b" , "a/**/b"   ,  false , true  ),
+        new(       "**9" ,   "c/a/x/y/b" , "a/**/b"   ,  false , false ),
+        new(       "*10" ,   "a/b/cxy/d" , "/**/*x*/" ,  false , true  ),
+        new(        "1*" ,           "a" , "*"        ,  false , true  ),
+        new(        "2*" ,         "a/b" , "a/*"      ,  false , true  ),
+        new(        "3*" ,       "x/a/b" , "a/*"      ,  false , false ),
+        new(        "4*" ,         "a/b" , "a/*/*"    ,  false , false ),
+        new(        "5*" ,     "a/b/c/d" , "a/*/*/d"  ,  false , true  ),
+        new(        "6*" ,   "a/b/x/c/d" , "a/*/*/d"  ,  false , false ),
+        new(        "7*" ,   "a/b/x/c/d" , "a/**/*/d" ,  false , true  ),
+        new(        "*1" ,         "a/b" , "*/b"      ,  false , true  ),
+        new(        "*2" ,         "a/b" , "*/*/b"    ,  false , false ),
+        new(       "1**" ,           "a" , "a/**"     ,  false , false ),
+        new(       "2**" ,          "a/" , "a/**"     ,  false , true  ),
+        new(       "3**" ,         "a/b" , "a/**"     ,  false , true  ),
+        new(       "4**" ,        "a/b/" , "a/**"     ,  false , true  ),
+        new(    "*.ext1" ,      "a/x.md" , "*.md"     ,  false , true  ),
+        new(    "*.ext2" ,    "a/b/x.md" , "*.md"     ,  false , true  ),
+        new(    "*.ext3" , "a/b.md/x.md" , "*.md"     ,  false , true  ),
+        new(    "*.ext4" ,        "a/md" , "*.md"     ,  false , false ),
+        new(    "*.ext5" ,         "a.b" , "a.*"      ,  false , true  ),
+        new(    "*.ext6" ,        "a.b/" , "a.*"      ,  false , true  ),
+        new(    "*.ext5" ,         "a.b" , "a.*/"     ,  false , false ),
+        new(    "*.ext7" ,        "a.b/" , "a.*/"     ,  false , true  ),
+        new(    "*.ext8" ,        "a.b"  , "/a.*"     ,  false , true  ),
+        new(    "*.ext9" ,        "a.b/" , "/a.*"     ,  false , true  ),
+        new(   "*.ext10" ,      "x/a.b/" , "/a.*"     ,  false , false ),
+        // New parser should return false, but returns true due to https://github.com/dotnet/runtime/issues/80076
+        // TODO globbug1 actually covers-up problem with the parser, where it converts "*" to "**/*".
+        new(  "globbug1" ,         "a/b" , "*"        ,  false , true  ),
+        new(  "globbug2" ,         "a/b" , "a/*"      ,  false , true  )
+        // @formatter:on
+    };
+
+    /// <summary>
+    /// A repro for https://github.com/dotnet/runtime/issues/80076
+    /// </summary>
+    [Test]
+    public void TestGlobBugRepro()
+    {
+        var globMatcher = new Matcher(StringComparison.Ordinal);
+        globMatcher.AddInclude("/*/");
+
+        var dir = new InMemoryDirectoryInfo(
+            rootDir: "/", 
+            files: new List<string> { "/a/b" });
+
+        var patternMatchingResult = globMatcher.Execute(dir);
+        // The expected behavior is "Is.False", but actual behavior is "Is.True".
+        Assert.That(patternMatchingResult.HasMatches, Is.True);
+    }
+
+    /// <summary>
+    /// Exercises Azure.Sdk.Tools.CodeOwnersParser.Tests.CodeOwnersFileTests.testCases.
+    /// See comment on that member for details.
+    /// </summary>
+    [TestCaseSource(nameof(testCases))]
+    public void TestParseAndFindOwnersForClosestMatch(TestCase testCase)
+    {
+        List<CodeOwnerEntry>? codeownersEntries =
+            CodeOwnersFile.ParseContent(testCase.CodeownersPath + "@owner");
+
+        VerifyFindOwnersForClosestMatch(testCase, codeownersEntries, useNewImpl: false, testCase.ExpectedLegacyMatch);
+        VerifyFindOwnersForClosestMatch(testCase, codeownersEntries, useNewImpl: true, testCase.ExpectedNewMatch);
+    }
+
+    private static void VerifyFindOwnersForClosestMatch(TestCase testCase,
+        List<CodeOwnerEntry> codeownersEntries,
+        bool useNewImpl,
+        bool expectedMatch)
+    {
+        CodeOwnerEntry? entryLegacy =
+            // Act
+            CodeOwnersFile.FindOwnersForClosestMatch(
+                codeownersEntries,
+                testCase.TargetPath,
+                useNewFindOwnersForClosestMatchImpl: useNewImpl);
+
+        Assert.That(entryLegacy.Owners.Count, Is.EqualTo(expectedMatch ? 1 : 0));
+    }
+
+    // ReSharper disable once NotAccessedPositionalProperty.Global
+    //   Reason: Name is present to make it easier to refer to and distinguish test cases in VS test runner.
+    public record TestCase(string Name, string TargetPath, string CodeownersPath, bool ExpectedLegacyMatch, bool ExpectedNewMatch);
+}

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/MainTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/MainTests.cs
@@ -41,17 +41,17 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests
         [TestCase("https://testLink")]
         public void TestOnError(string codeOwnerPath)
         {
-            Assert.AreEqual(1, Program.Main(codeOwnerPath, "sdk"));
+            Assert.That(Program.Main(codeOwnerPath, "sdk"), Is.EqualTo(1));
         }
 
         private static void TestExpectResult(List<string> expectReturn, string output)
         {
-            CodeOwnerEntry codeOwnerEntry = JsonSerializer.Deserialize<CodeOwnerEntry>(output);
+            CodeOwnerEntry? codeOwnerEntry = JsonSerializer.Deserialize<CodeOwnerEntry>(output);
             List<string> actualReturn = codeOwnerEntry!.Owners;
-            Assert.AreEqual(expectReturn.Count, actualReturn.Count);
+            Assert.That(actualReturn.Count, Is.EqualTo(expectReturn.Count));
             for (int i = 0; i < actualReturn.Count; i++)
             {
-                Assert.AreEqual(expectReturn[i], actualReturn[i]);
+                Assert.That(actualReturn[i], Is.EqualTo(expectReturn[i]));
             }
         }
     }

--- a/tools/code-owners-parser/CodeOwnersParser.sln
+++ b/tools/code-owners-parser/CodeOwnersParser.sln
@@ -15,6 +15,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\..\eng\common\scripts\get-codeowners.ps1 = ..\..\eng\common\scripts\get-codeowners.ps1
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Azure.Sdk.Tools.CodeOwnersParser.Tests", "Azure.Sdk.Tools.CodeOwnersParser.Tests\Azure.Sdk.Tools.CodeOwnersParser.Tests.csproj", "{66C9FF6A-32DD-4C3C-ABE1-F1F58C1C8129}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -33,6 +35,10 @@ Global
 		{798B8CAC-68FC-49FD-A0F6-51C0DC4A4D1D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{798B8CAC-68FC-49FD-A0F6-51C0DC4A4D1D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{798B8CAC-68FC-49FD-A0F6-51C0DC4A4D1D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{66C9FF6A-32DD-4C3C-ABE1-F1F58C1C8129}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{66C9FF6A-32DD-4C3C-ABE1-F1F58C1C8129}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{66C9FF6A-32DD-4C3C-ABE1-F1F58C1C8129}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{66C9FF6A-32DD-4C3C-ABE1-F1F58C1C8129}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
+++ b/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLine.Net" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/code-owners-parser/CodeOwnersParser/CodeOwnersFile.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/CodeOwnersFile.cs
@@ -59,13 +59,27 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
             return entries;
         }
 
-        public static CodeOwnerEntry ParseAndFindOwnersForClosestMatch(string codeOwnersFilePathOrUrl, string targetPath)
+        public static CodeOwnerEntry ParseAndFindOwnersForClosestMatch(
+            string codeOwnersFilePathOrUrl,
+            string targetPath,
+            bool useNewFindOwnersForClosestMatchImpl = false)
         {
             var codeOwnerEntries = ParseFile(codeOwnersFilePathOrUrl);
-            return FindOwnersForClosestMatch(codeOwnerEntries, targetPath);
+            return FindOwnersForClosestMatch(codeOwnerEntries, targetPath, useNewFindOwnersForClosestMatchImpl);
         }
 
-        public static CodeOwnerEntry FindOwnersForClosestMatch(List<CodeOwnerEntry> codeOwnerEntries, string targetPath)
+        public static CodeOwnerEntry FindOwnersForClosestMatch(
+            List<CodeOwnerEntry> codeOwnerEntries,
+            string targetPath,
+            bool useNewFindOwnersForClosestMatchImpl = false)
+        {
+            return useNewFindOwnersForClosestMatchImpl
+                ? new MatchedCodeOwnerEntry(codeOwnerEntries, targetPath).Value
+                : FindOwnersForClosestMatchLegacyImpl(codeOwnerEntries, targetPath);
+        }
+
+        private static CodeOwnerEntry FindOwnersForClosestMatchLegacyImpl(List<CodeOwnerEntry> codeOwnerEntries,
+            string targetPath)
         {
             // Normalize the start and end of the paths by trimming slash
             targetPath = targetPath.Trim('/');

--- a/tools/code-owners-parser/CodeOwnersParser/MatchedCodeOwnerEntry.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/MatchedCodeOwnerEntry.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.FileSystemGlobbing;
+
+namespace Azure.Sdk.Tools.CodeOwnersParser
+{
+    /// <summary>
+    /// Represents a CODEOWNERS file entry that matched to targetPath from
+    /// the list of entries, assumed to have been parsed from CODEOWNERS file.
+    ///
+    /// To obtain the value of the matched entry, reference "Value" member.
+    /// </summary>
+    internal class MatchedCodeOwnerEntry
+    {
+        public readonly CodeOwnerEntry Value;
+
+        private static readonly char[] unsupportedChars = { '[', ']', '!', '?' };
+
+        public MatchedCodeOwnerEntry(List<CodeOwnerEntry> entries, string targetPath)
+        {
+            this.Value = FindOwnersForClosestMatch(entries, targetPath);
+        }
+
+        /// <summary>
+        /// Returns a CodeOwnerEntry from codeOwnerEntries that matches targetPath
+        /// per algorithm described in:
+        /// https://git-scm.com/docs/gitignore#_pattern_format
+        /// and
+        /// https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
+        ///
+        /// If there is no match, returns "new CodeOwnerEntry()".
+        /// </summary>
+        private static CodeOwnerEntry FindOwnersForClosestMatch(
+            List<CodeOwnerEntry> codeownersEntries,
+            string targetPath)
+        {
+            // targetPath is assumed to be absolute w.r.t. repository root, hence we ensure
+            // it starts with "/" to denote that.
+            if (!targetPath.StartsWith("/"))
+                targetPath = "/" + targetPath;
+
+            // We do not trim or add the slash ("/") at the end of the targetPath because its
+            // presence influences the matching algorithm:
+            // Slash at the end denotes the target path is a directory, not a file, so it might
+            // match against a CODEOWNERS entry that matches only directories and not files.
+
+            // Entries below take precedence, hence we read the file from the bottom up.
+            // By convention, entries in CODEOWNERS should be sorted top-down in the order of:
+            // - 'RepoPath',
+            // - 'ServicePath'
+            // - and then 'PackagePath'.
+            // However, due to lack of validation, as of 12/29/2022 this is not always the case.
+            for (int i = codeownersEntries.Count - 1; i >= 0; i--)
+            {
+                string codeownersPath = codeownersEntries[i].PathExpression;
+                if (ContainsUnsupportedCharacters(codeownersPath))
+                {
+                    continue;
+                }
+
+                List<string> globPatterns = ConvertToGlobPatterns(codeownersPath);
+                PatternMatchingResult patternMatchingResult = MatchGlobPatterns(targetPath, globPatterns);
+                if (patternMatchingResult.HasMatches)
+                {
+                    return codeownersEntries[i];
+                }
+            }
+            // assert: none of the codeownersEntries matched targetPath
+            return new CodeOwnerEntry();
+        }
+
+        private static bool ContainsUnsupportedCharacters(string codeownersPath)
+            => unsupportedChars.Any(codeownersPath.Contains);
+
+        /// <summary>
+        /// Converts codeownersPath to a set of glob patterns to include in
+        /// glob matching. The conversion is a translation from codeowners and .gitignore
+        /// spec into glob. That is, it reduces the spec to glob rules,
+        /// which then can be checked against using glob matcher.
+        /// </summary>
+        /// <returns>
+        /// Usually 1 glob pattern to include in matching. In one special case
+        /// returns 2 patterns, which happens when the path needs to be interpreted
+        /// both as-is file, or as a directory prefix.
+        /// </returns>
+        private static List<string> ConvertToGlobPatterns(string codeownersPath)
+        {
+            codeownersPath = ConvertPrefix(codeownersPath);
+            var patternsToInclude = PatternsToInclude(codeownersPath);
+            return patternsToInclude;
+        }
+
+        private static string ConvertPrefix(string codeownersPath)
+        {
+            // Codeowners entry path starting with "/*" is equivalent to it starting with "*".
+            // Note this also covers cases when it starts with "/**".
+            if (codeownersPath.StartsWith("/*"))
+                codeownersPath = codeownersPath.Substring("/".Length);
+
+            // If the codeownersPath doesn't have any slash at the beginning or in the middle,
+            // then it means its start is relative to any directory in the repository,
+            // hence we prepend "**/" to reflect this as a glob pattern.
+            if (!codeownersPath.TrimEnd('/').Contains("/"))
+            {
+                codeownersPath = "**/" + codeownersPath;
+            }
+            // If, on the other hand, codeownersPath has to start at the root, we ensure
+            // it starts with slash to reflect that.
+            else 
+            {
+                if (!codeownersPath.StartsWith("/"))
+                {
+                    codeownersPath = "/" + codeownersPath;
+                }
+                else
+                {
+                    // codeownersPath already starts with "/", so nothing to prepend.
+                }
+            }
+
+            return codeownersPath;
+        }
+
+        private static List<string> PatternsToInclude(string codeownersPath)
+        {
+            List<string> patternsToInclude = new List<string>();
+
+            if (codeownersPath.EndsWith("/"))
+            {
+                patternsToInclude.Add(ConvertDirectorySuffix(codeownersPath));
+            }
+            else
+            {
+                patternsToInclude.Add(ConvertDirectorySuffix(codeownersPath + "/"));
+                patternsToInclude.Add(codeownersPath);
+            }
+
+            return patternsToInclude;
+        }
+
+        private static string ConvertDirectorySuffix(string codeownersPath)
+        {
+            // If the codeownersPath doesn't already end with "*",
+            // we need to append "**", to denote that codeownersPath has to match
+            // a prefix of the targetPath, not the entire path.
+            if (!codeownersPath.TrimEnd('/').EndsWith("*"))
+            {
+                codeownersPath += "**";
+            }
+            else
+            {
+                // codeownersPath directory already has stars in the suffix, so nothing to do.
+                // Example paths:
+                // apps/*/
+                // apps/**/
+            }
+
+            return codeownersPath;
+        }
+
+        private static PatternMatchingResult MatchGlobPatterns(
+            string targetPath,
+            List<string> patterns)
+        {
+            // Note we use StringComparison.Ordinal, not StringComparison.OrdinalIgnoreCase,
+            // as CODEOWNERS paths are case-sensitive.
+            var globMatcher = new Matcher(StringComparison.Ordinal);
+
+            foreach (var pattern in patterns)
+            {
+                globMatcher.AddInclude(pattern);
+            }
+            
+            var dir = new InMemoryDirectoryInfo(
+                // This 'rootDir: "/"' is used here only because the globMatcher API requires it.
+                rootDir: "/", 
+                files: new List<string> { targetPath });
+
+            var patternMatchingResult = globMatcher.Execute(dir);
+            return patternMatchingResult;
+        }
+    }
+}


### PR DESCRIPTION
This is a first PR to address:

- #2770 

## Changes made

Changes in [CodeOwnersFile.cs](https://github.com/Azure/azure-sdk-tools/pull/5030/files#diff-ee9b4b68edf43f257d84470fb4a37ffebc78b42e9d6fa0eedaabeb1416628427):

- In this PR I add a new implementation for matching entries in our CODEOWNERS file. **This implementation is disabled**, hidden behind a method feature flag parameter. 
- The method targeted by this PR is `CodeOwnersFile.FindOwnersForClosestMatch`. It now either calls its previous, unchanged, legacy implementation, now located in [CodeOwnersFile.FindOwnersForClosestMatchLegacyImpl](https://github.com/Azure/azure-sdk-tools/pull/5030/files#diff-ee9b4b68edf43f257d84470fb4a37ffebc78b42e9d6fa0eedaabeb1416628427R81), or the newly introduced implementation. The decision is [made here](https://github.com/Azure/azure-sdk-tools/pull/5030/files#diff-ee9b4b68edf43f257d84470fb4a37ffebc78b42e9d6fa0eedaabeb1416628427R76-R78) and is based on newly introduced method feature flag parameter, `useNewFindOwnersForClosestMatchImpl`. 
  - The `useNewFindOwnersForClosestMatchImpl` is by default `false`, meaning the code uses the legacy implementation. It is only ever set to `true` in the added tests.
- If `useNewFindOwnersForClosestMatchImpl` is `true`, then new implementation is used. That implementation's entry point is the newly-introduced [MatchedCodeOwnerEntry ctor](https://github.com/Azure/azure-sdk-tools/pull/5030/files#diff-30c0d1efa23b7260289c736ed51b407a59fafac23dece7348c08dddb3c64ec1bR19).

Newly added [MatchedCodeOwnerEntry.cs](https://github.com/Azure/azure-sdk-tools/pull/5030/files#diff-30c0d1efa23b7260289c736ed51b407a59fafac23dece7348c08dddb3c64ec1b) class:

- This class contains the logic for the new matching logic, as explained above.
- This class leverages [Microsoft.Extensions.FileSystemGlobbing](https://www.nuget.org/packages/Microsoft.Extensions.FileSystemGlobbing) ([namespace](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.filesystemglobbing?view=dotnet-plat-ext-7.0)) to reuse support for glob matching of `*` and `**` during path matching. See the class implementation and comments for details.

Newly added [Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs](https://github.com/Azure/azure-sdk-tools/pull/5030/files#diff-b396d224b17b2aac1b9c9db9d514ccf28255dcf37e41336f2302e24c563c78c9):

- This is a new project and a test class for testing the implementations of `FindOwnersForClosestMatch` directly. 
- It includes [a battery of over 50 test cases][battery] that achieve 100% code coverage both on the legacy and new parsing logic.
- The test battery also compares the behavior of the legacy and new matching logic, to be discussed w.r.t. backward compatibility issues and pre-existing bugs in the legacy logic.

Changes to [Azure.Sdk.Tools.RetrieveCodeOwners.Tests.csproj](https://github.com/Azure/azure-sdk-tools/pull/5030/files#diff-5272f6d935a874880addc7b67c8a12406291ae0d15c4e57cdf4c282b9570cd57):

- I updated and added some missing dependencies, based on the dependencies created when creating a new NUnit project in visual studio. 
    - This includes linter for NUnit, which resulted in some warnings around assertions, which broke PR build. I fixed them.
    - I also enabled strict nullability checking.

## Testing done

- Added the [battery] of tests with 100% coverage both of legacy and new implementation.
- There are also existing tests in [Azure.Sdk.Tools.RetrieveCodeOwners.Tests/MainTests.cs](https://github.com/Azure/azure-sdk-tools/pull/5030/files#diff-3cc91b617fdab1f05f05db30158b0867fa404612e1bc0953354d9e36fed07b13).

[battery]: https://github.com/Azure/azure-sdk-tools/pull/5030/files#diff-b396d224b17b2aac1b9c9db9d514ccf28255dcf37e41336f2302e24c563c78c9R24

## Next steps

- We need to discuss the discrepancies between legacy and new matching logic, as captured by the [battery] of tests. **Note that this is not a blocker to merging this PR**, as the new matching logic is currently unused beyond this test suite.
  - Notably, when the input path is e.g. `foo` the parser doesn't know if it is a file or a directory. This is a fundamental limitation, because CODEOWNERS entry of form `foo/` should match the path only if it is a directory, but not a file. We could work around this problem in two ways:
      - assume all `targetPaths` are files, always;
      - or assume that a `targetPath` is a directory if and only if it ends with `/`.
- As mentioned in the issue #2770, we also need to decide what to do with wildcard paths in our language repos that start to match once we enable the new matching logic. For example [these paths in azure-sdk-for-net CODEOWNERS](https://github.com/Azure/azure-sdk-for-net/blob/b8b0121fdbf309cefc08bae449c2fe768ef82100/.github/CODEOWNERS#L724-L725).
- Discovered a bug in the used library, have to find a workaround:  
    - https://github.com/dotnet/runtime/issues/80076
- In a follow-up PR, I am going to flip the feature flag to enable the new matching logic.
  - Once we are confident it works as expected, I am going to make another PR deleting the legacy logic.

## Reference

- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax  
- https://git-scm.com/docs/gitignore#_pattern_format  
- https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.filesystemglobbing.matcher?view=dotnet-plat-ext-7.0
- https://man7.org/linux/man-pages/man7/glob.7.html
