### PR TITLE
Updated ApiView to use clang-15 to work around MSVC STL changes; fixed warning in keyvault-admin ApiView

### DIFF
--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.cpp
@@ -55,8 +55,8 @@ void AzureClassesDatabase::CreateApiViewMessage(
     }
     case ApiViewMessages::InternalTypesInNonCorePackage: {
       newMessage.DiagnosticId = "CPA0007";
-      newMessage.DiagnosticText
-          = "'internal' types declared in a non-common package. Consider putting the type in the '_detail' namespace.";
+      newMessage.DiagnosticText = "'internal' types declared in a non-common package. Consider "
+                                  "putting the type in the '_detail' namespace.";
       newMessage.Level = ApiViewMessage::MessageLevel::Warning;
       break;
     }
@@ -65,6 +65,14 @@ void AzureClassesDatabase::CreateApiViewMessage(
       newMessage.DiagnosticText
           = "Implicit Constructor is found. Constructors should be marked 'explicit'";
       newMessage.Level = ApiViewMessage::MessageLevel::Info;
+      break;
+    }
+    case ApiViewMessages::UsingDirectiveFound: {
+      newMessage.DiagnosticId = "CPA0009";
+      newMessage.DiagnosticText = "Using Namespace directive found in header file. ";
+      newMessage.HelpLinkUri
+          = "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rs-using-directive";
+      newMessage.Level = ApiViewMessage::MessageLevel::Error;
       break;
     }
   }

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.hpp
@@ -33,4 +33,5 @@ enum class ApiViewMessages
   ProtectedFieldsInFinalClass, // Protected fields in final class
   InternalTypesInNonCorePackage, // Internal types in a non-core package
   ImplicitConstructor, // Constructor for a type is not marked "explicit".
+  UsingDirectiveFound, // "using namespace" directive found.
 };

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.cpp
@@ -2759,6 +2759,8 @@ std::unique_ptr<AstNode> AstNode::Create(
       //    azureClassesDatabase));
     case Decl::Kind::Using:
       return nullptr;
+    case Decl::Kind::UsingDirective:
+      return nullptr;
       //   return std::make_unique<AstUsing>(cast<UsingDecl>(decl));
     default: {
       llvm::errs() << raw_ostream::Colors::RED << "Unknown DECL node "

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.cpp
@@ -2148,6 +2148,39 @@ public:
   }
 };
 
+class AstUsingDirective : public AstNode {
+  std::string m_namedNamespace;
+
+public:
+  AstUsingDirective(
+      UsingDirectiveDecl const* usingDirective,
+      AzureClassesDatabase* const azureClassesDatabase,
+      std::shared_ptr<TypeHierarchy::TypeHierarchyNode> parentNode)
+      : AstNode(usingDirective), m_namedNamespace{usingDirective->getNominatedNamespaceAsWritten()
+                                                      ->getQualifiedNameAsString()}
+  {
+    azureClassesDatabase->CreateApiViewMessage(
+        ApiViewMessages::UsingDirectiveFound, m_namedNamespace);
+  }
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& dumpOptions) override
+  {
+    if (dumpOptions.NeedsLeftAlign)
+    {
+      dumper->LeftAlign();
+    }
+    dumper->InsertKeyword("using");
+    dumper->InsertWhitespace();
+    dumper->InsertKeyword("namespace");
+    dumper->InsertWhitespace();
+    dumper->InsertTypeName(m_namedNamespace, m_namedNamespace);
+    dumper->InsertPunctuation(';');
+    if (dumpOptions.NeedsTrailingNewline)
+    {
+      dumper->Newline();
+    }
+  }
+};
+
 class AstEnumerator : public AstNamedNode {
   std::unique_ptr<AstExpr> m_initializer;
 
@@ -2748,6 +2781,12 @@ std::unique_ptr<AstNode> AstNode::Create(
     case Decl::Kind::Friend:
       return std::make_unique<AstFriend>(cast<FriendDecl>(decl), azureClassesDatabase, parentNode);
 
+    case Decl::Kind::UsingDirective:
+      // A "UsingDirective" is a "using namespace" directive. We consider this to be an error
+      // condition, so we add an AstNode so the error will appear in the ApiView.
+      return std::make_unique<AstUsingDirective>(
+          cast<UsingDirectiveDecl>(decl), azureClassesDatabase, parentNode);
+
     case Decl::Kind::NamespaceAlias:
       return nullptr;
       //    return std::make_unique<AstNamespaceAlias>(cast<NamespaceAliasDecl>(decl,
@@ -2759,9 +2798,6 @@ std::unique_ptr<AstNode> AstNode::Create(
       //    azureClassesDatabase));
     case Decl::Kind::Using:
       return nullptr;
-    case Decl::Kind::UsingDirective:
-      return nullptr;
-      //   return std::make_unique<AstUsing>(cast<UsingDecl>(decl));
     default: {
       llvm::errs() << raw_ostream::Colors::RED << "Unknown DECL node "
                    << cast<NamedDecl>(decl)->getNameAsString()

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CMakeLists.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CMakeLists.txt
@@ -31,6 +31,7 @@ target_include_directories(ApiViewProcessor PRIVATE ${LLVM_INCLUDE_DIRS})
 llvm_map_components_to_libnames(llvm_libs 
        Support
        Option
+       WindowsDriver
        FrontEndOpenMP
 )
 
@@ -41,6 +42,7 @@ clangLex
 clangParse
 clangDriver
 clangSema
+clangSupport
 clangFrontend
 clangSerialization
 clangTooling

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ProcessorImpl.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ProcessorImpl.cpp
@@ -279,7 +279,6 @@ bool ApiViewProcessorImpl::CollectCppClassesVisitor::ShouldCollectNamedDecl(
       shouldCollect = true;
     }
   }
-
   // We don't even want to consider any types which are a member of a class.
   if (shouldCollect)
   {
@@ -399,7 +398,7 @@ int ApiViewProcessorImpl::ProcessApiView()
   // compilation database. Use the CurrentDirectorySetter to preserve and restore the current
   // directory across calls into the clang tooling.
   CurrentDirectorySetter currentDirectory{std::filesystem::current_path()};
-  
+
   // clang really likes all input paths to be absolute paths, so use the fiilesystem to
   // canonicalize the input filename and source location.
   std::filesystem::path tempFile = std::filesystem::temp_directory_path();

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/CMakeLists.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(parseTests
     TestCases/TemplateTests.cpp
     TestCases/ClassesWithInternalAndDetail.cpp 
     TestCases/ExpressionTests.cpp
-     TestCases/UsingNamespace.cpp)
+     TestCases/UsingNamespace.cpp )
 add_dependencies(parseTests ApiViewProcessor)
 
 target_include_directories(parseTests PRIVATE ${ApiViewProcessor_SOURCE_DIR})

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/CMakeLists.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/CMakeLists.txt
@@ -17,7 +17,7 @@ add_executable(parseTests
     TestCases/TemplateTests.cpp
     TestCases/ClassesWithInternalAndDetail.cpp 
     TestCases/ExpressionTests.cpp
-    )
+     TestCases/UsingNamespace.cpp)
 add_dependencies(parseTests ApiViewProcessor)
 
 target_include_directories(parseTests PRIVATE ${ApiViewProcessor_SOURCE_DIR})

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/TestCases/SimpleTest.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/TestCases/SimpleTest.cpp
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 #include <chrono>
+#include <cstddef>
 #include <map>
 #include <string>
 #include <vector>

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/TestCases/UsingNamespace.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/TestCases/UsingNamespace.cpp
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include <chrono>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace Test { namespace Inner {
+  class Fred {};
+}} // namespace Test::Inner
+
+using namespace Test::Inner;
+
+namespace A { namespace AB { namespace ABCD {
+    char* GlobalFunctionInAABABCD(int character);
+}}} // namespace A::AB::ABCD

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/tests.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/tests.cpp
@@ -238,7 +238,6 @@ TEST_F(TestParser, CompileWithErrors)
   }
 }
 
-
 struct NsDumper : AstDumper
 {
   // Inherited via AstDumper
@@ -451,11 +450,11 @@ TEST_F(TestParser, Class1)
 
   auto& db = processor.GetClassesDatabase();
   EXPECT_EQ(16ul, db->GetAstNodeMap().size());
-  
+
   NsDumper dumper;
   db->DumpClassDatabase(&dumper);
   EXPECT_EQ(31ul, dumper.Messages.size());
-  
+
   size_t internalTypes = 0;
   for (const auto& msg : dumper.Messages)
   {
@@ -465,7 +464,7 @@ TEST_F(TestParser, Class1)
     }
   }
   EXPECT_EQ(internalTypes, 8ul);
-  
+
   EXPECT_TRUE(SyntaxCheckClassDb(db, "Classes1.cpp"));
 }
 TEST_F(TestParser, Class2)
@@ -529,7 +528,42 @@ TEST_F(TestParser, Templates)
 
   auto& db = processor.GetClassesDatabase();
   // Until we get parsing types working correctly, we can't do the syntax check tests.
-//  EXPECT_TRUE(SyntaxCheckClassDb(db, "Template1.cpp"));
+  //  EXPECT_TRUE(SyntaxCheckClassDb(db, "Template1.cpp"));
+}
+
+TEST_F(TestParser, UsingNamespace)
+{
+  ApiViewProcessor processor("tests", R"({
+  "sourceFilesToProcess": [
+    "UsingNamespace.cpp"
+  ],
+  "additionalIncludeDirectories": [],
+  "additionalCompilerSwitches": null,
+  "allowInternal": false,
+  "includeDetail": false,
+  "includePrivate": false,
+  "filterNamespace": null
+}
+)"_json);
+
+  EXPECT_EQ(processor.ProcessApiView(), 0);
+
+  auto& db = processor.GetClassesDatabase();
+  EXPECT_TRUE(SyntaxCheckClassDb(db, "UsingNamespace1.cpp"));
+
+  NsDumper dumper;
+  db->DumpClassDatabase(&dumper);
+  EXPECT_EQ(1ul, dumper.Messages.size());
+
+  size_t usingNamespaces = 0;
+  for (const auto& msg : dumper.Messages)
+  {
+    if (msg.DiagnosticId == "CPA0009")
+    {
+      usingNamespaces += 1;
+    }
+  }
+  EXPECT_EQ(usingNamespaces, 1ul);
 }
 
 #if 0

--- a/tools/apiview/parsers/cpp-api-parser/README.md
+++ b/tools/apiview/parsers/cpp-api-parser/README.md
@@ -166,3 +166,9 @@ displayed in the ApiView tool.
 This tokenized representation is modeled in the following example JSON document found [here](https://github.com/Azure/azure-sdk-tools/blob/main/src/dotnet/APIView/apiview_token_gist.json)
 When this JSON file is parsed by the API View tool, it will create the following text in the ApiView:
 ![API View snippet defining `ClassLibrary1.dll`](https://i.imgur.com/ikfRmLM.png)
+
+#### VCPKG notes
+
+The `ParseAzureSdkCpp` tool uses a custom port for clang-15 because vcpkg does not currently have a port for clang-15 in the public repository.
+
+The clang-15 port files were taken from the [vcpkg repository](https://github.com/microsoft/vcpkg/pull/26902).

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/0001-Fix-install-paths.patch
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/0001-Fix-install-paths.patch
@@ -1,0 +1,208 @@
+ clang/cmake/modules/CMakeLists.txt              | 4 ++--
+ clang/utils/hmaptool/CMakeLists.txt             | 2 +-
+ compiler-rt/cmake/Modules/CompilerRTUtils.cmake | 2 +-
+ flang/cmake/modules/CMakeLists.txt              | 4 ++--
+ lld/cmake/modules/CMakeLists.txt                | 4 ++--
+ llvm/CMakeLists.txt                             | 2 +-
+ llvm/cmake/modules/AddLLVM.cmake                | 2 +-
+ llvm/cmake/modules/CMakeLists.txt               | 2 +-
+ mlir/cmake/modules/CMakeLists.txt               | 8 ++++----
+ mlir/test/CMakeLists.txt                        | 2 +-
+ openmp/tools/Modules/CMakeLists.txt             | 2 +-
+ polly/cmake/CMakeLists.txt                      | 8 ++++----
+ 12 files changed, 21 insertions(+), 21 deletions(-)
+
+diff --git a/clang/cmake/modules/CMakeLists.txt b/clang/cmake/modules/CMakeLists.txt
+index 6a7fa2fa27eb..a17f807ab155 100644
+--- a/clang/cmake/modules/CMakeLists.txt
++++ b/clang/cmake/modules/CMakeLists.txt
+@@ -6,13 +6,13 @@ include(FindPrefixFromConfig)
+ # Generate a list of CMake library targets so that other CMake projects can
+ # link against them. LLVM calls its version of this file LLVMExports.cmake, but
+ # the usual CMake convention seems to be ${Project}Targets.cmake.
+-set(CLANG_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/clang" CACHE STRING
++set(CLANG_INSTALL_PACKAGE_DIR "share/clang" CACHE STRING
+   "Path for CMake subdirectory for Clang (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/clang')")
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+ set(clang_cmake_builddir "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/clang")
+ 
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+-set(LLVM_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/llvm" CACHE STRING
++set(LLVM_INSTALL_PACKAGE_DIR "share/llvm" CACHE STRING
+   "Path for CMake subdirectory for LLVM (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/llvm')")
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+ set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
+diff --git a/clang/utils/hmaptool/CMakeLists.txt b/clang/utils/hmaptool/CMakeLists.txt
+index 511268069bd1..72915ec66504 100644
+--- a/clang/utils/hmaptool/CMakeLists.txt
++++ b/clang/utils/hmaptool/CMakeLists.txt
+@@ -1,4 +1,4 @@
+-install(PROGRAMS hmaptool DESTINATION "${CLANG_TOOLS_INSTALL_DIR}" COMPONENT hmaptool)
++install(PROGRAMS hmaptool DESTINATION "${LLVM_TOOLS_INSTALL_DIR}" COMPONENT hmaptool)
+ add_custom_target(hmaptool ALL DEPENDS "hmaptool")
+ set_target_properties(hmaptool PROPERTIES FOLDER "Utils")
+ 
+diff --git a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+index e322af89a042..0df6a7a775cd 100644
+--- a/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
++++ b/compiler-rt/cmake/Modules/CompilerRTUtils.cmake
+@@ -377,7 +377,7 @@ macro(load_llvm_config)
+       file(TO_CMAKE_PATH ${LLVM_CMAKE_DIR_FROM_LLVM_CONFIG} LLVM_CMAKE_DIR)
+     else()
+       file(TO_CMAKE_PATH ${LLVM_BINARY_DIR} LLVM_BINARY_DIR_CMAKE_STYLE)
+-      set(LLVM_CMAKE_DIR "${LLVM_BINARY_DIR_CMAKE_STYLE}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
++      set(LLVM_CMAKE_DIR "${LLVM_BINARY_DIR_CMAKE_STYLE}/share/llvm")
+     endif()
+ 
+     set(LLVM_CMAKE_INCLUDE_FILE "${LLVM_CMAKE_DIR}/LLVMConfig.cmake")
+diff --git a/flang/cmake/modules/CMakeLists.txt b/flang/cmake/modules/CMakeLists.txt
+index 105cc09bf850..460db6c1d9e7 100644
+--- a/flang/cmake/modules/CMakeLists.txt
++++ b/flang/cmake/modules/CMakeLists.txt
+@@ -5,13 +5,13 @@ include(FindPrefixFromConfig)
+ # Generate a list of CMake library targets so that other CMake projects can
+ # link against them. LLVM calls its version of this file LLVMExports.cmake, but
+ # the usual CMake convention seems to be ${Project}Targets.cmake.
+-set(FLANG_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/flang" CACHE STRING
++set(FLANG_INSTALL_PACKAGE_DIR "share/flang" CACHE STRING
+   "Path for CMake subdirectory for Flang (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/flang')")
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+ set(flang_cmake_builddir "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/flang")
+ 
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+-set(LLVM_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/llvm" CACHE STRING
++set(LLVM_INSTALL_PACKAGE_DIR "share/llvm" CACHE STRING
+   "Path for CMake subdirectory for LLVM (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/llvm')")
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+ set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
+diff --git a/lld/cmake/modules/CMakeLists.txt b/lld/cmake/modules/CMakeLists.txt
+index 57195bce45c9..e24c080725d7 100644
+--- a/lld/cmake/modules/CMakeLists.txt
++++ b/lld/cmake/modules/CMakeLists.txt
+@@ -5,13 +5,13 @@ include(FindPrefixFromConfig)
+ # Generate a list of CMake library targets so that other CMake projects can
+ # link against them. LLVM calls its version of this file LLVMExports.cmake, but
+ # the usual CMake convention seems to be ${Project}Targets.cmake.
+-set(LLD_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/lld" CACHE STRING
++set(LLD_INSTALL_PACKAGE_DIR "share/lld" CACHE STRING
+   "Path for CMake subdirectory for LLD (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/lld')")
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+ set(lld_cmake_builddir "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/lld")
+ 
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+-set(LLVM_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/llvm" CACHE STRING
++set(LLVM_INSTALL_PACKAGE_DIR "share/llvm" CACHE STRING
+   "Path for CMake subdirectory for LLVM (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/llvm')")
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+ set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
+diff --git a/llvm/CMakeLists.txt b/llvm/CMakeLists.txt
+index 4be91312271d..d6002808a205 100644
+--- a/llvm/CMakeLists.txt
++++ b/llvm/CMakeLists.txt
+@@ -325,7 +325,7 @@ set(LLVM_LIBDIR_SUFFIX "" CACHE STRING "Define suffix of library directory name
+ # LLVM_INSTALL_PACKAGE_DIR needs to be declared prior to adding the tools
+ # subdirectory in order to have the value available for llvm-config.
+ include(GNUInstallPackageDir)
+-set(LLVM_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/llvm" CACHE STRING
++set(LLVM_INSTALL_PACKAGE_DIR "share/llvm" CACHE STRING
+   "Path for CMake subdirectory for LLVM (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/llvm')")
+ 
+ set(LLVM_TOOLS_INSTALL_DIR "${CMAKE_INSTALL_BINDIR}" CACHE STRING
+diff --git a/llvm/cmake/modules/AddLLVM.cmake b/llvm/cmake/modules/AddLLVM.cmake
+index 057431208322..89cbba8a5676 100644
+--- a/llvm/cmake/modules/AddLLVM.cmake
++++ b/llvm/cmake/modules/AddLLVM.cmake
+@@ -1093,7 +1093,7 @@ function(process_llvm_pass_plugins)
+           message(FATAL_ERROR "LLVM_INSTALL_PACKAGE_DIR must be defined and writable. GEN_CONFIG should only be passe when building LLVM proper.")
+       endif()
+       # LLVM_INSTALL_PACKAGE_DIR might be absolute, so don't reuse below.
+-      set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
++      set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/share/llvm")
+       file(WRITE
+           "${llvm_cmake_builddir}/LLVMConfigExtensions.cmake"
+           "set(LLVM_STATIC_EXTENSIONS ${LLVM_STATIC_EXTENSIONS})")
+diff --git a/llvm/cmake/modules/CMakeLists.txt b/llvm/cmake/modules/CMakeLists.txt
+index 470881516915..36d2e9aa2120 100644
+--- a/llvm/cmake/modules/CMakeLists.txt
++++ b/llvm/cmake/modules/CMakeLists.txt
+@@ -3,7 +3,7 @@ include(LLVMDistributionSupport)
+ include(FindPrefixFromConfig)
+ 
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+-set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
++set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/share/llvm")
+ 
+ # First for users who use an installed LLVM, create the LLVMExports.cmake file.
+ set(LLVM_EXPORTS_FILE ${llvm_cmake_builddir}/LLVMExports.cmake)
+diff --git a/mlir/cmake/modules/CMakeLists.txt b/mlir/cmake/modules/CMakeLists.txt
+index 5fd9454cad93..af1d73a852c7 100644
+--- a/mlir/cmake/modules/CMakeLists.txt
++++ b/mlir/cmake/modules/CMakeLists.txt
+@@ -6,16 +6,16 @@ include(FindPrefixFromConfig)
+ # Generate a list of CMake library targets so that other CMake projects can
+ # link against them. LLVM calls its version of this file LLVMExports.cmake, but
+ # the usual CMake convention seems to be ${Project}Targets.cmake.
+-set(MLIR_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/mlir" CACHE STRING
++set(MLIR_INSTALL_PACKAGE_DIR "share/mlir" CACHE STRING
+   "Path for CMake subdirectory for Polly (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/polly')")
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+-set(mlir_cmake_builddir "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/mlir")
++set(mlir_cmake_builddir "${CMAKE_BINARY_DIR}/share/mlir")
+ 
+ # Keep this in sync with llvm/cmake/CMakeLists.txt!
+-set(LLVM_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/llvm" CACHE STRING
++set(LLVM_INSTALL_PACKAGE_DIR "share/llvm" CACHE STRING
+   "Path for CMake subdirectory for LLVM (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/llvm')")
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+-set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
++set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/share/llvm")
+ 
+ get_property(MLIR_EXPORTS GLOBAL PROPERTY MLIR_EXPORTS)
+ export(TARGETS ${MLIR_EXPORTS} FILE ${mlir_cmake_builddir}/MLIRTargets.cmake)
+diff --git a/mlir/test/CMakeLists.txt b/mlir/test/CMakeLists.txt
+index 74f805865d2d..998ddb3b48e8 100644
+--- a/mlir/test/CMakeLists.txt
++++ b/mlir/test/CMakeLists.txt
+@@ -8,7 +8,7 @@ endif()
+ # Passed to lit.site.cfg.py.so that the out of tree Standalone dialect test
+ # can find MLIR's CMake configuration
+ set(MLIR_CMAKE_DIR
+-  "${CMAKE_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/mlir")
++  "${CMAKE_BINARY_DIR}/share/mlir")
+ 
+ # Passed to lit.site.cfg.py.in to set up the path where to find the libraries
+ # for linalg integration tests.
+diff --git a/openmp/tools/Modules/CMakeLists.txt b/openmp/tools/Modules/CMakeLists.txt
+index 22d818eea72d..75aacc4468d4 100644
+--- a/openmp/tools/Modules/CMakeLists.txt
++++ b/openmp/tools/Modules/CMakeLists.txt
+@@ -12,4 +12,4 @@
+ 
+ 
+ install(FILES "FindOpenMPTarget.cmake"
+-              DESTINATION "${OPENMP_INSTALL_LIBDIR}/cmake/openmp")
++              DESTINATION "share/openmp")
+diff --git a/polly/cmake/CMakeLists.txt b/polly/cmake/CMakeLists.txt
+index 4c528d562e23..800080fb3f79 100644
+--- a/polly/cmake/CMakeLists.txt
++++ b/polly/cmake/CMakeLists.txt
+@@ -4,15 +4,15 @@ include(GNUInstallPackageDir)
+ include(ExtendPath)
+ include(FindPrefixFromConfig)
+ 
+-set(POLLY_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/polly" CACHE STRING
++set(POLLY_INSTALL_PACKAGE_DIR "share/polly" CACHE STRING
+   "Path for CMake subdirectory for Polly (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/polly')")
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+-set(polly_cmake_builddir "${POLLY_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/polly")
++set(polly_cmake_builddir "${POLLY_BINARY_DIR}/share/polly")
+ 
+-set(LLVM_INSTALL_PACKAGE_DIR "${CMAKE_INSTALL_PACKAGEDIR}/llvm" CACHE STRING
++set(LLVM_INSTALL_PACKAGE_DIR "share/llvm" CACHE STRING
+   "Path for CMake subdirectory for LLVM (defaults to '${CMAKE_INSTALL_PACKAGEDIR}/llvm')")
+ # CMAKE_INSTALL_PACKAGEDIR might be absolute, so don't reuse below.
+-set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/lib${LLVM_LIBDIR_SUFFIX}/cmake/llvm")
++set(llvm_cmake_builddir "${LLVM_BINARY_DIR}/share/llvm")
+ 
+ if (CMAKE_CONFIGURATION_TYPES)
+   set(POLLY_EXPORTS_FILE_NAME "PollyExports-$<LOWER_CASE:$<CONFIG>>.cmake")

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/0002-Fix-DR-1734.patch
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/0002-Fix-DR-1734.patch
@@ -1,0 +1,17 @@
+ llvm/include/llvm/Support/type_traits.h | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/llvm/include/llvm/Support/type_traits.h b/llvm/include/llvm/Support/type_traits.h
+index 7b7d5d991f3f..469b681deea3 100644
+--- a/llvm/include/llvm/Support/type_traits.h
++++ b/llvm/include/llvm/Support/type_traits.h
+@@ -176,7 +176,8 @@ class is_trivially_copyable {
+       (has_deleted_copy_assign || has_trivial_copy_assign) &&
+       (has_deleted_copy_constructor || has_trivial_copy_constructor);
+ 
+-#ifdef HAVE_STD_IS_TRIVIALLY_COPYABLE
++// due to DR 1734, a type can be std::is_trivially_copyable but not llvm::is_trivially_copyable
++#if 0
+   static_assert(value == std::is_trivially_copyable<T>::value,
+                 "inconsistent behavior between llvm:: and std:: implementation of is_trivially_copyable");
+ #endif

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/0003-Fix-tools-path.patch
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/0003-Fix-tools-path.patch
@@ -1,0 +1,16 @@
+ llvm/tools/llvm-config/llvm-config.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/llvm/tools/llvm-config/llvm-config.cpp b/llvm/tools/llvm-config/llvm-config.cpp
+index 2c6c55f89d38..f2b581559991 100644
+--- a/llvm/tools/llvm-config/llvm-config.cpp
++++ b/llvm/tools/llvm-config/llvm-config.cpp
+@@ -307,7 +307,7 @@ int main(int argc, char **argv) {
+   // bin dir).
+   sys::fs::make_absolute(CurrentPath);
+   CurrentExecPrefix =
+-      sys::path::parent_path(sys::path::parent_path(CurrentPath)).str();
++      sys::path::parent_path(sys::path::parent_path(sys::path::parent_path(CurrentPath))).str();
+ 
+   // Check to see if we are inside a development tree by comparing to possible
+   // locations (prefix style or CMake style).

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/0004-Fix-compiler-rt-install-path.patch
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/0004-Fix-compiler-rt-install-path.patch
@@ -1,0 +1,44 @@
+ clang/lib/Headers/CMakeLists.txt       | 2 +-
+ clang/runtime/CMakeLists.txt           | 2 +-
+ compiler-rt/cmake/base-config-ix.cmake | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/clang/lib/Headers/CMakeLists.txt b/clang/lib/Headers/CMakeLists.txt
+index 6e2060991b92..94ced7feda9b 100644
+--- a/clang/lib/Headers/CMakeLists.txt
++++ b/clang/lib/Headers/CMakeLists.txt
+@@ -420,7 +420,7 @@ add_header_target("openmp-resource-headers" ${openmp_wrapper_files})
+ add_header_target("windows-resource-headers" ${windows_only_files})
+ add_header_target("utility-resource-headers" ${utility_files})
+ 
+-set(header_install_dir lib${LLVM_LIBDIR_SUFFIX}/clang/${CLANG_VERSION}/include)
++set(header_install_dir tools/llvm/lib/clang/${CLANG_VERSION}/include)
+ 
+ #############################################################
+ # Install rules for the catch-all clang-resource-headers target
+diff --git a/clang/runtime/CMakeLists.txt b/clang/runtime/CMakeLists.txt
+index 9f4633bc85b1..6d7b70ee0dea 100644
+--- a/clang/runtime/CMakeLists.txt
++++ b/clang/runtime/CMakeLists.txt
+@@ -84,7 +84,7 @@ if(LLVM_BUILD_EXTERNAL_COMPILER_RT AND EXISTS ${COMPILER_RT_SRC_ROOT}/)
+                -DLLVM_LIT_ARGS=${LLVM_LIT_ARGS}
+                -DCOMPILER_RT_OUTPUT_DIR=${LLVM_LIBRARY_OUTPUT_INTDIR}/clang/${CLANG_VERSION}
+                -DCOMPILER_RT_EXEC_OUTPUT_DIR=${LLVM_RUNTIME_OUTPUT_INTDIR}
+-               -DCOMPILER_RT_INSTALL_PATH:PATH=lib${LLVM_LIBDIR_SUFFIX}/clang/${CLANG_VERSION}
++               -DCOMPILER_RT_INSTALL_PATH:PATH=tools/llvm/lib/clang/${CLANG_VERSION}
+                -DCOMPILER_RT_INCLUDE_TESTS=${LLVM_INCLUDE_TESTS}
+                -DCMAKE_INSTALL_PREFIX=${CMAKE_INSTALL_PREFIX}
+                -DLLVM_LIBDIR_SUFFIX=${LLVM_LIBDIR_SUFFIX}
+diff --git a/compiler-rt/cmake/base-config-ix.cmake b/compiler-rt/cmake/base-config-ix.cmake
+index 8a6219568b3f..f9c9f6478280 100644
+--- a/compiler-rt/cmake/base-config-ix.cmake
++++ b/compiler-rt/cmake/base-config-ix.cmake
+@@ -45,7 +45,7 @@ if (LLVM_TREE_AVAILABLE)
+   # Setup the paths where compiler-rt runtimes and headers should be stored.
+   set(COMPILER_RT_OUTPUT_DIR ${LLVM_LIBRARY_OUTPUT_INTDIR}/clang/${CLANG_VERSION})
+   set(COMPILER_RT_EXEC_OUTPUT_DIR ${LLVM_RUNTIME_OUTPUT_INTDIR})
+-  set(COMPILER_RT_INSTALL_PATH lib${LLVM_LIBDIR_SUFFIX}/clang/${CLANG_VERSION})
++  set(COMPILER_RT_INSTALL_PATH tools/llvm/lib/clang/${CLANG_VERSION})
+   option(COMPILER_RT_INCLUDE_TESTS "Generate and build compiler-rt unit tests."
+          ${LLVM_INCLUDE_TESTS})
+   option(COMPILER_RT_ENABLE_WERROR "Fail and stop if warning is triggered"

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/0005-Fix-tools-install-path.patch
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/0005-Fix-tools-install-path.patch
@@ -1,0 +1,207 @@
+ clang-tools-extra/clang-tidy/tool/CMakeLists.txt | 2 +-
+ clang-tools-extra/modularize/CMakeLists.txt      | 2 +-
+ clang/cmake/modules/AddClang.cmake               | 2 +-
+ clang/tools/c-index-test/CMakeLists.txt          | 2 +-
+ clang/tools/clang-format/CMakeLists.txt          | 2 +-
+ clang/tools/clang-linker-wrapper/CMakeLists.txt  | 2 +-
+ clang/tools/clang-nvlink-wrapper/CMakeLists.txt  | 2 +-
+ clang/tools/scan-build-py/CMakeLists.txt         | 4 ++--
+ clang/tools/scan-build/CMakeLists.txt            | 2 +-
+ clang/tools/scan-view/CMakeLists.txt             | 2 +-
+ flang/cmake/modules/AddFlang.cmake               | 2 +-
+ flang/tools/f18/CMakeLists.txt                   | 2 +-
+ flang/tools/flang-driver/CMakeLists.txt          | 2 +-
+ lld/cmake/modules/AddLLD.cmake                   | 2 +-
+ lldb/cmake/modules/AddLLDB.cmake                 | 2 +-
+ 15 files changed, 16 insertions(+), 16 deletions(-)
+
+diff --git a/clang-tools-extra/clang-tidy/tool/CMakeLists.txt b/clang-tools-extra/clang-tidy/tool/CMakeLists.txt
+index 3ce552872015..e09b917ae5f8 100644
+--- a/clang-tools-extra/clang-tidy/tool/CMakeLists.txt
++++ b/clang-tools-extra/clang-tidy/tool/CMakeLists.txt
+@@ -64,6 +64,6 @@ install(PROGRAMS clang-tidy-diff.py
+   DESTINATION "${CMAKE_INSTALL_DATADIR}/clang"
+   COMPONENT clang-tidy)
+ install(PROGRAMS run-clang-tidy.py
+-  DESTINATION "${CMAKE_INSTALL_BINDIR}"
++  DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
+   COMPONENT clang-tidy
+   RENAME run-clang-tidy)
+diff --git a/clang-tools-extra/modularize/CMakeLists.txt b/clang-tools-extra/modularize/CMakeLists.txt
+index fb17e353c39f..4b409e47446a 100644
+--- a/clang-tools-extra/modularize/CMakeLists.txt
++++ b/clang-tools-extra/modularize/CMakeLists.txt
+@@ -23,5 +23,5 @@ clang_target_link_libraries(modularize
+   )
+ 
+ install(TARGETS modularize
+-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++        RUNTIME DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
+         COMPONENT clang-extras)
+diff --git a/clang/cmake/modules/AddClang.cmake b/clang/cmake/modules/AddClang.cmake
+index 21ac332e4f5f..1aaf785bdc99 100644
+--- a/clang/cmake/modules/AddClang.cmake
++++ b/clang/cmake/modules/AddClang.cmake
+@@ -166,7 +166,7 @@ macro(add_clang_tool name)
+       get_target_export_arg(${name} Clang export_to_clangtargets)
+       install(TARGETS ${name}
+         ${export_to_clangtargets}
+-        RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++        RUNTIME DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
+         COMPONENT ${name})
+ 
+       if(NOT LLVM_ENABLE_IDE)
+diff --git a/clang/tools/c-index-test/CMakeLists.txt b/clang/tools/c-index-test/CMakeLists.txt
+index 0ae1b4e55244..e8a34e136194 100644
+--- a/clang/tools/c-index-test/CMakeLists.txt
++++ b/clang/tools/c-index-test/CMakeLists.txt
+@@ -49,7 +49,7 @@ if (NOT LLVM_INSTALL_TOOLCHAIN_ONLY)
+     set_property(TARGET c-index-test APPEND PROPERTY INSTALL_RPATH
+        "@executable_path/../../lib")
+   else()
+-    set(INSTALL_DESTINATION "${CMAKE_INSTALL_BINDIR}")
++    set(INSTALL_DESTINATION "${LLVM_TOOLS_INSTALL_DIR}")
+   endif()
+ 
+   install(TARGETS c-index-test
+diff --git a/clang/tools/clang-format/CMakeLists.txt b/clang/tools/clang-format/CMakeLists.txt
+index bbdef93b576b..8744e414da0a 100644
+--- a/clang/tools/clang-format/CMakeLists.txt
++++ b/clang/tools/clang-format/CMakeLists.txt
+@@ -36,5 +36,5 @@ install(PROGRAMS clang-format.py
+   DESTINATION "${CMAKE_INSTALL_DATADIR}/clang"
+   COMPONENT clang-format)
+ install(PROGRAMS git-clang-format
+-  DESTINATION "${CMAKE_INSTALL_BINDIR}"
++  DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
+   COMPONENT clang-format)
+diff --git a/clang/tools/clang-linker-wrapper/CMakeLists.txt b/clang/tools/clang-linker-wrapper/CMakeLists.txt
+index 88c19cad7b53..b50c9ff90586 100644
+--- a/clang/tools/clang-linker-wrapper/CMakeLists.txt
++++ b/clang/tools/clang-linker-wrapper/CMakeLists.txt
+@@ -44,4 +44,4 @@ target_link_libraries(clang-linker-wrapper
+   ${CLANG_LINKER_WRAPPER_LIB_DEPS}
+   )
+ 
+-install(TARGETS clang-linker-wrapper RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
++install(TARGETS clang-linker-wrapper RUNTIME DESTINATION "${LLVM_TOOLS_INSTALL_DIR}")
+diff --git a/clang/tools/clang-nvlink-wrapper/CMakeLists.txt b/clang/tools/clang-nvlink-wrapper/CMakeLists.txt
+index 2c979e509795..f22b801fe19a 100644
+--- a/clang/tools/clang-nvlink-wrapper/CMakeLists.txt
++++ b/clang/tools/clang-nvlink-wrapper/CMakeLists.txt
+@@ -22,4 +22,4 @@ target_link_libraries(clang-nvlink-wrapper
+   ${CLANG_NVLINK_WRAPPER_LIB_DEPS}
+   )
+ 
+-install(TARGETS clang-nvlink-wrapper RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}")
++install(TARGETS clang-nvlink-wrapper RUNTIME DESTINATION "${LLVM_TOOLS_INSTALL_DIR}")
+diff --git a/clang/tools/scan-build-py/CMakeLists.txt b/clang/tools/scan-build-py/CMakeLists.txt
+index 061dc7ef4dd9..91499600693b 100644
+--- a/clang/tools/scan-build-py/CMakeLists.txt
++++ b/clang/tools/scan-build-py/CMakeLists.txt
+@@ -43,7 +43,7 @@ foreach(BinFile ${BinFiles})
+                          ${CMAKE_BINARY_DIR}/bin/scan-build-py
+                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bin/scan-build)
+     install (PROGRAMS "bin/scan-build"
+-             DESTINATION "${CMAKE_INSTALL_BINDIR}"
++             DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
+              RENAME scan-build-py
+              COMPONENT scan-build-py)
+     list(APPEND Depends ${CMAKE_BINARY_DIR}/bin/scan-build-py)
+@@ -56,7 +56,7 @@ foreach(BinFile ${BinFiles})
+                          ${CMAKE_BINARY_DIR}/bin/
+                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bin/${BinFile})
+     install(PROGRAMS bin/${BinFile}
+-            DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
+             COMPONENT scan-build-py)
+     list(APPEND Depends ${CMAKE_BINARY_DIR}/bin/${BinFile})
+   endif()
+diff --git a/clang/tools/scan-build/CMakeLists.txt b/clang/tools/scan-build/CMakeLists.txt
+index ef687b0e90a1..a52af70443c3 100644
+--- a/clang/tools/scan-build/CMakeLists.txt
++++ b/clang/tools/scan-build/CMakeLists.txt
+@@ -47,7 +47,7 @@ if(CLANG_INSTALL_SCANBUILD)
+                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bin/${BinFile})
+     list(APPEND Depends ${CMAKE_BINARY_DIR}/bin/${BinFile})
+     install(PROGRAMS bin/${BinFile}
+-            DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
+             COMPONENT scan-build)
+   endforeach()
+ 
+diff --git a/clang/tools/scan-view/CMakeLists.txt b/clang/tools/scan-view/CMakeLists.txt
+index 07aec76ee66f..ca6a3380ad0c 100644
+--- a/clang/tools/scan-view/CMakeLists.txt
++++ b/clang/tools/scan-view/CMakeLists.txt
+@@ -20,7 +20,7 @@ if(CLANG_INSTALL_SCANVIEW)
+                        DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/bin/${BinFile})
+     list(APPEND Depends ${CMAKE_BINARY_DIR}/bin/${BinFile})
+     install(PROGRAMS bin/${BinFile}
+-            DESTINATION "${CMAKE_INSTALL_BINDIR}"
++            DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
+             COMPONENT scan-view)
+   endforeach()
+ 
+diff --git a/flang/cmake/modules/AddFlang.cmake b/flang/cmake/modules/AddFlang.cmake
+index d516ca31b51f..4a0d4ce80168 100644
+--- a/flang/cmake/modules/AddFlang.cmake
++++ b/flang/cmake/modules/AddFlang.cmake
+@@ -110,7 +110,7 @@ macro(add_flang_tool name)
+     get_target_export_arg(${name} Flang export_to_flangtargets)
+     install(TARGETS ${name}
+       ${export_to_flangtargets}
+-      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++      RUNTIME DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
+       COMPONENT ${name})
+ 
+     if(NOT LLVM_ENABLE_IDE)
+diff --git a/flang/tools/f18/CMakeLists.txt b/flang/tools/f18/CMakeLists.txt
+index dd0898730e2e..d01c2f8076e3 100644
+--- a/flang/tools/f18/CMakeLists.txt
++++ b/flang/tools/f18/CMakeLists.txt
+@@ -56,7 +56,7 @@ if (NOT WIN32)
+     @ONLY
+   )
+   add_custom_target(flang-to-external-fc ALL DEPENDS ${CMAKE_BINARY_DIR}/bin/flang-to-external-fc)
+-  install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/flang-to-external-fc DESTINATION "${CMAKE_INSTALL_BINDIR}")
++  install(PROGRAMS ${CMAKE_BINARY_DIR}/bin/flang-to-external-fc DESTINATION "${LLVM_TOOLS_INSTALL_DIR}")
+ endif()
+ 
+ # TODO Move this to a more suitable location
+diff --git a/flang/tools/flang-driver/CMakeLists.txt b/flang/tools/flang-driver/CMakeLists.txt
+index 94c8ce6d58f1..466d41c58b1d 100644
+--- a/flang/tools/flang-driver/CMakeLists.txt
++++ b/flang/tools/flang-driver/CMakeLists.txt
+@@ -42,4 +42,4 @@ if(FLANG_PLUGIN_SUPPORT)
+   export_executable_symbols_for_plugins(flang-new)
+ endif()
+ 
+-install(TARGETS flang-new DESTINATION "${CMAKE_INSTALL_BINDIR}")
++install(TARGETS flang-new DESTINATION "${LLVM_TOOLS_INSTALL_DIR}")
+diff --git a/lld/cmake/modules/AddLLD.cmake b/lld/cmake/modules/AddLLD.cmake
+index d3924f7243d4..f328b62ad8c8 100644
+--- a/lld/cmake/modules/AddLLD.cmake
++++ b/lld/cmake/modules/AddLLD.cmake
+@@ -47,7 +47,7 @@ macro(add_lld_tool name)
+     get_target_export_arg(${name} LLD export_to_lldtargets)
+     install(TARGETS ${name}
+       ${export_to_lldtargets}
+-      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++      RUNTIME DESTINATION "${LLVM_TOOLS_INSTALL_DIR}"
+       COMPONENT ${name})
+ 
+     if(NOT CMAKE_CONFIGURATION_TYPES)
+diff --git a/lldb/cmake/modules/AddLLDB.cmake b/lldb/cmake/modules/AddLLDB.cmake
+index 3291a7c808e1..9fe9b9a7940d 100644
+--- a/lldb/cmake/modules/AddLLDB.cmake
++++ b/lldb/cmake/modules/AddLLDB.cmake
+@@ -189,7 +189,7 @@ function(add_lldb_executable name)
+   endif()
+ 
+   if(ARG_GENERATE_INSTALL)
+-    set(install_dest bin)
++    set(install_dest "${LLVM_TOOLS_INSTALL_DIR}")
+     if(ARG_INSTALL_PREFIX)
+       set(install_dest ${ARG_INSTALL_PREFIX})
+     endif()

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/0006-Fix-libffi.patch
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/0006-Fix-libffi.patch
@@ -1,0 +1,16 @@
+ llvm/cmake/modules/FindFFI.cmake | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/llvm/cmake/modules/FindFFI.cmake b/llvm/cmake/modules/FindFFI.cmake
+index b0d859af8959..a756d0c8fdb0 100644
+--- a/llvm/cmake/modules/FindFFI.cmake
++++ b/llvm/cmake/modules/FindFFI.cmake
+@@ -34,7 +34,7 @@ else()
+   endif()
+ endif()
+ 
+-find_library(FFI_LIBRARIES ffi PATHS ${FFI_LIBRARY_DIR})
++find_library(FFI_LIBRARIES ffi libffi PATHS ${FFI_LIBRARY_DIR})
+ 
+ if(FFI_LIBRARIES)
+   include(CMakePushCheckState)

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/0007-Fix-install-bolt.patch
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/0007-Fix-install-bolt.patch
@@ -1,0 +1,21 @@
+ bolt/tools/driver/CMakeLists.txt | 7 -------
+ 1 file changed, 7 deletions(-)
+
+diff --git a/bolt/tools/driver/CMakeLists.txt b/bolt/tools/driver/CMakeLists.txt
+index e56be15dbcff..85b078e2e761 100644
+--- a/bolt/tools/driver/CMakeLists.txt
++++ b/bolt/tools/driver/CMakeLists.txt
+@@ -35,13 +35,6 @@ set(BOLT_DEPENDS
+   )
+ 
+ add_custom_target(bolt DEPENDS ${BOLT_DEPENDS})
+-install(PROGRAMS
+-  ${CMAKE_BINARY_DIR}/bin/llvm-bolt
+-  ${CMAKE_BINARY_DIR}/bin/perf2bolt
+-  ${CMAKE_BINARY_DIR}/bin/llvm-boltdiff
+-  DESTINATION ${CMAKE_INSTALL_BINDIR}
+-  COMPONENT bolt
+-  )
+ add_llvm_install_targets(install-bolt DEPENDS bolt COMPONENT bolt)
+ set_target_properties(bolt PROPERTIES FOLDER "BOLT")
+ set_target_properties(install-bolt PROPERTIES FOLDER "BOLT")

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/clang_usage.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/clang_usage.txt
@@ -1,0 +1,5 @@
+The package clang provides CMake targets:
+
+    find_package(Clang CONFIG REQUIRED)
+    target_include_directories(main PRIVATE ${CLANG_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE clangBasic clangLex clangParse clangAST ...)

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/flang_usage.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/flang_usage.txt
@@ -1,0 +1,5 @@
+The package flang provides CMake targets:
+
+    find_package(Flang CONFIG REQUIRED)
+    target_include_directories(main PRIVATE ${FLANG_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE flangFrontend flangFrontendTool ...)

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/lld_usage.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/lld_usage.txt
@@ -1,0 +1,5 @@
+The package lld provides CMake targets:
+
+    find_package(LLD CONFIG REQUIRED)
+    target_include_directories(main PRIVATE ${LLD_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE lldCommon lldCore lldDriver ...)

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/llvm_usage.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/llvm_usage.txt
@@ -1,0 +1,15 @@
+The package llvm provides CMake targets:
+
+    find_package(LLVM CONFIG REQUIRED)
+
+    list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
+    include(HandleLLVMOptions)
+    add_definitions(${LLVM_DEFINITIONS})
+
+    target_include_directories(main PRIVATE ${LLVM_INCLUDE_DIRS})
+
+    # Find the libraries that correspond to the LLVM components that we wish to use
+    llvm_map_components_to_libnames(llvm_libs Support Core IRReader ...)
+
+    # Link against LLVM libraries
+    target_link_libraries(main PRIVATE ${llvm_libs})

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/mlir_usage.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/mlir_usage.txt
@@ -1,0 +1,5 @@
+The package lld provides CMake targets:
+
+    find_package(MLIR CONFIG REQUIRED)
+    target_include_directories(main PRIVATE ${MLIR_INCLUDE_DIRS})
+    target_link_libraries(main PRIVATE MLIRIR MLIRParser MLIRPass MLIRSupport ...)

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/portfile.cmake
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/portfile.cmake
@@ -1,4 +1,4 @@
-set(LLVM_VERSION "15.0.1")
+set(LLVM_VERSION "15.0.7")
 
 vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
 
@@ -6,7 +6,7 @@ vcpkg_from_github(
     OUT_SOURCE_PATH SOURCE_PATH
     REPO llvm/llvm-project
     REF llvmorg-${LLVM_VERSION}
-    SHA512 d518de4860bd953c4728f00cb52aba37e1e8c2a0825b0a6cc046494f2ad4d1e1d07d36524c2aca87c7f27a5c07c21cdcf18ac73a03c2eed813ca46d24f31f445
+    SHA512 99beff9ee6f8c26f16ea53f03ba6209a119099cbe361701b0d5f4df9d5cc5f2f0da7c994c899a4cec876da8428564dc7a8e798226a9ba8b5c18a3ef8b181d39e
     HEAD_REF main
     PATCHES
         0001-Fix-install-paths.patch    # This patch fixes paths in ClangConfig.cmake, LLVMConfig.cmake, LLDConfig.cmake etc.

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/portfile.cmake
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/portfile.cmake
@@ -1,0 +1,333 @@
+set(LLVM_VERSION "15.0.1")
+
+vcpkg_check_linkage(ONLY_STATIC_LIBRARY)
+
+vcpkg_from_github(
+    OUT_SOURCE_PATH SOURCE_PATH
+    REPO llvm/llvm-project
+    REF llvmorg-${LLVM_VERSION}
+    SHA512 d518de4860bd953c4728f00cb52aba37e1e8c2a0825b0a6cc046494f2ad4d1e1d07d36524c2aca87c7f27a5c07c21cdcf18ac73a03c2eed813ca46d24f31f445
+    HEAD_REF main
+    PATCHES
+        0001-Fix-install-paths.patch    # This patch fixes paths in ClangConfig.cmake, LLVMConfig.cmake, LLDConfig.cmake etc.
+        0002-Fix-DR-1734.patch
+        0003-Fix-tools-path.patch
+        0004-Fix-compiler-rt-install-path.patch
+        0005-Fix-tools-install-path.patch
+        0006-Fix-libffi.patch
+        0007-Fix-install-bolt.patch
+)
+
+vcpkg_check_features(
+    OUT_FEATURE_OPTIONS FEATURE_OPTIONS
+    FEATURES
+        tools LLVM_BUILD_TOOLS
+        tools LLVM_INCLUDE_TOOLS
+        utils LLVM_BUILD_UTILS
+        utils LLVM_INCLUDE_UTILS
+        utils LLVM_INSTALL_UTILS
+        enable-rtti LLVM_ENABLE_RTTI
+        enable-ffi LLVM_ENABLE_FFI
+        enable-terminfo LLVM_ENABLE_TERMINFO
+        enable-threads LLVM_ENABLE_THREADS
+        enable-ios COMPILER_RT_ENABLE_IOS
+        enable-eh LLVM_ENABLE_EH
+        enable-bindings LLVM_ENABLE_BINDINGS
+)
+
+vcpkg_cmake_get_vars(cmake_vars_file)
+include("${cmake_vars_file}")
+
+# LLVM generates CMake error due to Visual Studio version 16.4 is known to miscompile part of LLVM.
+# LLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON disables this error.
+# See https://developercommunity.visualstudio.com/content/problem/845933/miscompile-boolean-condition-deduced-to-be-always.html
+# and thread "[llvm-dev] Longstanding failing tests - clang-tidy, MachO, Polly" on llvm-dev Jan 21-23 2020.
+list(APPEND FEATURE_OPTIONS
+    -DLLVM_TEMPORARILY_ALLOW_OLD_TOOLCHAIN=ON
+)
+
+# Force enable or disable external libraries
+set(llvm_external_libraries
+    zlib
+    libxml2
+)
+foreach(external_library IN LISTS llvm_external_libraries)
+    string(TOLOWER "enable-${external_library}" feature_name)
+    string(TOUPPER "LLVM_ENABLE_${external_library}" define_name)
+    if(feature_name IN_LIST FEATURES)
+        list(APPEND FEATURE_OPTIONS
+            -D${define_name}=FORCE_ON
+        )
+    else()
+        list(APPEND FEATURE_OPTIONS
+            -D${define_name}=OFF
+        )
+    endif()
+endforeach()
+
+# By default assertions are enabled for Debug configuration only.
+if("enable-assertions" IN_LIST FEATURES)
+    # Force enable assertions for all configurations.
+    list(APPEND FEATURE_OPTIONS
+        -DLLVM_ENABLE_ASSERTIONS=ON
+    )
+elseif("disable-assertions" IN_LIST FEATURES)
+    # Force disable assertions for all configurations.
+    list(APPEND FEATURE_OPTIONS
+        -DLLVM_ENABLE_ASSERTIONS=OFF
+    )
+endif()
+
+# LLVM_ABI_BREAKING_CHECKS can be WITH_ASSERTS (default), FORCE_ON or FORCE_OFF.
+# By default in LLVM, abi-breaking checks are enabled if assertions are enabled.
+# however, this breaks linking with the debug versions, since the option is
+# baked into the header files; thus, we always turn off LLVM_ABI_BREAKING_CHECKS
+# unless the user asks for it
+if("enable-abi-breaking-checks" IN_LIST FEATURES)
+    # Force enable abi-breaking checks.
+    list(APPEND FEATURE_OPTIONS
+        -DLLVM_ABI_BREAKING_CHECKS=FORCE_ON
+    )
+else()
+    # Force disable abi-breaking checks.
+    list(APPEND FEATURE_OPTIONS
+        -DLLVM_ABI_BREAKING_CHECKS=FORCE_OFF
+    )
+endif()
+
+set(LLVM_ENABLE_PROJECTS)
+if("bolt" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_PROJECTS "bolt")
+endif()
+if("clang" IN_LIST FEATURES OR "clang-tools-extra" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_PROJECTS "clang")
+    if("disable-clang-static-analyzer" IN_LIST FEATURES)
+        list(APPEND FEATURE_OPTIONS
+            # Disable ARCMT
+            -DCLANG_ENABLE_ARCMT=OFF
+            # Disable static analyzer
+            -DCLANG_ENABLE_STATIC_ANALYZER=OFF
+        )
+    endif()
+    # 1) LLVM/Clang tools are relocated from ./bin/ to ./tools/llvm/ (LLVM_TOOLS_INSTALL_DIR=tools/llvm)
+    # 2) Clang resource files are relocated from ./lib/clang/<version> to ./tools/llvm/lib/clang/<version> (see patch 0007-fix-compiler-rt-install-path.patch)
+    # So, the relative path should be changed from ../lib/clang/<version> to ./lib/clang/<version>
+    list(APPEND FEATURE_OPTIONS -DCLANG_RESOURCE_DIR=lib/clang/${LLVM_VERSION})
+endif()
+if("clang-tools-extra" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_PROJECTS "clang-tools-extra")
+endif()
+if("compiler-rt" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_PROJECTS "compiler-rt")
+endif()
+if("flang" IN_LIST FEATURES)
+    if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "MSVC" AND VCPKG_TARGET_ARCHITECTURE STREQUAL "x86")
+        message(FATAL_ERROR "Building Flang with MSVC is not supported on x86. Disable it until issues are fixed.")
+    endif()
+    list(APPEND LLVM_ENABLE_PROJECTS "flang")
+    list(APPEND FEATURE_OPTIONS
+        # Flang requires C++17
+        -DCMAKE_CXX_STANDARD=17
+    )
+endif()
+if("libclc" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_PROJECTS "libclc")
+endif()
+if("lld" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_PROJECTS "lld")
+endif()
+if("lldb" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_PROJECTS "lldb")
+    list(APPEND FEATURE_OPTIONS
+        -DLLDB_ENABLE_CURSES=OFF
+    )
+endif()
+if("mlir" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_PROJECTS "mlir")
+endif()
+if("openmp" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_PROJECTS "openmp")
+    # Perl is required for the OpenMP run-time
+    vcpkg_find_acquire_program(PERL)
+    get_filename_component(PERL_PATH ${PERL} DIRECTORY)
+    vcpkg_add_to_path(${PERL_PATH})
+    # Skip post-build check
+    set(VCPKG_POLICY_SKIP_DUMPBIN_CHECKS enabled)
+endif()
+if("polly" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_PROJECTS "polly")
+endif()
+if("pstl" IN_LIST FEATURES)
+    if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        message(FATAL_ERROR "Building pstl with MSVC is not supported. Disable it until issues are fixed.")
+    endif()
+    list(APPEND LLVM_ENABLE_PROJECTS "pstl")
+endif()
+
+set(LLVM_ENABLE_RUNTIMES)
+if("libcxx" IN_LIST FEATURES)
+    if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        message(FATAL_ERROR "Building libcxx with MSVC is not supported, as cl doesn't support the #include_next extension.")
+    endif()
+    list(APPEND LLVM_ENABLE_RUNTIMES "libcxx")
+endif()
+if("libcxxabi" IN_LIST FEATURES)
+    if(VCPKG_DETECTED_CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
+        message(FATAL_ERROR "Building libcxxabi with MSVC is not supported. Disable it until issues are fixed.")
+    endif()
+    list(APPEND LLVM_ENABLE_RUNTIMES "libcxxabi")
+endif()
+if("libunwind" IN_LIST FEATURES)
+    list(APPEND LLVM_ENABLE_RUNTIMES "libunwind")
+endif()
+
+# this is for normal targets
+set(known_llvm_targets
+    AArch64
+    AMDGPU
+    ARM
+    AVR
+    BPF
+    Hexagon
+    Lanai
+    Mips
+    MSP430
+    NVPTX
+    PowerPC
+    RISCV
+    Sparc
+    SystemZ
+    VE
+    WebAssembly
+    X86
+    XCore
+)
+
+set(LLVM_TARGETS_TO_BUILD "")
+foreach(llvm_target IN LISTS known_llvm_targets)
+    string(TOLOWER "target-${llvm_target}" feature_name)
+    if(feature_name IN_LIST FEATURES)
+        list(APPEND LLVM_TARGETS_TO_BUILD "${llvm_target}")
+    endif()
+endforeach()
+
+# this is for experimental targets
+set(known_llvm_experimental_targets
+    SPRIV
+)
+
+set(LLVM_EXPERIMENTAL_TARGETS_TO_BUILD "")
+foreach(llvm_target IN LISTS known_llvm_experimental_targets)
+    string(TOLOWER "target-${llvm_target}" feature_name)
+    if(feature_name IN_LIST FEATURES)
+        list(APPEND LLVM_EXPERIMENTAL_TARGETS_TO_BUILD "${llvm_target}")
+    endif()
+endforeach()
+
+vcpkg_find_acquire_program(PYTHON3)
+get_filename_component(PYTHON3_DIR ${PYTHON3} DIRECTORY)
+vcpkg_add_to_path(${PYTHON3_DIR})
+
+set(LLVM_LINK_JOBS 1)
+
+vcpkg_cmake_configure(
+    SOURCE_PATH ${SOURCE_PATH}/llvm
+    OPTIONS
+        ${FEATURE_OPTIONS}
+        -DLLVM_INCLUDE_EXAMPLES=OFF
+        -DLLVM_BUILD_EXAMPLES=OFF
+        -DLLVM_INCLUDE_TESTS=OFF
+        -DLLVM_BUILD_TESTS=OFF
+        -DLLVM_INCLUDE_BENCHMARKS=OFF
+        -DLLVM_BUILD_BENCHMARKS=OFF
+        # Force TableGen to be built with optimization. This will significantly improve build time.
+        -DLLVM_OPTIMIZED_TABLEGEN=ON
+        "-DLLVM_ENABLE_PROJECTS=${LLVM_ENABLE_PROJECTS}"
+        "-DLLVM_ENABLE_RUNTIMES=${LLVM_ENABLE_RUNTIMES}"
+        "-DLLVM_TARGETS_TO_BUILD=${LLVM_TARGETS_TO_BUILD}"
+        "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=${LLVM_EXPERIMENTAL_TARGETS_TO_BUILD}"
+        -DPACKAGE_VERSION=${LLVM_VERSION}
+        # Limit the maximum number of concurrent link jobs to 1. This should fix low amount of memory issue for link.
+        "-DLLVM_PARALLEL_LINK_JOBS=${LLVM_LINK_JOBS}"
+        -DLLVM_TOOLS_INSTALL_DIR=tools/llvm
+)
+
+vcpkg_cmake_install(ADD_BIN_TO_PATH)
+
+function(llvm_cmake_package_config_fixup package_name)
+    cmake_parse_arguments("arg" "DO_NOT_DELETE_PARENT_CONFIG_PATH" "FEATURE_NAME" "" ${ARGN})
+    if(NOT DEFINED arg_FEATURE_NAME)
+        set(arg_FEATURE_NAME ${package_name})
+    endif()
+    if("${arg_FEATURE_NAME}" STREQUAL "${PORT}" OR "${arg_FEATURE_NAME}" IN_LIST FEATURES)
+        set(args)
+        list(APPEND args PACKAGE_NAME "${package_name}")
+        if(arg_DO_NOT_DELETE_PARENT_CONFIG_PATH)
+            list(APPEND args "DO_NOT_DELETE_PARENT_CONFIG_PATH")
+        endif()
+        vcpkg_cmake_config_fixup(${args})
+        file(INSTALL "${SOURCE_PATH}/${package_name}/LICENSE.TXT" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${package_name}" RENAME copyright)
+        if(EXISTS "${CMAKE_CURRENT_LIST_DIR}/${package_name}_usage")
+            file(INSTALL "${CMAKE_CURRENT_LIST_DIR}/${package_name}_usage" DESTINATION "${CURRENT_PACKAGES_DIR}/share/${package_name}" RENAME usage)
+        endif()
+    endif()
+endfunction()
+
+llvm_cmake_package_config_fixup("clang" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+llvm_cmake_package_config_fixup("flang" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+llvm_cmake_package_config_fixup("lld" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+llvm_cmake_package_config_fixup("mlir" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+llvm_cmake_package_config_fixup("polly" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+llvm_cmake_package_config_fixup("ParallelSTL" FEATURE_NAME "pstl" DO_NOT_DELETE_PARENT_CONFIG_PATH)
+llvm_cmake_package_config_fixup("llvm")
+
+set(empty_dirs)
+
+if("clang-tools-extra" IN_LIST FEATURES)
+    list(APPEND empty_dirs "${CURRENT_PACKAGES_DIR}/include/clang-tidy/plugin")
+endif()
+
+if("flang" IN_LIST FEATURES)
+    list(APPEND empty_dirs "${CURRENT_PACKAGES_DIR}/include/flang/Config")
+    list(APPEND empty_dirs "${CURRENT_PACKAGES_DIR}/include/flang/CMakeFiles")
+    list(APPEND empty_dirs "${CURRENT_PACKAGES_DIR}/include/flang/Optimizer/CMakeFiles")
+    list(APPEND empty_dirs "${CURRENT_PACKAGES_DIR}/include/flang/Optimizer/CodeGen/CMakeFiles")
+    list(APPEND empty_dirs "${CURRENT_PACKAGES_DIR}/include/flang/Optimizer/Dialect/CMakeFiles")
+    list(APPEND empty_dirs "${CURRENT_PACKAGES_DIR}/include/flang/Optimizer/Transforms/CMakeFiles")
+endif()
+
+if(empty_dirs)
+    foreach(empty_dir IN LISTS empty_dirs)
+        if(NOT EXISTS "${empty_dir}")
+            message(SEND_ERROR "Directory '${empty_dir}' is not exist. Please remove it from the checking.")
+        else()
+            file(GLOB_RECURSE files_in_dir "${empty_dir}/*")
+            if(files_in_dir)
+                message(SEND_ERROR "Directory '${empty_dir}' is not empty. Please remove it from the checking.")
+            else()
+                file(REMOVE_RECURSE "${empty_dir}")
+            endif()
+        endif()
+    endforeach()
+endif()
+
+vcpkg_copy_tool_dependencies(${CURRENT_PACKAGES_DIR}/tools/${PORT})
+
+if(NOT DEFINED VCPKG_BUILD_TYPE OR VCPKG_BUILD_TYPE STREQUAL "debug")
+    file(REMOVE_RECURSE "${CURRENT_PACKAGES_DIR}/debug/include"
+        "${CURRENT_PACKAGES_DIR}/debug/share"
+        "${CURRENT_PACKAGES_DIR}/debug/tools"
+    )
+endif()
+
+if("mlir" IN_LIST FEATURES)
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mlir/MLIRConfig.cmake" "set(MLIR_MAIN_SRC_DIR \"${SOURCE_PATH}/mlir\")" "")
+    vcpkg_replace_string("${CURRENT_PACKAGES_DIR}/share/mlir/MLIRConfig.cmake" "${CURRENT_BUILDTREES_DIR}" "\${MLIR_INCLUDE_DIRS}")
+endif()
+
+# LLVM still generates a few DLLs in the static build:
+# * LLVM-C.dll
+# * libclang.dll
+# * LTO.dll
+# * Remarks.dll
+set(VCPKG_POLICY_DLLS_IN_STATIC_LIBRARY enabled)

--- a/tools/apiview/parsers/cpp-api-parser/ports/llvm/vcpkg.json
+++ b/tools/apiview/parsers/cpp-api-parser/ports/llvm/vcpkg.json
@@ -1,0 +1,384 @@
+{
+  "name": "llvm",
+  "version": "15.0.1",
+  "description": "The LLVM Compiler Infrastructure.",
+  "homepage": "https://llvm.org",
+  "license": "Apache-2.0",
+  "supports": "!uwp & !(arm & windows)",
+  "dependencies": [
+    {
+      "name": "vcpkg-cmake",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-config",
+      "host": true
+    },
+    {
+      "name": "vcpkg-cmake-get-vars",
+      "host": true
+    }
+  ],
+  "default-features": [
+    "clang",
+    "default-options",
+    "default-targets",
+    "lld",
+    "tools"
+  ],
+  "features": {
+    "bolt": {
+      "description": "BOLT is a post-link optimizer developed to speed up large applications.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    },
+    "clang": {
+      "description": "Include C Language Family Front-end.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "compiler-rt",
+            "tools"
+          ]
+        }
+      ]
+    },
+    "clang-tools-extra": {
+      "description": "Include Clang tools."
+    },
+    "compiler-rt": {
+      "description": "Include compiler's runtime libraries."
+    },
+    "default-options": {
+      "description": "Build with default options.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "disable-assertions",
+            "disable-clang-static-analyzer",
+            "enable-bindings",
+            "enable-terminfo",
+            "enable-threads",
+            "enable-zlib"
+          ]
+        }
+      ]
+    },
+    "default-targets": {
+      "description": "Build with platform-specific default targets.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-spirv"
+          ]
+        },
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-aarch64"
+          ],
+          "platform": "arm64"
+        },
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-x86"
+          ],
+          "platform": "x86 | x64"
+        },
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-arm"
+          ],
+          "platform": "arm & !arm64"
+        },
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-all"
+          ],
+          "platform": "!x86 & !x64 & !arm & !arm64"
+        }
+      ]
+    },
+    "disable-assertions": {
+      "description": "Build LLVM without assertions."
+    },
+    "disable-clang-static-analyzer": {
+      "description": "Build without static analyzer."
+    },
+    "enable-abi-breaking-checks": {
+      "description": "Build LLVM with LLVM_ABI_BREAKING_CHECKS=FORCE_ON."
+    },
+    "enable-assertions": {
+      "description": "Build LLVM with assertions."
+    },
+    "enable-bindings": {
+      "description": "Build bindings."
+    },
+    "enable-eh": {
+      "description": "Build LLVM with exception handler.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "enable-rtti"
+          ]
+        }
+      ]
+    },
+    "enable-ffi": {
+      "description": "Build LLVM with FFI.",
+      "dependencies": [
+        "libffi"
+      ]
+    },
+    "enable-ios": {
+      "description": "Build compiler-rt for iOS SDK.",
+      "dependencies": [
+        "target-arm"
+      ]
+    },
+    "enable-libxml2": {
+      "description": "Build with LibXml2.",
+      "dependencies": [
+        "libxml2"
+      ]
+    },
+    "enable-rtti": {
+      "description": "Build LLVM with run-time type information."
+    },
+    "enable-terminfo": {
+      "description": "Use terminfo database if available."
+    },
+    "enable-threads": {
+      "description": "Use threads if available."
+    },
+    "enable-zlib": {
+      "description": "Build with ZLib.",
+      "dependencies": [
+        "zlib"
+      ]
+    },
+    "flang": {
+      "description": "Include Fortran front end.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "clang",
+            "mlir",
+            "tools"
+          ]
+        }
+      ]
+    },
+    "libclc": {
+      "description": "Include OpenCL library."
+    },
+    "libcxx": {
+      "description": "Include libcxx library.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "libcxxabi"
+          ]
+        }
+      ]
+    },
+    "libcxxabi": {
+      "description": "Include libcxxabi library."
+    },
+    "libunwind": {
+      "description": "Include libunwind library."
+    },
+    "lld": {
+      "description": "Include LLVM linker.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    },
+    "lldb": {
+      "description": "Include LLVM debugger.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    },
+    "mlir": {
+      "description": "Include MLIR (Multi-Level IR Compiler Framework) project.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools"
+          ]
+        }
+      ]
+    },
+    "openmp": {
+      "description": "Include LLVM OpenMP libraries.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "utils"
+          ]
+        }
+      ]
+    },
+    "polly": {
+      "description": "Include Polly (Polyhedral optimizations for LLVM) project.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "tools",
+            "utils"
+          ]
+        }
+      ]
+    },
+    "pstl": {
+      "description": "Include pstl (Parallel STL) library."
+    },
+    "target-aarch64": {
+      "description": "Build with AArch64 backend."
+    },
+    "target-all": {
+      "description": "Build with all backends.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "target-aarch64",
+            "target-amdgpu",
+            "target-arm",
+            "target-avr",
+            "target-bpf",
+            "target-hexagon",
+            "target-lanai",
+            "target-mips",
+            "target-msp430",
+            "target-nvptx",
+            "target-powerpc",
+            "target-riscv",
+            "target-sparc",
+            "target-spirv",
+            "target-systemz",
+            "target-ve",
+            "target-webassembly",
+            "target-x86",
+            "target-xcore"
+          ]
+        }
+      ]
+    },
+    "target-amdgpu": {
+      "description": "Build with AMDGPU backend."
+    },
+    "target-arm": {
+      "description": "Build with ARM backend."
+    },
+    "target-avr": {
+      "description": "Build with AVR backend."
+    },
+    "target-bpf": {
+      "description": "Build with BPF backend."
+    },
+    "target-hexagon": {
+      "description": "Build with Hexagon backend."
+    },
+    "target-lanai": {
+      "description": "Build with Lanai backend."
+    },
+    "target-mips": {
+      "description": "Build with Mips backend."
+    },
+    "target-msp430": {
+      "description": "Build with MSP430 backend."
+    },
+    "target-nvptx": {
+      "description": "Build with NVPTX backend."
+    },
+    "target-powerpc": {
+      "description": "Build with PowerPC backend."
+    },
+    "target-riscv": {
+      "description": "Build with RISC-V backend."
+    },
+    "target-sparc": {
+      "description": "Build with Sparc backend."
+    },
+    "target-spirv": {
+      "description": "Build with Spriv backend."
+    },
+    "target-systemz": {
+      "description": "Build with SystemZ backend."
+    },
+    "target-ve": {
+      "description": "Build with VE backend."
+    },
+    "target-webassembly": {
+      "description": "Build with WebAssembly backend."
+    },
+    "target-x86": {
+      "description": "Build with X86 backend."
+    },
+    "target-xcore": {
+      "description": "Build with XCore backend."
+    },
+    "tools": {
+      "description": "Build LLVM tools.",
+      "dependencies": [
+        {
+          "name": "llvm",
+          "default-features": false,
+          "features": [
+            "enable-threads"
+          ]
+        }
+      ]
+    },
+    "utils": {
+      "description": "Build LLVM utils."
+    }
+  }
+}

--- a/tools/apiview/parsers/cpp-api-parser/vcpkg.json
+++ b/tools/apiview/parsers/cpp-api-parser/vcpkg.json
@@ -10,5 +10,8 @@
     },
     { "name": "gtest" },
     { "name": "tclap" }
-  ]
-}
+  ],
+  "vcpkg-configuration": {
+    "overlay-ports": [ "./ports/llvm" ]
+  }
+  }


### PR DESCRIPTION
Use a custom vcpkg port for clang-15 because vcpkg currently doesn't have clang-15 available.

clang-15 port files liberally stolen from https://github.com/microsoft/vcpkg/pull/26902.
