### PR TITLE
Updates for Codeowners changes

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -55,7 +55,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230505.2
+          --version 1.0.0-dev.20230629.2
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -34,7 +34,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230505.2
+          --version 1.0.0-dev.20230629.2
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/eng/common/scripts/get-codeowners.lib.ps1
+++ b/eng/common/scripts/get-codeowners.lib.ps1
@@ -1,6 +1,7 @@
 function Get-CodeownersTool([string] $ToolPath, [string] $DevOpsFeed, [string] $ToolVersion)
 {
   $codeownersToolCommand = Join-Path $ToolPath "retrieve-codeowners"
+  Write-Host "Checking for retrieve-codeowners in $ToolPath ..."
   # Check if the retrieve-codeowners tool exists or not.
   if (Get-Command $codeownersToolCommand -errorAction SilentlyContinue) {
     return $codeownersToolCommand
@@ -10,15 +11,16 @@ function Get-CodeownersTool([string] $ToolPath, [string] $DevOpsFeed, [string] $
   }
   Write-Host "Installing the retrieve-codeowners tool under tool path: $ToolPath ..."
 
-  # Run command under tool path to avoid dotnet tool install command checking .csproj files. 
+  # Run command under tool path to avoid dotnet tool install command checking .csproj files.
   # This is a bug for dotnet tool command. Issue: https://github.com/dotnet/sdk/issues/9623
   Push-Location $ToolPath
+  Write-Host "Executing: dotnet tool install --tool-path $ToolPath --add-source $DevOpsFeed --version $ToolVersion"
   dotnet tool install --tool-path $ToolPath --add-source $DevOpsFeed --version $ToolVersion "Azure.Sdk.Tools.RetrieveCodeOwners" | Out-Null
   Pop-Location
   # Test to see if the tool properly installed.
   if (!(Get-Command $codeownersToolCommand -errorAction SilentlyContinue)) {
     Write-Error "The retrieve-codeowners tool is not properly installed. Please check your tool path: $ToolPath"
-    return 
+    return
   }
   return $codeownersToolCommand
 }
@@ -30,7 +32,7 @@ of that path, as determined by CODEOWNERS file passed in $CodeownersFileLocation
 param.
 
 .PARAMETER TargetPath
-Required*. Path to file or directory whose owners are to be determined from a 
+Required*. Path to file or directory whose owners are to be determined from a
 CODEOWNERS file. e.g. sdk/core/azure-amqp/ or sdk/core/foo.txt.
 
 *for backward compatibility, you might provide $TargetDirectory instead.
@@ -45,7 +47,7 @@ Optional. An absolute path to the CODEOWNERS file against which the $TargetPath 
 will be checked to determine its owners.
 
 .PARAMETER ToolVersion
-Optional. The NuGet package version of the package containing the "retrieve-codeowners" 
+Optional. The NuGet package version of the package containing the "retrieve-codeowners"
 tool, around which this script is a wrapper.
 
 .PARAMETER ToolPath
@@ -60,8 +62,8 @@ https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net/NuGet/A
 Pipeline publishing the NuGet package to the feed, "tools - code-owners-parser":
 https://dev.azure.com/azure-sdk/internal/_build?definitionId=3188
 
-.PARAMETER VsoVariable 
-Optional. If provided, the determined owners, based on $TargetPath matched against CODEOWNERS file at $CodeownersFileLocation, 
+.PARAMETER VsoVariable
+Optional. If provided, the determined owners, based on $TargetPath matched against CODEOWNERS file at $CodeownersFileLocation,
 will be output to Azure DevOps pipeline log as variable named $VsoVariable.
 
 Reference:
@@ -80,7 +82,7 @@ function Get-Codeowners(
   [string] $TargetDirectory,
   [string] $ToolPath = (Join-Path ([System.IO.Path]::GetTempPath()) "codeowners-tool"),
   [string] $DevOpsFeed = "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json",
-  [string] $ToolVersion = "1.0.0-dev.20230306.3",
+  [string] $ToolVersion = "1.0.0-dev.20230629.2",
   [string] $VsoVariable = "",
   [string] $CodeownersFileLocation = "",
   [switch] $IncludeNonUserAliases
@@ -100,12 +102,14 @@ function Get-Codeowners(
     return ,@()
   }
 
+  $jsonOutputFile = New-TemporaryFile
   $codeownersToolCommand = Get-CodeownersTool -ToolPath $ToolPath -DevOpsFeed $DevOpsFeed -ToolVersion $ToolVersion
-  Write-Host "Executing: & $codeownersToolCommand --target-path $TargetPath --codeowners-file-path-or-url $CodeownersFileLocation --exclude-non-user-aliases:$(!$IncludeNonUserAliases)"
+  Write-Host "Executing: & $codeownersToolCommand --target-path $TargetPath --codeowners-file-path-or-url $CodeownersFileLocation --exclude-non-user-aliases:$(!$IncludeNonUserAliases) --owners-data-output-file $jsonOutputFile"
   $commandOutput = & $codeownersToolCommand `
       --target-path $TargetPath `
       --codeowners-file-path-or-url $CodeownersFileLocation `
       --exclude-non-user-aliases:$(!$IncludeNonUserAliases) `
+      --owners-data-output-file $jsonOutputFile `
       2>&1
 
   if ($LASTEXITCODE -ne 0) {
@@ -116,14 +120,15 @@ function Get-Codeowners(
     Write-Host "Command $codeownersToolCommand executed successfully (exit code = 0). Command output string length: $($commandOutput.length)"
   }
 
-# Assert: $commandOutput is a valid JSON representing:
-# - a single CodeownersEntry, if the $TargetPath was a single path
-# - or a dictionary of CodeownerEntries, keyes by each path resolved from a $TargetPath glob path.
-#
-# For implementation details, see Azure.Sdk.Tools.RetrieveCodeOwners.Program.Main
+  # Assert: $commandOutput is a valid JSON representing:
+  # - a single CodeownersEntry, if the $TargetPath was a single path
+  # - or a dictionary of CodeownerEntries, keyes by each path resolved from a $TargetPath glob path.
+  #
+  # For implementation details, see Azure.Sdk.Tools.RetrieveCodeOwners.Program.Main
 
-$codeownersJson = $commandOutput | ConvertFrom-Json
-  
+  $fileContents = Get-Content $jsonOutputFile -Raw
+  $codeownersJson = ConvertFrom-Json -InputObject $fileContents
+
   if ($VsoVariable) {
     $codeowners = $codeownersJson.Owners -join ","
     Write-Host "##vso[task.setvariable variable=$VsoVariable;]$codeowners"


### PR DESCRIPTION
There was a [recent change to CodeOwnersParser](https://github.com/Azure/azure-sdk-tools/pull/6366) and we'll now lookup the users for a team when we encounter a team in CODEOWNERS. _Note: The caveat with this is that teams in CODEOWNERS files need to have write permissions and should all be child teams of Azure/azure-sdk-write._ The update to CodeOwnersParser requires updates to the following:
1. github-event-processor uses CodeOwnersParser in a couple of existing rules and should allow us to expand the [Initial Issue Triage](https://github.com/Azure/azure-sdk-tools/blob/main/tools/github-event-processor/RULES.md#initial-issue-triage) rule.
2. get-codeowners.lib.ps1 (currently only used by the [Metadata-Helpers.sp1](https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/scripts/Helpers/Metadata-Helpers.ps1#L75) needed to use the updated version of the RetrieveCodeOwners.