### PR TITLE
Disable delete option for PR API reviews

### DIFF
--- a/src/dotnet/APIView/APIViewIntegrationTests/TestsBaseFixture.cs
+++ b/src/dotnet/APIView/APIViewIntegrationTests/TestsBaseFixture.cs
@@ -27,6 +27,7 @@ namespace APIViewIntegrationTests
 
         public PackageNameManager PackageNameManager { get; private set; }
         public ReviewManager ReviewManager { get; private set; }
+        public CosmosReviewRepository ReviewRepository { get; private set; }
         public ClaimsPrincipal User { get; private set; }
 
         public TestsBaseFixture()
@@ -63,7 +64,7 @@ namespace APIViewIntegrationTests
             _ = dataBaseResponse.Database.CreateContainerIfNotExistsAsync("Reviews", "/id");
             _ = dataBaseResponse.Database.CreateContainerIfNotExistsAsync("Comments", "/ReviewId");
             _ = dataBaseResponse.Database.CreateContainerIfNotExistsAsync("Profiles", "/id");
-            var cosmosReviewRepository = new CosmosReviewRepository(config);
+            ReviewRepository = new CosmosReviewRepository(config);
             var cosmosCommentsRepository = new CosmosCommentsRepository(config);
             var cosmosUserProfileRepository = new CosmosUserProfileRepository(config);
 
@@ -79,7 +80,7 @@ namespace APIViewIntegrationTests
             authorizationServiceMoq.Setup(_ => _.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<Object>(), It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
                 .ReturnsAsync(AuthorizationResult.Success);
 
-            var notificationManager = new NotificationManager(config, cosmosReviewRepository, cosmosUserProfileRepository);
+            var notificationManager = new NotificationManager(config, ReviewRepository, cosmosUserProfileRepository);
 
             var devopsArtifactRepositoryMoq = new Mock<IDevopsArtifactRepository>();
             devopsArtifactRepositoryMoq.Setup(_ => _.DownloadPackageArtifact(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
@@ -89,7 +90,7 @@ namespace APIViewIntegrationTests
                 .Returns(Task.CompletedTask);
 
             ReviewManager = new ReviewManager(
-                authorizationServiceMoq.Object, cosmosReviewRepository, blobCodeFileRepository, blobOriginalsRepository, cosmosCommentsRepository,
+                authorizationServiceMoq.Object, ReviewRepository, blobCodeFileRepository, blobOriginalsRepository, cosmosCommentsRepository,
                 languageService, notificationManager, devopsArtifactRepositoryMoq.Object, PackageNameManager);
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewsPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewsPartial.cshtml
@@ -48,7 +48,7 @@
                                 <span>@review.FilterType.ToString()</span>
                             </td>
                             <td>
-                                @if (review.Author == User.GetGitHubLogin())
+                                @if (review.Author == User.GetGitHubLogin() && review.FilterType == ReviewType.Manual)
                                 {
                                     <a asp-page="./Delete" asp-route-id="@review.ReviewId">
                                         <button type="button" class="btn pt-0 pb-0 ps-1 pe-1 btn-outline-danger"><i class="fas fa-times-circle"></i> Delete</button>

--- a/src/dotnet/APIView/APIViewWeb/Repositories/UnDeletableReviewException.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/UnDeletableReviewException.cs
@@ -5,7 +5,7 @@ using System;
 
 namespace APIViewWeb.Repositories
 {
-    internal class UnDeletableReviewException : Exception
+    public class UnDeletableReviewException : Exception
     {
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/UnDeletableReviewException.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/UnDeletableReviewException.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+
+namespace APIViewWeb.Repositories
+{
+    internal class UnDeletableReviewException : Exception
+    {
+    }
+}


### PR DESCRIPTION
We currently allow deletion of API reviews created from PR and this causes baseline of PR API review (which is current latest of automatic API review revision) also to get deleted. Besides deleting a API review from PR causes to leave incomplete data about API review in APIView. We should not allow deleting API review created by automatically.