### PR TITLE
[http-fault-injector] Set UseAppHost=false

### DIFF
--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
@@ -4,6 +4,11 @@
     <VersionPrefix>0.2.1</VersionPrefix>
 
     <TargetFramework>net6.0</TargetFramework>
+
+    <!--
+      UseAppHost=false enables HTTPS on Mac with no keychain popup.
+      Workaround for https://github.com/dotnet/sdk/issues/22544.
+    -->
     <UseAppHost>false</UseAppHost>
 
     <IsPackable>true</IsPackable>

--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
@@ -4,6 +4,7 @@
     <VersionPrefix>0.2.0</VersionPrefix>
 
     <TargetFramework>net6.0</TargetFramework>
+    <UseAppHost>false</UseAppHost>
 
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>

--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.2.1</VersionPrefix>
 
     <TargetFramework>net6.0</TargetFramework>
     <UseAppHost>false</UseAppHost>


### PR DESCRIPTION
- Enables HTTPS on Mac with no keychain popup
- Workaround for https://github.com/dotnet/sdk/issues/22544
