### PR TITLE
Add manual tools for reporting information required to enable regex-based wildcard-supporting `CODEOWNERS` matcher on all remaining repositories in scope.

### DIFF
--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
@@ -54,6 +54,15 @@ public class CodeownersManualAnalysisTests
 
     private const string CodeownersFilePathSuffix = "/.github/CODEOWNERS";
 
+    /// <summary>
+    /// This file is expected to be manually created by you, in your local repo clone.
+    /// For details of usage of this file, see:
+    ///
+    ///   WriteTwoCodeownersFilesOwnersDiffToCsv
+    /// 
+    /// </summary>
+    private const string SecondaryCodeownersFilePathSuffix = "/.github/CODEOWNERS2";
+
     // Current dir, ".", is expected to be a dir in local clone of Azure/azure-sdk-tools repo,
     // where "." denotes "<cloneRoot>/artifacts/bin/Azure.Sdk.Tools.CodeOwnersParser.Tests/Debug/net6.0".
     private const string CurrentDir = "/artifacts/bin/Azure.Sdk.Tools.CodeOwnersParser.Tests/Debug/net6.0";
@@ -62,7 +71,7 @@ public class CodeownersManualAnalysisTests
 
     [Test] // Runtime <1s
     public void OwnersForAzureDev()
-        => WriteOwnersToCsv(
+        => WriteOwnersToCsvUsingRegexMatcher(
             targetDirPathSuffix: "/../azure-dev",
             outputFileNamePrefix: "azure-dev",
             ignoredPathPrefixes: ".git|artifacts");
@@ -81,7 +90,7 @@ public class CodeownersManualAnalysisTests
 
     [Test] // Runtime <1s
     public void OwnersForAzureSdkTools()
-        => WriteOwnersToCsv(
+        => WriteOwnersToCsvUsingRegexMatcher(
             targetDirPathSuffix: "",
             outputFileNamePrefix: "azure-sdk-tools",
             ignoredPathPrefixes: ".git|artifacts");
@@ -93,60 +102,42 @@ public class CodeownersManualAnalysisTests
     // https://github.com/Azure/azure-sdk-for-android/blob/main/.github/CODEOWNERS
     // No build failure notifications are configured for this repo.
     // Runtime: <1s
-    [Test] 
-    public void OwnersDiffForAzureSdkForAndroid() 
-        => WriteLangRepoOwnersDiffToCsv("android", pathsToDelete: new []{ "/**/ci.yml" });
+    [Test] public void OwnersDiffForAzureSdkForAndroid() => WriteLangRepoOwnersDiffToCsv("android");
 
     // https://github.com/Azure/azure-sdk-for-c/blob/main/.github/CODEOWNERS
     // Runtime: <1s
-    [Test] 
-    public void OwnersDiffForAzureSdkForC() 
-        => WriteLangRepoOwnersDiffToCsv("c", pathsToDelete: new []{ "/**/ci.yml" });
+    [Test] public void OwnersDiffForAzureSdkForC() => WriteLangRepoOwnersDiffToCsv("c");
 
     // https://github.com/Azure/azure-sdk-for-cpp/blob/main/.github/CODEOWNERS
     // Runtime: <1s
-    [Test] 
-    public void OwnersDiffForAzureSdkForCpp() 
-        => WriteLangRepoOwnersDiffToCsv("cpp", pathsToDelete: new []{ "/**/ci.yml", "/**/tests.yml" });
+    [Test] public void OwnersDiffForAzureSdkForCpp() => WriteLangRepoOwnersDiffToCsv("cpp");
 
     // https://github.com/Azure/azure-sdk-for-go/blob/main/.github/CODEOWNERS
     // Runtime: ~2s
-    [Test] 
-    public void OwnersDiffForAzureSdkForGo() 
-        => WriteLangRepoOwnersDiffToCsv("go", pathsToDelete: new []{ "/**/ci.yml", "/**/tests.yml" });
+    [Test] public void OwnersDiffForAzureSdkForGo() => WriteLangRepoOwnersDiffToCsv("go");
 
     // https://github.com/Azure/azure-sdk-for-ios/blob/main/.github/CODEOWNERS
     // No build failure notifications are configured for this repo.
     // Runtime: <1s
-    [Test] 
-    public void OwnersDiffForAzureSdkForIos() 
-        => WriteLangRepoOwnersDiffToCsv("ios", pathsToDelete: new []{ "/**/ci.yml" });
+    [Test] public void OwnersDiffForAzureSdkForIos() => WriteLangRepoOwnersDiffToCsv("ios");
 
     // https://github.com/Azure/azure-sdk-for-java/blob/main/.github/CODEOWNERS
     // Runtime: ~2m 32s
-    [Test] 
-    public void OwnersDiffForAzureSdkForJava() 
-        => WriteLangRepoOwnersDiffToCsv("java", pathsToDelete: new []{ "/**/ci.yml", "/**/tests.yml" });
+    [Test] public void OwnersDiffForAzureSdkForJava() => WriteLangRepoOwnersDiffToCsv("java");
 
     // https://github.com/Azure/azure-sdk-for-js/blob/main/.github/CODEOWNERS
     // Runtime: ~3m 49s
-    [Test] 
-    public void OwnersDiffForAzureSdkForJs() 
-        => WriteLangRepoOwnersDiffToCsv("js", pathsToDelete: new []{ "/**/ci.yml", "/**/tests.yml" });
+    [Test] public void OwnersDiffForAzureSdkForJs() => WriteLangRepoOwnersDiffToCsv("js");
 
     // https://github.com/Azure/azure-sdk-for-net/blob/main/.github/CODEOWNERS
     // These pathsToDelete have been since deleted by this PR:
     // https://github.com/Azure/azure-sdk-for-net/pull/33595
     // Runtime: ~1m 01s
-    [Test] 
-    public void OwnersDiffForAzureSdkForNet() 
-        => WriteLangRepoOwnersDiffToCsv("net", pathsToDelete: new []{ "/**/ci.yml", "/**/tests.yml" });
+    [Test] public void OwnersDiffForAzureSdkForNet() => WriteLangRepoOwnersDiffToCsv("net");
 
     // https://github.com/Azure/azure-sdk-for-python/blob/main/.github/CODEOWNERS
     // Runtime: ~45s
-    [Test]
-    public void OwnersDiffForAzureSdkForPython() 
-        => WriteLangRepoOwnersDiffToCsv("python", pathsToDelete: new []{ "/**/ci.yml", "/**/tests.yml" });
+    [Test] public void OwnersDiffForAzureSdkForPython() => WriteLangRepoOwnersDiffToCsv("python");
 
     #endregion
 
@@ -154,7 +145,7 @@ public class CodeownersManualAnalysisTests
 
     [Test]
     public void MatcherDiffForAzureSdkTools()
-        => WriteMatcherDiffToCsv(
+        => WriteMatcherOwnersDiffToCsv(
             // Empty string here means to just use the root directory of the local "azure-sdk-tools" clone,
             // which is supposed to contain the code you are reading right now.
             targetDirPathSuffix: "",
@@ -163,7 +154,7 @@ public class CodeownersManualAnalysisTests
 
     [Test] // Runtime: ~1m 30s
     public void MatcherDiffForAzureSdkForNet()
-        => WriteMatcherDiffToCsv(
+        => WriteMatcherOwnersDiffToCsv(
             targetDirPathSuffix: LangRepoTargetDirPathSuffix("net"),
             outputFilePrefix: "azure-sdk-for-net_matcher");
 
@@ -172,31 +163,40 @@ public class CodeownersManualAnalysisTests
     #region Parameterized tests - Owners
 
     private void WriteLangRepoOwnersToCsv(string langName)
-        => WriteOwnersToCsv(
+        => WriteOwnersToCsvUsingRegexMatcher(
             targetDirPathSuffix: LangRepoTargetDirPathSuffix(langName),
             outputFileNamePrefix: $"azure-sdk-for-{langName}",
             ignoredPathPrefixes: ".git|artifacts");
 
-    private void WriteOwnersToCsv(
+    private void WriteOwnersToCsvUsingRegexMatcher(
         string targetDirPathSuffix,
         string outputFileNamePrefix,
         string ignoredPathPrefixes = Program.DefaultIgnoredPrefixes)
-        => WriteOwnersToCsv(
+    {
+        string rootDir = PathNavigatingToRootDir(CurrentDir);
+        string targetDir = rootDir + targetDirPathSuffix;
+        Debug.Assert(Directory.Exists(targetDir),
+            $"Ensure you have cloned the repo into '{targetDir}'. " +
+            "See comments on CodeownersManualAnalysisTests and WriteOwnersToCsv for details.");
+        Debug.Assert(File.Exists(targetDir + CodeownersFilePathSuffix), 
+            $"Ensure you have cloned the repo into '{targetDir}'. " +
+            "See comments on CodeownersManualAnalysisTests and WriteOwnersToCsv for details.");
+        WriteOwnersToCsv(
             targetDirPathSuffix,
             CodeownersFilePathSuffix,
             ignoredPathPrefixes,
             useRegexMatcher: true,
             outputFileNamePrefix);
+    }
 
     #endregion
 
     #region Parameterized tests - Owners diff
 
     private void WriteLangRepoOwnersDiffToCsv(string langName, params string[] pathsToDelete)
-        => WriteOwnersDiffToCsv(
+        => WriteTwoCodeownersFilesOwnersDiffToCsv(
             targetDirPathSuffix: LangRepoTargetDirPathSuffix(langName),
             outputFileNamePrefix: $"azure-sdk-for-{langName}",
-            pathsToDelete,
             ignoredPathPrefixes: ".git|artifacts");
 
     /// <summary>
@@ -206,43 +206,44 @@ public class CodeownersManualAnalysisTests
     ///
     /// with following meanings bound to LEFT and RIGHT:
     ///
-    /// LEFT: RetrieveCodeowners configuration using the the new regex-based wildcard-supporting matcher,
-    /// and given input repository CODEOWNERS file.
+    /// LEFT: RetrieveCodeowners configuration using the new regex-based wildcard-supporting matcher,
+    /// and given input local repository clone CODEOWNERS file.
     ///
-    /// RIGHT: RetrieveCodeowners configuration using the the new regex-based wildcard-supporting matcher
-    /// (same as for LEFT), and given input repository CODEOWNERS file with 'pathsToDelete' paths deleted from it.
+    /// RIGHT: RetrieveCodeowners configuration using the new regex-based wildcard-supporting matcher
+    /// (same as for LEFT), and given input repository CODEOWNERS2 file.
+    /// The CODEOWNERS2 file is expected to be created manually by you. This way you can diff CODEOWNERS
+    /// to whatever version of it you want to express in CODEOWNERS2. For example, CODEOWNERS2 could have
+    /// contents of CODEOWNERS as seen in an open PR pending being merged.
     ///
     /// As such, it is useful to determine how owners will change if paths like "/**/ci.yml" or "/**/tests.yml"
     /// are deleted from the CODEOWNERS file.
     /// Such owners change will naturally affect both auto-assigned PR reviewers,
     /// as well as recipients of build failure notifications.
     /// </summary>
-    private void WriteOwnersDiffToCsv(
+    private void WriteTwoCodeownersFilesOwnersDiffToCsv(
         string targetDirPathSuffix,
         string outputFileNamePrefix,
-        string[] pathsToDelete,
         string ignoredPathPrefixes = Program.DefaultIgnoredPrefixes)
     {
-        (string codeownersCopyPath, string codeownersCopyPathSuffix) = CreateCodeownersCopyWithPathsDeleted(
-            targetDirPathSuffix,
-            CodeownersFilePathSuffix,
-            pathsToDelete);
+        string rootDir = PathNavigatingToRootDir(CurrentDir);
+        string targetDir = rootDir + targetDirPathSuffix;
+        Debug.Assert(Directory.Exists(targetDir),
+            $"Ensure you have cloned the repo into '{targetDir}'. " +
+            "See comments on CodeownersManualAnalysisTests and WriteTwoCodeownersFilesOwnersDiffToCsv for details.");
+        Debug.Assert(File.Exists(targetDir + CodeownersFilePathSuffix), 
+            $"Ensure you have cloned the repo into '{targetDir}'. " +
+            "See comments on CodeownersManualAnalysisTests and WriteTwoCodeownersFilesOwnersDiffToCsv for details.");
+        Debug.Assert(File.Exists(targetDir + SecondaryCodeownersFilePathSuffix), 
+            $"Ensure you have created '{Path.GetFullPath(targetDir + SecondaryCodeownersFilePathSuffix)}'. " +
+            $"See comment on WriteTwoCodeownersFilesOwnersDiffToCsv for details.");
 
-        try
-        {
-            WriteOwnersDiffToCsv(
-                new[]
-                {
-                    (targetDirPathSuffix, CodeownersFilePathSuffix, ignoredPathPrefixes, useRegexMatcher: true),
-                    (targetDirPathSuffix, codeownersCopyPathSuffix, ignoredPathPrefixes, useRegexMatcher: true)
-                },
-                outputFileNamePrefix);
-        }
-        finally
-        {
-            if (File.Exists(codeownersCopyPath))
-                File.Delete(codeownersCopyPath);
-        }
+        WriteOwnersDiffToCsv(
+            new[]
+            {
+                (targetDirPathSuffix, CodeownersFilePathSuffix, ignoredPathPrefixes, useRegexMatcher: true),
+                (targetDirPathSuffix, SecondaryCodeownersFilePathSuffix, ignoredPathPrefixes, useRegexMatcher: true)
+            },
+            outputFileNamePrefix);
     }
 
     /// <summary>
@@ -252,10 +253,10 @@ public class CodeownersManualAnalysisTests
     ///
     /// with following meanings bound to LEFT and RIGHT:
     ///
-    /// LEFT: RetrieveCodeowners configuration using given input repository CODEOWNERS file,
+    /// LEFT: RetrieveCodeowners configuration using given input local repository clone CODEOWNERS file,
     /// and using the legacy prefix-based CODEOWNERS paths matcher.
     ///
-    /// RIGHT: RetrieveCodeowners configuration using given input repository CODEOWNERS file,
+    /// RIGHT: RetrieveCodeowners configuration using given input local repository clone CODEOWNERS file,
     /// and using the new regex-based wildcard-supporting matcher.
     /// prefix-based CODEOWNERS paths matcher.
     ///
@@ -264,11 +265,20 @@ public class CodeownersManualAnalysisTests
     /// The PR reviewers will remain unchanged, as they use the GitHub CODEOWNERS
     /// interpreter which independent of ours and always supported wildcards.
     /// </summary>
-    private void WriteMatcherDiffToCsv(
+    private void WriteMatcherOwnersDiffToCsv(
         string targetDirPathSuffix,
         string outputFilePrefix,
         string ignoredPathPrefixes = Program.DefaultIgnoredPrefixes)
     {
+        string rootDir = PathNavigatingToRootDir(CurrentDir);
+        string targetDir = rootDir + targetDirPathSuffix;
+        Debug.Assert(Directory.Exists(targetDir),
+            $"Ensure you have cloned the repo into '{targetDir}'. " +
+            "See comments on CodeownersManualAnalysisTests and WriteMatcherOwnersDiffToCsv for details.");
+        Debug.Assert(File.Exists(targetDir + CodeownersFilePathSuffix),
+            $"Ensure you have cloned the repo into '{targetDir}'. " +
+            "See comments on CodeownersManualAnalysisTests and WriteMatcherOwnersDiffToCsv for details.");
+
         WriteOwnersDiffToCsv(
             new[]
             {
@@ -407,7 +417,7 @@ public class CodeownersManualAnalysisTests
             {
                 // We do not support "the path is to file while it should be to directory" validation for paths
                 // with wildcards yet. To do that, we would first need to resolve the path and see if there exists
-                // a concrete path that includes the the CODEOWNERS paths supposed-file-name as
+                // a concrete path that includes the CODEOWNERS paths supposed-file-name as
                 // infix dir.
                 // For example, /a/**/b could match against /a/foo/b/c, meaning
                 // the path is invalid.
@@ -444,25 +454,6 @@ public class CodeownersManualAnalysisTests
                     $"| {string.Join(",", entry.Owners)}" +
                     "| INVALID_PATH_CONTAINS_UNSUPPORTED_FRAGMENTS")
             .ToList();
-
-    private static (string codeownersCopy, string codeownersCopyPathSuffix)
-        CreateCodeownersCopyWithPathsDeleted(
-            string targetDirPathSuffix,
-            string codeownersFilePathSuffix,
-            string[] pathsToDelete)
-    {
-        string rootDir = PathNavigatingToRootDir(CurrentDir);
-        string targetDir = rootDir + targetDirPathSuffix;
-        string codeownersPath = targetDir + codeownersFilePathSuffix;
-
-        var codeownersLines = File.ReadAllLines(codeownersPath);
-        codeownersLines = codeownersLines
-            .Where(line => !pathsToDelete.Any(line.Contains)).ToArray();
-
-        var codeownersCopyPath = codeownersPath + "-copy";
-        File.WriteAllLines(codeownersCopyPath, codeownersLines);
-        return (codeownersCopyPath, codeownersFilePathSuffix + "-copy");
-    }
 
     /// <summary>
     /// Writes to .csv file the difference of owners for all paths in given repository,

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
@@ -99,6 +99,13 @@ public class CodeownersManualAnalysisTests
 
     #region Tests - Owners diffs for the prefix-based vs regex-based CODEOWNERS matchers, plus differing contents.
 
+    [Test] // Runtime <1s
+    public void OwnersDiffForAzureDev()
+        => WriteTwoCodeownersFilesAndMatcherOwnersDiffToCsv(
+            targetDirPathSuffix: "/../azure-dev",
+            outputFileNamePrefix: "azure-dev",
+            ignoredPathPrefixes: ".git|artifacts");
+
     // https://github.com/Azure/azure-sdk-for-android/blob/main/.github/CODEOWNERS
     // No build failure notifications are configured for this repo.
     // Runtime: <1s
@@ -130,8 +137,6 @@ public class CodeownersManualAnalysisTests
     [Test] public void OwnersDiffForAzureSdkForJs() => WriteLangRepoOwnersDiffToCsv("js");
 
     // https://github.com/Azure/azure-sdk-for-net/blob/main/.github/CODEOWNERS
-    // These pathsToDelete have been since deleted by this PR:
-    // https://github.com/Azure/azure-sdk-for-net/pull/33595
     // Runtime: ~1m 01s
     [Test] public void OwnersDiffForAzureSdkForNet() => WriteLangRepoOwnersDiffToCsv("net");
 
@@ -174,7 +179,7 @@ public class CodeownersManualAnalysisTests
 
     #region Parameterized tests - Owners diff
 
-    private void WriteLangRepoOwnersDiffToCsv(string langName, params string[] pathsToDelete)
+    private void WriteLangRepoOwnersDiffToCsv(string langName)
         => WriteTwoCodeownersFilesAndMatcherOwnersDiffToCsv(
             targetDirPathSuffix: LangRepoTargetDirPathSuffix(langName),
             outputFileNamePrefix: $"azure-sdk-for-{langName}",

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
@@ -158,14 +158,14 @@ public class CodeownersManualAnalysisTests
             // Empty string here means to just use the root directory of the local "azure-sdk-tools" clone,
             // which is supposed to contain the code you are reading right now.
             targetDirPathSuffix: "",
-            outputFilePrefix: "azure-sdk-tools",
+            outputFilePrefix: "azure-sdk-tools_matcher",
             ignoredPathPrefixes: ".git|artifacts");
 
     [Test] // Runtime: ~1m 30s
     public void MatcherDiffForAzureSdkForNet()
         => WriteMatcherDiffToCsv(
             targetDirPathSuffix: LangRepoTargetDirPathSuffix("net"),
-            outputFilePrefix: "azure-sdk-for-net");
+            outputFilePrefix: "azure-sdk-for-net_matcher");
 
     #endregion
 

--- a/tools/code-owners-parser/CodeOwnersParser.sln.DotSettings
+++ b/tools/code-owners-parser/CodeOwnersParser.sln.DotSettings
@@ -2,4 +2,5 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PR/@EntryIndexedValue">PR</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=azconfig/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=CODEOWNERS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=misalign/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=prepending/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/tools/code-owners-parser/CodeOwnersParser/MatchedCodeownersEntry.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/MatchedCodeownersEntry.cs
@@ -28,7 +28,7 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
     /// https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax
     /// https://git-scm.com/docs/gitignore#_pattern_format
     /// </summary>
-    internal class MatchedCodeownersEntry
+    public class MatchedCodeownersEntry
     {
         /// <summary>
         /// Token for temporarily substituting "**" in regex, to avoid it being escaped when
@@ -47,6 +47,10 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
         /// See comment on IsCodeownersPathValid
         /// </summary>
         public bool IsValid => IsCodeownersPathValid(this.Value.PathExpression);
+
+        public static bool ContainsUnsupportedFragments(string codeownersPath)
+            => ContainsUnsupportedCharacters(codeownersPath)
+               || ContainsUnsupportedSequences(codeownersPath);
 
         /// <summary>
         /// Any CODEOWNERS path with these characters will be skipped.
@@ -113,10 +117,6 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
         }
 
         private CodeownersEntry NoMatchCodeownersEntry { get; } = new CodeownersEntry();
-
-        private static bool ContainsUnsupportedFragments(string codeownersPath)
-            => ContainsUnsupportedCharacters(codeownersPath)
-               || ContainsUnsupportedSequences(codeownersPath);
 
         /// <summary>
         /// See the comment on unsupportedChars.
@@ -284,7 +284,7 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
         /// - if the path expression does not end with "/", at least one matching
         /// file exists in the repository.
         /// </summary>
-        private bool IsCodeownersPathValid(string codeownersPathExpression)
+        private static bool IsCodeownersPathValid(string codeownersPathExpression)
             => codeownersPathExpression.StartsWith("/") && !ContainsUnsupportedFragments(codeownersPathExpression);
     }
 }

--- a/tools/notification-configuration/notification-configuration.sln.DotSettings
+++ b/tools/notification-configuration/notification-configuration.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=AAD/@EntryIndexedValue">AAD</s:String>
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/Abbreviations/=PR/@EntryIndexedValue">PR</s:String>
-	<s:Boolean x:Key="/Default/UserDictionary/Words/=CODEOWNERS/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=CODEOWNERS/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=misalign/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
## PR context

This PR is done in preparation to enable the new regex-based wildcard-supporting `CODEOWNERS` matcher for Azure SDK repositories that have configured routing of build failure notifications via ADO groups, as explained in:
- #5088

This PR is a continuation of work done by this PR:
- #5245

This PR provides information required to make a PR analogous to this one, but for the remaining repositories in scope:

- https://github.com/Azure/azure-sdk-for-net/pull/33584

This PR is a prerequisite to enabling the new matcher on all the remaining repositories in scope, in similar way as this PR does:
- https://github.com/Azure/azure-sdk-tools/pull/5241

Thus, overall, this PR contributes to:
- #5135
- https://github.com/Azure/azure-sdk-tools/pull/5088
- https://github.com/Azure/azure-sdk-tools/issues/2770

## Changes made

- Added support for reporting CODEOWNERS paths that are missing prefix `/`;
- Added support for reporting issues with owners for all repositories in scope;
- Added support for diffing owners changed between CODEOWNERS and manually provided local CODEOWNERS2 (used for diffing changes in PRs pending merging);
- Added documentation in form of comments;
- Did significant refactoring.