### PR TITLE
Revert `Azure.ClientSdk.Analyzers` library to target `netstandard2.0` instead of `net6.0`.

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- This library is fixed to netstandard2.0 as we target the lowest common framework for shared libraries 
-    to allow them to be used in the widest possible set of applications. -->
+    <!-- This library is fixed to netstandard2.0 due to:
+    https://github.com/Azure/azure-sdk-tools/pull/5048#issuecomment-1382298227
+    -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <BuildOutputTargetFolder>analyzers/dotnet/cs/</BuildOutputTargetFolder>
     <VersionPrefix>0.1.1</VersionPrefix>

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- This library is fixed to netstandard2.0 due to:
-    https://github.com/Azure/azure-sdk-tools/pull/5048#issuecomment-1382298227
+    <!-- This library is fixed to netstandard2.0. For context, please see:
+    https://github.com/Azure/azure-sdk-tools/pull/5048
     -->
     <TargetFramework>netstandard2.0</TargetFramework>
     <BuildOutputTargetFolder>analyzers/dotnet/cs/</BuildOutputTargetFolder>

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
@@ -1,7 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <!-- This library is fixed to netstandard2.0 as we target the lowest common framework for shared libraries 
+    to allow them to be used in the widest possible set of applications. -->
+    <TargetFramework>netstandard2.0</TargetFramework>
     <BuildOutputTargetFolder>analyzers/dotnet/cs/</BuildOutputTargetFolder>
     <VersionPrefix>0.1.1</VersionPrefix>
     <LangVersion>8</LangVersion>

--- a/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
+++ b/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
@@ -2,9 +2,7 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <!-- This library is fixed to netstandard2.0 as we target the lowest common framework for shared libraries 
-    to allow them to be used in the widest possible set of applications. -->
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
+++ b/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
@@ -2,7 +2,9 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
-    <TargetFramework>net6.0</TargetFramework>
+    <!-- This library is fixed to netstandard2.0 as we target the lowest common framework for shared libraries 
+    to allow them to be used in the widest possible set of applications. -->
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**UPDATE** 1/13/2023: this PR is required as it broke things. See:
- https://github.com/Azure/azure-sdk-tools/pull/5048#issuecomment-1382298227
- https://github.com/Azure/azure-sdk-tools/pull/5029/files#r1069929465

**UPDATE** 1/4/2023: I decided to abandon this PR. See [my comment below](https://github.com/Azure/azure-sdk-tools/pull/5048#issuecomment-1371768721) why.

This PR reverts changes in:

- #5029

plus adds a comment why.