### PR TITLE
Allow `Restore` to discard pending changes

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -335,13 +335,6 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             }
         }
 
-        // Scenario 3 - Restore from Tag, add and remove files, Reset response Y
-        // 1. Restore from Tag python/tables_9e81fb
-        // 2. Expect: 4 files with versions they were checked in with
-        // 3. Update add/remove files
-        // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
-        // 5. Reset with Y
-        // 6. Expect: each file should be at it's initial version, the version that was in the original Tag
         [EnvironmentConditionalSkipTheory]
         [InlineData(
         @"{

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -335,6 +335,85 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
             }
         }
 
+        // Scenario 3 - Restore from Tag, add and remove files, Reset response Y
+        // 1. Restore from Tag python/tables_9e81fb
+        // 2. Expect: 4 files with versions they were checked in with
+        // 3. Update add/remove files
+        // 4. Expect: Untouched files are the same versions as step 2, added files are version 1, removed files are gone
+        // 5. Reset with Y
+        // 6. Expect: each file should be at it's initial version, the version that was in the original Tag
+        [EnvironmentConditionalSkipTheory]
+        [InlineData(
+        @"{
+              ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
+              ""AssetsRepoPrefixPath"": ""pull/scenarios"",
+              ""AssetsRepoId"": """",
+              ""TagPrefix"": ""main"",
+              ""Tag"": ""python/tables_9e81fb""
+        }")]
+        [Trait("Category", "Integration")]
+        public async Task VerifyRestoreDiscardsChanges(string inputJson)
+        {
+            var folderStructure = new string[]
+            {
+                GitStoretests.AssetsJson
+            };
+
+            Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
+            var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure);
+            try
+            {
+                var jsonFileLocation = Path.Join(testFolder, GitStoretests.AssetsJson);
+
+                var parsedConfiguration = await _defaultStore.ParseConfigurationFile(jsonFileLocation);
+                await _defaultStore.Restore(jsonFileLocation);
+
+                // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
+                // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
+                // will be a forward one as expected by git but on Windows this won't result in a usable path.
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
+
+                // Verify files from Tag
+                Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 2));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
+
+                // Delete a couple of files
+                File.Delete(Path.Combine(localFilePath, "file2.txt"));
+                File.Delete(Path.Combine(localFilePath, "file4.txt"));
+
+                // Add a file
+                TestHelpers.CreateFileWithInitialVersion(localFilePath, "file5.txt");
+
+                // Verify the set of files after the additions/deletions
+                Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 2));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file5.txt", 1));
+
+                // simulate a feature branch checkout in the langauge repo. change the targeted
+                // tag in place. The changes from lines above should be automatically discarded.
+                var existingAssets = TestHelpers.LoadAssetsFromFile(jsonFileLocation);
+                existingAssets.Tag = "python/tables_fc54d0";
+                TestHelpers.UpdateAssetsFile(existingAssets, jsonFileLocation);
+
+                await _defaultStore.Restore(jsonFileLocation);
+
+                // Verify the only files there are ones from the Tag
+                Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 1));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 1));
+                await TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
+            }
+            finally
+            {
+                DirectoryHelper.DeleteGitDirectory(testFolder);
+            }
+        }
+
         [EnvironmentConditionalSkipTheory]
         [InlineData(
         @"{

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -162,7 +162,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 InitializeAssetsRepo(config);
             }
 
-            CheckoutRepoAtConfig(config);
+            CheckoutRepoAtConfig(config, true);
             await BreadCrumb.Update(config);
 
             return config.AssetsRepoLocation.ToString();
@@ -214,11 +214,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
             if (allowReset)
             {
-                Clean(config);
-
                 if (!string.IsNullOrWhiteSpace(config.Tag))
                 {
-                    CheckoutRepoAtConfig(config);
+                    CheckoutRepoAtConfig(config, true);
                     await BreadCrumb.Update(config);
                 }
             }
@@ -302,7 +300,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// Given a configuration, set the sparse-checkout directory for the config, then attempt checkout of the targeted Tag.
         /// </summary>
         /// <param name="config"></param>
-        public void CheckoutRepoAtConfig(GitAssetsConfiguration config)
+        /// <param name="cleanEnabled">A newly initialized repo should not be 'cleaned', as that will result in a git error. However, a new
+        /// clone looks the same as being on the wrong tag. This variable allows us to prevent over-active cleaning that would result in exceptions.</param>
+        public void CheckoutRepoAtConfig(GitAssetsConfiguration config, bool cleanEnabled = true)
         {
             // we are already on a targeted tag and as such don't want to discard our recordings
             if (Assets.TryGetValue(config.AssetsJsonRelativeLocation.ToString(), out var value) && value == config.Tag)
@@ -312,7 +312,10 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             // if we are NOT on our targeted tag, before we attempt to switch we need to reset without asking for permission
             else
             {
-                Clean(config);
+                if (cleanEnabled)
+                {
+                    Clean(config);
+                }
             }
 
             var checkoutPaths = ResolveCheckoutPaths(config);
@@ -477,7 +480,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     throw GenerateInvokeException(e.Result);
                 }
 
-                CheckoutRepoAtConfig(config);
+                CheckoutRepoAtConfig(config, false);
                 workCompleted = true;
             }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -162,7 +162,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 InitializeAssetsRepo(config);
             }
 
-            CheckoutRepoAtConfig(config, true);
+            CheckoutRepoAtConfig(config, cleanEnabled: true);
             await BreadCrumb.Update(config);
 
             return config.AssetsRepoLocation.ToString();
@@ -216,7 +216,8 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             {
                 if (!string.IsNullOrWhiteSpace(config.Tag))
                 {
-                    CheckoutRepoAtConfig(config, true);
+                    Clean(config);
+                    CheckoutRepoAtConfig(config, cleanEnabled: false);
                     await BreadCrumb.Update(config);
                 }
             }
@@ -477,7 +478,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     throw GenerateInvokeException(e.Result);
                 }
 
-                CheckoutRepoAtConfig(config, false);
+                CheckoutRepoAtConfig(config, cleanEnabled: false);
                 workCompleted = true;
             }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -310,12 +310,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 return;
             }
             // if we are NOT on our targeted tag, before we attempt to switch we need to reset without asking for permission
-            else
+            else if (cleanEnabled)
             {
-                if (cleanEnabled)
-                {
-                    Clean(config);
-                }
+                Clean(config);
             }
 
             var checkoutPaths = ResolveCheckoutPaths(config);


### PR DESCRIPTION
The original thought is that if you had pending changes, but wanted to swap to a different checked out tag for an `assets.json`, you would be **prevented** from doing so with

> you have pending changes

So that folks can avoid discarding recordings. However, because a lot of these are running behind a shim or some other surrounding script, folks don't see the proxy output clearly. Because they can't see what's going wrong with the proxy, they don't know what to try next.

This PR will eliminate this scenario.

CC @mssfang @samvaity  for FYI