### PR TITLE
[test resources] Fix regression - base name overrides in CI

### DIFF
--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -23,6 +23,12 @@ function GetBaseAndResourceGroupNames(
     [string]$serviceDirectoryName,
     [bool]$CI
 ) {
+    if ($baseNameDefault) {
+        $base = $baseNameDefault.ToLowerInvariant()
+        $group = $resourceGroupNameDefault ? $resourceGroupNameDefault : ("rg-$baseNameDefault".ToLowerInvariant())
+        return $base, $group
+    }
+
     if ($CI) {
         $base = 't' + (New-Guid).ToString('n').Substring(0, 16)
         # Format the resource group name based on resource group naming recommendations and limitations.
@@ -34,12 +40,6 @@ function GetBaseAndResourceGroupNames(
 
         Log "Generated resource base name '$base' and resource group name '$group' for CI build"
 
-        return $base, $group
-    }
-
-    if ($baseNameDefault) {
-        $base = $baseNameDefault.ToLowerInvariant()
-        $group = $resourceGroupNameDefault ? $resourceGroupNameDefault : ("rg-$baseNameDefault".ToLowerInvariant())
         return $base, $group
     }
 


### PR DESCRIPTION
This PR fixes an issue introduced in https://github.com/Azure/azure-sdk-tools/pull/5242 which stopped respecting BaseName parameter overrides in CI mode. This caused issues in stress deployments where we intentionally override BaseName to get a short name hash and need the value to match up with other places where inject it.

CC @richardpark-msft @lmolkova 