### PR TITLE
Update `PipelineOwnersExtractorVersion` to `1.0.0-dev.20230211.1` to deploy `PipelineOwnersExtractor` pipeline fix for spurious MSI Azure credential

### DIFF
--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -2,4 +2,4 @@ variables:
   OfficialBuildId: $(Build.BuildNumber)
   skipComponentGovernanceDetection: true
   NotificationsCreatorVersion: '1.0.0-dev.20230127.4'
-  PipelineOwnersExtractorVersion: '1.0.0-dev.20230105.1'
+  PipelineOwnersExtractorVersion: '1.0.0-dev.20230211.1'


### PR DESCRIPTION
Update the package version to deploy following change:
- https://github.com/Azure/azure-sdk-tools/pull/5354