### PR TITLE
Hyperlink from eng/common job-matrix README to matrix_generator.md

### DIFF
--- a/eng/common/scripts/job-matrix/README.md
+++ b/eng/common/scripts/job-matrix/README.md
@@ -2,4 +2,4 @@
 
 The documentation for Azure Pipelines Matrix Generator can be found at
 
-`azure-sdk-tools/doc/common/matrix_generator.md`
+[`azure-sdk-tools/doc/common/matrix_generator.md`](https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/matrix_generator.md)


### PR DESCRIPTION
This PR is a follow-up to 
- #5027

This change couldn't have been made before #5027 was merged because it caused CI link validation to fail.