### PR TITLE
Update Swagger parser version used for manual API review gen

### DIFF
--- a/eng/pipelines/apiview-review-gen-swagger.yml
+++ b/eng/pipelines/apiview-review-gen-swagger.yml
@@ -27,7 +27,7 @@ jobs:
   - script: >
       dotnet tool install
       Azure.Sdk.Tools.SwaggerApiParser
-      --version 1.0.5-dev.20230131.3
+      --version 1.0.7-dev.20230209.6
       --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
       --tool-path $(SwaggerParserInstallPath)
     workingDirectory: $(SwaggerParserInstallPath)


### PR DESCRIPTION
Latest version: https://github.com/Azure/azure-sdk-tools/releases/tag/Azure.Sdk.Tools.SwaggerApiParser_1.0.7-dev.20230209.6

Fixes: https://github.com/Azure/azure-sdk-tools/issues/5400