### PR TITLE
Create build-docker-image.md

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -33,12 +33,12 @@
 /tools/                          @azure/azure-sdk-eng
 /tools/check-enforcer/           @praveenkuttappan @weshaggard
 /tools/github-issues/            @praveenkuttappan @weshaggard
-/tools/js-sdk-release-tools/     @dw511214992 @qiaozha @MaryGao
+/tools/js-sdk-release-tools/     @qiaozha @MaryGao
 /tools/mock-service-host/        @changlong-liu @tadelesh
 /tools/perf-automation/          @mikeharder @benbp
 /tools/pipeline-generator/       @weshaggard @benbp
 /tools/pipeline-witness/         @praveenkuttappan @weshaggard
-/tools/sdk-generation-pipeline/  @dw511214992 @chunyu3 @zzvswxy @weshaggard
+/tools/sdk-generation-pipeline/  @weshaggard @praveenkuttappan @maririos
 /tools/sdk-testgen/              @changlong-liu @tadelesh
 /tools/stress-cluster/           @benbp @ckairen
 /tools/test-proxy/               @scbedd @mikeharder

--- a/tools/sdk-generation-pipeline/ci.yml
+++ b/tools/sdk-generation-pipeline/ci.yml
@@ -165,8 +165,6 @@ stages:
               sdkRepo: 'azure-sdk-for-java'
             PYTHON:
               sdkRepo: 'azure-sdk-for-python'
-            GO:
-              sdkRepo: 'azure-sdk-for-go'
             Net:
               sdkRepo: 'azure-sdk-for-net'
         steps:

--- a/tools/sdk-generation-pipeline/documents/docker/build-docker-image.md
+++ b/tools/sdk-generation-pipeline/documents/docker/build-docker-image.md
@@ -1,0 +1,9 @@
+If you want to rebuild the docker image, you only can do it in your local. It's suggested to create a release pipeline to build it. (We don't do it because sometimes it will be timeout because the pipeline costs much time in building docker image, but now the agent pool should be very quick and can build the docker image quickly.)
+Steps to rebuild the docker image:
+1. `cd tools/sdk-generation-pipeline`
+2. `rush update`
+3. `rush rebuild`
+4. `cd packages/sdk-generation-cli`
+5. `rushx pack`
+6. `cd ../.. # go to tools/sdk-generation-pipeline`
+7. `docker build -t sdkgeneration.azurecr.io/sdk-generation:beta-1.0 .`

--- a/tools/sdk-generation-pipeline/documents/docker/build-docker-image.md
+++ b/tools/sdk-generation-pipeline/documents/docker/build-docker-image.md
@@ -1,4 +1,5 @@
-If you want to rebuild the docker image, you only can do it in your local. It's suggested to create a release pipeline to build it. (We don't do it because sometimes it will be timeout because the pipeline costs much time in building docker image, but now the agent pool should be very quick and can build the docker image quickly.)
+If you want to rebuild the docker image, you only can do it in your local. It's suggested to create a release pipeline to build it. (Previously we find that sometimes it will be timeout because the pipeline costs much time in building and pushing docker image, but now the agent pool should be very fast.)
+
 Steps to rebuild the docker image:
 1. `cd tools/sdk-generation-pipeline`
 2. `rush update`


### PR DESCRIPTION
remove go because the test is deprecated and the pipeline is not used by go sdk.