### PR TITLE
Where applicable, update Windows pools used to `azsdk-pool-mms-win-2022-general` and rename `vmImage` to the `windows-20xx` format

### DIFF
--- a/doc/common/matrix_generator.md
+++ b/doc/common/matrix_generator.md
@@ -671,7 +671,7 @@ Given a matrix like below with `JavaTestVersion` marked as a non-sparse paramete
 {
   "matrix": {
     "Agent": {
-      "windows-2022": { "OSVmImage": "MMS2022", "Pool": "azsdk-pool-mms-win-2022-general" },
+      "windows-2022": { "OSVmImage": "windows-2022", "Pool": "azsdk-pool-mms-win-2022-general" },
       "ubuntu-2204": { "OSVmImage": "MMSUbuntu22.04", "Pool": "azsdk-pool-mms-ubuntu-2204-general" },
       "macos-11": { "OSVmImage": "macos-11", "Pool": "Azure Pipelines" }
     },

--- a/eng/common-tests/matrix-generator/samples/matrix.json
+++ b/eng/common-tests/matrix-generator/samples/matrix.json
@@ -21,7 +21,7 @@
   ],
   "exclude": [
     {
-      "OSVmImage": "MMS2022",
+      "OSVmImage": "windows-2022",
       "framework": "netcoreapp2.1"
     }
   ]

--- a/eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
+++ b/eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
@@ -22,7 +22,7 @@ stages:
           matrix:
             Windows:
               Pool: 'azsdk-pool-mms-win-2022-general'
-              Image: 'MMS2022'
+              Image: 'windows-2022'
             Linux:
               Pool: azsdk-pool-mms-ubuntu-2204-general
               Image: MMSUbuntu22.04

--- a/eng/pipelines/agent-pool-migration.yml
+++ b/eng/pipelines/agent-pool-migration.yml
@@ -78,7 +78,7 @@ parameters:
     - MigrateFrom: windows2019
       MigrateTo: windows2022
     - MigrateFrom: MMS2019
-      MigrateTo: MMS2022
+      MigrateTo: windows-2022
 - name: ShortForMigrateFrom
   type: string
   default: ''

--- a/eng/pipelines/apiview-review-gen-swagger.yml
+++ b/eng/pipelines/apiview-review-gen-swagger.yml
@@ -4,7 +4,7 @@ trigger: none
 
 pool:
   name: azsdk-pool-mms-win-2022-general
-  vmImage: MMS2022
+  vmImage: windows-2022
 
 variables:
   SwaggerParserInstallPath: $(Pipeline.Workspace)/SwaggerApiParser

--- a/eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
+++ b/eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
@@ -39,7 +39,7 @@ jobs:
   - job: AzurePartnerDropsToNuget
     pool:
       name: azsdk-pool-mms-win-2022-general
-      vmImage: MMS2022
+      vmImage: windows-2022
 
     steps:
       - checkout: self

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -123,7 +123,7 @@ stages:
           matrix:
             Windows:
               Pool: azsdk-pool-mms-win-2022-general
-              Image: MMS2022
+              Image: windows-2022
             Linux:
               Pool: azsdk-pool-mms-ubuntu-2204-general
               Image: MMSUbuntu22.04

--- a/src/dotnet/APIView/apiview-sync-staging.yml
+++ b/src/dotnet/APIView/apiview-sync-staging.yml
@@ -14,7 +14,7 @@ stages:
       - job: 'BlobCopy'
         pool:
           name: azsdk-pool-mms-win-2022-general
-          vmImage: MMS2022
+          vmImage: windows-2022
 
         steps:
         - pwsh: |

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -52,7 +52,7 @@ stages:
 
         pool:
           name: azsdk-pool-mms-win-2022-general
-          vmImage: MMS2022
+          vmImage: windows-2022
 
         steps:
           - task: NodeTool@0
@@ -142,7 +142,7 @@ stages:
 
         pool:
           name: azsdk-pool-mms-win-2022-general
-          vmImage: MMS2022
+          vmImage: windows-2022
 
         steps:
           - template: /eng/common/pipelines/templates/steps/cosmos-emulator.yml

--- a/tools/apiview/parsers/cpp-api-parser/ci.yml
+++ b/tools/apiview/parsers/cpp-api-parser/ci.yml
@@ -32,7 +32,7 @@ stages:
         timeoutInMinutes: 300
         pool:
           name: azsdk-pool-mms-win-2022-general
-          vmImage: MMS2022
+          vmImage: windows-2022
 
         steps:
           - pwsh: |
@@ -105,7 +105,7 @@ stages:
           environment: github
           pool:
             name: azsdk-pool-mms-win-2022-general
-            vmImage: MMS2022
+            vmImage: windows-2022
           
           strategy: 
             runOnce: 


### PR DESCRIPTION
Where applicable, update Windows pools used to `azsdk-pool-mms-win-2022-general` and rename `vmImage` to the `windows-20xx` format.

This discussion explains why chose given `vmImage` format:

[Mike Harder: 1ES Hosted Pool image name changes](https://teams.microsoft.com/l/message/19:59dbfadafb5e41c4890e2cd3d74cc7ba@thread.skype/1676491855184?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1676491855184&teamName=Azure%20SDK&channelName=Engineering%20System%20%F0%9F%9B%A0%EF%B8%8F&createdTime=1676491855184)
posted in Azure SDK / Engineering System 🛠️ at Wednesday, February 15, 2023 12:10 PM

For further context, please see:
- https://github.com/Azure/azure-sdk-tools/issues/3407

Note that:
- searching for `MMS2021` returned no results
- searching for `azsdk-pool-mms-win-2019` returned no result except in a tool whose goal is to migrate such strings, hence nothing to do.