### PR TITLE
Update Profile Directory

### DIFF
--- a/eng/common/pipelines/templates/jobs/perf.yml
+++ b/eng/common/pipelines/templates/jobs/perf.yml
@@ -168,8 +168,8 @@ jobs:
 
   - task: PublishPipelineArtifact@1
     inputs:
-      targetPath: $(System.DefaultWorkingDirectory)/${{ parameters.Language }}-profile.zip
-      artifactName: ${{ parameters.Language }}-profile.zip
+      targetPath: $(System.DefaultWorkingDirectory)/profile.zip
+      artifactName: profile.zip
     condition: ${{ parameters.Profile }}
 
   - template: /eng/common/TestResources/remove-test-resources.yml

--- a/eng/common/pipelines/templates/jobs/perf.yml
+++ b/eng/common/pipelines/templates/jobs/perf.yml
@@ -168,8 +168,8 @@ jobs:
 
   - task: PublishPipelineArtifact@1
     inputs:
-      targetPath: $(System.DefaultWorkingDirectory)/profile.zip
-      artifactName: profile.zip
+      targetPath: $(System.DefaultWorkingDirectory)/${{ parameters.Language }}-profile.zip
+      artifactName: ${{ parameters.Language }}-profile.zip
     condition: ${{ parameters.Profile }}
 
   - template: /eng/common/TestResources/remove-test-resources.yml

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
@@ -127,7 +127,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
             var profilingConfig = "";
             if (profile)
             {
-                var profileOutputPath = Path.GetFullPath(Util.GetProfileDirectory(WorkingDirectory), $"{testName}_{profileCount++}.jfr");
+                var profileOutputPath = Path.GetFullPath(Path.Combine(Util.GetProfileDirectory(WorkingDirectory), $"{testName}_{profileCount++}.jfr"));
                 profilingConfig = $"-XX:StartFlightRecording=filename={profileOutputPath},maxsize=1gb";
 
                 // If Java 8 is the version of Java being used add '-XX:+UnlockCommercialFeatures' as that is required to run Java Flight Recording in Java 8.

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
@@ -127,7 +127,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
             var profilingConfig = "";
             if (profile)
             {
-                var profileOutputPath = Path.GetFullPath(Util.GetProfileDirectory(WorkingDirectory), $"{testName}_{profileCount++}.jfr"));
+                var profileOutputPath = Path.GetFullPath(Util.GetProfileDirectory(WorkingDirectory), $"{testName}_{profileCount++}.jfr");
                 profilingConfig = $"-XX:StartFlightRecording=filename={profileOutputPath},maxsize=1gb";
 
                 // If Java 8 is the version of Java being used add '-XX:+UnlockCommercialFeatures' as that is required to run Java Flight Recording in Java 8.

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Java.cs
@@ -127,8 +127,8 @@ namespace Azure.Sdk.Tools.PerfAutomation
             var profilingConfig = "";
             if (profile)
             {
-                var profileOutputPath = Path.GetFullPath(Path.Combine(ProfileDirectory, $"{testName}_{profileCount++}.jfr"));
-                profilingConfig = $"-XX:+FlightRecorder -XX:StartFlightRecording=filename={profileOutputPath},maxsize=1gb";
+                var profileOutputPath = Path.GetFullPath(Util.GetProfileDirectory(WorkingDirectory), $"{testName}_{profileCount++}.jfr"));
+                profilingConfig = $"-XX:StartFlightRecording=filename={profileOutputPath},maxsize=1gb";
 
                 // If Java 8 is the version of Java being used add '-XX:+UnlockCommercialFeatures' as that is required to run Java Flight Recording in Java 8.
                 // Don't add '-XX:+UnlockCommercialFeatures' if it is any other version as this causes the JVM to crash on an unrecognized VM options.

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/LanguageBase.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/LanguageBase.cs
@@ -9,8 +9,6 @@ namespace Azure.Sdk.Tools.PerfAutomation
     {
         protected abstract Language Language { get; }
 
-        protected string ProfileDirectory => Path.GetFullPath(Path.Combine(WorkingDirectory, Language + "-profile"));
-
         public string WorkingDirectory { get; set; }
 
         public abstract Task CleanupAsync(string project);

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Program.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Program.cs
@@ -13,7 +13,6 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
-using static Azure.Sdk.Tools.PerfAutomation.Program;
 
 namespace Azure.Sdk.Tools.PerfAutomation
 {

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Program.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Program.cs
@@ -13,6 +13,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using YamlDotNet.Core;
 using YamlDotNet.Serialization;
+using static Azure.Sdk.Tools.PerfAutomation.Program;
 
 namespace Azure.Sdk.Tools.PerfAutomation
 {
@@ -209,7 +210,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
 
             if (options.Profile)
             {
-                profileDirectory = Directory.CreateDirectory(Path.Combine(options.RepoRoot, "profile"));
+                profileDirectory = Directory.CreateDirectory(Util.GetProfileDirectory(options.RepoRoot));
             }
 
             foreach (var packageVersions in selectedPackageVersions)

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Program.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Program.cs
@@ -231,7 +231,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
 
             if (options.Profile)
             {
-                ZipFile.CreateFromDirectory(profileDirectory.FullName, Path.Combine(profileDirectory.Parent.FullName, profileDirectory.Name + ".zip"));
+                ZipFile.CreateFromDirectory(profileDirectory.FullName, Path.Combine(profileDirectory.Parent.FullName, $"{options.Language}-{profileDirectory.Name}.zip"));
             }
         }
 

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Util.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Util.cs
@@ -109,5 +109,17 @@ namespace Azure.Sdk.Tools.PerfAutomation
                 }
             }
         }
+
+        /// <summary>
+        /// Gets the directory where profiles should be written to during performance testing.
+        /// 
+        /// The directory is based on the repository root folder.
+        /// </summary>
+        /// <param name="repoRoot">The repository root folder path.</param>
+        /// <returns>The directory where profiles should be written.</returns>
+        public static string GetProfileDirectory(string repoRoot)
+        {
+            return Path.Combine(repoRoot, "profile");
+        }
     }
 }


### PR DESCRIPTION
Updates profiling in performance pipeline to use new profiling directory. Performance test runs will now only run one language so there is no need to prefix the profiling directory with the language name and it can now just be called `profile`.