### PR TITLE
`notification-configuration`: write out repo URL used to obtain CODEOWNERS file

### DIFF
--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -186,8 +186,8 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
                 }
 
                 // Get contents of CODEOWNERS
-                logger.LogInformation("Fetching CODEOWNERS file");
                 Uri repoUrl = pipeline.Repository.Url;
+                logger.LogInformation("Fetching CODEOWNERS file from repo url '{repoUrl}'", repoUrl);
 
                 if (repoUrl != null)
                 {


### PR DESCRIPTION
In this PR I am printing out to STDOUT the full URL of the repository from which the `CODEOWNERS` file is be parsed by the `notification-configurator`.

I need this because I am planning to make the `CODEOWNERS` file path matching logic to behave differently based on the repository from which the file is originating. This will enable me to do gradual rollout of the regex-based matcher.

Details here:
- https://github.com/Azure/azure-sdk-tools/pull/5088#issuecomment-1397427097