### PR TITLE
Update `.NET` from `6.0.403` to `7.0.102` + `DOTNET_ROLL_FORWARD`: `Major` + fix wrong quotes in `install-net.yml`

### DIFF
--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -5,12 +5,22 @@ parameters:
     default: ''
 
 steps:
+  # We set DOTNET_ROLL_FORWARD so that .NET assemblies targeting older versions of .NET can run on newer ones.
+  # See also:
+  # https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet#options-for-running-an-application
+  # https://learn.microsoft.com/en-us/dotnet/core/runtime-discovery/troubleshoot-app-launch?pivots=os-windows#required-framework-not-found
+  # https://aka.ms/dotnet/app-launch-failed
+  # https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell
+  # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=powershell
+  - pwsh: |
+      echo "##vso[task.setvariable variable=DOTNET_ROLL_FORWARD;]Major"
+    displayName: "Set DOTNET_ROLL_FORWARD to Major"
   # https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines
   - task: UseDotNet@2
     displayName: "Use .NET SDK ${{ coalesce( parameters.DotNetCoreVersion, 'from global.json') }}"
     retryCountOnTaskFailure: 3
     inputs:
-      ${{ if eq( 'parameters.DotNetCoreVersion', '') }}:
+      ${{ if eq( parameters.DotNetCoreVersion, '') }}:
         useGlobalJson: true
       ${{ else }}:
         version: ${{ parameters.DotNetCoreVersion }}

--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Microsoft.Build.Traversal": "3.2.0"
   },
   "sdk": {
-    "version": "6.0.403",
+    "version": "7.0.102",
     "rollForward": "feature"
   }
 }


### PR DESCRIPTION
This .NET version is available on the Ubuntu 22.04 pools we use per:

- https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2204-Readme.md#net-tools
- https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/1es-hosted-azure-devops-pools/createpoolimage

This PR also sets `DOTNET_ROLL_FORWARD` to `Major` so that tools targetting .NET `6.0` can run on .NET `7.0`.

For context, please see [this teams chat](https://teams.microsoft.com/l/message/19:59dbfadafb5e41c4890e2cd3d74cc7ba@thread.skype/1675890941633?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1675885183657&teamName=Azure%20SDK&channelName=Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F&createdTime=1675890941633) and this comment:
- https://github.com/Azure/azure-sdk-tools/pull/5328#pullrequestreview-1290001058

Related:
- https://github.com/Azure/azure-sdk-tools/pull/5380