### PR TITLE
Update sdk-testgen vmImage to ubuntu-22.04

### DIFF
--- a/tools/sdk-testgen/ci.yml
+++ b/tools/sdk-testgen/ci.yml
@@ -27,7 +27,7 @@ pr:
 
 pool:
   name: azsdk-pool-mms-ubuntu-2204-general
-  vmImage: MMSUbuntu22.04
+  vmImage: ubuntu-22.04
 
 variables:
   NugetSecurityAnalysisWarningLevel: "none"


### PR DESCRIPTION
A follow-up to:
- https://github.com/Azure/azure-sdk-tools/pull/6004

Applying this change, which has been reverted in #6004:
- https://github.com/Azure/azure-sdk-tools/pull/6004/commits/ac1c9b7652274f9961e76f718ec3ea9c9ad4f268

Related work:
- https://github.com/Azure/azure-sdk-tools/issues/5472