### PR TITLE
Skip invalid file path when generating swagger API review

### DIFF
--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/CHANGELOG
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/CHANGELOG
@@ -1,18 +1,22 @@
 # Release History
 
-# 1.0.7 (2-9-2023)
+## 1.0.8 (3-1-2023)
+
++ Skip any invalid swagger file path when generating API review
+
+## 1.0.7 (2-9-2023)
 
 + Support header parameter in operation parameters
 + Support header response in operation responses
 + For schemaCache, use absolute path as key
 
-# 1.0.6 (2-2-2023)
+## 1.0.6 (2-2-2023)
 
 + Remove APIView and APIViewWeb dependency 
 + Fix don't resolve response issue
 + Add null check for array item
 
-# 1.0.5 (1-18-2023)
+## 1.0.5 (1-18-2023)
 
 + Fix root schema circular reference issue by adding root schema ref in refChain.
 

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/Program.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/Program.cs
@@ -89,7 +89,7 @@ internal class Program
             if (!File.Exists(swaggerFilePath))
             {
                 // Suppressing this error when swagger file is missing or path is incorrect
-                // Ideally any incorrect path to swagger file reference in README should be caught by validation tool
+                // Ideally any incorrect swagger file path reference in README should be caught by validation tool
                 Console.WriteLine($"Invalid file path to swagger file. Skipping {swaggerFilePath}.");
                 continue;
             }

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/Program.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/Program.cs
@@ -88,7 +88,10 @@ internal class Program
         {
             if (!File.Exists(swaggerFilePath))
             {
-                throw new FileNotFoundException(swaggerFilePath);
+                // Suppressing this error when swagger file is missing or path is incorrect
+                // Ideally any incorrect path to swagger file reference in README should be caught by validation tool
+                Console.WriteLine($"Invalid file path to swagger file. Skipping {swaggerFilePath}.");
+                continue;
             }
 
             var swaggerLink = idx < swaggerLinks.Count ? swaggerLinks[idx] : "";
@@ -100,8 +103,7 @@ internal class Program
             swaggerSpec.swaggerFilePath = Path.GetFullPath(swaggerFilePath);
             swaggerSpec.swaggerLink = swaggerLink;
             swaggerSpecs.Add(swaggerSpec);
-            root.AddDefinitionToCache(swaggerSpec, swaggerSpec.swaggerFilePath);
-                
+            root.AddDefinitionToCache(swaggerSpec, swaggerSpec.swaggerFilePath);                
         }
 
         foreach (var swaggerSpec in swaggerSpecs)

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiParser.csproj
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiParser.csproj
@@ -6,7 +6,7 @@
     <ToolCommandName>swaggerAPIParser</ToolCommandName>
     <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>swagger_api_parser</RootNamespace>
-    <VersionPrefix>1.0.7</VersionPrefix>
+    <VersionPrefix>1.0.8</VersionPrefix>
     <AssemblyName>Azure.Sdk.Tools.SwaggerApiParser</AssemblyName>
     <SignAssembly>True</SignAssembly>
     <InformationalVersion>$(OfficialBuildId)</InformationalVersion>


### PR DESCRIPTION
Swagger API review is generated from source as well as target branch when a user submits a swagger PR. We can correct file path if swagger file path is incorrect in source side as part of PR changes. API review gen step from target branch is failing if any swagger file path is already incorrect on readme in target branch. This PR is to temporarily skip any invalid file to unblock Swagger  API review gen step.

@chidozieononiwu @ruowan @maririos 