### PR TITLE
Improve warning messages on invalid `CODEOWNERS` paths.

### DIFF
--- a/tools/code-owners-parser/CodeOwnersParser/MatchedCodeownersEntry.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/MatchedCodeownersEntry.cs
@@ -163,7 +163,8 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
             {
                 Console.Error.WriteLine(
                     $"CODEOWNERS path \"{codeownersPath}\" ends with " +
-                    "unsupported sequence of \"/**\". Replace it with \"/\".");
+                    "unsupported sequence of \"/**\". Replace it with \"/\". " +
+                    "Until then this path will never match.");
                 return true;
             }
 
@@ -173,7 +174,8 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
             {
                 Console.Error.WriteLine(
                     $"CODEOWNERS path \"{codeownersPath}\" ends with " +
-                    "unsupported sequence of \"/**/\". Replace it with \"/\".");
+                    "unsupported sequence of \"/**/\". Replace it with \"/\". " +
+                    "Until then this path will never match.");
                 return true;
             }
 
@@ -184,8 +186,9 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
             {
                 Console.Error.WriteLine(
                     $"CODEOWNERS path \"{codeownersPath}\" contains " +
-                    "unsupported sequence of \"**\" that is not \"/**/\". Replace it with \"*\". " +
-                    "Until then this path will never match.");
+                    "unsupported sequence of \"**\". Double star can be used only within slashes \"/**/\" " +
+                    "or as a top-level catch all path of \"/**\". "  +
+                    "Currently this path will never match.");
                 return true;
             }
 

--- a/tools/code-owners-parser/CodeOwnersParser/MatchedCodeownersEntry.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/MatchedCodeownersEntry.cs
@@ -173,7 +173,7 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
             {
                 Console.Error.WriteLine(
                     $"CODEOWNERS path \"{codeownersPath}\" ends with " +
-                    "unsupported sequence of \"/**/\". Replace it with \"/**\".");
+                    "unsupported sequence of \"/**/\". Replace it with \"/\".");
                 return true;
             }
 


### PR DESCRIPTION
This PR improves some warning messages on invalid `CODEOWNERS` paths. It is a follow-up to PR:
- #5308

As such, it contribute to:
- #2770 