### PR TITLE
Switch to using standard PAT tokens instead of base 64

### DIFF
--- a/eng/common/scripts/Add-RetentionLease.ps1
+++ b/eng/common/scripts/Add-RetentionLease.ps1
@@ -26,19 +26,7 @@ Set-StrictMode -Version 3
 
 . (Join-Path $PSScriptRoot common.ps1)
 
-$unencodedAuthToken = "nobody:$AccessToken"
-$unencodedAuthTokenBytes = [System.Text.Encoding]::UTF8.GetBytes($unencodedAuthToken)
-$encodedAuthToken = [System.Convert]::ToBase64String($unencodedAuthTokenBytes)
-
-if ($isDevOpsRun) {
-  # We are doing this here so that there is zero chance that this token is emitted in Azure Pipelines
-  # build logs. Azure Pipelines will see this text and register the secret as a value it should *** out
-  # before being transmitted to the server (and shown in logs). It means if the value is accidentally
-  # leaked anywhere else that it won't be visible. The downside is that when the script is executed
-  # on a local development box, it will be visible.
-  Write-Host "##vso[task.setvariable variable=_throwawayencodedaccesstoken;issecret=true;]$($encodedAuthToken)"
-}
-
+$encodedAuthToken = Get-Base64EncodedToken $AccessToken
 
 LogDebug "Checking for existing leases on run: $RunId"
 $existingLeases = Get-RetentionLeases -Organization $Organization -Project $Project -DefinitionId $DefinitionId -RunId $RunId -OwnerId $OwnerId -Base64EncodedAuthToken $encodedAuthToken

--- a/eng/common/scripts/Invoke-DevOpsAPI.ps1
+++ b/eng/common/scripts/Invoke-DevOpsAPI.ps1
@@ -8,12 +8,8 @@ function Get-Base64EncodedToken([string]$AuthToken)
   $unencodedAuthTokenBytes = [System.Text.Encoding]::UTF8.GetBytes($unencodedAuthToken)
   $encodedAuthToken = [System.Convert]::ToBase64String($unencodedAuthTokenBytes)
 
-  if ($isDevOpsRun) {
-    # We are doing this here so that there is zero chance that this token is emitted in Azure Pipelines
-    # build logs. Azure Pipelines will see this text and register the secret as a value it should *** out
-    # before being transmitted to the server (and shown in logs). It means if the value is accidentally
-    # leaked anywhere else that it won't be visible. The downside is that when the script is executed
-    # on a local development box, it will be visible.
+  if (Test-SupportsDevOpsLogging) {
+    # Mark the encoded value as a secret so that DevOps will star any references to it that might end up in the logs
     Write-Host "##vso[task.setvariable variable=_throwawayencodedaccesstoken;issecret=true;]$($encodedAuthToken)"
   }
 

--- a/eng/common/scripts/logging.ps1
+++ b/eng/common/scripts/logging.ps1
@@ -1,8 +1,11 @@
-$isDevOpsRun = ($null -ne $env:SYSTEM_TEAMPROJECTID)
+function Test-SupportsDevOpsLogging()
+{
+    return ($null -ne $env:SYSTEM_TEAMPROJECTID)
+}
 
 function LogWarning
 {
-    if ($isDevOpsRun) 
+    if (Test-SupportsDevOpsLogging)
     {
         Write-Host "##vso[task.LogIssue type=warning;]$args"
     }
@@ -14,11 +17,11 @@ function LogWarning
 
 function LogError
 {
-    if ($isDevOpsRun) 
+    if (Test-SupportsDevOpsLogging)
     {
         Write-Host "##vso[task.LogIssue type=error;]$args"
     }
-    else 
+    else
     {
         Write-Error "$args"
     }
@@ -26,11 +29,11 @@ function LogError
 
 function LogDebug
 {
-    if ($isDevOpsRun) 
+    if (Test-SupportsDevOpsLogging)
     {
         Write-Host "[debug]$args"
     }
-    else 
+    else
     {
         Write-Debug "$args"
     }

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -93,7 +93,7 @@ steps:
           -DefinitionId "$(${{repo}}-template-definition-id)"
           -VsoQueuedPipelines "QUEUEDPIPELINES"
           -CancelPreviousBuilds $True
-          -Base64EncodedAuthToken "$(azuresdk-azure-sdk-devops-build-queuing-pat)"
+          -AuthToken $(System.AccessToken)
 
     - task: PowerShell@2
       displayName: Queue live-test template pipeline
@@ -109,7 +109,7 @@ steps:
           -DefinitionId "$(${{repo}}-template-tests-definition-id)"
           -VsoQueuedPipelines "QUEUEDPIPELINES"
           -CancelPreviousBuilds $True
-          -Base64EncodedAuthToken "$(azuresdk-azure-sdk-devops-build-queuing-pat)"
+          -AuthToken $(System.AccessToken)
 
   - task: PowerShell@2
     displayName: Write Queued Pipeline Information to Tools PR


### PR DESCRIPTION
For most of these we can use the standard System.AccessToken given to the build instead of maintaining a specific token. However that token isn't base 64 encoded so we need to encode it.

With this we can stop explicitly passing PAT's unless we need to access another DevOps org and we also don't have to remember to keep the PAT's in KV base 64 encoded.