### PR TITLE
Add retry on specific git output

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitProcessHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitProcessHandlerTests.cs
@@ -15,6 +15,62 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             DebugLogger.ConfigureLogger(loggerFactory);
         }
 
+        const string longTimeOutError = @"
+            Cloning into '.'...
+            fatal: unable to access 'https://github.com/Azure/azure-sdk-assets/': Failed to connect to github.com port 443: Operation timed out
+
+
+            at Azure.Sdk.Tools.TestProxy.Store.GitStore.InitializeAssetsRepo(GitAssetsConfiguration config, Boolean forceInit) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs:line 456
+            at Azure.Sdk.Tools.TestProxy.Store.GitStore.Restore(String pathToAssetsJson) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs:line 152
+            at Azure.Sdk.Tools.TestProxy.Startup.Run(Object commandObj) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs:line 154
+            at CommandLine.ParserResultExtensions.WithParsedAsync[T](ParserResult`1 result, Func`2 action)
+            at Azure.Sdk.Tools.TestProxy.Startup.Main(String[] args) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs:line 67
+            at Azure.Sdk.Tools.TestProxy.Startup.<Main>(String[] args)";
+
+        const string tooManyRequestsError = @"fatal: unable to access 'https://github.com/Azure/azure-sdk-assets/': The requested URL returned error: 429
+        fatal: could not fetch 26bfd3d8ada54a78573cb64f6fa79c8d4a300c8c from promisor remote
+
+             at Azure.Sdk.Tools.TestProxy.Store.GitStore.CheckoutRepoAtConfig(GitAssetsConfiguration config) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs:line 330
+             at Azure.Sdk.Tools.TestProxy.Store.GitStore.InitializeAssetsRepo(GitAssetsConfiguration config, Boolean forceInit) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs:line 459
+             at Azure.Sdk.Tools.TestProxy.Store.GitStore.Restore(String pathToAssetsJson) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs:line 152
+             at Azure.Sdk.Tools.TestProxy.RecordingHandler.RestoreAssetsJson(String assetsJson, Boolean forceCheckout) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs:line 164
+             at Azure.Sdk.Tools.TestProxy.RecordingHandler.StartPlaybackAsync(String sessionId, HttpResponse outgoingResponse, RecordingType mode, String assetsPath) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs:line 373
+             at Azure.Sdk.Tools.TestProxy.Playback.Start() in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs:line 46
+             at lambda_method37(Closure , Object )";
+
+        const string longTimeOutWithValue = @"fatal: unable to access 'https://github.com/Azure/azure-sdk-assets/': Failed to connect to github.com port 443 after 21019 ms: Couldn't connect to server
+      fatal: could not fetch 87d05b71fcffcf3c7fa8e611bda09b505ff586a4 from promisor remote
+
+
+         at Azure.Sdk.Tools.TestProxy.Store.GitStore.CheckoutRepoAtConfig(GitAssetsConfiguration config) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs:line 330
+         at Azure.Sdk.Tools.TestProxy.Store.GitStore.InitializeAssetsRepo(GitAssetsConfiguration config, Boolean forceInit) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs:line 459
+         at Azure.Sdk.Tools.TestProxy.Store.GitStore.Restore(String pathToAssetsJson) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs:line 152
+         at Azure.Sdk.Tools.TestProxy.RecordingHandler.RestoreAssetsJson(String assetsJson, Boolean forceCheckout) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs:line 164
+         at Azure.Sdk.Tools.TestProxy.RecordingHandler.StartPlaybackAsync(String sessionId, HttpResponse outgoingResponse, RecordingType mode, String assetsPath) in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs:line 373
+         at Azure.Sdk.Tools.TestProxy.Playback.Start() in /mnt/vss/_work/1/s/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs:line 46
+         at lambda_method37(Closure , Object )";
+
+        [Theory]
+        [InlineData("", longTimeOutError, 1, true)]
+        [InlineData("", tooManyRequestsError, 1, true)]
+        [InlineData("", longTimeOutWithValue, 1, true)]
+        [InlineData("", "fatal: unable to access 'https://github.com/Azure/azure-sdk-assets/': Failed to connect to github.com port 443 after 1 ms: Couldn't connect to server", 1, true)]
+        [InlineData("", "fatal: unable to access 'https://github.com/Azure/azure-sdk-assets/': Failed to connect to github.com port 443 after 0 ms: Couldn't connect to server", 1, true)]
+        [InlineData("", "fatal: unable to access 'https://github.com/Azure/azure-sdk-assets/': Failed to connect to github.com port 443 after ms: Couldn't connect to server", 1, false)]
+        [InlineData("", "", 0, false)]
+        public void VerifyGitExceptionParser(string inputStdOut, string inputStdErr, int exitCode, bool expectedResult)
+        {
+            var processHandler = new GitProcessHandler();
+            var commandResult = new CommandResult();
+            commandResult.StdOut = inputStdOut;
+            commandResult.StdErr = inputStdErr;
+            commandResult.ExitCode = exitCode;
+
+            var checkResult = processHandler.IsRetriableGitError(commandResult);
+
+            Assert.Equal(expectedResult, checkResult);
+        }
+
         [Theory]
         // 2.37.0 is the min version of git required by the TestProxy
         // Windows git version strings

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -1,15 +1,11 @@
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
-using Microsoft.Extensions.Internal;
-using NuGet.Protocol.Core.Types;
 
 namespace Azure.Sdk.Tools.TestProxy.Store
 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -4,6 +4,8 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
+using System.Threading;
+using System.Threading.Tasks;
 using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
 
@@ -176,9 +178,16 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                             {
                                 break;
                             }
-                            if (!IsRetriableGitError(result))
+                            var continueToAttempt = IsRetriableGitError(result);
+
+                            if (!continueToAttempt)
                             {
                                 throw new GitProcessException(result);
+                            }
+
+                            if (continueToAttempt)
+                            {
+                                Task.Delay(attempts * 2 * 1000).Wait();
                             }
                             attempts++;
                         }
@@ -325,6 +334,11 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                                 break;
                             }
                             continueToAttempt = IsRetriableGitError(commandResult);
+
+                            if (continueToAttempt)
+                            {
+                                Task.Delay(attempts * 2 * 1000).Wait();
+                            }
                             attempts++;
                         }
                     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -213,7 +213,6 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// Check Azure/azure-sdk-tools#5660 for additional detail on occurrence.
         /// </summary>
         /// <param name="result"></param>
-        /// <param name="repoId">The id of the git repo being retrieved from. Used within format string to assist pattern matching errors.</param>
         /// <returns></returns>
         public bool IsRetriableGitError(CommandResult result)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -128,8 +128,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 try
                 {
                     int attempts = 1;
-                    bool continueToAttempt = true;
-                    while (continueToAttempt && attempts <= RETRY_INTERMITTENT_FAILURE_COUNT)
+                    while (attempts <= RETRY_INTERMITTENT_FAILURE_COUNT)
                     {
                         DebugLogger.LogInformation($"git {arguments}");
 
@@ -177,14 +176,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                             {
                                 break;
                             }
-                            else if (result.ExitCode != 0)
+                            if (!IsRetriableGitError(result))
                             {
-                                continueToAttempt = IsRetriableGitError(result);
-
-                                if(!continueToAttempt)
-                                {
-                                    throw new GitProcessException(result);
-                                }
+                                throw new GitProcessException(result);
                             }
                             attempts++;
                         }
@@ -330,10 +324,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                             {
                                 break;
                             }
-                            else if (commandResult.ExitCode != 0)
-                            {
-                                continueToAttempt = IsRetriableGitError(commandResult);
-                            }
+                            continueToAttempt = IsRetriableGitError(commandResult);
                             attempts++;
                         }
                     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -129,7 +129,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 {
                     int attempts = 1;
                     bool continueToAttempt = true;
-                    while (attempts <= RETRY_INTERMITTENT_FAILURE_COUNT)
+                    while (continueToAttempt && attempts <= RETRY_INTERMITTENT_FAILURE_COUNT)
                     {
                         DebugLogger.LogInformation($"git {arguments}");
 
@@ -279,7 +279,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 {
                     int attempts = 1;
                     bool continueToAttempt = true;
-                    while (attempts <= RETRY_INTERMITTENT_FAILURE_COUNT)
+                    while (continueToAttempt && attempts <= RETRY_INTERMITTENT_FAILURE_COUNT)
                     {
                         DebugLogger.LogInformation($"git {arguments}");
                         var output = new List<string>();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitProcessHandler.cs
@@ -4,7 +4,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Text.RegularExpressions;
-using System.Threading;
 using System.Threading.Tasks;
 using Azure.Sdk.Tools.TestProxy.Common;
 using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
@@ -185,11 +184,12 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                                 throw new GitProcessException(result);
                             }
 
-                            if (continueToAttempt)
+                            attempts++;
+
+                            if (continueToAttempt && attempts < RETRY_INTERMITTENT_FAILURE_COUNT)
                             {
                                 Task.Delay(attempts * 2 * 1000).Wait();
                             }
-                            attempts++;
                         }
                     }
                 }
@@ -335,11 +335,11 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                             }
                             continueToAttempt = IsRetriableGitError(commandResult);
 
-                            if (continueToAttempt)
+                            attempts++;
+                            if (continueToAttempt && attempts < RETRY_INTERMITTENT_FAILURE_COUNT)
                             {
                                 Task.Delay(attempts * 2 * 1000).Wait();
                             }
-                            attempts++;
                         }
                     }
                 }


### PR DESCRIPTION
Attempts to address #5660

Given the fact that we're shelling out and the exit code isn't different for every error, this looks like the way to go.