### PR TITLE
Make `PipelineOwnersExtractor` compile again + refactor

### DIFF
--- a/tools/pipeline-owners-extractor/Azure.Sdk.Tools.PipelineOwnersExtractor/Configuration/PostConfigureKeyVaultSettings.cs
+++ b/tools/pipeline-owners-extractor/Azure.Sdk.Tools.PipelineOwnersExtractor/Configuration/PostConfigureKeyVaultSettings.cs
@@ -1,7 +1,6 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Text.RegularExpressions;
-
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 

--- a/tools/pipeline-owners-extractor/Azure.Sdk.Tools.PipelineOwnersExtractor/Configuration/SecretClientProvider.cs
+++ b/tools/pipeline-owners-extractor/Azure.Sdk.Tools.PipelineOwnersExtractor/Configuration/SecretClientProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Azure.Core;
 using Azure.Security.KeyVault.Secrets;

--- a/tools/pipeline-owners-extractor/Azure.Sdk.Tools.PipelineOwnersExtractor/Program.cs
+++ b/tools/pipeline-owners-extractor/Azure.Sdk.Tools.PipelineOwnersExtractor/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -31,7 +31,9 @@ namespace Azure.Sdk.Tools.PipelineOwnersExtractor
                     services.AddSingleton<TokenCredential, DefaultAzureCredential>();
                     services.AddSingleton<ISecretClientProvider, SecretClientProvider>();
                     services.Configure<PipelineOwnerSettings>(context.Configuration);
-                    services.AddSingleton<IPostConfigureOptions<PipelineOwnerSettings>, PostConfigureKeyVaultSettings<PipelineOwnerSettings>>();
+                    services
+                        .AddSingleton<IPostConfigureOptions<PipelineOwnerSettings>,
+                            PostConfigureKeyVaultSettings<PipelineOwnerSettings>>();
                     services.AddSingleton<GitHubService>();
                     services.AddSingleton(CreateGithubAadConverter);
                     services.AddSingleton(CreateAzureDevOpsService);

--- a/tools/pipeline-owners-extractor/PipelineOwnersExtractor.sln.DotSettings
+++ b/tools/pipeline-owners-extractor/PipelineOwnersExtractor.sln.DotSettings
@@ -1,0 +1,2 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=CODEOWNERS/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>


### PR DESCRIPTION
Recently I made some changes to our `Azure.Sdk.Tools.CodeOwnersParser` and somehow missed the fact this project depends on it. I also:
- de-`var`-ified some assignments and broke lines at 120 chars.