### PR TITLE
Add default output to call to `trust-proxy-certificate.ps1`

### DIFF
--- a/eng/common/scripts/trust-proxy-certificate.ps1
+++ b/eng/common/scripts/trust-proxy-certificate.ps1
@@ -5,5 +5,5 @@ if ($TestProxyTrustCertFn -and (Test-Path "Function:$TestProxyTrustCertFn"))
     &$TestProxyTrustCertFn
 }
 else {
-    Write-Host "No implementation of TestProxyTrustCertFn provided in eng/scripts/Language-Settings.ps1"
+    Write-Host "No implementation of Import-Dev-Cert-<language> provided in eng/scripts/Language-Settings.ps1."
 }

--- a/eng/common/scripts/trust-proxy-certificate.ps1
+++ b/eng/common/scripts/trust-proxy-certificate.ps1
@@ -4,3 +4,6 @@ if ($TestProxyTrustCertFn -and (Test-Path "Function:$TestProxyTrustCertFn"))
 {
     &$TestProxyTrustCertFn
 }
+else {
+    Write-Host "No implementation of TestProxyTrustCertFn provided in eng/scripts/Language-Settings.ps1"
+}

--- a/eng/common/scripts/trust-proxy-certificate.ps1
+++ b/eng/common/scripts/trust-proxy-certificate.ps1
@@ -4,6 +4,7 @@ if ($TestProxyTrustCertFn -and (Test-Path "Function:$TestProxyTrustCertFn"))
 {
     &$TestProxyTrustCertFn
 }
-else {
+else 
+{
     Write-Host "No implementation of Import-Dev-Cert-<language> provided in eng/scripts/Language-Settings.ps1."
 }


### PR DESCRIPTION
[Query of failures graciously provided by @benbp](https://dataexplorer.azure.com/clusters/azsdkengsys.westus2/databases/Pipelines?query=H4sIAAAAAAAAA2WPTU/DMAyG7/sVVk4taputnYaYVBC7IXFAgztKE7fL6JIocZlA/Hj6gdimXXyw/fp5vOl0q970AVttcIvSejXj/AeOO/QIryQ8DVOokI6IBiIlCKnvRPk8L9J5kS6WMWQZXPdXcTy7PnQPorHRYqniM84WnQ2arP96UlCWwB6/O49cDDUN6iOtrU+lc+wssxnMp/V8VeTF3e0/7QakNSS0CcCehWk60fQKDqWutWQgjOqJoWtpZNVCt6hYn3be7lHSyTa5MEsgkJeCIrYjcmHNucLPbJTMpD2cdDlL4GW6NaQYf68GWe5HaHioJvWyX/v7Iv4Fh2EaS4gBAAA=)

This is occurring _most often_ when there is no output from this script due to no implementation of `Import-Dev-Cert-<Language>`. This _should not be failing_ and I truly believe this is a devops issue, but in the meantime perhaps this can reduce incidence.