### PR TITLE
Refresh API review when additional changes are detected 

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/PullRequestManager.cs
@@ -326,11 +326,16 @@ namespace APIViewWeb.Managers
             {
                 // Check if API surface level matches with any revisions
                 var renderedCodeFile = new RenderedCodeFile(codeFile);
-                if (await IsReviewSame(review, renderedCodeFile))
+                // pullRequestModel.ReviewId == null means: First time getting a request to check for API changes in the given package for a PR 
+                if (pullRequestModel.ReviewId == null)
                 {
-                    return;
-                }
-
+                    //No API changes detected from baseline
+                    if (await IsReviewSame(review, renderedCodeFile))
+                    {
+                        return;
+                    }
+                }                
+                // Below steps will remove last revision from previously created API review from the pull request and recreate new revision using latest token code file
                 if (pullRequestModel.ReviewId != null)
                 {
                     //Refresh baseline using latest from automatic review


### PR DESCRIPTION
Swagger API review, generated from PR, is not refreshed even if additional API changes are made in the PR.
Fixes #https://github.com/Azure/azure-sdk-tools/issues/5376