### PR TITLE
Make Json files the source of truth for DocsMS

### DIFF
--- a/eng/common/scripts/Update-DocsMsPackages.ps1
+++ b/eng/common/scripts/Update-DocsMsPackages.ps1
@@ -3,16 +3,12 @@
 Update docs.microsoft.com CI configuration with provided metadata
 
 .DESCRIPTION
-Update docs.microsoft.com CI configuration with metadata in the Azure/azure-sdk
-metadata CSV file and information in the docs.microsoft.com repo's own /metadata
-folder. The docs.microsoft.com repo's /metadata folder allows onboarding of
+Update docs.microsoft.com CI configuration with metadata in the docs.microsoft.com repo's
+/metadata folder. The docs.microsoft.com repo's /metadata folder allows onboarding of
 packages which have not released to a central package manager.
 
-* Use packages in the Azure/azure-sdk metadata CSV where New == true and 
-  Hide != true
-* Add metadata from files in the metadata/ folder to the CSV metadata
 * Onboard new packages, update existing tracked packages, leave other packages
-  in place. (This is implemented on a per-language basis by 
+  in place. (This is implemented on a per-language basis by
   $UpdateDocsMsPackagesFn)
 
 .PARAMETER DocRepoLocation
@@ -25,7 +21,7 @@ variable is meant to be used in the domain-specific business logic in
 &$UpdateDocsMsPackagesFn
 
 .PARAMETER ImageId
-Optional The docker image for package validation in format of '$containerRegistry/$imageName:$tag'. 
+Optional The docker image for package validation in format of '$containerRegistry/$imageName:$tag'.
 e.g. azuresdkimages.azurecr.io/jsrefautocr:latest
 
 #>
@@ -42,27 +38,27 @@ param (
 
 . (Join-Path $PSScriptRoot common.ps1)
 
-function GetDocsMetadataForMoniker($moniker) { 
+function GetDocsMetadataForMoniker($moniker) {
   $searchPath = Join-Path $DocRepoLocation 'metadata' $moniker
-  if (!(Test-Path $searchPath)) { 
-    return @() 
+  if (!(Test-Path $searchPath)) {
+    return @()
   }
   $paths = Get-ChildItem -Path $searchPath -Filter *.json
 
-  $metadata = @() 
-  foreach ($path in $paths) { 
+  $metadata = @()
+  foreach ($path in $paths) {
     $fileContents = Get-Content $path -Raw
     $fileObject = ConvertFrom-Json -InputObject $fileContents
     $versionGa = ''
-    $versionPreview = '' 
-    if ($moniker -eq 'latest') { 
+    $versionPreview = ''
+    if ($moniker -eq 'latest') {
       $versionGa = $fileObject.Version
-    } else { 
+    } else {
       $versionPreview = $fileObject.Version
     }
 
     $entry = @{
-      Package = $fileObject.Name; 
+      Package = $fileObject.Name;
       VersionGA = $versionGa;
       VersionPreview = $versionPreview;
       RepoPath = $fileObject.ServiceDirectory;
@@ -78,14 +74,12 @@ function GetDocsMetadataForMoniker($moniker) {
 
   return $metadata
 }
-function GetDocsMetadata() {
-  # Read metadata from CSV
-  $csvMetadata = (Get-CSVMetadata).Where({ ($_.New -eq 'true' -or $_.MSDocService -ne '') -and $_.Hide -ne 'true'})
 
+function GetDocsMetadata() {
   # Read metadata from docs repo
   $metadataByPackage = @{}
-  foreach ($package in GetDocsMetadataForMoniker 'latest') { 
-    if ($metadataByPackage.ContainsKey($package.Package)) { 
+  foreach ($package in GetDocsMetadataForMoniker 'latest') {
+    if ($metadataByPackage.ContainsKey($package.Package)) {
       LogWarning "Duplicate package in latest metadata: $($package.Package)"
     }
     Write-Host "Adding latest package: $($package.Package)"
@@ -103,37 +97,9 @@ function GetDocsMetadata() {
     }
   }
 
-  # Override CSV metadata version information before returning
-  $outputMetadata = @()
-  foreach ($item in $csvMetadata) {
-    if ($metadataByPackage.ContainsKey($item.Package)) {
-      Write-Host "Overriding CSV metadata from docs repo for $($item.Package)"
-      $matchingPackage = $metadataByPackage[$item.Package]
+  # TODO - Add a call to GetDocsMetadataForMoniker for 'legacy' when that is implemented
 
-      # Only update the version from metadata present in the docs repo IF there
-      # is a specified version. The absence of package metadata in the docs repo
-      # (e.g. no GA version) does not imply that the CSV metadata is incorrect.
-      if ($matchingPackage.VersionGA) {
-        $item.VersionGA = $matchingPackage.VersionGA
-      }
-      if ($matchingPackage.VersionPreview) { 
-        $item.VersionPreview = $matchingPackage.VersionPreview
-      }
-    }
-    $outputMetadata += $item
-  }
-
-  # Add entries present in the docs repo which are not present in CSV. These are
-  # usually packages which have not yet published a preview or GA version.
-  foreach ($item in $metadataByPackage.Values) { 
-    $matchingPackagesInCsvMetadata = $csvMetadata.Where({ $_.Package -eq $item.Package })
-    if (!$matchingPackagesInCsvMetadata) { 
-      Write-Host "Adding package from docs metadata that is not found in CSV metadata: $($item.Package)"
-      $outputMetadata  += $item
-    }
-  }
-
-  return $outputMetadata
+  return $metadataByPackage.Values
 }
 
 if ($UpdateDocsMsPackagesFn -and (Test-Path "Function:$UpdateDocsMsPackagesFn")) {
@@ -141,13 +107,13 @@ if ($UpdateDocsMsPackagesFn -and (Test-Path "Function:$UpdateDocsMsPackagesFn"))
   try {
     $docsMetadata = GetDocsMetadata
     &$UpdateDocsMsPackagesFn -DocsRepoLocation $DocRepoLocation -DocsMetadata $docsMetadata -PackageSourceOverride $PackageSourceOverride -DocValidationImageId $ImageId
-  } catch { 
+  } catch {
     LogError "Exception while updating docs.ms packages"
-    LogError $_ 
+    LogError $_
     LogError $_.ScriptStackTrace
     exit 1
   }
-  
+
 } else {
   LogError "The function for '$UpdateFn' was not found.`
   Make sure it is present in eng/scripts/Language-Settings.ps1 and referenced in eng/common/scripts/common.ps1.`


### PR DESCRIPTION
Make Json files the source of truth when generating the ToC/Docs. For libraries released from our engineering system the json files get updated as part of the release process. For libraries released outside of our engineering system, [we have a process](https://dev.azure.com/azure-sdk/internal/_wiki/wikis/internal.wiki/953/Releasing-docs-outside-of-Azure-SDK-Engineering-System) which we've trimmed down so the team just needs to add/update their own json files. As a result of this, pulling data from the CSV is no longer necessary.

Fixes #6117 