### PR TITLE
Update changeloggen project's PackAsTool to true

### DIFF
--- a/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen/Azure.SDK.Management.ChangelogGen.csproj
+++ b/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen/Azure.SDK.Management.ChangelogGen.csproj
@@ -1,10 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackAsTool>True</PackAsTool>
+    <ToolCommandName>changelogGen-mgmt</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen/Azure.SDK.Management.ChangelogGen.csproj
+++ b/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen/Azure.SDK.Management.ChangelogGen.csproj
@@ -6,7 +6,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>True</PackAsTool>
-    <ToolCommandName>changelogGen-mgmt</ToolCommandName>
+    <ToolCommandName>changelog-gen-mgmt</ToolCommandName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Update changeloggen project's PackAsTool property to be true so that it can be installed and used through 'dotnet tool install' easily when using the tool from .net azure sdk repo. 