### PR TITLE
Add detection of `CODEOWNERS` paths that are missing suffix slash; add support for diffing to `CODEOWNERS` version with some paths removed; add tools for analyzing azure-sdk-for-python `CODEOWNERS`.

### DIFF
--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
@@ -27,7 +27,7 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests;
 /// selecting "|" as column separator.
 /// </summary>
 [TestFixture(Ignore = "Tools to be used manually")]
-public class CodeownersDiffTests
+public class CodeownersManualAnalysisTests
 {
     private const string DefaultIgnoredPathPrefixes = Program.DefaultIgnoredPrefixes;
     private const string OwnersDiffOutputPathSuffix = "_owners_diff.csv";

--- a/tools/code-owners-parser/CodeOwnersParser/CodeownersFile.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/CodeownersFile.cs
@@ -57,7 +57,8 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
             var codeownersEntries = GetCodeownersEntriesFromFileOrUrl(codeownersFilePathOrUrl);
 
             Dictionary<string, CodeownersEntry> codeownersEntriesByPath = targetPath
-                .ResolveGlob(targetDir, ignoredPathPrefixes).ToDictionary(
+                .ResolveGlob(targetDir, ignoredPathPrefixes)
+                .ToDictionary(
                     path => path,
                     path => GetMatchingCodeownersEntry(
                         path,


### PR DESCRIPTION
## PR context

This PR is done in preparation to enable the new regex-based wildcard-supporting `CODEOWNERS` matcher for `azure-sdk-for-python` language repository.

It is a continuation of work done by this PR:
- #5165

This PR provides information required to make a PR analogous to this one, but for `azure-sdk-for-python` repo:
- https://github.com/Azure/azure-sdk-for-net/pull/33584

This PR is a prerequisite to enabling the new matcher on `azure-sdk-for-python`, in similar way as this PR does:
- https://github.com/Azure/azure-sdk-tools/pull/5241

Thus, overall, this PR contributes to:
- https://github.com/Azure/azure-sdk-tools/pull/5088
- https://github.com/Azure/azure-sdk-tools/issues/2770

## Changes made

- Added support for outputting `CODEOWNERS` paths that are missing suffix slash, i.e. paths that would match a directory in the repository if they would have the suffix `/`. Because they don't, and the directory exists, such paths currently won't ever match anything.
- Added support for diffing `CODEOWNERS` owners to its equivalent with some paths removed. This is used to determine how build failure notification recipients will change when `/**/ci.yml` and `/**/tests.yml` paths are removed, similarly as it was done here:
    - https://github.com/Azure/azure-sdk-for-net/pull/33595
- Added tools (implemented as unit tests) for outputting relevant `CODEOWNERS` information for `azure-sdk-for-python`: both paths that are missing suffix slashes, as well as expected changes to build failure notification recipients when `/**/ci.yml` and `/**/tests.yml` paths are removed.