### PR TITLE
Asset-Sync Documentation Update

### DIFF
--- a/tools/test-proxy/documentation/asset-sync/README.md
+++ b/tools/test-proxy/documentation/asset-sync/README.md
@@ -2,6 +2,8 @@
 
 The `test-proxy` optionally offers integration with other git repositories for **storing** and **retrieving** recordings. This enables the proxy to work against repositories that do not emplace their test recordings directly alongside their test implementations.
 
+Colloquially, any file that is stored externally using the `asset-sync` feature of the `test-proxy` is called an `asset`.
+
 ![asset sync block diagram](../_images/asset_sync_block_diagram.png)
 
 In the context of a `monorepo`, this means that we store FAR less data per feature. To update recordings, the only change alongside the source code is to update the targeted tag.
@@ -11,6 +13,7 @@ With the addition of asset-sync capabilities, the test-proxy now responds to a n
 The header `x-recording-assets-file` will contain a value of where the `assets.json` is located within the language repo, expressed as a relative path. EG `sdk/tables/assets.json`.
 
 The combination of the the `assets.json` context and the original test-path will allow the test-proxy to restore a set of recordings to a path, then _load_ the recording from that newly gathered data. The path to the recording file within the external assets repo can be _predictably_ calculated and retrieved given just the location of the `assets.json` within the code repo, the requested file name during playback or record start, and the properties within the assets.json itself. The diagram above has colors to show how the paths are used in context.
+
 
 ## The `assets.json` and how it enables external recordings
 

--- a/tools/test-proxy/documentation/asset-sync/README.md
+++ b/tools/test-proxy/documentation/asset-sync/README.md
@@ -14,7 +14,6 @@ The header `x-recording-assets-file` will contain a value of where the `assets.j
 
 The combination of the the `assets.json` context and the original test-path will allow the test-proxy to restore a set of recordings to a path, then _load_ the recording from that newly gathered data. The path to the recording file within the external assets repo can be _predictably_ calculated and retrieved given just the location of the `assets.json` within the code repo, the requested file name during playback or record start, and the properties within the assets.json itself. The diagram above has colors to show how the paths are used in context.
 
-
 ## The `assets.json` and how it enables external recordings
 
 An `assets.json` contains _targeting_ information for use by the test-proxy when restoring (or updating) recordings "below" a specific path.


### PR DESCRIPTION
@konrad-jamrozik  you said that we never really specified what an `asset` was in another PR. I thought you were right right up until I read the intro to the doc

```
# Asset Sync (Retrieve External Test Recordings)

The `test-proxy` optionally offers integration with other git repositories for **storing** and **retrieving** recordings. This enables the proxy to work against repositories that do not emplace their test recordings directly alongside their test implementations.
```

I feel like this is extremely clear about  `asset-sync` does, but I never actually tied it to the keyword `assets`. This PR does that for clarity 👍 