### PR TITLE
Repair Failing Livetests Again

### DIFF
--- a/eng/pipelines/templates/steps/test-proxy-local-tool.yml
+++ b/eng/pipelines/templates/steps/test-proxy-local-tool.yml
@@ -9,7 +9,7 @@ steps:
       dotnet tool install --tool-path $(Build.BinariesDirectory)/test-proxy `
         --prerelease `
         --add-source $(Build.ArtifactStagingDirectory) `
-        test-proxy
+        azure.sdk.tools.testproxy
     displayName: "Install test-proxy from local file"
     workingDirectory: $(Build.SourcesDirectory)/tools/test-proxy
 


### PR DESCRIPTION
Because I renamed the proxy _back_ to `azure.sdk.tools.testproxy`. 😤 

Example of current failure: 
![image](https://user-images.githubusercontent.com/45376673/217986834-aebb2934-b4a1-4bfe-854c-6ed3104f6dc4.png)

