### PR TITLE
Update Approve label

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -47,7 +47,7 @@
                                 <span class="small text-muted">Approves the current revision of the API</span>
                                 <div class="d-grid gap-2">
                                     <button type="button" class="btn btn-success" data-bs-toggle="modal" data-bs-target="#approveModel">
-                                        Approve With Modal
+                                        Approve
                                     </button>
                                 </div>
                             }


### PR DESCRIPTION
Approve label is incorrect when there are open conversations. Updated label from `Approval with Modal` to `Approve`