### PR TITLE
Add `global.json` and other missing paths to `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,7 +4,7 @@
 /*                               @azure/azure-sdk-eng
 /.devcontainer/                  @azure/azure-sdk-eng
 /doc/                            @azure/azure-sdk-eng
-# Note: directories below are scheduled to be reorganizeed.
+# Note: directories below are scheduled to be reorganized.
 # For details, see: https://github.com/Azure/azure-sdk-tools/issues/5056
 /.azure-pipelines/               @azure/azure-sdk-eng
 /config/                         @azure/azure-sdk-eng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,17 @@
 ################
+# Misc
+################
+/*                               @azure/azure-sdk-eng
+/.azure-pipelines/               @azure/azure-sdk-eng
+/.devcontainer/                  @azure/azure-sdk-eng
+/artifacts/                      @azure/azure-sdk-eng
+/config/                         @azure/azure-sdk-eng
+/doc/                            @azure/azure-sdk-eng
+/scripts/                        @azure/azure-sdk-eng
+/src/                            @azure/azure-sdk-eng
+/web/                            @azure/azure-sdk-eng
+
+################
 # Automation
 ################
 
@@ -9,7 +22,6 @@
 ###########
 # Eng Sys
 ###########
-global.json                      @azure/azure-sdk-eng
 /eng/                            @azure/azure-sdk-eng
 /eng/common/                     @sima-zhu @weshaggard @benbp
 /eng/common/TestResources/       @benbp @weshaggard @heaths

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,11 +2,12 @@
 # Misc
 ################
 /*                               @azure/azure-sdk-eng
-/.azure-pipelines/               @azure/azure-sdk-eng
 /.devcontainer/                  @azure/azure-sdk-eng
-/artifacts/                      @azure/azure-sdk-eng
-/config/                         @azure/azure-sdk-eng
 /doc/                            @azure/azure-sdk-eng
+# Note: directories below are scheduled to be reorganizeed.
+# For details, see: https://github.com/Azure/azure-sdk-tools/issues/5056
+/.azure-pipelines/               @azure/azure-sdk-eng
+/config/                         @azure/azure-sdk-eng
 /scripts/                        @azure/azure-sdk-eng
 /src/                            @azure/azure-sdk-eng
 /web/                            @azure/azure-sdk-eng

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,6 +9,7 @@
 ###########
 # Eng Sys
 ###########
+global.json                      @azure/azure-sdk-eng
 /eng/                            @azure/azure-sdk-eng
 /eng/common/                     @sima-zhu @weshaggard @benbp
 /eng/common/TestResources/       @benbp @weshaggard @heaths


### PR DESCRIPTION
This PR contributes to:

- #5009

With this PR merged, the CODEOWNERS file should have 100% coverage of all files and directories currently in the repository.