### PR TITLE
Fix broken relative paths in `matrix-generator` tests and samples + make the tests runnable by `common-tests/ci.yml`.

### DIFF
--- a/eng/common-tests/matrix-generator/samples/matrix-test.yml
+++ b/eng/common-tests/matrix-generator/samples/matrix-test.yml
@@ -6,7 +6,7 @@ variables:
 jobs:
   - template: /eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
     parameters:
-      JobTemplatePath: /eng/common/scripts/job-matrix/samples/matrix-job-sample.yml
+      JobTemplatePath: /eng/common-tests/matrix-generator/samples/matrix-job-sample.yml
       AdditionalParameters: {}
       Pool: Azure Pipelines
       OsVmImage: ubuntu-18.04
@@ -22,11 +22,11 @@ jobs:
         - .*Framework.*=net5.0/net5.1
       MatrixConfigs:
         - Name: base_product_matrix
-          Path: eng/common/scripts/job-matrix/samples/matrix.json
+          Path: eng/common-tests/matrix-generator/samples/matrix.json
           Selection: all
           GenerateVMJobs: true
         - Name: sparse_product_matrix
-          Path: eng/common/scripts/job-matrix/samples/matrix.json
+          Path: eng/common-tests/matrix-generator/samples/matrix.json
           Selection: sparse
           NonSparseParameters:
             - framework

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.filter.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.filter.tests.ps1
@@ -1,7 +1,7 @@
 Import-Module Pester
 
 BeforeAll {
-    . $PSScriptRoot/../job-matrix-functions.ps1
+    . $PSScriptRoot/../../../common/scripts/job-matrix/job-matrix-functions.ps1
 
     $matrixConfig = @"
 {

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.filter.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.filter.tests.ps1
@@ -15,7 +15,7 @@ BeforeAll {
     $config = GetMatrixConfigFromJson $matrixConfig
 }
 
-Describe "Matrix Filter" -Tag "filter" {
+Describe "Matrix Filter" -Tag "UnitTest", "filter" {
     It "Should filter by matrix display name" -TestCases @(
         @{ regex = "windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
         @{ regex = "windows2022_netcoreapp21_modetest"; expectedFirst = "windows2022_netcoreapp21_modetest"; length = 1 }

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
@@ -125,7 +125,16 @@ Describe "Platform Matrix nonSparse" -Tag "UnitTest", "nonsparse" {
     }
 }
 
-Describe "Platform Matrix Import" -Tag "UnitTest", "import" {
+# This test is currently disabled (it doesn't have "UnitTest" tag) as it fails on line:
+#
+#   $matrix = GenerateMatrix $importConfig "sparse"
+#
+# with message:
+# 
+#   ParameterBindingArgumentTransformationException: Cannot process argument transformation on parameter 'parameters'. Cannot convert the "System.Collections.Hashtable" value of type "System.Collections.Hashtable" to type "MatrixParameter".
+#
+# See https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2102328&view=logs&j=375fdae1-accf-5db0-5fc3-af258c8525cc&t=9e9d0eca-bdb6-593f-47d7-63cf69095eca&l=22
+Describe "Platform Matrix Import" -Tag "import" {
     It "Should generate a sparse matrix where the entire base matrix is imported" {
         $matrixJson = @'
 {

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
@@ -125,7 +125,8 @@ Describe "Platform Matrix nonSparse" -Tag "UnitTest", "nonsparse" {
     }
 }
 
-# This test is currently disabled (it doesn't have "UnitTest" tag) as it fails on line:
+# This test is currently disabled (it doesn't have "UnitTest" tag) as it fails 
+# in test "Should generate a sparse matrix where the entire base matrix is imported" on line:
 #
 #   $matrix = GenerateMatrix $importConfig "sparse"
 #
@@ -133,7 +134,11 @@ Describe "Platform Matrix nonSparse" -Tag "UnitTest", "nonsparse" {
 # 
 #   ParameterBindingArgumentTransformationException: Cannot process argument transformation on parameter 'parameters'. Cannot convert the "System.Collections.Hashtable" value of type "System.Collections.Hashtable" to type "MatrixParameter".
 #
-# See https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2102328&view=logs&j=375fdae1-accf-5db0-5fc3-af258c8525cc&t=9e9d0eca-bdb6-593f-47d7-63cf69095eca&l=22
+# See full build failure:
+# https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2102328&view=logs&j=375fdae1-accf-5db0-5fc3-af258c8525cc&t=9e9d0eca-bdb6-593f-47d7-63cf69095eca&l=22
+#
+# Issue to track:
+# https://github.com/Azure/azure-sdk-tools/issues/5098
 Describe "Platform Matrix Import" -Tag "import" {
     It "Should generate a sparse matrix where the entire base matrix is imported" {
         $matrixJson = @'

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
@@ -18,7 +18,7 @@ BeforeAll {
     }
 }
 
-Describe "Platform Matrix nonSparse" -Tag "nonsparse" {
+Describe "Platform Matrix nonSparse" -Tag "UnitTest", "nonsparse" {
     BeforeEach {
         $matrixJson = @'
 {
@@ -125,7 +125,7 @@ Describe "Platform Matrix nonSparse" -Tag "nonsparse" {
     }
 }
 
-Describe "Platform Matrix Import" -Tag "import" {
+Describe "Platform Matrix Import" -Tag "UnitTest", "import" {
     It "Should generate a sparse matrix where the entire base matrix is imported" {
         $matrixJson = @'
 {
@@ -376,7 +376,7 @@ Describe "Platform Matrix Import" -Tag "import" {
 
 }
 
-Describe "Platform Matrix Replace" -Tag "replace" {
+Describe "Platform Matrix Replace" -Tag "UnitTest", "replace" {
     It "Should parse replacement syntax" -TestCases @(
          @{ query = 'foo=bar/baz'; key = '^foo$'; value = '^bar$'; replace = 'baz' },
          @{ query = 'foo=\/p:bar/\/p:baz'; key = '^foo$'; value = '^\/p:bar$'; replace = '/p:baz' },

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
@@ -2,7 +2,7 @@ Import-Module Pester
 
 
 BeforeAll {
-    . $PSScriptRoot/../job-matrix-functions.ps1
+  . $PSScriptRoot/../../../common/scripts/job-matrix/job-matrix-functions.ps1
 
     function CompareMatrices([Array]$matrix, [Array]$expected) {
         $matrix.Length | Should -Be $expected.Length

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
@@ -88,7 +88,7 @@ Describe "Platform Matrix nonSparse" -Tag "UnitTest", "nonsparse" {
         $matrixJson = @'
 {
     "matrix": {
-        "$IMPORT": "./eng/common/scripts/job-matrix/tests/test-import-matrix.json",
+        "$IMPORT": "./matrix-generator/tests/test-import-matrix.json",
         "TestField1": "test1"
     },
     "exclude": [ { "Baz": "importedBaz" } ]
@@ -130,7 +130,7 @@ Describe "Platform Matrix Import" -Tag "UnitTest", "import" {
         $matrixJson = @'
 {
     "matrix": {
-        "$IMPORT": "./eng/common/scripts/job-matrix/tests/test-import-matrix.json"
+        "$IMPORT": "./matrix-generator/tests/test-import-matrix.json"
     },
     "include": [
         {
@@ -173,7 +173,7 @@ Describe "Platform Matrix Import" -Tag "UnitTest", "import" {
         $matrixJson = @'
 {
     "matrix": {
-        "$IMPORT": "./eng/common/scripts/job-matrix/tests/test-import-matrix.json",
+        "$IMPORT": "./matrix-generator/tests/test-import-matrix.json",
         "TestField1": "test1",
         "TestField2": "test2"
     },
@@ -206,7 +206,7 @@ Describe "Platform Matrix Import" -Tag "UnitTest", "import" {
         $matrixJson = @'
 {
     "matrix": {
-        "$IMPORT": "./eng/common/scripts/job-matrix/tests/test-import-matrix.json",
+        "$IMPORT": "./matrix-generator/tests/test-import-matrix.json",
         "testField": [ "test1", "test2" ]
     }
 }
@@ -235,7 +235,7 @@ Describe "Platform Matrix Import" -Tag "UnitTest", "import" {
         "importedBaz": "importedBazNameOverride"
     },
     "matrix": {
-        "$IMPORT": "./eng/common/scripts/job-matrix/tests/test-import-matrix.json",
+        "$IMPORT": "./matrix-generator/tests/test-import-matrix.json",
         "testField": [ "test1", "test2" ]
     }
 }
@@ -251,7 +251,7 @@ Describe "Platform Matrix Import" -Tag "UnitTest", "import" {
         $matrixJson = @'
 {
     "matrix": {
-        "$IMPORT": "./eng/common/scripts/job-matrix/tests/test-import-matrix.json",
+        "$IMPORT": "./matrix-generator/tests/test-import-matrix.json",
         "testField1": [ "test11", "test12" ],
         "testField2": [ "test21", "test22" ]
     }
@@ -299,7 +299,7 @@ Describe "Platform Matrix Import" -Tag "UnitTest", "import" {
         $matrixJson = @'
 {
     "matrix": {
-        "$IMPORT": "./eng/common/scripts/job-matrix/tests/test-import-matrix.json",
+        "$IMPORT": "./matrix-generator/tests/test-import-matrix.json",
         "testField": [ "test1", "test2", "test3" ],
     },
     "include": [
@@ -364,7 +364,7 @@ Describe "Platform Matrix Import" -Tag "UnitTest", "import" {
         $matrixJson = @'
 {
     "matrix": {
-        "$IMPORT": "./eng/common/scripts/job-matrix/tests/test-import-matrix.json",
+        "$IMPORT": "./matrix-generator/tests/test-import-matrix.json",
         "Foo": [ "fooOverride1", "fooOverride2" ],
     }
 }
@@ -450,7 +450,7 @@ Describe "Platform Matrix Replace" -Tag "UnitTest", "replace" {
         $matrixJson = @'
 {
     "matrix": {
-        "$IMPORT": "./eng/common/scripts/job-matrix/tests/test-import-matrix.json",
+        "$IMPORT": "./matrix-generator/tests/test-import-matrix.json",
         "testField": [ "test1", "test2" ]
     }
 }
@@ -550,7 +550,7 @@ Describe "Platform Matrix Replace" -Tag "UnitTest", "replace" {
     "replaceme": ""
   },
   "matrix": {
-    "$IMPORT": "./eng/common/scripts/job-matrix/tests/test-import-matrix.json",
+    "$IMPORT": "./matrix-generator/tests/test-import-matrix.json",
     "replaceme": "replaceme"
   }
 }

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.tests.ps1
@@ -1,7 +1,7 @@
 Import-Module Pester
 
 BeforeAll {
-    . $PSScriptRoot/../job-matrix-functions.ps1
+    . $PSScriptRoot/../../../common/scripts/job-matrix/job-matrix-functions.ps1
 
     $matrixConfig = @"
 {

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.tests.ps1
@@ -48,7 +48,7 @@ BeforeAll {
 "@
 }
 
-Describe "Matrix-Lookup" -Tag "lookup" {
+Describe "Matrix-Lookup" -Tag "UnitTest", "lookup" {
     It "Should navigate a 2d matrix: <row> <col>" -TestCases @(
          @{ row = 0; col = 0; expected = 1 },
          @{ row = 0; col = 1; expected = 2 },
@@ -148,7 +148,7 @@ Describe "Matrix-Lookup" -Tag "lookup" {
     }
 }
 
-Describe "Matrix-Reverse-Lookup" -Tag "lookup" {
+Describe "Matrix-Reverse-Lookup" -Tag "UnitTest", "lookup" {
     It "Should lookup a 2d matrix index: <index>" -TestCases @(
          @{ index = 0; expected = @(0,0) }
          @{ index = 1; expected = @(0,1) }
@@ -251,7 +251,7 @@ Describe "Matrix-Reverse-Lookup" -Tag "lookup" {
     }
 }
 
-Describe 'Matrix-Set' -Tag "set" {
+Describe 'Matrix-Set' -Tag "UnitTest", "set" {
     It "Should set a matrix element" -TestCases @(
         @{ value = "set"; index = @(0,0,0,0); arrayIndex = 0 }
         @{ value = "ones"; index = @(0,1,1,1); arrayIndex = 13 }
@@ -264,7 +264,7 @@ Describe 'Matrix-Set' -Tag "set" {
     }
 }
 
-Describe "Platform Matrix Generation" -Tag "generate" {
+Describe "Platform Matrix Generation" -Tag "UnitTest", "generate" {
     BeforeEach {
         $matrixConfigForGenerate = @"
 {
@@ -373,7 +373,7 @@ Describe "Platform Matrix Generation" -Tag "generate" {
     }
 }
 
-Describe "Config File Object Conversion" -Tag "convert" {
+Describe "Config File Object Conversion" -Tag "UnitTest", "convert" {
     BeforeEach {
         $config = GetMatrixConfigFromJson $matrixConfig
     }
@@ -390,7 +390,7 @@ Describe "Config File Object Conversion" -Tag "convert" {
     }
 }
 
-Describe "Platform Matrix Post Transformation" -Tag "transform" {
+Describe "Platform Matrix Post Transformation" -Tag "UnitTest", "transform" {
     BeforeEach {
         $config = GetMatrixConfigFromJson $matrixConfig
     }
@@ -486,7 +486,7 @@ Describe "Platform Matrix Post Transformation" -Tag "transform" {
     }
 }
 
-Describe "Platform Matrix Generation With Object Fields" -Tag "objectfields" {
+Describe "Platform Matrix Generation With Object Fields" -Tag "UnitTest", "objectfields" {
     BeforeEach {
         $matrixConfigForObject = @"
 {
@@ -572,7 +572,7 @@ Describe "Platform Matrix Generation With Object Fields" -Tag "objectfields" {
     }
 }
 
-Describe "Platform Matrix Job and Display Names" -Tag "displaynames" {
+Describe "Platform Matrix Job and Display Names" -Tag "UnitTest", "displaynames" {
     BeforeEach {
         $matrixConfigForGenerate = @"
 {

--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -380,7 +380,7 @@ function ProcessImport([MatrixParameter[]]$matrix, [String]$selection, [Array]$n
     }
 
     if (!(Test-Path $importPath)) {
-        Write-Error "`$IMPORT path '$importPath' does not exist."
+        Write-Error "`$IMPORT path '$importPath' does not exist. Current dir: $(Get-Location)"
         exit 1
     }
     $importedMatrixConfig = GetMatrixConfigFromFile (Get-Content -Raw $importPath)


### PR DESCRIPTION
This PR fixes paths I forgot to update when I did this PR:
- #5027

And as such this PR contributes to addressing:
- #4995

It also adds `UnitTest` tags to the `matrix-generator` tests so [`common-tests/ci.yml` pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=5809) executes them.

### Related work

- #5098
