### PR TITLE
[Perf] Upgrade java core package versions

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/tests.yml
@@ -59,9 +59,9 @@ Services:
       Project: sdk/core/azure-core-perf
       PrimaryPackage: 'com.azure:azure-core'
       PackageVersions:
-      - 'com.azure:azure-core': 1.34.0
-        'com.azure:azure-core-http-netty': 1.12.7
-        'com.azure:azure-core-http-okhttp': 1.11.4
+      - 'com.azure:azure-core': 1.36.0
+        'com.azure:azure-core-http-netty': 1.13.0
+        'com.azure:azure-core-http-okhttp': 1.11.6
       - 'com.azure:azure-core': source
         'com.azure:azure-core-http-netty': source
         'com.azure:azure-core-http-okhttp': source


### PR DESCRIPTION
- Fixes build break running perf tests on older package versions caused by Azure/azure-sdk-for-java#32573

Validation build: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2171243&view=results