### PR TITLE
[http-fault-injector] Target net7.0 to enable HTTPS on Mac with no keychain popup

### DIFF
--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
@@ -3,9 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>0.2.0</VersionPrefix>
 
-    <!--
-      net7.0 enables HTTPS on Mac with no keychain popup (https://github.com/dotnet/aspnetcore/issues/41879)
-    -->
+    <!-- net7.0 enables HTTPS on Mac with no keychain popup (https://github.com/dotnet/aspnetcore/issues/41879) -->
     <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>true</IsPackable>

--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
@@ -3,7 +3,10 @@
   <PropertyGroup>
     <VersionPrefix>0.2.0</VersionPrefix>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <!--
+      net7.0 enables HTTPS on Mac with no keychain popup (https://github.com/dotnet/aspnetcore/issues/41879)
+    -->
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
- Fixed in https://github.com/dotnet/aspnetcore/issues/41879