### PR TITLE
Unhardcode C# lang versions, making them use TFM default (currently `10.0` due to TFM of `net6.0`).

### DIFF
--- a/eng/Directory.Build.props
+++ b/eng/Directory.Build.props
@@ -4,7 +4,6 @@
     <Configuration Condition="'$(Configuration)' == ''">Debug</Configuration>
     <Platform Condition="'$(Platform)' == ''">AnyCPU</Platform>
     <PlatformName Condition="'$(PlatformName)' == ''">$(Platform)</PlatformName>
-    <LangVersion>8.0</LangVersion>
     <SignAssembly>true</SignAssembly>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/src/dotnet/APIView/APIView/APIView.csproj
+++ b/src/dotnet/APIView/APIView/APIView.csproj
@@ -5,7 +5,6 @@
     <ApplicationIcon />
     <OutputType>Exe</OutputType>
     <StartupObject />
-    <LangVersion>Latest</LangVersion>
     <SignAssembly>True</SignAssembly>
   </PropertyGroup>
 

--- a/src/dotnet/APIView/APIViewIntegrationTests/APIViewIntegrationTests.csproj
+++ b/src/dotnet/APIView/APIViewIntegrationTests/APIViewIntegrationTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <UserSecretsId>02d57eb4-c954-413d-8ad3-3534aee82452</UserSecretsId>

--- a/src/dotnet/APIView/APIViewUnitTests/APIViewUnitTests.csproj
+++ b/src/dotnet/APIView/APIViewUnitTests/APIViewUnitTests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <EmbeddedResourceUseDependentUponConvention>false</EmbeddedResourceUseDependentUponConvention>

--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <RootNamespace>APIViewWeb</RootNamespace>
     <AssemblyName>APIViewWeb</AssemblyName>
     <UserSecretsId>79cceff6-d533-4370-a0ee-f3321a343907</UserSecretsId>

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFrameworks>net6.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
@@ -5,6 +5,11 @@
     https://github.com/Azure/azure-sdk-tools/pull/5048
     -->
     <TargetFramework>netstandard2.0</TargetFramework>
+    <!--
+    Need to set LangVersion manually as netstandard2.0 targets 7.3 by default.
+    https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version
+    -->
+    <LangVersion>10.0</LangVersion>
     <BuildOutputTargetFolder>analyzers/dotnet/cs/</BuildOutputTargetFolder>
     <VersionPrefix>0.1.1</VersionPrefix>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.csproj
@@ -7,7 +7,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <BuildOutputTargetFolder>analyzers/dotnet/cs/</BuildOutputTargetFolder>
     <VersionPrefix>0.1.1</VersionPrefix>
-    <LangVersion>8</LangVersion>
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
   </PropertyGroup>
 

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiParser.csproj
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiParser.csproj
@@ -6,7 +6,6 @@
     <ToolCommandName>swaggerAPIParser</ToolCommandName>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>swagger_api_parser</RootNamespace>
-    <LangVersion>Latest</LangVersion>
     <VersionPrefix>1.0.5</VersionPrefix>
     <AssemblyName>Azure.Sdk.Tools.SwaggerApiParser</AssemblyName>
     <SignAssembly>True</SignAssembly>

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParserTest/SwaggerApiParserTest.csproj
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParserTest/SwaggerApiParserTest.csproj
@@ -3,10 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
-
         <IsPackable>false</IsPackable>
-
-        <LangVersion>10</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/Azure.Sdk.Tools.CodeOwnersParser.Tests.csproj
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.CodeOwnersParser.Tests/Azure.Sdk.Tools.CodeOwnersParser.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/Azure.Sdk.Tools.RetrieveCodeOwners.Tests.csproj
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/Azure.Sdk.Tools.RetrieveCodeOwners.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners/Azure.Sdk.Tools.RetrieveCodeOwners.csproj
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners/Azure.Sdk.Tools.RetrieveCodeOwners.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <PackAsTool>true</PackAsTool>

--- a/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
+++ b/tools/code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Azure.Sdk.Tools.PipelineWitness.csproj
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Azure.Sdk.Tools.PipelineWitness.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-    <LangVersion>10.0</LangVersion>
     <UserSecretsId>bc5587e8-3503-4e1a-816c-1e219e4047f6</UserSecretsId>
   </PropertyGroup>
 

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/Azure.Sdk.Tools.SnippetGenerator.Tests.csproj
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/Azure.Sdk.Tools.SnippetGenerator.Tests.csproj
@@ -3,7 +3,6 @@
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <IsPackable>false</IsPackable>
-        <LangVersion>latest</LangVersion>
     </PropertyGroup>
 
     <ItemGroup>

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Azure.Sdk.Tools.SnippetGenerator.csproj
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Azure.Sdk.Tools.SnippetGenerator.csproj
@@ -7,7 +7,6 @@
     <ToolCommandName>snippet-generator</ToolCommandName>
     <VersionPrefix>1.0.0</VersionPrefix>
     <AssemblyName>Azure.Sdk.Tools.SnippetGenerator</AssemblyName>
-    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
As in subject. Because we use `net6.0`, [currently the default lang version is `10.0`](https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version#defaults).

Previously the lang version was forced by [`eng/Directory.Build.props`](https://github.com/Azure/azure-sdk-tools/pull/5175/files#diff-81138f4f0bdd24607d3d5979bdc08f91e9cfe44255de13ce958719925f1ae88b), hence many projects were overriding it. With this PR this is no longer necessary.

The need for this work was discovered during the following:
- https://github.com/Azure/azure-sdk-tools/pull/5134#discussion_r1070172769