### PR TITLE
Add tool link checks in nightly link checks

### DIFF
--- a/eng/pipelines/githubio-linkcheck.yml
+++ b/eng/pipelines/githubio-linkcheck.yml
@@ -13,83 +13,83 @@ jobs:
   displayName: Check and Cache Links
   timeoutInMinutes: 0
   steps:
-  - task: PowerShell@2
-    displayName: 'azure-sdk link check'
-    condition: succeededOrFailed()
-    inputs:
-      pwsh: true
-      filePath: eng/common/scripts/Verify-Links.ps1
-      arguments: >
-        -urls "https://azure.github.io/azure-sdk/index.html"
-        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-        -inputCacheFile "$(cachefile)"
-        -outputCacheFile "$(cachefile)"
-        -devOpsLogging: $true
+  # - task: PowerShell@2
+  #   displayName: 'azure-sdk link check'
+  #   condition: succeededOrFailed()
+  #   inputs:
+  #     pwsh: true
+  #     filePath: eng/common/scripts/Verify-Links.ps1
+  #     arguments: >
+  #       -urls "https://azure.github.io/azure-sdk/index.html"
+  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+  #       -inputCacheFile "$(cachefile)"
+  #       -outputCacheFile "$(cachefile)"
+  #       -devOpsLogging: $true
 
-  - task: PowerShell@2
-    displayName: 'azure-sdk link check with caching'
-    condition: succeededOrFailed()
-    inputs:
-      pwsh: true
-      filePath: eng/common/scripts/Verify-Links.ps1
-      arguments: >
-        -urls "https://azure.github.io/azure-sdk/index.html"
-        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-        -inputCacheFile "$(cachefile)"
-        -outputCacheFile "$(cachefile)"
-        -devOpsLogging: $true
+  # - task: PowerShell@2
+  #   displayName: 'azure-sdk link check with caching'
+  #   condition: succeededOrFailed()
+  #   inputs:
+  #     pwsh: true
+  #     filePath: eng/common/scripts/Verify-Links.ps1
+  #     arguments: >
+  #       -urls "https://azure.github.io/azure-sdk/index.html"
+  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+  #       -inputCacheFile "$(cachefile)"
+  #       -outputCacheFile "$(cachefile)"
+  #       -devOpsLogging: $true
 
-  - task: PowerShell@2
-    displayName: 'java link check'
-    condition: succeededOrFailed()
-    inputs:
-      pwsh: true
-      filePath: eng/common/scripts/Verify-Links.ps1
-      arguments: >
-        -urls "https://azure.github.io/azure-sdk-for-java/index.html"
-        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-        -inputCacheFile "$(cachefile)"
-        -outputCacheFile "$(cachefile)"
-        -devOpsLogging: $true
+  # - task: PowerShell@2
+  #   displayName: 'java link check'
+  #   condition: succeededOrFailed()
+  #   inputs:
+  #     pwsh: true
+  #     filePath: eng/common/scripts/Verify-Links.ps1
+  #     arguments: >
+  #       -urls "https://azure.github.io/azure-sdk-for-java/index.html"
+  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+  #       -inputCacheFile "$(cachefile)"
+  #       -outputCacheFile "$(cachefile)"
+  #       -devOpsLogging: $true
 
-  - task: PowerShell@2
-    displayName: 'js link check'
-    condition: succeededOrFailed()
-    inputs:
-      pwsh: true
-      filePath: eng/common/scripts/Verify-Links.ps1
-      arguments: >
-        -urls "https://azure.github.io/azure-sdk-for-js/index.html"
-        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-        -inputCacheFile "$(cachefile)"
-        -outputCacheFile "$(cachefile)"
-        -devOpsLogging: $true
+  # - task: PowerShell@2
+  #   displayName: 'js link check'
+  #   condition: succeededOrFailed()
+  #   inputs:
+  #     pwsh: true
+  #     filePath: eng/common/scripts/Verify-Links.ps1
+  #     arguments: >
+  #       -urls "https://azure.github.io/azure-sdk-for-js/index.html"
+  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+  #       -inputCacheFile "$(cachefile)"
+  #       -outputCacheFile "$(cachefile)"
+  #       -devOpsLogging: $true
 
-  - task: PowerShell@2
-    displayName: 'net link check'
-    condition: succeededOrFailed()
-    inputs:
-      pwsh: true
-      filePath: eng/common/scripts/Verify-Links.ps1
-      arguments: >
-        -urls "https://azure.github.io/azure-sdk-for-net/index.html"
-        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-        -inputCacheFile "$(cachefile)"
-        -outputCacheFile "$(cachefile)"
-        -devOpsLogging: $true
+  # - task: PowerShell@2
+  #   displayName: 'net link check'
+  #   condition: succeededOrFailed()
+  #   inputs:
+  #     pwsh: true
+  #     filePath: eng/common/scripts/Verify-Links.ps1
+  #     arguments: >
+  #       -urls "https://azure.github.io/azure-sdk-for-net/index.html"
+  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+  #       -inputCacheFile "$(cachefile)"
+  #       -outputCacheFile "$(cachefile)"
+  #       -devOpsLogging: $true
 
-  - task: PowerShell@2
-    displayName: 'python link check'
-    condition: succeededOrFailed()
-    inputs:
-      pwsh: true
-      filePath: eng/common/scripts/Verify-Links.ps1
-      arguments: >
-        -urls "https://azure.github.io/azure-sdk-for-python/index.html"
-        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-        -inputCacheFile "$(cachefile)"
-        -outputCacheFile "$(cachefile)"
-        -devOpsLogging: $true
+  # - task: PowerShell@2
+  #   displayName: 'python link check'
+  #   condition: succeededOrFailed()
+  #   inputs:
+  #     pwsh: true
+  #     filePath: eng/common/scripts/Verify-Links.ps1
+  #     arguments: >
+  #       -urls "https://azure.github.io/azure-sdk-for-python/index.html"
+  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+  #       -inputCacheFile "$(cachefile)"
+  #       -outputCacheFile "$(cachefile)"
+  #       -devOpsLogging: $true
         
   - task: PowerShell@2
     displayName: 'tools link check'
@@ -105,10 +105,10 @@ jobs:
         -outputCacheFile "$(cachefile)"
         -devOpsLogging: $true
 
-  - publish: $(cachefile)
-    artifact: verify-links-cache.txt
-    condition: succeededOrFailed()
-    displayName: Upload verified links
+  # - publish: $(cachefile)
+  #   artifact: verify-links-cache.txt
+  #   condition: succeededOrFailed()
+  #   displayName: Upload verified links
 
   - pwsh: |
       azcopy copy '$(cachefile)' 'https://azuresdkartifacts.blob.core.windows.net/verify-links-cache$(azuresdkartifacts-verify-links-cache-sas)'

--- a/eng/pipelines/githubio-linkcheck.yml
+++ b/eng/pipelines/githubio-linkcheck.yml
@@ -90,6 +90,19 @@ jobs:
         -inputCacheFile "$(cachefile)"
         -outputCacheFile "$(cachefile)"
         -devOpsLogging: $true
+        
+  - task: PowerShell@2
+    displayName: 'tools link check'
+    condition: succeededOrFailed()
+    inputs:
+      pwsh: true
+      filePath: eng/common/scripts/Verify-Links.ps1
+      arguments: >
+        -urls '(Get-ChildItem -Path ./ -Recurse -Include *.md)'
+        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+        -inputCacheFile "$(cachefile)"
+        -outputCacheFile "$(cachefile)"
+        -devOpsLogging: $true
 
   - publish: $(cachefile)
     artifact: verify-links-cache.txt

--- a/eng/pipelines/githubio-linkcheck.yml
+++ b/eng/pipelines/githubio-linkcheck.yml
@@ -99,6 +99,7 @@ jobs:
       filePath: eng/common/scripts/Verify-Links.ps1
       arguments: >
         -urls '(Get-ChildItem -Path ./ -Recurse -Include *.md)'
+        -rootUrl "file://$(System.DefaultWorkingDirectory)"        
         -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
         -inputCacheFile "$(cachefile)"
         -outputCacheFile "$(cachefile)"

--- a/eng/pipelines/githubio-linkcheck.yml
+++ b/eng/pipelines/githubio-linkcheck.yml
@@ -13,83 +13,83 @@ jobs:
   displayName: Check and Cache Links
   timeoutInMinutes: 0
   steps:
-  # - task: PowerShell@2
-  #   displayName: 'azure-sdk link check'
-  #   condition: succeededOrFailed()
-  #   inputs:
-  #     pwsh: true
-  #     filePath: eng/common/scripts/Verify-Links.ps1
-  #     arguments: >
-  #       -urls "https://azure.github.io/azure-sdk/index.html"
-  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-  #       -inputCacheFile "$(cachefile)"
-  #       -outputCacheFile "$(cachefile)"
-  #       -devOpsLogging: $true
+  - task: PowerShell@2
+    displayName: 'azure-sdk link check'
+    condition: succeededOrFailed()
+    inputs:
+      pwsh: true
+      filePath: eng/common/scripts/Verify-Links.ps1
+      arguments: >
+        -urls "https://azure.github.io/azure-sdk/index.html"
+        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+        -inputCacheFile "$(cachefile)"
+        -outputCacheFile "$(cachefile)"
+        -devOpsLogging: $true
 
-  # - task: PowerShell@2
-  #   displayName: 'azure-sdk link check with caching'
-  #   condition: succeededOrFailed()
-  #   inputs:
-  #     pwsh: true
-  #     filePath: eng/common/scripts/Verify-Links.ps1
-  #     arguments: >
-  #       -urls "https://azure.github.io/azure-sdk/index.html"
-  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-  #       -inputCacheFile "$(cachefile)"
-  #       -outputCacheFile "$(cachefile)"
-  #       -devOpsLogging: $true
+  - task: PowerShell@2
+    displayName: 'azure-sdk link check with caching'
+    condition: succeededOrFailed()
+    inputs:
+      pwsh: true
+      filePath: eng/common/scripts/Verify-Links.ps1
+      arguments: >
+        -urls "https://azure.github.io/azure-sdk/index.html"
+        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+        -inputCacheFile "$(cachefile)"
+        -outputCacheFile "$(cachefile)"
+        -devOpsLogging: $true
 
-  # - task: PowerShell@2
-  #   displayName: 'java link check'
-  #   condition: succeededOrFailed()
-  #   inputs:
-  #     pwsh: true
-  #     filePath: eng/common/scripts/Verify-Links.ps1
-  #     arguments: >
-  #       -urls "https://azure.github.io/azure-sdk-for-java/index.html"
-  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-  #       -inputCacheFile "$(cachefile)"
-  #       -outputCacheFile "$(cachefile)"
-  #       -devOpsLogging: $true
+  - task: PowerShell@2
+    displayName: 'java link check'
+    condition: succeededOrFailed()
+    inputs:
+      pwsh: true
+      filePath: eng/common/scripts/Verify-Links.ps1
+      arguments: >
+        -urls "https://azure.github.io/azure-sdk-for-java/index.html"
+        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+        -inputCacheFile "$(cachefile)"
+        -outputCacheFile "$(cachefile)"
+        -devOpsLogging: $true
 
-  # - task: PowerShell@2
-  #   displayName: 'js link check'
-  #   condition: succeededOrFailed()
-  #   inputs:
-  #     pwsh: true
-  #     filePath: eng/common/scripts/Verify-Links.ps1
-  #     arguments: >
-  #       -urls "https://azure.github.io/azure-sdk-for-js/index.html"
-  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-  #       -inputCacheFile "$(cachefile)"
-  #       -outputCacheFile "$(cachefile)"
-  #       -devOpsLogging: $true
+  - task: PowerShell@2
+    displayName: 'js link check'
+    condition: succeededOrFailed()
+    inputs:
+      pwsh: true
+      filePath: eng/common/scripts/Verify-Links.ps1
+      arguments: >
+        -urls "https://azure.github.io/azure-sdk-for-js/index.html"
+        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+        -inputCacheFile "$(cachefile)"
+        -outputCacheFile "$(cachefile)"
+        -devOpsLogging: $true
 
-  # - task: PowerShell@2
-  #   displayName: 'net link check'
-  #   condition: succeededOrFailed()
-  #   inputs:
-  #     pwsh: true
-  #     filePath: eng/common/scripts/Verify-Links.ps1
-  #     arguments: >
-  #       -urls "https://azure.github.io/azure-sdk-for-net/index.html"
-  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-  #       -inputCacheFile "$(cachefile)"
-  #       -outputCacheFile "$(cachefile)"
-  #       -devOpsLogging: $true
+  - task: PowerShell@2
+    displayName: 'net link check'
+    condition: succeededOrFailed()
+    inputs:
+      pwsh: true
+      filePath: eng/common/scripts/Verify-Links.ps1
+      arguments: >
+        -urls "https://azure.github.io/azure-sdk-for-net/index.html"
+        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+        -inputCacheFile "$(cachefile)"
+        -outputCacheFile "$(cachefile)"
+        -devOpsLogging: $true
 
-  # - task: PowerShell@2
-  #   displayName: 'python link check'
-  #   condition: succeededOrFailed()
-  #   inputs:
-  #     pwsh: true
-  #     filePath: eng/common/scripts/Verify-Links.ps1
-  #     arguments: >
-  #       -urls "https://azure.github.io/azure-sdk-for-python/index.html"
-  #       -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
-  #       -inputCacheFile "$(cachefile)"
-  #       -outputCacheFile "$(cachefile)"
-  #       -devOpsLogging: $true
+  - task: PowerShell@2
+    displayName: 'python link check'
+    condition: succeededOrFailed()
+    inputs:
+      pwsh: true
+      filePath: eng/common/scripts/Verify-Links.ps1
+      arguments: >
+        -urls "https://azure.github.io/azure-sdk-for-python/index.html"
+        -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
+        -inputCacheFile "$(cachefile)"
+        -outputCacheFile "$(cachefile)"
+        -devOpsLogging: $true
         
   - task: PowerShell@2
     displayName: 'tools link check'
@@ -98,17 +98,17 @@ jobs:
       pwsh: true
       filePath: eng/common/scripts/Verify-Links.ps1
       arguments: >
-        -urls (Get-ChildItem -Path ./ -Recurse -Include *.md)
+        -urls (Get-ChildItem -Path ./eng/common -Recurse -Include *.md)
         -rootUrl "file://$(System.DefaultWorkingDirectory)"        
         -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
         -inputCacheFile "$(cachefile)"
         -outputCacheFile "$(cachefile)"
         -devOpsLogging: $true
 
-  # - publish: $(cachefile)
-  #   artifact: verify-links-cache.txt
-  #   condition: succeededOrFailed()
-  #   displayName: Upload verified links
+  - publish: $(cachefile)
+    artifact: verify-links-cache.txt
+    condition: succeededOrFailed()
+    displayName: Upload verified links
 
   - pwsh: |
       azcopy copy '$(cachefile)' 'https://azuresdkartifacts.blob.core.windows.net/verify-links-cache$(azuresdkartifacts-verify-links-cache-sas)'

--- a/eng/pipelines/githubio-linkcheck.yml
+++ b/eng/pipelines/githubio-linkcheck.yml
@@ -98,7 +98,7 @@ jobs:
       pwsh: true
       filePath: eng/common/scripts/Verify-Links.ps1
       arguments: >
-        -urls '(Get-ChildItem -Path ./ -Recurse -Include *.md)'
+        -urls (Get-ChildItem -Path ./ -Recurse -Include *.md)
         -rootUrl "file://$(System.DefaultWorkingDirectory)"        
         -ignoreLinksFile "./eng/pipelines/githubio-linkcheck-ignore-links.txt"
         -inputCacheFile "$(cachefile)"


### PR DESCRIPTION
We need to add a place to help catch broken links in things like eng/common so that we can fix them before they break more pipelines in the other languages. This will enable us to find them from the nightly run.