### PR TITLE
Update Ubuntu `18.04` to `2X.04` ; update `MMSUbuntu2X.04` to `ubuntu-2X.04`

### DIFF
--- a/doc/common/matrix_generator.md
+++ b/doc/common/matrix_generator.md
@@ -604,7 +604,7 @@ For example, given a matrix config like below:
 {
   "matrix": {
     "Agent": {
-      "ubuntu-2204": { "OSVmImage": "MMSUbuntu22.04", "Pool": "azsdk-pool-mms-ubuntu-2204-general" }
+      "ubuntu-2204": { "OSVmImage": "ubuntu-22.04", "Pool": "azsdk-pool-mms-ubuntu-2204-general" }
     },
     "JavaTestVersion": [ "1.8", "1.11" ]
   }
@@ -618,12 +618,12 @@ The normal matrix output (without replacements), looks like:
 $ ./Create-JobMatrix.ps1 -ConfigPath <test> -Selection all
 {
   "ubuntu2204_18": {
-    "OSVmImage": "MMSUbuntu22.04",
+    "OSVmImage": "ubuntu-22.04",
     "Pool": "azsdk-pool-mms-ubuntu-2204-general",
     "JavaTestVersion": "1.8"
   },
   "ubuntu2204_111": {
-    "OSVmImage": "MMSUbuntu22.04",
+    "OSVmImage": "ubuntu-22.04",
     "Pool": "azsdk-pool-mms-ubuntu-2204-general",
     "JavaTestVersion": "1.11"
   }
@@ -640,12 +640,12 @@ $ $replacements = @('.*Version=1.11/2.0', 'Pool=(.*ubuntu.*)-general/$1-custom')
 $ ../Create-JobMatrix.ps1 -ConfigPath ./test.Json -Selection all -Replace $replacements
 {
   "ubuntu2204_18": {
-    "OSVmImage": "MMSUbuntu22.04",
+    "OSVmImage": "ubuntu-22.04",
     "Pool": "azsdk-pool-mms-ubuntu-2204-custom",
     "JavaTestVersion": "1.8"
   },
   "ubuntu2204_20": {
-    "OSVmImage": "MMSUbuntu22.04",
+    "OSVmImage": "ubuntu-22.04",
     "Pool": "azsdk-pool-mms-ubuntu-2204-custom",
     "JavaTestVersion": "2.0"
   }
@@ -672,7 +672,7 @@ Given a matrix like below with `JavaTestVersion` marked as a non-sparse paramete
   "matrix": {
     "Agent": {
       "windows-2022": { "OSVmImage": "windows-2022", "Pool": "azsdk-pool-mms-win-2022-general" },
-      "ubuntu-2204": { "OSVmImage": "MMSUbuntu22.04", "Pool": "azsdk-pool-mms-ubuntu-2204-general" },
+      "ubuntu-2204": { "OSVmImage": "ubuntu-22.04", "Pool": "azsdk-pool-mms-ubuntu-2204-general" },
       "macos-11": { "OSVmImage": "macos-11", "Pool": "Azure Pipelines" }
     },
     "JavaTestVersion": [ "1.8", "1.11" ],

--- a/doc/common/matrix_generator.md
+++ b/doc/common/matrix_generator.md
@@ -623,7 +623,7 @@ $ ./Create-JobMatrix.ps1 -ConfigPath <test> -Selection all
     "JavaTestVersion": "1.8"
   },
   "ubuntu2204_111": {
-    "OSVmImage": "MMSUbuntu18.04",
+    "OSVmImage": "MMSUbuntu22.04",
     "Pool": "azsdk-pool-mms-ubuntu-2204-general",
     "JavaTestVersion": "1.11"
   }
@@ -644,7 +644,7 @@ $ ../Create-JobMatrix.ps1 -ConfigPath ./test.Json -Selection all -Replace $repla
     "Pool": "azsdk-pool-mms-ubuntu-2204-custom",
     "JavaTestVersion": "1.8"
   },
-  "ubuntu1804_20": {
+  "ubuntu2204_20": {
     "OSVmImage": "MMSUbuntu22.04",
     "Pool": "azsdk-pool-mms-ubuntu-2204-custom",
     "JavaTestVersion": "2.0"

--- a/eng/common-tests/matrix-generator/samples/matrix-test.yml
+++ b/eng/common-tests/matrix-generator/samples/matrix-test.yml
@@ -9,7 +9,7 @@ jobs:
       JobTemplatePath: /eng/common-tests/matrix-generator/samples/matrix-job-sample.yml
       AdditionalParameters: {}
       Pool: Azure Pipelines
-      OsVmImage: ubuntu-18.04
+      OsVmImage: ubuntu-20.04
       CloudConfig:
         SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
         Location: eastus2

--- a/eng/common-tests/matrix-generator/samples/matrix.json
+++ b/eng/common-tests/matrix-generator/samples/matrix.json
@@ -4,7 +4,7 @@
   },
   "matrix": {
     "Agent": {
-      "ubuntu": { "OSVmImage": "ubuntu-18.04", "Pool": "Azure Pipelines" },
+      "ubuntu": { "OSVmImage": "ubuntu-20.04", "Pool": "Azure Pipelines" },
       "windows": { "OSVmImage": "windows-2022", "Pool": "Azure Pipelines" },
       "macOS": { "OSVmImage": "macos-11", "Pool": "Azure Pipelines" }
     },

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.filter.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.filter.tests.ps1
@@ -6,7 +6,7 @@ BeforeAll {
     $matrixConfig = @"
 {
     "matrix": {
-        "operatingSystem": [ "windows-2022", "ubuntu-18.04", "macos-11" ],
+        "operatingSystem": [ "windows-2022", "ubuntu-20.04", "macos-11" ],
         "framework": [ "net461", "netcoreapp2.1" ],
         "additionalArguments": [ "", "mode=test" ]
     }
@@ -19,7 +19,7 @@ Describe "Matrix Filter" -Tag "UnitTest", "filter" {
     It "Should filter by matrix display name" -TestCases @(
         @{ regex = "windows.*"; expectedFirst = "windows2022_net461"; length = 4 }
         @{ regex = "windows2022_netcoreapp21_modetest"; expectedFirst = "windows2022_netcoreapp21_modetest"; length = 1 }
-        @{ regex = ".*ubuntu.*"; expectedFirst = "ubuntu1804_net461"; length = 4 }
+        @{ regex = ".*ubuntu.*"; expectedFirst = "ubuntu2004_net461"; length = 4 }
     ) {
         [array]$matrix = GenerateMatrix $config "all" $regex
         $matrix.Length | Should -Be $length

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
@@ -490,7 +490,7 @@ Describe "Platform Matrix Replace" -Tag "UnitTest", "replace" {
 {
   "matrix": {
     "Agent": {
-      "ubuntu-1804": { "OSVmImage": "MMSUbuntu18.04", "Pool": "azsdk-pool-mms-ubuntu-1804-general" }
+      "ubuntu-2004": { "OSVmImage": "MMSUbuntu20.04", "Pool": "azsdk-pool-mms-ubuntu-2004-general" }
     },
     "JavaTestVersion": [ "1.8", "1.11" ]
   }
@@ -501,16 +501,16 @@ Describe "Platform Matrix Replace" -Tag "UnitTest", "replace" {
 
         $matrix.Length | Should -Be 2
         # Replacements of inner values will preserve the grouping name
-        $matrix[0].name | Should -Be "ubuntu1804_20"
+        $matrix[0].name | Should -Be "ubuntu2004_20"
         $matrix[0].parameters.JavaTestVersion | Should -Be "2.0"
         $matrix[0].parameters.Pool | Should -Be "custom-ubuntu-pool"
-        $matrix[0].parameters.OSVmImage | Should -Be "MMSUbuntu18.04"
+        $matrix[0].parameters.OSVmImage | Should -Be "MMSUbuntu20.04"
 
         # Make sure non-literal keys still replace under the hood
         $matrix = GenerateMatrix $importConfig "all" -replace ".*=.*ubuntu.*/custom-ubuntu-pool"
 
         $matrix.Length | Should -Be 2
-        $matrix[0].name | Should -Be "ubuntu1804_18"
+        $matrix[0].name | Should -Be "ubuntu2004_18"
         $matrix[0].parameters.Pool | Should -Be "custom-ubuntu-pool"
     }
 

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
@@ -490,7 +490,7 @@ Describe "Platform Matrix Replace" -Tag "UnitTest", "replace" {
 {
   "matrix": {
     "Agent": {
-      "ubuntu-2004": { "OSVmImage": "MMSUbuntu20.04", "Pool": "azsdk-pool-mms-ubuntu-2004-general" }
+      "ubuntu-2004": { "OSVmImage": "ubuntu-20.04", "Pool": "azsdk-pool-mms-ubuntu-2004-general" }
     },
     "JavaTestVersion": [ "1.8", "1.11" ]
   }
@@ -504,7 +504,7 @@ Describe "Platform Matrix Replace" -Tag "UnitTest", "replace" {
         $matrix[0].name | Should -Be "ubuntu2004_20"
         $matrix[0].parameters.JavaTestVersion | Should -Be "2.0"
         $matrix[0].parameters.Pool | Should -Be "custom-ubuntu-pool"
-        $matrix[0].parameters.OSVmImage | Should -Be "MMSUbuntu20.04"
+        $matrix[0].parameters.OSVmImage | Should -Be "ubuntu-20.04"
 
         # Make sure non-literal keys still replace under the hood
         $matrix = GenerateMatrix $importConfig "all" -replace ".*=.*ubuntu.*/custom-ubuntu-pool"

--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.tests.ps1
@@ -11,7 +11,7 @@ BeforeAll {
     "matrix": {
         "operatingSystem": [
           "windows-2022",
-          "ubuntu-18.04",
+          "ubuntu-20.04",
           "macos-11"
         ],
         "framework": [
@@ -40,7 +40,7 @@ BeforeAll {
             "framework": "netcoreapp2.1"
         },
         {
-            "operatingSystem": ["macos-11", "ubuntu-18.04"],
+            "operatingSystem": ["macos-11", "ubuntu-20.04"],
             "additionalArguments": "--enableFoo"
         }
     ]
@@ -274,7 +274,7 @@ Describe "Platform Matrix Generation" -Tag "UnitTest", "generate" {
     "matrix": {
         "operatingSystem": [
           "windows-2022",
-          "ubuntu-18.04",
+          "ubuntu-20.04",
           "macos-11"
         ],
         "framework": [
@@ -318,7 +318,7 @@ Describe "Platform Matrix Generation" -Tag "UnitTest", "generate" {
         $element.name | Should -Be "windows2022_net461"
 
         $element = GetNdMatrixElement @(1, 1, 1) $matrix $dimensions
-        $element.name | Should -Be "ubuntu1804_netcoreapp21_withFoo"
+        $element.name | Should -Be "ubuntu2004_netcoreapp21_withFoo"
 
         $element = GetNdMatrixElement @(2, 1, 1) $matrix $dimensions
         $element.name | Should -Be "macOS11_netcoreapp21_withFoo"
@@ -335,7 +335,7 @@ Describe "Platform Matrix Generation" -Tag "UnitTest", "generate" {
         $element.additionalArguments | Should -Be ""
 
         $element = GetNdMatrixElement @(1, 1, 1) $matrix $dimensions
-        $element.parameters.operatingSystem | Should -Be "ubuntu-18.04"
+        $element.parameters.operatingSystem | Should -Be "ubuntu-20.04"
         $element.parameters.framework | Should -Be "netcoreapp2.1"
         $element.parameters.additionalArguments | Should -Be "--enableFoo"
 
@@ -347,7 +347,7 @@ Describe "Platform Matrix Generation" -Tag "UnitTest", "generate" {
 
     It "Should initialize a sparse matrix from an N-dimensional matrix" -TestCases @(
         @{ i = 0; name = "windows2022_net461"; operatingSystem = "windows-2022"; framework = "net461"; additionalArguments = ""; }
-        @{ i = 1; name = "ubuntu1804_netcoreapp21_withfoo"; operatingSystem = "ubuntu-18.04"; framework = "netcoreapp2.1"; additionalArguments = "--enableFoo"; }
+        @{ i = 1; name = "ubuntu2004_netcoreapp21_withfoo"; operatingSystem = "ubuntu-20.04"; framework = "netcoreapp2.1"; additionalArguments = "--enableFoo"; }
         @{ i = 2; name = "macOS11_net461"; operatingSystem = "macos-11"; framework = "net461"; additionalArguments = ""; }
     ) {
         $sparseMatrix = GenerateSparseMatrix $generateConfig.matrixParameters $generateConfig.displayNamesLookup
@@ -435,9 +435,9 @@ Describe "Platform Matrix Post Transformation" -Tag "UnitTest", "transform" {
         $matrix[1].parameters.framework | Should -Be "netcoreapp2.1"
         $matrix[1].parameters.additionalArguments | Should -Be "--enableFoo"
 
-        $matrix[2].name | Should -Be "ubuntu1804_net461"
+        $matrix[2].name | Should -Be "ubuntu2004_net461"
         $matrix[2].parameters.framework | Should -Be "net461"
-        $matrix[2].parameters.operatingSystem | Should -Be "ubuntu-18.04"
+        $matrix[2].parameters.operatingSystem | Should -Be "ubuntu-20.04"
         $matrix[2].parameters.additionalArguments | Should -Be ""
 
         $matrix[4].name | Should -Be "macOS11_net461"
@@ -580,7 +580,7 @@ Describe "Platform Matrix Job and Display Names" -Tag "UnitTest", "displaynames"
         "--enableFoo": "withfoo"
     },
     "matrix": {
-        "operatingSystem": "ubuntu-18.04",
+        "operatingSystem": "ubuntu-20.04",
         "framework": [
           "net461",
           "netcoreapp2.1"
@@ -603,18 +603,18 @@ Describe "Platform Matrix Job and Display Names" -Tag "UnitTest", "displaynames"
         $generateconfig.displayNamesLookup["netcoreapp2.1"] = (New-Object string[] 150) -join "a"
         $matrix = GenerateFullMatrix $generateconfig.matrixParameters $generateconfig.displayNamesLookup
 
-        $matrix[0].name | Should -Be "ubuntu1804_123some456invalid_formatnamefoo_TestObjectValueName"
+        $matrix[0].name | Should -Be "ubuntu2004_123some456invalid_formatnamefoo_TestObjectValueName"
 
         $matrix[1].name.Length | Should -Be 100
         # The withfoo part of the argument gets cut off at the character limit
-        $matrix[1].name | Should -BeLike "ubuntu1804_aaaaaaaaaaaaaaaaa*"
+        $matrix[1].name | Should -BeLike "ubuntu2004_aaaaaaaaaaaaaaaaa*"
     }
 
     It "Should create a valid display name when there are leading numbers" {
-        $generateconfig.displayNamesLookup["ubuntu-18.04"] = '123_ubuntu1804'
+        $generateconfig.displayNamesLookup["ubuntu-20.04"] = '123_ubuntu2004'
         $matrix = GenerateFullMatrix $generateconfig.matrixParameters $generateconfig.displayNamesLookup
 
-        $matrix[0].name | Should -Be "job_123_ubuntu1804_net461_TestObjectValueName"
+        $matrix[0].name | Should -Be "job_123_ubuntu2004_net461_TestObjectValueName"
     }
 
     It "Should create a valid job name when there are leading numbers" {
@@ -649,6 +649,6 @@ Describe "Platform Matrix Job and Display Names" -Tag "UnitTest", "displaynames"
 
     It "Should generate a display name with null and object values" {
         $matrix = GenerateMatrix $generateConfig "sparse"
-        $matrix[0].name | Should -Be "ubuntu1804_net461_TestObjectValueName"
+        $matrix[0].name | Should -Be "ubuntu2004_net461_TestObjectValueName"
     }
 }

--- a/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
+++ b/eng/common/pipelines/templates/jobs/archetype-sdk-tests-generate.yml
@@ -30,7 +30,7 @@ parameters:
   default: azsdk-pool-mms-ubuntu-2204-general
 - name: OsVmImage
   type: string
-  default: MMSUbuntu22.04
+  default: ubuntu-22.04
 # This parameter is only necessary if there are multiple invocations of this template within the SAME STAGE.
 # When that occurs, provide a name other than the default value.
 - name: GenerateJobName

--- a/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
 - job: PreparePipelines
   pool:
     name: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: MMSUbuntu22.04
+    vmImage: ubuntu-22.04
   steps:
     - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
     - template: /eng/common/pipelines/templates/steps/set-default-branch.yml

--- a/eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
+++ b/eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
@@ -26,7 +26,7 @@ stages:
               Image: windows-2022
             Linux:
               Pool: azsdk-pool-mms-ubuntu-2204-general
-              Image: MMSUbuntu22.04
+              Image: ubuntu-22.04
             Mac:
               Pool: Azure Pipelines
               Image: macos-11

--- a/eng/containers/ci.yml
+++ b/eng/containers/ci.yml
@@ -4,21 +4,21 @@ parameters:
   default:
   - name: mock_attestation
     pool: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: MMSUbuntu22.04
+    vmImage: ubuntu-22.04
     dockerRepo: 'keyvault-mock-attestation'
     dockerFile: 'tools/keyvault-mock-attestation/Dockerfile'
     stableTags:
     - 'latest'
   - name: stress_watcher
     pool: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: MMSUbuntu22.04
+    vmImage: ubuntu-22.04
     dockerRepo: 'stress/watcher'
     dockerFile: 'tools/stress-cluster/services/Stress.Watcher/Dockerfile'
     stableTags:
     - 'latest'
   - name: stress_deploy_test_resources
     pool: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: MMSUbuntu22.04
+    vmImage: ubuntu-22.04
     dockerRepo: 'stress/deploy-test-resources'
     prepareScript: tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/prepare.ps1
     dockerFile: 'tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/Dockerfile'

--- a/eng/pipelines/apiview-review-gen-cadl.yml
+++ b/eng/pipelines/apiview-review-gen-cadl.yml
@@ -12,7 +12,7 @@ parameters:
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: MMSUbuntu22.04
+  vmImage: ubuntu-22.04
 
 variables:
   NodeVersion: '18.x'

--- a/eng/pipelines/apiview-review-gen-javascript.yml
+++ b/eng/pipelines/apiview-review-gen-javascript.yml
@@ -4,7 +4,7 @@ trigger: none
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: MMSUbuntu22.04
+  vmImage: ubuntu-22.04
 
 parameters:
   - name: Reviews

--- a/eng/pipelines/apiview-review-gen-python.yml
+++ b/eng/pipelines/apiview-review-gen-python.yml
@@ -4,7 +4,7 @@ trigger: none
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: MMSUbuntu22.04
+  vmImage: ubuntu-22.04
 
 parameters:
   - name: Reviews

--- a/eng/pipelines/apiview-review-gen-typespec.yml
+++ b/eng/pipelines/apiview-review-gen-typespec.yml
@@ -12,7 +12,7 @@ parameters:
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: MMSUbuntu22.04
+  vmImage: ubuntu-22.04
 
 variables:
   NodeVersion: '18.x'

--- a/eng/pipelines/doc-warden.yml
+++ b/eng/pipelines/doc-warden.yml
@@ -28,7 +28,7 @@ jobs:
 
   pool:
     name: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: MMSUbuntu22.04
+    vmImage: ubuntu-22.04
 
   steps:
   - task: UsePythonVersion@0
@@ -77,7 +77,7 @@ jobs:
 
   pool:
     name: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: MMSUbuntu22.04
+    vmImage: ubuntu-22.04
 
   steps:
 

--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -40,7 +40,7 @@ pr:
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: MMSUbuntu22.04
+  vmImage: ubuntu-22.04
 
 stages:
   - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:

--- a/eng/pipelines/git-tasks.yml
+++ b/eng/pipelines/git-tasks.yml
@@ -33,7 +33,7 @@ jobs:
     displayName: "Delete ${{parameters.TagName}} tag from ${{parameters.Repository}} repository"
     environment: github-operation-approvals
     pool:
-      name: azsdk-pool-mms-ubuntu-1804-general
+      name: azsdk-pool-mms-ubuntu-2004-general
     strategy:
       runOnce:
         deploy:

--- a/eng/pipelines/githubio-linkcheck.yml
+++ b/eng/pipelines/githubio-linkcheck.yml
@@ -3,7 +3,7 @@ pr: none
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: MMSUbuntu22.04
+  vmImage: ubuntu-22.04
 
 variables:
   cachefile: verify-links-cache.txt

--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -66,7 +66,7 @@ stages:
     timeoutInMinutes: 0
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
 
     steps:
     - template: /eng/common/pipelines/templates/steps/cache-ps-modules.yml

--- a/eng/pipelines/merge-docs-main-to-live.yml
+++ b/eng/pipelines/merge-docs-main-to-live.yml
@@ -29,7 +29,7 @@ jobs:
     displayName: 'ReleaseDocsMs: ${{repo.RepoName}}'
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
     variables:
       DocRepoLocation: $(Pipeline.Workspace)/docs
     steps:

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -22,7 +22,7 @@ jobs:
 
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
 
     variables:
       - template: /eng/pipelines/templates/variables/globals.yml

--- a/eng/pipelines/mirror-repos.yml
+++ b/eng/pipelines/mirror-repos.yml
@@ -5,7 +5,7 @@ pr: none
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: MMSUbuntu22.04
+  vmImage: ubuntu-22.04
 
 jobs:
   - job: SyncRepos

--- a/eng/pipelines/notifications.yml
+++ b/eng/pipelines/notifications.yml
@@ -35,7 +35,7 @@ stages:
 
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
 
     variables:
       Organization: azure-sdk

--- a/eng/pipelines/pipeline-generation-single.yml
+++ b/eng/pipelines/pipeline-generation-single.yml
@@ -22,7 +22,7 @@ jobs:
 - job: GeneratePipeline
   pool:
     name: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: MMSUbuntu22.04
+    vmImage: ubuntu-22.04
   steps:
   - checkout: none
   - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -33,7 +33,7 @@ jobs:
 - job: GeneratePipelines
   pool:
     name: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: MMSUbuntu22.04
+    vmImage: ubuntu-22.04
   timeoutInMinutes: 120
   strategy:
     matrix:

--- a/eng/pipelines/pipeline-owners-extraction.yml
+++ b/eng/pipelines/pipeline-owners-extraction.yml
@@ -14,7 +14,7 @@ stages:
     timeoutInMinutes: 120
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
 
     variables:
       Organization: azure-sdk

--- a/eng/pipelines/publish-docker-image.yml
+++ b/eng/pipelines/publish-docker-image.yml
@@ -1,7 +1,7 @@
 # Additional sample inputs can be found in `eng/containers/ci.yml`, but here is an example.
 # - name: test_proxy_linux
 #   pool: azsdk-pool-mms-ubuntu-2204-general
-#   vmImage: MMSUbuntu22.04
+#   vmImage: ubuntu-22.04
 #   dockerRepo: 'engsys/testproxy-lin'
 #   additionalDockerArgs: ''
 #   prepareScript: tools/test-proxy/docker/prepare.ps1
@@ -93,7 +93,7 @@ jobs:
               - container_build_${{ config.name }}
         pool:
           name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: MMSUbuntu22.04
+          vmImage: ubuntu-22.04
 
         steps:
           - task: Docker@2

--- a/eng/pipelines/setup-tutorial-branch.yml
+++ b/eng/pipelines/setup-tutorial-branch.yml
@@ -45,7 +45,7 @@ jobs:
 - job: SetupTutorialBranch
   pool:
     name: azsdk-pool-mms-ubuntu-2004-general
-    vmImage: MMSUbuntu22.04
+    vmImage: ubuntu-22.04
   steps:
     - task: PowerShell@2
       displayName: 'Setup Tutorial Branch'

--- a/eng/pipelines/templates/jobs/stress-cluster-provision.yml
+++ b/eng/pipelines/templates/jobs/stress-cluster-provision.yml
@@ -15,7 +15,7 @@ jobs:
       displayName: 'Provision'
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
     steps:
       - pwsh: |
           $subscriptionConfiguration = @'

--- a/eng/pipelines/templates/jobs/stress-test-release.yml
+++ b/eng/pipelines/templates/jobs/stress-test-release.yml
@@ -45,7 +45,7 @@ jobs:
           Filters: '@{}'
   pool:
     name: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: MMSUbuntu22.04
+    vmImage: ubuntu-22.04
   steps:
     - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
       parameters:

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-azure-function.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-azure-function.yml
@@ -13,7 +13,7 @@ stages:
       - job: BuildPackage
         pool:
           name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: MMSUbuntu22.04
+          vmImage: ubuntu-22.04
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
           - pwsh: |
@@ -38,7 +38,7 @@ stages:
           environment: ${{ parameters.StagingEnvironmentName }}
           pool:
             name: azsdk-pool-mms-ubuntu-2204-general
-            vmImage: MMSUbuntu22.04
+            vmImage: ubuntu-22.04
           strategy:
             runOnce:
               deploy:
@@ -65,7 +65,7 @@ stages:
           environment: ${{ parameters.ProductionEnvironmentName }}
           pool:
             name: azsdk-pool-mms-ubuntu-2204-general
-            vmImage: MMSUbuntu22.04
+            vmImage: ubuntu-22.04
           strategy:
             runOnce:
                 deploy:

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-azure-webapp.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-azure-webapp.yml
@@ -17,7 +17,7 @@ stages:
       - job: BuildPackage
         pool:
           name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: MMSUbuntu22.04
+          vmImage: ubuntu-22.04
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
           - pwsh: |
@@ -42,7 +42,7 @@ stages:
           environment: ${{ parameters.Staging.EnvironmentName }}
           pool:
             name: azsdk-pool-mms-ubuntu-2204-general
-            vmImage: MMSUbuntu22.04
+            vmImage: ubuntu-22.04
           strategy:
             runOnce:
               deploy:
@@ -69,7 +69,7 @@ stages:
           environment: ${{ parameters.Production.EnvironmentName }}
           pool:
             name: azsdk-pool-mms-ubuntu-2204-general
-            vmImage: MMSUbuntu22.04
+            vmImage: ubuntu-22.04
           strategy:
             runOnce:
                 deploy:

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -54,7 +54,7 @@ stages:
 
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
 
     jobs:
       - job: BuildAndPackage
@@ -126,7 +126,7 @@ stages:
               Image: windows-2022
             Linux:
               Pool: azsdk-pool-mms-ubuntu-2204-general
-              Image: MMSUbuntu22.04
+              Image: ubuntu-22.04
             Mac:
               Pool: Azure Pipelines
               Image: macos-11

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
@@ -28,7 +28,7 @@ stages:
 
         pool:
           name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: MMSUbuntu22.04
+          vmImage: ubuntu-22.04
 
         steps:
           - template: /eng/pipelines/templates/steps/use-python-version.yml
@@ -59,7 +59,7 @@ stages:
 
           pool:
             name: azsdk-pool-mms-ubuntu-2204-general
-            vmImage: MMSUbuntu22.04
+            vmImage: ubuntu-22.04
 
           steps:
             - template: /eng/pipelines/templates/steps/use-python-version.yml
@@ -77,7 +77,7 @@ stages:
         displayName: 'Publish ${{ parameters.PackageName }} package to devops feed'
         pool:
           name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: MMSUbuntu22.04
+          vmImage: ubuntu-22.04
         steps:
         - checkout: none
         - download: current

--- a/eng/pipelines/tools-repo-versioning.yml
+++ b/eng/pipelines/tools-repo-versioning.yml
@@ -5,7 +5,7 @@ pr: none
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: MMSUbuntu22.04
+  vmImage: ubuntu-22.04
 
 jobs:
   - job: TagToolsRepo

--- a/tools/apiview/emitters/typespec-apiview/ci.yml
+++ b/tools/apiview/emitters/typespec-apiview/ci.yml
@@ -34,7 +34,7 @@ stages:
 
         pool:
           name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: MMSUbuntu22.04
+          vmImage: ubuntu-22.04
 
         steps:
           - task: NodeTool@0
@@ -76,7 +76,7 @@ stages:
         displayName: 'Publish typespec-apiview package to devops feed'
         pool:
           name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: MMSUbuntu22.04
+          vmImage: ubuntu-22.04
         steps:
         - checkout: none
         - download: current

--- a/tools/apiview/parsers/js-api-parser/ci.yml
+++ b/tools/apiview/parsers/js-api-parser/ci.yml
@@ -34,7 +34,7 @@ stages:
 
         pool:
           name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: MMSUbuntu22.04
+          vmImage: ubuntu-22.04
 
         steps:
           - task: NodeTool@0
@@ -75,7 +75,7 @@ stages:
         displayName: 'Publish ts-genapi package to devops feed'
         pool:
           name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: MMSUbuntu22.04
+          vmImage: ubuntu-22.04
         steps:
         - checkout: none
         - download: current

--- a/tools/oav-traffic-converter/ci.yml
+++ b/tools/oav-traffic-converter/ci.yml
@@ -31,7 +31,7 @@ stages:
 
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
 
     jobs:
       - job: Test
@@ -62,7 +62,7 @@ stages:
       condition: succeeded()
       pool:
         name: azsdk-pool-mms-ubuntu-2204-general
-        vmImage: MMSUbuntu22.04
+        vmImage: ubuntu-22.04
 
       jobs:
       - job: approve

--- a/tools/sdk-generation-pipeline/build-publish-docker-image.yml
+++ b/tools/sdk-generation-pipeline/build-publish-docker-image.yml
@@ -25,7 +25,7 @@ variables:
 
 pool:
   name: "azsdk-pool-mms-ubuntu-2004-general"
-  vmImage: "MMSUbuntu20.04"
+  vmImage: "ubuntu-20.04"
   
 stages:
   - stage: Build

--- a/tools/sdk-generation-pipeline/ci.yml
+++ b/tools/sdk-generation-pipeline/ci.yml
@@ -43,7 +43,7 @@ variables:
 
 pool:
   name: "azsdk-pool-mms-ubuntu-2004-general"
-  vmImage: "MMSUbuntu20.04"
+  vmImage: "ubuntu-20.04"
   
 stages:
   - stage: Build

--- a/tools/sdk-generation-pipeline/sdk-generation-pipeline.yml
+++ b/tools/sdk-generation-pipeline/sdk-generation-pipeline.yml
@@ -83,7 +83,7 @@ stages:
       - job: SdkGeneration
         pool:
           name: azsdk-pool-mms-ubuntu-2004-general
-          vmImage: MMSUbuntu20.04
+          vmImage: ubuntu-20.04
         timeoutInMinutes: 180
         displayName: ${{ parameters.sdkToGenerate }}-${{ parameters.serviceType }}-${{ parameters.service }}
         steps:

--- a/tools/sdk-testgen/ci.yml
+++ b/tools/sdk-testgen/ci.yml
@@ -27,7 +27,7 @@ pr:
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: MMSUbuntu22.04
+  vmImage: ubuntu-22.04
 
 variables:
   NugetSecurityAnalysisWarningLevel: "none"

--- a/tools/sdk-testgen/ci.yml
+++ b/tools/sdk-testgen/ci.yml
@@ -27,7 +27,7 @@ pr:
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: ubuntu-22.04
+  vmImage: MMSUbuntu22.04
 
 variables:
   NugetSecurityAnalysisWarningLevel: "none"

--- a/tools/stress-cluster/ci.yml
+++ b/tools/stress-cluster/ci.yml
@@ -20,7 +20,7 @@ jobs:
   - job: Analyze
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
     steps:
       - template: /eng/common/pipelines/templates/steps/verify-links.yml
         parameters:

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -29,7 +29,7 @@ extends:
     DockerDeployments:
     - name: test_proxy_linux
       pool: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
       dockerRepo: 'engsys/testproxy-lin'
       prepareScript: tools/test-proxy/docker/prepare.ps1
       dockerFile: 'tools/test-proxy/docker/dockerfile'
@@ -37,7 +37,7 @@ extends:
       - 'latest'
     - name: test_proxy_linux_arm64
       pool: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: MMSUbuntu22.04
+      vmImage: ubuntu-22.04
       dockerRepo: 'engsys/testproxy-lin-arm64'
       prepareScript: 'tools/test-proxy/docker/prepare.ps1 -qemu'
       additionalDockerArgs: '--build-arg ARCH=-arm64v8 --platform linux/arm64'


### PR DESCRIPTION
Update the used Ubuntu images per
- https://github.com/Azure/azure-sdk-tools/issues/5472

I always updated the images to `20.04`. The only places where I change `18` to `22` (instead of `20`) is only to fix the fact the image was already on `22` but the related/surrounding symbols in the code weren't updated from 18 to 22.

Also update the obsolete `MMSUbuntu2X.04` image names to `ubuntu-2X.04`.

Cannot update [`vmImage: MMSUbuntu22.04` in `sdk-testgen/ci.yml`](https://github.com/Azure/azure-sdk-tools/blob/ac1c9b7652274f9961e76f718ec3ea9c9ad4f268/tools/sdk-testgen/ci.yml#L30)
due to a [test failure](https://dev.azure.com/azure-sdk/public/_build/results?buildId=2711283&view=logs&j=581dff44-701d-5151-898f-1ce7c446a9da&t=b0f2af0f-e4e0-5a87-98df-4b37caaea309&l=1553)