### PR TITLE
True Version Override in Proxy Tooling

### DIFF
--- a/eng/common/testproxy/override-proxy-version.ps1
+++ b/eng/common/testproxy/override-proxy-version.ps1
@@ -1,0 +1,25 @@
+<#
+.SYNOPSIS
+Replaces target test-proxy version present in target_version.txt.
+
+.PARAMETER TargetVersion
+The replacement version. Used in its entirety, so don't exclude parts of the version definition.
+#>
+[cmdletbinding(SupportsShouldProcess=$True)]
+param(
+   [Parameter(mandatory=$true)] [string] $TargetVersion
+)
+
+$versionFile = Join-Path $PSScriptRoot "target_version.txt"
+$existingVersionText = Get-Content -Raw -Path $versionFile
+$existingVersion = $existingVersionText.Trim()
+
+if ($PSCmdLet.ShouldProcess($versionFile)){
+   Write-Host "Replacing version `"$existingVersion`" with version `"$TargetVersion`" in $versionFile."
+   Set-Content -Path $versionFile -Value "$TargetVersion`n"   
+}
+else {
+   Write-Host "Would replace version `"$existingVersion`" with version `"$TargetVersion`" in $versionFile."
+}
+
+

--- a/eng/common/testproxy/test-proxy-docker.yml
+++ b/eng/common/testproxy/test-proxy-docker.yml
@@ -10,6 +10,15 @@ steps:
     displayName: 'Language Specific Certificate Trust'
     condition: and(succeeded(), ${{ parameters.condition }})
 
+  - task: PowerShell@2
+    displayName: 'Override proxy version if necessary'
+    condition: and(succeeded(), ${{ parameters.condition }}, ne('${{ parameters.targetVersion }}', ''))
+    inputs:
+      targetType: filePath
+      filePath: '${{ parameters.templateRoot }}/eng/common/testproxy/override-proxy-version.ps1'
+      arguments: '-TargetVersion "${{ parameters.targetVersion }}"'
+      pwsh: true
+
   - pwsh: |
       docker info
     displayName: 'Dump active docker information'

--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -11,14 +11,17 @@ steps:
     displayName: 'Language Specific Certificate Trust'
     condition: and(succeeded(), ${{ parameters.condition }})
 
+  - task: PowerShell@2
+    displayName: 'Override proxy version if necessary'
+    condition: and(succeeded(), ${{ parameters.condition }}, ne('${{ parameters.targetVersion }}', ''))
+    inputs:
+      targetType: filePath
+      filePath: '${{ parameters.templateRoot }}/eng/common/testproxy/override-proxy-version.ps1'
+      arguments: '-TargetVersion "${{ parameters.targetVersion }}"'
+      pwsh: true
+
   - pwsh: |
       $version = $(Get-Content "${{ parameters.templateRoot }}/eng/common/testproxy/target_version.txt" -Raw).Trim()
-      $overrideVersion = "${{ parameters.targetVersion }}"
-
-      if($overrideVersion) {
-        Write-Host "Overriding default target proxy version of '$version' with override $overrideVersion."
-        $version = $overrideVersion
-      }
 
       dotnet tool install azure.sdk.tools.testproxy `
         --tool-path $(Build.BinariesDirectory)/test-proxy `


### PR DESCRIPTION
In the event that I actually break folks with a proxy version upgrade in `target_version.txt`, I want to be certain that our templates have true override that we can easily set when calling our template.

Even if they set it so that it doesn't start the proxy, they can invoke the `test-proxy-tool` yaml with `runProxy` set to false, so it still overrides the version but doesn't actually run it for them. Then if their tooling looks at `target_version.txt` that will be properly overwritten.

Before this change, _our_ tooling would boot up the proper proxy override version, but not update the actual file at rest in the repo. Any dependent tooling would therefor be looking for the wrong version of the proxy.

This PR is in reaction to a situation that came up with @billwert and @samvaity . They don't honor the `target_version.txt` yet, but if they _did_, before this PR an override wouldn't have worked for them. I'd like to avoid that when we eventually really need this to work.

`eng/common` changes won't be created until after release week, no reason to rock the boat.