### PR TITLE
Add Template for Upload of Proxy Logs

### DIFF
--- a/eng/common/testproxy/publish-proxy-logs.yml
+++ b/eng/common/testproxy/publish-proxy-logs.yml
@@ -1,0 +1,9 @@
+parameters:
+  rootFolder: '$(Build.SourcesDirectory)'
+
+steps:
+  - template: ../pipelines/templates/steps/publish-artifact.yml
+    parameters:
+      ArtifactName: "proxy-logs"
+      ArtifactPath: "${{ parameters.rootFolder }}/test-proxy.log"
+

--- a/eng/common/testproxy/publish-proxy-logs.yml
+++ b/eng/common/testproxy/publish-proxy-logs.yml
@@ -2,8 +2,15 @@ parameters:
   rootFolder: '$(Build.SourcesDirectory)'
 
 steps:
+  - pwsh: |
+      Copy-Item -Path "${{ parameters.rootFolder }}/test-proxy.log" -Destination "${{ parameters.rootFolder }}/proxy.log"
+    displayName: Copy Log File
+
   - template: ../pipelines/templates/steps/publish-artifact.yml
     parameters:
-      ArtifactName: "proxy-logs"
-      ArtifactPath: "${{ parameters.rootFolder }}/test-proxy.log"
+      ArtifactName: "$(System.JobName)-proxy-logs"
+      ArtifactPath: "${{ parameters.rootFolder }}/proxy.log"
 
+  - pwsh: |
+      Remove-Item -Force ${{ parameters.rootFolder }}/proxy.log
+    displayName: Cleanup Copied Log File

--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -42,13 +42,13 @@ steps:
     - pwsh: |
         Start-Process $(Build.BinariesDirectory)/test-proxy/test-proxy.exe `
           -ArgumentList "--storage-location ${{ parameters.rootFolder }}" `
-          -NoNewWindow -PassThru -RedirectStandardOutput ${{ parameters.templateRoot }}/test-proxy.log
+          -NoNewWindow -PassThru -RedirectStandardOutput ${{ parameters.rootFolder }}/test-proxy.log
       displayName: 'Run the testproxy - windows'
       condition: and(succeeded(), eq(variables['Agent.OS'],'Windows_NT'), ${{ parameters.condition }})
 
     # nohup does NOT continue beyond the current session if you use it within powershell
     - bash: |
-        nohup $(Build.BinariesDirectory)/test-proxy/test-proxy > ${{ parameters.templateRoot }}/test-proxy.log &
+        nohup $(Build.BinariesDirectory)/test-proxy/test-proxy > ${{ parameters.rootFolder }}/test-proxy.log &
       displayName: "Run the testproxy - linux/mac"
       condition: and(succeeded(), ne(variables['Agent.OS'],'Windows_NT'), ${{ parameters.condition }})
       workingDirectory: "${{ parameters.rootFolder }}"


### PR DESCRIPTION
If you're using a simple invocation of the `test-proxy-tool.yml`, you will be able to call the following before your tests run.

```yml
- template: /eng/common/testproxy/test-proxy-tool.yml
  parameters:
    rootFolder: $(Build.SourcesDirectory)/sdk/core
```

One will be able to call:

```yml
- template: /eng/common/testproxy/publish-proxy-logs.yml
  parameters:
    rootFolder: $(Build.SourcesDirectory)/sdk/core
```

As long as you reflect the same `rootFolder` argument to publish-proxy-logs, they will be picked up and uploaded as artifacts.

[Example Invocation](https://dev.azure.com/azure-sdk/public/_build/results?buildId=2139544)

What the artifacts look like:
![image](https://user-images.githubusercontent.com/45376673/214681466-57ea5311-bc54-44ca-b2b9-acdec929238c.png)

Resolves the other half of #5204