### PR TITLE
Update swagger manual review gen pipeline to use a variable for swagg…

### DIFF
--- a/eng/pipelines/apiview-review-gen-swagger.yml
+++ b/eng/pipelines/apiview-review-gen-swagger.yml
@@ -27,7 +27,7 @@ jobs:
   - script: >
       dotnet tool install
       Azure.Sdk.Tools.SwaggerApiParser
-      --version 1.0.7-dev.20230227.3
+      --version $(SWAGGER_API_PARSER_VERSION)
       --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
       --tool-path $(SwaggerParserInstallPath)
     workingDirectory: $(SwaggerParserInstallPath)


### PR DESCRIPTION
Update swagger manual review gen pipeline to use a variable we can configure at pipeline level to pass parser version to make it easier to update parser version when a new parser is released.