### PR TITLE
Update the scheduled event governor based upon the actions rate limit

### DIFF
--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
@@ -458,14 +458,14 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests
 
         /// <summary>
         /// Override for the GitHubEventClient funcion which computes this based upon the repository's core rate limit.
-        /// Since this isn't necessary for the tests, just return the ActionRateLimitNonEnterprise/10.
+        /// Since this isn't necessary for the tests, just return the 100 which is the size of one page.
         /// </summary>
         /// <returns>int</returns>
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
         public override async Task<int> ComputeScheduledTaskUpdateLimit()
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
-            return RateLimitConstants.ActionRateLimitNonEnterprise/10;
+            return 100;
         }
     }
 }

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
@@ -455,5 +455,17 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests
         {
             return _gitHubIssuesToLock;
         }
+
+        /// <summary>
+        /// Override for the GitHubEventClient funcion which computes this based upon the repository's core rate limit.
+        /// Since this isn't necessary for the tests, just return the ActionRateLimitNonEnterprise/10.
+        /// </summary>
+        /// <returns>int</returns>
+#pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
+        public override async Task<int> ComputeScheduledTaskUpdateLimit()
+#pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
+        {
+            return RateLimitConstants.ActionRateLimitNonEnterprise/10;
+        }
     }
 }

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Constants/RateLimitConstants.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Constants/RateLimitConstants.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.GitHubEventProcessor.Constants
+{
+    public class RateLimitConstants
+    {
+        // https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
+        // When using the GITHUB_TOKEN the number of Actions per hour for an Enterprise repository is 15000/hour
+        public const int ActionRateLimitEnterprise = 15000;
+        // When using the GITHUB_TOKEN the number of Actions per hour for an Non-enterprise repository is 1000/hour
+        public const int ActionRateLimitNonEnterprise = 1000;
+
+        // https://docs.github.com/en/rest/search?apiVersion=2022-11-28#about-search
+        // The SearchIssues API has a rate limit of 1000 results which resets every 60 seconds
+        public const int SearchIssuesRateLimit = 1000;
+    }
+}

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Constants/RateLimitConstants.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Constants/RateLimitConstants.cs
@@ -8,12 +8,6 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Constants
 {
     public class RateLimitConstants
     {
-        // https://docs.github.com/en/rest/overview/resources-in-the-rest-api?apiVersion=2022-11-28#rate-limits-for-requests-from-github-actions
-        // When using the GITHUB_TOKEN the number of Actions per hour for an Enterprise repository is 15000/hour
-        public const int ActionRateLimitEnterprise = 15000;
-        // When using the GITHUB_TOKEN the number of Actions per hour for an Non-enterprise repository is 1000/hour
-        public const int ActionRateLimitNonEnterprise = 1000;
-
         // https://docs.github.com/en/rest/search?apiVersion=2022-11-28#about-search
         // The SearchIssues API has a rate limit of 1000 results which resets every 60 seconds
         public const int SearchIssuesRateLimit = 1000;

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
@@ -125,6 +125,8 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
         // for action processing which uses a shared event.
         protected List<GitHubIssueToUpdate> _gitHubIssuesToUpdate = new List<GitHubIssueToUpdate>();
 
+        public int CoreRateLimit { get; set; } = 0;
+
         public RulesConfiguration RulesConfiguration
         {
             get { return _rulesConfiguration; }
@@ -267,6 +269,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
         public async Task WriteRateLimits(string prependMessage = null)
         {
             var miscRateLimit = await GetRateLimits();
+            CoreRateLimit = miscRateLimit.Resources.Core.Limit;
             // Get the Minutes till reset.
             TimeSpan span = miscRateLimit.Resources.Core.Reset.UtcDateTime.Subtract(DateTime.UtcNow);
             // In the message, cast TotalMinutes to an int to get a whole number of minutes.
@@ -279,10 +282,37 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
         }
 
         /// <summary>
-        /// Write the current rate limit and remaining number of transactions.
+        /// Return the number of updates a scheduled task can make. The Core Rate Limit that GitHub Actions can make is 15000/hour
+        /// for enterprise and 1000/hour for non-enterprise. The max number of results that can be retried from SearchIssues is 1000.
+        /// The CoreRateLimit is set when WriteRateLimits is called and this is done at the start of processing in Main. If the core
+        /// rate limit is 15000, return 1000, otherwise return 100 which is 1/10th of the hourly limit for non-enterprise repository.
         /// </summary>
-        /// <param name="prependMessage">Optional message to prepend to the rate limit message.</param>
-        public async Task WriteSearchRateLimits(string prependMessage = null)
+        /// <returns>The number updates a scheduled task can make.</returns>
+        public virtual async Task<int> ComputeScheduledTaskUpdateLimit()
+        {
+            // CoreRateLimit will be set in WriteRateLimits but if that hasn't been called yet, call it now.
+            if (CoreRateLimit == 0)
+            {
+                var miscRateLimit = await GetRateLimits();
+                CoreRateLimit = miscRateLimit.Resources.Core.Limit;
+            }
+            // If the repository is an enterprise repository allow the max number search results, 1000, to be processed.
+            if (CoreRateLimit == RateLimitConstants.ActionRateLimitEnterprise)
+            {
+                return RateLimitConstants.SearchIssuesRateLimit;
+            }
+            else
+            {
+                // For non-enterprise return 1/10th of the non-enterprise rate limit
+                return RateLimitConstants.ActionRateLimitNonEnterprise/10;
+            }
+        }
+
+    /// <summary>
+    /// Write the current rate limit and remaining number of transactions.
+    /// </summary>
+    /// <param name="prependMessage">Optional message to prepend to the rate limit message.</param>
+    public async Task WriteSearchRateLimits(string prependMessage = null)
         {
             var miscRateLimit = await GetRateLimits();
             // Get the Seconds till reset. Unlike the core rate limit which resets every hour, the search rate limit

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
@@ -290,29 +290,28 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
         /// <returns>The number updates a scheduled task can make.</returns>
         public virtual async Task<int> ComputeScheduledTaskUpdateLimit()
         {
+            int updateLimit = 0;
+
             // CoreRateLimit will be set in WriteRateLimits but if that hasn't been called yet, call it now.
             if (CoreRateLimit == 0)
             {
                 var miscRateLimit = await GetRateLimits();
                 CoreRateLimit = miscRateLimit.Resources.Core.Limit;
             }
-            // If the repository is an enterprise repository allow the max number search results, 1000, to be processed.
-            if (CoreRateLimit == RateLimitConstants.ActionRateLimitEnterprise)
+            updateLimit = CoreRateLimit / 10;
+            if (updateLimit > RateLimitConstants.SearchIssuesRateLimit)
             {
-                return RateLimitConstants.SearchIssuesRateLimit;
+                updateLimit = RateLimitConstants.SearchIssuesRateLimit;
             }
-            else
-            {
-                // For non-enterprise return 1/10th of the non-enterprise rate limit
-                return RateLimitConstants.ActionRateLimitNonEnterprise/10;
-            }
+            Console.WriteLine($"Setting the scheduled task update limit to: {updateLimit}");
+            return updateLimit;
         }
 
-    /// <summary>
-    /// Write the current rate limit and remaining number of transactions.
-    /// </summary>
-    /// <param name="prependMessage">Optional message to prepend to the rate limit message.</param>
-    public async Task WriteSearchRateLimits(string prependMessage = null)
+        /// <summary>
+        /// Write the current rate limit and remaining number of transactions.
+        /// </summary>
+        /// <param name="prependMessage">Optional message to prepend to the rate limit message.</param>
+        public async Task WriteSearchRateLimits(string prependMessage = null)
         {
             var miscRateLimit = await GetRateLimits();
             // Get the Seconds till reset. Unlike the core rate limit which resets every hour, the search rate limit


### PR DESCRIPTION
Previously, I was ulta-conservative on the governor for scheduled events. The limit was set to 100 items per scheduled task run which is still correct for non-enterprise repository actions. For enterprise, however, the actions rate limit is 15,000 and, in that case, we can allow the scheduled tasks to process up to 1000, which is the number of results you can get back from search calls in a given time without hitting the secondary rate limit.

I also put the scheduled event into a try/finally since, we can hit the secondary rate limit on subsequent calls to get the next page of results. If that happens, we still need to process any pending changes made from previous pages of search results, if there are any.