### PR TITLE
[Test-Proxy] Point users to language repository test documentation

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -1,5 +1,15 @@
 # Azure SDK Tools Test Proxy
 
+**To users writing SDK tests:** This document is not intended to be a test preperation reference. You should instead refer
+to documentation in your specific language repository in order to configure recorded tests.
+
+[Java](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md)
+| [JavaScript](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Quickstart-on-how-to-write-tests.md)
+| [.NET](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core.TestFramework/README.md)
+| [Python](https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/tests.md)
+
+## Table of contents
+
 - [Azure SDK Tools Test Proxy](#azure-sdk-tools-test-proxy)
   - [Installation](#installation)
     - [Via Local Compile or .NET](#via-local-compile-or-net)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -7,6 +7,8 @@ to documentation in your specific language repository in order to configure reco
 | [JavaScript](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Quickstart-on-how-to-write-tests.md)
 | [.NET](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core.TestFramework/README.md)
 | [Python](https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/tests.md)
+| [C++](https://github.com/Azure/azure-sdk-for-cpp/blob/main/doc/TestProxy.md)
+| [Go](https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/developer_setup.md)
 
 ## Table of contents
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -3,12 +3,14 @@
 **To users writing SDK tests:** This document is not intended to be a test preperation reference. You should instead refer
 to documentation in your specific language repository in order to configure recorded tests.
 
-[Java](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md)
-| [JavaScript](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Quickstart-on-how-to-write-tests.md)
-| [.NET](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core.TestFramework/README.md)
-| [Python](https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/tests.md)
-| [C++](https://github.com/Azure/azure-sdk-for-cpp/blob/main/doc/TestProxy.md)
-| [Go](https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/developer_setup.md)
+#### Test documentation by language:
+
+- [Java](https://github.com/Azure/azure-sdk-for-java/blob/main/CONTRIBUTING.md)
+- [JavaScript](https://github.com/Azure/azure-sdk-for-js/blob/main/documentation/Quickstart-on-how-to-write-tests.md)
+- [.NET](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core.TestFramework/README.md)
+- [Python](https://github.com/Azure/azure-sdk-for-python/blob/main/doc/dev/tests.md)
+- [C++](https://github.com/Azure/azure-sdk-for-cpp/blob/main/doc/TestProxy.md)
+- [Go](https://github.com/Azure/azure-sdk-for-go/blob/main/documentation/developer_setup.md)
 
 ## Table of contents
 


### PR DESCRIPTION
We recently had an instance where a partner team intended to set up the test proxy tool for testing their already-migrated Python library. Instead of referring to our language-specific test docs, though, they found this `azure-sdk-tools` documentation; this made them think that they had to set up the test proxy tool manually with .NET/Docker, but Python's tooling actually handles tool installation and startup for them.

To avoid this issue, I think it would be good to have a disclaimer at the start of this document to let people know that this isn't meant for test writers' reference. I added links to what seem to be the test-writing guides for each language, but it would be great if each language's test proxy owner could double-check them 🙂