### PR TITLE
Enable the new, regex-based, wildcard-supporting CODEOWNERS matcher

### DIFF
--- a/tools/code-owners-parser/CodeOwnersParser/CodeownersFile.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/CodeownersFile.cs
@@ -8,7 +8,7 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
 {
     public static class CodeownersFile
     {
-        private const bool UseRegexMatcherDefault = false;
+        private const bool UseRegexMatcherDefault = true;
 
         public static List<CodeownersEntry> GetCodeownersEntriesFromFileOrUrl(
             string codeownersFilePathOrUrl)


### PR DESCRIPTION
This PR enables the parser introduced in:

- #5063

And as such, this PR contributes to:

- #2770

Before a package published out of this PR is depended upon, a review of affected `CODEOWNERS` files is necessary, as explained in `Behavior change of existing CODEOWNERS paths with wildcards` section of this comment:
- https://github.com/Azure/azure-sdk-tools/issues/2770#issuecomment-1338923752

Full behavior difference between the old and new parser can be determined by comparing the two rightmost columns of this [test battery](https://github.com/Azure/azure-sdk-tools/blob/61a1d763b704d3d787c667a968fbbd6bb089c9fb/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/CodeOwnersFileTests.cs#L29-L132).

This parser will be executed by the [`automation - build-failure-notification-subscriptions`](https://dev.azure.com/azure-sdk/internal/_build?definitionId=679) pipeline, once the package it depends on is published and updated, similar as it is done in this PR:
- #5085

As a result, the following `CODEOWNERS` files are expected to be affected, and thus require a review:

- https://github.com/Azure/azure-dev/blob/main/.github/CODEOWNERS
- https://github.com/Azure/azure-sdk-for-c/blob/main/.github/CODEOWNERS
- https://github.com/Azure/azure-sdk-for-cpp/blob/main/.github/CODEOWNERS
- https://github.com/Azure/azure-sdk-for-go/blob/main/.github/CODEOWNERS
- https://github.com/Azure/azure-sdk-for-java/blob/main/.github/CODEOWNERS
- https://github.com/Azure/azure-sdk-for-js/blob/main/.github/CODEOWNERS
- https://github.com/Azure/azure-sdk-for-net/blob/main/.github/CODEOWNERS
- https://github.com/Azure/azure-sdk-for-python/blob/main/.github/CODEOWNERS

Following files won't be affected, as they are not triggered by the pipeline, whose source is [`notifications.yml`](https://github.com/Azure/azure-sdk-tools/blob/main/eng/pipelines/notifications.yml):

- https://github.com/Azure/azure-sdk-for-android/blob/main/.github/CODEOWNERS
- https://github.com/Azure/azure-sdk-for-ios/blob/main/.github/CODEOWNERS
- https://github.com/Azure/azure-sdk-tools/blob/main/.github/CODEOWNERS

In addition, following work needs to be implemented and applied to the CODEOWNERS files before we can enable support for wildcards:

- #5181

### Related work

- #4859