### PR TITLE
Creating `config` verb and adding `locate/show` sub-verbs

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/CLICommandOptions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/CLICommandOptions.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine;
+using CommandLine;
 
 namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions
 {
@@ -7,7 +7,7 @@ namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions
     /// </summary>
     class CLICommandOptions : DefaultOptions
     {
-        [Option('a', "assets-json-path", Required = true, HelpText = "Required for Push/Reset/Restore. This should be a path to a valid assets.json within a language repository.")]
+        [Option('a', "assets-json-path", Required = true, HelpText = "Required for any operation that requires an assets.json path. Currently Push/Reset/Restore. This should be a path to a valid assets.json within a language repository.")]
         public string AssetsJsonPath { get; set; }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/ConfigOptions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/ConfigOptions.cs
@@ -1,4 +1,4 @@
-using CommandLine.Text;
+﻿using CommandLine.Text;
 using CommandLine;
 
 namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions
@@ -6,8 +6,8 @@ namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions
     /// <summary>
     /// Any unique options to the push command will reside here.
     /// </summary>
-    [Verb("config", HelpText = "Interact with an assets.json.")]
-    class ConfigOptions : CLICommandOptions
+    [Verb("push", HelpText = "Push the assets, referenced by assets.json, into git.")]
+    class PushOptions : CLICommandOptions
     {
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/ConfigOptions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/ConfigOptions.cs
@@ -1,4 +1,4 @@
-﻿using CommandLine.Text;
+using CommandLine.Text;
 using CommandLine;
 
 namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions
@@ -6,8 +6,8 @@ namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions
     /// <summary>
     /// Any unique options to the push command will reside here.
     /// </summary>
-    [Verb("push", HelpText = "Push the assets, referenced by assets.json, into git.")]
-    class PushOptions : CLICommandOptions
+    [Verb("config", HelpText = "Interact with an assets.json.")]
+    class ConfigOptions : CLICommandOptions
     {
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/ConfigVerbs/ConfigOptions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/ConfigVerbs/ConfigOptions.cs
@@ -1,0 +1,13 @@
+using CommandLine;
+
+namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions.ConfigVerbs
+{
+    /// <summary>
+    /// This option allows combines with arg skipping in Main() to allow access to simple sub-verb under command "config"
+    /// </summary>
+    [Verb("locate", HelpText = "Show the location of the restored code for a given assets.json.")]
+    class ShowOptions : CLICommandOptions
+    {
+
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/ConfigVerbs/LocateOptions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/ConfigVerbs/LocateOptions.cs
@@ -1,0 +1,13 @@
+using CommandLine;
+
+namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions.ConfigVerbs
+{
+    /// <summary>
+    /// This option allows combines with arg skipping in Main() to allow access to simple sub-verb under command "config"
+    /// </summary>
+    [Verb("locate", HelpText = "Show the location of the restored code for a given assets.json.")]
+    class LocateOptions : CLICommandOptions
+    {
+
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/ConfigVerbs/ShowOptions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/ConfigVerbs/ShowOptions.cs
@@ -5,7 +5,7 @@ namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions.ConfigVerbs
     /// <summary>
     /// This option allows combines with arg skipping in Main() to allow access to simple sub-verb under command "config"
     /// </summary>
-    [Verb("locate", HelpText = "Show the location of the restored code for a given assets.json.")]
+    [Verb("show", HelpText = "Show various details about a given assets.json.")]
     class ShowOptions : CLICommandOptions
     {
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/PushOptions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandParserOptions/PushOptions.cs
@@ -6,8 +6,8 @@ namespace Azure.Sdk.Tools.TestProxy.CommandParserOptions
     /// <summary>
     /// Any unique options to the push command will reside here.
     /// </summary>
-    [Verb("config", HelpText = "Interact with an assets.json.")]
-    class ConfigOptions : CLICommandOptions
+    [Verb("push", HelpText = "Push the assets, referenced by assets.json, into git.")]
+    class PushOptions : CLICommandOptions
     {
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -507,7 +507,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 path = Path.Join(contextDirectory, pathToAssetsJson.Replace("\\", "/"));
             }
 
-            return path;
+            return path.Replace("\\", "/");
         }
 
         public async Task Restore(string pathToAssetsJson)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -218,11 +218,11 @@ namespace Azure.Sdk.Tools.TestProxy
                     break;
                 case ShowOptions showOptions:
                     assetsJson = RecordingHandler.GetAssetsJsonLocation(showOptions.AssetsJsonPath, TargetLocation);
-                    
+                    System.Console.WriteLine("Showing the detailed info about this assets.json");
                     break;
                 case LocateOptions locateOptions:
                     assetsJson = RecordingHandler.GetAssetsJsonLocation(locateOptions.AssetsJsonPath, TargetLocation);
-
+                    System.Console.WriteLine(await DefaultStore.GetPath(assetsJson));
                     break;
                 default:
                     throw new ArgumentException("Invalid verb. The only supported verbs are start, push, reset and restore.");

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -192,7 +192,6 @@ namespace Azure.Sdk.Tools.TestProxy
 
         private static async Task Run(object commandObj)
         {
-            new GitProcessHandler().VerifyGitMinVersion();
             DefaultOptions defaultOptions = (DefaultOptions)commandObj;
 
             TargetLocation = resolveRepoLocation(defaultOptions.StorageLocation);
@@ -202,17 +201,21 @@ namespace Azure.Sdk.Tools.TestProxy
             switch (commandObj)
             {
                 case StartOptions startOptions:
+                    new GitProcessHandler().VerifyGitMinVersion();
                     StartServer(startOptions);
                     break;
                 case PushOptions pushOptions:
+                    new GitProcessHandler().VerifyGitMinVersion();
                     var assetsJson = RecordingHandler.GetAssetsJsonLocation(pushOptions.AssetsJsonPath, TargetLocation);
                     await DefaultStore.Push(assetsJson);
                     break;
                 case ResetOptions resetOptions:
+                    new GitProcessHandler().VerifyGitMinVersion();
                     assetsJson = RecordingHandler.GetAssetsJsonLocation(resetOptions.AssetsJsonPath, TargetLocation);
                     await DefaultStore.Reset(assetsJson);
                     break;
                 case RestoreOptions restoreOptions:
+                    new GitProcessHandler().VerifyGitMinVersion();
                     assetsJson = RecordingHandler.GetAssetsJsonLocation(restoreOptions.AssetsJsonPath, TargetLocation);
                     await DefaultStore.Restore(assetsJson);
                     break;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -66,16 +66,16 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// </summary>
         /// <param name="pathToAssetsJson"></param>
         /// <returns></returns>
-        public async Task<string> GetPath(string pathToAssetsJson)
+        public async Task<NormalizedString> GetPath(string pathToAssetsJson)
         {
             var config = await ParseConfigurationFile(pathToAssetsJson);
 
             if (!string.IsNullOrWhiteSpace(config.AssetsRepoPrefixPath.ToString()))
             {
-                return Path.Combine(config.AssetsRepoLocation.ToString(), config.AssetsRepoPrefixPath.ToString());
+                return new NormalizedString(Path.Combine(config.AssetsRepoLocation.ToString(), config.AssetsRepoPrefixPath.ToString()));
             }
 
-            return config.AssetsRepoLocation.ToString();
+            return new NormalizedString(config.AssetsRepoLocation.ToString());
         }
 
         /// <summary>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/IAssetsStore.cs
@@ -1,5 +1,6 @@
 using System.IO;
 using System.Threading.Tasks;
+using Azure.Sdk.tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Console;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
@@ -29,6 +30,6 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// </summary>
         /// <param name="pathToAssetsJson"></param>
         /// <returns></returns>
-        public abstract Task<string> GetPath(string pathToAssetsJson);
+        public abstract Task<NormalizedString> GetPath(string pathToAssetsJson);
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/NullStore.cs
@@ -1,6 +1,7 @@
 using System.IO;
 using System.Net;
 using System.Threading.Tasks;
+using Azure.Sdk.tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
 using Azure.Sdk.Tools.TestProxy.Console;
 
@@ -23,6 +24,6 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             return new AssetsConfiguration();
         }
 
-        public Task<string> GetPath(string pathToAssetsJson) { return null; }
+        public Task<NormalizedString> GetPath(string pathToAssetsJson) { return null; }
     }
 }


### PR DESCRIPTION
Resolves #4652 

@JimSuplizio wanted to get your opinion on this. It appears that `CommandLineParser` doesn't treat `sub-verbs`/`sub-commands` as a thing. [Example of what I'm looking for](https://learn.microsoft.com/en-us/dotnet/standard/commandline/define-commands#define-subcommands). 

[Here is where I was inspired in my approach to skip and pass to different parser](https://github.com/commandlineparser/commandline/issues/13#issuecomment-429634063).

I think that outside of doing what I do here, we are going to need to rewrite to `System.CommandLine` to get the sub-command experience we want.

Honestly this feels pretty hacky, though I think that the results for the users is what we want/expect.

Example Usage:

```bash
test-proxy.exe config locate -a sdk/keyvault/azure-keyvault-keys/assets.json --storage-location=C:/repo/sdk-for-python
C:/repo/sdk-for-python/.assets/Y0iKQSfTwa/python
```

todo:

- [ ] clean up hackiness a bit
- [ ] Add integration tests for our expected scenarios
