### PR TITLE
Always use regex matcher when determining contacts for build failure notifications

### DIFF
--- a/tools/notification-configuration/notification-creator/Contacts.cs
+++ b/tools/notification-configuration/notification-creator/Contacts.cs
@@ -120,37 +120,10 @@ internal class Contacts
         CodeownersEntry matchingCodeownersEntry =
             CodeownersFile.GetMatchingCodeownersEntry(
                 process.YamlFilename,
-                codeownersEntries,
-                UseRegexMatcher(repoUrl));
+                codeownersEntries);
 
         matchingCodeownersEntry.ExcludeNonUserAliases();
 
         return matchingCodeownersEntry;
-    }
-
-    /// <summary>
-    /// Whether the new regex-based CODEOWNERS matcher that supports wildcards should be used
-    /// for given repository. This method exists to allow incremental roll-out
-    /// of the new matcher [1].
-    ///
-    /// Note that enabling the new matcher will not change the reviewers assigned to
-    /// PRs, because this is handled by built-in GitHub matcher. 
-    /// But it will change who receives build failure notifications.
-    ///
-    /// [1] https://github.com/Azure/azure-sdk-tools/pull/5088
-    /// </summary>
-    private bool UseRegexMatcher(string repoUrl)
-    {
-        // Expected repoUrl: https://github.com/Azure/azure-sdk-for-net
-        if (repoUrl.Contains("azure-sdk-for-net"))
-        {
-            // Work that was done to facilitate enabling the matcher in this repo:
-            // https://github.com/Azure/azure-sdk-for-net/pull/33584 - Fix invalid paths in CODEOWNERS
-            // https://github.com/Azure/azure-sdk-for-net/pull/33595 - Remove CODEOWNERS rules /**/ci.yml and /**/tests.yml
-            // https://github.com/Azure/azure-sdk-for-net/pull/33597 - Add missing /sdk/<dir> rules
-            return true;
-        }
-
-        return false;
     }
 }


### PR DESCRIPTION
This PR is a follow-up to:
- https://github.com/Azure/azure-sdk-tools/pull/5452
- #5437

That previous PR was aiming to enable the new regex-based matcher everywhere, but didn't. Now it will, once the NuGet feed is updated. This is because by not passing the `useRegexMatcher` argument, I am relying on the default of `true`, set by:
- #5088
- #5437

Related work:
- #2770 