### PR TITLE
Skip Produce Executable Job if not needed

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -91,7 +91,7 @@ stages:
             artifact: packages
             condition: succeededOrFailed()
 
-      - ${{ if not(parameters.StandaloneExeMatrix) }}:
+      - ${{ if ne(length(parameters.StandaloneExeMatrix), 0) }}:
         - job: Produce_Executables
 
           strategy:

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -91,7 +91,7 @@ stages:
             artifact: packages
             condition: succeededOrFailed()
 
-      ${{ if not(parameters.StandaloneExeMatrix) }}:
+      - ${{ if not(parameters.StandaloneExeMatrix) }}:
         - job: Produce_Executables
 
           strategy:

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -91,31 +91,32 @@ stages:
             artifact: packages
             condition: succeededOrFailed()
 
-      - job: Produce_Executables
+      ${{ if not(parameters.StandaloneExeMatrix) }}:
+        - job: Produce_Executables
 
-        strategy:
-          matrix:
-            linux:
-              imageName: 'ubuntu-22.04'
-              poolName: 'azsdk-pool-mms-ubuntu-2204-general'
-              artifactName: 'linux_windows'
-            mac:
-              imageName: 'macos-11'
-              poolName: 'Azure Pipelines'
-              artifactName: 'mac'
+          strategy:
+            matrix:
+              linux:
+                imageName: 'ubuntu-22.04'
+                poolName: 'azsdk-pool-mms-ubuntu-2204-general'
+                artifactName: 'linux_windows'
+              mac:
+                imageName: 'macos-11'
+                poolName: 'Azure Pipelines'
+                artifactName: 'mac'
 
-        pool:
-          name: $(poolName)
-          vmImage: $(imageName)
+          pool:
+            name: $(poolName)
+            vmImage: $(imageName)
 
-        steps:
-          - template: /eng/pipelines/templates/steps/install-dotnet.yml
+          steps:
+            - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
-          - template: /eng/pipelines/templates/steps/produce-net-standalone-packs.yml
-            parameters:
-              StagingDirectory: $(Build.ArtifactStagingDirectory)
-              BuildMatrix: ${{ parameters.StandaloneExeMatrix }}
-              TargetDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
+            - template: /eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+              parameters:
+                StagingDirectory: $(Build.ArtifactStagingDirectory)
+                BuildMatrix: ${{ parameters.StandaloneExeMatrix }}
+                TargetDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
 
       - job: Test
 


### PR DESCRIPTION
If we aren't building standalone exe's skip the job all together.

Looks like this wasn't covered in the original change at https://github.com/Azure/azure-sdk-tools/pull/5174#discussion_r1137972871