### PR TITLE
[Pylint] vararg bug fix

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -1295,21 +1295,28 @@ class CheckDocstringParameters(BaseChecker):
         :return: None
         """
         arg_names = []
+        vararg_name = None
         # specific case for constructor where docstring found in class def
         if isinstance(node, astroid.ClassDef):
             for constructor in node.body:
                 if isinstance(constructor, astroid.FunctionDef) and constructor.name == "__init__":
                     arg_names = [arg.name for arg in constructor.args.args]
+                    vararg_name = node.args.vararg
                     break
 
         if isinstance(node, astroid.FunctionDef):
             arg_names = [arg.name for arg in node.args.args]
+            vararg_name = node.args.vararg
 
         try:
             # not every method will have a docstring so don't crash here, just return
             docstring = node.doc.split(":")
         except AttributeError:
             return
+        
+        # If there is a vararg, treat it as a param
+        if vararg_name:
+            arg_names.append(vararg_name)
 
         docparams = {}
         for idx, line in enumerate(docstring):

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3389,6 +3389,23 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
+    def test_docstring_vararg_keyword_args(self):
+        node = astroid.extract_node(
+            """
+            def function_foo(x, y, *z, a="Hello", b="World"):
+                '''
+                :param x: x
+                :type x: str
+                :param str y: y
+                :param str z: z
+                :keyword str a: a
+                :keyword str b: b
+                '''
+            """
+        )
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
     def test_docstring_varag_no_type(self):
         node = astroid.extract_node(
             """

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3376,6 +3376,7 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
 
     def test_docstring_vararg(self):
         node = astroid.extract_node(
+            # Check that we recognize *args as param in docstring
             """
             def function_foo(x, y, *z):
                 '''
@@ -3390,6 +3391,7 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
             self.checker.visit_functiondef(node)
 
     def test_docstring_vararg_keyword_args(self):
+        # Check that we recognize kwargs after *args in docstring
         node = astroid.extract_node(
             """
             def function_foo(x, y, *z, a="Hello", b="World"):
@@ -3407,6 +3409,7 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
             self.checker.visit_functiondef(node)
 
     def test_docstring_varag_no_type(self):
+        # Error on documenting kwargs as param after *args in docstring
         node = astroid.extract_node(
             """
             def function_foo(*x, y, z):

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3391,7 +3391,7 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
             self.checker.visit_functiondef(node)
 
     def test_docstring_vararg_keyword_args(self):
-        # Check that we recognize kwargs after *args in docstring
+        # Check that we recognize keyword-only args after *args in docstring
         node = astroid.extract_node(
             """
             def function_foo(x, y, *z, a="Hello", b="World"):
@@ -3409,7 +3409,7 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
             self.checker.visit_functiondef(node)
 
     def test_docstring_varag_no_type(self):
-        # Error on documenting kwargs as param after *args in docstring
+        # Error on documenting keyword only args as param after *args in docstring
         node = astroid.extract_node(
             """
             def function_foo(*x, y, z):

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3368,3 +3368,56 @@ class TestDeleteOperationReturnType(pylint.testutils.CheckerTestCase):
         )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
+
+class TestDocstringParameters(pylint.testutils.CheckerTestCase):
+
+    """Test that we are checking the docstring is correct"""
+    CHECKER_CLASS = checker.CheckDocstringParameters
+
+    def test_docstring_vararg(self):
+        node = astroid.extract_node(
+            """
+            def function_foo(x, y, *z):
+                '''
+                :param x: x
+                :type x: str
+                :param str y: y
+                :param str z: z
+                '''
+            """
+        )
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
+
+    def test_docstring_varag_no_type(self):
+        node = astroid.extract_node(
+            """
+            def function_foo(*x, y, z):
+                '''
+                :param x: x
+                :param str y: y
+                :param str z: z
+                '''
+            """
+        )
+        with self.assertAddsMessages(
+                pylint.testutils.MessageTest(
+                    msg_id="docstring-missing-type",
+                    line=2,
+                    args='x',
+                    node=node,
+                    col_offset=0, 
+                    end_line=2, 
+                    end_col_offset=16
+                ),
+                pylint.testutils.MessageTest(
+                    msg_id="docstring-should-be-keyword",
+                    line=2,
+                    args='y, z',
+                    node=node,
+                    col_offset=0, 
+                    end_line=2, 
+                    end_col_offset=16
+                )
+        ):
+            self.checker.visit_functiondef(node)


### PR DESCRIPTION
varargs were not being pulled in when checking docstring args