### PR TITLE
Update rule name and criteria

### DIFF
--- a/tools/github-event-processor/RULES.md
+++ b/tools/github-event-processor/RULES.md
@@ -514,7 +514,7 @@ OR
       - "Sorry, @{commenter}, only the original author can reopen this pull request."
   ```
 
-## Reset auto-merge approvals on untrusted changes
+## Reset approvals for untrusted changes
 
 ### Trigger
 
@@ -524,7 +524,7 @@ OR
 ### Criteria
 
 - Pull request is open
-- Pull request has "auto-merge" label
+- auto-merge has been enabled through the GitHub UI on the pull request
 - User who pushed the changes does NOT have a collaborator association
 - User who pushed changes does NOT have write permission
 - User who pushed changes does NOT have admin permission


### PR DESCRIPTION
The rule name is actually ResetApprovalsForUntrustedChanges and the criteria listed was incorrect. There is no more auto-merge label, the rule is looking at whether or not Enable auto-merge was set on the PR through the GitHub UI.