### PR TITLE
Improve status command output and improve error handling

### DIFF
--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Cli/Commands/StatusCommand.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Cli/Commands/StatusCommand.cs
@@ -1,5 +1,8 @@
-﻿using System.CommandLine.Invocation;
+using System.CommandLine.Invocation;
+using System.Reflection;
+using System.Text;
 using System.Text.Json;
+using System.Text.Json.Serialization;
 using Azure.Sdk.Tools.SecretRotation.Configuration;
 using Azure.Sdk.Tools.SecretRotation.Core;
 
@@ -17,13 +20,130 @@ public class StatusCommand : RotationCommandBase
         var timeProvider = new TimeProvider();
         IEnumerable<RotationPlan> plans = rotationConfiguration.GetAllRotationPlans(logger, timeProvider);
 
+        List<(RotationPlan Plan, RotationPlanStatus Status)> statuses = new();
+
         foreach (RotationPlan plan in plans)
         {
-            Console.WriteLine();
-            Console.WriteLine($"{plan.Name}:");
-
+            logger.LogInformation($"Getting status for plan '{plan.Name}'");
             RotationPlanStatus status = await plan.GetStatusAsync();
-            Console.WriteLine(JsonSerializer.Serialize(status, new JsonSerializerOptions { WriteIndented = true }));
+
+            if (logger.IsEnabled(LogLevel.Debug))
+            {
+                var builder = new StringBuilder();
+
+                builder.AppendLine($"  Plan:");
+                builder.AppendLine($"    RotationPeriod: {plan.RotationPeriod}");
+                builder.AppendLine($"    RotationThreshold: {plan.RotationThreshold}");
+                builder.AppendLine($"    RevokeAfterPeriod: {plan.RevokeAfterPeriod}");
+
+                builder.AppendLine($"  Status:");
+                builder.AppendLine($"    ExpirationDate: {status.ExpirationDate}");
+                builder.AppendLine($"    Expired: {status.Expired}");
+                builder.AppendLine($"    ThresholdExpired: {status.ThresholdExpired}");
+                builder.AppendLine($"    RequiresRevocation: {status.RequiresRevocation}");
+                builder.AppendLine($"    Exception: {status.Exception?.Message}");
+
+                logger.LogDebug(builder.ToString());
+            }
+
+
+            statuses.Add((plan, status));
         }
+
+        var errored = statuses.Where(x => x.Status.Exception is not null).ToArray();
+        var expired = statuses.Except(errored).Where(x => x.Status is { Expired: true }).ToArray();
+        var expiring = statuses.Except(errored).Where(x => x.Status is { Expired: false, ThresholdExpired: true }).ToArray();
+        var upToDate = statuses.Except(errored).Where(x => x.Status is { Expired: false, ThresholdExpired: false }).ToArray();
+
+        var statusBuilder = new StringBuilder();
+
+        void AppendStatusSection(IList<(RotationPlan Plan, RotationPlanStatus Status)> sectionStatuses, string header)
+        {
+            if (!sectionStatuses.Any())
+            {
+                return;
+            }
+
+            statusBuilder.AppendLine();
+            statusBuilder.AppendLine(header);
+            foreach ((RotationPlan plan, RotationPlanStatus status) in sectionStatuses)
+            {
+                foreach (string line in GetPlanStatusLine(plan, status).Split("\n"))
+                {
+                    statusBuilder.Append("  ");
+                    statusBuilder.AppendLine(line);
+                }
+            }
+        }
+
+        AppendStatusSection(expired, "Expired:");
+        AppendStatusSection(expiring, "Expiring:");
+        AppendStatusSection(upToDate, "Up-to-date:");
+        AppendStatusSection(errored, "Error reading plan status:");
+
+        logger.LogInformation(statusBuilder.ToString());
+
+        if (expired.Any())
+        {
+            invocationContext.ExitCode = 1;
+        }
+    }
+
+    private static string GetPlanStatusLine(RotationPlan plan, RotationPlanStatus status)
+    {
+        if (status.Exception != null)
+        {
+            return $"{plan.Name}:\n  {status.Exception.Message}";
+        }
+
+        DateTimeOffset? expirationDate = status.ExpirationDate;
+
+        DateTimeOffset now = DateTimeOffset.UtcNow;
+
+        string expiration = expirationDate.HasValue
+            ? $"{FormatTimeSpan(expirationDate.Value.Subtract(now))}"
+            : "No expiration date";
+
+        return $"{plan.Name} - {expiration} / ({FormatTimeSpan(plan.RotationPeriod)} @ {FormatTimeSpan(plan.RotationThreshold)})";
+    }
+
+    private static string FormatTimeSpan(TimeSpan timeSpan)
+    {
+        if (timeSpan == TimeSpan.Zero)
+        {
+            return "0d";
+        }
+
+        StringBuilder builder = new StringBuilder();
+
+        if (timeSpan.Days > 0)
+        {
+            builder.Append(timeSpan.Days);
+            builder.Append('d');
+        }
+
+        if (timeSpan.Days < 2 && timeSpan.TotalDays - timeSpan.Days > 0)
+        {
+            if (timeSpan.Hours > 0)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(' ');
+                }
+                builder.Append(timeSpan.Hours);
+                builder.Append('h');
+            }
+            if (timeSpan.Minutes > 0)
+            {
+                if (builder.Length > 0)
+                {
+                    builder.Append(' ');
+                }
+                builder.Append(timeSpan.Minutes);
+                builder.Append('m');
+            }
+        }
+
+        return builder.ToString();
     }
 }

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Configuration/PlanConfiguration.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Configuration/PlanConfiguration.cs
@@ -18,7 +18,7 @@ public class PlanConfiguration
         ReadCommentHandling = JsonCommentHandling.Skip,
     };
 
-    private static readonly Regex schemaPattern = new (@"https\://raw\.githubusercontent\.com/azure/azure-sdk-tools/(?<branch>.+?)/schemas/secretrotation/(?<version>.+?)/schema\.json", RegexOptions.IgnoreCase);
+    private static readonly Regex schemaPattern = new (@"/(?<version>.+?)/plan\.json", RegexOptions.IgnoreCase);
 
     public string Name { get; set; } = string.Empty;
 

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Core/RotationPlanStatus.cs
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Core/RotationPlanStatus.cs
@@ -1,4 +1,4 @@
-﻿using Azure.Sdk.Tools.SecretRotation.Core;
+using Azure.Sdk.Tools.SecretRotation.Core;
 
 namespace Azure.Sdk.Tools.SecretRotation.Core;
 
@@ -13,4 +13,8 @@ public class RotationPlanStatus
     public SecretState? PrimaryStoreState { get; set; }
 
     public IReadOnlyList<SecretState>? SecondaryStoreStates { get; set; }
+
+    public DateTimeOffset? ExpirationDate { get; set; }
+
+    public RotationException? Exception { get; set; }
 }

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/four.json
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/four.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/schemas/secretrotation/1.0.0/schema.json",
+  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/tools/secret-rotation/schema/1.0.0/plan.json",
   "rotationThreshold": "9.00:00:00",
   "rotationPeriod": "12.00:00:00",
   "tags": [ "even", "d" ],

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/named-1.json
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/named-1.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/schemas/secretrotation/1.0.0/schema.json",
+  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/tools/secret-rotation/schema/1.0.0/plan.json",
   "rotationThreshold": "9.00:00:00",
   "rotationPeriod": "12.00:00:00",
   "name": "five",

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/named-2.json
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/named-2.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/schemas/secretrotation/1.0.0/schema.json",
+  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/tools/secret-rotation/schema/1.0.0/plan.json",
   "rotationThreshold": "9.00:00:00",
   "rotationPeriod": "12.00:00:00",
   "name":  "six",

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/one.json
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/one.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/schemas/secretrotation/1.0.0/schema.json",
+  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/tools/secret-rotation/schema/1.0.0/plan.json",
   "rotationThreshold": "9.00:00:00",
   "rotationPeriod": "12.00:00:00",
   "tags": [ "odd", "a" ],

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/three.json
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/three.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/schemas/secretrotation/1.0.0/schema.json",
+  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/tools/secret-rotation/schema/1.0.0/plan.json",
   "rotationThreshold": "9.00:00:00",
   "rotationPeriod": "12.00:00:00",
   "tags": [ "odd", "c" ],

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/two.json
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/TagMatching/two.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/schemas/secretrotation/1.0.0/schema.json",
+  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/tools/secret-rotation/schema/1.0.0/plan.json",
   "rotationThreshold": "9.00:00:00",
   "rotationPeriod": "12.00:00:00",
   "tags": [ "even", "b" ],

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/Valid/manual-value.json
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/Valid/manual-value.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/schemas/secretrotation/1.0.0/schema.json",
+  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/tools/secret-rotation/schema/1.0.0/plan.json",
   "rotationPeriod": "1.00:00:00",
   "rotationThreshold": "23:59:00",
   "revokeAfterPeriod": "00:05:00",

--- a/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/Valid/random-string.json
+++ b/tools/secret-rotation/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/Valid/random-string.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/schemas/secretrotation/1.0.0/schema.json",
+  "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/tools/secret-rotation/schema/1.0.0/plan.json",
   "rotationThreshold": "9.00:00:00",
   "rotationPeriod": "12.00:00:00",
   "tags": [ "random" ],

--- a/tools/secret-rotation/schema/1.0.0/plan.json
+++ b/tools/secret-rotation/schema/1.0.0/plan.json
@@ -1,6 +1,6 @@
 {
     "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://example.com/product.schema.json",
+    "$id": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/tools/secret-rotation/schema/1.0.0/plan.json",
     "title": "PlanConfiguration",
     "description": "A secret rotation plan",
     "type": "object",
@@ -19,6 +19,10 @@
         },
         "revokeAfterPeriod": {
             "description": "Time span indicating when the old secret values should be revoked after rotation",
+            "type": "string"
+        },
+        "description": {
+            "description": "A description of the secret being rotated by this plan",
             "type": "string"
         },
         "tags": {
@@ -60,6 +64,10 @@
                 }
             },
             "minItems": 1
+        },
+        "$schema": {
+            "description": "JSON Schema URI (used by some editors)",
+            "type": "string"
         }
     },
     "required": [ "rotationThreshold", "rotationPeriod", "stores" ],


### PR DESCRIPTION
Move schema into the tool folder
 
Greatly improve status command output

Fix exception handling in Key Vault stores
- Key Vault 404 exception messages are very long, causing overly verbose console output when a secret is missing