### PR TITLE
Java ApiView: Add context to annotation id

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -1031,7 +1031,7 @@ public class JavaASTAnalyser implements Analyser {
                     addToken(makeWhitespace());
                 }
 
-                addToken(new Token(TYPE_NAME, "@" + annotation.getName().toString(), makeId(annotation)));
+                addToken(new Token(TYPE_NAME, "@" + annotation.getName().toString(), makeId(annotation, nodeWithAnnotations)));
                 if (showAnnotationProperties) {
                     if (annotation instanceof NormalAnnotationExpr) {
                         addToken(new Token(PUNCTUATION, "("));

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
@@ -10,6 +10,8 @@ import com.github.javaparser.ast.body.BodyDeclaration;
 import com.github.javaparser.ast.body.CallableDeclaration;
 import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
 import com.github.javaparser.ast.body.ConstructorDeclaration;
+import com.github.javaparser.ast.body.EnumConstantDeclaration;
+import com.github.javaparser.ast.body.EnumDeclaration;
 import com.github.javaparser.ast.body.FieldDeclaration;
 import com.github.javaparser.ast.body.MethodDeclaration;
 import com.github.javaparser.ast.body.TypeDeclaration;
@@ -17,6 +19,7 @@ import com.github.javaparser.ast.body.VariableDeclarator;
 import com.github.javaparser.ast.comments.Comment;
 import com.github.javaparser.ast.comments.JavadocComment;
 import com.github.javaparser.ast.expr.AnnotationExpr;
+import com.github.javaparser.ast.nodeTypes.NodeWithAnnotations;
 import com.github.javaparser.ast.nodeTypes.NodeWithJavadoc;
 
 import java.util.Collections;
@@ -197,9 +200,38 @@ public final class ASTUtils {
         return MAKE_ID.matcher(fullPath).replaceAll("-");
     }
 
-    public static String makeId(AnnotationExpr annotation) {
-        int line = annotation.getBegin().orElseThrow(RuntimeException::new).line;
-        return makeId(getNodeFullyQualifiedName(annotation.getParentNode()) + "." + annotation.getNameAsString() + "-L" + line);
+    public static String makeId(AnnotationExpr annotation, NodeWithAnnotations<?> nodeWithAnnotations) {
+        String annotationContext = getAnnotationContext(nodeWithAnnotations);
+
+        String idSuffix = "-" + annotationContext;
+        if (annotationContext.isEmpty()) {
+            idSuffix = "-L" + annotation.getBegin().orElseThrow(RuntimeException::new).line;
+        }
+        return makeId(getNodeFullyQualifiedName(annotation.getParentNode()) + "." + annotation.getNameAsString() + idSuffix);
+    }
+
+    private static String getAnnotationContext(NodeWithAnnotations<?> nodeWithAnnotations) {
+        if (nodeWithAnnotations == null) {
+            return "";
+        }
+        if (nodeWithAnnotations instanceof MethodDeclaration) {
+            MethodDeclaration methodDeclaration = (MethodDeclaration) nodeWithAnnotations;
+            return methodDeclaration.getDeclarationAsString(true, true, true);
+        } else if (nodeWithAnnotations instanceof ClassOrInterfaceDeclaration) {
+            ClassOrInterfaceDeclaration classOrInterfaceDeclaration = (ClassOrInterfaceDeclaration) nodeWithAnnotations;
+            return classOrInterfaceDeclaration.getNameAsString();
+        } else if (nodeWithAnnotations instanceof EnumDeclaration) {
+            EnumDeclaration enumDeclaration = (EnumDeclaration) nodeWithAnnotations;
+            return enumDeclaration.getNameAsString();
+        } else if (nodeWithAnnotations instanceof EnumConstantDeclaration) {
+            EnumConstantDeclaration enumValueDeclaration = (EnumConstantDeclaration) nodeWithAnnotations;
+            return enumValueDeclaration.getNameAsString();
+        } else if (nodeWithAnnotations instanceof ConstructorDeclaration) {
+            ConstructorDeclaration constructorDeclaration = (ConstructorDeclaration) nodeWithAnnotations;
+            return constructorDeclaration.getDeclarationAsString(true, true, true);
+        } else {
+            return "";
+        }
     }
 
     /**

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
@@ -203,9 +203,12 @@ public final class ASTUtils {
     public static String makeId(AnnotationExpr annotation, NodeWithAnnotations<?> nodeWithAnnotations) {
         String annotationContext = getAnnotationContext(nodeWithAnnotations);
 
-        String idSuffix = "-" + annotationContext;
+        String idSuffix;
+
         if (annotationContext == null || annotationContext.isEmpty()) {
             idSuffix = "-L" + annotation.getBegin().orElseThrow(RuntimeException::new).line;
+        } else {
+            idSuffix = "-" + annotationContext;
         }
         return makeId(getNodeFullyQualifiedName(annotation.getParentNode()) + "." + annotation.getNameAsString() + idSuffix);
     }
@@ -216,6 +219,7 @@ public final class ASTUtils {
         }
         if (nodeWithAnnotations instanceof MethodDeclaration) {
             MethodDeclaration methodDeclaration = (MethodDeclaration) nodeWithAnnotations;
+            // use the method declaration string instead of method name as there can be overloads
             return methodDeclaration.getDeclarationAsString(true, true, true);
         } else if (nodeWithAnnotations instanceof ClassOrInterfaceDeclaration) {
             ClassOrInterfaceDeclaration classOrInterfaceDeclaration = (ClassOrInterfaceDeclaration) nodeWithAnnotations;
@@ -228,6 +232,7 @@ public final class ASTUtils {
             return enumValueDeclaration.getNameAsString();
         } else if (nodeWithAnnotations instanceof ConstructorDeclaration) {
             ConstructorDeclaration constructorDeclaration = (ConstructorDeclaration) nodeWithAnnotations;
+            // use the constructor declaration string instead of the name as there can be overloads
             return constructorDeclaration.getDeclarationAsString(true, true, true);
         } else {
             return "";

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/util/ASTUtils.java
@@ -204,7 +204,7 @@ public final class ASTUtils {
         String annotationContext = getAnnotationContext(nodeWithAnnotations);
 
         String idSuffix = "-" + annotationContext;
-        if (annotationContext.isEmpty()) {
+        if (annotationContext == null || annotationContext.isEmpty()) {
             idSuffix = "-L" + annotation.getBegin().orElseThrow(RuntimeException::new).line;
         }
         return makeId(getNodeFullyQualifiedName(annotation.getParentNode()) + "." + annotation.getNameAsString() + idSuffix);


### PR DESCRIPTION
Currently, annotation ids include line numbers which can change when the source code changes and results in incorrectly showing a diff in API view.
![image](https://user-images.githubusercontent.com/51379715/218405365-8fb7e382-d7ad-4662-9744-fd36cb350f0b.png)

This PR changes the annotation id to use the context (i.e the node on which the annotation is defined) to create the id.



Before:

```json
{
    "DefinitionId" : "com.azure.data.appconfiguration.ConfigurationAsyncClient.ServiceClient-L51",
    "Kind" : 6,
    "Value" : "@ServiceClient"
  },
```

After
```json
{
    "DefinitionId" : "com.azure.data.appconfiguration.ConfigurationAsyncClient.ServiceClient-ConfigurationAsyncClient",
    "Kind" : 6,
    "Value" : "@ServiceClient"
  },
```