### PR TITLE
Have event processor get configs from raw githubusercontent instead of needing a sparse checkout

### DIFF
--- a/tools/code-owners-parser/CodeOwnersParser/FileHelpers.cs
+++ b/tools/code-owners-parser/CodeOwnersParser/FileHelpers.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Net;
 using System.Net.Http;
 
 namespace Azure.Sdk.Tools.CodeOwnersParser
@@ -22,10 +23,42 @@ namespace Azure.Sdk.Tools.CodeOwnersParser
 
         private static string GetUrlContents(string url)
         {
+            int maxRetries = 3;
+            int attempts = 1;
+            int delayTimeInMs = 1000;
             using HttpClient client = new HttpClient();
-            HttpResponseMessage response =
-                client.GetAsync(url).ConfigureAwait(false).GetAwaiter().GetResult();
-            return response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+            while (attempts <= maxRetries)
+            {
+                try
+                {
+                    HttpResponseMessage response = client.GetAsync(url).ConfigureAwait(false).GetAwaiter().GetResult();
+                    if (response.StatusCode == HttpStatusCode.OK)
+                    {
+                        // This writeline is probably unnecessary but good to have if there are previous attempts that failed
+                        Console.WriteLine($"GetUrlContents for {url} attempt number {attempts} succeeded.");
+                        return response.Content.ReadAsStringAsync().ConfigureAwait(false).GetAwaiter().GetResult();
+                    }
+                    else
+                    {
+                        Console.WriteLine($"GetUrlContents attempt number {attempts}. Non-{HttpStatusCode.OK} status code trying to fetch {url}. Status Code = {response.StatusCode}");
+                    }
+                }
+                catch (HttpRequestException httpReqEx)
+                {
+                    // HttpRequestException means the request failed due to an underlying issue such as network connectivity,
+                    // DNS failure, server certificate validation or timeout.
+                    Console.WriteLine($"GetUrlContents attempt number {attempts}. HttpRequestException trying to fetch {url}. Exception message = {httpReqEx.Message}");
+                    if (attempts == maxRetries)
+                    {
+                        // At this point the retries have been exhausted, let this rethrow
+                        throw;
+                    }
+                }
+                System.Threading.Thread.Sleep(delayTimeInMs);
+                attempts++;
+            }
+            // This will only get hit if the final retry is non-OK status code
+            throw new FileLoadException($"Unable to fetch {url} after {maxRetries}. See above for status codes for each attempt.");
         }
     }
 }

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
@@ -39,8 +39,8 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests
 
         public SearchIssuesResult SearchIssuesResultReturn { get; set; } = new SearchIssuesResult();
 
-        public MockGitHubEventClient(string productHeaderName, string? rulesConfigLocation = null) : 
-            base(productHeaderName, rulesConfigLocation)
+        public MockGitHubEventClient(string productHeaderName) : 
+            base(productHeaderName)
         {
 
         }

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Constants/ConfigConstants.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Constants/ConfigConstants.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.GitHubEventProcessor.Constants
+{
+    public class ConfigConstants
+    {
+        public const string RawGitHubUserContentUrl = "https://raw.githubusercontent.com";
+        public const string DefaultBranch = "main";
+    }
+}

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
@@ -131,13 +131,18 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
 
         public RulesConfiguration RulesConfiguration
         {
-            get { return _rulesConfiguration; }
+            get {
+                if (null == _rulesConfiguration) 
+                {
+                    _rulesConfiguration = LoadRulesConfiguration();
+                }
+                return _rulesConfiguration; 
+            }
         }
 
-        public GitHubEventClient(string productHeaderName, string rulesConfigLocation = null)
+        public GitHubEventClient(string productHeaderName)
         {
             _gitHubClient = CreateClientWithGitHubEnvToken(productHeaderName);
-            _rulesConfiguration = LoadRulesConfiguration(rulesConfigLocation);
         }
 
         /// <summary>
@@ -940,5 +945,20 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
             }
             return returnList;
         }
+
+         public string CreateURLForConfigEntry(Repository repository, string subdirectory, string fileName)
+        {
+            // https://raw.githubusercontent.com/Azure/azure-sdk-for-net/main/.github/
+            // The Full URL is BaseUrl + repositoryFullName + defaultBranch + remoteFilePath + fileName
+            string fileUrl = $"{ConfigConstants.RawGitHubUserContentUrl}/{repository.FullName}/{ConfigConstants.DefaultBranch}/{subdirectory}/{fileName}";
+            return fileUrl;
+        }
+
+        public void SetConfigEntryOverrides(Repository repository)
+        {
+            CodeOwnerUtils.codeOwnersFilePathOverride = CreateURLForConfigEntry(repository, CodeOwnerUtils.CodeownersSubDirectory, CodeOwnerUtils.CodeownersFileName);
+            RulesConfiguration.rulesConfigFilePathOverride = CreateURLForConfigEntry(repository, RulesConfiguration.RulesConfigSubDirectory, RulesConfiguration.RulesConfigFileName);
+        }
+
     }
 }

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
@@ -946,7 +946,14 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
             return returnList;
         }
 
-         public string CreateURLForConfigEntry(Repository repository, string subdirectory, string fileName)
+        /// <summary>
+        /// Create a raw github URL (https://raw.githubusercontent.com) for a file in a given repository
+        /// </summary>
+        /// <param name="repository">Octkit.Repository from the event payload</param>
+        /// <param name="subdirectory">Subdirectory where the file lives</param>
+        /// <param name="fileName">name of the file</param>
+        /// <returns></returns>
+        public string CreateRawGitHubURLForFile(Repository repository, string subdirectory, string fileName)
         {
             // https://raw.githubusercontent.com/Azure/azure-sdk-for-net/main/.github/
             // The Full URL is BaseUrl + repositoryFullName + defaultBranch + remoteFilePath + fileName
@@ -954,10 +961,15 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
             return fileUrl;
         }
 
+        /// <summary>
+        /// Set the config file overrides for codeowners and rulesconfig which will cause them to get pulled
+        /// from the URL instead of requiring a sparse checkout of the configuration directory in order to run.
+        /// </summary>
+        /// <param name="repository">Octkit.Repository from the event payload</param>
         public void SetConfigEntryOverrides(Repository repository)
         {
-            CodeOwnerUtils.codeOwnersFilePathOverride = CreateURLForConfigEntry(repository, CodeOwnerUtils.CodeownersSubDirectory, CodeOwnerUtils.CodeownersFileName);
-            RulesConfiguration.rulesConfigFilePathOverride = CreateURLForConfigEntry(repository, RulesConfiguration.RulesConfigSubDirectory, RulesConfiguration.RulesConfigFileName);
+            CodeOwnerUtils.codeOwnersFilePathOverride = CreateRawGitHubURLForFile(repository, CodeOwnerUtils.CodeownersSubDirectory, CodeOwnerUtils.CodeownersFileName);
+            RulesConfiguration.rulesConfigFilePathOverride = CreateRawGitHubURLForFile(repository, RulesConfiguration.RulesConfigSubDirectory, RulesConfiguration.RulesConfigFileName);
         }
 
     }

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Program.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Program.cs
@@ -41,12 +41,14 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
                 case EventConstants.Issues:
                     {
                         IssueEventGitHubPayload issueEventPayload = serializer.Deserialize<IssueEventGitHubPayload>(rawJson);
+                        gitHubEventClient.SetConfigEntryOverrides(issueEventPayload.Repository);
                         await IssueProcessing.ProcessIssueEvent(gitHubEventClient, issueEventPayload);
                         break;
                     }
                 case EventConstants.IssueComment:
                     {
                         IssueCommentPayload issueCommentPayload = serializer.Deserialize<IssueCommentPayload>(rawJson);
+                        gitHubEventClient.SetConfigEntryOverrides(issueCommentPayload.Repository);
                         // IssueComment events are for both issues and pull requests. If the comment is on a pull request,
                         // then Issue's PullRequest object in the payload will be non-null
                         if (issueCommentPayload.Issue.PullRequest != null)
@@ -65,12 +67,14 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
                         // The pull_request, because of the auto_merge processing, requires more than just deserialization of the
                         // the rawJson.
                         PullRequestEventGitHubPayload prEventPayload = PullRequestProcessing.DeserializePullRequest(rawJson, serializer);
+                        gitHubEventClient.SetConfigEntryOverrides(prEventPayload.Repository);
                         await PullRequestProcessing.ProcessPullRequestEvent(gitHubEventClient, prEventPayload);
                         break;
                     }
                 case EventConstants.PullRequestReview:
                     {
                         PullRequestReviewEventPayload prReviewEventPayload = serializer.Deserialize<PullRequestReviewEventPayload>(rawJson);
+                        gitHubEventClient.SetConfigEntryOverrides(prReviewEventPayload.Repository);
                         await PullRequestReviewProcessing.ProcessPullRequestReviewEvent(gitHubEventClient, prReviewEventPayload);
                         break;
                     }
@@ -87,6 +91,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
                         }
 
                         ScheduledEventGitHubPayload scheduledEventPayload = serializer.Deserialize<ScheduledEventGitHubPayload>(rawJson);
+                        gitHubEventClient.SetConfigEntryOverrides(scheduledEventPayload.Repository);
                         string cronTaskToRun = args[2];
                         await ScheduledEventProcessing.ProcessScheduledEvent(gitHubEventClient, scheduledEventPayload, cronTaskToRun);
                         break;

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Utils/CodeOwnerUtils.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Utils/CodeOwnerUtils.cs
@@ -13,8 +13,8 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Utils
     /// </summary>
     public class CodeOwnerUtils
     {
-        private static readonly string CodeownersFileName = "CODEOWNERS";
-        private static readonly string CodeownersSubDirectory = ".github";
+        public static readonly string CodeownersFileName = "CODEOWNERS";
+        public static readonly string CodeownersSubDirectory = ".github";
 
         static List<CodeownersEntry> _codeOwnerEntries = null;
         public static string codeOwnersFilePathOverride = null;


### PR DESCRIPTION
Instead if requiring a sparse-checkout in the action, pull the config files (CODEOWNERS and rules config) files from the raw githubusercontent.

One thing of note here: I realize it's odd that I'm using the FileHelpers from the CodeOwnersParser to load the rules config file but there's no common utilities project and I really didn't want to copy the code and have to add the retry logic in multiple places.

The other change was when rules are loaded. Previously rules were loaded when the GitHubEventClient was constructed but now, like the CODEOWNERS, which is loaded when it's first needed.

The DirectoryUtil is going to remain until we know we can absolutely remove it.