### PR TITLE
[test resources] Consolidate naming logic and generate short hash names for local use

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -586,7 +586,9 @@ try {
                 Location = $Location
             }
         } else {
-            Write-Error "Resource group '$ResourceGroupName' already exists." -Category ResourceExists -RecommendedAction "Delete resource group '$ResourceGroupName', or overwrite it when redeploying."
+            Write-Error "Resource group '$ResourceGroupName' already exists." `
+                            -Category ResourceExists `
+                            -RecommendedAction "Delete resource group '$ResourceGroupName', or overwrite it when redeploying."
         }
     }
 
@@ -608,7 +610,10 @@ try {
                 $displayName = "$($baseName)$suffix.$ResourceType-resources.azure.sdk"
             }
 
-            $servicePrincipalWrapper = NewServicePrincipalWrapper -subscription $SubscriptionId -resourceGroup $ResourceGroupName -displayName $DisplayName
+            $servicePrincipalWrapper = NewServicePrincipalWrapper `
+                                        -subscription $SubscriptionId `
+                                        -resourceGroup $ResourceGroupName `
+                                        -displayName $DisplayName
 
             $global:AzureTestPrincipal = $servicePrincipalWrapper
             $global:AzureTestSubscription = $SubscriptionId
@@ -635,7 +640,8 @@ try {
             }
         }
         catch {
-            Write-Warning "The Object ID of the test application was unable to be queried. You may want to consider passing it explicitly with the 'TestApplicationOid` parameter."
+            Write-Warning "The Object ID of the test application was unable to be queried. " + `
+                          "You may want to consider passing it explicitly with the 'TestApplicationOid` parameter."
             throw $_.Exception
         }
 
@@ -652,7 +658,11 @@ try {
     # If the role hasn't been explicitly assigned to the resource group and a cached service principal is in use,
     # query to see if the grant is needed.
     if (!$resourceGroupRoleAssigned -and $AzureTestPrincipal) {
-        $roleAssignment = Get-AzRoleAssignment -ObjectId $AzureTestPrincipal.Id -RoleDefinitionName 'Owner' -ResourceGroupName "$ResourceGroupName" -ErrorAction SilentlyContinue
+        $roleAssignment = Get-AzRoleAssignment `
+                            -ObjectId $AzureTestPrincipal.Id `
+                            -RoleDefinitionName 'Owner' `
+                            -ResourceGroupName "$ResourceGroupName" `
+                            -ErrorAction SilentlyContinue
         $resourceGroupRoleAssigned = ($roleAssignment.RoleDefinitionName -eq 'Owner')
     }
 
@@ -662,12 +672,18 @@ try {
    # the explicit grant.
    if (!$resourceGroupRoleAssigned) {
         Log "Attempting to assigning the 'Owner' role for '$ResourceGroupName' to the Test Application '$TestApplicationId'"
-        $principalOwnerAssignment = New-AzRoleAssignment -RoleDefinitionName "Owner" -ApplicationId "$TestApplicationId" -ResourceGroupName "$ResourceGroupName" -ErrorAction SilentlyContinue
+        $principalOwnerAssignment = New-AzRoleAssignment `
+                                        -RoleDefinitionName "Owner" `
+                                        -ApplicationId "$TestApplicationId" `
+                                        -ResourceGroupName "$ResourceGroupName" `
+                                        -ErrorAction SilentlyContinue
 
         if ($principalOwnerAssignment.RoleDefinitionName -eq 'Owner') {
             Write-Verbose "Successfully assigned ownership of '$ResourceGroupName' to the Test Application '$TestApplicationId'"
         } else {
-            Write-Warning "The 'Owner' role for '$ResourceGroupName' could not be assigned. You may need to manually grant 'Owner' for the resource group to the Test Application '$TestApplicationId' if it does not have subscription-level permissions."
+            Write-Warning "The 'Owner' role for '$ResourceGroupName' could not be assigned. " + `
+                          "You may need to manually grant 'Owner' for the resource group to the " + `
+                          "Test Application '$TestApplicationId' if it does not have subscription-level permissions."
         }
     }
 

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -323,6 +323,13 @@ function SetDeploymentOutputs(
             Log "Persist the following environment variables based on your detected shell ($shell):`n"
         }
 
+        # Write overwrite warnings first, since local execution prints a runnable command to export variables
+        foreach ($key in $deploymentOutputs.Keys) {
+            if ([Environment]::GetEnvironmentVariable($key)) {
+                Write-Warning "Deployment outputs will overwrite pre-existing environment variable '$key'"
+            }
+        }
+
         # Marking values as secret by allowed keys below is not sufficient, as there may be outputs set in the ARM/bicep
         # file that re-mark those values as secret (since all user-provided deployment outputs are treated as secret by default).
         # This variable supports a second check on not marking previously allowed keys/values as secret.

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -147,14 +147,13 @@ if (!$ResourceGroupName) {
             exit 0
         }
     } else {
-        if (!$BaseName) {
-            $UserName = GetUserName
-            $BaseName = GetBaseName $UserName $ServiceDirectory
-            Log "BaseName was not set. Using default base name '$BaseName'"
-        }
-
-        # Format the resource group name like in New-TestResources.ps1.
-        $ResourceGroupName = "rg-$BaseName"
+        $serviceName = GetServiceLeafDirectoryName $ServiceDirectory
+        $BaseName, $ResourceGroupName = GetBaseAndResourceGroupNames `
+            -baseNameDefault $BaseName `
+            -resourceGroupNameDefault $ResourceGroupName `
+            -user (GetUserName) `
+            -serviceDirectoryName $serviceName `
+            -CI $CI
     }
 }
 

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -16,10 +16,40 @@ function GetUserName() {
     return $UserName
 }
 
-function GetBaseName([string]$user, [string]$serviceDirectoryName) {
+function GetBaseAndResourceGroupNames(
+    [string]$baseNameDefault,
+    [string]$resourceGroupNameDefault,
+    [string]$user,
+    [string]$serviceDirectoryName,
+    [bool]$CI
+) {
+    if ($CI) {
+        $base = 't' + (New-Guid).ToString('n').Substring(0, 16)
+        # Format the resource group name based on resource group naming recommendations and limitations.
+        $generatedGroup = "rg-{0}-$BaseName" -f ($serviceName -replace '[\.\\\/:]', '-').ToLowerInvariant().Substring(0, [Math]::Min($serviceName.Length, 90 - $BaseName.Length - 4)).Trim('-')
+        $group = $resourceGroupNameDefault ? $resourceGroupNameDefault : $generatedGroup
+
+        Log "Generated resource base name '$base' and resource group name '$group' for CI build"
+
+        return $base, $group
+    }
+
+    if ($baseNameDefault) {
+        $base = $baseNameDefault.ToLowerInvariant()
+        $group = $resourceGroupNameDefault ? $resourceGroupNameDefault : ("rg-$baseNameDefault".ToLowerInvariant())
+        return $base, $group
+    }
+
     # Handle service directories in nested directories, e.g. `data/aztables`
     $serviceDirectorySafeName = $serviceDirectoryName -replace '[\./\\]', ''
-    return "$user$serviceDirectorySafeName".ToLowerInvariant()
+    # Hash to keep resource names short enough to not break naming restrictions (e.g. keyvault name length)
+    $baseNameStream = [IO.MemoryStream]::new([Text.Encoding]::UTF8.GetBytes("${user}${serviceDirectorySafeName}"))
+    $base = 't' + (Get-FileHash -InputStream $baseNameStream -Algorithm SHA1).Hash.Substring(0, 16).ToLowerInvariant()
+    $group = $resourceGroupNameDefault ? $resourceGroupNameDefault : "rg-${user}${serviceDirectorySafeName}".ToLowerInvariant();
+
+    Log "BaseName was not set. Generating resource group name '$group' and resource base name '$base'"
+
+    return $base, $group
 }
 
 function ShouldMarkValueAsSecret([string]$serviceName, [string]$key, [string]$value, [array]$allowedValues = @())

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -26,7 +26,10 @@ function GetBaseAndResourceGroupNames(
     if ($CI) {
         $base = 't' + (New-Guid).ToString('n').Substring(0, 16)
         # Format the resource group name based on resource group naming recommendations and limitations.
-        $generatedGroup = "rg-{0}-$BaseName" -f ($serviceName -replace '[\.\\\/:]', '-').ToLowerInvariant().Substring(0, [Math]::Min($serviceName.Length, 90 - $BaseName.Length - 4)).Trim('-')
+        $generatedGroup = "rg-{0}-$base" -f ($serviceName -replace '[\.\\\/:]', '-').
+                            Substring(0, [Math]::Min($serviceDirectoryName.Length, 90 - $base.Length - 4)).
+                            Trim('-').
+                            ToLowerInvariant()
         $group = $resourceGroupNameDefault ? $resourceGroupNameDefault : $generatedGroup
 
         Log "Generated resource base name '$base' and resource group name '$group' for CI build"

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -49,7 +49,7 @@ function GetBaseAndResourceGroupNames(
     $seed = $resourceGroupNameDefault ? $resourceGroupNameDefault : "${user}${serviceDirectorySafeName}"
     $baseNameStream = [IO.MemoryStream]::new([Text.Encoding]::UTF8.GetBytes("$seed"))
     # Hash to keep resource names short enough to not break naming restrictions (e.g. keyvault name length)
-    $base = 't' + (Get-FileHash -InputStream $baseNameStream -Algorithm SHA1).Hash.Substring(0, 16).ToLowerInvariant()
+    $base = 't' + (Get-FileHash -InputStream $baseNameStream -Algorithm SHA256).Hash.Substring(0, 16).ToLowerInvariant()
     $group = $resourceGroupNameDefault ? $resourceGroupNameDefault : "rg-${user}${serviceDirectorySafeName}".ToLowerInvariant();
 
     Log "BaseName was not set. Generating resource group name '$group' and resource base name '$base'"

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -45,8 +45,10 @@ function GetBaseAndResourceGroupNames(
 
     # Handle service directories in nested directories, e.g. `data/aztables`
     $serviceDirectorySafeName = $serviceDirectoryName -replace '[\./\\]', ''
+    # Seed off resource group name if set to avoid name conflicts with deployments where it is not set
+    $seed = $resourceGroupNameDefault ? $resourceGroupNameDefault : "${user}${serviceDirectorySafeName}"
+    $baseNameStream = [IO.MemoryStream]::new([Text.Encoding]::UTF8.GetBytes("$seed"))
     # Hash to keep resource names short enough to not break naming restrictions (e.g. keyvault name length)
-    $baseNameStream = [IO.MemoryStream]::new([Text.Encoding]::UTF8.GetBytes("${user}${serviceDirectorySafeName}"))
     $base = 't' + (Get-FileHash -InputStream $baseNameStream -Algorithm SHA1).Hash.Substring(0, 16).ToLowerInvariant()
     $group = $resourceGroupNameDefault ? $resourceGroupNameDefault : "rg-${user}${serviceDirectorySafeName}".ToLowerInvariant();
 

--- a/eng/common/TestResources/Update-TestResources.ps1
+++ b/eng/common/TestResources/Update-TestResources.ps1
@@ -75,7 +75,7 @@ $BaseName, $ResourceGroupName = GetBaseAndResourceGroupNames `
     -resourceGroupNameDefault $ResourceGroupName `
     -user (GetUserName) `
     -serviceDirectoryName $serviceName `
-    -CI $CI
+    -CI $false
 
 # This script is intended for interactive users. Make sure they are logged in or fail.
 $context = Get-AzContext

--- a/eng/common/TestResources/Update-TestResources.ps1
+++ b/eng/common/TestResources/Update-TestResources.ps1
@@ -69,17 +69,13 @@ $exitActions = @({
     }
 })
 
-# Make sure $ResourceGroupName is set.
-if (!$ResourceGroupName) {
-    # Make sure $BaseName is set.
-    if (!$BaseName) {
-        $UserName = GetUserName
-        $BaseName = GetBaseName $UserName $ServiceDirectory
-        Log "BaseName was not set. Using default base name '$BaseName'"
-    }
-
-    $ResourceGroupName = "rg-$BaseName"
-}
+$serviceName = GetServiceLeafDirectoryName $ServiceDirectory
+$BaseName, $ResourceGroupName = GetBaseAndResourceGroupNames `
+    -baseNameDefault $BaseName `
+    -resourceGroupNameDefault $ResourceGroupName `
+    -user (GetUserName) `
+    -serviceDirectoryName $serviceName `
+    -CI $CI
 
 # This script is intended for interactive users. Make sure they are logged in or fail.
 $context = Get-AzContext


### PR DESCRIPTION
Follow up fix related to discussion on https://github.com/Azure/azure-sdk-for-net/pull/33262

- Make name generation simpler and more consistent across test resource scripts (found a bug where remove-testresources.ps1 would not have worked for nested service directories like data/aztables)
- Use a short hash for resource names deployed locally, to avoid edge cases where a long service directory or username causes resource names to be too long for validation (e.g. keyvault).
- Fix issue with `EnvironmentVariables` ref getting updated from the parameters when splatting in CI mode and polluting the env variable outputs on subsequent runs in the same shell.
- Add more warning logging if we're overwriting environment variables, for #4931

Fixes #4931