### PR TITLE
Create API review for JS packages with namespace in api extractor model

### DIFF
--- a/tools/apiview/parsers/js-api-parser/export.ts
+++ b/tools/apiview/parsers/js-api-parser/export.ts
@@ -16,6 +16,9 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
     builder.lineId(item.canonicalReference.toString());
     builder.indent();
     if (item instanceof ApiDeclaredItem) {
+        if ( item.kind === ApiItemKind.Namespace) {
+            builder.splitAppend(`declare namespace ${item.displayName} `, item.canonicalReference.toString(), item.displayName);
+        }
         for (const token of item.excerptTokens) {
             if (token.kind === ExcerptTokenKind.Reference)
             {
@@ -35,6 +38,7 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
     {
         case ApiItemKind.Interface:
         case ApiItemKind.Class:
+        case ApiItemKind.Namespace:
             typeKind = item.kind.toLowerCase();
             break
         case ApiItemKind.TypeAlias:
@@ -56,7 +60,8 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
     }
 
     if (item.kind === ApiItemKind.Interface ||
-        item.kind === ApiItemKind.Class)
+        item.kind === ApiItemKind.Class ||
+        item.kind === ApiItemKind.Namespace)
     {
         if (item.members.length > 0)
         {

--- a/tools/apiview/parsers/js-api-parser/package.json
+++ b/tools/apiview/parsers/js-api-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/ts-genapi",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "main": "index.js",
   "publishConfig":{"registry":"https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"},

--- a/tools/apiview/parsers/js-api-parser/tokensBuilder.ts
+++ b/tools/apiview/parsers/js-api-parser/tokensBuilder.ts
@@ -30,6 +30,7 @@ export class TokensBuilder
         "import",
         "in",
         "instanceof",
+        "namespace",
         "new",
         "null",
         "return",


### PR DESCRIPTION
API review JSON input file has namespace model and all public API details are under this namespace model.  APIView parser currently ignores namespace and any below members which causes issues for packages that has all it's members under a namespace. For e.g API review for change in  PR https://github.com/Azure/azure-sdk-for-js-pr/pull/236/files#diff-6dc05287911739aecce4b2d7cbc4df5699df151c14f032b5a14990cd3f5b2762 is empty.

This PR will process namespace model and its child nodes.