### PR TITLE
Fixes for uploading proxy logs

### DIFF
--- a/eng/common/testproxy/publish-proxy-logs.yml
+++ b/eng/common/testproxy/publish-proxy-logs.yml
@@ -5,12 +5,14 @@ steps:
   - pwsh: |
       Copy-Item -Path "${{ parameters.rootFolder }}/test-proxy.log" -Destination "${{ parameters.rootFolder }}/proxy.log"
     displayName: Copy Log File
+    condition: succeededOrFailed()
 
   - template: ../pipelines/templates/steps/publish-artifact.yml
     parameters:
-      ArtifactName: "$(System.JobName)-proxy-logs"
+      ArtifactName: "$(System.StageName)-$(System.JobName)-$(System.JobAttempt)-proxy-logs"
       ArtifactPath: "${{ parameters.rootFolder }}/proxy.log"
 
   - pwsh: |
       Remove-Item -Force ${{ parameters.rootFolder }}/proxy.log
     displayName: Cleanup Copied Log File
+    condition: succeededOrFailed()


### PR DESCRIPTION
Two fixes:
1) Add `condition: succeededOrFailed()` to the copy/delete steps so they run if there are earlier failures in the pipeline.
2) Add more discrimination to the artifact name to prevent potential collisions.