### PR TITLE
Update `NotificationConfiguration` package to `20230214.1` to enable `CODEOWNERS` regex matcher everywhere

### DIFF
--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
   OfficialBuildId: $(Build.BuildNumber)
   skipComponentGovernanceDetection: true
-  NotificationsCreatorVersion: '1.0.0-dev.20230127.4'
+  NotificationsCreatorVersion: '1.0.0-dev.20230214.1'
   PipelineOwnersExtractorVersion: '1.0.0-dev.20230211.1'


### PR DESCRIPTION
As in subject; the following PR gets deployed with this change:
- https://github.com/Azure/azure-sdk-tools/pull/5437

As a result, all build failure notification recipients will be determined based on the new regex-based, wildcard-supporting `CODEOWNERS` matcher, as opposed to the obsolete prefix-based one.

As a result, after this PR is merged, the next run of the pipeline [`automation - build-failure-notification-subscriptions`](https://dev.azure.com/azure-sdk/internal/_build?definitionId=679&_a=summary) will change the build failure notification recipients.

Related work:
- #2770 