### PR TITLE
fix(build): cadl build error when repo url does not end with `.git`

### DIFF
--- a/eng/common/scripts/Cadl-Project-Sync.ps1
+++ b/eng/common/scripts/Cadl-Project-Sync.ps1
@@ -44,10 +44,10 @@ function GetGitRemoteValue([string]$repo) {
         $gitRemotes = (git remote -v)
         foreach ($remote in $gitRemotes) {
             if ($remote.StartsWith("origin")) {
-                if ($remote -match 'https://github.com/\S+[\.git]') {
+                if ($remote -match 'https://github.com/\S+') {
                     $result = "https://github.com/$repo.git"
                     break
-                } elseif ($remote -match "git@github.com:\S+[\.git]"){
+                } elseif ($remote -match "git@github.com:\S+"){
                     $result = "git@github.com:$repo.git"
                     break
                 } else {


### PR DESCRIPTION
`[.git]` is a char set which means the url should ends with either `.`, or `g`, or `i`, or `t`. So if the url doesn't end with `.git` then there is no match which results in error.

The fix is to remove `[.git]` char set. We don't need `(.git)*` either, because `\S+` will suppress it.