### PR TITLE
Improvements to APIView/Java tooling

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -150,8 +150,10 @@ public class JavaASTAnalyser implements Analyser {
 
     private boolean filterFilePaths(Path filePath) {
         String fileName = filePath.toString();
-        // Skip paths that are directories or are in implementation.
-        if (Files.isDirectory(filePath) || fileName.contains("implementation")) {
+        // Skip paths that are directories, in implementation, or are files contained within META-INF
+        if (Files.isDirectory(filePath)
+                || fileName.contains("implementation")
+                || fileName.contains("META-INF")) {
             return false;
         } else {
             // Only include Java files.
@@ -210,9 +212,9 @@ public class JavaASTAnalyser implements Analyser {
 //            combinedTypeSolver.add(new SourceJarTypeSolver(inputFile));
 
             ParserConfiguration parserConfiguration = new ParserConfiguration()
-                .setStoreTokens(true)
-                .setSymbolResolver(new JavaSymbolSolver(combinedTypeSolver))
-                .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_11);
+                    .setStoreTokens(true)
+                    .setSymbolResolver(new JavaSymbolSolver(combinedTypeSolver))
+                    .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_11);
 
             // Configure JavaParser to use type resolution
             StaticJavaParser.setConfiguration(parserConfiguration);
@@ -223,10 +225,10 @@ public class JavaASTAnalyser implements Analyser {
             if (path.endsWith("package-info.java")) {
                 compilationUnit.getPackageDeclaration().ifPresent(pd -> {
                     compilationUnit.getAllComments().stream()
-                        .filter(Comment::isJavadocComment)
-                        .map(Comment::asJavadocComment)
-                        .findFirst()
-                        .ifPresent(comment -> packageNameToPackageInfoJavaDoc.put(pd.getNameAsString(), comment));
+                            .filter(Comment::isJavadocComment)
+                            .map(Comment::asJavadocComment)
+                            .findFirst()
+                            .ifPresent(comment -> packageNameToPackageInfoJavaDoc.put(pd.getNameAsString(), comment));
                 });
 
                 return Optional.empty();
@@ -617,7 +619,7 @@ public class JavaASTAnalyser implements Analyser {
 
                 // create a unique id for enum constants
                 final String name = enumConstantDeclaration.getNameAsString();
-                final String definitionId = makeId(enumDeclaration.getFullyQualifiedName().get() + "." + counter);
+                final String definitionId = makeId(enumConstantDeclaration);// makeId(enumDeclaration.getFullyQualifiedName().get() + "." + counter);
                 final boolean isDeprecated = enumConstantDeclaration.isAnnotationPresent("Deprecated");
 
                 if (isDeprecated) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -212,9 +212,9 @@ public class JavaASTAnalyser implements Analyser {
 //            combinedTypeSolver.add(new SourceJarTypeSolver(inputFile));
 
             ParserConfiguration parserConfiguration = new ParserConfiguration()
-                    .setStoreTokens(true)
-                    .setSymbolResolver(new JavaSymbolSolver(combinedTypeSolver))
-                    .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_11);
+                .setStoreTokens(true)
+                .setSymbolResolver(new JavaSymbolSolver(combinedTypeSolver))
+                .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_11);
 
             // Configure JavaParser to use type resolution
             StaticJavaParser.setConfiguration(parserConfiguration);
@@ -225,10 +225,10 @@ public class JavaASTAnalyser implements Analyser {
             if (path.endsWith("package-info.java")) {
                 compilationUnit.getPackageDeclaration().ifPresent(pd -> {
                     compilationUnit.getAllComments().stream()
-                            .filter(Comment::isJavadocComment)
-                            .map(Comment::asJavadocComment)
-                            .findFirst()
-                            .ifPresent(comment -> packageNameToPackageInfoJavaDoc.put(pd.getNameAsString(), comment));
+                        .filter(Comment::isJavadocComment)
+                        .map(Comment::asJavadocComment)
+                        .findFirst()
+                        .ifPresent(comment -> packageNameToPackageInfoJavaDoc.put(pd.getNameAsString(), comment));
                 });
 
                 return Optional.empty();

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -617,9 +617,10 @@ public class JavaASTAnalyser implements Analyser {
                 // annotations
                 getAnnotations(enumConstantDeclaration, false, false);
 
-                // create a unique id for enum constants
+                // create a unique id for enum constants by using the fully-qualified constant name
+                // (package, enum name, and enum constant name)
                 final String name = enumConstantDeclaration.getNameAsString();
-                final String definitionId = makeId(enumConstantDeclaration);// makeId(enumDeclaration.getFullyQualifiedName().get() + "." + counter);
+                final String definitionId = makeId(enumConstantDeclaration);
                 final boolean isDeprecated = enumConstantDeclaration.isAnnotationPresent("Deprecated");
 
                 if (isDeprecated) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
@@ -24,7 +24,7 @@ public class Diagnostics {
     private final List<DiagnosticRule> diagnostics = new ArrayList<>();
 
     public Diagnostics() {
-//        diagnostics.add(new PackageNameDiagnosticRule());
+        diagnostics.add(new PackageNameDiagnosticRule());
         diagnostics.add(new ImportsDiagnosticRule("com.sun"));
         diagnostics.add(new IllegalPackageAPIExportsDiagnosticRule("implementation", "netty"));
         diagnostics.add(new NoPublicFieldsDiagnosticRule());

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/Diagnostics.java
@@ -24,7 +24,7 @@ public class Diagnostics {
     private final List<DiagnosticRule> diagnostics = new ArrayList<>();
 
     public Diagnostics() {
-        diagnostics.add(new PackageNameDiagnosticRule());
+//        diagnostics.add(new PackageNameDiagnosticRule());
         diagnostics.add(new ImportsDiagnosticRule("com.sun"));
         diagnostics.add(new IllegalPackageAPIExportsDiagnosticRule("implementation", "netty"));
         diagnostics.add(new NoPublicFieldsDiagnosticRule());
@@ -52,6 +52,7 @@ public class Diagnostics {
         diagnostics.add(new BuilderTraitsDiagnosticRule());
         diagnostics.add(new MavenPackageAndDescriptionDiagnosticRule());
         diagnostics.add(new ExpandableStringEnumDiagnosticRule());
+        diagnostics.add(new UpperCaseEnumValuesDiagnosticRule());
 
         // common APIs for all builders (below we will do rules for http or amqp builders)
         diagnostics.add(new RequiredBuilderMethodsDiagnosticRule(null)

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingAnnotationsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingAnnotationsDiagnosticRule.java
@@ -15,7 +15,7 @@ public class MissingAnnotationsDiagnosticRule implements DiagnosticRule {
     @Override
     public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
         getClasses(cu)
-            .filter(type -> getPackageName(type).equals("com.azure"))   // we only want to give this guidance to Azure SDK developers
+            .filter(type -> getPackageName(type).startsWith("com.azure"))   // we only want to give this guidance to Azure SDK developers
             .forEach(typeDeclaration -> {
                 String className = typeDeclaration.getNameAsString();
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingAnnotationsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingAnnotationsDiagnosticRule.java
@@ -25,7 +25,7 @@ public class MissingAnnotationsDiagnosticRule implements DiagnosticRule {
                 if (!typeDeclaration.isAnnotationPresent("ServiceClientBuilder")) {
                     listing.addDiagnostic(new Diagnostic(
                         INFO,
-                        makeId(cu),
+                        makeId(typeDeclaration),
                         "Classes named *Builder are potential candidates to have the @ServiceClientBuilder annotation applied.",
                         "https://azure.github.io/azure-sdk/java_introduction.html#service-client-creation"));
                 }
@@ -34,7 +34,7 @@ public class MissingAnnotationsDiagnosticRule implements DiagnosticRule {
                 if (!typeDeclaration.isAnnotationPresent("ServiceClient")) {
                     listing.addDiagnostic(new Diagnostic(
                         INFO,
-                        makeId(cu),
+                        makeId(typeDeclaration),
                         "Classes named *Client are potential candidates to have the @ServiceClient annotation applied.",
                         "https://azure.github.io/azure-sdk/java_introduction.html#service-client"));
                 }
@@ -56,7 +56,7 @@ public class MissingAnnotationsDiagnosticRule implements DiagnosticRule {
                     // warn user to double check
                     listing.addDiagnostic(new Diagnostic(
                         WARNING,
-                        makeId(cu),
+                        makeId(typeDeclaration),
                     "There is a low number of methods annotated with @ServiceMethod. " +
                             "Please review to ensure all appropriate methods have this annotation.",
                         "https://azure.github.io/azure-sdk/java_introduction.html#service-client"));

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingAnnotationsDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingAnnotationsDiagnosticRule.java
@@ -7,61 +7,60 @@ import com.github.javaparser.ast.CompilationUnit;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getClasses;
-import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.getPublicOrProtectedMethods;
-import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.makeId;
-
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.*;
 import static com.azure.tools.apiview.processor.model.DiagnosticKind.*;
 
 public class MissingAnnotationsDiagnosticRule implements DiagnosticRule {
 
     @Override
     public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
-        getClasses(cu).forEach(typeDeclaration -> {
-            String className = typeDeclaration.getNameAsString();
+        getClasses(cu)
+            .filter(type -> getPackageName(type).equals("com.azure"))   // we only want to give this guidance to Azure SDK developers
+            .forEach(typeDeclaration -> {
+                String className = typeDeclaration.getNameAsString();
 
-            if (className.endsWith("Builder")) {
-                // check if @ServiceClientBuilder annotation is present
-                if (!typeDeclaration.isAnnotationPresent("ServiceClientBuilder")) {
-                    listing.addDiagnostic(new Diagnostic(
-                        INFO,
-                        makeId(typeDeclaration),
-                        "Classes named *Builder are potential candidates to have the @ServiceClientBuilder annotation applied.",
-                        "https://azure.github.io/azure-sdk/java_introduction.html#service-client-creation"));
-                }
-            } else if (className.endsWith("Client")) {
-                // check if the @ServiceClient annotation is present
-                if (!typeDeclaration.isAnnotationPresent("ServiceClient")) {
-                    listing.addDiagnostic(new Diagnostic(
-                        INFO,
-                        makeId(typeDeclaration),
-                        "Classes named *Client are potential candidates to have the @ServiceClient annotation applied.",
-                        "https://azure.github.io/azure-sdk/java_introduction.html#service-client"));
-                }
-
-                // check all public / protected methods in client classes. Because we can't easily determine if a method
-                // should have an annotation, all we can do is count the number of methods that are annotated and compare
-                // this with the total number of methods. If the ratio is not high enough, we will warn the user that there
-                // may be missing annotations.
-                final AtomicInteger methodCount = new AtomicInteger();
-                final AtomicInteger annotatedMethodCount = new AtomicInteger();
-                getPublicOrProtectedMethods(cu).forEach(methodDeclaration -> {
-                    methodCount.incrementAndGet();
-                    if (methodDeclaration.isAnnotationPresent("ServiceMethod")) {
-                        annotatedMethodCount.incrementAndGet();
+                if (className.endsWith("Builder")) {
+                    // check if @ServiceClientBuilder annotation is present
+                    if (!typeDeclaration.isAnnotationPresent("ServiceClientBuilder")) {
+                        listing.addDiagnostic(new Diagnostic(
+                            INFO,
+                            makeId(typeDeclaration),
+                            "Classes named *Builder are potential candidates to have the @ServiceClientBuilder annotation applied.",
+                            "https://azure.github.io/azure-sdk/java_introduction.html#service-client-creation"));
                     }
-                });
+                } else if (className.endsWith("Client")) {
+                    // check if the @ServiceClient annotation is present
+                    if (!typeDeclaration.isAnnotationPresent("ServiceClient")) {
+                        listing.addDiagnostic(new Diagnostic(
+                            INFO,
+                            makeId(typeDeclaration),
+                            "Classes named *Client are potential candidates to have the @ServiceClient annotation applied.",
+                            "https://azure.github.io/azure-sdk/java_introduction.html#service-client"));
+                    }
 
-                if (annotatedMethodCount.get() / (double) methodCount.get() < 0.75) {
-                    // warn user to double check
-                    listing.addDiagnostic(new Diagnostic(
-                        WARNING,
-                        makeId(typeDeclaration),
-                    "There is a low number of methods annotated with @ServiceMethod. " +
-                            "Please review to ensure all appropriate methods have this annotation.",
-                        "https://azure.github.io/azure-sdk/java_introduction.html#service-client"));
+                    // check all public / protected methods in client classes. Because we can't easily determine if a method
+                    // should have an annotation, all we can do is count the number of methods that are annotated and compare
+                    // this with the total number of methods. If the ratio is not high enough, we will warn the user that there
+                    // may be missing annotations.
+                    final AtomicInteger methodCount = new AtomicInteger();
+                    final AtomicInteger annotatedMethodCount = new AtomicInteger();
+                    getPublicOrProtectedMethods(cu).forEach(methodDeclaration -> {
+                        methodCount.incrementAndGet();
+                        if (methodDeclaration.isAnnotationPresent("ServiceMethod")) {
+                            annotatedMethodCount.incrementAndGet();
+                        }
+                    });
+
+                    if (annotatedMethodCount.get() / (double) methodCount.get() < 0.75) {
+                        // warn user to double check
+                        listing.addDiagnostic(new Diagnostic(
+                            WARNING,
+                            makeId(typeDeclaration),
+                        "There is a low number of methods annotated with @ServiceMethod. " +
+                                "Please review to ensure all appropriate methods have this annotation.",
+                            "https://azure.github.io/azure-sdk/java_introduction.html#service-client"));
+                    }
                 }
-            }
         });
     }
 }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavadocCodeSnippetsRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/MissingJavadocCodeSnippetsRule.java
@@ -34,7 +34,7 @@ public class MissingJavadocCodeSnippetsRule implements DiagnosticRule {
                 if (!javadocContainsCodeSnippetTag(typeDeclaration.getJavadocComment().get().getContent())) {
                     listing.addDiagnostic((new Diagnostic(
                             INFO,
-                            makeId(cu),
+                            makeId(typeDeclaration),
                             "JavaDoc for clients and builders should include code samples to instantiate clients.",
                             "https://github.com/Azure/azure-sdk-for-java/wiki/JavaDoc-with-CodeSnippet"
                     )));
@@ -57,7 +57,7 @@ public class MissingJavadocCodeSnippetsRule implements DiagnosticRule {
                 if (!serviceMethodHasCodesnippets) {
                     listing.addDiagnostic((new Diagnostic(
                             INFO,
-                            makeId(cu),
+                            makeId(typeDeclaration),
                             "JavaDoc for service methods should include code samples.",
                             "https://github.com/Azure/azure-sdk-for-java/wiki/JavaDoc-with-CodeSnippet"
                     )));

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/UpperCaseEnumValuesDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/UpperCaseEnumValuesDiagnosticRule.java
@@ -1,0 +1,33 @@
+package com.azure.tools.apiview.processor.diagnostics.rules;
+
+import com.azure.tools.apiview.processor.diagnostics.DiagnosticRule;
+import com.azure.tools.apiview.processor.model.APIListing;
+import com.azure.tools.apiview.processor.model.Diagnostic;
+import com.github.javaparser.ast.CompilationUnit;
+import com.github.javaparser.ast.body.TypeDeclaration;
+
+import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.*;
+import static com.azure.tools.apiview.processor.model.DiagnosticKind.WARNING;
+
+public class UpperCaseEnumValuesDiagnosticRule implements DiagnosticRule {
+
+    @Override
+    public void scanIndividual(final CompilationUnit cu, final APIListing listing) {
+        // if the CompilationUnit is an enum, check that all of the enum values are upper case, adding a diagnostic
+        // if they are not.
+        getClasses(cu)
+            .filter(TypeDeclaration::isEnumDeclaration)
+            .map(TypeDeclaration::asEnumDeclaration)
+            .forEach(enumDeclaration -> {
+                enumDeclaration.getEntries().forEach(enumConstantDeclaration -> {
+                    String name = enumConstantDeclaration.getName().asString();
+                    if (!name.equals(name.toUpperCase())) {
+                        listing.addDiagnostic(new Diagnostic(
+                            WARNING,
+                            makeId(enumConstantDeclaration),
+                            "All enum constants should be upper case, using underscores as necessary between words."));
+                    }
+                });
+            });
+    }
+}

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/UpperCaseEnumValuesDiagnosticRule.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/diagnostics/rules/UpperCaseEnumValuesDiagnosticRule.java
@@ -9,6 +9,9 @@ import com.github.javaparser.ast.body.TypeDeclaration;
 import static com.azure.tools.apiview.processor.analysers.util.ASTUtils.*;
 import static com.azure.tools.apiview.processor.model.DiagnosticKind.WARNING;
 
+/**
+ * This diagnostic encourages developers to use upper case enum values, with underscores between words.
+ */
 public class UpperCaseEnumValuesDiagnosticRule implements DiagnosticRule {
 
     @Override

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/maven/Pom.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/maven/Pom.java
@@ -161,7 +161,7 @@ public class Pom implements MavenGAV {
     private Gav createGav(final XPath xPath, final Document xmlDocument, final String root) throws XPathExpressionException {
         final String groupIdExpression = root + "/groupId";
         final Node groupIdNode = (Node) xPath.evaluate(groupIdExpression, xmlDocument, XPathConstants.NODE);
-        final String groupId = groupIdNode == null ? "" : groupIdNode.getTextContent();
+        String groupId = groupIdNode == null ? "" : groupIdNode.getTextContent();
 
         final String artifactIdExpression = root + "/artifactId";
         final Node artifactIdNode = (Node) xPath.evaluate(artifactIdExpression, xmlDocument, XPathConstants.NODE);
@@ -169,7 +169,20 @@ public class Pom implements MavenGAV {
 
         final String versionExpression = root + "/version";
         final Node versionNode = (Node) xPath.evaluate(versionExpression, xmlDocument, XPathConstants.NODE);
-        final String version = versionNode == null ? "" : versionNode.getTextContent();
+        String version = versionNode == null ? "" : versionNode.getTextContent();
+
+        // it is possible to inherit the groupId and version from the parent, so if group ID or version is empty here,
+        // lets go up to the parent to get it from there
+        if (groupId.isEmpty()) {
+            final String parentGroupIdExpression = root + "/parent/groupId";
+            final Node parentGroupIdNode = (Node) xPath.evaluate(parentGroupIdExpression, xmlDocument, XPathConstants.NODE);
+            groupId = parentGroupIdNode == null ? "" : parentGroupIdNode.getTextContent();
+        }
+        if (version.isEmpty()) {
+            final String parentVersionExpression = root + "/parent/version";
+            final Node parentVersionNode = (Node) xPath.evaluate(parentVersionExpression, xmlDocument, XPathConstants.NODE);
+            version = parentVersionNode == null ? "" : parentVersionNode.getTextContent();
+        }
 
         return new Gav(groupId, artifactId, version);
     }


### PR DESCRIPTION
A number of fixes to the Java APIView tooling, discovered and developed as I went about creating APIView reviews for the Java Semantic Kernel library. You can see the generated APIView reviews for these libraries here:

https://apiview.dev/Assemblies/Review/8aa5b4eae87c47a9996bf9c80163812e
https://apiview.dev/Assemblies/Review/f52ac2e951734ee0a2c010481892fe32
https://apiview.dev/Assemblies/Review/73736094cf044f70b82a0618a97776f4

Here are the changes I have made:

 * Support for when a pom.xml does not explicitly state a groupId or version - look up in parent, if it is available.
 * Don't analyse files in META-INF, as some builds put .java files in there, and they are not always valid Java.
 * Fixing issue where not all inner types are discovered when calling getClasses. This also resulted in some additional bugs being identified in diagnostics, where the reported issue was at the parent type rather than the child type, so I fixed those.
 * Add new diagnostic to warn developers to use proper casing for enum constant values.
 * Made it so that Azure SDK specific errors are only applied to libraries with com.azure package namespaces.