### PR TITLE
Turn off git auto gc for sparse-checkout

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -46,6 +46,10 @@ steps:
                 git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) .
               }
 
+              # Turn off git GC for sparse checkout. Note: The devops checkout task does this by default
+              Write-Host "git config gc.auto 0"
+              git config gc.auto 0
+
               Write-Host "git sparse-checkout init"
               git sparse-checkout init
 


### PR DESCRIPTION
@benbp I've tested this change in my throwaway Java [release branch](https://github.com/Azure/azure-sdk-for-java/blob/release/spring-test-no-release/eng/common/pipelines/templates/steps/sparse-checkout.yml#L49). The placement of the call was specifically after the clone command which is the command that first creates the git directory.

The [pipeline run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2842804&view=logs&j=3517b659-d3e8-545e-d9c6-aff172e087bb&t=0ebe3253-9a8a-510d-335c-c28d789c1ff8) I'd done also removed the interim call I'd added to Java's release yml to ensure everything worked.

Fixes #6294 