### PR TITLE
Support uploading API review token file for CADL review

### DIFF
--- a/src/dotnet/APIView/APIViewIntegrationTests/ReviewManagerTests.cs
+++ b/src/dotnet/APIView/APIViewIntegrationTests/ReviewManagerTests.cs
@@ -52,7 +52,7 @@ namespace APIViewIntegrationTests
             var reviewManager = testsBaseFixture.ReviewManager;
             var user = testsBaseFixture.User;
             var review = await testsBaseFixture.ReviewManager.CreateReviewAsync(user, fileNameA, "Revision1", fileStreamA, false, "Swagger", true);
-            await reviewManager.AddRevisionAsync(user, review.ReviewId, fileNameB, "Revision2", fileStreamB, true);
+            await reviewManager.AddRevisionAsync(user, review.ReviewId, fileNameB, "Revision2", fileStreamB, "Swagger", true);
             review = await reviewManager.GetReviewAsync(user, review.ReviewId);
             var headingWithDiffInSections = review.Revisions[0].HeadingsOfSectionsWithDiff[review.Revisions[1].RevisionId];
             Assert.All(headingWithDiffInSections,
@@ -65,7 +65,7 @@ namespace APIViewIntegrationTests
             var reviewManager = testsBaseFixture.ReviewManager;
             var user = testsBaseFixture.User;
             var review = await reviewManager.CreateReviewAsync(user, fileNameC, "Azure.Analytics.Purview.Account", fileStreamC, false, "Swagger", true);
-            await reviewManager.AddRevisionAsync(user, review.ReviewId, fileNameD, "Azure.Analytics.Purview.Account", fileStreamD, true);
+            await reviewManager.AddRevisionAsync(user, review.ReviewId, fileNameD, "Azure.Analytics.Purview.Account", fileStreamD, "Swagger", true);
             review = await reviewManager.GetReviewAsync(user, review.ReviewId);
             var headingWithDiffInSections = review.Revisions[0].HeadingsOfSectionsWithDiff[review.Revisions[1].RevisionId];
             Assert.All(headingWithDiffInSections,

--- a/src/dotnet/APIView/APIViewWeb/Client/src/revisions.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/revisions.ts
@@ -1,4 +1,4 @@
-﻿$(() => {
+$(() => {
   $(document).on("click", ".revision-rename-icon", e => {
     toggleNameField($(e.target));
   });
@@ -16,4 +16,12 @@
     renameIcon.toggle();
     renameIcon.siblings(".revision-name-input").toggle();
   }
+
+  const languageSelect = $('#revision-language-select');
+  languageSelect.on('change', function (e) {
+    const fileSelectors = $(".package-file-selector");
+    for (var i = 0; i < fileSelectors.length; i++) {
+      $(fileSelectors[i]).toggleClass("hidden-row");
+    }
+  });
 });

--- a/src/dotnet/APIView/APIViewWeb/Managers/IReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/IReviewManager.cs
@@ -20,7 +20,7 @@ namespace APIViewWeb.Managers
             IEnumerable<string> search, IEnumerable<string> languages, bool? isClosed, IEnumerable<int> filterTypes, bool? isApproved, int offset, int limit, string orderBy);
         public Task DeleteReviewAsync(ClaimsPrincipal user, string id);
         public Task<ReviewModel> GetReviewAsync(ClaimsPrincipal user, string id);
-        public Task AddRevisionAsync(ClaimsPrincipal user, string reviewId, string name, string label, Stream fileStream, bool awaitComputeDiff = false);
+        public Task AddRevisionAsync(ClaimsPrincipal user, string reviewId, string name, string label, Stream fileStream, string language = "", bool awaitComputeDiff = false);
         public Task<CodeFile> CreateCodeFile(string originalName, Stream fileStream, bool runAnalysis, MemoryStream memoryStream, string language = null);
         public Task<ReviewCodeFileModel> CreateReviewCodeFileModel(string revisionId, MemoryStream memoryStream, CodeFile codeFile);
         public Task DeleteRevisionAsync(ClaimsPrincipal user, string id, string revisionId);

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -204,11 +204,12 @@ namespace APIViewWeb.Managers
             string name,
             string label,
             Stream fileStream,
+            string language = "",
             bool awaitComputeDiff = false)
         {
             var review = await GetReviewAsync(user, reviewId);
             await AssertAutomaticReviewModifier(user, review);
-            await AddRevisionAsync(user, review, name, label, fileStream, review.Language, awaitComputeDiff);
+            await AddRevisionAsync(user, review, name, label, fileStream, language, awaitComputeDiff);
         }
 
         public async Task<CodeFile> CreateCodeFile(

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml
@@ -46,7 +46,21 @@
                             }
                             else
                             {
-                                <div class="form-group package-selector">
+                                <div class="form-group">
+                                    <span>
+                                        <select asp-for="Language" class="selectpicker show-menu-arrow shadow-sm mr-20 ml-20" data-style="btn-light btn-sm border" data-selected-text-format="value" id="revision-language-select">
+                                            <option selected value="Cadl">Cadl</option>
+                                            <option value="Json" data-content="Json">Json</option>
+                                        </select>
+                                    </span>
+                                </div>
+                                <div class="form-group package-file-selector hidden-row">
+                                    <div class="custom-file">
+                                        <input name="upload" type="file" class="custom-file-input">
+                                        <label for="upload" class="custom-file-label">Select file to add</label>
+                                    </div>
+                                </div>
+                                <div class="form-group package-file-selector">
                                     <input asp-for="FilePath" class="form-control" type="text" placeholder="Enter URL to package root source. For e.g. URL to CADL file">
                                 </div>
                             }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml.cs
@@ -29,6 +29,9 @@ namespace APIViewWeb.Pages.Assemblies
         [FromForm]
         public string FilePath { get; set; }
 
+        [FromForm]
+        public string Language { get; set; }
+
         public async Task<IActionResult> OnGetAsync(string id)
         {
             TempData["Page"] = "revisions";
@@ -48,7 +51,7 @@ namespace APIViewWeb.Pages.Assemblies
             if (upload != null)
             {
                 var openReadStream = upload.OpenReadStream();
-                await _manager.AddRevisionAsync(User, id, upload.FileName, Label, openReadStream);
+                await _manager.AddRevisionAsync(User, id, upload.FileName, Label, openReadStream, language: Language);
             }
             else
             {


### PR DESCRIPTION
CADL review can only be created using a link to CADL repo. This is not sufficient in all cases if CADL source repo has different folder structure or when a user wants to emit token file locally and upload as a revision using different cadl emitter version. This PR is to add an option so user can choose Json token file as source to create a revision.