### PR TITLE
Remove remaining bare `pip install` usage

### DIFF
--- a/eng/pipelines/apiview-review-gen-python.yml
+++ b/eng/pipelines/apiview-review-gen-python.yml
@@ -35,8 +35,8 @@ jobs:
       versionSpec: '$(PythonVersion)'
 
   - script: |
-      pip install virtualenv aiohttp chardet trio
-      pip install api-stub-generator==$(ApiStubVersion) --index-url $(PythonIndexUrl)
+      python -m pip install virtualenv aiohttp chardet trio
+      python -m pip install api-stub-generator==$(ApiStubVersion) --index-url $(PythonIndexUrl)
     displayName: 'Install api-stub-generator'
 
   - template: /eng/pipelines/templates/steps/apiview-review-gen.yml

--- a/eng/pipelines/doc-warden.yml
+++ b/eng/pipelines/doc-warden.yml
@@ -37,8 +37,8 @@ jobs:
       versionSpec: 3.6
 
   - script: |
-     pip install setuptools 
-     pip install wheel twine readme-renderer[md]
+     python -m pip install setuptools 
+     python -m pip install wheel twine readme-renderer[md]
     displayName: 'Prep Environment'
 
   - script: |
@@ -87,8 +87,8 @@ jobs:
       versionSpec: 3.6
 
   - script: |
-      pip install setuptools 
-      pip install wheel twine readme-renderer[md]
+      python -m pip install setuptools 
+      python -m pip install wheel twine readme-renderer[md]
 
       cd $(Build.SourcesDirectory)
       mkdir sdk-for-js
@@ -103,7 +103,7 @@ jobs:
     displayName: 'Setup Environment'
 
   - script: |
-      pip install -e $(Build.SourcesDirectory)/packages/python-packages/doc-warden/
+      python -m pip install -e $(Build.SourcesDirectory)/packages/python-packages/doc-warden/
     displayName: 'Install doc-warden'
 
   - script: |

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -34,7 +34,7 @@ jobs:
 
       - script: |
           set -e
-          pip install -r $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages_requirements.txt
+          python -m pip install -r $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages_requirements.txt
         displayName: Install Requirements
 
       - pwsh: |

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
@@ -37,7 +37,7 @@ stages:
 
           - script: |
               python --version
-              pip install virtualenv aiohttp chardet trio setuptools wheel packaging
+              python -m pip install virtualenv aiohttp chardet trio setuptools wheel packaging
             displayName: 'Setup Python Environment'
 
           - pwsh: |
@@ -85,7 +85,7 @@ stages:
 
         - script: |
             set -e
-            pip install twine
+            python -m pip install twine
           displayName: Install Twine
 
         - task: TwineAuthenticate@0

--- a/eng/pipelines/templates/steps/use-python-version.yml
+++ b/eng/pipelines/templates/steps/use-python-version.yml
@@ -9,7 +9,7 @@ steps:
       versionSpec: 3.8
 
   - pwsh: |
-      pip install packaging==20.4
+      python -m pip install packaging==20.4
     displayName: Prep Environment
 
   # select the appropriate version from manifest if present

--- a/packages/python-packages/api-stub-generator/ci.yml
+++ b/packages/python-packages/api-stub-generator/ci.yml
@@ -36,6 +36,6 @@ extends:
 
     - script: |
         cd $(Build.SourcesDirectory)/packages/python-packages/api-stub-generator
-        pip install tox
+        python -m pip install tox
         tox -e pytest,stubgen
       displayName: Run APIView tests

--- a/src/dotnet/APIView/apiview-sync-staging.yml
+++ b/src/dotnet/APIView/apiview-sync-staging.yml
@@ -39,6 +39,6 @@ stages:
 
         - script: |
             cd $(Build.SourcesDirectory)/eng/python/apiview-syncdb/
-            pip install -r requirements.txt
+            python -m pip install -r requirements.txt
             python ./sync_cosmosdb.py --dest-url $(apiview-staging-cosmos-url) --dest-key $(apiview-staging-cosmos-key) --db-name $(apiview-cosmosdb-name) --backup-connection-string $(apiview-cosmos-backup-connection)
           displayName: Sync CosmosDB

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -97,7 +97,7 @@ stages:
 
           - script: |
               python --version
-              pip install virtualenv aiohttp chardet trio
+              python -m pip install virtualenv aiohttp chardet trio
             displayName: 'Setup Python Environment'
 
           - pwsh: |

--- a/tools/pylint-extensions/pylint-guidelines-checker/ci.yml
+++ b/tools/pylint-extensions/pylint-guidelines-checker/ci.yml
@@ -31,8 +31,8 @@ extends:
     PackageName: 'Azure SDK Pylint Plugin'
     TestSteps:
     - script: |
-        pip install -r dev_requirements.txt
-        pip install -e .
+        python -m pip install -r dev_requirements.txt
+        python -m pip install -e .
       displayName: 'Install Test Requirements'
       workingDirectory: $(Build.SourcesDirectory)/tools/pylint-extensions/pylint-guidelines-checker
 

--- a/tools/test-proxy/tests.yml
+++ b/tools/test-proxy/tests.yml
@@ -205,8 +205,8 @@ stages:
             rootFolder: $(CLONE_LOCATION)
 
         - pwsh: |
-            pip install -r dev_requirements.txt
-            pip install .
+            python -m pip install -r dev_requirements.txt
+            python -m pip install .
           displayName: 'Install requirements and package'
           workingDirectory: $(CLONE_LOCATION)/sdk/tables/azure-data-tables/
 


### PR DESCRIPTION
In favor of calling the pip module via `python -m `.

This should be an entirely 1:1 change. I don't expect any new issues from this.