### PR TITLE
Update `global.json` `Microsoft.Build.Traversal` from `1.0.45` to `3.2.0`

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "Microsoft.Build.Traversal": "1.0.45"
+    "Microsoft.Build.Traversal": "3.2.0"
   },
   "sdk": {
     "version": "6.0.403",


### PR DESCRIPTION
This PR contributes to:

- #5009

Reference:
https://www.nuget.org/packages/Microsoft.Build.Traversal#versions-body-tab