### PR TITLE
[stress testing] Enable nodepool update via bicep and update node SKUs

### DIFF
--- a/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
+++ b/eng/common/scripts/stress-testing/deploy-stress-tests.ps1
@@ -10,11 +10,7 @@ param(
     [switch]$PushImages,
     [string]$ClusterGroup,
     [string]$DeployId,
-
-    [Parameter(ParameterSetName = 'DoLogin', Mandatory = $true)]
     [switch]$Login,
-
-    [Parameter(ParameterSetName = 'DoLogin')]
     [string]$Subscription,
 
     # Default to true in Azure Pipelines environments

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -117,12 +117,11 @@ function DeployStressTests(
         }
         $clusterGroup = 'rg-stress-cluster-prod'
         $subscription = 'Azure SDK Test Resources'
+    } elseif (!$clusterGroup -or !$subscription) {
+        throw "clusterGroup and subscription parameters must be specified when deploying to an environment that is not pg or prod."
     }
 
     if ($login) {
-        if (!$clusterGroup -or !$subscription) {
-            throw "clusterGroup and subscription parameters must be specified when logging into an environment that is not pg or prod."
-        }
         Login -subscription $subscription -clusterGroup $clusterGroup -pushImages:$pushImages
     }
 
@@ -160,7 +159,9 @@ function DeployStressTests(
             -environment $environment `
             -repositoryBase $repository `
             -pushImages:$pushImages `
-            -login:$login
+            -login:$login `
+            -clusterGroup $clusterGroup `
+            -subscription $subscription
     }
 
     if ($FailedCommands.Count -lt $pkgs.Count) {
@@ -185,7 +186,9 @@ function DeployStressPackage(
     [string]$environment,
     [string]$repositoryBase,
     [switch]$pushImages,
-    [switch]$login
+    [switch]$login,
+    [string]$clusterGroup,
+    [string]$subscription
 ) {
     $registry = RunOrExitOnFailure az acr list -g $clusterGroup --subscription $subscription -o json
     $registryName = ($registry | ConvertFrom-Json).name

--- a/tools/stress-cluster/chaos/README.md
+++ b/tools/stress-cluster/chaos/README.md
@@ -484,15 +484,14 @@ The `stress-test-addons` helm library will handle a scenarios matrix automatical
 
 ### Node Size Requirements
 
-The stress test cluster is deployed with several node SKUs (see [agentPoolProfiles declaration and
+The stress test cluster may be deployed with several node SKUs (see [agentPoolProfiles declaration and
 variables](https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/cluster/azure/cluster/cluster.bicep)), with tests defaulting to the SKU labeled 'default'.
 By adding the `nodeSelector` field to the job spec, you can override which nodes the test container will
 be provisioned to. For support adding a custom or dedicated node SKU, reach out to the EngSys team.
 
 Available common SKUs in stress test clusters:
 
-- 'default' - Standard\_D2\_v3
-- 'highMem' - Standard\_D4ds\_v4
+- 'default' - Standard\_D4ds\_v4
 
 To deploy a stress test to a custom node (see also
 [example](https://github.com/Azure/azure-sdk-tools/blob/main/tools/stress-cluster/chaos/examples/network-stress-example/templates/testjob.yaml)):
@@ -500,7 +499,7 @@ To deploy a stress test to a custom node (see also
 ```
 spec:
   nodeSelector:
-    sku: 'highMem'
+    sku: '<nodepool sku label>'
   containers:
     < container spec ... >
 ```

--- a/tools/stress-cluster/cluster/README.md
+++ b/tools/stress-cluster/cluster/README.md
@@ -55,8 +55,12 @@ Cluster buildout and deployment involves three main steps which are automated in
 
 1. Provision static resources (service principal, role assignments, static keyvault).
 1. Provision cluster resources (`main.bicep` entrypoint, standard ARM subscription deployment).
+    - NOTE: if the nodepool configuration for the AKS cluster needs to be updated, it cannot be done
+      alongside a deployment to the cluster itself. In order to update the nodepool configuration only, pass
+      the `-UpdateNodes` parameter to the provision script.
 1. Provision stress infrastructures resources into the Azure Kubernetes Service cluster via helm
    (`./kubernetes/stress-infrastructure` helm chart).
+
 
 ## Dev Cluster
 

--- a/tools/stress-cluster/cluster/azure/cluster/acr.bicep
+++ b/tools/stress-cluster/cluster/azure/cluster/acr.bicep
@@ -19,19 +19,19 @@ resource registry 'Microsoft.ContainerRegistry/registries@2019-12-01-preview' = 
 
 // Add AcrPush and AcrPull roles to access groups
 resource acrPushRole 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for objectId in objectIds: {
-  name: '${guid('azureContainerRegistryPushRole', objectId, resourceGroup().id)}'
+  name: guid('azureContainerRegistryPushRole', objectId, resourceGroup().id)
   scope: registry
   properties: {
-    roleDefinitionId: '${subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8311e382-0749-4cb8-b61a-304f252e45ec')}'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '8311e382-0749-4cb8-b61a-304f252e45ec')
     principalId: objectId
   }
 }]
 
 resource acrPullRole 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = [for objectId in objectIds: {
-  name: '${guid('azureContainerRegistryPullRole', objectId, resourceGroup().id)}'
+  name: guid('azureContainerRegistryPullRole', objectId, resourceGroup().id)
   scope: registry
   properties: {
-    roleDefinitionId: '${subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')}'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d')
     principalId: objectId
   }
 }]

--- a/tools/stress-cluster/cluster/azure/cluster/cluster.bicep
+++ b/tools/stress-cluster/cluster/azure/cluster/cluster.bicep
@@ -4,35 +4,20 @@ param groupSuffix string
 param dnsPrefix string = 's1'
 param clusterName string
 param location string = resourceGroup().location
-param enableHighMemAgentPool bool = false
+// AKS does not allow agentPool updates via existing managed cluster resources
+param updateNodes bool = false
 
 // monitoring parameters
 param workspaceId string
 
-var kubernetesVersion = '1.24.3'
+var kubernetesVersion = '1.25.4'
 var nodeResourceGroup = 'rg-nodes-${dnsPrefix}-${clusterName}-${groupSuffix}'
 
-var defaultAgentPool = {
-  name: 'default'
-  count: 3
-  minCount: 3
-  maxCount: 9
-  mode: 'System'
-  vmSize: 'Standard_D2_v3'
-  type: 'VirtualMachineScaleSets'
-  osType: 'Linux'
-  enableAutoScaling: true
-  enableEncryptionAtHost: true
-  nodeLabels: {
-      'sku': 'default'
-  }
-}
-
-var highMemAgentPool = {
-  name: 'highmemory'
+var systemAgentPool = {
+  name: 'system'
   count: 1
   minCount: 1
-  maxCount: 3
+  maxCount: 4
   mode: 'System'
   vmSize: 'Standard_D4ds_v4'
   type: 'VirtualMachineScaleSets'
@@ -40,17 +25,33 @@ var highMemAgentPool = {
   enableAutoScaling: true
   enableEncryptionAtHost: true
   nodeLabels: {
-      'sku': 'highMem'
+    sku: 'system'
   }
 }
 
-var agentPools = concat([
-        defaultAgentPool
-    ], enableHighMemAgentPool ? [
-        highMemAgentPool
-    ] : [])
+var defaultAgentPool = {
+  name: 'default'
+  count: 3
+  minCount: 5
+  maxCount: 24
+  mode: 'User'
+  vmSize: 'Standard_D4ds_v4'
+  type: 'VirtualMachineScaleSets'
+  osType: 'Linux'
+  osDiskType: 'Ephemeral'
+  enableAutoScaling: true
+  enableEncryptionAtHost: true
+  nodeLabels: {
+    sku: 'default'
+  }
+}
 
-resource cluster 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
+var agentPools = [
+    systemAgentPool
+    defaultAgentPool
+]
+
+resource newCluster 'Microsoft.ContainerService/managedClusters@2022-09-02-preview' = if (!updateNodes) {
   name: clusterName
   location: location
   tags: tags
@@ -83,14 +84,39 @@ resource cluster 'Microsoft.ContainerService/managedClusters@2020-09-01' = {
   }
 }
 
+resource existingCluster 'Microsoft.ContainerService/managedClusters@2022-09-02-preview' existing = if (updateNodes) {
+  name: clusterName
+}
+
+// Workaround for duplicate variable names when conditionals are in use
+// See https://github.com/Azure/bicep/issues/1410
+var cluster = updateNodes ? existingCluster : newCluster
+
+resource pools 'Microsoft.ContainerService/managedClusters/agentPools@2022-09-02-preview' = [for pool in agentPools: if (updateNodes) {
+  parent: existingCluster
+  name: pool.name
+  properties: {
+    count: pool.count
+    minCount: pool.minCount
+    maxCount: pool.maxCount
+    mode: pool.mode
+    vmSize: pool.vmSize
+    type: pool.type
+    osType: pool.osType
+    enableAutoScaling: pool.enableAutoScaling
+    // enableEncryptionAtHost: pool.enableEncryptionAtHost
+    nodeLabels: pool.nodeLabels
+  }
+}]
+
 // Add Monitoring Metrics Publisher role to omsagent identity. Required to publish metrics data to
 // cluster resource container insights.
 // https://docs.microsoft.com/azure/azure-monitor/containers/container-insights-update-metrics
-resource metricsPublisher 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = {
-  name: '${guid('monitoringMetricsPublisherRole', resourceGroup().id)}'
-  scope: cluster
+resource metricsPublisher 'Microsoft.Authorization/roleAssignments@2020-04-01-preview' = if (!updateNodes) {
+  name: guid('monitoringMetricsPublisherRole', resourceGroup().id)
+  scope: newCluster
   properties: {
-    roleDefinitionId: '${subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3913510d-42f4-4e42-8a64-420c390055eb')}'
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '3913510d-42f4-4e42-8a64-420c390055eb')
     // NOTE: using objectId over clientId seems to handle cross-region propagation delays better for newly created identities
     principalId: cluster.properties.addonProfiles.omsagent.identity.objectId
   }
@@ -99,4 +125,4 @@ resource metricsPublisher 'Microsoft.Authorization/roleAssignments@2020-04-01-pr
 output secretProviderObjectId string = cluster.properties.addonProfiles.azureKeyvaultSecretsProvider.identity.objectId
 output secretProviderClientId string = cluster.properties.addonProfiles.azureKeyvaultSecretsProvider.identity.clientId
 output kubeletIdentityObjectId string = cluster.properties.identityProfile.kubeletidentity.objectId
-output clusterName string = cluster.name
+output clusterName string = clusterName

--- a/tools/stress-cluster/cluster/azure/monitoring/stress-status-workbook.bicep
+++ b/tools/stress-cluster/cluster/azure/monitoring/stress-status-workbook.bicep
@@ -1,4 +1,5 @@
 param logAnalyticsResource string
+param location string = resourceGroup().location
 
 @description('The friendly name for the workbook that is used in the Gallery or Saved List.  This name must be unique within a resource group.')
 param workbookDisplayName string
@@ -233,7 +234,7 @@ var workbookContent = {
 
 resource workbookId_resource 'microsoft.insights/workbooks@2021-03-08' = {
   name: workbookId
-  location: resourceGroup().location
+  location: location
   kind: 'shared'
   properties: {
     displayName: workbookDisplayName

--- a/tools/stress-cluster/cluster/azure/monitoring/stress-test-workbook.bicep
+++ b/tools/stress-cluster/cluster/azure/monitoring/stress-test-workbook.bicep
@@ -1,4 +1,5 @@
 param logAnalyticsResource string
+param location string = resourceGroup().location
 
 @description('The friendly name for the workbook that is used in the Gallery or Saved List.  This name must be unique within a resource group.')
 param workbookDisplayName string
@@ -308,7 +309,7 @@ var workbookContent = {
 
 resource workbookId_resource 'microsoft.insights/workbooks@2021-03-08' = {
   name: workbookId
-  location: resourceGroup().location
+  location: location
   kind: 'shared'
   properties: {
     displayName: workbookDisplayName

--- a/tools/stress-cluster/cluster/azure/parameters/dev.json
+++ b/tools/stress-cluster/cluster/azure/parameters/dev.json
@@ -14,10 +14,10 @@
     "clusterLocation": {
       "value": "westus2"
     },
-    "staticTestSecretsKeyvaultName": {
+    "staticTestKeyvaultName": {
       "value": // add me, e.g. stress-secrets-<your alias>
     },
-    "staticTestSecretsKeyvaultGroup": {
+    "staticTestKeyvaultGroup": {
       "value": // add me, e.g. rg-stress-secrets-<your alias>
     },
     "tags": {

--- a/tools/stress-cluster/cluster/azure/parameters/pg.json
+++ b/tools/stress-cluster/cluster/azure/parameters/pg.json
@@ -14,14 +14,11 @@
     "clusterLocation": {
       "value": "westus3"
     },
-    "staticTestSecretsKeyvaultName": {
+    "staticTestKeyvaultName": {
       "value": "stress-secrets-pg"
     },
-    "staticTestSecretsKeyvaultGroup": {
+    "staticTestKeyvaultGroup": {
       "value": "rg-stress-secrets-pg"
-    },
-    "enableHighMemAgentPool": {
-        "value": true
     },
     "tags": {
       "value": {

--- a/tools/stress-cluster/cluster/azure/parameters/prod.json
+++ b/tools/stress-cluster/cluster/azure/parameters/prod.json
@@ -17,10 +17,10 @@
     "monitoringLocation": {
       "value": "centralus"
     },
-    "staticTestSecretsKeyvaultName": {
+    "staticTestKeyvaultName": {
       "value": "stress-secrets-prod"
     },
-    "staticTestSecretsKeyvaultGroup": {
+    "staticTestKeyvaultGroup": {
       "value": "rg-stress-secrets-prod"
     },
     "tags": {

--- a/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/templates/stresswatcher.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/templates/stresswatcher.yaml
@@ -18,7 +18,7 @@ spec:
         app: stress-watcher
     spec:
       nodeSelector:
-        sku: 'default'
+        sku: 'system'
       initContainers:
         # Init container template for injecting secrets
         # (e.g. app insights instrumentation key, azure client credentials)


### PR DESCRIPTION
- Updating stress cluster node SKUs - use d4v4 everywhere, separate system from user pools, and add stress-watcher to the system pool
- Enable updating stress cluster nodepools via bicep deployment via an `-UpdateNodes` switch.
- Remove warnings from bicep build
- Update documentation for pool SKU label selectors
- Minor provision script fixes: missing object id and custom environment parameter validation

Fixes #4830