### PR TITLE
Support DataFactoryElement in sdk_testgen

### DIFF
--- a/tools/sdk-testgen/packages/autorest.testmodeler/CHANGELOG.json
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@autorest/testmodeler",
   "entries": [
     {
+      "version": "2.6.0",
+      "tag": "@autorest/testmodeler_v2.6.0",
+      "date": "Mon, 19 Jun 2023 08:50:04 GMT",
+      "comments": {
+        "minor": [
+          {
+            "comment": "Support DataFactoryElement"
+          }
+        ]
+      }
+    },
+    {
       "version": "2.5.2",
       "tag": "@autorest/testmodeler_v2.5.2",
       "date": "Wed, 14 Jun 2023 08:54:31 GMT",

--- a/tools/sdk-testgen/packages/autorest.testmodeler/CHANGELOG.md
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/testmodeler
 
-This log was last generated on Wed, 14 Jun 2023 08:54:31 GMT and should not be manually modified.
+This log was last generated on Mon, 19 Jun 2023 08:50:04 GMT and should not be manually modified.
+
+## 2.6.0
+Mon, 19 Jun 2023 08:50:04 GMT
+
+### Minor changes
+
+- Support DataFactoryElement
 
 ## 2.5.2
 Wed, 14 Jun 2023 08:54:31 GMT

--- a/tools/sdk-testgen/packages/autorest.testmodeler/package.json
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@autorest/testmodeler",
-    "version": "2.5.3",
+    "version": "2.6.0",
     "description": "Autorest extension for testmodeler",
     "main": "dist/index.js",
     "scripts": {

--- a/tools/sdk-testgen/packages/autorest.testmodeler/package.json
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@autorest/testmodeler",
-    "version": "2.5.2",
+    "version": "2.5.3",
     "description": "Autorest extension for testmodeler",
     "main": "dist/index.js",
     "scripts": {

--- a/tools/sdk-testgen/packages/autorest.testmodeler/src/core/model.ts
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/src/core/model.ts
@@ -5,27 +5,27 @@ import * as path from 'path';
 import { ApiScenarioLoader } from 'oav/dist/lib/apiScenario/apiScenarioLoader';
 import {
     ArraySchema,
+    BinarySchema,
+    BooleanSchema,
     CodeModel,
     ComplexSchema,
+    DateTimeSchema,
     DictionarySchema,
+    DurationSchema,
     ImplementationLocation,
     Languages,
-    ObjectSchema,
-    Property,
-    StringSchema,
     NumberSchema,
-    BooleanSchema,
-    DateTimeSchema,
-    DurationSchema,
-    BinarySchema,
-    UriSchema,
     Operation,
     OperationGroup,
+    ObjectSchema,
     Parameter,
+    Property,
     Schema,
     SchemaResponse,
     SchemaType,
     SecurityScheme,
+    StringSchema,
+    UriSchema,
     codeModelSchema,
 } from '@autorest/codemodel';
 import { AutorestExtensionHost, Session, startSession } from '@autorest/extension-base';
@@ -130,8 +130,8 @@ export class ExampleValue {
         extensions: Record<string, any>,
         searchDescents = true,
     ): ExampleValue {
-        const X_MS_FORMAT = "x-ms-format";
-        const X_MS_FORMAT_ELEMENT_TYPE = "x-ms-format-element-type";
+        const xMsFormat = 'x-ms-format';
+        const xMsFormatElementType = 'x-ms-format-element-type';
         const instance = new ExampleValue(schema, language);
         if (!schema) {
             instance.rawValue = rawValue;
@@ -214,54 +214,55 @@ export class ExampleValue {
                 }
             }
         }
-        else if (schema.type === SchemaType.AnyObject && extensions && extensions[X_MS_FORMAT] && extensions[X_MS_FORMAT].startsWith("dfe-")) {
+        else if (schema.type === SchemaType.AnyObject && extensions && extensions[xMsFormat] && extensions[xMsFormat].startsWith('dfe-')) {
             // Becuase DataFactoryElement is defined as AnyObject schema, so have to explicitly build it's example value according to x_ms_format here
-            const DFE_OBJECT_TYPE = "type";
-            const DFE_OBJECT_TYPE_VALUES = ["Expression", "SecureString", "AzureKeyVaultSecretReference"];
-            const DFE_OBJECT_VALUE = "value";
-            const DFE_OBJECT_SCHEMA_PREFIX = "DataFactoryElement-";
-            let createSchemaForDfeObject = (raw: any, dfeFormat: string): ObjectSchema | undefined => {
-                if (Object(raw) && raw[DFE_OBJECT_TYPE] && raw[DFE_OBJECT_VALUE] && DFE_OBJECT_TYPE_VALUES.includes(raw[DFE_OBJECT_TYPE])) {
-                    var r = new ObjectSchema(DFE_OBJECT_SCHEMA_PREFIX + raw[DFE_OBJECT_TYPE], "");
-                    r.addProperty(new Property(DFE_OBJECT_TYPE, "", new StringSchema(`${dfeFormat}-${DFE_OBJECT_TYPE}`, "")));
-                    r.addProperty(new Property(DFE_OBJECT_VALUE, "", new StringSchema(`${dfeFormat}-${DFE_OBJECT_VALUE}`, "")));
+            const dfeObjectType = 'type';
+            const dfeObjectValue = 'value';
+            const dfeObjectTypeValues = ['Expression', 'SecureString', 'AzureKeyVaultSecretReference'];
+            const dfeObjectSchemaPrefix = 'DataFactoryElement-';
+            const createSchemaForDfeObject = (raw: any, dfeFormat: string): ObjectSchema | undefined => {
+                if (Object(raw) && raw[dfeObjectType] && raw[dfeObjectValue] && dfeObjectTypeValues.includes(raw[dfeObjectType])) {
+                    var r = new ObjectSchema(dfeObjectSchemaPrefix + raw[dfeObjectType], '');
+                    r.addProperty(new Property(dfeObjectType, '', new StringSchema(`${dfeFormat}-${dfeObjectType}`, '')));
+                    r.addProperty(new Property(dfeObjectValue, '', new StringSchema(`${dfeFormat}-${dfeObjectValue}`, '')));
                     return r;
                 }
                 return undefined;
-            }
-            let createSchemaForDfeLiteral = (raw: any, dfeFormat: string, eleFormat: string): Schema => {
+            };
+            const createSchemaForDfeLiteral = (raw: any, dfeFormat: string, eleFormat: string): Schema => {
                 switch (dfeFormat) {
-                    case "dfe-string": return new StringSchema(dfeFormat, "");
-                    case "dfe-bool": return new BooleanSchema(dfeFormat, "");
-                    case "dfe-int": return new NumberSchema(dfeFormat, "", SchemaType.Integer, 32);
-                    case "dfe-double": return new NumberSchema(dfeFormat, "", SchemaType.Number, 64);
-                    case "dfe-date-time": return new DateTimeSchema(dfeFormat, "");
-                    case "dfe-duration": return new DurationSchema(dfeFormat, "");
-                    case "dfe-uri": return new UriSchema(dfeFormat, "");
-                    case "dfe-list-string": return new ArraySchema(dfeFormat, "", new StringSchema(dfeFormat + "-element", ""));
-                    case "dfe-key-value-pairs": return new DictionarySchema(dfeFormat, "", new StringSchema(dfeFormat + "-element", ""));
-                    case "dfe-object": return new BinarySchema("");
-                    case "dfe-list-generic":
+                    case 'dfe-string': return new StringSchema(dfeFormat, '');
+                    case 'dfe-bool': return new BooleanSchema(dfeFormat, '');
+                    case 'dfe-int': return new NumberSchema(dfeFormat, '', SchemaType.Integer, 32);
+                    case 'dfe-double': return new NumberSchema(dfeFormat, '', SchemaType.Number, 64);
+                    case 'dfe-date-time': return new DateTimeSchema(dfeFormat, '');
+                    case 'dfe-duration': return new DurationSchema(dfeFormat, '');
+                    case 'dfe-uri': return new UriSchema(dfeFormat, '');
+                    case 'dfe-list-string': return new ArraySchema(dfeFormat, '', new StringSchema(dfeFormat + '-element', ''));
+                    case 'dfe-key-value-pairs': return new DictionarySchema(dfeFormat, '', new StringSchema(dfeFormat + '-element', ''));
+                    case 'dfe-object': return new BinarySchema('');
+                    case 'dfe-list-generic':
                         // TODO: do we need to search more schema store for the element?
                         // just searching object schemas seems enough for now. Consider add more when needed
-                        var eleSchema = session.model.schemas.objects.find(s => s.language.default.name === eleFormat);
-                        if (!eleSchema)
-                            throw new Error("Can't find schema for the element of DataFactoryElement with type dfe-list-generic: " + (eleFormat ?? "<null>"));
-                        return new ArraySchema(dfeFormat, "", eleSchema);
+                        const eleSchema = session.model.schemas.objects.find((s) => s.language.default.name === eleFormat);
+                        if (!eleSchema) {
+                            throw new Error('Cant find schema for the element of DataFactoryElement with type dfe-list-generic: ' + (eleFormat ?? '<null>'));
+                        }
+                        return new ArraySchema(dfeFormat, '', eleSchema);
                     default:
-                        throw new Error("Unknown dfeFormat" + dfeFormat);
+                        throw new Error('Unknown dfeFormat' + dfeFormat);
                 }
-            }
+            };
 
-            let format = extensions[X_MS_FORMAT];
-            let elementFormat = extensions[X_MS_FORMAT_ELEMENT_TYPE];
+            const format = extensions[xMsFormat];
+            const elementFormat = extensions[xMsFormatElementType];
 
-            var dfeObjSchema = createSchemaForDfeObject(rawValue, format);
+            const dfeObjSchema = createSchemaForDfeObject(rawValue, format);
             if (dfeObjSchema) {
                 return this.createInstance(session, rawValue, usedProperties, dfeObjSchema, language, undefined, searchDescents);
             }
             else {
-                var dfeLiterlSchema = createSchemaForDfeLiteral(rawValue, format, elementFormat);
+                const dfeLiterlSchema = createSchemaForDfeLiteral(rawValue, format, elementFormat);
                 return this.createInstance(session, rawValue, usedProperties, dfeLiterlSchema, language, undefined, searchDescents);
             }
         }
@@ -279,7 +280,7 @@ export class ExampleParameter {
 
     public constructor(session: Session<TestCodeModel>, parameter: Parameter, rawValue: any) {
         this.parameter = parameter;
-        this.exampleValue = ExampleValue.createInstance(session, rawValue, new Set(), parameter?.schema, parameter.language, parameter.extensions   );
+        this.exampleValue = ExampleValue.createInstance(session, rawValue, new Set(), parameter?.schema, parameter.language, parameter.extensions);
     }
 }
 

--- a/tools/sdk-testgen/packages/autorest.testmodeler/src/core/model.ts
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/src/core/model.ts
@@ -215,7 +215,7 @@ export class ExampleValue {
             }
         }
         else if (schema.type === SchemaType.AnyObject && extensions && extensions[X_MS_FORMAT] && extensions[X_MS_FORMAT].startsWith("dfe-")) {
-            // Rebuild example value for DataFactoryElement
+            // Becuase DataFactoryElement is defined as AnyObject schema, so have to explicitly build it's example value according to x_ms_format here
             const DFE_OBJECT_TYPE = "type";
             const DFE_OBJECT_TYPE_VALUES = ["Expression", "SecureString", "AzureKeyVaultSecretReference"];
             const DFE_OBJECT_VALUE = "value";

--- a/tools/sdk-testgen/packages/autorest.testmodeler/test/unittest/core/__snapshots__/testModel.ts.snap
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/test/unittest/core/__snapshots__/testModel.ts.snap
@@ -35,6 +35,185 @@ ExampleParameter {
 }
 `;
 
+exports[`ExampleValue.createInstance(...) create with DataFactoryElement 1`] = `
+ExampleValue {
+  "language": Object {
+    "default": Object {
+      "description": "mocked description",
+      "name": "mocked name",
+    },
+  },
+  "parentsValue": Object {},
+  "properties": Object {
+    "type": ExampleValue {
+      "language": Languages {
+        "default": Object {
+          "description": "",
+          "name": "type",
+        },
+      },
+      "rawValue": "Expression",
+      "schema": StringSchema {
+        "language": Languages {
+          "default": Object {
+            "description": "",
+            "name": "dfe-string-type",
+          },
+        },
+        "protocol": Protocols {},
+        "type": "string",
+      },
+    },
+    "value": ExampleValue {
+      "language": Languages {
+        "default": Object {
+          "description": "",
+          "name": "value",
+        },
+      },
+      "rawValue": "@dataset().MyFolderPath",
+      "schema": StringSchema {
+        "language": Languages {
+          "default": Object {
+            "description": "",
+            "name": "dfe-string-value",
+          },
+        },
+        "protocol": Protocols {},
+        "type": "string",
+      },
+    },
+  },
+  "schema": ObjectSchema {
+    "language": Languages {
+      "default": Object {
+        "description": "",
+        "name": "DataFactoryElement-Expression",
+      },
+    },
+    "properties": Array [
+      Property {
+        "language": Languages {
+          "default": Object {
+            "description": "",
+            "name": "type",
+          },
+        },
+        "protocol": Protocols {},
+        "schema": StringSchema {
+          "language": Languages {
+            "default": Object {
+              "description": "",
+              "name": "dfe-string-type",
+            },
+          },
+          "protocol": Protocols {},
+          "type": "string",
+        },
+        "serializedName": "type",
+      },
+      Property {
+        "language": Languages {
+          "default": Object {
+            "description": "",
+            "name": "value",
+          },
+        },
+        "protocol": Protocols {},
+        "schema": StringSchema {
+          "language": Languages {
+            "default": Object {
+              "description": "",
+              "name": "dfe-string-value",
+            },
+          },
+          "protocol": Protocols {},
+          "type": "string",
+        },
+        "serializedName": "value",
+      },
+    ],
+    "protocol": Protocols {},
+    "type": "object",
+  },
+}
+`;
+
+exports[`ExampleValue.createInstance(...) create with DataFactoryElement with Literal value 1`] = `
+ExampleValue {
+  "elements": Array [
+    ExampleValue {
+      "language": undefined,
+      "rawValue": "a",
+      "schema": StringSchema {
+        "language": Languages {
+          "default": Object {
+            "description": "",
+            "name": "dfe-list-string-element",
+          },
+        },
+        "protocol": Protocols {},
+        "type": "string",
+      },
+    },
+    ExampleValue {
+      "language": undefined,
+      "rawValue": "b",
+      "schema": StringSchema {
+        "language": Languages {
+          "default": Object {
+            "description": "",
+            "name": "dfe-list-string-element",
+          },
+        },
+        "protocol": Protocols {},
+        "type": "string",
+      },
+    },
+    ExampleValue {
+      "language": undefined,
+      "rawValue": "c",
+      "schema": StringSchema {
+        "language": Languages {
+          "default": Object {
+            "description": "",
+            "name": "dfe-list-string-element",
+          },
+        },
+        "protocol": Protocols {},
+        "type": "string",
+      },
+    },
+  ],
+  "language": Object {
+    "default": Object {
+      "description": "mocked description",
+      "name": "mocked name",
+    },
+  },
+  "schema": ArraySchema {
+    "elementType": StringSchema {
+      "language": Languages {
+        "default": Object {
+          "description": "",
+          "name": "dfe-list-string-element",
+        },
+      },
+      "protocol": Protocols {},
+      "type": "string",
+    },
+    "language": Languages {
+      "default": Object {
+        "description": "",
+        "name": "dfe-list-string",
+      },
+    },
+    "protocol": Protocols {},
+    "type": "array",
+  },
+}
+`;
+
 exports[`ExampleValue.createInstance(...) create with primitive schema 1`] = `
 ExampleValue {
   "language": Object {

--- a/tools/sdk-testgen/packages/autorest.testmodeler/test/unittest/core/testModel.ts
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/test/unittest/core/testModel.ts
@@ -31,7 +31,7 @@ describe('ExampleValue.createInstance(...)', () => {
     it('create with primitive schema', async () => {
         const spyCreateInstance = jest.spyOn(ExampleValue, 'createInstance');
         const rawValue = [1, 2, 3];
-        const instance = ExampleValue.createInstance(mockedSession, rawValue, new Set(), MockTool.createSchema(SchemaType.Any), MockTool.createLanguages(),undefined);
+        const instance = ExampleValue.createInstance(mockedSession, rawValue, new Set(), MockTool.createSchema(SchemaType.Any), MockTool.createLanguages(), undefined);
         expect(spyCreateInstance).toHaveBeenCalledTimes(1);
         expect(instance).toMatchSnapshot();
     });
@@ -39,18 +39,22 @@ describe('ExampleValue.createInstance(...)', () => {
     it('create with DataFactoryElement', async () => {
         const spyCreateInstance = jest.spyOn(ExampleValue, 'createInstance');
         const rawValue = {
-            "value": "@dataset().MyFolderPath",
-            "type": "Expression"
+            value: '@dataset().MyFolderPath',
+            type: 'Expression',
         };
-        const instance = ExampleValue.createInstance(mockedSession, rawValue, new Set(), MockTool.createSchema(SchemaType.AnyObject), MockTool.createLanguages(), { "x-ms-format": "dfe-string" });
+        const instance = ExampleValue.createInstance(mockedSession, rawValue, new Set(), MockTool.createSchema(SchemaType.AnyObject), MockTool.createLanguages(), {
+            'x-ms-format': 'dfe-string',
+        });
         expect(spyCreateInstance).toHaveBeenCalledTimes(4);
         expect(instance).toMatchSnapshot();
     });
 
     it('create with DataFactoryElement with Literal value', async () => {
         const spyCreateInstance = jest.spyOn(ExampleValue, 'createInstance');
-        const rawValue = ["a", "b", "c"];
-        const instance = ExampleValue.createInstance(mockedSession, rawValue, new Set(), MockTool.createSchema(SchemaType.AnyObject), MockTool.createLanguages(), { "x-ms-format": "dfe-list-string" });
+        const rawValue = ['a', 'b', 'c'];
+        const instance = ExampleValue.createInstance(mockedSession, rawValue, new Set(), MockTool.createSchema(SchemaType.AnyObject), MockTool.createLanguages(), {
+            'x-ms-format': 'dfe-list-string',
+        });
         expect(spyCreateInstance).toHaveBeenCalledTimes(5);
         expect(instance).toMatchSnapshot();
     });
@@ -64,7 +68,7 @@ describe('ExampleValue.createInstance(...)', () => {
             new Set(),
             MockTool.createArraySchema(MockTool.createSchema(SchemaType.Integer)),
             MockTool.createLanguages(),
-            undefined
+            undefined,
         );
         expect(spyCreateInstance).toHaveBeenCalledTimes(rawValue.length + 1);
         expect(instance).toMatchSnapshot();
@@ -85,7 +89,7 @@ describe('ExampleValue.createInstance(...)', () => {
                 properties: [MockTool.createProperty('abc', integerSchema), MockTool.createProperty('bcd', integerSchema)],
             }),
             MockTool.createLanguages(),
-            undefined
+            undefined,
         );
         expect(spyCreateInstance).toHaveBeenCalledTimes(Object.keys(rawValue).length + 1);
         expect(instance).toMatchSnapshot();
@@ -106,7 +110,7 @@ describe('ExampleValue.createInstance(...)', () => {
                 elementType: integerSchema,
             }),
             MockTool.createLanguages(),
-            undefined
+            undefined,
         );
         expect(spyCreateInstance).toHaveBeenCalledTimes(Object.keys(rawValue).length + 1);
         expect(instance).toMatchSnapshot();

--- a/tools/sdk-testgen/packages/autorest.testmodeler/test/unittest/core/testModel.ts
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/test/unittest/core/testModel.ts
@@ -31,8 +31,27 @@ describe('ExampleValue.createInstance(...)', () => {
     it('create with primitive schema', async () => {
         const spyCreateInstance = jest.spyOn(ExampleValue, 'createInstance');
         const rawValue = [1, 2, 3];
-        const instance = ExampleValue.createInstance(mockedSession, rawValue, new Set(), MockTool.createSchema(SchemaType.Any), MockTool.createLanguages());
+        const instance = ExampleValue.createInstance(mockedSession, rawValue, new Set(), MockTool.createSchema(SchemaType.Any), MockTool.createLanguages(),undefined);
         expect(spyCreateInstance).toHaveBeenCalledTimes(1);
+        expect(instance).toMatchSnapshot();
+    });
+
+    it('create with DataFactoryElement', async () => {
+        const spyCreateInstance = jest.spyOn(ExampleValue, 'createInstance');
+        const rawValue = {
+            "value": "@dataset().MyFolderPath",
+            "type": "Expression"
+        };
+        const instance = ExampleValue.createInstance(mockedSession, rawValue, new Set(), MockTool.createSchema(SchemaType.AnyObject), MockTool.createLanguages(), { "x-ms-format": "dfe-string" });
+        expect(spyCreateInstance).toHaveBeenCalledTimes(4);
+        expect(instance).toMatchSnapshot();
+    });
+
+    it('create with DataFactoryElement with Literal value', async () => {
+        const spyCreateInstance = jest.spyOn(ExampleValue, 'createInstance');
+        const rawValue = ["a", "b", "c"];
+        const instance = ExampleValue.createInstance(mockedSession, rawValue, new Set(), MockTool.createSchema(SchemaType.AnyObject), MockTool.createLanguages(), { "x-ms-format": "dfe-list-string" });
+        expect(spyCreateInstance).toHaveBeenCalledTimes(5);
         expect(instance).toMatchSnapshot();
     });
 
@@ -45,6 +64,7 @@ describe('ExampleValue.createInstance(...)', () => {
             new Set(),
             MockTool.createArraySchema(MockTool.createSchema(SchemaType.Integer)),
             MockTool.createLanguages(),
+            undefined
         );
         expect(spyCreateInstance).toHaveBeenCalledTimes(rawValue.length + 1);
         expect(instance).toMatchSnapshot();
@@ -65,6 +85,7 @@ describe('ExampleValue.createInstance(...)', () => {
                 properties: [MockTool.createProperty('abc', integerSchema), MockTool.createProperty('bcd', integerSchema)],
             }),
             MockTool.createLanguages(),
+            undefined
         );
         expect(spyCreateInstance).toHaveBeenCalledTimes(Object.keys(rawValue).length + 1);
         expect(instance).toMatchSnapshot();
@@ -85,6 +106,7 @@ describe('ExampleValue.createInstance(...)', () => {
                 elementType: integerSchema,
             }),
             MockTool.createLanguages(),
+            undefined
         );
         expect(spyCreateInstance).toHaveBeenCalledTimes(Object.keys(rawValue).length + 1);
         expect(instance).toMatchSnapshot();


### PR DESCRIPTION
We are supporting DFE(DataFactoryElement) in SDK Sample Generation which needs the corresponding support in SDK_Testgen to generate Example Model properly. In detail. the DFE is special and is defined as AnyObject schema now which causes its Example value won't be generated properly. We are adding support for it to generate Example model properly from it's x-ms-format definition. 

If you are interested, detail information about DataFactoryElement can be found at https://gist.github.com/JoshLove-msft/e7e85e44d6fd24c87e362a37260c9d21