### PR TITLE
Revert "Install `.NET 7.0.x` from `global.json` and `.NET 6.0.0` runtime. Remove `DotNetCoreVersion` param. (#5395)

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -15,6 +15,9 @@ parameters:
   - name: TestDirectory
     type: string
     default: ''
+  - name: DotNetCoreVersion
+    type: string
+    default: ''
   - name: NoWarn
     type: boolean
     default: false
@@ -62,6 +65,8 @@ stages:
 
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
+            parameters:
+              DotNetCoreVersion: ${{ parameters.DotNetCoreVersion }}
               
           - script: 'dotnet pack /p:ArtifactsPackagesDir=$(packagesToPublishDir) $(Warn) -c Release'
             displayName: 'Build and Package'
@@ -110,6 +115,8 @@ stages:
 
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
+            parameters:
+              DotNetCoreVersion: ${{ parameters.DotNetCoreVersion }}
 
           - template: /eng/pipelines/templates/steps/produce-net-standalone-packs.yml
             parameters:
@@ -137,6 +144,8 @@ stages:
 
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
+            parameters:
+              DotNetCoreVersion: ${{ parameters.DotNetCoreVersion }}
 
           - script: 'dotnet test /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) $(Warn) --logger trx'
             displayName: 'Test'
@@ -152,7 +161,7 @@ stages:
             condition: succeededOrFailed()
             inputs:
               testResultsFiles: '**/*.trx'
-              testRunTitle: $(System.JobDisplayName)
+              testRunTitle: $(System.JobDisplayName) ${{ parameters.DotNetCoreVersion }}
               testResultsFormat: 'VSTest'
               mergeTestResults: true
 

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -1,25 +1,29 @@
+parameters:
+  # Use this parameter if you want to override the .NET SDK set by global.json
+  - name: DotNetCoreVersion
+    type: string
+    default: ''
+
 steps:
-
-  # We aim to keep .NET SDK coming from global.json to bethe newest, to enable us to use the latest & greatest,
-  # and allow us to gradually migrate our .NET sources to such version.
-  # About global.json: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json
-  - task: UseDotNet@2 # About UseDotNet@2 task: https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines
-    displayName: "Use .NET SDK from global.json"
-    retryCountOnTaskFailure: 3
-    inputs:
-      useGlobalJson: true
-
-  # We install .NET 6.0.x runtime in addition to .NET coming from global.json because most of our tools target 6.0.x.
-  # Once we migrate all tools to a newer .NET version, we should update this to install that version instead.
+  # We set DOTNET_ROLL_FORWARD so that .NET assemblies targeting older versions of .NET can run on newer ones.
+  # See also:
+  # https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet#options-for-running-an-application
+  # https://learn.microsoft.com/en-us/dotnet/core/runtime-discovery/troubleshoot-app-launch?pivots=os-windows#required-framework-not-found
+  # https://aka.ms/dotnet/app-launch-failed
+  # https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell
+  # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=powershell
+  - pwsh: |
+      echo "##vso[task.setvariable variable=DOTNET_ROLL_FORWARD;]Major"
+    displayName: "Set DOTNET_ROLL_FORWARD to Major"
+  # https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines
   - task: UseDotNet@2
-    displayName: "Use .NET runtime 6.0.x"
+    displayName: "Use .NET SDK ${{ coalesce( parameters.DotNetCoreVersion, 'from global.json') }}"
     retryCountOnTaskFailure: 3
     inputs:
-      packageType: runtime
-      version: 6.0.x
-      # performMultiLevelLookup comes into play when given .NET executable target runtime is different
-      # than the installed .NET SDK. Without this, such runtime would not be found.
-      performMultiLevelLookup: true
+      ${{ if eq( parameters.DotNetCoreVersion, '') }}:
+        useGlobalJson: true
+      ${{ else }}:
+        version: ${{ parameters.DotNetCoreVersion }}
 
 # Future work: add NuGet packages caching. See:
 # https://github.com/Azure/azure-sdk-tools/issues/5086


### PR DESCRIPTION
This reverts commit 3efd6804e9eb976d9e60bc9b5dfa2fecb9a9aac7.

Reason: failure of `tools - test-proxy - ci`:
https://dev.azure.com/azure-sdk/public/_build/results?buildId=2177474&view=results

Build to verify that the reversal works:
https://dev.azure.com/azure-sdk/public/_build/results?buildId=2177528&view=results

Possibly related doc to help debug the issue:
https://github.com/dotnet/core-setup/blob/master/Documentation/design-docs/multilevel-sharedfx-lookup.md#global-locations