### PR TITLE
[Python APIView] Fix `datetime.datetime` not appearing

### DIFF
--- a/packages/python-packages/api-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/api-stub-generator/CHANGELOG.md
@@ -5,6 +5,7 @@ Fix incorrect type annotation.
 Update to follow best practices for accessing '__annotations__'.
 Fixed issue where class decorators were not displayed.
 Fixed issue where ivars appeared as cvars.
+Fixed issue where type hints did not appear for datetime.datetime types.
 
 ## Version 0.3.6 (2022-10-27)
 Suppressed unwanted base class methods in DPG libraries.

--- a/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
+++ b/packages/python-packages/api-stub-generator/apistub/nodes/_base_node.py
@@ -116,9 +116,9 @@ def get_qualified_name(obj, namespace: str) -> str:
     value = name_regex.search(name).group(0)
     if module_name and module_name.startswith(namespace):
         value = f"{module_name}.{name}"
-    elif module_name and value.startswith(module_name):
+    elif module_name and module_name != value and value.startswith(module_name):
         # strip the module name if it isn't the namespace (example: typing)
-        value = value[len(module_name) +1:]
+        value = value[len(module_name) + 1:]
 
     if args and "[" not in value:
         arg_string = ", ".join(args)

--- a/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
+++ b/packages/python-packages/api-stub-generator/tests/class_parsing_test.py
@@ -103,13 +103,13 @@ class TestClassParsing:
         actuals = _render_lines(_tokenize(class_node))
         expected = [
             "class PublicPrivateClass:",
+            'ivar public_datetime: datetime',
             "ivar public_dict: dict = {'a': 'b'}",
-            'ivar public_var: str = "SOMEVAL"',
+            'ivar public_var: str = "SOMEVAL"'
         ]
         _check_all(actuals, expected, obj)
-        assert actuals[4].lstrip() == "def __init__(self)"
-        assert actuals[6].lstrip() == "def public_func(self, **kwargs) -> str"
-
+        assert actuals[5].lstrip() == "def __init__(self)"
+        assert actuals[7].lstrip() == "def public_func(self, **kwargs) -> str"
     def test_required_kwargs(self):
         obj = RequiredKwargObject
         class_node = ClassNode(name=obj.__name__, namespace=obj.__name__, parent_node=None, obj=obj, pkg_root_namespace=self.pkg_namespace)

--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -9,6 +9,7 @@
 import abc
 from azure.core import CaseInsensitiveEnumMeta
 from collections.abc import Sequence
+import datetime
 from enum import Enum, EnumMeta
 import functools
 from typing import Any, overload, Dict, TypedDict, Union, Optional, Generic, TypeVar, NewType, ClassVar
@@ -139,6 +140,8 @@ FakeTypedDict = TypedDict(
 class PublicPrivateClass:
 
     public_var: str = "SOMEVAL"
+
+    public_datetime: datetime.datetime
 
     _private_var: str
 


### PR DESCRIPTION
Fix #5630.