### PR TITLE
[TypeSpec APIView] ﻿Unrestrict dependencies

### DIFF
--- a/tools/apiview/emitters/typespec-apiview/CHANGELOG.md
+++ b/tools/apiview/emitters/typespec-apiview/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release History
 
+## Version 0.4.4 (04-18-2023)
+Support future beta releases of TypeSpec.
+
+## Version 0.4.3 (04-17-2023)
+Support latest release of TypeSpec.
+
 ## Version 0.4.2 (03-16-2023)
 Support latest release of TypeSpec.
 

--- a/tools/apiview/emitters/typespec-apiview/package.json
+++ b/tools/apiview/emitters/typespec-apiview/package.json
@@ -54,14 +54,13 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@azure-tools/typespec-azure-core": ">=0.26 <1.0",
-    "@azure-tools/typespec-autorest": ">=0.26 <1.0",
     "@typespec/compiler": ">=0.40 <1.0",
-    "@typespec/http": ">=0.40 <1.0",
-    "@typespec/rest": ">=0.40 <1.0",
     "@typespec/versioning": ">=0.40 <1.0"
   },
   "devDependencies": {
+    "@azure-tools/typespec-azure-core": ">=0.26 <1.0",
+    "@typespec/http": ">=0.40 <1.0",
+    "@typespec/rest": ">=0.40 <1.0",
     "@typespec/eslint-plugin": ">=0.40 <1.0",
     "@typespec/library-linter": ">=0.40 <1.0",
     "@typespec/prettier-plugin-typespec": ">=0.40 <1.0",

--- a/tools/apiview/emitters/typespec-apiview/package.json
+++ b/tools/apiview/emitters/typespec-apiview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-apiview",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "author": "Microsoft Corporation",
   "description": "Library for emitting APIView token files from TypeSpec",
   "homepage": "https://github.com/Azure/azure-sdk-tools",
@@ -54,18 +54,18 @@
     "!dist/test/**"
   ],
   "dependencies": {
-    "@azure-tools/typespec-azure-core": "0.29.0",
-    "@azure-tools/typespec-autorest": "0.29.0",
-    "@typespec/compiler": "0.43.0",
-    "@typespec/http": "0.43.1",
-    "@typespec/rest": "0.43.0",
-    "@typespec/versioning": "0.43.0"
+    "@azure-tools/typespec-azure-core": ">=0.26 <1.0",
+    "@azure-tools/typespec-autorest": ">=0.26 <1.0",
+    "@typespec/compiler": ">=0.40 <1.0",
+    "@typespec/http": ">=0.40 <1.0",
+    "@typespec/rest": ">=0.40 <1.0",
+    "@typespec/versioning": ">=0.40 <1.0"
   },
   "devDependencies": {
-    "@typespec/eslint-plugin": "~0.43.0",
-    "@typespec/library-linter": "~0.43.0",
-    "@typespec/prettier-plugin-typespec": "^0.43.0",
-    "@typespec/eslint-config-typespec": "~0.6.0",
+    "@typespec/eslint-plugin": ">=0.40 <1.0",
+    "@typespec/library-linter": ">=0.40 <1.0",
+    "@typespec/prettier-plugin-typespec": ">=0.40 <1.0",
+    "@typespec/eslint-config-typespec": "0.x",
     "@types/mocha": "~9.1.0",
     "@types/node": "~16.0.3",
     "@changesets/cli": "^2.24.4",

--- a/tools/apiview/emitters/typespec-apiview/package.json
+++ b/tools/apiview/emitters/typespec-apiview/package.json
@@ -58,9 +58,9 @@
     "@typespec/versioning": ">=0.40 <1.0"
   },
   "devDependencies": {
-    "@azure-tools/typespec-azure-core": ">=0.26 <1.0",
-    "@typespec/http": ">=0.40 <1.0",
-    "@typespec/rest": ">=0.40 <1.0",
+    "@azure-tools/typespec-azure-core": "0.29.0",
+    "@typespec/http": "0.43.1",
+    "@typespec/rest": "0.43.0",
     "@typespec/eslint-plugin": ">=0.40 <1.0",
     "@typespec/library-linter": ">=0.40 <1.0",
     "@typespec/prettier-plugin-typespec": ">=0.40 <1.0",

--- a/tools/apiview/emitters/typespec-apiview/package.json
+++ b/tools/apiview/emitters/typespec-apiview/package.json
@@ -53,7 +53,7 @@
     "dist/**",
     "!dist/test/**"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "@azure-tools/typespec-azure-core": ">=0.26 <1.0",
     "@azure-tools/typespec-autorest": ">=0.26 <1.0",
     "@typespec/compiler": ">=0.40 <1.0",

--- a/tools/apiview/emitters/typespec-apiview/src/version.ts
+++ b/tools/apiview/emitters/typespec-apiview/src/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "0.4.3";
+export const LIB_VERSION = "0.4.4";


### PR DESCRIPTION
Should allow APIView to "just work" with future TypeSpec releases without the need for a release. 