### PR TITLE
Batch background review update when parser version changes

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/IReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/IReviewManager.cs
@@ -30,7 +30,7 @@ namespace APIViewWeb.Managers
         public Task ApprovePackageNameAsync(ClaimsPrincipal user, string id);
         public Task<bool> IsReviewSame(ReviewRevisionModel revision, RenderedCodeFile renderedCodeFile);
         public Task<ReviewRevisionModel> CreateMasterReviewAsync(ClaimsPrincipal user, string originalName, string label, Stream fileStream, bool compareAllRevisions);
-        public Task UpdateReviewBackground();
+        public Task UpdateReviewBackground(HashSet<string> updateDisabledLanguages, int backgroundBatchProcessCount);
         public Task<CodeFile> GetCodeFile(string repoName, string buildId, string artifactName, string packageName, string originalFileName, string codeFileName,
             MemoryStream originalFileStream, string baselineCodeFileName = "", MemoryStream baselineStream = null, string project = "public");
         public Task<ReviewRevisionModel> CreateApiReview(ClaimsPrincipal user, string buildId, string artifactName, string originalFileName, string label,


### PR DESCRIPTION
API review is updated when parser version changes as part of background task during server startup. This causes too many pipelines running in parallel when running one pipeline for each review to be updated. This PR has changes to:
1. Batch process reviews to be updated with an option to configure batch size
2. Also add an option to disable a specific language from background update task instead of disabling the task for all languages due to an issue in one language.