### PR TITLE
[TypeScript Parser] support release tags

### DIFF
--- a/tools/apiview/parsers/js-api-parser/export.ts
+++ b/tools/apiview/parsers/js-api-parser/export.ts
@@ -4,7 +4,6 @@ import {
     ApiItemKind,
     ApiDeclaredItem,
     ExcerptTokenKind,
-    ApiPropertyItem,
     ReleaseTag
   } from '@microsoft/api-extractor-model';
 

--- a/tools/apiview/parsers/js-api-parser/export.ts
+++ b/tools/apiview/parsers/js-api-parser/export.ts
@@ -73,7 +73,6 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
         item.kind === ApiItemKind.Class ||
         item.kind === ApiItemKind.Namespace)
     {
-        
         if (item.members.length > 0)
         {
             builder

--- a/tools/apiview/parsers/js-api-parser/export.ts
+++ b/tools/apiview/parsers/js-api-parser/export.ts
@@ -3,7 +3,9 @@ import {
     ApiItem,
     ApiItemKind,
     ApiDeclaredItem,
-    ExcerptTokenKind
+    ExcerptTokenKind,
+    ApiPropertyItem,
+    ReleaseTag
   } from '@microsoft/api-extractor-model';
 
 import { writeFile } from 'fs';
@@ -15,6 +17,15 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
 {
     builder.lineId(item.canonicalReference.toString());
     builder.indent();
+    const releaseTag = getReleaseTag(item);
+    const parentReleaseTag = getReleaseTag(item.parent);
+    if(releaseTag && releaseTag !== parentReleaseTag) {
+        if(item.parent.kind === ApiItemKind.EntryPoint) {
+            builder.newline();
+        }
+        builder.annotate(releaseTag);
+    }
+    
     if (item instanceof ApiDeclaredItem) {
         if ( item.kind === ApiItemKind.Namespace) {
             builder.splitAppend(`declare namespace ${item.displayName} `, item.canonicalReference.toString(), item.displayName);
@@ -63,6 +74,7 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
         item.kind === ApiItemKind.Class ||
         item.kind === ApiItemKind.Namespace)
     {
+        
         if (item.members.length > 0)
         {
             builder
@@ -92,6 +104,17 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
     else
     { 
         builder.newline();
+    }
+}
+
+function getReleaseTag(item: ApiItem & {releaseTag?: ReleaseTag}): "alpha" | "beta" | undefined {
+    switch(item.releaseTag) {
+        case ReleaseTag.Beta:
+            return "beta";
+        case ReleaseTag.Alpha:
+            return "alpha";
+        default:
+            return undefined;
     }
 }
 
@@ -125,7 +148,7 @@ var apiViewFile: IApiViewFile = {
     Navigation: navigation,
     Tokens: builder.tokens,
     PackageName: apiModel.packages[0].name,
-    VersionString: "1.0.3",
+    VersionString: "1.0.4",
     Language: "JavaScript"
 }
 

--- a/tools/apiview/parsers/js-api-parser/tokensBuilder.ts
+++ b/tools/apiview/parsers/js-api-parser/tokensBuilder.ts
@@ -1,10 +1,11 @@
-import { ApiViewTokenKind, IApiViewToken } from "./models";
+
+import {ApiViewTokenKind, IApiViewToken} from './models';
 
 const jsTokens = require("js-tokens");
-
 const ANNOTATION_TOKEN = "@";
 
-export class TokensBuilder {
+export class TokensBuilder
+{
     tokens: IApiViewToken[] = [];
     indentString: string = "";
     keywords: string[] = [
@@ -70,8 +71,7 @@ export class TokensBuilder {
         "from",
         "of",
         "keyof",
-        "readonly",
-    ];
+        "readonly"];
 
     annotate(value: string): TokensBuilder {
         this.tokens.push({
@@ -83,116 +83,138 @@ export class TokensBuilder {
         return this;
     }
 
-    indent(): TokensBuilder {
+    indent(): TokensBuilder
+    {
         this.tokens.push({
             Kind: ApiViewTokenKind.Whitespace,
-            Value: this.indentString,
+            Value: this.indentString
         });
         return this;
     }
 
-    incIndent(): TokensBuilder {
-        this.indentString = " ".repeat(this.indentString.length + 4);
+    incIndent(): TokensBuilder
+    {
+        this.indentString = ' '.repeat(this.indentString.length + 4); 
         return this;
     }
 
-    decIndent(): TokensBuilder {
-        this.indentString = " ".repeat(this.indentString.length - 4);
+    decIndent(): TokensBuilder
+    {
+        this.indentString = ' '.repeat(this.indentString.length - 4); 
         return this;
     }
 
-    newline(): TokensBuilder {
+    newline(): TokensBuilder
+    {
         this.tokens.push({
-            Kind: ApiViewTokenKind.Newline,
+            Kind: ApiViewTokenKind.Newline
         });
         return this;
     }
 
-    lineId(id: string): TokensBuilder {
+    lineId(id: string): TokensBuilder
+    {
         this.tokens.push({
             Kind: ApiViewTokenKind.LineIdMarker,
-            DefinitionId: id,
+            DefinitionId: id
         });
         return this;
     }
 
-    typeReference(id: string, name: string): TokensBuilder {
+    typeReference(id: string, name: string): TokensBuilder
+    {
         this.tokens.push({
             Kind: ApiViewTokenKind.TypeName,
             NavigateToId: id,
-            Value: name,
+            Value: name
         });
         return this;
     }
 
-    space(s: string = " "): TokensBuilder {
+    space(s: string = " "): TokensBuilder
+    {
         this.tokens.push({
             Kind: ApiViewTokenKind.Whitespace,
-            Value: s,
+            Value: s
         });
         return this;
     }
 
-    punct(s: string): TokensBuilder {
+    punct(s: string): TokensBuilder
+    {
         this.tokens.push({
             Kind: ApiViewTokenKind.Punctuation,
-            Value: s,
+            Value: s
         });
         return this;
     }
 
-    string(s: string): TokensBuilder {
+    string(s: string): TokensBuilder
+    {
         this.tokens.push({
             Kind: ApiViewTokenKind.StringLiteral,
-            Value: s,
+            Value: s
         });
         return this;
     }
 
-    text(s: string): TokensBuilder {
+    text(s: string): TokensBuilder
+    {
         this.tokens.push({
             Kind: ApiViewTokenKind.Text,
-            Value: s,
+            Value: s
         });
         return this;
     }
 
-    keyword(s: string): TokensBuilder {
+    keyword(s: string): TokensBuilder
+    {
         this.tokens.push({
             Kind: ApiViewTokenKind.Keyword,
-            Value: s,
+            Value: s
         });
         return this;
     }
 
-    splitAppend(s: string, currentTypeId: string, currentTypeName: string) {
-        s.split("\n").forEach((line, index, array) => {
-            if (index > 0) {
+    splitAppend(s: string, currentTypeId: string, currentTypeName: string)
+    {
+        s.split("\n").forEach((line, index, array)  => {
+            if (index > 0)
+            {
                 this.indent();
             }
 
             var tokens: any[] = Array.from(jsTokens(line));
-            tokens.forEach((token) => {
-                if (this.keywords.indexOf(token.value) > 0) {
+            tokens.forEach(token => 
+            {
+                if (this.keywords.indexOf(token.value) > 0)
+                {
                     this.keyword(token.value);
-                } else if (token.value === currentTypeName) {
-                    this.tokens.push({
-                        Kind: ApiViewTokenKind.TypeName,
-                        DefinitionId: currentTypeId,
-                        Value: token.value,
-                    });
-                } else if (token.type === "StringLiteral") {
+                }
+                else if (token.value === currentTypeName)
+                {
+                    this.tokens.push({ Kind: ApiViewTokenKind.TypeName, DefinitionId: currentTypeId, Value: token.value });
+                }
+                else if (token.type === "StringLiteral")
+                {
                     this.string(token.value);
-                } else if (token.type === "Punctuator") {
+                }
+                else if (token.type === "Punctuator")
+                {
                     this.punct(token.value);
-                } else if (token.type === "WhiteSpace") {
+                }
+                else if (token.type === "WhiteSpace")
+                {
                     this.space(token.value);
-                } else {
+                }
+                else
+                {
                     this.text(token.value);
                 }
             });
-
-            if (index < array.length - 1) {
+            
+            if (index < array.length - 1)
+            {
                 this.newline();
             }
         });

--- a/tools/apiview/parsers/js-api-parser/tokensBuilder.ts
+++ b/tools/apiview/parsers/js-api-parser/tokensBuilder.ts
@@ -1,10 +1,10 @@
-
-import {ApiViewTokenKind, IApiViewToken} from './models';
+import { ApiViewTokenKind, IApiViewToken } from "./models";
 
 const jsTokens = require("js-tokens");
 
-export class TokensBuilder
-{
+const ANNOTATION_TOKEN = "@";
+
+export class TokensBuilder {
     tokens: IApiViewToken[] = [];
     indentString: string = "";
     keywords: string[] = [
@@ -70,140 +70,129 @@ export class TokensBuilder
         "from",
         "of",
         "keyof",
-        "readonly"];
+        "readonly",
+    ];
 
-    indent(): TokensBuilder
-    {
+    annotate(value: string): TokensBuilder {
+        this.tokens.push({
+            Kind: ApiViewTokenKind.StringLiteral,
+            Value: `${ANNOTATION_TOKEN}${value}`,
+        });
+
+        this.newline().indent()
+        return this;
+    }
+
+    indent(): TokensBuilder {
         this.tokens.push({
             Kind: ApiViewTokenKind.Whitespace,
-            Value: this.indentString
+            Value: this.indentString,
         });
         return this;
     }
 
-    incIndent(): TokensBuilder
-    {
-        this.indentString = ' '.repeat(this.indentString.length + 4); 
+    incIndent(): TokensBuilder {
+        this.indentString = " ".repeat(this.indentString.length + 4);
         return this;
     }
 
-    decIndent(): TokensBuilder
-    {
-        this.indentString = ' '.repeat(this.indentString.length - 4); 
+    decIndent(): TokensBuilder {
+        this.indentString = " ".repeat(this.indentString.length - 4);
         return this;
     }
 
-    newline(): TokensBuilder
-    {
+    newline(): TokensBuilder {
         this.tokens.push({
-            Kind: ApiViewTokenKind.Newline
+            Kind: ApiViewTokenKind.Newline,
         });
         return this;
     }
 
-    lineId(id: string): TokensBuilder
-    {
+    lineId(id: string): TokensBuilder {
         this.tokens.push({
             Kind: ApiViewTokenKind.LineIdMarker,
-            DefinitionId: id
+            DefinitionId: id,
         });
         return this;
     }
 
-    typeReference(id: string, name: string): TokensBuilder
-    {
+    typeReference(id: string, name: string): TokensBuilder {
         this.tokens.push({
             Kind: ApiViewTokenKind.TypeName,
             NavigateToId: id,
-            Value: name
+            Value: name,
         });
         return this;
     }
 
-    space(s: string = " "): TokensBuilder
-    {
+    space(s: string = " "): TokensBuilder {
         this.tokens.push({
             Kind: ApiViewTokenKind.Whitespace,
-            Value: s
+            Value: s,
         });
         return this;
     }
 
-    punct(s: string): TokensBuilder
-    {
+    punct(s: string): TokensBuilder {
         this.tokens.push({
             Kind: ApiViewTokenKind.Punctuation,
-            Value: s
+            Value: s,
         });
         return this;
     }
 
-    string(s: string): TokensBuilder
-    {
+    string(s: string): TokensBuilder {
         this.tokens.push({
             Kind: ApiViewTokenKind.StringLiteral,
-            Value: s
+            Value: s,
         });
         return this;
     }
 
-    text(s: string): TokensBuilder
-    {
+    text(s: string): TokensBuilder {
         this.tokens.push({
             Kind: ApiViewTokenKind.Text,
-            Value: s
+            Value: s,
         });
         return this;
     }
 
-    keyword(s: string): TokensBuilder
-    {
+    keyword(s: string): TokensBuilder {
         this.tokens.push({
             Kind: ApiViewTokenKind.Keyword,
-            Value: s
+            Value: s,
         });
         return this;
     }
 
-    splitAppend(s: string, currentTypeId: string, currentTypeName: string)
-    {
-        s.split("\n").forEach((line, index, array)  => {
-            if (index > 0)
-            {
+    splitAppend(s: string, currentTypeId: string, currentTypeName: string) {
+        s.split("\n").forEach((line, index, array) => {
+            if (index > 0) {
                 this.indent();
             }
 
             var tokens: any[] = Array.from(jsTokens(line));
-            tokens.forEach(token => 
-            {
-                if (this.keywords.indexOf(token.value) > 0)
-                {
+            tokens.forEach((token) => {
+                if (this.keywords.indexOf(token.value) > 0) {
                     this.keyword(token.value);
-                }
-                else if (token.value === currentTypeName)
-                {
-                    this.tokens.push({ Kind: ApiViewTokenKind.TypeName, DefinitionId: currentTypeId, Value: token.value });
-                }
-                else if (token.type === "StringLiteral")
-                {
+                } else if (token.value === currentTypeName) {
+                    this.tokens.push({
+                        Kind: ApiViewTokenKind.TypeName,
+                        DefinitionId: currentTypeId,
+                        Value: token.value,
+                    });
+                } else if (token.type === "StringLiteral") {
                     this.string(token.value);
-                }
-                else if (token.type === "Punctuator")
-                {
+                } else if (token.type === "Punctuator") {
                     this.punct(token.value);
-                }
-                else if (token.type === "WhiteSpace")
-                {
+                } else if (token.type === "WhiteSpace") {
                     this.space(token.value);
-                }
-                else
-                {
+                } else {
                     this.text(token.value);
                 }
             });
-            
-            if (index < array.length - 1)
-            {
+
+            if (index < array.length - 1) {
                 this.newline();
             }
         });


### PR DESCRIPTION
This change adds support for displaying api-extractor release tags [(doc)](https://api-extractor.com/pages/tsdoc/tag_beta/)


![image](https://user-images.githubusercontent.com/21109913/234415342-d707b6e4-d302-402f-b623-4225d4358de7.png)


