### PR TITLE
[Pylint] Infer raise

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -1384,7 +1384,7 @@ class CheckDocstringParameters(BaseChecker):
         function_decorators = node.decoratornames()
         try:
             returns = next(node.infer_call_result()).as_string()
-            if returns == "None":
+            if returns == "None" or returns == astroid.Uninferable:
                 return
         except (astroid.exceptions.InferenceError, AttributeError):
             # this function doesn't return anything, just return

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -1384,6 +1384,7 @@ class CheckDocstringParameters(BaseChecker):
         function_decorators = node.decoratornames()
         try:
             returns = next(node.infer_call_result()).as_string()
+            # If returns None, or raises an error ignore
             if returns == "None" or returns == astroid.Uninferable:
                 return
         except (astroid.exceptions.InferenceError, AttributeError):

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3507,3 +3507,16 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
         )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
+
+    def test_docstring_raises(self):
+        node = astroid.extract_node(
+            """
+            def function_foo():
+                '''
+                :raises: ValueError
+                '''
+                raise ValueError("hello")
+            """
+        )
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)


### PR DESCRIPTION
It seems that raise exceptions as inferred as inferrable when alone in a function:


def func()
  raise ValueError --- uniferable

def func()
   print("waht")
   raise ValueError ---- None


I believe this is a bug in astroid that we can work-around with this fix