### PR TITLE
Pin dependencies used by api parser

### DIFF
--- a/tools/apiview/parsers/js-api-parser/package.json
+++ b/tools/apiview/parsers/js-api-parser/package.json
@@ -1,17 +1,17 @@
 {
   "name": "@azure-tools/ts-genapi",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "",
   "main": "index.js",
   "publishConfig": {
     "registry": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
   },
   "dependencies": {
-    "@microsoft/api-extractor-model": "^7.22.2",
+    "@microsoft/api-extractor-model": "^7.26.1",
     "js-tokens": "^6.0.0"
   },
   "devDependencies": {
-    "@types/node": "^14.0.0",
+    "@types/node": "^12.20.55",
     "ts-node": "^10.0.0",
     "typescript": "~4.8.0"
   },


### PR DESCRIPTION
Pin @types/node and api-extractor model dependencies