### PR TITLE
Use local HEAD commit to create tsp-location.yaml

### DIFF
--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -171,6 +171,8 @@ if ($generateFromLocalTypeSpec) {
   if (!(Test-Path -Path $tspLocationYamlPath)) {
     # try to create tsp-location.yaml using HEAD commit of the local spec repo
     Write-Warning "Failed to find tsp-location.yaml in '$sdkProjectFolder'. Trying to create tsp-location.yaml using HEAD commit of the local spec repo then proceed the sdk generation based upon local typespecs at $specRepoRoot. Alternatively, please make sure to provide CommitHash and RepoUrl parameters when running this script."
+    # set default repo to Azure/azure-rest-api-specs
+    $repo = "Azure/azure-rest-api-specs"
     try {
       Push-Location $specRepoRoot
       $CommitHash = $(git rev-parse HEAD)

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -177,15 +177,12 @@ if ($generateFromLocalTypeSpec) {
       Push-Location $specRepoRoot
       $CommitHash = $(git rev-parse HEAD)
       $gitOriginUrl = (git remote get-url origin)
-      foreach ($remote in $gitOriginUrl) {
-        Write-Host "Checking remote $remote"
-        if ($remote.StartsWith("origin")) {
-          if ($remote -match '(.*)?github.com:(?<repo>[^/]*/azure-rest-api-specs(-pr)?)(.git)?') {
-            $repo = $Matches["repo"]
-            Write-Host "Found remote origin: $repo"
-            break
-          }
-        }
+      if ($gitOriginUrl -and $gitOriginUrl -match '(.*)?github.com:(?<repo>[^/]*/azure-rest-api-specs(-pr)?)(.git)?') {
+        $repo = $Matches["repo"]
+        Write-Host "Found git origin repo: $repo"
+      }
+      else {
+        Write-Warning "Failed to find git origin repo of the local spec repo at specRepoRoot: $specRepoRoot. Using default repo: $repo"
       }
     }
     catch {

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -177,10 +177,10 @@ if ($generateFromLocalTypeSpec) {
       Push-Location $specRepoRoot
       $CommitHash = $(git rev-parse HEAD)
       $gitOriginUrl = (git remote get-url origin)
-      foreach ($remote in $gitRemotes) {
+      foreach ($remote in $gitOriginUrl) {
         Write-Host "Checking remote $remote"
         if ($remote.StartsWith("origin")) {
-          if ($remote -match '(.*)?github.com:(?<repo>[^/]*/azure-rest-api-specs).git') {
+          if ($remote -match '(.*)?github.com:(?<repo>[^/]*/azure-rest-api-specs(-pr)?)(.git)?') {
             $repo = $Matches["repo"]
             Write-Host "Found remote origin: $repo"
             break
@@ -189,7 +189,7 @@ if ($generateFromLocalTypeSpec) {
       }
     }
     catch {
-      Write-Error "Failed to get HEAD commit or remote origin of the local spec repo at $specRepoRoot."
+      Write-Error "Failed to get HEAD commit or remote origin of the local spec repo at specRepoRoot: $specRepoRoot."
       exit 1
     }
     finally {

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -165,15 +165,39 @@ if (Test-Path $tmpTspConfigPath) {
 
 $sdkProjectFolder = ""
 if ($generateFromLocalTypeSpec) {
+  Write-Host "Generating sdk code based on local type specs at $specRepoRoot."
   $sdkProjectFolder = Get-TspLocationFolder $tspConfigYaml $sdkRepoRootPath
   $tspLocationYamlPath = Join-Path $sdkProjectFolder "tsp-location.yaml"
   if (!(Test-Path -Path $tspLocationYamlPath)) {
-    Write-Error "Failed to find tsp-location.yaml in '$sdkProjectFolder', please make sure to provide CommitHash and RepoUrl parameters along with the local path of tspconfig.yaml in order to create tsp-location.yaml."
-    exit 1
+    # try to create tsp-location.yaml using HEAD commit of the local spec repo
+    Write-Warning "Failed to find tsp-location.yaml in '$sdkProjectFolder'. Trying to create tsp-location.yaml using HEAD commit of the local spec repo then proceed the sdk generation based upon local typespecs at $specRepoRoot. Alternatively, please make sure to provide CommitHash and RepoUrl parameters when running this script."
+    try {
+      Push-Location $specRepoRoot
+      $CommitHash = $(git rev-parse HEAD)
+      $gitRemotes = (git remote -v)
+      foreach ($remote in $gitRemotes) {
+        Write-Host "Checking remote $remote"
+        if ($remote.StartsWith("origin")) {
+          if ($remote -match '(.*)?github.com:(?<repo>[^/]*/azure-rest-api-specs).git') {
+            $repo = $Matches["repo"]
+            Write-Host "Found remote origin: $repo"
+            break
+          }
+        }
+      }
+    }
+    catch {
+      Write-Error "Failed to get HEAD commit or remote origin of the local spec repo at $specRepoRoot."
+      exit 1
+    }
+    finally {
+      Pop-Location
+    }
+    $sdkProjectFolder = CreateUpdate-TspLocation $tspConfigYaml $TypeSpecProjectDirectory $CommitHash $repo $sdkRepoRootPath  
   }
 } else {
   # call CreateUpdate-TspLocation function
-  $sdkProjectFolder = CreateUpdate-TspLocation $tspConfigYaml $TypeSpecProjectDirectory $CommitHash $repo $sdkRepoRootPath  
+  $sdkProjectFolder = CreateUpdate-TspLocation $tspConfigYaml $TypeSpecProjectDirectory $CommitHash $repo $sdkRepoRootPath
 }
 
 # call TypeSpec-Project-Sync.ps1

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -165,7 +165,7 @@ if (Test-Path $tmpTspConfigPath) {
 
 $sdkProjectFolder = ""
 if ($generateFromLocalTypeSpec) {
-  Write-Host "Generating sdk code based on local type specs at $specRepoRoot."
+  Write-Host "Generating sdk code based on local type specs at specRepoRoot: $specRepoRoot."
   $sdkProjectFolder = Get-TspLocationFolder $tspConfigYaml $sdkRepoRootPath
   $tspLocationYamlPath = Join-Path $sdkProjectFolder "tsp-location.yaml"
   if (!(Test-Path -Path $tspLocationYamlPath)) {

--- a/eng/common/scripts/TypeSpec-Project-Process.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Process.ps1
@@ -176,7 +176,7 @@ if ($generateFromLocalTypeSpec) {
     try {
       Push-Location $specRepoRoot
       $CommitHash = $(git rev-parse HEAD)
-      $gitRemotes = (git remote -v)
+      $gitOriginUrl = (git remote get-url origin)
       foreach ($remote in $gitRemotes) {
         Write-Host "Checking remote $remote"
         if ($remote.StartsWith("origin")) {


### PR DESCRIPTION
In local spec repo scenario, script would use the local cloned spec repo HEAD commit to create `tsp-location.yaml` if the file doesn't exist. Once the file is created, script would proceed the sdk generation based upon the local spec repo folder.

@weshaggard 