### PR TITLE
Add team/user store to pipeline-owners-extracton

### DIFF
--- a/eng/pipelines/pipeline-owners-extraction.yml
+++ b/eng/pipelines/pipeline-owners-extraction.yml
@@ -44,6 +44,6 @@ stages:
       - pwsh: |
           dotnet run --blobStorageURI "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob?$(azuresdkartifacts-azure-sdk-write-teams-sas)"
         displayName: 'Fetch and store team/user data'
-        workingDirectory: '/eng/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore'
+        workingDirectory: '/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore'
         env:
           GITHUB_TOKEN: $(azuresdkartifacts-azure-sdk-write-teams-github-pat)

--- a/eng/pipelines/pipeline-owners-extraction.yml
+++ b/eng/pipelines/pipeline-owners-extraction.yml
@@ -44,6 +44,6 @@ stages:
       - pwsh: |
           dotnet run --blobStorageURI "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob?$(azuresdkartifacts-azure-sdk-write-teams-sas)"
         displayName: 'Fetch and store team/user data'
-        workingDirectory: '/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore'
+        workingDirectory: tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore
         env:
           GITHUB_TOKEN: $(azuresdkartifacts-azure-sdk-write-teams-github-pat)

--- a/eng/pipelines/pipeline-owners-extraction.yml
+++ b/eng/pipelines/pipeline-owners-extraction.yml
@@ -40,3 +40,10 @@ stages:
         displayName: Publish pipelineOwners artifact
         artifact: pipelineOwners
         condition: succeededOrFailed()
+
+      - pwsh: |
+          dotnet run --blobStorageURI "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob?$(azuresdkartifacts-azure-sdk-write-teams-sas)"
+        displayName: 'Fetch and store team/user data'
+        workingDirectory: '/eng/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore'
+        env:
+          GITHUB_TOKEN: $(azuresdkartifacts-azure-sdk-write-teams-github-pat)

--- a/tools/github-team-user-store/README.md
+++ b/tools/github-team-user-store/README.md
@@ -26,3 +26,6 @@ The json blob is read anonymously. The json blob is created from the dictionary 
     var list = JsonSerializer.Deserialize<List<KeyValuePair<string, List<string>>>>(rawJson);
     var TeamUSerDictionary = list.ToDictionary((keyItem) => keyItem.Key, (valueItem) => valueItem.Value);
 ```
+
+### The pipeline where this will run
+This will run as part of the [pipeline-owners-extracton](https://dev.azure.com/azure-sdk/internal/_build?definitionId=5112&_a=summary) pipeline.


### PR DESCRIPTION
Add the build/run of github-team-user-store to the pipeline-owners-extraction. The variable group, [azuresdkartifacts azure-sdk-write-teams variables](https://dev.azure.com/azure-sdk/internal/_library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=133&path=azuresdkartifacts%20azure-sdk-write-teams%20variables), has already been added to the pipeline.