### PR TITLE
Update github-event-processor's ci.yml triggers to only include main

### DIFF
--- a/tools/github-event-processor/YmlAndConfigFiles/event-processor.yml
+++ b/tools/github-event-processor/YmlAndConfigFiles/event-processor.yml
@@ -62,6 +62,7 @@ jobs:
           --version 1.0.0-dev.20230313.4
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
+        working-directory: .github/workflows
         shell: bash
       # End-Install
 

--- a/tools/github-event-processor/YmlAndConfigFiles/scheduled-event-processor.yml
+++ b/tools/github-event-processor/YmlAndConfigFiles/scheduled-event-processor.yml
@@ -39,6 +39,7 @@ jobs:
           --version 1.0.0-dev.20230313.4
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
+        working-directory: .github/workflows
         shell: bash
       # End-Install
 

--- a/tools/github-event-processor/ci.yml
+++ b/tools/github-event-processor/ci.yml
@@ -3,9 +3,6 @@ trigger:
   branches:
     include:
       - main
-      - feature/*
-      - release/*
-      - hotfix/*
   paths:
     include:
       - tools/github-event-processor


### PR DESCRIPTION
Clean up the triggers so the CI build only happens in main.

Also added a working-directory to the install steps in the actions yml files. It turns out, on Linux and Mac, dotnet tool install will fail it the working directory has any proj files in. This is, apparently, [a known issue](https://github.com/dotnet/sdk/issues/9623#issuecomment-1476692192) that's been around for several years.