### PR TITLE
Replace the glob-based CODEOWNERS parser with regex-based

### DIFF
--- a/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs
@@ -1,6 +1,4 @@
-using System;
 using System.Collections.Generic;
-using Microsoft.Extensions.FileSystemGlobbing;
 using NUnit.Framework;
 
 namespace Azure.Sdk.Tools.CodeOwnersParser.Tests;
@@ -26,112 +24,108 @@ public class CodeOwnersFileTests
     private static readonly TestCase[] testCases =
     {
         // @formatter:off
-        //       TestCase:        Path:                 Expected match:
-        //           Name,        Target , Codeown.   , Legacy , New
-        new(         "1" ,           "a" , "a"        ,   true , true  ),
-        new(         "2" ,           "a" , "a/"       ,   true , false ), // New parser doesn't match as codeowners path expects directory, but it is unclear if target is directory, or not.
-        new(         "3" ,         "a/b" , "a/b"      ,   true , true  ),
-        new(         "4" ,         "a/b" , "/a/b"     ,   true , true  ),
-        new(         "5" ,         "a/b" , "a/b/"     ,   true , false ), // New parser doesn't match as codeowners path expects directory, but it is unclear if target is directory, or not.
-        new(         "6" ,        "/a/b" , "a/b"      ,   true , true  ),
-        new(         "7" ,        "/a/b" , "/a/b"     ,   true , true  ),
-        new(         "8" ,        "/a/b" , "a/b/"     ,   true , false ), // New parser doesn't match as codeowners path expects directory, but it is unclear if target is directory, or not.
-        new(         "9" ,        "a/b/" , "a/b"      ,   true , true  ),
-        new(        "10" ,        "a/b/" , "/a/b"     ,   true , true  ),
-        new(        "11" ,        "a/b/" , "a/b/"     ,   true , true  ),
-        new(        "12" ,       "/a/b/" , "a/b"      ,   true , true  ),
-        new(        "13" ,       "/a/b/" , "/a/b"     ,   true , true  ),
-        new(        "14" ,       "/a/b/" , "a/b/"     ,   true , true  ),
-        new(        "15" ,       "/a/b/" , "/a/b/"    ,   true , true  ),
-        new(        "16" ,      "/a/b/c" , "a/b"      ,   true , true  ),
-        new(        "17" ,      "/a/b/c" , "/a/b"     ,   true , true  ),
-        new(        "18" ,      "/a/b/c" , "a/b/"     ,   true , true  ),
-        new(        "19" ,    "/a/b/c/d" , "/a/b/"    ,   true , true  ),
-        new(    "casing" ,         "ABC" , "abc"      ,   true , false ), // New parser doesn't match as it is case-sensitive, per codeowners spec
-        new(  "chained1" ,       "a/b/c" , "a"        ,   true , true  ),
-        new(  "chained2" ,       "a/b/c" , "b"        ,  false , true  ), // New parser matches per codeowners and .gitignore spec
-        new(  "chained3" ,       "a/b/c" , "b/"       ,  false , true  ), // New parser matches per codeowners and .gitignore spec
-        new(  "chained4" ,       "a/b/c" , "c"        ,  false , true  ), // New parser matches per codeowners and .gitignore spec
-        new(  "chained5" ,       "a/b/c" , "c/"       ,  false , false ),
-        new(  "chained6" ,     "a/b/c/d" , "c/"       ,  false , true  ), // New parser matches per codeowners and .gitignore spec
-        new(  "chained7" ,   "a/b/c/d/e" , "c/"       ,  false , true  ), // New parser matches per codeowners and .gitignore spec
-        new(  "chained8" ,       "a/b/c" , "b/c"      ,  false , false ), // TODO need to verify if CODEOWNERS actually follows this rule of "middle slashes prevent path relativity" from .gitignore, or not.
-        new(  "chained9" ,           "a" , "a/b/c"    ,  false , false ),
-        new( "chained10" ,           "c" , "a/b/c"    ,  false , false ),
-        // Cases not supported by the new parser.
-        new(   "unsupp1" ,          "!a" , "!a"       ,   true , false ),
-        new(   "unsupp2" ,           "b" , "!a"       ,  false , false ),
-        new(   "unsupp3" ,        "a[b"  , "a[b"      ,   true , false ),
-        new(   "unsupp4" ,        "a]b"  , "a]b"      ,   true , false ),
-        new(   "unsupp5" ,        "a?b"  , "a?b"      ,   true , false ),
-        new(   "unsupp6" ,        "axb"  , "a?b"      ,  false , false ),
-        // The cases below test for wildcard support by the new parser. Legacy parser skips over wildcards.
-        new(       "**1" ,           "a" , "**/a"     ,  false , true  ), 
-        new(       "**2" ,           "a" , "**/b/a"   ,  false , false ), 
-        new(       "**3" ,           "a" , "**/a/b"   ,  false , false ), 
-        new(       "**4" ,           "a" , "/**/a"    ,  false , true  ),
-        new(       "**5" ,         "a/b" , "a/**/b"   ,  false , true  ),
-        new(       "**6" ,       "a/x/b" , "a/**/b"   ,  false , true  ),
-        new(       "**7" ,       "a/y/b" , "a/**/b"   ,  false , true  ),
-        new(       "**8" ,     "a/x/y/b" , "a/**/b"   ,  false , true  ),
-        new(       "**9" ,   "c/a/x/y/b" , "a/**/b"   ,  false , false ),
-        new(       "*10" ,   "a/b/cxy/d" , "/**/*x*/" ,  false , true  ),
-        new(        "1*" ,           "a" , "*"        ,  false , true  ),
-        new(        "2*" ,         "a/b" , "a/*"      ,  false , true  ),
-        // There is discrepancy between GitHub CODEOWNERS behavior [1] and .gitignore behavior here
-        // CODEOWNERS will not match this path, while .gitignore will
-        // [1] The "docs/*" example in https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
-        // [2] Confirmed empirically. The .gitignore will match "a/*" to "a/b" and thus ignore everything.
-        new(        "3*" ,       "a/b/c" , "a/*"      ,  false , true  ),
-        new(        "4*" ,       "x/a/b" , "a/*"      ,  false , false ),
-        new(       "1*/" ,         "a/b" , "a/*/"     ,  false , false ),
-        new(       "2*/" ,        "a/b/" , "a/*/"     ,  false , true  ),
-        new(       "3*/" ,       "a/b/c" , "a/*/"     ,  false , true  ),
-        new(      "1*/*" ,         "a/b" , "a/*/*"    ,  false , false ),
-        new(      "2*/*" ,     "a/b/c/d" , "a/*/*/d"  ,  false , true  ),
-        new(      "3*/*" ,   "a/b/x/c/d" , "a/*/*/d"  ,  false , false ),
-        new(     "1**/*" ,   "a/b/x/c/d" , "a/**/*/d" ,  false , true  ),
-        new(        "*1" ,         "a/b" , "*/b"      ,  false , true  ),
-        new(      "*/*1" ,         "a/b" , "*/*/b"    ,  false , false ),
-        new(       "1**" ,           "a" , "a/**"     ,  false , false ),
-        new(       "2**" ,          "a/" , "a/**"     ,  false , true  ),
-        new(       "3**" ,         "a/b" , "a/**"     ,  false , true  ),
-        new(       "4**" ,        "a/b/" , "a/**"     ,  false , true  ),
-        new(    "*.ext1" ,      "a/x.md" , "*.md"     ,  false , true  ),
-        new(    "*.ext2" ,    "a/b/x.md" , "*.md"     ,  false , true  ),
-        new(    "*.ext3" , "a/b.md/x.md" , "*.md"     ,  false , true  ),
-        new(    "*.ext4" ,        "a/md" , "*.md"     ,  false , false ),
-        new(    "*.ext5" ,         "a.b" , "a.*"      ,  false , true  ),
-        new(    "*.ext6" ,        "a.b/" , "a.*"      ,  false , true  ),
-        new(    "*.ext5" ,         "a.b" , "a.*/"     ,  false , false ),
-        new(    "*.ext7" ,        "a.b/" , "a.*/"     ,  false , true  ),
-        new(    "*.ext8" ,        "a.b"  , "/a.*"     ,  false , true  ),
-        new(    "*.ext9" ,        "a.b/" , "/a.*"     ,  false , true  ),
-        new(   "*.ext10" ,      "x/a.b/" , "/a.*"     ,  false , false ),
-        // New parser should return false, but returns true due to https://github.com/dotnet/runtime/issues/80076
-        // TODO globbug1 actually covers-up problem with the parser, where it converts "*" to "**/*".
-        new(  "globbug1" ,         "a/b" , "*"        ,  false , true  ),
-        new(  "globbug2" ,      "a/b/c/" , "a/*/"     ,  false , true  )
+        //    Path:               Expected match:
+        //    Codeowners , Target        , Legacy , New
+        new(        "/a" , "a"           ,   true , true  ),
+        new(        "/a" , "A"           ,   true , false ),
+        new(        "/a" , "/a"          ,   true , true  ),
+        new(        "/a" , "a/"          ,   true , false ),
+        new(        "/a" , "/a/"         ,   true , false ),
+        new(        "/a" , "/a/b"        ,   true , false ),
+        new(        "/a" , "/a/b/"       ,   true , false ),
+        new(        "/a" , "/x/a/b"      ,  false , false ),
+        new(         "a" , "a"           ,   true , true  ),
+        new(         "a" , "A"           ,   true , false ),
+        new(         "a" , "/a"          ,   true , true  ),
+        new(         "a" , "a/"          ,   true , false ),
+        new(         "a" , "/a/"         ,   true , false ),
+        new(         "a" , "/a/b"        ,   true , false ),
+        new(         "a" , "/a/b/"       ,   true , false ),
+        new(         "a" , "/x/a/b"      ,  false , false ),
+        new(       "/a/" , "a"           ,   true , true  ),
+        new(       "/a/" , "/a"          ,   true , true  ),
+        new(       "/a/" , "a/"          ,   true , true  ),
+        new(       "/a/" , "/a/"         ,   true , true  ),
+        new(       "/a/" , "/a/b"        ,   true , true  ),
+        new(       "/a/" , "/a/b/"       ,   true , true  ),
+        new(       "/a/" , "/A/b/"       ,   true , false ),
+        new(       "/a/" , "/x/a/b"      ,  false , false ),
+        new(     "/a/b/" , "/a"          ,  false , false ),
+        new(     "/a/b/" , "/a/"         ,  false , false ),
+        new(     "/a/b/" , "/a/b"        ,   true , true  ),
+        new(     "/a/b/" , "/a/b/"       ,   true , true  ),
+        new(     "/a/b/" , "/a/b/c"      ,   true , true  ),
+        new(     "/a/b/" , "/a/b/c/"     ,   true , true  ),
+        new(     "/a/b/" , "/a/b/c/d"    ,   true , true  ),
+        new(      "/a/b" , "/a"          ,  false , false ),
+        new(      "/a/b" , "/a/"         ,  false , false ),
+        new(      "/a/b" , "/a/b"        ,   true , true  ),
+        new(      "/a/b" , "/a/b/"       ,   true , false ),
+        new(      "/a/b" , "/a/b/c"      ,   true , false ),
+        new(      "/a/b" , "/a/b/c/"     ,   true , false ),
+        new(      "/a/b" , "/a/b/c/d"    ,   true , false ),
+        new(       "/!a" , "!a"          ,   true , false ),
+        new(       "/!a" , "b"           ,  false , false ),
+        new(      "/a[b" , "a[b"         ,   true , false ),
+        new(      "/a]b" , "a]b"         ,   true , false ),
+        new(      "/a?b" , "a?b"         ,   true , false ),
+        new(      "/a?b" , "axb"         ,  false , false ),
+        new(        "/*" , "a"           ,  false , true  ),
+        new(        "/*" , "a/"          ,  false , false ),
+        new(        "/*" , "a/b"         ,  false , false ),
+        new(       "/**" , "a"           ,  false , true  ),
+        new(       "/**" , "a/"          ,  false , true  ),
+        new(       "/**" , "a/b"         ,  false , true  ),
+        new(      "/a/*" , "a"           ,  false , false ), // Not sure if this should not match.
+        new(      "/a/*" , "a/"          ,  false , true  ),
+        new(      "/a/*" , "a/b"         ,  false , true  ),
+        new(      "/a/*" , "a/b/"        ,  false , false ),
+        new(      "/a/*" , "a/b/c"       ,  false , false ),
+        new(     "/a/**" , "a"           ,  false , true  ), // Not sure if this should match.
+        new(     "/a/**" , "a/"          ,  false , true  ),
+        new(     "/a/**" , "a/b"         ,  false , true  ),
+        new(     "/a/**" , "a/b/"        ,  false , true  ),
+        new(     "/a/**" , "a/b/c"       ,  false , true  ),
+        new(    "/**/a/" , "a"           ,  false , true  ),
+        new(    "/**/a/" , "a/"          ,  false , true  ),
+        new(    "/**/a/" , "a/b"         ,  false , true  ),
+        new(    "/**/b/" , "a/b"         ,  false , true  ),
+        new(    "/**/b/" , "a/c"         ,  false , false ),
+        new(   "/a/*/b/" , "a/b"         ,  false , false ),
+        new(   "/a/*/b/" , "a/x/b"       ,  false , true  ),
+        new(   "/a/*/b/" , "a/x/b/c"     ,  false , true  ),
+        new(   "/a/*/b/" , "a/x/c"       ,  false , false ),
+        new(   "/a/*/b/" , "a/x/y/b"     ,  false , false ),
+        new(  "/a/**/b/" , "a/b"         ,  false , true  ),
+        new(  "/a/**/b/" , "a/x/b"       ,  false , true  ),
+        new(  "/a/**/b/" , "a/x/y/b"     ,  false , true  ),
+        new(  "/a/**/b/" , "a/x/y/c"     ,  false , false ),
+        new(     "a/*/*" , "a/b"         ,  false , false ),
+        new(  "/a/*/*/d" , "a/b/c/d"     ,  false , true  ),
+        new(  "/a/*/*/d" , "a/b/x/c/d"   ,  false , false ),
+        new( "/a/**/*/d" , "a/b/x/c/d"   ,  false , true  ),
+        new(     "*/*/b" , "a/b"         ,  false , false ),
+        new(      "/a*/" , "abc"         ,  false , true  ),
+        new(     "/*b*/" , "abc"         ,  false , true  ),
+        new(      "/*c/" , "abc"         ,  false , true  ),
+        new(     "/a*c/" , "abc"         ,  false , true  ),
+        new(  "/**/*x*/" , "a/b/cxy/d"   ,  false , true  ),
+        new(   "/a/*.md" , "a/x.md"      ,  false , true  ),
+        new( "/*/*/*.md" , "a/b/x.md"    ,  false , true  ),
+        new(   "**/*.md" , "a/b.md/x.md" ,  false , true  ),
+        new(     "/*.md" , "a/md"        ,  false , false ),
+        new(      "/a.*" , "a.b"         ,  false , true  ),
+        new(      "/a.*" , "a.b/"        ,  false , false ),
+        new(      "/a.*" , "x/a.b/"      ,  false , false ),
+        new(     "/a.*/" , "a.b"         ,  false , true  ),
+        new(     "/a.*/" , "a.b/"        ,  false , true  ),
+        new(    "/**/*x*/AB/*/CD" , "a/b/cxy/AB/fff/CD"     , false, true  ),
+        new(    "/**/*x*/AB/*/CD" , "a/b/cxy/AB/ff/ff/CD"   , false, false ),
+        new( "/**/*x*/AB/**/CD/*" , "a/b/cxy/AB/ff/ff/CD"   , false, false ),
+        new( "/**/*x*/AB/**/CD/*" , "a/b/cxy/AB/ff/ff/CD/h" , false, true  ),
+
         // @formatter:on
     };
-
-    /// <summary>
-    /// A repro for https://github.com/dotnet/runtime/issues/80076
-    /// </summary>
-    [Test]
-    public void TestGlobBugRepro()
-    {
-        var globMatcher = new Matcher(StringComparison.Ordinal);
-        globMatcher.AddInclude("/*/");
-
-        var dir = new InMemoryDirectoryInfo(
-            rootDir: "/", 
-            files: new List<string> { "/a/b" });
-
-        var patternMatchingResult = globMatcher.Execute(dir);
-        // The expected behavior is "Is.False", but actual behavior is "Is.True".
-        Assert.That(patternMatchingResult.HasMatches, Is.True);
-    }
 
     /// <summary>
     /// Exercises Azure.Sdk.Tools.CodeOwnersParser.Tests.CodeOwnersFileTests.testCases.
@@ -147,7 +141,8 @@ public class CodeOwnersFileTests
         VerifyFindOwnersForClosestMatch(testCase, codeownersEntries, useNewImpl: true, testCase.ExpectedNewMatch);
     }
 
-    private static void VerifyFindOwnersForClosestMatch(TestCase testCase,
+    private static void VerifyFindOwnersForClosestMatch(
+        TestCase testCase,
         List<CodeOwnerEntry> codeownersEntries,
         bool useNewImpl,
         bool expectedMatch)
@@ -162,7 +157,9 @@ public class CodeOwnersFileTests
         Assert.That(entryLegacy.Owners.Count, Is.EqualTo(expectedMatch ? 1 : 0));
     }
 
-    // ReSharper disable once NotAccessedPositionalProperty.Global
-    //   Reason: Name is present to make it easier to refer to and distinguish test cases in VS test runner.
-    public record TestCase(string Name, string TargetPath, string CodeownersPath, bool ExpectedLegacyMatch, bool ExpectedNewMatch);
+    public record TestCase(
+        string CodeownersPath,
+        string TargetPath,
+        bool ExpectedLegacyMatch,
+        bool ExpectedNewMatch);
 }

--- a/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs
@@ -73,9 +73,15 @@ public class CodeOwnersFileTests
         new(        "/*" , "a"           ,  false , true  ),
         new(        "/*" , "a/"          ,  false , false ),
         new(        "/*" , "a/b"         ,  false , false ),
+        new(        "/*" , "["           ,  false , true  ),
+        new(        "/*" , "]"           ,  false , true  ),
+        new(        "/*" , "!"           ,  false , true  ),
         new(       "/**" , "a"           ,  false , true  ),
         new(       "/**" , "a/"          ,  false , true  ),
         new(       "/**" , "a/b"         ,  false , true  ),
+        new(       "/**" , "["           ,  false , true  ),
+        new(       "/**" , "]"           ,  false , true  ),
+        new(       "/**" , "!"           ,  false , true  ),
         new(      "/a/*" , "a"           ,  false , false ), // Not sure if this should not match.
         new(      "/a/*" , "a/"          ,  false , true  ),
         new(      "/a/*" , "a/b"         ,  false , true  ),
@@ -123,7 +129,7 @@ public class CodeOwnersFileTests
         new(    "/**/*x*/AB/*/CD" , "a/b/cxy/AB/fff/CD"     , false, true  ),
         new(    "/**/*x*/AB/*/CD" , "a/b/cxy/AB/ff/ff/CD"   , false, false ),
         new( "/**/*x*/AB/**/CD/*" , "a/b/cxy/AB/ff/ff/CD"   , false, false ),
-        new( "/**/*x*/AB/**/CD/*" , "a/b/cxy/AB/ff/ff/CD/h" , false, true  ),
+        new( "/**/*x*/AB/**/CD/*" , "a/b/cxy/AB/[]/!!/CD/h" , false, true  ),
 
         // @formatter:on
     };

--- a/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs
@@ -8,18 +8,18 @@ public class CodeOwnersFileTests
 {
     /// <summary>
     /// A battery of test cases specifying behavior of new logic matching target
-    /// path to CODEOWNERS entries , and comparing it to existing, legacy logic.
+    /// path to CODEOWNERS entries, and comparing it to existing, legacy logic.
     ///
-    /// The logic that has changed lives in CodeOwnersFile.FindOwnersForClosestMatch.
-    ///
-    /// The new logic supports matching against wildcards, while the old one doesn't.
+    /// The logic that has changed is located in CodeOwnersFile.FindOwnersForClosestMatch.
     ///
     /// In the test case table below, any discrepancy between legacy and new
-    /// parser expected matches that doesn't pertain to wildcard matching denotes
-    /// a potential backward compatibility and/or existing defect in the legacy parser.
-    /// 
+    /// matcher expected matches that doesn't pertain to wildcard matching denotes
+    /// a potential backward compatibility and/or existing defect in the legacy matcher.
+    ///
     /// For further details, please see:
-    /// https://github.com/Azure/azure-sdk-tools/issues/2770
+    /// - Class comment for Azure.Sdk.Tools.CodeOwnersParser.MatchedCodeOwnerEntry
+    /// - https://github.com/Azure/azure-sdk-tools/issues/2770
+    /// - https://github.com/Azure/azure-sdk-tools/issues/4859
     /// </summary>
     private static readonly TestCase[] testCases =
     {
@@ -96,6 +96,7 @@ public class CodeOwnersFileTests
         new(   "/a/*/b/" , "a/x/b/c"     ,  false , true  ),
         new(   "/a/*/b/" , "a/x/c"       ,  false , false ),
         new(   "/a/*/b/" , "a/x/y/b"     ,  false , false ),
+        new(    "/a**b/" , "a/x/y/b"     ,  false , true  ),
         new(  "/a/**/b/" , "a/b"         ,  false , true  ),
         new(  "/a/**/b/" , "a/x/b"       ,  false , true  ),
         new(  "/a/**/b/" , "a/x/y/b"     ,  false , true  ),

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners/Program.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners/Program.cs
@@ -23,7 +23,7 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners
             bool filterOutNonUserAliases = false
             )
         {
-            var target = targetDirectory.ToLower().Trim();
+            var target = targetDirectory.Trim();
             try {
                 var codeOwnerEntry = CodeOwnersFile.ParseAndFindOwnersForClosestMatch(codeOwnerFilePath, target);
                 if (filterOutNonUserAliases)

--- a/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
+++ b/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
@@ -7,7 +7,6 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLine.Net" Version="2.3.0" />
-    <PackageReference Include="Microsoft.Extensions.FileSystemGlobbing" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
+++ b/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLine.Net" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/code-owners-parser/CodeOwnersParser/MatchedCodeOwnerEntry.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/MatchedCodeOwnerEntry.cs
@@ -8,6 +8,12 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
     /// Represents a CODEOWNERS file entry that matched to targetPath from
     /// the list of entries, assumed to have been parsed from CODEOWNERS file.
     ///
+    /// This is a new matcher, compared to the old one, located in:
+    /// CodeOwnersFile.FindOwnersForClosestMatchLegacyImpl()
+    /// This new matcher supports matching against wildcards, while the old one doesn't.
+    /// This new matcher is designed to work with CODEOWNERS file validation:
+    /// https://github.com/Azure/azure-sdk-tools/issues/4859
+    ///
     /// To use this class, construct it.
     /// 
     /// To obtain the value of the matched entry, reference "Value" member.
@@ -39,7 +45,7 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
         /// <summary>
         /// Any CODEOWNERS path with these characters will be skipped.
         /// Note these are valid parts of file paths, but we are not supporting
-        /// them to simplify the parser logic.
+        /// them to simplify the matcher logic.
         /// </summary>
         private static readonly char[] unsupportedChars = { '[', ']', '!', '?' };
 
@@ -157,8 +163,11 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
                 pattern += "$";
             }
 
+            // Note that the "/**/" case is implicitly covered by "**/".
             pattern = pattern.Replace("_DOUBLE_STAR_/", "(.*)");
+            // This case is necessary to cover suffix case, e.g. "/foo/bar/**".
             pattern = pattern.Replace("/_DOUBLE_STAR_", "(.*)");
+            // This case is necessary to cover inline **, e.g. "/a**b/".
             pattern = pattern.Replace("_DOUBLE_STAR_", "(.*)");
             pattern = pattern.Replace("_SINGLE_STAR_", "([^/]*)");
             return new Regex(pattern);

--- a/tools/identity-resolution/identity-resolution.csproj
+++ b/tools/identity-resolution/identity-resolution.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Notifications.WebApi" Version="16.170.0" />
     <PackageReference Include="YamlDotNet" Version="6.1.1" />

--- a/tools/notification-configuration/notification-creator/Azure.Sdk.Tools.NotificationConfiguration.csproj
+++ b/tools/notification-configuration/notification-creator/Azure.Sdk.Tools.NotificationConfiguration.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.19317.1" />
   </ItemGroup>
 

--- a/tools/notification-configuration/notification-creator/Program.cs
+++ b/tools/notification-configuration/notification-creator/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.Services.Common;
@@ -39,12 +39,10 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
             var devOpsCreds = new VssBasicCredential("nobody", devOpsToken);
             var devOpsConnection = new VssConnection(new Uri($"https://dev.azure.com/{organization}/"), devOpsCreds);
 
-#pragma warning disable CS0618 // Type or member is obsolete
             var loggerFactory = LoggerFactory.Create(builder =>
             {
-                builder.AddConsole(config => { config.IncludeScopes = true; });
+                builder.AddSimpleConsole(config => { config.IncludeScopes = true; });
             });
-#pragma warning restore CS0618 // Type or member is obsolete
             var devOpsServiceLogger = loggerFactory.CreateLogger<AzureDevOpsService>();
             var notificationConfiguratorLogger = loggerFactory.CreateLogger<NotificationConfigurator>();
 


### PR DESCRIPTION
This PR is a follow-up to:

- #5030

It rewrites the new parser logic to match the rules as outlined in:
- https://github.com/Azure/azure-sdk-tools/issues/4859#issuecomment-1370360622

The new parser now supports diagnostic logging via `Microsoft.Extensions.Logging.Console`. To make this work, I took a dependency on this package, version `7.0.0`, and updated that package and `Microsoft.Extensions.Logging` to `7.0.0` in the code that uses `CodeOwnersParser` as dependency, to avoid the "package version downgrade detected" build failure.