### PR TITLE
Resolve Multi-Restore Deadlock

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -43,6 +43,21 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
         public GitStoreBreadcrumb BreadCrumb = new GitStoreBreadcrumb();
 
+        /// <summary>
+        /// We need to lock repo inititialization behind a semaphore queue.
+        /// This is due to the fact that Restore() can be called from multiple parallel
+        /// requests, as multiple "startplayback" can be firing at the same time.
+        /// 
+        /// While the Restore() action itself is idempotent, the Initialization of the assets repo
+        /// is NOT. We will use this queue to force ONE single initialization at a time.
+        /// 
+        /// We don't want to gate ALL initializations behind the same gate though. We can restore 
+        /// multiple DIFFERENT assets.jsons at the same time. It's specifically when two restores for the SAME
+        /// assets.json are fired that we run into problems.
+        /// 
+        /// Everything else will still run in parallel.
+        /// </summary>
+        private ConcurrentDictionary<string, TaskQueue> InitTasks = new ConcurrentDictionary<string, TaskQueue>();
 
         public ConcurrentDictionary<string, string> Assets = new ConcurrentDictionary<string, string>();
 
@@ -453,34 +468,39 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <returns></returns>
         public bool InitializeAssetsRepo(GitAssetsConfiguration config, bool forceInit = false)
         {
-            var assetRepo = config.AssetsRepoLocation;
-            var initialized = IsAssetsRepoInitialized(config);
             var workCompleted = false;
+            var initQueue = InitTasks.GetOrAdd(config.AssetsRepoLocation, new TaskQueue());
 
-            if (forceInit)
+            initQueue.Enqueue(() =>
             {
-                DirectoryHelper.DeleteGitDirectory(assetRepo.ToString());
-                Directory.CreateDirectory(assetRepo.ToString());
-                initialized = false;
-            }
+                var assetRepo = config.AssetsRepoLocation;
+                var initialized = IsAssetsRepoInitialized(config);
 
-            if (!initialized)
-            {
-                try
+                if (forceInit)
                 {
-                    var cloneUrl = GetCloneUrl(config.AssetsRepo, config.RepoRoot);
-                    // The -c core.longpaths=true is basically for Windows and is a noop for other platforms
-                    GitHandler.Run($"clone -c core.longpaths=true --no-checkout --filter=tree:0 {cloneUrl} .", config);
-                    GitHandler.Run($"sparse-checkout init", config);
-                }
-                catch(GitProcessException e)
-                {
-                    throw GenerateInvokeException(e.Result);
+                    DirectoryHelper.DeleteGitDirectory(assetRepo.ToString());
+                    Directory.CreateDirectory(assetRepo.ToString());
+                    initialized = false;
                 }
 
-                CheckoutRepoAtConfig(config, cleanEnabled: false);
-                workCompleted = true;
-            }
+                if (!initialized)
+                {
+                    try
+                    {
+                        var cloneUrl = GetCloneUrl(config.AssetsRepo, config.RepoRoot);
+                        // The -c core.longpaths=true is basically for Windows and is a noop for other platforms
+                        GitHandler.Run($"clone -c core.longpaths=true --no-checkout --filter=tree:0 {cloneUrl} .", config);
+                        GitHandler.Run($"sparse-checkout init", config);
+                    }
+                    catch (GitProcessException e)
+                    {
+                        throw GenerateInvokeException(e.Result);
+                    }
+
+                    CheckoutRepoAtConfig(config, cleanEnabled: false);
+                    workCompleted = true;
+                }
+            });
 
             return workCompleted;
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -44,7 +44,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         public GitStoreBreadcrumb BreadCrumb = new GitStoreBreadcrumb();
 
         /// <summary>
-        /// We need to lock repo inititialization behind a semaphore queue.
+        /// We need to lock repo inititialization behind a queue.
         /// This is due to the fact that Restore() can be called from multiple parallel
         /// requests, as multiple "startplayback" can be firing at the same time.
         /// 


### PR DESCRIPTION
Resolves #6238

This PR gates initialization of a git repo behind a tiny task queue. We do this because if we don't, we run into the following situation:

1. The Java team runs tests truly in parallel. This means that multiple tests are attempting to load up the recordings for playback.
2. As multiple tests are attempting to load, there is no assets repo present, so we have to do a `restore` operation for each.
3. Our `git` invocations are already work-queued, so the actual `restore` action won't throw. This is because once the repo is `git init`-ed, `git checkout` can be fired multiple times without error, as attempting to check out the same tag is an errorless action.

Given all the above context, we are wrapping the whole `Init` function that checks/initializes each assets repo slice (per assets.json that is being restored) in an additional work queue. This will mean that two parallel requests that are triggering `restore` will WAIT for whichever one starts first to finish. After we are past the `init` speedbump, the `restore` can run at their leisure.

FYI @samvaity thank you for the report. When I ship a new version of the proxy, I'll ensure that I remove the `restore` calls that I inserted into your pipeline.