### PR TITLE
Update cadl to TypeSpec

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/LanguageServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/LanguageServiceTests.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using ApiView;
+using APIViewWeb;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace APIViewUnitTests
+{
+    public class LanguageServiceTests
+    {
+        [Fact]
+        public void TypeSpectLanguageService_Supports_Multiple_Extensions()
+        {
+            var languageService = new TypeSpecLanguageService(new ConfigurationBuilder().Build());
+            Assert.True(languageService.IsSupportedFile("specification/cognitiveservices/HealthInsights/healthinsights.common/primitives.cadl"));
+            Assert.True(languageService.IsSupportedFile("specification/cognitiveservices/HealthInsights/healthinsights.common/primitives.tsp"));
+            Assert.False(languageService.IsSupportedFile("specification/cognitiveservices/HealthInsights/healthinsights.common/primitives.json"));
+        }
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Client/src/pages/index.ts
+++ b/src/dotnet/APIView/APIViewWeb/Client/src/pages/index.ts
@@ -128,7 +128,7 @@ $(() => {
     $("#uploadModel").find(".card-body > div").addClass("d-none");
     var helpName = "#" + val.toLowerCase() + "-help";
     $(helpName).removeClass("d-none");
-    if (val == 'Cadl' || prevLanguageValue == 'Cadl') {
+    if (val == 'TypeSpec' || prevLanguageValue == 'TypeSpec') {
       const fileSelectors = $(".package-selector");
       for (var i = 0; i < fileSelectors.length; i++) {
         $(fileSelectors[i]).toggleClass("d-none");

--- a/src/dotnet/APIView/APIViewWeb/Helpers/LanguageServiceHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/LanguageServiceHelpers.cs
@@ -1,7 +1,27 @@
+using System.Collections.Generic;
+using System.Linq;
+
 namespace APIViewWeb.Helpers
 {
     public class LanguageServiceHelpers
     {
         public static string[] SupportedLanguages = new string[] { "C", "C++", "C#", "TypeSpec", "Go", "Java", "JavaScript", "Json", "Kotlin", "Python", "Swagger", "Swift", "Xml" };
+
+        public static IEnumerable<string> MapLanguageAliases(IEnumerable<string> languages)
+        {
+            HashSet<string> result = new HashSet<string>();
+
+            foreach (var language in languages) 
+            {
+                if (language.Equals("TypeSpec") || language.Equals("Cadl"))
+                {
+                    result.Add("Cadl");
+                    result.Add("TypeSpec");
+                }
+                result.Add(language);
+            }
+
+            return result.ToList();
+        }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Helpers/LanguageServiceHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/LanguageServiceHelpers.cs
@@ -2,6 +2,6 @@ namespace APIViewWeb.Helpers
 {
     public class LanguageServiceHelpers
     {
-        public static string[] SupportedLanguages = new string[] { "C", "C++", "C#", "Cadl", "Go", "Java", "JavaScript", "Json", "Kotlin", "Python", "Swagger", "Swift", "Xml" };
+        public static string[] SupportedLanguages = new string[] { "C", "C++", "C#", "TypeSpec", "Go", "Java", "JavaScript", "Json", "Kotlin", "Python", "Swagger", "Swift", "Xml" };
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -71,7 +71,7 @@ namespace APIViewWeb
 
         public override string Name { get; } = "C";
 
-        public override string Extension { get; } = ".zip";
+        public override string [] Extensions { get; } = { ".zip" };
 
         public override bool CanUpdate(string versionString) => versionString != CurrentVersion;
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -17,7 +17,7 @@ namespace APIViewWeb
     {
         private static Regex _packageNameParser = new Regex("([A-Za-z.]*[a-z]).([\\S]*)", RegexOptions.Compiled);
         public override string Name { get; } = "C#";
-        public override string Extension { get; } = ".dll";
+        public override string[] Extensions { get; } = { ".dll" };
 
         public override bool IsSupportedFile(string name)
         {

--- a/src/dotnet/APIView/APIViewWeb/Languages/CppLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CppLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -114,7 +114,7 @@ namespace APIViewWeb
 
         public override string Name { get; } = "C++";
 
-        public override string Extension { get; } = ".cppast";
+        public override string [] Extensions { get; } = { ".cppast" };
 
         public override bool CanUpdate(string versionString) => versionString != CurrentVersion;
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/GoLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/GoLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -13,7 +13,7 @@ namespace APIViewWeb
     public class GoLanguageService : LanguageProcessor
     {
         public override string Name { get; } = "Go";
-        public override string Extension { get; } = ".gosource";
+        public override string [] Extensions { get; } = { ".gosource" };
         public override string ProcessName { get; } = "apiviewgo";
         public override string VersionString { get; } = "2";
 
@@ -36,7 +36,7 @@ namespace APIViewWeb
             zipStream.Position = 0;
             var archive = new ZipArchive(zipStream);            
             archive.ExtractToDirectory(tempDirectory);
-            var packageRootDirectory = originalFilePath.Replace(Extension, "");
+            var packageRootDirectory = originalFilePath.Replace(Extensions[0], "");
 
             try
             {

--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.IO;
@@ -8,7 +8,7 @@ namespace APIViewWeb
     public class JavaLanguageService : LanguageProcessor
     {
         public override string Name { get; } = "Java";
-        public override string Extension { get; } = ".jar";
+        public override string[] Extensions { get; } = { ".jar" };
         public override string ProcessName { get; } = "java";
         public override string VersionString { get; } = "apiview-java-processor-1.28.0.jar";
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaScriptLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaScriptLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -9,7 +9,7 @@ namespace APIViewWeb
     public class JavaScriptLanguageService : LanguageProcessor
     {
         public override string Name { get; } = "JavaScript";
-        public override string Extension { get; } = ".api.json";
+        public override string[] Extensions { get; } = { ".api.json" };
         public override string ProcessName { get; } = "node";
         public override string VersionString { get; } = "1";
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/JsonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JsonLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -11,7 +11,7 @@ namespace APIViewWeb
     public class JsonLanguageService : LanguageService
     {
         public override string Name { get; } = "Json";
-        public override string Extension { get; } = ".json";
+        public override string[] Extensions { get; } = { ".json" };
 
         public override bool CanUpdate(string versionString) => false;
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/LanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/LanguageService.cs
@@ -8,14 +8,16 @@ using APIViewWeb.Models;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights;
 using APIViewWeb.Helpers;
+using Microsoft.VisualStudio.Services.Common;
+using System.Linq;
 
 namespace APIViewWeb
 {
     public abstract class LanguageService
     {
         public abstract string Name { get; }
-        public abstract string Extension { get; }
-        public virtual bool IsSupportedFile(string name) => name.EndsWith(Extension, StringComparison.OrdinalIgnoreCase);
+        public abstract string [] Extensions { get; }
+        public virtual bool IsSupportedFile(string name) => Extensions.Any(x => name.EndsWith(x, StringComparison.OrdinalIgnoreCase));
         public abstract bool CanUpdate(string versionString);
         public abstract Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis);
         public virtual bool IsReviewGenByPipeline { get; set; } = false;

--- a/src/dotnet/APIView/APIViewWeb/Languages/ProtocolLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/ProtocolLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Configuration;
@@ -8,7 +8,7 @@ namespace APIViewWeb
     public class ProtocolLanguageService : LanguageProcessor
     {
         public override string Name { get; } = "Protocol";
-        public override string Extension { get; } = ".yaml";
+        public override string[] Extensions { get; } = { ".yaml" };
         public override string VersionString { get; } = "0.1.0";
 
         private readonly string _protocolProcessor;

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -16,7 +16,7 @@ namespace APIViewWeb
     public class PythonLanguageService : LanguageProcessor
     {
         public override string Name { get; } = "Python";
-        public override string Extension { get; } = ".whl";
+        public override string[] Extensions { get; } = { ".whl" };
         public override string VersionString { get; } = "0.3.5";
 
         private readonly string _pythonExecutablePath;

--- a/src/dotnet/APIView/APIViewWeb/Languages/SwaggerLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/SwaggerLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -12,7 +12,7 @@ namespace APIViewWeb
     {
         public override string Name { get; } = "Swagger";
 
-        public override string Extension { get; } = ".swagger";
+        public override string[] Extensions { get; } = { ".swagger" };
 
         public override string VersionString { get; } = "0";
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/TypeSpecLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/TypeSpecLanguageService.cs
@@ -12,22 +12,22 @@ using Newtonsoft.Json;
 
 namespace APIViewWeb
 {
-    public class CadlLanguageService : LanguageProcessor
+    public class TypeSpecLanguageService : LanguageProcessor
     {
-        public override string Name { get; } = "Cadl";
+        public override string Name { get; } = "TypeSpec";
 
-        public override string Extension { get; } = ".cadl";
+        public override string Extension { get; } = ".tsp";
 
         public override string VersionString { get; } = "0";
 
         public override string ProcessName => throw new NotImplementedException();
 
-        private string _cadlSpecificPathPrefix;
+        private string _typeSpecSpecificPathPrefix;
 
-        public CadlLanguageService(IConfiguration configuration)
+        public TypeSpecLanguageService(IConfiguration configuration)
         {
             IsReviewGenByPipeline = true;
-            _cadlSpecificPathPrefix = configuration["CADL-Specification-path-prefix"] ?? "/specification";
+            _typeSpecSpecificPathPrefix = "/specification";
         }
         public override async Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis)
         {
@@ -46,20 +46,20 @@ namespace APIViewWeb
         public override bool GeneratePipelineRunParams(ReviewGenPipelineParamModel param)
         {
             var filePath = param.FileName;
-            // Verify cadl source file path is a GitHub URL to cadl package root 
+            // Verify TypeSpec source file path is a GitHub URL to TypeSpec package root 
             if (filePath == null || !filePath.StartsWith("https://github.com/"))
                 return false;
           
-            if (!filePath.Contains("/tree/") || !filePath.Contains(_cadlSpecificPathPrefix))
+            if (!filePath.Contains("/tree/") || !filePath.Contains(_typeSpecSpecificPathPrefix))
                 return false;
 
             filePath = filePath.Replace("https://github.com/", "");
             var sourceUrlparts = filePath.Split("/tree/", 2);
             param.SourceRepoName = sourceUrlparts[0];
-            sourceUrlparts = sourceUrlparts[1].Split(_cadlSpecificPathPrefix, 2);
+            sourceUrlparts = sourceUrlparts[1].Split(_typeSpecSpecificPathPrefix, 2);
             param.SourceBranchName = sourceUrlparts[0];
-            param.FileName = $"{_cadlSpecificPathPrefix}{sourceUrlparts[1]}";
-            _telemetryClient.TrackTrace($"Pipeline parameters to run CADL API rview gen pipeline: '{JsonConvert.SerializeObject(param)}'");
+            param.FileName = $"{_typeSpecSpecificPathPrefix}{sourceUrlparts[1]}";
+            _telemetryClient.TrackTrace($"Pipeline parameters to run TypeSpec API rview gen pipeline: '{JsonConvert.SerializeObject(param)}'");
 
             return true;
         }

--- a/src/dotnet/APIView/APIViewWeb/Languages/TypeSpecLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/TypeSpecLanguageService.cs
@@ -16,7 +16,7 @@ namespace APIViewWeb
     {
         public override string Name { get; } = "TypeSpec";
 
-        public override string Extension { get; } = ".tsp";
+        public override string [] Extensions { get; } = { ".tsp", ".cadl" };
 
         public override string VersionString { get; } = "0";
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/XmlLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/XmlLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.IO;
@@ -8,7 +8,7 @@ namespace APIViewWeb
     public class XmlLanguageService : LanguageProcessor
     {
         public override string Name { get; } = "Xml";
-        public override string Extension { get; } = ".xml";
+        public override string[] Extensions { get; } = { ".xml" };
         public override string ProcessName { get; } = "java";
         public override string VersionString { get; } = "apiview-java-processor-1.28.0.jar";
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml
@@ -102,7 +102,7 @@
                                     <input asp-for="Upload.Files" type="file" class="form-control" id="uploadReviewFile">
                                 </div>
                                 <div class="form-group package-selector d-none mb-3">
-                                    <input asp-for="Upload.FilePath" class="form-control" type="text" placeholder="Enter URL to package root source. For e.g. URL to CADL file">
+                                    <input asp-for="Upload.FilePath" class="form-control" type="text" placeholder="Enter URL to package root source. For e.g. URL to TypeSpec file">
                                 </div>
                                 <div class="form-group mb-3 d-none">
                                     <div class="form-check">

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml.cs
@@ -13,6 +13,7 @@ using APIViewWeb.Managers;
 using Octokit;
 using Microsoft.TeamFoundation.Common;
 using APIViewWeb.Helpers;
+using Microsoft.VisualStudio.Services.Common;
 
 namespace APIViewWeb.Pages.Assemblies
 {
@@ -170,6 +171,8 @@ namespace APIViewWeb.Pages.Assemblies
                 isApproved = null;
             }
             var offset = (pageNo - 1) * pageSize;
+
+            languages = LanguageServiceHelpers.MapLanguageAliases(languages);
 
             PagedResults = await _manager.GetPagedReviewsAsync(search, languages, isClosed, filterTypesAsInt, isApproved, offset, pageSize, sortField);
         }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Profile.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Profile.cshtml
@@ -19,7 +19,7 @@
         "dark-theme",
         "dark-solarized-theme"
     };
-    string[] Languages = { "C", "C#", "C++", "CADL", "Go", "Java", "JavaScript", "Python", "Swagger", "Swift" };
+    string[] Languages = LanguageServiceHelpers.SupportedLanguages;
     var userPreference = (TempData["UserPreference"] as UserPreferenceModel) ?? new UserPreferenceModel();
     var theme = userPreference.Theme ?? "light-theme";
 }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -112,8 +112,8 @@
                 {
                     <span class="small text-muted">Current Revision Approval Pending</span>                }
             </li>
-            @if (Model.Review.Revisions.LastOrDefault()?.Files.LastOrDefault()?.PackageName != null && 
-                 Model.Review.Language != "Swagger" && Model.Review.Language != "TypeSpec")
+            @if (Model.Review.Revisions.LastOrDefault()?.Files.LastOrDefault()?.PackageName != null &&
+            !(LanguageServiceHelpers.MapLanguageAliases(new List<string> { "Swagger", "TypeSpec" })).Contains(Model.Review.Language))
             {
                 var approver = Model.Review.ApprovedForFirstReleaseBy ?? Model.Review.Revisions.LastOrDefault(r => r.IsApproved)?.Approvers?.FirstOrDefault();
                 @if (!Model.Review.IsApprovedForFirstRelease)

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -113,7 +113,7 @@
                     <span class="small text-muted">Current Revision Approval Pending</span>                }
             </li>
             @if (Model.Review.Revisions.LastOrDefault()?.Files.LastOrDefault()?.PackageName != null && 
-                 Model.Review.Language != "Swagger" && Model.Review.Language != "Cadl")
+                 Model.Review.Language != "Swagger" && Model.Review.Language != "TypeSpec")
             {
                 var approver = Model.Review.ApprovedForFirstReleaseBy ?? Model.Review.Revisions.LastOrDefault(r => r.IsApproved)?.Approvers?.FirstOrDefault();
                 @if (!Model.Review.IsApprovedForFirstRelease)

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml
@@ -42,7 +42,7 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        @if (Model.Review.Language != "TypeSpec")
+                        @if (!(LanguageServiceHelpers.MapLanguageAliases(new List<string> { "TypeSpec" })).Contains(Model.Review.Language))
                         {
                             <div class="input-group mb-3 custom-file-label">
                                 <label class="input-group-text small" for="uploadRevisionFile">Select file to add</label>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Revisions.cshtml
@@ -42,7 +42,7 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        @if (Model.Review.Language != "Cadl")
+                        @if (Model.Review.Language != "TypeSpec")
                         {
                             <div class="input-group mb-3 custom-file-label">
                                 <label class="input-group-text small" for="uploadRevisionFile">Select file to add</label>
@@ -54,7 +54,7 @@
                             <div class="form-group mb-3">
                                 <p class="small mb-0">Select Language</p>
                                 <select asp-for="Language" id="revision-language-select">
-                                    <option selected value="Cadl">Cadl</option>
+                                    <option selected value="TypeSpec">TypeSpec</option>
                                     <option value="Json" data-content="Json">Json</option>
                                 </select>
                             </div>
@@ -63,7 +63,7 @@
                                 <input name="upload" for="upload" type="file" class="form-control" id="uploadRevisionFile">
                             </div>
                             <div class="form-group package-file-selector mb-3">
-                                <input asp-for="FilePath" class="form-control" type="text" placeholder="Enter URL to package root source. For e.g. URL to CADL file">
+                                <input asp-for="FilePath" class="form-control" type="text" placeholder="Enter URL to package root source. For e.g. URL to TypeSpec file">
                             </div>
                         }
                         <div>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewUploadHelp.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewUploadHelp.cshtml
@@ -132,10 +132,10 @@
                 </ol>
             </p>
         </div>
-        <div class="d-none" id="cadl-help">
+        <div class="d-none" id="typespec-help">
             <p class="card-text">
                 <ol>
-                    Provide URL to cadl project root path.
+                    Provide URL to typespec project root path.
                 </ol>
             </p>
         </div>

--- a/src/dotnet/APIView/APIViewWeb/README.md
+++ b/src/dotnet/APIView/APIViewWeb/README.md
@@ -60,10 +60,10 @@ You can rename a swagger file as mentioned below and upload it to APIView in cas
 1. Rename swagger json to replace file extension to .swagger `Rename-Item PetSwagger.json -NewName PetSwagger.swagger`
 2. Upload renamed `.swagger` file
 
-### CADL
-CADL API review is generated automatically from a pull request and this should be good enough in most scenarios. You can also generate API review manually for a CADL package by providing URL path to CADL package specification root path.
-1. Click and `Create Review` and select CADL from language dropdown.
-2. Provide URL to cadl project root path.
+### TypeSpec
+TypeSpec API review is generated automatically from a pull request and this should be good enough in most scenarios. You can also generate API review manually for a TypeSpec package by providing URL path to TypeSpec package specification root path.
+1. Click and `Create Review` and select TypeSpec from language dropdown.
+2. Provide URL to typespec project root path.
 
 
 ## How does it retrieve public API information

--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -113,7 +113,7 @@ namespace APIViewWeb
             services.AddSingleton<LanguageService, SwaggerLanguageService>();
             services.AddSingleton<LanguageService, SwiftLanguageService>();
             services.AddSingleton<LanguageService, XmlLanguageService>();
-            services.AddSingleton<LanguageService, CadlLanguageService>();
+            services.AddSingleton<LanguageService, TypeSpecLanguageService>();
 
             if (Environment.IsDevelopment() && Configuration["AuthenticationScheme"] == "Test")
             {


### PR DESCRIPTION
CADL to TypeSpec rename. Should resolve https://github.com/Azure/azure-sdk-tools/issues/5635

Blocked by:
Updates to https://github.com/Azure/azure-sdk-tools/blob/7c10ce5ef4641263b81e775aa181d82750a83da1/src/dotnet/APIView/APIViewWeb/Languages/CadlLanguageService.cs
Updated to DataBase