### PR TITLE
Update versions of packages `RetrieveCodeOwners`, `NotificationConfiguration` and `PipelineOwnersExtractor` to most recent as of 1/8/2023

### DIFF
--- a/eng/common/scripts/get-codeowners.ps1
+++ b/eng/common/scripts/get-codeowners.ps1
@@ -1,7 +1,7 @@
 param (
   [string]$TargetDirectory = "", # Code path to code owners. e.g sdk/core/azure-amqp
   [string]$CodeOwnerFileLocation = (Resolve-Path $PSScriptRoot/../../../.github/CODEOWNERS), # The absolute path of CODEOWNERS file. 
-  [string]$ToolVersion = "1.0.0-dev.20221215.1", 
+  [string]$ToolVersion = "1.0.0-dev.20230108.6", 
   [string]$ToolPath = (Join-Path ([System.IO.Path]::GetTempPath()) "codeowners-tool-path"), # The place to check the tool existence. Put temp path as default
   [string]$DevOpsFeed = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json", # DevOp tool feeds.
   [string]$VsoVariable = "", # Option of write code owners into devop variable

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -2,5 +2,5 @@ variables:
   OfficialBuildId: $(Build.BuildNumber)
   skipComponentGovernanceDetection: true
   DotNetCoreVersion: '6.x'
-  NotificationsCreatorVersion: '1.0.0-dev.20221011.1'
-  PipelineOwnersExtractorVersion: '1.0.0-dev.20221011.1'
+  NotificationsCreatorVersion: '1.0.0-dev.20230108.1'
+  PipelineOwnersExtractorVersion: '1.0.0-dev.20230105.1'


### PR DESCRIPTION
code-owners-parser:
- https://dev.azure.com/azure-sdk/internal/_build?definitionId=3188
- https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net/NuGet/Azure.Sdk.Tools.RetrieveCodeOwners/overview/1.0.0-dev.20230108.6

notification-configurator:
- https://dev.azure.com/azure-sdk/internal/_build?definitionId=1815
- https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net/NuGet/Azure.Sdk.Tools.NotificationConfiguration/overview/1.0.0-dev.20230108.1

pipeline-owners-extractor:
- https://dev.azure.com/azure-sdk/internal/_build?definitionId=5109
- https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net/NuGet/Azure.Sdk.Tools.PipelineOwnersExtractor/overview/1.0.0-dev.20230105.1


This PR should unblock currently failing pipeline of [automation - build-failure-notification-subscriptions](https://dev.azure.com/azure-sdk/internal/_build?definitionId=679&_a=summary).