### PR TITLE
stress test error out for breaking helm versions

### DIFF
--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -386,8 +386,15 @@ function generateRetryTestsHelmValues ($pkg, $releaseName, $generatedHelmValues)
     $podOutput = RunOrExitOnFailure kubectl get pods -n $pkg.namespace -o json
     $pods = $podOutput | ConvertFrom-Json
 
+    # helm version example: v3.11.2+g912ebc1
+    $helmVer = (helm version --short).substring(1) -replace '\+.*',''
+    $helmVer = [AzureEngSemanticVersion]::new($helmVer)
+    $minHelmVer =[AzureEngSemanticVersion]::new("3.11.0")
+    Write-Host $helmVer.CompareTo($minHelmVer)
+    if ($helmVer.CompareTo($minHelmVer) -le 0) {
+        throw "Please update helm to version >= 3.11.0`nAdditional information for updating helm version can be found here: https://helm.sh/docs/intro/install/"
+    }
     # Get all jobs within this helm release
-    
     $helmStatusOutput = RunOrExitOnFailure helm status -n $pkg.Namespace $pkg.ReleaseName --show-resources
     # -----Example output-----
     # NAME: <Release Name>

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -4,6 +4,7 @@ $ErrorActionPreference = 'Stop'
 $FailedCommands = New-Object Collections.Generic.List[hashtable]
 
 . (Join-Path $PSScriptRoot "../Helpers" PSModule-Helpers.ps1)
+. (Join-Path $PSScriptRoot "../SemVer.ps1")
 
 $limitRangeSpec = @"
 apiVersion: v1
@@ -389,8 +390,7 @@ function generateRetryTestsHelmValues ($pkg, $releaseName, $generatedHelmValues)
     # helm version example: v3.11.2+g912ebc1
     $helmVer = (helm version --short).substring(1) -replace '\+.*',''
     $helmVer = [AzureEngSemanticVersion]::new($helmVer)
-    $minHelmVer =[AzureEngSemanticVersion]::new("3.11.0")
-    Write-Host $helmVer.CompareTo($minHelmVer)
+    $minHelmVer = [AzureEngSemanticVersion]::new("3.11.0")
     if ($helmVer.CompareTo($minHelmVer) -le 0) {
         throw "Please update helm to version >= 3.11.0`nAdditional information for updating helm version can be found here: https://helm.sh/docs/intro/install/"
     }

--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -394,7 +394,6 @@ function CheckDependencies()
 }
 
 function generateRetryTestsHelmValues ($pkg, $releaseName, $generatedHelmValues) {
-    CheckDependencies
 
     $podOutput = RunOrExitOnFailure kubectl get pods -n $pkg.namespace -o json
     $pods = $podOutput | ConvertFrom-Json


### PR DESCRIPTION
Stress test deployment now requires helm version 3.11.0+, now throwing a more descriptive error