### PR TITLE
Take 2 - Install `.NET 6.0.x` SDK. Remove `DotNetCoreVersion` param. `Undo DOTNET_ROLL_FORWARD`.

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -15,9 +15,6 @@ parameters:
   - name: TestDirectory
     type: string
     default: ''
-  - name: DotNetCoreVersion
-    type: string
-    default: ''
   - name: NoWarn
     type: boolean
     default: false
@@ -65,8 +62,6 @@ stages:
 
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
-            parameters:
-              DotNetCoreVersion: ${{ parameters.DotNetCoreVersion }}
               
           - script: 'dotnet pack /p:ArtifactsPackagesDir=$(packagesToPublishDir) $(Warn) -c Release'
             displayName: 'Build and Package'
@@ -115,8 +110,6 @@ stages:
 
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
-            parameters:
-              DotNetCoreVersion: ${{ parameters.DotNetCoreVersion }}
 
           - template: /eng/pipelines/templates/steps/produce-net-standalone-packs.yml
             parameters:
@@ -144,8 +137,6 @@ stages:
 
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
-            parameters:
-              DotNetCoreVersion: ${{ parameters.DotNetCoreVersion }}
 
           - script: 'dotnet test /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) $(Warn) --logger trx'
             displayName: 'Test'
@@ -161,7 +152,7 @@ stages:
             condition: succeededOrFailed()
             inputs:
               testResultsFiles: '**/*.trx'
-              testRunTitle: $(System.JobDisplayName) ${{ parameters.DotNetCoreVersion }}
+              testRunTitle: $(System.JobDisplayName)
               testResultsFormat: 'VSTest'
               mergeTestResults: true
 

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -1,29 +1,25 @@
-parameters:
-  # Use this parameter if you want to override the .NET SDK set by global.json
-  - name: DotNetCoreVersion
-    type: string
-    default: ''
-
 steps:
-  # We set DOTNET_ROLL_FORWARD so that .NET assemblies targeting older versions of .NET can run on newer ones.
-  # See also:
-  # https://learn.microsoft.com/en-us/dotnet/core/tools/dotnet#options-for-running-an-application
-  # https://learn.microsoft.com/en-us/dotnet/core/runtime-discovery/troubleshoot-app-launch?pivots=os-windows#required-framework-not-found
-  # https://aka.ms/dotnet/app-launch-failed
-  # https://learn.microsoft.com/en-us/azure/devops/pipelines/scripts/logging-commands?view=azure-devops&tabs=powershell
-  # https://learn.microsoft.com/en-us/azure/devops/pipelines/process/set-variables-scripts?view=azure-devops&tabs=powershell
-  - pwsh: |
-      echo "##vso[task.setvariable variable=DOTNET_ROLL_FORWARD;]Major"
-    displayName: "Set DOTNET_ROLL_FORWARD to Major"
-  # https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines
-  - task: UseDotNet@2
-    displayName: "Use .NET SDK ${{ coalesce( parameters.DotNetCoreVersion, 'from global.json') }}"
+
+  # We aim to keep .NET SDK coming from global.json to bethe newest, to enable us to use the latest & greatest,
+  # and allow us to gradually migrate our .NET sources to such version.
+  # About global.json: https://learn.microsoft.com/en-us/dotnet/core/tools/global-json
+  - task: UseDotNet@2 # About UseDotNet@2 task: https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines
+    displayName: "Use .NET SDK from global.json"
     retryCountOnTaskFailure: 3
     inputs:
-      ${{ if eq( parameters.DotNetCoreVersion, '') }}:
-        useGlobalJson: true
-      ${{ else }}:
-        version: ${{ parameters.DotNetCoreVersion }}
+      useGlobalJson: true
+
+  # We install .NET 6.0.x runtime in addition to .NET coming from global.json because most of our tools target 6.0.x.
+  # Once we migrate all tools to a newer .NET version, we should update this to install that version instead.
+  - task: UseDotNet@2
+    displayName: "Use .NET runtime 6.0.x"
+    retryCountOnTaskFailure: 3
+    inputs:
+      packageType: runtime
+      version: 6.0.x
+      # performMultiLevelLookup comes into play when given .NET executable target runtime is different
+      # than the installed .NET SDK. Without this, such runtime would not be found.
+      performMultiLevelLookup: true
 
 # Future work: add NuGet packages caching. See:
 # https://github.com/Azure/azure-sdk-tools/issues/5086

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -12,14 +12,14 @@ steps:
   # We install .NET 6.0.x runtime in addition to .NET coming from global.json because most of our tools target 6.0.x.
   # Once we migrate all tools to a newer .NET version, we should update this to install that version instead.
   - task: UseDotNet@2
-    displayName: "Use .NET runtime 6.0.x"
+    displayName: "Use .NET SDK 6.0.x"
     retryCountOnTaskFailure: 3
     inputs:
-      packageType: runtime
+      packageType: sdk
       version: 6.0.x
       # performMultiLevelLookup comes into play when given .NET executable target runtime is different
       # than the installed .NET SDK. Without this, such runtime would not be found.
       performMultiLevelLookup: true
 
 # Future work: add NuGet packages caching. See:
-# https://github.com/Azure/azure-sdk-tools/issues/5086
+# https://github.com/Azure/azure-sdk-tools/issues/5086  

--- a/eng/pipelines/templates/steps/install-dotnet.yml
+++ b/eng/pipelines/templates/steps/install-dotnet.yml
@@ -9,12 +9,14 @@ steps:
     inputs:
       useGlobalJson: true
 
-  # We install .NET 6.0.x runtime in addition to .NET coming from global.json because most of our tools target 6.0.x.
+  # We install .NET 6.0.x SDK in addition to .NET coming from global.json because most of our tools target 6.0.x.
   # Once we migrate all tools to a newer .NET version, we should update this to install that version instead.
   - task: UseDotNet@2
     displayName: "Use .NET SDK 6.0.x"
     retryCountOnTaskFailure: 3
     inputs:
+      # We must install sdk, not just runtime, as it is required by some of our tools, like test-proxy.
+      # For context, see PR: TODO
       packageType: sdk
       version: 6.0.x
       # performMultiLevelLookup comes into play when given .NET executable target runtime is different


### PR DESCRIPTION
This is take two on this PR:
- https://github.com/Azure/azure-sdk-tools/pull/5395

after it had to be reverted by:
- https://github.com/Azure/azure-sdk-tools/pull/5398

This time it works because I am installing `.NET 6.0` **SDK** as opposed to `.NET 6.0` **runtime**. 

### Testing done

A build that proves it works (previously this pipeline was failing, see above):

https://dev.azure.com/azure-sdk/public/_build/results?buildId=2179897&view=results