### PR TITLE
Replace secret rotation --expiring option with --force

### DIFF
--- a/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Commands/RotateCommand.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Commands/RotateCommand.cs
@@ -1,4 +1,4 @@
-﻿using System.CommandLine;
+using System.CommandLine;
 using System.CommandLine.Invocation;
 using Azure.Sdk.Tools.SecretRotation.Configuration;
 using Azure.Sdk.Tools.SecretRotation.Core;
@@ -7,19 +7,19 @@ namespace Azure.Sdk.Tools.SecretManagement.Cli.Commands;
 
 public class RotateCommand : RotationCommandBase
 {
-    private readonly Option<bool> expiringOption = new(new[] { "--expiring", "-e" }, "Only rotate expiring secrets");
+    private readonly Option<bool> forceOption = new(new[] { "--force", "-f" }, "Force rotation of secrets outside of their expiration window.");
     private readonly Option<bool> whatIfOption = new(new[] { "--dry-run", "-d" }, "Preview the changes that will be made without submitting them.");
 
     public RotateCommand() : base("rotate", "Rotate one, expiring or all secrets")
     {
-        AddOption(this.expiringOption);
+        AddOption(this.forceOption);
         AddOption(this.whatIfOption);
     }
 
     protected override async Task HandleCommandAsync(ILogger logger, RotationConfiguration rotationConfiguration,
         InvocationContext invocationContext)
     {
-        bool onlyRotateExpiring = invocationContext.ParseResult.GetValueForOption(this.expiringOption);
+        bool force = invocationContext.ParseResult.GetValueForOption(this.forceOption);
         bool whatIf = invocationContext.ParseResult.GetValueForOption(this.whatIfOption);
 
         var timeProvider = new TimeProvider();
@@ -28,7 +28,7 @@ public class RotateCommand : RotationCommandBase
 
         foreach (RotationPlan plan in plans)
         {
-            await plan.ExecuteAsync(onlyRotateExpiring, whatIf);
+            await plan.ExecuteAsync(onlyRotateExpiring: !force, whatIf);
         }
     }
 }

--- a/tools/secret-management/docs/rotation.md
+++ b/tools/secret-management/docs/rotation.md
@@ -6,7 +6,7 @@ Rotation happens in 5 main phases:
 
 The rotation plan's primary store is read to get the current value and metadata for a secret.
 The expiration date is compared to the plan's expiration and rotation thresholds.
-If the `--expired` option is specified and the plan's expiration date is not within the rotation or expiration thresholds, the plan will not be rotated.
+By default, if the plan's expiration date is not within the rotation or expiration thresholds, the plan will not be rotated.  To rotate plans that are not yet expired or expiring, use the `--force` option.
 
 ## Origination
 


### PR DESCRIPTION
The current default behavior is to rotate all secrets, including those that are not expiring, unless the --expiring option is used.

This change replaces that with a default behavior of only rotating expiring secrets unless the --force options is used, which would then also rotate the secrets that are not yet expiring.