### PR TITLE
Fix PS optional arg issue to not pass empty args

### DIFF
--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -24,8 +24,9 @@ param(
     [Parameter(Mandatory = $true)]
     [string] $GitUrl,
 
+    # Explicitly set this to null so that PS command line parser doesn't try to parse and pass it as ""
     [Parameter(Mandatory = $false)]
-    [string] $PushArgs = "",
+    [string] $PushArgs = $null,
 
     [Parameter(Mandatory = $false)]
     [string] $RemoteName = "azure-sdk-fork",
@@ -83,7 +84,7 @@ if (!$SkipCommit) {
         $amendOption = "--amend"
     }
     else {
-        # Explicitly set this to null so that PS command line parser doesn't try to parse pass it as ""
+        # Explicitly set this to null so that PS command line parser doesn't try to parse and pass it as ""
         $amendOption = $null
     }
     Write-Host "git -c user.name=`"azure-sdk`" -c user.email=`"azuresdk@microsoft.com`" commit $amendOption -am `"$CommitMsg`""


### PR DESCRIPTION
Another follow-up of https://github.com/Azure/azure-sdk-tools/pull/4746 when moving to PS 7.3.

Follow-up to https://github.com/Azure/azure-sdk-tools/pull/4746