### PR TITLE
Fix issue in email notification when override email is not set

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
@@ -15,8 +15,8 @@ using APIViewWeb.Repositories;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights;
 using System.Net.Http;
-using System.Net.Http.Json;
-using Newtonsoft.Json;
+using System.Text.Json;
+
 
 namespace APIViewWeb.Managers
 {
@@ -223,7 +223,7 @@ namespace APIViewWeb.Managers
             var httpClient = new HttpClient();
             try
             {
-                var requestBodyJson = JsonConvert.SerializeObject(requestBody);
+                var requestBodyJson = JsonSerializer.Serialize(requestBody);
                 _telemetryClient.TrackTrace($"Sending email address request to logic apps. request: {requestBodyJson}");
                 var response = await httpClient.PostAsync(_emailSenderServiceUrl, new StringContent(requestBodyJson, Encoding.UTF8, "application/json"));
                 if (response.StatusCode !=  HttpStatusCode.OK && response.StatusCode != HttpStatusCode.Accepted)

--- a/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
@@ -16,6 +16,7 @@ using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights;
 using System.Net.Http;
 using System.Net.Http.Json;
+using Newtonsoft.Json;
 
 namespace APIViewWeb.Managers
 {
@@ -217,12 +218,14 @@ namespace APIViewWeb.Managers
                 _telemetryClient.TrackTrace($"Email sender service URL is not configured. Email will not be sent to {emailToList} with subject: {subject}");
                 return;
             }
-
-            var requestBody = new EmailModel(_testEmailToAddress ?? emailToList, subject, content);
+            var emailToAddress = !string.IsNullOrEmpty(_testEmailToAddress) ? _testEmailToAddress : emailToList;
+            var requestBody = new EmailModel(emailToAddress, subject, content);
             var httpClient = new HttpClient();
             try
             {
-                var response = await httpClient.PostAsync(_emailSenderServiceUrl, JsonContent.Create<EmailModel>(requestBody));
+                var requestBodyJson = JsonConvert.SerializeObject(requestBody);
+                _telemetryClient.TrackTrace($"Sending email address request to logic apps. request: {requestBodyJson}");
+                var response = await httpClient.PostAsync(_emailSenderServiceUrl, new StringContent(requestBodyJson, Encoding.UTF8, "application/json"));
                 if (response.StatusCode !=  HttpStatusCode.OK && response.StatusCode != HttpStatusCode.Accepted)
                 {
                     _telemetryClient.TrackTrace($"Failed to send email to user {emailToList} with subject: {subject}, status code: {response.StatusCode}, Details: {response.ToString}");


### PR DESCRIPTION
- Add trace for each email notification
- Fix issue when override email address for testing is empty. Currently request is sent to logic app with empty email address.