### PR TITLE
Add devops-pat and az website stores to secret rotation

### DIFF
--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Azure/Azure.Sdk.Tools.SecretRotation.Azure.csproj
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Azure/Azure.Sdk.Tools.SecretRotation.Azure.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Azure.Core" Version="1.25.0" />
+    <PackageReference Include="Azure.Identity" Version="1.8.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+  </ItemGroup>
+
+</Project>

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Azure/ISecretProvider.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Azure/ISecretProvider.cs
@@ -1,0 +1,8 @@
+using Azure.Core;
+
+namespace Azure.Sdk.Tools.SecretRotation.Azure;
+
+public interface ISecretProvider
+{
+    Task<string> GetSecretValueAsync(TokenCredential credential, Uri secretUri);
+}

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Azure/SecretProvider.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Azure/SecretProvider.cs
@@ -1,0 +1,46 @@
+﻿using System.Text.RegularExpressions;
+using Azure.Core;
+using Azure.Security.KeyVault.Secrets;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Sdk.Tools.SecretRotation.Azure;
+
+public class SecretProvider : ISecretProvider
+{
+    private static readonly Regex secretRegex = new (@"(?<vault>https://.*?\.vault\.azure\.net)/secrets/(?<secret>.*)", RegexOptions.Compiled, TimeSpan.FromSeconds(5));
+    private readonly ILogger logger;
+
+    public SecretProvider(ILogger logger)
+    {
+        this.logger = logger;
+    }
+
+    public async Task<string> GetSecretValueAsync(TokenCredential credential, Uri secretUri)
+    {
+        Match match = secretRegex.Match(secretUri.AbsoluteUri);
+
+        if (!match.Success)
+        {
+            throw new ArgumentException("Unable to parse uri as a Key Vault secret uri");
+        }
+
+        string vaultUrl = match.Groups["vault"].Value;
+        string secretName = match.Groups["secret"].Value;
+
+        try
+        {
+            var secretClient = new SecretClient(new Uri(vaultUrl), credential);
+
+            this.logger.LogDebug("Retrieving value for secret '{SecretUrl}'", secretUri);
+
+            KeyVaultSecret secret = await secretClient.GetSecretAsync(secretName);
+
+            return secret.Value;
+        }
+        catch (Exception exception)
+        {
+            this.logger.LogError(exception, "Unable to read secret {SecretName} from vault {VaultUrl}", secretName, vaultUrl);
+            throw;
+        }
+    }
+}

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Cli/Azure.Sdk.Tools.SecretRotation.Cli.csproj
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Cli/Azure.Sdk.Tools.SecretRotation.Cli.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0-windows</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>secrets</ToolCommandName>

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Cli/Azure.Sdk.Tools.SecretRotation.Cli.csproj
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Cli/Azure.Sdk.Tools.SecretRotation.Cli.csproj
@@ -20,6 +20,7 @@
 	  <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Configuration\Azure.Sdk.Tools.SecretRotation.Configuration.csproj" />
 	  <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Core\Azure.Sdk.Tools.SecretRotation.Core.csproj" />
 	  <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Stores.AzureActiveDirectory\Azure.Sdk.Tools.SecretRotation.Stores.AzureActiveDirectory.csproj" />
+	  <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService\Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService.csproj" />
 	  <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps\Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps.csproj" />
 	  <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Stores.Generic\Azure.Sdk.Tools.SecretRotation.Stores.Generic.csproj" />
 	  <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Stores.KeyVault\Azure.Sdk.Tools.SecretRotation.Stores.KeyVault.csproj" />

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Cli/Commands/RotationCommandBase.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Cli/Commands/RotationCommandBase.cs
@@ -1,9 +1,11 @@
-﻿using System.CommandLine;
+using System.CommandLine;
 using System.CommandLine.Invocation;
 using Azure.Identity;
+using Azure.Sdk.Tools.SecretRotation.Azure;
 using Azure.Sdk.Tools.SecretRotation.Configuration;
 using Azure.Sdk.Tools.SecretRotation.Core;
 using Azure.Sdk.Tools.SecretRotation.Stores.AzureActiveDirectory;
+using Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService;
 using Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps;
 using Azure.Sdk.Tools.SecretRotation.Stores.Generic;
 using Azure.Sdk.Tools.SecretRotation.Stores.KeyVault;
@@ -68,8 +70,11 @@ public abstract class RotationCommandBase : Command
             [KeyVaultSecretStore.MappingKey] = KeyVaultSecretStore.GetSecretStoreFactory(tokenCredential, logger),
             [KeyVaultCertificateStore.MappingKey] = KeyVaultCertificateStore.GetSecretStoreFactory(tokenCredential, logger),
             [ManualActionStore.MappingKey] = ManualActionStore.GetSecretStoreFactory(logger, new ConsoleValueProvider()),
+            [ServiceAccountPersonalAccessTokenStore.MappingKey] = ServiceAccountPersonalAccessTokenStore.GetSecretStoreFactory(tokenCredential, new SecretProvider(logger), logger),
             [ServiceConnectionParameterStore.MappingKey] = ServiceConnectionParameterStore.GetSecretStoreFactory(tokenCredential, logger),
-            [AadApplicationSecretStore.MappingKey] = AadApplicationSecretStore.GetSecretStoreFactory(tokenCredential, logger)
+            [AadApplicationSecretStore.MappingKey] = AadApplicationSecretStore.GetSecretStoreFactory(tokenCredential, logger),
+            [AzureWebsiteStore.MappingKey] = AzureWebsiteStore.GetSecretStoreFactory(tokenCredential, logger),
+            [AadApplicationSecretStore.MappingKey] = AadApplicationSecretStore.GetSecretStoreFactory(tokenCredential, logger),
         };
     }
 }

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Configuration/StoreConfiguration.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Configuration/StoreConfiguration.cs
@@ -20,6 +20,9 @@ public class StoreConfiguration
     [JsonPropertyName("name")] 
     public string? Name { get; set; }
 
+    [JsonPropertyName("updateAfterPrimary")]
+    public bool UpdateAfterPrimary { get; set; }
+
     public string ResolveStoreName(string configurationKey)
     {
         return Name ?? $"{configurationKey} ({Type})";

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Core/SecretStore.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Core/SecretStore.cs
@@ -1,4 +1,4 @@
-﻿namespace Azure.Sdk.Tools.SecretRotation.Core;
+namespace Azure.Sdk.Tools.SecretRotation.Core;
 
 public abstract class SecretStore
 {
@@ -12,7 +12,15 @@ public abstract class SecretStore
 
     public virtual bool CanRevoke => false;
 
-    public string? Name { get; set; }
+    public virtual string? Name { get; set; }
+
+    public virtual bool UpdateAfterPrimary { get; set; }
+
+    public virtual bool IsPrimary { get; set; }
+
+    public virtual bool IsOrigin { get; set; }
+
+
 
     // Read
 

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Core/SecretValue.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Core/SecretValue.cs
@@ -1,4 +1,4 @@
-﻿namespace Azure.Sdk.Tools.SecretRotation.Core;
+namespace Azure.Sdk.Tools.SecretRotation.Core;
 
 public class SecretValue
 {
@@ -10,13 +10,13 @@ public class SecretValue
     public string Value { get; set; } = string.Empty;
 
     /// <summary>
-    ///     A state object created by origin stores that can be used in post-rotation annotation.
+    ///     A state object created by primary stores that can be used in post-rotation annotation.
     /// </summary>
     /// <remarks>
-    ///     This is a round-trip object that will be returned to the origin IStateStore once all other stores are updated.
-    ///     For example, a Key Vault origin may store the original KeyVaultCertificate reference in OriginState.
+    ///     This is a round-trip object that will be returned to the primary IStateStore once all other stores are updated.
+    ///     For example, a Key Vault primary may store the original KeyVaultCertificate reference in PrimaryState.
     /// </remarks>
-    public object? OriginState { get; set; }
+    public object? PrimaryState { get; set; }
 
     // During propagation, origin and secondary stores can add tags to be written to the primary store during the completion/annotation phase.
     // These tags are used during revocation to ensure the appropriate origin or downstream resource is revoked.

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService/Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService.csproj
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService/Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService.csproj
@@ -1,0 +1,11 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <PackageReference Include="Azure.ResourceManager.AppService" Version="1.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Configuration\Azure.Sdk.Tools.SecretRotation.Configuration.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService/AzureWebsiteStore.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService/AzureWebsiteStore.cs
@@ -1,0 +1,114 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.Core;
+using Azure.ResourceManager;
+using Azure.ResourceManager.AppService;
+using Azure.Sdk.Tools.SecretRotation.Configuration;
+using Azure.Sdk.Tools.SecretRotation.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService;
+
+public class AzureWebsiteStore : SecretStore
+{
+    public const string MappingKey = "Azure Website";
+
+    private readonly TokenCredential credential;
+    private readonly ILogger logger;
+    private readonly string subscriptionId;
+    private readonly string resourceGroupName;
+    private readonly string websiteName;
+    private readonly RotationAction rotationAction;
+
+    public AzureWebsiteStore(string subscriptionId, string resourceGroupName, string websiteName, RotationAction rotationAction,
+        TokenCredential credential, ILogger logger)
+    {
+        this.subscriptionId = subscriptionId;
+        this.resourceGroupName = resourceGroupName;
+        this.websiteName = websiteName;
+        this.rotationAction = rotationAction;
+        this.credential = credential;
+        this.logger = logger;
+    }
+
+    public override bool CanWrite => true;
+
+    public static Func<StoreConfiguration, SecretStore> GetSecretStoreFactory(TokenCredential credential, ILogger logger)
+    {
+        return configuration =>
+        {
+            var parameters = configuration.Parameters?.Deserialize<Parameters>();
+
+            if (string.IsNullOrEmpty(parameters?.SubscriptionId))
+            {
+                throw new Exception("Missing required parameter 'subscriptionId'");
+            }
+
+            if (string.IsNullOrEmpty(parameters?.ResourceGroup))
+            {
+                throw new Exception("Missing required parameter 'resourceGroup'");
+            }
+
+            if (string.IsNullOrEmpty(parameters?.Website))
+            {
+                throw new Exception("Missing required parameter 'website'");
+            }
+
+            return new AzureWebsiteStore(
+                parameters.SubscriptionId,
+                parameters.ResourceGroup,
+                parameters.Website,
+                parameters.RotationAction,
+                credential,
+                logger);
+        };
+    }
+
+    public override async Task WriteSecretAsync(SecretValue secretValue, SecretState currentState, DateTimeOffset? revokeAfterDate, bool whatIf)
+    {
+        ResourceIdentifier resourceId = WebSiteResource.CreateResourceIdentifier(this.subscriptionId, this.resourceGroupName, this.websiteName);
+        ArmClient client = new ArmClient(this.credential);
+        WebSiteResource website = client.GetWebSiteResource(resourceId);
+
+        if (this.rotationAction == RotationAction.None)
+        {
+            return;
+        }
+
+        if (!whatIf)
+        {
+            this.logger.LogInformation("Restarting Azure Website '{SubscriptionId}/{ResourceGroup}/{Website}'", this.subscriptionId, this.resourceGroupName, this.websiteName);
+
+            await website.RestartAsync(softRestart: false, synchronous: true);
+        }
+        else
+        {
+            this.logger.LogInformation("WHAT IF: Restart Azure Website '{SubscriptionId}/{ResourceGroup}/{Website}'", this.subscriptionId, this.resourceGroupName, this.websiteName);
+        }
+    }
+
+    public enum RotationAction
+    {
+        [JsonPropertyName("none")]
+        None,
+
+        [JsonPropertyName("restartWebsite")]
+        RestartWebsite,
+    }
+
+    private class Parameters
+    {
+        [JsonPropertyName("subscriptionId")]
+        public string? SubscriptionId { get; set; }
+
+        [JsonPropertyName("resourceGroup")]
+        public string? ResourceGroup { get; set; }
+
+        [JsonPropertyName("website")]
+        public string? Website { get; set; }
+
+        [JsonPropertyName("rotationAction")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public RotationAction RotationAction { get; set; }
+    }
+}

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps.csproj
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.8.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.170.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi" Version="16.170.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.216.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi" Version="19.216.0-preview" />
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Azure\Azure.Sdk.Tools.SecretRotation.Azure.csproj" />
     <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Configuration\Azure.Sdk.Tools.SecretRotation.Configuration.csproj" />
     <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Core\Azure.Sdk.Tools.SecretRotation.Core.csproj" />
   </ItemGroup>

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps/ServiceAccountPersonalAccessTokenStore.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps/ServiceAccountPersonalAccessTokenStore.cs
@@ -180,22 +180,22 @@ public class ServiceAccountPersonalAccessTokenStore : SecretStore
                     "WHAT IF: Remove PAT with authorization id '{AuthorizationId}' from '{OrganizationUrl}'",
                     authorizationId,
                     $"https://dev.azure.com/{this.organization}");
+
+                return;
             }
-            else
+
+            try
             {
-                try
-                {
-                    this.logger.LogInformation(
-                        "Removing PAT with authorization id '{AuthorizationId}' from '{OrganizationUrl}'",
-                        authorizationId,
-                        $"https://dev.azure.com/{this.organization}");
-                    
-                    await client.RevokeAsync(authorizationId);
-                }
-                catch (SessionTokenNotFoundException)
-                {
-                    // ignore "not found" exception on delete
-                }
+                this.logger.LogInformation(
+                    "Removing PAT with authorization id '{AuthorizationId}' from '{OrganizationUrl}'",
+                    authorizationId,
+                    $"https://dev.azure.com/{this.organization}");
+
+                await client.RevokeAsync(authorizationId);
+            }
+            catch (SessionTokenNotFoundException)
+            {
+                // ignore "not found" exception on delete
             }
         };
     }

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps/ServiceAccountPersonalAccessTokenStore.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps/ServiceAccountPersonalAccessTokenStore.cs
@@ -1,0 +1,262 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Sdk.Tools.SecretRotation.Azure;
+using Azure.Sdk.Tools.SecretRotation.Configuration;
+using Azure.Sdk.Tools.SecretRotation.Core;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.Services.Client;
+using Microsoft.VisualStudio.Services.Common;
+using Microsoft.VisualStudio.Services.DelegatedAuthorization;
+using Microsoft.VisualStudio.Services.DelegatedAuthorization.Client;
+using Microsoft.VisualStudio.Services.WebApi;
+using AccessToken = Azure.Core.AccessToken;
+
+namespace Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps;
+
+public class ServiceAccountPersonalAccessTokenStore : SecretStore
+{
+    public const string MappingKey = "Service Account ADO PAT";
+    private const string AzureDevOpsApplicationId = "499b84ac-1321-427f-aa17-267ca6975798";
+    private const string AzureCliApplicationId = "04b07795-8ddb-461a-bbee-02f9e1bf7b46";
+
+    private readonly ILogger logger;
+    private readonly string organization;
+    private readonly string patDisplayName;
+    private readonly string scopes;
+    private readonly string serviceAccountTenantId;
+    private readonly string serviceAccountName;
+    private readonly Uri serviceAccountPasswordSecret;
+    private readonly RevocationAction revocationAction;
+    private readonly TokenCredential tokenCredential;
+    private readonly ISecretProvider secretProvider;
+
+    private ServiceAccountPersonalAccessTokenStore(ILogger logger,
+        string organization,
+        string patDisplayName,
+        string scopes,
+        string serviceAccountTenantId,
+        string serviceAccountName,
+        Uri serviceAccountPasswordSecret,
+        RevocationAction revocationAction,
+        TokenCredential tokenCredential,
+        ISecretProvider secretProvider)
+    {
+        this.logger = logger;
+        this.organization = organization;
+        this.patDisplayName = patDisplayName;
+        this.scopes = scopes;
+        this.serviceAccountTenantId = serviceAccountTenantId;
+        this.serviceAccountName = serviceAccountName;
+        this.serviceAccountPasswordSecret = serviceAccountPasswordSecret;
+        this.revocationAction = revocationAction;
+        this.tokenCredential = tokenCredential;
+        this.secretProvider = secretProvider;
+    }
+
+    public override bool CanOriginate => true;
+
+    public override bool CanRevoke => true;
+
+    public static Func<StoreConfiguration, SecretStore> GetSecretStoreFactory(TokenCredential credential, ISecretProvider secretProvider, ILogger logger)
+    {
+        return configuration =>
+        {
+            var parameters = configuration.Parameters?.Deserialize<Parameters>();
+
+            if (string.IsNullOrEmpty(parameters?.Organization))
+            {
+                throw new Exception("Missing required parameter 'organization'");
+            }
+
+            if (string.IsNullOrEmpty(parameters.PatDisplayName))
+            {
+                throw new Exception("Missing required parameter 'patDisplayName'");
+            }
+
+            if (string.IsNullOrEmpty(parameters.Scopes))
+            {
+                throw new Exception("Missing required parameter 'scopes'");
+            }
+
+            if (string.IsNullOrEmpty(parameters.ServiceAccountTenantId))
+            {
+                throw new Exception("Missing required parameter 'serviceAccountTenantId'");
+            }
+
+            if (string.IsNullOrEmpty(parameters.ServiceAccountName))
+            {
+                throw new Exception("Missing required parameter 'serviceAccountName'");
+            }
+
+            if (string.IsNullOrEmpty(parameters.ServiceAccountPasswordSecret))
+            {
+                throw new Exception("Missing required parameter 'serviceAccountPasswordSecret'");
+            }
+
+            if (!Uri.TryCreate(parameters.ServiceAccountPasswordSecret, UriKind.Absolute, out Uri? serviceAccountPasswordSecret))
+            {
+                throw new Exception("Unable to parse Uri from parameter 'serviceAccountPasswordSecret'");
+            }
+
+            return new ServiceAccountPersonalAccessTokenStore(
+                logger,
+                parameters.Organization,
+                parameters.PatDisplayName,
+                parameters.Scopes,
+                parameters.ServiceAccountTenantId,
+                parameters.ServiceAccountName,
+                serviceAccountPasswordSecret!,
+                parameters.RevocationAction,
+                credential,
+                secretProvider);
+        };
+    }
+
+    public override async Task<SecretValue> OriginateValueAsync(SecretState currentState, DateTimeOffset expirationDate, bool whatIf)
+    {
+        VssConnection connection = await GetConnectionAsync();
+        TokensHttpClient client = connection.GetClient<TokensHttpClient>();
+
+        if (whatIf)
+        {
+            this.logger.LogInformation("WHAT IF: Post tokens/pat request to Azure DevOps");
+
+            return new SecretValue { Value = string.Empty, ExpirationDate = expirationDate };
+        }
+
+        this.logger.LogInformation("Posting pat creation request to '{OrganizationUrl}'",
+        $"https://dev.azure.com/{this.organization}");
+
+        PatTokenResult result = await client.CreatePatAsync(new PatTokenCreateRequest { AllOrgs = false, DisplayName = this.patDisplayName, Scope = this.scopes, ValidTo = expirationDate.UtcDateTime });
+
+        string authorizationId = result.PatToken.AuthorizationId.ToString();
+
+        this.logger.LogInformation("Azure DevOps responded with authorization id '{AuthorizationId}'", authorizationId);
+
+        return new SecretValue
+        {
+            Value = result.PatToken.Token,
+            ExpirationDate = result.PatToken.ValidTo,
+            Tags = { ["AdoPatAuthorizationId"] = authorizationId }
+        };
+    }
+
+    private static async Task<AccessToken> GetDevopsBearerTokenAsync(TokenCredential credential)
+    {
+        string[] scopes = { $"{AzureDevOpsApplicationId}/.default" };
+
+        var tokenRequestContext = new TokenRequestContext(scopes, parentRequestId: null);
+
+        AccessToken authenticationResult = await credential.GetTokenAsync(tokenRequestContext, CancellationToken.None);
+
+        return authenticationResult;
+    }
+
+    public override Func<Task>? GetRevocationActionAsync(SecretState secretState, bool whatIf)
+    {
+        if (!secretState.Tags.TryGetValue("AdoPatAuthorizationId", out string? authorizationIdString) ||
+            this.revocationAction != RevocationAction.Revoke)
+        {
+            return null;
+        }
+
+        if (!Guid.TryParse(authorizationIdString, out Guid authorizationId))
+        {
+            this.logger.LogWarning("Unable to parse Authorization Id as a Guid: '{AuthorizationId}'", authorizationIdString);
+            return null;
+        }
+
+        return async () =>
+        {
+            VssConnection connection = await GetConnectionAsync();
+            TokensHttpClient client = connection.GetClient<TokensHttpClient>();
+
+            // use the application's object id and the keyId to revoke the old password
+            if (whatIf)
+            {
+                this.logger.LogInformation(
+                    "WHAT IF: Remove PAT with authorization id '{AuthorizationId}' from '{OrganizationUrl}'",
+                    authorizationId,
+                    $"https://dev.azure.com/{this.organization}");
+            }
+            else
+            {
+                try
+                {
+                    this.logger.LogInformation(
+                        "Removing PAT with authorization id '{AuthorizationId}' from '{OrganizationUrl}'",
+                        authorizationId,
+                        $"https://dev.azure.com/{this.organization}");
+                    
+                    await client.RevokeAsync(authorizationId);
+                }
+                catch (SessionTokenNotFoundException)
+                {
+                    // ignore "not found" exception on delete
+                }
+            }
+        };
+    }
+    
+    private static async Task<VssCredentials> GetVssCredentials(TokenCredential credential)
+    {
+        AccessToken token = await GetDevopsBearerTokenAsync(credential);
+
+        return new VssAadCredential(new VssAadToken("Bearer", token.Token));
+    }
+
+    private async Task<VssConnection> GetConnectionAsync()
+    {
+        this.logger.LogDebug("Getting service account password from secret '{SecretName}'", this.serviceAccountPasswordSecret);
+
+        string serviceAccountPassword = await this.secretProvider.GetSecretValueAsync(this.tokenCredential, this.serviceAccountPasswordSecret);
+
+        this.logger.LogDebug("Getting token and devops client for 'dev.azure.com/{Organization}'", this.organization);
+
+        var serviceAccountCredential = new UsernamePasswordCredential(this.serviceAccountName, serviceAccountPassword, this.serviceAccountTenantId, AzureCliApplicationId);
+
+        VssCredentials vssCredentials = await GetVssCredentials(serviceAccountCredential);
+
+        var connection = new VssConnection(new Uri($"https://vssps.dev.azure.com/{organization}"), vssCredentials);
+
+        await connection.ConnectAsync();
+
+        return connection;
+    }
+
+    private enum RevocationAction
+    {
+        [JsonPropertyName("none")]
+        None = 0,
+
+        [JsonPropertyName("revoke")]
+        Revoke = 1
+    }
+
+    private class Parameters
+    {
+        [JsonPropertyName("organization")]
+        public string? Organization { get; set; }
+
+        [JsonPropertyName("patDisplayName")]
+        public string? PatDisplayName { get; set; }
+
+        [JsonPropertyName("scopes")]
+        public string? Scopes { get; set; }
+
+        [JsonPropertyName("serviceAccountTenantId")]
+        public string? ServiceAccountTenantId { get; set; }
+
+        [JsonPropertyName("serviceAccountName")]
+        public string? ServiceAccountName { get; set; }
+
+        [JsonPropertyName("serviceAccountPasswordSecret")]
+        public string? ServiceAccountPasswordSecret { get; set; }
+
+        [JsonPropertyName("revocationAction")]
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        public RevocationAction RevocationAction { get; set; }
+    }
+}

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps/ServiceAccountPersonalAccessTokenStore.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps/ServiceAccountPersonalAccessTokenStore.cs
@@ -219,7 +219,7 @@ public class ServiceAccountPersonalAccessTokenStore : SecretStore
 
         VssCredentials vssCredentials = await GetVssCredentials(serviceAccountCredential);
 
-        var connection = new VssConnection(new Uri($"https://vssps.dev.azure.com/{organization}"), vssCredentials);
+        var connection = new VssConnection(new Uri($"https://vssps.dev.azure.com/{this.organization}"), vssCredentials);
 
         await connection.ConnectAsync();
 

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationConfigurationTests.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationConfigurationTests.cs
@@ -27,7 +27,7 @@ public class RotationConfigurationTests
     [Test]
     public void LoadFrom_ValidPath_ReturnConfiguration()
     {
-        string validPath = TestFiles.ResolvePath("TestConfigurations/valid/random-string.json");
+        string validPath = TestFiles.ResolvePath("TestConfigurations/Valid/random-string.json");
         var storeFactories = new Dictionary<string, Func<StoreConfiguration, SecretStore>>();
 
         // Act
@@ -39,7 +39,7 @@ public class RotationConfigurationTests
     [Test]
     public void GetPlan_ValidConfiguration_ReturnsPlan()
     {
-        string configurationPath = TestFiles.ResolvePath("TestConfigurations/valid/random-string.json");
+        string configurationPath = TestFiles.ResolvePath("TestConfigurations/Valid/random-string.json");
 
         var storeFactories = new Dictionary<string, Func<StoreConfiguration, SecretStore>>
         {

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.sln
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.sln
@@ -26,6 +26,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.SecretRotation.Azure", "Azure.Sdk.Tools.SecretRotation.Azure\Azure.Sdk.Tools.SecretRotation.Azure.csproj", "{C7116D4F-2156-4623-BA3A-CE605592D386}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService", "Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService\Azure.Sdk.Tools.SecretRotation.Stores.AzureAppService.csproj", "{653CFBB4-2DA4-4925-A050-F37EF5BE823F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -64,6 +68,14 @@ Global
 		{67C87A2D-AF22-4C36-B99B-7E1A60B07B04}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{67C87A2D-AF22-4C36-B99B-7E1A60B07B04}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{67C87A2D-AF22-4C36-B99B-7E1A60B07B04}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C7116D4F-2156-4623-BA3A-CE605592D386}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C7116D4F-2156-4623-BA3A-CE605592D386}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C7116D4F-2156-4623-BA3A-CE605592D386}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C7116D4F-2156-4623-BA3A-CE605592D386}.Release|Any CPU.Build.0 = Release|Any CPU
+		{653CFBB4-2DA4-4925-A050-F37EF5BE823F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{653CFBB4-2DA4-4925-A050-F37EF5BE823F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{653CFBB4-2DA4-4925-A050-F37EF5BE823F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{653CFBB4-2DA4-4925-A050-F37EF5BE823F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -73,6 +85,7 @@ Global
 		{DEE3F30A-5B2E-4C44-B273-A9703CAAFE35} = {B06067D2-6F7C-4281-A2AC-4E7DBD94C5DD}
 		{0D73540F-FB12-4555-846F-3E45D93219D7} = {B06067D2-6F7C-4281-A2AC-4E7DBD94C5DD}
 		{67C87A2D-AF22-4C36-B99B-7E1A60B07B04} = {B06067D2-6F7C-4281-A2AC-4E7DBD94C5DD}
+		{653CFBB4-2DA4-4925-A050-F37EF5BE823F} = {B06067D2-6F7C-4281-A2AC-4E7DBD94C5DD}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {5C35D5F5-EED1-4FA7-941C-02D71B34D9BA}


### PR DESCRIPTION
- Add Azure DevOps PAT store for service accounts
  - This uses service account credentials defined in the store's parameters to authenticate into ADO
  - PATs are issued against the service account, not the tool runner
- Add Azure App Service store for restarting websites after rotation
  - The store is configured with UpdateAfterPrimary so the website restart happens after the secret is stored in the vault.
- Update rotation logic to support post-primary stores and rotation-complete annotation
- To accommodate the post-primary website restart, the new rotation flow is:
    1. Originate in origin
    2. Write to Secondaries where UpdateAfterPrimary == false
    3. Write to Primary if Primary != Origin
    4. Write to Secondaries where UpdateAfterPrimary == true
    5. Annotate Primary with "rotation-complete: true"