### PR TITLE
Add differentiation between a null body and an empty body 

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -87,6 +87,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var playbackContext = new DefaultHttpContext();
             var recordingId = Guid.NewGuid().ToString();
             playbackContext.Request.Headers["x-recording-id"] = recordingId;
+
             var playbackController = new Playback(testRecordingHandler, new NullLoggerFactory())
             {
                 ControllerContext = new ControllerContext()

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Azure.Sdk.Tools.TestProxy.Common;
@@ -31,6 +31,11 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             var body = await HttpRequestInteractions.GetBody(Request);
 
+            if (body == null)
+            {
+                throw new HttpException(HttpStatusCode.BadRequest, "When starting playback, a null body is not a valid input.");
+            }
+
             string file = HttpRequestInteractions.GetBodyKey(body, "x-recording-file", allowNulls: true);
             string recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
             var assetsJson = RecordingHandler.GetAssetsJsonLocation(
@@ -47,7 +52,7 @@ namespace Azure.Sdk.Tools.TestProxy
             }
             else
             {
-                throw new HttpException(HttpStatusCode.BadRequest, "At least one of either JSON body key 'x-recording-file' or header 'x-recording-id' must be populated when starting playback.");
+                throw new HttpException(HttpStatusCode.BadRequest, "When starting playback, a body must be provided with least one JSON body key 'x-recording-file' or header 'x-recording-id' must be populated when starting playback.");
             }
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
@@ -52,7 +52,7 @@ namespace Azure.Sdk.Tools.TestProxy
             }
             else
             {
-                throw new HttpException(HttpStatusCode.BadRequest, "When starting playback, a body must be provided with least one JSON body key 'x-recording-file' or header 'x-recording-id' must be populated when starting playback.");
+                throw new HttpException(HttpStatusCode.BadRequest, "At least one of either JSON body key 'x-recording-file' or header 'x-recording-id' must be populated when starting playback.");
             }
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
@@ -31,11 +31,6 @@ namespace Azure.Sdk.Tools.TestProxy
         {
             var body = await HttpRequestInteractions.GetBody(Request);
 
-            if (body == null)
-            {
-                throw new HttpException(HttpStatusCode.BadRequest, "When starting playback, a null body is not a valid input.");
-            }
-
             string file = HttpRequestInteractions.GetBodyKey(body, "x-recording-file", allowNulls: true);
             string recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
             var assetsJson = RecordingHandler.GetAssetsJsonLocation(

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -415,8 +415,7 @@ Start the recording **without a `x-recording-file` body value**.
 
 ```jsonc
 // targeted URI: https://localhost:5001/record/start
-// the request body will be EMPTY
-{}
+// the request body will be NULL / unset
 ```
 
 The POST will return a valid recordingId value which we will call `X`.
@@ -430,6 +429,8 @@ To load this recording for playback...
     "x-recording-id": "X"
 }
 ```
+
+When attempting to use in-memory recording, you cannot submit empty body `{}` to `/Record/Start`. Doing so will result in an error, as it is _expecting_ a recording file if a body provided.
 
 ### See example implementations
 


### PR DESCRIPTION
Before this PR, a user could start a recording with a a target file, or _no_ target file. No target file being provided means the recording should be entirely in-memory.

```jsonc
// POST /Record/Playback
// body
{
  "x-recording-file": "blah.json"
}
// returns x-recording-id for use by recording framework
```

```jsonc
// POST /Record/Playback
// body
{
}
// returns x-recording-id for use by recording framework
```

@samvaity recently was debugging a proxy start, and while the issue ended up being that the request body wasn't being formed correctly, the test-proxy didn't _inform_ Sameeksha about that problem. To the test-proxy, @samvaity was just starting an in-memory recording.

The perf framework currently sends _no_ body when attempting to start an in-memory recording. We will take advantage of that fact to ship a breaking change. If you want an in-memory recording, _send no body_.

This change allows us to easily bifurcate these behaviors, and give our users some actual detail to their errors!

