### PR TITLE
Add diagnostic rules for ExpandableStringEnum

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
@@ -51,6 +51,7 @@ public class Diagnostics {
         ));
         diagnostics.add(new BuilderTraitsDiagnosticRule());
         diagnostics.add(new MavenPackageAndDescriptionDiagnosticRule());
+        diagnostics.add(new ExpandableStringEnumDiagnosticRule());
 
         // common APIs for all builders (below we will do rules for http or amqp builders)
         diagnostics.add(new RequiredBuilderMethodsDiagnosticRule(null)

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ExpandableStringEnumDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ExpandableStringEnumDiagnosticRule.java
@@ -42,10 +42,10 @@ public class ExpandableStringEnumDiagnosticRule implements DiagnosticRule {
             AtomicBoolean hasValuesMethod = new AtomicBoolean(false);
             getPublicOrProtectedMethods(cu).forEach(method -> {
                 final String methodName = method.getNameAsString();
-                if (methodName.equals("fromString") && method.isPublic()) {
+                if (methodName.equals("fromString") && method.isPublic() && method.isStatic()) {
                     hasFromStringMethod.set(true);
                 }
-                if (methodName.equals(("values")) && method.isPublic()) {
+                if (methodName.equals(("values")) && method.isPublic() && method.isStatic()) {
                     hasValuesMethod.set(true);
                 }
             });

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ExpandableStringEnumDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/ExpandableStringEnumDiagnosticRule.java
@@ -1,0 +1,69 @@
+package com.azure.tools.apiview.processor.diagnostics.rules;
+
+import com.azure.tools.apiview.processor.diagnostics.DiagnosticRule;
+import com.azure.tools.apiview.processor.model.APIListing;
+import com.azure.tools.apiview.processor.model.Diagnostic;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.ClassOrInterfaceDeclaration;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getClassName;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPublicOrProtectedMethods;
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
+import static com.azure.tools.apiview.processor.model.DiagnosticKind.ERROR;
+import static com.azure.tools.apiview.processor.model.DiagnosticKind.WARNING;
+
+/**
+ * Diagnostic rule to validate if types extending from ExpandableStringEnum include
+ * fromString() and values() methods.
+ */
+public class ExpandableStringEnumDiagnosticRule implements DiagnosticRule {
+
+    @Override
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
+
+        cu.getPrimaryType().ifPresent(typeDeclaration -> {
+            if (typeDeclaration instanceof ClassOrInterfaceDeclaration) {
+                ClassOrInterfaceDeclaration classDeclaration = (ClassOrInterfaceDeclaration) typeDeclaration;
+                // check if the type extends ExpandableStringEnum
+                if (classDeclaration.getExtendedTypes() != null
+                        && classDeclaration.getExtendedTypes().stream()
+                        .anyMatch(extendedType -> extendedType.getNameAsString().equals("ExpandableStringEnum"))) {
+                    checkRequiredMethodsExist(cu, listing);
+                }
+            }
+        });
+    }
+
+    private static void checkRequiredMethodsExist(CompilationUnit cu, APIListing listing) {
+        getClassName(cu).ifPresent(className -> {
+            AtomicBoolean hasFromStringMethod = new AtomicBoolean(false);
+            AtomicBoolean hasValuesMethod = new AtomicBoolean(false);
+            getPublicOrProtectedMethods(cu).forEach(method -> {
+                final String methodName = method.getNameAsString();
+                if (methodName.equals("fromString") && method.isPublic()) {
+                    hasFromStringMethod.set(true);
+                }
+                if (methodName.equals(("values")) && method.isPublic()) {
+                    hasValuesMethod.set(true);
+                }
+            });
+
+            if (!hasFromStringMethod.get()) {
+                // missing public fromString method is an error.
+                listing.addDiagnostic(new Diagnostic(
+                        ERROR,
+                        makeId(cu),
+                        "Types extending ExpandableStringEnum should include public static fromString() method."));
+            }
+            if (!hasValuesMethod.get()) {
+                // Missing values method can be logged at warning level.
+                listing.addDiagnostic(new Diagnostic(
+                        WARNING,
+                        makeId(cu),
+                        "Types extending ExpandableStringEnum should include public static values() method."));
+            }
+        });
+    }
+}


### PR DESCRIPTION
### Missing `fromString()` method


![image](https://user-images.githubusercontent.com/51379715/230545209-80b75cd6-cb70-45a1-850f-448ed4260f42.png)


### Missing `values()` method

![image](https://user-images.githubusercontent.com/51379715/230545280-77024362-3035-4c5f-a6c9-27ede4fff9b2.png)
