### PR TITLE
Revert "Disable auto gpg signing (#5047)"

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -123,7 +123,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     }
                     SetOrigin(config);
 
-                    GitHandler.Run($"tag -c tag.gpgsign=false {generatedTagName}", config);
+                    GitHandler.Run($"tag {generatedTagName}", config);
                     GitHandler.Run($"push origin {generatedTagName}", config);
                     HideOrigin(config);
                 }


### PR DESCRIPTION
This reverts commit f1c5c78b27b6f9510ffab2d9dba522472ea67916.

Re-opening #4720

All livetests broken by this change. Apparently this configuration element is honored a different way than I originally coded it. Need to figure out what's going on in livetests and resolve. Reverting this until I can do that (as the test-proxy asset-sync functionality is currently broken by the original PR)