### PR TITLE
Few update on common process script

### DIFF
--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -119,15 +119,15 @@ if ($TypeSpecProjectDirectory -match '^https://github.com/(?<repo>Azure/azure-re
   $CommitHash = $Matches["commit"]
   # TODO support the branch name in url then get the commithash from branch name
 } else {
+  $tspConfigPath = Join-Path $TypeSpecProjectDirectory "tspconfig.yaml"
+  if (!(Test-Path $tspConfigPath)) {
+    Write-Error "Failed to find tspconfig.yaml in '$TypeSpecProjectDirectory'"
+    exit 1
+  }
   if ($TypeSpecProjectDirectory -match "^.*/(?<path>specification/.*)$") {
     $TypeSpecProjectDirectory = $Matches["path"]
   } else {
     Write-Error "'$TypeSpecProjectDirectory' doesn't have 'specification' in path."
-    exit 1
-  }
-  $tspConfigPath = Join-Path $TypeSpecProjectDirectory "tspconfig.yaml"
-  if (!(Test-Path $tspConfigPath)) {
-    Write-Error "Failed to find tspconfig.yaml in '$TypeSpecProjectDirectory'"
     exit 1
   }
 }
@@ -145,3 +145,4 @@ $sdkProjectFolder = CreateUpdate-TspLocation $tspConfigYaml $TypeSpecProjectDire
 & "$PSScriptRoot/TypeSpec-Project-Sync.ps1" $sdkProjectFolder
 # call TypeSpec-Project-Generate.ps1
 & "$PSScriptRoot/TypeSpec-Project-Generate.ps1" $sdkProjectFolder
+return $sdkProjectFolder

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -143,6 +143,9 @@ $sdkProjectFolder = CreateUpdate-TspLocation $tspConfigYaml $TypeSpecProjectDire
 
 # call TypeSpec-Project-Sync.ps1
 & "$PSScriptRoot/TypeSpec-Project-Sync.ps1" $sdkProjectFolder
+if ($LASTEXITCODE) { exit $LASTEXITCODE }
+
 # call TypeSpec-Project-Generate.ps1
 & "$PSScriptRoot/TypeSpec-Project-Generate.ps1" $sdkProjectFolder
+
 return $sdkProjectFolder

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -161,5 +161,6 @@ if ($LASTEXITCODE) { exit $LASTEXITCODE }
 # call TypeSpec-Project-Generate.ps1
 $generateScript = Join-Path $PSScriptRoot TypeSpec-Project-Generate.ps1
 & $generateScript $sdkProjectFolder
+if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
 return $sdkProjectFolder

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -36,14 +36,14 @@ function CreateUpdate-TspLocation([System.Object]$tspConfig, [string]$TypeSpecPr
   # Create service-dir if not exist
   $serviceDir = Join-Path $repoRoot $serviceDir
   if (!(Test-Path -Path $serviceDir)) {
-    New-Item -Path $serviceDir -ItemType Directory
+    New-Item -Path $serviceDir -ItemType Directory | Out-Null
     Write-Host "created service folder $serviceDir"
   }
 
   # Create package-dir if not exist
   $packageDir = Join-Path $serviceDir $packageDir
   if (!(Test-Path -Path $packageDir)) {
-    New-Item -Path $packageDir -ItemType Directory
+    New-Item -Path $packageDir -ItemType Directory | Out-Null
     Write-Host "created package folder $packageDir"
   }
 

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -87,22 +87,13 @@ function Get-PackageDir([System.Object]$tspConfig) {
   return $packageDir
 }
 
-$repo = ""
-if ($RepoUrl) {
-  if ($RepoUrl -match "^https://github.com/(?<repo>[^/]*/azure-rest-api-specs(-pr)?).*") {
-    $repo = $Matches["repo"]
-  }
-  else {
-    Write-Host "Parameter 'RepoUrl' has incorrect value: $RepoUrl. It should be similar like 'https://github.com/Azure/azure-rest-api-specs'"
-    exit 1
-  }
-}
-
 $repoRootPath =  (Join-Path $PSScriptRoot .. .. ..)
 $repoRootPath = Resolve-Path $repoRootPath
 $repoRootPath = $repoRootPath -replace "\\", "/"
 $tspConfigPath = Join-Path $repoRootPath 'tspconfig.yaml'
 $tmpTspConfigPath = $tspConfigPath
+$repo = ""
+# remote url scenario
 # example url of tspconfig.yaml: https://github.com/Azure/azure-rest-api-specs-pr/blob/724ccc4d7ef7655c0b4d5c5ac4a5513f19bbef35/specification/containerservice/Fleet.Management/tspconfig.yaml
 if ($TypeSpecProjectDirectory -match '^https://github.com/(?<repo>Azure/azure-rest-api-specs(-pr)?)/blob/(?<commit>[0-9a-f]{40})/(?<path>.*)/tspconfig.yaml$') {
   try {
@@ -119,6 +110,7 @@ if ($TypeSpecProjectDirectory -match '^https://github.com/(?<repo>Azure/azure-re
   $CommitHash = $Matches["commit"]
   # TODO support the branch name in url then get the commithash from branch name
 } else {
+  # local path scenario
   $tspConfigPath = Join-Path $TypeSpecProjectDirectory "tspconfig.yaml"
   if (!(Test-Path $tspConfigPath)) {
     Write-Error "Failed to find tspconfig.yaml in '$TypeSpecProjectDirectory'"
@@ -127,7 +119,22 @@ if ($TypeSpecProjectDirectory -match '^https://github.com/(?<repo>Azure/azure-re
   if ($TypeSpecProjectDirectory -match "^.*/(?<path>specification/.*)$") {
     $TypeSpecProjectDirectory = $Matches["path"]
   } else {
-    Write-Error "'$TypeSpecProjectDirectory' doesn't have 'specification' in path."
+    Write-Error "$TypeSpecProjectDirectory doesn't have 'specification' in path."
+    exit 1
+  }
+  if (!$CommitHash) {
+    Write-Error "Parameter of Commithash is not provided in the local path scenario."
+    exit 1
+  }
+  if (!$RepoUrl) {
+    Write-Error "Parameter of RepoUrl:$RepoUrl is not provided in the local path scenario."
+    exit 1
+  }
+  if ($RepoUrl -match "^https://github.com/(?<repo>[^/]*/azure-rest-api-specs(-pr)?).*") {
+    $repo = $Matches["repo"]
+  }
+  else {
+    Write-Error "Parameter 'RepoUrl' has incorrect value:$RepoUrl. It should be similar like 'https://github.com/Azure/azure-rest-api-specs'"
     exit 1
   }
 }

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -120,7 +120,8 @@ if ($TypeSpecProjectDirectory -match '^https://github.com/(?<repo>Azure/azure-re
     Write-Error "Failed to find tspconfig.yaml in '$TypeSpecProjectDirectory'"
     exit 1
   }
-  if ($TypeSpecProjectDirectory -match "^.*[\\/](?<path>specification[\\/].*)$") {
+  $TypeSpecProjectDirectory = $TypeSpecProjectDirectory.Replace("\", "/")
+  if ($TypeSpecProjectDirectory -match "^.*/(?<path>specification/.*)$") {
     $TypeSpecProjectDirectory = $Matches["path"]
   } else {
     Write-Error "$TypeSpecProjectDirectory doesn't have 'specification' in path."

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -59,11 +59,15 @@ function CreateUpdate-TspLocation([System.Object]$tspConfig, [string]$TypeSpecPr
 
   # Update tsp-location.yaml
   $tspLocationYaml["commit"] = $CommitHash
+  Write-Host "updated tsp-location.yaml commit to $CommitHash"
   $tspLocationYaml["repo"] = $repo
+  Write-Host "updated tsp-location.yaml repo to $repo"
   $tspLocationYaml["directory"] = $TypeSpecProjectDirectory
+  Write-Host "updated tsp-location.yaml directory to $TypeSpecProjectDirectory"
   $tspLocationYaml["additionalDirectories"] = $additionalDirs
+  Write-Host "updated tsp-location.yaml additionalDirectories to $additionalDirs"
   $tspLocationYaml |ConvertTo-Yaml | Out-File $tspLocationYamlPath
-  Write-Host "updated tsp-location.yaml in $packageDir"
+  Write-Host "finished updating tsp-location.yaml in $packageDir"
   return $packageDir
 }
 
@@ -116,7 +120,7 @@ if ($TypeSpecProjectDirectory -match '^https://github.com/(?<repo>Azure/azure-re
     Write-Error "Failed to find tspconfig.yaml in '$TypeSpecProjectDirectory'"
     exit 1
   }
-  if ($TypeSpecProjectDirectory -match "^.*/(?<path>specification/.*)$") {
+  if ($TypeSpecProjectDirectory -match "^.*[\\/](?<path>specification[\\/].*)$") {
     $TypeSpecProjectDirectory = $Matches["path"]
   } else {
     Write-Error "$TypeSpecProjectDirectory doesn't have 'specification' in path."
@@ -149,10 +153,12 @@ if (Test-Path $tmpTspConfigPath) {
 $sdkProjectFolder = CreateUpdate-TspLocation $tspConfigYaml $TypeSpecProjectDirectory $CommitHash $repo $repoRootPath
 
 # call TypeSpec-Project-Sync.ps1
-& "$PSScriptRoot/TypeSpec-Project-Sync.ps1" $sdkProjectFolder
+$syncScript = Join-Path $PSScriptRoot TypeSpec-Project-Sync.ps1
+& $syncScript $sdkProjectFolder
 if ($LASTEXITCODE) { exit $LASTEXITCODE }
 
 # call TypeSpec-Project-Generate.ps1
-& "$PSScriptRoot/TypeSpec-Project-Generate.ps1" $sdkProjectFolder
+$generateScript = Join-Path $PSScriptRoot TypeSpec-Project-Generate.ps1
+& $generateScript $sdkProjectFolder
 
 return $sdkProjectFolder


### PR DESCRIPTION
- Revert change of `TypeSpecProjectDirectory` path match as it's used to load tspconfig firstly
- Stop execution if returning failure after call sync script
- Add repo variable assignment in local path scenario

//CC: @weshaggard 