### PR TITLE
Updating the stress-debug-share-example

### DIFF
--- a/tools/stress-cluster/chaos/examples/network-stress-example/.gitignore
+++ b/tools/stress-cluster/chaos/examples/network-stress-example/.gitignore
@@ -1,0 +1,6 @@
+# generated based on the values in your scenarios-matrix.yaml
+generatedValues.yaml
+
+# the temp output when we compile your .bicep template with resources
+stress-test-resources.json
+

--- a/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/.gitignore
+++ b/tools/stress-cluster/chaos/examples/network-stress-scenarios-example/.gitignore
@@ -1,0 +1,6 @@
+# generated based on the values in your scenarios-matrix.yaml
+generatedValues.yaml
+
+# the temp output when we compile your .bicep template with resources
+stress-test-resources.json
+

--- a/tools/stress-cluster/chaos/examples/stress-debug-share-example/.gitignore
+++ b/tools/stress-cluster/chaos/examples/stress-debug-share-example/.gitignore
@@ -1,0 +1,6 @@
+# generated based on the values in your scenarios-matrix.yaml
+generatedValues.yaml
+
+# the temp output when we compile your .bicep template with resources
+stress-test-resources.json
+

--- a/tools/stress-cluster/chaos/examples/stress-debug-share-example/scenarios-matrix.yaml
+++ b/tools/stress-cluster/chaos/examples/stress-debug-share-example/scenarios-matrix.yaml
@@ -1,3 +1,4 @@
 matrix:
   scenarios:
-    - stress
+    filesharedemo:
+      dataToBeWritten: "hello world"

--- a/tools/stress-cluster/chaos/examples/stress-debug-share-example/templates/debug-share-job.yaml
+++ b/tools/stress-cluster/chaos/examples/stress-debug-share-example/templates/debug-share-job.yaml
@@ -6,16 +6,30 @@ metadata:
 spec:
   containers:
     - name: debug-share-example
+      # Your base image will be different - the only requirement is that it has some form of `sh`
       image: busybox
       command: ['sh', '-c']
       args:
         - |
-            set -ex;
+            # -e: exit on non-zero exit code
+            # -x: echo out all executed commands
+            set -ex;    
+
+            # your log folder doesn't exist when your app starts, so make sure you
+            # create it.
             mkdir -p $DEBUG_SHARE;
+            
+            # OPTIONAL: If your app can only write to your current working 
+            # directory then you'll also want to cd into the folder you 
+            # created before running your test:
             cd $DEBUG_SHARE;
+
+            # This is where you'd run your command, along with any Helm macro
+            # replacements that are needed.
+            
             pwd;
-            ls -R $DEBUG_SHARE_ROOT;
-            echo "debug share example success" > success;
+            ls -R $DEBUG_SHARE;
+            echo "debug share example success {{ .Stress.dataToBeWritten }}" > success;
             cat success;
       # The file share is mounted by default at the path $DEBUG_SHARE
       # when including the container-env template

--- a/tools/stress-cluster/chaos/examples/stress-deployment-example/.gitignore
+++ b/tools/stress-cluster/chaos/examples/stress-deployment-example/.gitignore
@@ -1,0 +1,6 @@
+# generated based on the values in your scenarios-matrix.yaml
+generatedValues.yaml
+
+# the temp output when we compile your .bicep template with resources
+stress-test-resources.json
+


### PR DESCRIPTION
Just adding in some comments to make it a bit easier to understand what's mandatory and what's not and adding in individual .gitignore files for common stuff.