### PR TITLE
`Info/Active/` now offers data for individual sessions

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/Exceptions/SessionNotActiveException.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/Exceptions/SessionNotActiveException.cs
@@ -1,0 +1,14 @@
+using System;
+namespace Azure.Sdk.Tools.TestProxy.Common.Exceptions
+{
+    public class SessionNotActiveException: Exception
+    {
+        public SessionNotActiveException()
+        {
+        }
+        public SessionNotActiveException(string message)
+        : base(message)
+        {
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Info.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Info.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Azure.Sdk.Tools.TestProxy.Models;
@@ -33,9 +33,9 @@ namespace Azure.Sdk.Tools.TestProxy
         }
 
         [HttpGet]
-        public async Task<ContentResult> Active()
+        public async Task<ContentResult> Active(string id="")
         {
-            var dataModel = new ActiveMetadataModel(_recordingHandler);
+            var dataModel = new ActiveMetadataModel(_recordingHandler, recordingId: id);
             var viewHtml = await RenderViewAsync(this, "ActiveExtensions", dataModel);
 
             return new ContentResult

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Info.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Info.cs
@@ -43,9 +43,9 @@ namespace Azure.Sdk.Tools.TestProxy
                 var dataModel = new ActiveMetadataModel(_recordingHandler, recordingId: id);
                 content = await RenderViewAsync(this, "ActiveExtensions", dataModel);
             }
-            // if an httpException is thrown, we have passed in an invalid recordingId, otherwise it'll be an unhandled
+            // if a SessionNotActiveException is thrown, we have passed in an invalid recordingId, otherwise it'll be an unhandled
             // exception, which the exception middleware should surface just fine.
-            catch (HttpException)
+            catch (SessionNotActiveException)
             {
                 content = await RenderViewAsync(this, "Error", new ActiveMetadataModel(id));
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Info.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Info.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
 using Azure.Sdk.Tools.TestProxy.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Rendering;
@@ -35,13 +36,24 @@ namespace Azure.Sdk.Tools.TestProxy
         [HttpGet]
         public async Task<ContentResult> Active(string id="")
         {
-            var dataModel = new ActiveMetadataModel(_recordingHandler, recordingId: id);
-            var viewHtml = await RenderViewAsync(this, "ActiveExtensions", dataModel);
+            string content = string.Empty;
+
+            try
+            {
+                var dataModel = new ActiveMetadataModel(_recordingHandler, recordingId: id);
+                content = await RenderViewAsync(this, "ActiveExtensions", dataModel);
+            }
+            // if an httpException is thrown, we have passed in an invalid recordingId, otherwise it'll be an unhandled
+            // exception, which the exception middleware should surface just fine.
+            catch (HttpException)
+            {
+                content = await RenderViewAsync(this, "Error", new ActiveMetadataModel(id));
+            }
 
             return new ContentResult
             {
                 ContentType = "text/html",
-                Content = viewHtml
+                Content = content
             };
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/ActiveMetadataModel.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/ActiveMetadataModel.cs
@@ -8,11 +8,17 @@ using System.IO;
 using Azure.Sdk.Tools.TestProxy.Common;
 using System.Collections.Concurrent;
 using Microsoft.CodeAnalysis.Operations;
+using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
 
 namespace Azure.Sdk.Tools.TestProxy.Models
 {
     public class ActiveMetadataModel : RunTimeMetaDataModel
     {
+        public ActiveMetadataModel(string recordingId)
+        {
+            RecordingId = recordingId;
+        }
+
         public ActiveMetadataModel(RecordingHandler pageRecordingHandler)
         {
             Descriptions = _populateFromHandler(pageRecordingHandler, "");
@@ -39,6 +45,7 @@ namespace Azure.Sdk.Tools.TestProxy.Models
                 handler.InMemorySessions
             };
 
+            var recordingFound = false;
             if (!string.IsNullOrWhiteSpace(recordingId)){
                 foreach (var sessionDict in searchCollections)
                 { 
@@ -51,8 +58,15 @@ namespace Azure.Sdk.Tools.TestProxy.Models
                         {
                             matcher = session.CustomMatcher;
                         }
+
+                        recordingFound = true;
                         break;
                     }
+                }
+
+                if (!recordingFound)
+                {
+                    throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"{recordingId} is not found in any Playback, Recording, or In-Memory sessions.");
                 }
             }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/ActiveMetadataModel.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/ActiveMetadataModel.cs
@@ -51,6 +51,7 @@ namespace Azure.Sdk.Tools.TestProxy.Models
                         {
                             matcher = session.CustomMatcher;
                         }
+                        break;
                     }
                 }
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/ActiveMetadataModel.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/ActiveMetadataModel.cs
@@ -66,7 +66,7 @@ namespace Azure.Sdk.Tools.TestProxy.Models
 
                 if (!recordingFound)
                 {
-                    throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"{recordingId} is not found in any Playback, Recording, or In-Memory sessions.");
+                    throw new SessionNotActiveException($"{recordingId} is not found in any Playback, Recording, or In-Memory sessions.");
                 }
             }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/ActiveMetadataModel.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/ActiveMetadataModel.cs
@@ -42,7 +42,7 @@ namespace Azure.Sdk.Tools.TestProxy.Models
             if (!string.IsNullOrWhiteSpace(recordingId)){
                 List<RecordedTestSanitizer> additionalSanitizers = new List<RecordedTestSanitizer>();
 
-                if(!handler.RecordingSessions.TryGetValue(recordingId, out var recordSession))
+                if(handler.RecordingSessions.TryGetValue(recordingId, out var recordSession))
                 {
                     sanitizers = sanitizers.Concat(recordSession.AdditionalSanitizers);
                     transforms = transforms.Concat(recordSession.AdditionalTransforms);
@@ -52,14 +52,14 @@ namespace Azure.Sdk.Tools.TestProxy.Models
                         matcher = recordSession.CustomMatcher;
                     }
                 }
-                else if (!handler.PlaybackSessions.TryGetValue(recordingId, out var playbackSession))
+                else if (handler.PlaybackSessions.TryGetValue(recordingId, out var playbackSession))
                 {
                     sanitizers = sanitizers.Concat(playbackSession.AdditionalSanitizers);
                     transforms = transforms.Concat(playbackSession.AdditionalTransforms);
 
-                    if (recordSession.CustomMatcher != null)
+                    if (playbackSession.CustomMatcher != null)
                     {
-                        matcher = recordSession.CustomMatcher;
+                        matcher = playbackSession.CustomMatcher;
                     }
                 }
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/ActiveMetadataModel.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/ActiveMetadataModel.cs
@@ -7,6 +7,7 @@ using System.Xml;
 using System.IO;
 using Azure.Sdk.Tools.TestProxy.Common;
 using System.Collections.Concurrent;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Azure.Sdk.Tools.TestProxy.Models
 {
@@ -31,35 +32,25 @@ namespace Azure.Sdk.Tools.TestProxy.Models
             var transforms = (IEnumerable<ResponseTransform>) handler.Transforms;
             var matcher = handler.Matcher;
 
-            //List<ConcurrentDictionary<string, ModifiableRecordSession>> searchCollections = new List<ConcurrentDictionary<string, ModifiableRecordSession>>()
-            //{
-            //    handler.PlaybackSessions,
-            //    handler.RecordingSessions,
-            //    handler.InMemorySessions
-            //}; 
-            // TODO: convert this guy
+            List<ConcurrentDictionary<string, ModifiableRecordSession>> searchCollections = new List<ConcurrentDictionary<string, ModifiableRecordSession>>()
+            {
+                handler.PlaybackSessions,
+                handler.RecordingSessions,
+                handler.InMemorySessions
+            };
 
             if (!string.IsNullOrWhiteSpace(recordingId)){
-                List<RecordedTestSanitizer> additionalSanitizers = new List<RecordedTestSanitizer>();
-
-                if(handler.RecordingSessions.TryGetValue(recordingId, out var recordSession))
-                {
-                    sanitizers = sanitizers.Concat(recordSession.AdditionalSanitizers);
-                    transforms = transforms.Concat(recordSession.AdditionalTransforms);
-
-                    if (recordSession.CustomMatcher != null)
+                foreach (var sessionDict in searchCollections)
+                { 
+                    if (sessionDict.TryGetValue(recordingId, out var session))
                     {
-                        matcher = recordSession.CustomMatcher;
-                    }
-                }
-                else if (handler.PlaybackSessions.TryGetValue(recordingId, out var playbackSession))
-                {
-                    sanitizers = sanitizers.Concat(playbackSession.AdditionalSanitizers);
-                    transforms = transforms.Concat(playbackSession.AdditionalTransforms);
+                        sanitizers = sanitizers.Concat(session.AdditionalSanitizers);
+                        transforms = transforms.Concat(session.AdditionalTransforms);
 
-                    if (playbackSession.CustomMatcher != null)
-                    {
-                        matcher = playbackSession.CustomMatcher;
+                        if (session.CustomMatcher != null)
+                        {
+                            matcher = session.CustomMatcher;
+                        }
                     }
                 }
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/RunTimeMetadataModel.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/RunTimeMetadataModel.cs
@@ -76,32 +76,37 @@ namespace Azure.Sdk.Tools.TestProxy.Models
             var arguments = new List<Tuple<string, string>>();
 
             var filteredFields = fields.Where(x => x.FieldType.Name == "String" || x.FieldType.Name == "ApplyCondition");
-            foreach (FieldInfo field in filteredFields)
-            {
-                var prop = field.GetValue(target);
-                string propValue;
-                if(prop == null)
-                {
-                    propValue = "This argument is unset or null.";
-                }
-                else
-                {
-                    if(field.FieldType.Name == "ApplyCondition")
-                    {
-                        propValue = prop.ToString();
 
-                        if(propValue == null)
-                        {
-                            continue;
-                        }
+            // we only want to crawl the fields if it is an inherited type. customizations are not offered
+            // when looking at a base RecordMatcher, ResponseTransform, or RecordedTestSanitizer
+            // These 3 will have a basetype of Object
+            if (tType.BaseType != typeof(Object))
+            {
+                foreach (FieldInfo field in filteredFields)
+                {
+                    var prop = field.GetValue(target);
+                    string propValue;
+                    if (prop == null)
+                    {
+                        propValue = "This argument is unset or null.";
                     }
                     else
                     {
-                        propValue = "\"" + prop.ToString() + "\"";
+                        if (field.FieldType.Name == "ApplyCondition")
+                        {
+                            propValue = prop.ToString();
+
+                            if (propValue == null)
+                            {
+                                continue;
+                            }
+                        }
+                        else
+                        {
+                            propValue = "\"" + prop.ToString() + "\"";
+                        }
                     }
-                }
-                if (!field.Name.Contains("BackingField"))
-                {
+
                     arguments.Add(new Tuple<string, string>(field.Name, propValue));
                 }
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/RunTimeMetadataModel.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Models/RunTimeMetadataModel.cs
@@ -100,8 +100,10 @@ namespace Azure.Sdk.Tools.TestProxy.Models
                         propValue = "\"" + prop.ToString() + "\"";
                     }
                 }
-                
-                arguments.Add(new Tuple<string, string>(field.Name, propValue));
+                if (!field.Name.Contains("BackingField"))
+                {
+                    arguments.Add(new Tuple<string, string>(field.Name, propValue));
+                }
             }
 
             return new CtorDescription()

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -1,20 +1,21 @@
 {
+  "profiles": {
+    "Azure.Sdk.Tools.TestProxy": {
+      "commandName": "Project",
+      "workingDirectory": "C:/repo/sdk-for-java",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "Logging__LogLevel__Microsoft": "Information"
+      },
+      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+    }
+  },
   "iisSettings": {
     "windowsAuthentication": false,
     "anonymousAuthentication": true,
     "iisExpress": {
       "applicationUrl": "http://localhost:5001/",
       "sslPort": 44362
-    }
-  },
-  "profiles": {
-    "Azure.Sdk.Tools.TestProxy": {
-      "commandName": "Project",
-      "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "Logging__LogLevel__Microsoft": "Information"
-      },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
     }
   }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -2,7 +2,6 @@
   "profiles": {
     "Azure.Sdk.Tools.TestProxy": {
       "commandName": "Project",
-      "workingDirectory": "C:/repo/sdk-for-java",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "Logging__LogLevel__Microsoft": "Information"

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -30,6 +30,7 @@
       - [A note about where sanitizers apply](#a-note-about-where-sanitizers-apply)
     - [For Sanitizers, Matchers, or Transforms in general](#for-sanitizers-matchers-or-transforms-in-general)
     - [Viewing available/active Sanitizers, Matchers, and Transforms](#viewing-availableactive-sanitizers-matchers-and-transforms)
+      - [To see customizations on a specific recording](#to-see-customizations-on-a-specific-recording)
     - [Resetting active Sanitizers, Matchers, and Transforms](#resetting-active-sanitizers-matchers-and-transforms)
       - [Reset the session](#reset-the-session)
       - [Reset for a specific recordingId](#reset-for-a-specific-recordingid)
@@ -456,9 +457,20 @@ Currently, the configured set of transforms/playback/sanitizers are NOT propogat
 Launch the test-proxy through your chosen method, then visit:
 
 - `<proxyUrl>/Info/Available` to see all available
-- `<proxyUrl>/Info/Active` to see all currently active.
+- `<proxyUrl>/Info/Active` to see all currently active for all sessions.
 
 Note that the `constructor arguments` that are documented must be present (where documented as such) in the body of the POST sent to the Admin Interface.
+
+#### To see customizations on a specific recording
+
+This only works **while a session is available**. A specific session is only available _before_ it has been stopped. Once that happens it has been written to disk or evacuated from server memory.
+
+Example flow
+
+- Start playback for "hello_world.json"
+- Receive a recordingId back
+- Place a breakpoint **before** the part of your code that calls `/Record/Stop` or `Playback/Stop`.
+- Visit the url `<proxyUrl>/Info/Active?id=<your-recording-id>`
 
 ### Resetting active Sanitizers, Matchers, and Transforms
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Views/Info/ActiveExtensions.cshtml
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Views/Info/ActiveExtensions.cshtml
@@ -14,9 +14,19 @@
     @await Html.PartialAsync("css.cshtml")
 </head>
 <body>
-    <h1>
-        Test-Proxy - Active Extensions
-    </h1>
+    @if (!string.IsNullOrWhiteSpace(Model.RecordingId))
+    {
+        <h1>
+            Active Extensions for @Model.RecordingId
+        </h1>
+    }
+    else
+    {
+        <h1>
+            Active Extensions for All Sessions
+        </h1>
+    }
+
 
     @if (!string.IsNullOrWhiteSpace(Model.RecordingId))
     {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Views/Info/ActiveExtensions.cshtml
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Views/Info/ActiveExtensions.cshtml
@@ -27,7 +27,7 @@
     else
     {
         <p>
-            The below extensions are currently configured.
+            The below extensions are currently configured for all sessions.
         </p>
     }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Views/Info/ActiveExtensions.cshtml
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Views/Info/ActiveExtensions.cshtml
@@ -1,4 +1,4 @@
-﻿@using Azure.Sdk.Tools.TestProxy.Models; 
+@using Azure.Sdk.Tools.TestProxy.Models;
 @model ActiveMetadataModel
 
 @{
@@ -17,9 +17,20 @@
     <h1>
         Test-Proxy - Active Extensions
     </h1>
-    <p>
-        The below extensions are currently configured.
-    </p>
+
+    @if (!string.IsNullOrWhiteSpace(Model.RecordingId))
+    {
+        <p>
+            The below extensions are configured for recording <b>@Model.RecordingId</b>.
+        </p>
+    }
+    else
+    {
+        <p>
+            The below extensions are currently configured.
+        </p>
+    }
+
     <p>
         To observe ALL extensions (rather than just what is currently active), visit <a href="/Info/Available">/Info/Available</a>. For clarity, note that argument values below are surrounded in quotes. The actual value itself being utilized by
         the test-proxy does not contain these quotes.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Views/Info/Error.cshtml
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Views/Info/Error.cshtml
@@ -1,0 +1,29 @@
+@using Azure.Sdk.Tools.TestProxy.Models;
+@model ActiveMetadataModel
+
+@{
+    Layout = null;
+}
+
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width" />
+    <title>An error has occured.</title>
+
+    @await Html.PartialAsync("css.cshtml")
+</head>
+<body>
+    <h1>
+        Unable to locate @Model.RecordingId.
+    </h1>
+
+    <p>
+        Unfortunately, a recording id with value "@Model.RecordingId" can not be located in currently active Playback, Recording, or In-Memory sessions.
+    </p>
+
+    <p>
+        Please confirm that the recording-id in question has <b>NOT</b> been stopped yet. Once a record/playback session has ended, the customizations for that particular session can no longer be retrieved.
+    </p>
+</body>
+</html>


### PR DESCRIPTION
Resolves #5362 

@samvaity is working on transition appconfiguration to test-proxy for java. As she was doing that, she wanted to see the `order of application` of the sanitizers _after_ they are registered. This is because the java framework does a lot of behind-the-scenes work to pregister more than a few sanitizers.

It is a much easier experience to debug if folks can _actually see_ the session level customizations when they view the `Info/Active` page.

Of course, the proviso is that you can't get active information for a recording or playback session that has ended, but the test-proxy should enable this regardless.

How to use it? Before your recording stops, and while you have that recordingId on hand, hit a browser with URL:

`<proxyurl>/Info/Active?id=<recordingId>`

TODO:
- [x] Honor argument with optional specific recordingId
- [x] Confirm via visual inspection that content is rendering properly
- [x] We are patching out the odd `BackingField` that is showing up on `RecordedTestSanitizer`, by excluding any of the fields that show up on the base classes `RecordedTestSanitizer`, `ResponseTransform`, and `RecordMatcher`. These don't offer any customizations, so we can safely exclude their fields.
- [x] Add error page for unrecognized recording Id
