### PR TITLE
Ensure old version of urllib3 is pinned

### DIFF
--- a/eng/scripts/download_targeted_packages_requirements.txt
+++ b/eng/scripts/download_targeted_packages_requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4>=4.11.1
 requests>=2.27.1
+urllib3<2
 twine==3.1.1
 pipgrip>=0.8.0


### PR DESCRIPTION
`urllib3` 2.0.0+ has released. This is a breaking change package.

`twine` has an unsafe requirement on `urllib3`, so we started blowing up on upload. Attempting a pin to work around.