### PR TITLE
[Test Proxy] Add "Accept-Language" header to the ignore list - Update RecordMatcher.cs

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -63,7 +63,8 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             "Referrer",
             "Referer",
             "Origin",
-            "Content-Length"
+            "Content-Length",
+            "Accept-Language"
         };
 
         /// <summary>


### PR DESCRIPTION
Ignoring the `"Accept-Language"` header

@timovv shared the discomfort about the number of times he had to re-record because his locale is en-CA instead of en-US.

And @jeremymeng 's puppeteer upgrade may unveil a pain later on, example below

> `RecorderError: Unable to find a record for the request POST https://keyvault_name.vault.azure.net/keys/listKeyName-cangettheversionsofakeypaged-/create?api-version=7.4 Header differences: <sec-ch-ua> values differ, request <"HeadlessChrome";v="113", "Chromium";v="113", "Not-A.Brand";v="24">, record <> <Accept-Language> is absent in request, value <en-US> Body differences:`


`sec-ch-ua` is just fixed in #6151