### PR TITLE
[Test Proxy] Fix typo - Update RecordMatcher.cs

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -57,7 +57,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             "x-ms-useragent",
             "x-ms-version",
             "If-None-Match",
-            "sec-cha-ua",
+            "sec-ch-ua",
             "sec-ch-ua-mobile",
             "sec-ch-ua-platform",
             "Referrer",


### PR DESCRIPTION
## History
In order to skip matching the browser's dynamic headers for our recordings, we skipped the headers listed in https://github.com/Azure/azure-sdk-tools/pull/2185#discussion_r751718764

And this was Scott's reaction and the typo crept in
[[Test-Proxy] Header Exclusion Updates by scbedd · Pull Request #2317 · Azure/azure-sdk-tools (github.com)](https://github.com/Azure/azure-sdk-tools/pull/2317)

## Context on how we found it
@jeremymeng was upgrading the puppeteer version and the `"sec-ch-ua"` header mismatch occurred, and @timovv pointed out the list. 
We could've used a sanitizer, but fixing the source feels righteous.