### PR TITLE
Install  `.NET 6.0.x` runtime. Remove `DotNetCoreVersion` param. Undo `DOTNET_ROLL_FORWARD`.

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -15,9 +15,6 @@ parameters:
   - name: TestDirectory
     type: string
     default: ''
-  - name: DotNetCoreVersion
-    type: string
-    default: ''
   - name: NoWarn
     type: boolean
     default: false
@@ -65,8 +62,6 @@ stages:
 
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
-            parameters:
-              DotNetCoreVersion: ${{ parameters.DotNetCoreVersion }}
               
           - script: 'dotnet pack /p:ArtifactsPackagesDir=$(packagesToPublishDir) $(Warn) -c Release'
             displayName: 'Build and Package'
@@ -115,8 +110,6 @@ stages:
 
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
-            parameters:
-              DotNetCoreVersion: ${{ parameters.DotNetCoreVersion }}
 
           - template: /eng/pipelines/templates/steps/produce-net-standalone-packs.yml
             parameters:
@@ -144,8 +137,6 @@ stages:
 
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
-            parameters:
-              DotNetCoreVersion: ${{ parameters.DotNetCoreVersion }}
 
           - script: 'dotnet test /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) $(Warn) --logger trx'
             displayName: 'Test'
@@ -161,7 +152,7 @@ stages:
             condition: succeededOrFailed()
             inputs:
               testResultsFiles: '**/*.trx'
-              testRunTitle: $(System.JobDisplayName) ${{ parameters.DotNetCoreVersion }}
+              testRunTitle: $(System.JobDisplayName)
               testResultsFormat: 'VSTest'
               mergeTestResults: true
 

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -1,29 +1,25 @@
-parameters:
-  # Use this parameter if you want to override the .NET SDK set by global.json
-  - name: DotNetCoreVersion
-    type: string
-    default: ''
-
 steps:
-  # We set DOTNET_ROLL_FORWARD so that .NET assemblies targeting older versions of .NET can run on newer ones.
-  # See also:
-  # https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet#options-for-running-an-application
-  # https://learn.microsoft.com/en-us/dotnet/core/runtime-discovery/troubleshoot-app-launch?pivots=os-windows#required-framework-not-found
-  # https://aka.ms/dotnet/app-launch-failed
-  # https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell
-  # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=powershell
-  - pwsh: |
-      echo "##vso[task.setvariable variable=DOTNET_ROLL_FORWARD;]Major"
-    displayName: "Set DOTNET_ROLL_FORWARD to Major"
-  # https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines
-  - task: UseDotNet@2
-    displayName: "Use .NET SDK ${{ coalesce( parameters.DotNetCoreVersion, 'from global.json') }}"
+
+  # We aim to keep .NET SDK coming from global.json to bethe newest, to enable us to use the latest & greatest,
+  # and allow us to gradually migrate our .NET sources to such version.
+  # About global.json: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json
+  - task: UseDotNet@2 # About UseDotNet@2 task: https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines
+    displayName: "Use .NET SDK from global.json"
     retryCountOnTaskFailure: 3
     inputs:
-      ${{ if eq( parameters.DotNetCoreVersion, '') }}:
-        useGlobalJson: true
-      ${{ else }}:
-        version: ${{ parameters.DotNetCoreVersion }}
+      useGlobalJson: true
+
+  # We install .NET 6.0.x runtime in addition to .NET coming from global.json because most of our tools target 6.0.x.
+  # Once we migrate all tools to a newer .NET version, we should update this to install that version instead.
+  - task: UseDotNet@2
+    displayName: "Use .NET runtime 6.0.x"
+    retryCountOnTaskFailure: 3
+    inputs:
+      packageType: runtime
+      version: 6.0.x
+      # performMultiLevelLookup comes into play when given .NET executable target runtime is different
+      # than the installed .NET SDK. Without this, such runtime would not be found.
+      performMultiLevelLookup: true
 
 # Future work: add NuGet packages caching. See:
 # https://github.com/Azure/azure-sdk-tools/issues/5086


### PR DESCRIPTION
Changes made per this comment:
- https://github.com/Azure/azure-sdk-tools/pull/5379#issuecomment-1424766311

and my discussion with @weshaggard 

We were already using the newest .NET SDK to build things; it comes from [`global.json`](https://learn.microsoft.com/en-us/dotnet/core/tools/global-json). But with this PR, we also install `.NET 6.0.x` runtime, so that our tooling targeting it runs against it.

### A note on parameter support

I have removed `DotNetCoreVersion` because:

- Setting `global.json` `.NET` to `6.0.x` and trying to override with `DotNetCoreVersion 7.0.x` does not work (<- this may not be true, but we want to have newest .NET in `global.json` anyway).
- Setting `global.json` `.NET` to `7.0.x` and overriding with `DotNetCoreVersion 6.0.x` would work, but then the parameter would have to be passed in many places, as most of our tools target `6.0.x`.
- We could change the `DotNetCoreVersion` to something like `SkipRuntimeInstall`; in such case, the `.NET 6.0.x` would be installed by default, but then for tools migrated to `7.0.x` one could skip it by passing `SkipRuntimeInstall`. Once all tools are migrated to `7.0.x` we could update this file to no longer install `6.0.x` runtime and get rid of all such `SkipRuntimeInstall` arguments. However, this seems to me as some amount of work not necessarily worth the effort.

Having said that, once we need more flexibility for the runtimes installed, we could add the param back.

### Testing done

This build confirms that an assembly targeting `7.0.x` works (I made `Azure.Sdk.Tools.RetrieveCodeOwners` and `Azure.Sdk.Tools.CodeOwnsersParser` target `7.0.0` for this build):

- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2177144&view=results

This build confirms that an assembly targeting `6.0.x` works:
- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2177181&view=logs&s=c0a22914-42ba-51eb-e68d-84c64519cae1