### PR TITLE
Add Sanitizer that Normalizes Text Bodies

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/post_delete_get_content_lineendings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/post_delete_get_content_lineendings.json
@@ -17,7 +17,7 @@
         "x-ms-date": "Tue, 18 May 2021 23:27:42 GMT",
         "x-ms-version": "2019-02-02"
       },
-      "RequestBody": "{\r\n \u0022TableName\u0022:    \u0022listtable09bf2a3d\u0022}",
+      "RequestBody": "{\u000D\u000A \u0022TableName\u0022:    \u0022listtable09bf2a3d\u0022}",
       "StatusCode": 201,
       "ResponseHeaders": {
         "Cache-Control": "no-cache",

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/post_delete_get_content_lineendings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Test.RecordEntries/post_delete_get_content_lineendings.json
@@ -1,0 +1,44 @@
+{
+  "Entries": [
+    {
+      "RequestUri": "https://fakeazsdktestaccount.table.core.windows.net/Tables",
+      "RequestMethod": "POST",
+      "RequestHeaders": {
+        "Accept": "application/json;odata=minimalmetadata",
+        "Accept-Encoding": "gzip, deflate",
+        "Authorization": "Sanitized",
+        "Connection": "keep-alive",
+        "Content-Length": "34",
+        "Content-Type": "application/json;odata=nometadata",
+        "DataServiceVersion": "3.0",
+        "Date": "Tue, 18 May 2021 23:27:42 GMT",
+        "User-Agent": "azsdk-python-data-tables/12.0.0b7 Python/3.8.6 (Windows-10-10.0.19041-SP0)",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-date": "Tue, 18 May 2021 23:27:42 GMT",
+        "x-ms-version": "2019-02-02"
+      },
+      "RequestBody": "{\r\n \u0022TableName\u0022:    \u0022listtable09bf2a3d\u0022}",
+      "StatusCode": 201,
+      "ResponseHeaders": {
+        "Cache-Control": "no-cache",
+        "Content-Type": "application/json; odata=minimalmetadata; streaming=true; charset=utf-8",
+        "Date": "Tue, 18 May 2021 23:27:43 GMT",
+        "Location": "https://fakeazsdktestaccount.table.core.windows.net/Tables(\u0027listtable09bf2a3d\u0027)",
+        "Server": [
+          "Windows-Azure-Table/1.0",
+          "Microsoft-HTTPAPI/2.0"
+        ],
+        "Transfer-Encoding": "chunked",
+        "X-Content-Type-Options": "nosniff",
+        "x-ms-client-request-id": "a4c24b7a-b830-11eb-a05e-10e7c6392c5a",
+        "x-ms-request-id": "d2270777-c002-0072-313d-4ce19f000000",
+        "x-ms-version": "2019-02-02"
+      },
+      "ResponseBody": {
+        "odata.metadata": "https://fakeazsdktestaccount.table.core.windows.net/$metadata#Tables/@Element",
+        "TableName": "listtable09bf2a3d"
+      }
+    }
+  ],
+  "Variables": {}
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/BodyLineEndingSanitizer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/BodyLineEndingSanitizer.cs
@@ -1,0 +1,32 @@
+using Azure.Sdk.Tools.TestProxy.Common;
+using System;
+using System.Text;
+
+namespace Azure.Sdk.Tools.TestProxy.Sanitizers
+{
+    /// <summary>
+    /// This sanitizer operates on a RecordSession entry and applies value replacement to the Request and Response bodies contained therein. It only replaces \r\n with \n.
+    /// </summary>
+    public class BodyLineEndingSanitizer : BodyStringSanitizer
+    {
+        public static string _targetValue = "\r\n";
+        public static string _newValue = "\n";
+
+        /// <summary>
+        /// This sanitizer 
+        /// </summary>
+        /// <param name="condition">
+        /// A condition that dictates when this sanitizer applies to a request/response pair. The content of this key should be a JSON object that contains configuration keys. 
+        /// Currently, that only includes the key "uriRegex". This translates to an object that looks like '{ "uriRegex": "when this regex matches, apply the sanitizer" }'. Defaults to "apply always."
+        /// </param>
+        public BodyLineEndingSanitizer(ApplyCondition condition = null) : base(target: _targetValue, value: _newValue, condition: condition)
+        {
+            Condition = condition;
+        }
+
+        public override string SanitizeTextBody(string contentType, string body)
+        {
+            return StringSanitizer.ReplaceValue(inputValue: body, targetValue: _targetValue, replacementValue: _newValue);
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/UriSubscriptionIdSanitizer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/UriSubscriptionIdSanitizer.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Sdk.Tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Common;
 
 namespace Azure.Sdk.Tools.TestProxy.Sanitizers
 {
@@ -23,7 +23,7 @@ namespace Azure.Sdk.Tools.TestProxy.Sanitizers
         /// A condition that dictates when this sanitizer applies to a request/response pair. The content of this key should be a JSON object that contains configuration keys. 
         /// Currently, that only includes the key "uriRegex". This translates to an object that looks like '{ "uriRegex": "when this regex matches, apply the sanitizer" }'. Defaults to "apply always."
         /// </param>
-        public UriSubscriptionIdSanitizer(string value = "00000000-0000-0000-0000-000000000000", ApplyCondition condition = null): base(value: value, regex: _regex, groupForReplace: _groupForReplace)
+        public UriSubscriptionIdSanitizer(string value = "00000000-0000-0000-0000-000000000000", ApplyCondition condition = null): base(value: value, regex: _regex, groupForReplace: _groupForReplace, condition: condition)
         {
             Condition = condition;
 


### PR DESCRIPTION
related to #2453

...and discover that the NormalizeJsonBodies already applies in the testcase I created.

@JoshLove-msft how were you getting `\r\n` injected into the request in a way that didn't auto normalize? I'd assume it's because it's NOT a json body and still somehow includes `\r\n`. multipart/mixed?

I'm not certain how the management folks ran into this. What does `normalize` even mean in this case? The only way it wouldn't be auto-normalized is if the user deliberately sent a request with this material within it, in which case I don't want to replace it. That's what was recorded. 