### PR TITLE
Add openapi hub redirect app

### DIFF
--- a/tools/openapihub-redirect/README.md
+++ b/tools/openapihub-redirect/README.md
@@ -1,0 +1,20 @@
+This is a simple web app to redirect users to either [openapihub](https://openapihub.azure-devex-tools.com) if they are on corp net, or [openapi hub access docs](https://aka.ms/openapihub-landing) if they are off corp net.
+This site is configured to load from `https://portal.azure-devex-tools.com` via the [app service domain config](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/8c0e0d10-c2d6-42b8-b1d9-e7132b6f18a3/resourceGroups/openapi-platform-preview/providers/Microsoft.Web/sites/hub-redirect-app/domainsandsslv2) and the [azure-devex-tools DNS zone](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/8c0e0d10-c2d6-42b8-b1d9-e7132b6f18a3/resourceGroups/openapi-platform-preview/providers/Microsoft.Network/dnszones/azure-devex-tools.com/overview).
+
+To update this app:
+
+1. Update `app.py` and/or `index.html`
+1. Enable basic authentication under General Settings [here](https://ms.portal.azure.com/#@microsoft.onmicrosoft.com/resource/subscriptions/8c0e0d10-c2d6-42b8-b1d9-e7132b6f18a3/resourceGroups/openapi-platform-preview/providers/Microsoft.Web/sites/hub-redirect-app/configuration)
+1. Run the following commands from this directory:
+
+```
+az login
+az account set -s 'OpenAPI Platform - Preview'
+
+# Install dependencies and archive app contents
+pip install flask
+pwsh -c Compress-Archive -path '*' -DestinationPath app.zip
+
+# Deploy zip file to azure app service
+az webapp deploy --resource-group openapi-platform-preview --name hub-redirect-app --src-path app.zip --type zip
+```

--- a/tools/openapihub-redirect/app.py
+++ b/tools/openapihub-redirect/app.py
@@ -1,0 +1,15 @@
+from flask import Flask
+
+app = Flask(__name__)
+
+html = ''
+with (open('index.html', 'r')) as f:
+    html = f.read()
+
+@app.route("/")
+def home():
+    return f"{html}"
+
+@app.route("/<path:path>", methods=['GET'])
+def all_routes(path):
+    return f"{html}"

--- a/tools/openapihub-redirect/index.html
+++ b/tools/openapihub-redirect/index.html
@@ -1,0 +1,45 @@
+<html>
+<head>
+<script>
+  var request = new XMLHttpRequest();
+  var url = new URL(window.location.href);
+  url.hostname = 'openapihub.azure-devex-tools.com';
+  url.protocol = 'https:';
+  url.port = '443';
+  console.log(url.href);
+  var redirect = url.href;
+
+  request.open('GET', redirect, true);
+  request.timeout = 5000;
+
+  request.onload = handleCorpNet;
+  request.onerror = handleCorpNet;
+  request.ontimeout = handleNoCorpNet;
+
+  function handleCorpNet() {
+    console.log('there is a connection');
+    setTimeout(function() {
+      window.location.href = redirect;
+    }, 5000);
+  }
+
+  function handleNoCorpNet() {
+    console.log('there is no connection');
+    window.location.href = 'https://aka.ms/openapihub-landing';
+  }
+
+  request.send();
+</script>
+<style>
+.readme {
+    font: normal normal 16px/1.5 "Segoe UI", Helvetica, Arial, sans-serif;
+}
+</style>
+</head>
+
+<div class="readme">
+  <h2>portal.azure-devex-tools.com has moved to openapihub.azure-devex-tools.com</h2>
+  <p><b>Corp net access will soon be required to access this site. See <a href="https://aka.ms/openapihub-landing">https://aka.ms/openapihub-landing</a> for access instructions.</b></p>
+  <p>Redirecting in 5 seconds...</p>
+</div>
+</html>


### PR DESCRIPTION
This is a simple web app we deploy to app services that `portal.azure-devex-tools.com` lands on. This app does a client-side check to see if `openapihub.azure-devex-tools.com` is accessible and if so redirects to it, preserving any path and query parameters. If it is not accessible, the site redirects to https://aka.ms/openapihub-landing which tells users how to get access to corp net if they are not on campus.