### PR TITLE
Parametrize `ArtifactName` in `detect-pending-changes.yml`

### DIFF
--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -1,6 +1,7 @@
 parameters:
   ArtifactPath: $(Build.ArtifactStagingDirectory)
   Artifacts: []
+  ArtifactName: 'packages'
 
 steps:
   - pwsh: |
@@ -20,6 +21,7 @@ steps:
         -PullRequestNumber $(System.PullRequest.PullRequestNumber)
         -RepoFullName $(Build.Repository.Name)
         -APIViewUri $(ApiChangeDetectRequestUrl)
+        -ArtifactName ${{ parameters.ArtifactName }}
       pwsh: true
     displayName: Detect API changes
     condition: and(succeededOrFailed(), eq(variables['Build.Reason'],'PullRequest'))


### PR DESCRIPTION
This will be utilized later in [this PR](https://github.com/Azure/azure-sdk-for-python/pull/30173).

We need to honor a different artifact name `packages-extended` instead of `packages`  when submitting APIReview.