### PR TITLE
Bugfix: when looking for a match in `CODEOWNERS`, do not emit error message for commented out paths

### DIFF
--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests;
 /// Enable the new, regex-based, wildcard-supporting CODEOWNERS matcher
 /// https://github.com/Azure/azure-sdk-tools/pull/5088
 /// </summary>
-[TestFixture]//(Ignore = "Tools to be used manually")]
+[TestFixture(Ignore = "Tools to be used manually")]
 public class CodeownersManualAnalysisTests
 {
     private const string OwnersDiffOutputPathSuffix = "_owners_diff.csv";

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Sdk.Tools.RetrieveCodeOwners.Tests;
 /// Enable the new, regex-based, wildcard-supporting CODEOWNERS matcher
 /// https://github.com/Azure/azure-sdk-tools/pull/5088
 /// </summary>
-[TestFixture(Ignore = "Tools to be used manually")]
+[TestFixture]//(Ignore = "Tools to be used manually")]
 public class CodeownersManualAnalysisTests
 {
     private const string OwnersDiffOutputPathSuffix = "_owners_diff.csv";
@@ -331,7 +331,7 @@ public class CodeownersManualAnalysisTests
     }
 
     // Possible future work:
-    // instead of returning lines with issues, consider returning the  modified & fixed CODEOWNERS file. 
+    // instead of returning lines with issues, consider returning the modified & fixed CODEOWNERS file. 
     // It could work by reading all the lines, then replacing the wrong
     // lines by using dict replacement. Need to be careful about retaining spaces to not misalign,
     // e.g.
@@ -352,6 +352,7 @@ public class CodeownersManualAnalysisTests
         outputLines.AddRange(PathsWithMissingPrefixSlash(entries));
         outputLines.AddRange(PathsWithMissingSuffixSlash(targetDir, entries, paths));
         outputLines.AddRange(InvalidPaths(entries));
+        // TODO: add a check here for CODEOWNERS paths that do not match any dir or file.
 
         return outputLines;
     }
@@ -414,9 +415,13 @@ public class CodeownersManualAnalysisTests
     private static bool MatchesNamePrefix(string[] paths, string trimmedPathExpression)
         => paths.Any(
             path =>
-                path.TrimStart('/').StartsWith(trimmedPathExpression)
-                && path.TrimStart('/').Length != trimmedPathExpression.Length
-                && !path.TrimStart('/').Substring(trimmedPathExpression.Length).StartsWith('/'));
+            {
+                string trimmedPath = path.TrimStart('/');
+                bool pathIsChildDir = trimmedPath.Substring(trimmedPathExpression.Length).StartsWith('/');
+                return trimmedPath.StartsWith(trimmedPathExpression)
+                       && trimmedPath.Length != trimmedPathExpression.Length
+                       && !pathIsChildDir;
+            });
 
     private static bool MatchesDirExactly(string targetDir, string trimmedPathExpression)
     {

--- a/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
+++ b/tools/code-owners-parser/Azure.Sdk.Tools.RetrieveCodeOwners.Tests/CodeownersManualAnalysisTests.cs
@@ -417,7 +417,9 @@ public class CodeownersManualAnalysisTests
             path =>
             {
                 string trimmedPath = path.TrimStart('/');
-                bool pathIsChildDir = trimmedPath.Substring(trimmedPathExpression.Length).StartsWith('/');
+                bool pathIsChildDir = trimmedPath.Contains("/")
+                                      && trimmedPath.Length > trimmedPathExpression.Length
+                                      && trimmedPath.Substring(trimmedPathExpression.Length).StartsWith('/');
                 return trimmedPath.StartsWith(trimmedPathExpression)
                        && trimmedPath.Length != trimmedPathExpression.Length
                        && !pathIsChildDir;

--- a/tools/code-owners-parser/CodeOwnersParser/MatchedCodeownersEntry.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/MatchedCodeownersEntry.cs
@@ -63,9 +63,6 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
                && !ContainsUnsupportedCharacters(codeownersPathExpression) 
                && !ContainsUnsupportedSequences(codeownersPathExpression);
 
-        private static bool IsCommentedOutPath(string codeownersPathExpression)
-            => codeownersPathExpression.Trim().StartsWith("#");
-
         /// <summary>
         /// Any CODEOWNERS path with these characters will be skipped.
         /// Note these are valid parts of file paths, but we are not supporting
@@ -131,6 +128,16 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
         }
 
         private CodeownersEntry NoMatchCodeownersEntry { get; } = new CodeownersEntry();
+
+        /// <summary>
+        /// We do not output any error message in case the path is commented out,
+        /// as a) such paths are expected to be processed and discarded by this logic
+        /// and b) outputting error messages would possibly result in output
+        /// truncation, truncating the resulting json, and thus making the output of the
+        /// calling tool malformed.
+        /// </summary>
+        private static bool IsCommentedOutPath(string codeownersPathExpression)
+            => codeownersPathExpression.Trim().StartsWith("#");
 
         /// <summary>
         /// See the comment on unsupportedChars.

--- a/tools/code-owners-parser/CodeOwnersParser/MatchedCodeownersEntry.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/MatchedCodeownersEntry.cs
@@ -59,8 +59,12 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
         /// See the class comment to understand this method purpose.
         /// </summary>
         public static bool IsCodeownersPathValid(string codeownersPathExpression)
-            => !ContainsUnsupportedCharacters(codeownersPathExpression) 
+            => !IsCommentedOutPath(codeownersPathExpression)
+               && !ContainsUnsupportedCharacters(codeownersPathExpression) 
                && !ContainsUnsupportedSequences(codeownersPathExpression);
+
+        private static bool IsCommentedOutPath(string codeownersPathExpression)
+            => codeownersPathExpression.Trim().StartsWith("#");
 
         /// <summary>
         /// Any CODEOWNERS path with these characters will be skipped.


### PR DESCRIPTION
Before this change, commented out paths in `CODEOWNERS` violated the rule that the paths should start with `/`. As a result, the `Console.Err` was spammed with error messages, resulting in `Console.Out` truncation for `azure-sdk-for-js` and `azure-sdk-for-java` repos, making it impossible to deserialize the result written to `Console.Out` into valid json. This broke `CodeownersManualAnalysisTests` with `OutOfMemoryException` upon getting value from `Console.Err`.

This bug was introduced by:
- #5330

as that PR stopped prepending missing `/` and instead started outputting message to `Console.Err` if they were missing.

## Secondary fix

This PR also fixes a bug related to validating paths.