### PR TITLE
Fix NullReferenceException happening in ApiPath

### DIFF
--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerSpec/ApiPath.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerSpec/ApiPath.cs
@@ -36,6 +36,11 @@ public class ApiPath
                 {
                     if (this.parameters != null)
                     {
+                        if (operation.parameters == null)
+                        {
+                            operation.parameters = new List<Parameter>();
+                        }
+
                         operation.parameters.AddRange(this.parameters);
                     }   
                     ret.Add(method, operation);

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParserTest/fixtures/azureopenai.json
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParserTest/fixtures/azureopenai.json
@@ -7,6 +7,11 @@
   },
   "paths": {
     "/deployments": {
+      "parameters": [
+        {
+          "$ref": "#/parameters/apiVersionQueryParameter"
+        }
+      ],
       "get": {
         "tags": [
           "Deployments:"
@@ -15,11 +20,6 @@
         "operationId": "Deployments_List",
         "produces": [
           "application/json"
-        ],
-        "parameters": [
-          {
-            "$ref": "#/parameters/apiVersionQueryParameter"
-          }
         ],
         "responses": {
           "200": {
@@ -54,9 +54,6 @@
           "application/json"
         ],
         "parameters": [
-          {
-            "$ref": "#/parameters/apiVersionQueryParameter"
-          },
           {
             "in": "body",
             "name": "body",


### PR DESCRIPTION
Ensure ApiPath does not get a NullReferenceExcepton when copying common parameters to operation method parameters.

Previously, when the operation method does not have any parameters a NullRefferenceException occurs when attempting to copy the common parameters to the operation method.

I encountered this when working on DevCenter RP and it looks like others have hit this issue as well: #5810 