### PR TITLE
Convert Inline Table Rows to Individual CodeLines

### DIFF
--- a/eng/pipelines/templates/steps/apiview-ui-tests.yml
+++ b/eng/pipelines/templates/steps/apiview-ui-tests.yml
@@ -1,7 +1,4 @@
 parameters:
-  - name: TestingDataContainer
-    type: string
-    default: 'https://apiviewuitest.blob.core.windows.net/testingdata'
   - name: NodeVersion
     type: string
     default: ''
@@ -53,31 +50,8 @@ steps:
     AZURE_TENANT_ID: "$(apiview-appconfig-tenant-id)"
     AZURE_CLIENT_SECRET: "$(apiview-appconfig-client-secret)"
     APIVIEW_APPROVERS: "azure-sdk"
-
-- task: Powershell@2
-  inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/scripts/copy-from-blobstorage.ps1
-    arguments: >
-      -SourceBlobPath '${{ parameters.TestingDataContainer }}'
-      -ApplicationId $(apiviewstorageaccess-application-id)
-      -DestinationDirectory $(Build.BinariesDirectory)
-    pwsh: true
-  displayName: 'Copy from Test Files From Blob'
-  env:
-    AZCOPY_SPA_CLIENT_SECRET: $(apiviewstorageaccess-service-principal-key)
-
-- task: Powershell@2
-  inputs:
-    filePath: $(Build.SourcesDirectory)/eng/common/scripts/copy-from-blobstorage.ps1
-    arguments: >
-      -SourceBlobPath '${{ parameters.TestingDataContainer }}'
-      -ApplicationId $(apiviewstorageaccess-application-id)
-      -DestinationDirectory $(Build.BinariesDirectory)
-    pwsh: true
-  displayName: 'Copy from Test Files From Blob'
-  env:
-    AZCOPY_SPA_CLIENT_SECRET: $(apiviewstorageaccess-service-principal-key)
-
+    APIVIEW_SWAGGERMETADATABACKGROUNDTASKDISABLED: "true"
+    
 - task: DotNetCoreCLI@2
   displayName: 'Build & Test (UI)'
   env:

--- a/eng/pipelines/templates/steps/apiview-ui-tests.yml
+++ b/eng/pipelines/templates/steps/apiview-ui-tests.yml
@@ -1,4 +1,7 @@
 parameters:
+  - name: TestingDataContainer
+    type: string
+    default: 'https://apiviewuitest.blob.core.windows.net/testingdata'
   - name: NodeVersion
     type: string
     default: ''
@@ -51,6 +54,18 @@ steps:
     AZURE_CLIENT_SECRET: "$(apiview-appconfig-client-secret)"
     APIVIEW_APPROVERS: "azure-sdk"
     APIVIEW_SWAGGERMETADATABACKGROUNDTASKDISABLED: "true"
+
+- task: Powershell@2
+  inputs:
+    filePath: $(Build.SourcesDirectory)/eng/common/scripts/copy-from-blobstorage.ps1
+    arguments: >
+      -SourceBlobPath '${{ parameters.TestingDataContainer }}'
+      -ApplicationId $(apiviewstorageaccess-application-id)
+      -DestinationDirectory $(Build.BinariesDirectory)
+    pwsh: true
+  displayName: 'Copy from Test Files From Blob'
+  env:
+    AZCOPY_SPA_CLIENT_SECRET: $(apiviewstorageaccess-service-principal-key)
     
 - task: DotNetCoreCLI@2
   displayName: 'Build & Test (UI)'

--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -44,6 +44,7 @@ namespace ApiView
             (int Count, int Curr) tableRowCount = (0, 0);
             TreeNode<CodeLine> section = null;
             int leafSectionPlaceHolderNumber = 0;
+            bool skipNewLine = false;
 
             foreach (var token in node)
             {
@@ -57,7 +58,14 @@ namespace ApiView
                 switch (token.Kind)
                 {
                     case CodeFileTokenKind.Newline:
-                        CaptureCodeLine(list, sections, nodesInProcess, ref section, stringBuilder, ref lineNumber, ref leafSectionPlaceHolderNumber, ref currentId, isDocumentationRange, isHiddenApiToken);
+                        if (skipNewLine)
+                        {
+                            skipNewLine = false;
+                        }
+                        else 
+                        {
+                            CaptureCodeLine(list, sections, nodesInProcess, ref section, stringBuilder, ref lineNumber, ref leafSectionPlaceHolderNumber, ref currentId, isDocumentationRange, isHiddenApiToken);
+                        }
                         break;
 
                     case CodeFileTokenKind.DocumentRangeStart:
@@ -191,6 +199,7 @@ namespace ApiView
                         break;
 
                     case CodeFileTokenKind.TableEnd:
+                        skipNewLine = true;
                         break;
 
                     case CodeFileTokenKind.LeafSectionPlaceholder:

--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -33,6 +33,7 @@ namespace ApiView
         {
             var stringBuilder = new StringBuilder();
             string currentId = null;
+            string currentTableId = null;
             bool isDocumentationRange = false;
             bool isHiddenApiToken = false;
             bool isDeprecatedToken = false;
@@ -56,43 +57,7 @@ namespace ApiView
                 switch (token.Kind)
                 {
                     case CodeFileTokenKind.Newline:
-                        int ? sectionKey = (nodesInProcess.Count > 0 && section == null) ? sections.Count: null;
-                        CodeLine codeLine = new CodeLine(stringBuilder.ToString(), currentId, String.Empty, ++lineNumber, sectionKey, isDocumentation: isDocumentationRange, isHiddenApi: isHiddenApiToken);
-                        if (leafSectionPlaceHolderNumber != 0)
-                        {
-                            lineNumber += leafSectionPlaceHolderNumber - 1;
-                            leafSectionPlaceHolderNumber = 0;
-                        }
-                        if (nodesInProcess.Count > 0)
-                        {
-                            if (nodesInProcess.Peek().Equals(SectionType.Heading))
-                            {
-                                if (section == null)
-                                {
-                                    section = new TreeNode<CodeLine>(codeLine);
-                                    list.Add(codeLine);
-                                }
-                                else
-                                {
-                                    section = section.AddChild(codeLine);
-                                }
-                            }
-                            else
-                            {
-                                section.AddChild(codeLine);
-                            }
-                        }
-                        else
-                        {
-                            if (section != null)
-                            {
-                                sections.Add(sections.Count, section);
-                                section = null;
-                            }
-                            list.Add(codeLine);
-                        }
-                        currentId = null;
-                        stringBuilder.Clear();
+                        CaptureCodeLine(list, sections, nodesInProcess, ref section, stringBuilder, ref lineNumber, ref leafSectionPlaceHolderNumber, ref currentId, isDocumentationRange, isHiddenApiToken);
                         break;
 
                     case CodeFileTokenKind.DocumentRangeStart:
@@ -154,8 +119,7 @@ namespace ApiView
                         break;
 
                     case CodeFileTokenKind.TableBegin:
-                        stringBuilder.Append("<table class=\"table table-sm\">");
-                        currentId = (token.DefinitionId != null) ? token.DefinitionId : currentId;
+                        currentTableId = (token.DefinitionId != null) ? token.DefinitionId : currentId;
                         break;
 
                     case CodeFileTokenKind.TableColumnCount:
@@ -171,25 +135,27 @@ namespace ApiView
                     case CodeFileTokenKind.TableColumnName:
                         if (tableColumnCount.Curr == 0)
                         {
-                            stringBuilder.Append($"<thead><tr>");
-                            stringBuilder.Append($"<th height=\"30\" scope=\"col\">");
+                            stringBuilder.Append($"<ul class=\"list-group list-group-horizontal\">");
+                            stringBuilder.Append($"<li class=\"list-group-item\">");
                             RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
-                            stringBuilder.Append("</th>");
+                            stringBuilder.Append("</li>");
                             tableColumnCount.Curr++;
                         }
                         else if (tableColumnCount.Curr == tableColumnCount.Count - 1)
                         {
-                            stringBuilder.Append($"<th height=\"30\" scope=\"col\">");
+                            currentId = $"{currentTableId}-th";
+                            stringBuilder.Append($"<li class=\"list-group-item\">");
                             RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
-                            stringBuilder.Append("</th>");
-                            stringBuilder.Append("</tr></thead><tbody>");
+                            stringBuilder.Append("</li>");
+                            stringBuilder.Append("</ul>");
                             tableColumnCount.Curr = 0;
+                            CaptureCodeLine(list, sections, nodesInProcess, ref section, stringBuilder, ref lineNumber, ref leafSectionPlaceHolderNumber, ref currentId, isDocumentationRange, isHiddenApiToken);
                         }
                         else
                         {
-                            stringBuilder.Append($"<th height=\"30\" scope=\"col\">");
+                            stringBuilder.Append($"<li class=\"list-group-item\">");
                             RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
-                            stringBuilder.Append("</th>");
+                            stringBuilder.Append("</li>");
                             tableColumnCount.Curr++;
                         }
                         break;
@@ -197,35 +163,34 @@ namespace ApiView
                     case CodeFileTokenKind.TableCellBegin:
                         if (tableColumnCount.Curr == 0)
                         {
-                            var rowId = $"{currentId}-tr-{tableRowCount.Curr + 1}";
-                            stringBuilder.Append($"<tr data-inline-id=\"{rowId}\"><td height=\"30\"><a class=\"line-comment-button\">+</a>");
+                            stringBuilder.Append($"<ul class=\"list-group list-group-horizontal\">");
+                            stringBuilder.Append($"<li class=\"list-group-item\">");
                             tableColumnCount.Curr++;
                         }
                         else if (tableColumnCount.Curr == tableColumnCount.Count - 1)
                         {
-                            stringBuilder.Append($"<td height=\"30\">");
+                            currentId = $"{currentTableId}-tr-{tableRowCount.Curr + 1}";
+                            stringBuilder.Append($"<li class=\"list-group-item\">");
                             tableColumnCount.Curr = 0;
                             tableRowCount.Curr++;
                         }
                         else
                         {
-                            stringBuilder.Append($"<td height=\"30\">");
+                            stringBuilder.Append($"<li class=\"list-group-item\">");
                             tableColumnCount.Curr++;
                         }
                         break;
 
                     case CodeFileTokenKind.TableCellEnd:
-                        stringBuilder.Append($"</td height=\"30\">");
+                        stringBuilder.Append("</li>");
                         if (tableColumnCount.Curr == 0)
                         {
-                            stringBuilder.Append($"</tr>");
+                            stringBuilder.Append("</ul>");
+                            CaptureCodeLine(list, sections, nodesInProcess, ref section, stringBuilder, ref lineNumber, ref leafSectionPlaceHolderNumber, ref currentId, isDocumentationRange, isHiddenApiToken);
                         }
                         break;
 
                     case CodeFileTokenKind.TableEnd:
-                        stringBuilder.Append($"</tbody>");
-                        stringBuilder.Append("</table>");
-
                         break;
 
                     case CodeFileTokenKind.LeafSectionPlaceholder:
@@ -262,11 +227,51 @@ namespace ApiView
         protected virtual void StartDocumentationRange(StringBuilder stringBuilder) { }
         protected virtual void CloseDocumentationRange(StringBuilder stringBuilder) { }
 
-        private void UpdateDefinitionId(CodeFileToken token, string currentId)
+        private void CaptureCodeLine(List<CodeLine> list, Dictionary<int, TreeNode<CodeLine>> sections, Stack<SectionType> nodesInProcess,
+             ref TreeNode<CodeLine> section, StringBuilder stringBuilder, ref int lineNumber, ref int leafSectionPlaceHolderNumber, ref string currentId,
+             bool isDocumentationRange = false, bool isHiddenApiToken = false)
         {
-            currentId = (token.DefinitionId != null) ? token.DefinitionId : currentId;
+            int? sectionKey = (nodesInProcess.Count > 0 && section == null) ? sections.Count : null;
+            CodeLine codeLine = new CodeLine(stringBuilder.ToString(), currentId, String.Empty, ++lineNumber, sectionKey, isDocumentation: isDocumentationRange, isHiddenApi: isHiddenApiToken);
+            if (leafSectionPlaceHolderNumber != 0)
+            {
+                lineNumber += leafSectionPlaceHolderNumber - 1;
+                leafSectionPlaceHolderNumber = 0;
+            }
+            if (nodesInProcess.Count > 0)
+            {
+                if (nodesInProcess.Peek().Equals(SectionType.Heading))
+                {
+                    if (section == null)
+                    {
+                        section = new TreeNode<CodeLine>(codeLine);
+                        list.Add(codeLine);
+                    }
+                    else
+                    {
+                        section = section.AddChild(codeLine);
+                    }
+                }
+                else
+                {
+                    section.AddChild(codeLine);
+                }
+            }
+            else
+            {
+                if (section != null)
+                {
+                    sections.Add(sections.Count, section);
+                    section = null;
+                }
+                list.Add(codeLine);
+            }
+            currentId = null;
+            stringBuilder.Clear();
         }
     }
+
+ 
 
     public struct RenderResult
     {

--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -61,6 +61,7 @@ namespace ApiView
                         if (skipNewLine)
                         {
                             skipNewLine = false;
+                            lineNumber++;
                         }
                         else 
                         {
@@ -144,26 +145,26 @@ namespace ApiView
                         if (tableColumnCount.Curr == 0)
                         {
                             stringBuilder.Append($"<ul class=\"list-group list-group-horizontal\">");
-                            stringBuilder.Append($"<li class=\"list-group-item\">");
+                            stringBuilder.Append($"<li class=\"list-group-item border-top\"><strong>");
                             RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
-                            stringBuilder.Append("</li>");
+                            stringBuilder.Append("</strong></li>");
                             tableColumnCount.Curr++;
                         }
                         else if (tableColumnCount.Curr == tableColumnCount.Count - 1)
                         {
                             currentId = $"{currentTableId}-th";
-                            stringBuilder.Append($"<li class=\"list-group-item\">");
+                            stringBuilder.Append($"<li class=\"list-group-item border-top\"><strong>");
                             RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
-                            stringBuilder.Append("</li>");
+                            stringBuilder.Append("</strong></li>");
                             stringBuilder.Append("</ul>");
                             tableColumnCount.Curr = 0;
                             CaptureCodeLine(list, sections, nodesInProcess, ref section, stringBuilder, ref lineNumber, ref leafSectionPlaceHolderNumber, ref currentId, isDocumentationRange, isHiddenApiToken);
                         }
                         else
                         {
-                            stringBuilder.Append($"<li class=\"list-group-item\">");
+                            stringBuilder.Append($"<li class=\"list-group-item border-top\"><strong>");
                             RenderToken(token, stringBuilder, isDeprecatedToken, isHiddenApiToken);
-                            stringBuilder.Append("</li>");
+                            stringBuilder.Append("</strong></li>");
                             tableColumnCount.Curr++;
                         }
                         break;

--- a/src/dotnet/APIView/APIView/CodeFileRenderer.cs
+++ b/src/dotnet/APIView/APIView/CodeFileRenderer.cs
@@ -44,7 +44,6 @@ namespace ApiView
             (int Count, int Curr) tableRowCount = (0, 0);
             TreeNode<CodeLine> section = null;
             int leafSectionPlaceHolderNumber = 0;
-            bool skipNewLine = false;
 
             foreach (var token in node)
             {
@@ -58,15 +57,7 @@ namespace ApiView
                 switch (token.Kind)
                 {
                     case CodeFileTokenKind.Newline:
-                        if (skipNewLine)
-                        {
-                            skipNewLine = false;
-                            lineNumber++;
-                        }
-                        else 
-                        {
-                            CaptureCodeLine(list, sections, nodesInProcess, ref section, stringBuilder, ref lineNumber, ref leafSectionPlaceHolderNumber, ref currentId, isDocumentationRange, isHiddenApiToken);
-                        }
+                        CaptureCodeLine(list, sections, nodesInProcess, ref section, stringBuilder, ref lineNumber, ref leafSectionPlaceHolderNumber, ref currentId, isDocumentationRange, isHiddenApiToken);
                         break;
 
                     case CodeFileTokenKind.DocumentRangeStart:
@@ -200,7 +191,6 @@ namespace ApiView
                         break;
 
                     case CodeFileTokenKind.TableEnd:
-                        skipNewLine = true;
                         break;
 
                     case CodeFileTokenKind.LeafSectionPlaceholder:

--- a/src/dotnet/APIView/APIView/Model/CodeFile.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFile.cs
@@ -122,6 +122,12 @@ namespace ApiView
                         {
                             numberOfLinesinLeafSection++;
                         }
+
+                        if (isLeaf && token.Kind == CodeFileTokenKind.TableRowCount)
+                        {
+                            numberOfLinesinLeafSection += (Convert.ToInt16(token.Value));
+                        }
+
                         section.Add(token);
                     }
                     index++;

--- a/src/dotnet/APIView/APIView/Model/CodeFile.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFile.cs
@@ -125,7 +125,7 @@ namespace ApiView
 
                         if (isLeaf && token.Kind == CodeFileTokenKind.TableRowCount)
                         {
-                            numberOfLinesinLeafSection += (Convert.ToInt16(token.Value));
+                            numberOfLinesinLeafSection += (Convert.ToInt16(token.Value)) + 1;
                         }
 
                         section.Add(token);

--- a/src/dotnet/APIView/APIViewIntegrationTests/APIViewIntegrationTests.csproj
+++ b/src/dotnet/APIView/APIViewIntegrationTests/APIViewIntegrationTests.csproj
@@ -12,10 +12,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.10.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.26.1" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.13" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
     <PackageReference Include="Moq" Version="4.18.2" />

--- a/src/dotnet/APIView/APIViewIntegrationTests/ReviewManagerTests.cs
+++ b/src/dotnet/APIView/APIViewIntegrationTests/ReviewManagerTests.cs
@@ -4,6 +4,11 @@ using System.IO;
 using System;
 using APIViewWeb;
 using APIViewWeb.Repositories;
+using Newtonsoft.Json;
+using APIViewWeb.Models;
+using System.Collections.Generic;
+using ApiView;
+using FluentAssertions;
 
 namespace APIViewIntegrationTests
 {
@@ -89,6 +94,56 @@ namespace APIViewIntegrationTests
             Assert.Equal(ReviewType.PullRequest, review.FilterType);
 
             await Assert.ThrowsAsync<UnDeletableReviewException>(async () => await reviewManager.DeleteRevisionAsync(user, review.ReviewId, review.Revisions[0].RevisionId));
+        }
+
+        [Fact]
+        public async Task UpdateSwaggerReviewsMetaData_Test()
+        {
+            string reviewJson = File.ReadAllText(Path.Join(testsBaseFixture.TestDataPath, "account.swagger-cosmos-data.json"));
+            ReviewModel testReview = JsonConvert.DeserializeObject<ReviewModel>(reviewJson);
+            await testsBaseFixture.ReviewRepository.UpsertReviewAsync(testReview);
+
+            DirectoryInfo directoryInfo = new DirectoryInfo(Path.Join(testsBaseFixture.TestDataPath, "testComments"));
+
+            foreach(var file in directoryInfo.GetFiles())
+            {
+                string commentJson = File.ReadAllText(file.FullName);
+                CommentModel comment = JsonConvert.DeserializeObject<CommentModel>(commentJson);
+                await testsBaseFixture.CommentRepository.UpsertCommentAsync(comment);
+            }
+
+            foreach (var revision in testReview.Revisions)
+            {
+                string codeFileJson = File.ReadAllText(Path.Join(testsBaseFixture.TestDataPath, "codeFiles", revision.Files[0].ReviewFileId));
+                CodeFile testCodeFile = JsonConvert.DeserializeObject<CodeFile>(codeFileJson);
+                await testsBaseFixture.BlobCodeFileRepository.UpsertCodeFileAsync(revision.RevisionId, revision.Files[0].ReviewFileId, testCodeFile);
+            } 
+
+            await testsBaseFixture.ReviewManager.UpdateSwaggerReviewsMetaData();
+
+            ReviewModel updatedReview = await testsBaseFixture.ReviewRepository.GetReviewAsync(testReview.ReviewId);
+            IEnumerable<CommentModel> updatedComments = await testsBaseFixture.CommentRepository.GetCommentsAsync(testReview.ReviewId);
+
+            List<string> expectedCommentIds = new List<string>() {
+                "-account.swagger-General-consumes",
+                "-account.swagger-Paths-/",
+                "-account.swagger-Paths-/collections-0-operationId-Collections_ListCollections-QueryParameters-table-tr-2",
+                "-account.swagger-Paths-/collections-0-operationId-Collections_ListCollections-Responses-200-table-tr-3"
+            };
+
+            foreach (var comment in updatedComments)
+            {
+                expectedCommentIds.Should().Contain(comment.ElementId);
+            }
+
+            int[] expectedLineNumbers = { 1, 2, 3, 7, 8, 9, 10, 11, 20, 26, 811, 1101, 1108};
+            var renderedCodeFile = await testsBaseFixture.BlobCodeFileRepository.GetCodeFileAsync(updatedReview.Revisions[1]);
+            renderedCodeFile.Render(false);
+
+            for (int i = 0; i < renderedCodeFile.RenderResult.CodeLines.Length; i++)
+            {
+                Assert.Equal(renderedCodeFile.RenderResult.CodeLines[i].LineNumber, expectedLineNumbers[i]);
+            }
         }
     }
 }

--- a/src/dotnet/APIView/APIViewIntegrationTests/ReviewManagerTests.cs
+++ b/src/dotnet/APIView/APIViewIntegrationTests/ReviewManagerTests.cs
@@ -96,7 +96,7 @@ namespace APIViewIntegrationTests
             await Assert.ThrowsAsync<UnDeletableReviewException>(async () => await reviewManager.DeleteRevisionAsync(user, review.ReviewId, review.Revisions[0].RevisionId));
         }
 
-        [Fact]
+        [Fact(Skip = "Need Resource to run so won't run on PR piplines plus Only needed once.")]
         public async Task UpdateSwaggerReviewsMetaData_Test()
         {
             string reviewJson = File.ReadAllText(Path.Join(testsBaseFixture.TestDataPath, "account.swagger-cosmos-data.json"));
@@ -136,7 +136,7 @@ namespace APIViewIntegrationTests
                 expectedCommentIds.Should().Contain(comment.ElementId);
             }
 
-            int[] expectedLineNumbers = { 1, 2, 3, 7, 8, 9, 10, 11, 20, 26, 811, 1101, 1108};
+            int[] expectedLineNumbers = { 1, 2, 3, 7, 8, 9, 10, 11, 20, 26, 860, 1184, 1193};
             var renderedCodeFile = await testsBaseFixture.BlobCodeFileRepository.GetCodeFileAsync(updatedReview.Revisions[1]);
             renderedCodeFile.Render(false);
 

--- a/src/dotnet/APIView/APIViewUnitTests/CodeFileRendererTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CodeFileRendererTests.cs
@@ -51,8 +51,8 @@ namespace APIViewUnitTests
 
         [Theory]
         [InlineData(0, 3, 14)]
-        [InlineData(1, 17, 57)]
-        [InlineData(2, 59, 83)]
+        [InlineData(1, 17, 58)]
+        [InlineData(2, 60, 85)]
         public void RenderedResult_Sections_Has_Correct_Lines_In_Sections(int sectionPosition, int firstLineNumber, int lastLineNumber)
         {
             var sectionKey = renderedCodeFile.RenderResult.Sections[sectionPosition].Data.SectionKey;

--- a/src/dotnet/APIView/APIViewUnitTests/CodeFileRendererTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CodeFileRendererTests.cs
@@ -39,7 +39,7 @@ namespace APIViewUnitTests
             Assert.Equal(2, codeLines[1].LineNumber);
             Assert.Equal(15, codeLines[2].LineNumber);
             Assert.Equal(16, codeLines[3].LineNumber);
-            Assert.Equal(58, codeLines[4].LineNumber);
+            Assert.Equal(60, codeLines[4].LineNumber);
         }
 
         [Fact]
@@ -51,8 +51,8 @@ namespace APIViewUnitTests
 
         [Theory]
         [InlineData(0, 3, 14)]
-        [InlineData(1, 17, 58)]
-        [InlineData(2, 60, 85)]
+        [InlineData(1, 17, 59)]
+        [InlineData(2, 61, 87)]
         public void RenderedResult_Sections_Has_Correct_Lines_In_Sections(int sectionPosition, int firstLineNumber, int lastLineNumber)
         {
             var sectionKey = renderedCodeFile.RenderResult.Sections[sectionPosition].Data.SectionKey;

--- a/src/dotnet/APIView/APIViewUnitTests/ReviewManagerTests.cs.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ReviewManagerTests.cs.cs
@@ -1,0 +1,8 @@
+using Moq;
+
+namespace APIViewUnitTests
+{
+    public class ReviewManagerTests
+    {
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Client/css/shared/codeline.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/shared/codeline.scss
@@ -76,6 +76,7 @@
 .code-inner .list-group-item {
     border-radius: 0px;
     border-top: 0px;
+    padding: 0.25rem 1rem;
 }
 
 .code-inner > .list-group-horizontal > .list-group-item:first-child {

--- a/src/dotnet/APIView/APIViewWeb/Client/css/shared/codeline.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/shared/codeline.scss
@@ -66,24 +66,46 @@
     stroke: var(--text-muted-color);
 }
 
-.code-inner > table {
-    display: inline-table;
-    position: relative;
+.code-inner > .list-group {
+    border-radius: 0px;
     width: 50%;
-    table-layout: auto;
     white-space: normal;
+    border-top: 0px;
 }
 
-.code-inner td, .code-inner th, .code-inner thead, .code-inner tbody, .code-inner table, .code-inner tr {
-    border: 1px solid var(--border-color);
+.code-inner .list-group-item {
+    border-radius: 0px;
+    border-top: 0px;
 }
 
-.code-inner > .table thead th {
-    border-bottom: 1px solid var(--border-color);
+.code-inner > .list-group-horizontal > .list-group-item:first-child {
+    border-bottom-left-radius: 0px;
+    border-top-right-radius: 0px;
+    width: 15%;
 }
 
-.code-inner .table > :not(:last-child) > :last-child > * {
-    border-bottom-color: var(--border-color);
+.code-inner > .list-group-horizontal > .list-group-item:nth-child(2) {
+    border-bottom-left-radius: 0px;
+    border-top-right-radius: 0px;
+    width: 15%;
+}
+
+.code-inner > .list-group-horizontal > .list-group-item:nth-child(3) {
+    border-bottom-left-radius: 0px;
+    border-top-right-radius: 0px;
+    width: 15%;
+}
+
+.code-inner > .list-group-horizontal > .list-group-item:nth-child(4) {
+    border-bottom-left-radius: 0px;
+    border-top-right-radius: 0px;
+    width: 15%;
+}
+
+.code-inner > .list-group-horizontal > .list-group-item:last-child {
+    border-top-right-radius: 0px;
+    border-bottom-left-radius: 0px;
+    width: 40%;
 }
 
 .deprecated {

--- a/src/dotnet/APIView/APIViewWeb/Client/css/shared/codeline.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/shared/codeline.scss
@@ -274,6 +274,10 @@ code {
     background-color: rgba(248,81,73,0.3);
 }
 
+.code-added .list-group-item, .code-removed .list-group-item {
+    background-color: transparent;
+}
+
 .code-delta {
     background-color: rgba(248,201,67,0.3);
 }

--- a/src/dotnet/APIView/APIViewWeb/HostedServices/SwaggerReviewsBackgroundHostedService.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/SwaggerReviewsBackgroundHostedService.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using APIViewWeb.Managers;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Hosting;
+
+namespace APIViewWeb.HostedServices
+{
+    public class SwaggerReviewsBackgroundHostedService : BackgroundService
+    {
+        private readonly bool _isDisabled;
+        private readonly IReviewManager _reviewManager;
+
+        static TelemetryClient _telemetryClient = new (TelemetryConfiguration.CreateDefault());
+
+
+        public SwaggerReviewsBackgroundHostedService(IReviewManager reviewManager, IConfiguration configuration)
+        {
+            _reviewManager = reviewManager;
+            if (bool.TryParse(configuration["SwaggerMetaDataBackgroundTaskDisabled"], out bool taskDisabled))
+            {
+                _isDisabled = taskDisabled;
+            }
+        }
+
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+        {
+            if (!_isDisabled)
+            {
+                try 
+                {
+                    await _reviewManager.UpdateSwaggerReviewsMetaData();
+                }
+                catch (Exception ex)
+                {
+                    _telemetryClient.TrackException(ex);
+                }
+                
+            }
+        }
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Managers/IReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/IReviewManager.cs
@@ -40,6 +40,7 @@ namespace APIViewWeb.Managers
         public Task UpdateReviewCodeFiles(string repoName, string buildId, string artifact, string project);
         public Task RequestApproversAsync(ClaimsPrincipal User, string ReviewId, HashSet<string> reviewers);
         public Task GetLineNumbersOfHeadingsOfSectionsWithDiff(string reviewId, ReviewRevisionModel revision);
+        public Task UpdateSwaggerReviewsMetaData();
         public TreeNode<InlineDiffLine<CodeLine>> ComputeSectionDiff(TreeNode<CodeLine> before, TreeNode<CodeLine> after, RenderedCodeFile beforeFile, RenderedCodeFile afterFile);
         public Task<bool> IsApprovedForFirstRelease(string language, string packageName);
     }

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -10,7 +10,9 @@ using System.Security.Claims;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Xml;
 using ApiView;
+using APIView;
 using APIView.DIff;
 using APIView.Model;
 using APIViewWeb.Models;
@@ -19,6 +21,8 @@ using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Azure;
+using Microsoft.VisualStudio.Services.Common;
 
 namespace APIViewWeb.Managers
 {
@@ -383,6 +387,79 @@ namespace APIViewWeb.Managers
                     }
                 }                
             }            
+        }
+
+        public async Task UpdateSwaggerReviewsMetaData()
+        {
+            var reviews = await _reviewsRepository.GetReviewsAsync(isClosed: false, language: "Swagger", fetchAllPages: true);
+
+            foreach (var review in reviews)
+            {
+                var comments = await _commentsRepository.GetCommentsAsync(review.ReviewId);
+                
+                foreach (var comment in comments)
+                {
+                    if (comment.ElementId.EndsWith("table") && !String.IsNullOrEmpty(comment.GroupNo))
+                    {
+                        comment.ElementId = comment.ElementId + $"-tr-{comment.GroupNo}";
+                        await _commentsRepository.UpsertCommentAsync(comment);
+                    }
+                }
+
+                foreach (var revision in review.Revisions)
+                {
+                    // Update Number of Lines in LeafSections
+                    var renderedCodeFile = await _codeFileRepository.GetCodeFileAsync(revision);
+
+                    for (int i = 0; i < renderedCodeFile.CodeFile.Tokens.Length; i++)
+                    {
+                        if (renderedCodeFile.CodeFile.Tokens[i].Kind == CodeFileTokenKind.LeafSectionPlaceholder)
+                        {
+                            var leafSection = renderedCodeFile.CodeFile.LeafSections[(Convert.ToInt16(renderedCodeFile.CodeFile.Tokens[i].Value))];
+                            CodeLine[] renderedLeafSection = CodeFileHtmlRenderer.Normal.Render(leafSection);
+                            renderedCodeFile.CodeFile.Tokens[i].NumberOfLinesinLeafSection = renderedLeafSection.Length;
+                        }
+                    }
+
+                    await _codeFileRepository.UpsertCodeFileAsync(revision.RevisionId, revision.SingleFile.ReviewFileId, renderedCodeFile.CodeFile);
+                    await GetLineNumbersOfHeadingsOfSectionsWithDiff(review.ReviewId, revision);
+
+                    bool entireFileRendered = false;
+
+                    foreach (var comment in comments)
+                    {
+                        if ((comment.RevisionId == revision.RevisionId) && comment.ElementId.EndsWith("table") && String.IsNullOrEmpty(comment.GroupNo))
+                        {
+                            int rowCount = 0;
+
+                            if (!entireFileRendered)
+                                renderedCodeFile.Render(false);
+
+                            foreach (var codeLine in renderedCodeFile.RenderResult.CodeLines)
+                            {
+                                if (codeLine.SectionKey != null)
+                                {
+                                    var sectionLines = renderedCodeFile.GetCodeLineSection((int)codeLine.SectionKey);
+
+                                    foreach (var sectionLine in sectionLines)
+                                    {
+                                        if (!String.IsNullOrEmpty(sectionLine.ElementId) && sectionLine.ElementId.StartsWith(comment.ElementId))
+                                            rowCount++;
+                                    }
+                                    if (rowCount > 1)
+                                    {
+                                        comment.ElementId = comment.ElementId + $"-tr-{rowCount - 1}";
+                                        await _commentsRepository.UpsertCommentAsync(comment);
+                                        break;
+                                    }
+                                }
+                            }
+                            if (rowCount > 0)
+                                break;
+                        }
+                    }
+                }
+            }                                                                                                                                                                                                                       
         }
 
         // Languages that full ysupport sandboxing updates reviews using Azure devops pipeline

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -391,7 +391,10 @@ namespace APIViewWeb.Managers
 
         public async Task UpdateSwaggerReviewsMetaData()
         {
-            var reviews = await _reviewsRepository.GetReviewsAsync(isClosed: false, language: "Swagger", fetchAllPages: true);
+            IList<ReviewModel> reviews = (await _reviewsRepository.GetReviewsAsync(isClosed: false, language: "Swagger", fetchAllPages: true)).ToList();
+            reviews.AddRange(await _reviewsRepository.GetReviewsAsync(isClosed: true, language: "Swagger", fetchAllPages: true));
+
+            int reviewsProcessed = 0;
 
             foreach (var review in reviews)
             {
@@ -455,10 +458,15 @@ namespace APIViewWeb.Managers
                                 }
                             }
                             if (rowCount > 0)
+                            {
                                 break;
+                            }
                         }
                     }
                 }
+                reviewsProcessed++;
+                _telemetryClient.TrackTrace("Swagger Reviews Updated: " + reviewsProcessed);
+
             }                                                                                                                                                                                                                       
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -220,6 +220,7 @@ namespace APIViewWeb
             services.AddSingleton<IAuthorizationHandler, UsageSampleOwnerRequirementHandler>();
             services.AddHostedService<ReviewBackgroundHostedService>();
             services.AddHostedService<PullRequestBackgroundHostedService>();
+            services.AddHostedService<SwaggerReviewsBackgroundHostedService>();
             services.AddAutoMapper(Assembly.GetExecutingAssembly());
         }
 

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -42,6 +42,7 @@ variables:
   NugetSecurityAnalysisWarningLevel: 'none'
   AzuriteConnectionString: "DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;BlobEndpoint=http://127.0.0.1:10000/devstoreaccount1"
   CosmosEmulatorConnectionString: "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw=="
+  TestingDataContainer: "https://apiviewuitest.blob.core.windows.net/testingdata"
   ${{ if ne(variables['System.TeamProject'], 'internal') }}:
     CollectCoverage: false
   ${{ if eq(variables['System.TeamProject'], 'internal') }}:
@@ -208,6 +209,18 @@ stages:
             inputs:
               codeCoverageTool: Cobertura
               summaryFileLocation: $(Build.ArtifactStagingDirectory)\coverage\Cobertura.xml
+
+          - task: Powershell@2
+            inputs:
+              filePath: $(Build.SourcesDirectory)/eng/common/scripts/copy-from-blobstorage.ps1
+              arguments: >
+                -SourceBlobPath $(TestingDataContainer)
+                -ApplicationId $(apiviewstorageaccess-application-id)
+                -DestinationDirectory $(Build.BinariesDirectory)
+              pwsh: true
+            displayName: 'Copy from Test Files From Blob'
+            env:
+              AZCOPY_SPA_CLIENT_SECRET: $(apiviewstorageaccess-service-principal-key)
 
           - script: >-
               dotnet test src/dotnet/APIView/APIViewIntegrationTests/APIViewIntegrationTests.csproj

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -210,18 +210,6 @@ stages:
               codeCoverageTool: Cobertura
               summaryFileLocation: $(Build.ArtifactStagingDirectory)\coverage\Cobertura.xml
 
-          - task: Powershell@2
-            inputs:
-              filePath: $(Build.SourcesDirectory)/eng/common/scripts/copy-from-blobstorage.ps1
-              arguments: >
-                -SourceBlobPath $(TestingDataContainer)
-                -ApplicationId $(apiviewstorageaccess-application-id)
-                -DestinationDirectory $(Build.BinariesDirectory)
-              pwsh: true
-            displayName: 'Copy from Test Files From Blob'
-            env:
-              AZCOPY_SPA_CLIENT_SECRET: $(apiviewstorageaccess-service-principal-key)
-
           - script: >-
               dotnet test src/dotnet/APIView/APIViewIntegrationTests/APIViewIntegrationTests.csproj
               --logger trx


### PR DESCRIPTION
- Split Swagger Inline Tables into separated code lines.

- Add Background task that
   - Updates Precomputed Line Numbers Metadata.
   - Updates referencing comments
   - Updates Precomputed Diff Line Metadata.
   
   Resolves https://github.com/Azure/azure-sdk-tools/issues/5831
   
   Demo Link https://apiviewuat.azurewebsites.net/Assemblies/Review/1872ee16e46e4b288026e05aff3a5776?revisionId=14688791636e4b73ae1e9426155031f7&diffRevisionId=9a716effb6174b98ae0da797cf5903d3&doc=False&diffOnly=False


BEFORE
<img width="1693" alt="SwaggerTablesBefore" src="https://user-images.githubusercontent.com/31145988/229651429-60e50c9e-b205-4273-a52f-e91c403313da.png">

AFTER
<img width="1145" alt="SwaggerAfter" src="https://user-images.githubusercontent.com/31145988/229651471-fca1f44e-663c-4845-97ef-3b92a0259744.png">
<img width="1123" alt="SwaggerAfterTwo" src="https://user-images.githubusercontent.com/31145988/229651477-0e8d2730-d903-4f60-895c-0f0c2ec65245.png">

