### PR TITLE
Extract `Contacts` class + related refactorings to `NotificationConfigurator` class.

### DIFF
--- a/tools/identity-resolution/Services/GitHubService.cs
+++ b/tools/identity-resolution/Services/GitHubService.cs
@@ -35,7 +35,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
         /// </summary>
         /// <param name="repoUrl">GitHub repository URL</param>
         /// <returns>Contents fo the located CODEOWNERS file</returns>
-        public async Task<List<CodeownersEntry>> GetCodeownersFile(Uri repoUrl)
+        public async Task<List<CodeownersEntry>> GetCodeownersFileEntries(Uri repoUrl)
         {
             List<CodeownersEntry> result;
             if (codeownersFileCache.TryGetValue(repoUrl.ToString(), out result))

--- a/tools/identity-resolution/Services/GitHubService.cs
+++ b/tools/identity-resolution/Services/GitHubService.cs
@@ -68,7 +68,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
             }
 
             logger.LogWarning("Could not retrieve CODEOWNERS file URL = {0} ResponseCode = {1}", codeOwnersUrl, result.StatusCode);
-            return default;
+            return null;
         }
 
     }

--- a/tools/notification-configuration/notification-creator/Contacts.cs
+++ b/tools/notification-configuration/notification-creator/Contacts.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using Azure.Sdk.Tools.CodeOwnersParser;
+using Microsoft.Extensions.Logging;
+using Microsoft.TeamFoundation.Build.WebApi;
+
+namespace Azure.Sdk.Tools.NotificationConfiguration;
+
+/// <summary>
+/// This class represents a set of contacts obtained from CODEOWNERS file
+/// located in repository attached to given build definition.
+///
+/// The contacts are the CODEOWNERS path owners of path that matches the build definition file path.
+///
+/// To obtain the contacts, construct this class and then call GetFromBuildDefinitionRepoCodeowners(buildDefinition).
+/// </summary>
+internal class Contacts
+{
+    private readonly ILogger log;
+    private readonly GitHubService gitHubService;
+
+    // Type 2 maps to a build definition YAML file in the repository
+    private const int BuildDefinitionYamlProcessType = 2;
+
+    internal Contacts(GitHubService gitHubService, ILogger log)
+    {
+        this.log = log;
+        this.gitHubService = gitHubService;
+    }
+
+    /// <summary>
+    /// See the class comment.
+    /// </summary>
+    public async Task<List<string>> GetFromBuildDefinitionRepoCodeowners(BuildDefinition buildDefinition)
+    {
+        if (buildDefinition.Process.Type != BuildDefinitionYamlProcessType)
+        {
+            this.log.LogDebug(
+                "buildDefinition.Process.Type for buildDefinition.Name = '{buildDefinitionName}' " +
+                "is not BuildDefinitionYamlProcessType = {BuildDefinitionYamlProcessType}.",
+                buildDefinition.Name,
+                BuildDefinitionYamlProcessType);
+            return null;
+        }
+
+        Uri repoUrl = GetCodeownersRepoUrl(buildDefinition);
+
+        if (repoUrl == null)
+        {
+            // assert: the reason why repoUrl is null has been already logged.
+            return null;
+        }
+
+        List<CodeownersEntry> codeownersEntries = await gitHubService.GetCodeownersFileEntries(repoUrl);
+
+        if (codeownersEntries == default)
+        {
+            this.log.LogInformation("CODEOWNERS file in '{repoUrl}' not found, skipping sync.", repoUrl);
+            return null;
+        }
+
+        if (buildDefinition.Process is not YamlProcess process)
+        {
+            this.log.LogError(
+                "buildDefinition.Process as YamlProcess is null. buildDefinition.Name: '{buildDefinitionName}'",
+                buildDefinition.Name);
+            return null;
+        }
+
+        // process.YamlFilename is misleading here. It is actually a file path, not file name.
+        // E.g. it is "sdk/foo_service/ci.yml".
+        string buildDefinitionFilePath = process.YamlFilename; 
+
+        this.log.LogInformation(
+            "Searching CODEOWNERS for matching path for '{buildDefinitionFilePath}'",
+            buildDefinitionFilePath);
+
+        CodeownersEntry matchingCodeownersEntry = GetMatchingCodeownersEntry(process, codeownersEntries);
+        List<string> contacts = matchingCodeownersEntry.Owners;
+
+        this.log.LogInformation(
+            "Found matching contacts (owners) in CODEOWNERS. " +
+            "Searched path = '{buildDefinitionOwnerFile}', Contacts# = {contactsCount}",
+            buildDefinitionFilePath,
+            contacts.Count);
+
+        return contacts;
+    }
+
+    private Uri GetCodeownersRepoUrl(BuildDefinition buildDefinition)
+    {
+        Uri repoUrl = buildDefinition.Repository.Url;
+        this.log.LogInformation("Fetching CODEOWNERS file from repoUrl: '{repoUrl}'", repoUrl);
+
+        if (repoUrl != null)
+        {
+            repoUrl = new Uri(Regex.Replace(repoUrl.ToString(), @"\.git$", String.Empty));
+        }
+        else
+        {
+            this.log.LogError(
+                "No repository url returned from buildDefinition. " +
+                "buildDefinition.Name: '{buildDefinitionName}' " +
+                "buildDefinition.Repository.Id: {buildDefinitionRepositoryId}",
+                buildDefinition.Name,
+                buildDefinition.Repository.Id);
+        }
+
+        return repoUrl;
+    }
+
+
+    private CodeownersEntry GetMatchingCodeownersEntry(YamlProcess process, List<CodeownersEntry> codeownersEntries)
+    {
+        CodeownersEntry matchingCodeownersEntry =
+            CodeownersFile.GetMatchingCodeownersEntry(process.YamlFilename, codeownersEntries);
+
+        matchingCodeownersEntry.ExcludeNonUserAliases();
+
+        return matchingCodeownersEntry;
+    }
+}


### PR DESCRIPTION
## Changes made

This PR improves logged messages and refactors `NotificationConfigurator` class logic related to obtaining list of contacts to send notifications to based on CODEOWNERS file from repository to which given pipeline pertains.

The main change is extraction of `Contacts` class from `NotificationConfigurator` class, with entry method being `Contacts.GetFromBuildDefinitionRepoCodeowners(BuildDefinition buildDefinition)`.

I also made related improvements to log messages and naming in surrounding code. Most notably, I made the naming more consistent and got rid of some synonyms or mismatched names, like `BuildDefinition` being named `Pipeline`.

## Test plan

Once this PR is merged and package published, I will run the [`automation - build-failure-notification-subscriptions` pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=679&_a=summary) from a branch that uses the new package and report how it went here. I do not expect any issues as the PR is composed only of automated refactoring and logged messages updates.

If there are problems, I will re-run the pipeline from `main` to restore the notification setup.

## Context

This PR originated by salvaging refactored code from this PR:
- #5194

And significantly expanding upon it.

In general, I have bunch of related work upcoming pertaining to the logic modified in this PR, hence I am working on improving the code. Related issues:
- #5089
- #4859