### PR TITLE
Silence proxy test failures caused by security update

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -18,6 +18,9 @@ parameters:
   - name: NoWarn
     type: boolean
     default: false
+  - name: TestPreSteps
+    type: object
+    default: []
   - name: TestPostSteps
     type: object
     default: []
@@ -36,6 +39,7 @@ parameters:
   - name: ReleaseBinaries
     type: boolean
     default: false
+
 
 variables:
   - template: ../variables/globals.yml
@@ -138,6 +142,8 @@ stages:
 
         steps:
           - template: /eng/pipelines/templates/steps/install-dotnet.yml
+
+          - ${{ parameters.TestPreSteps }}
 
           - script: 'dotnet test /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) $(Warn) --logger trx'
             displayName: 'Test'

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -66,3 +66,7 @@ extends:
     - rid: linux-arm64
       framework: net6.0
       assembly: Azure.Sdk.Tools.TestProxy
+    TestPreSteps:
+      - pwsh: |
+          #vso[task.setvariable variable=COMPlus_Pkcs12UnspecifiedPasswordIterationLimit]-1
+        displayName: Override Acceptable Password Iteration Count


### PR DESCRIPTION
See #6357 for additional context

I _believe_ that this security update just caused us to start breaking. The crazy part is that retrying will actually sometimes work.

Definitely need to dig into this a bit, but want to see the build succeed consistently as well