### PR TITLE
Fix playback always discarding pending changes

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -414,6 +414,74 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
               ""AssetsRepoPrefixPath"": ""pull/scenarios"",
               ""AssetsRepoId"": """",
               ""TagPrefix"": ""main"",
+              ""Tag"": ""python/tables_9e81fb""
+        }")]
+        [Trait("Category", "Integration")]
+        public async Task VerifyRestoreMaintainsChanges(string inputJson)
+        {
+            var folderStructure = new string[]
+            {
+                GitStoretests.AssetsJson
+            };
+
+            Assets assets = JsonSerializer.Deserialize<Assets>(inputJson);
+            var testFolder = TestHelpers.DescribeTestFolder(assets, folderStructure);
+            try
+            {
+                var jsonFileLocation = Path.Join(testFolder, GitStoretests.AssetsJson);
+
+                var parsedConfiguration = await _defaultStore.ParseConfigurationFile(jsonFileLocation);
+                await _defaultStore.Restore(jsonFileLocation);
+
+                // Calling Path.GetFullPath of the Path.Combine will ensure any directory separators are normalized for
+                // the OS the test is running on. The reason being is that AssetsRepoPrefixPath, if there's a separator,
+                // will be a forward one as expected by git but on Windows this won't result in a usable path.
+                string localFilePath = Path.GetFullPath(Path.Combine(parsedConfiguration.AssetsRepoLocation.ToString(), parsedConfiguration.AssetsRepoPrefixPath.ToString()));
+
+                // Verify files from Tag
+                Assert.Equal(4, System.IO.Directory.EnumerateFiles(localFilePath).Count());
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file2.txt", 2));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 2));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file4.txt", 1));
+
+                // Delete a couple of files
+                File.Delete(Path.Combine(localFilePath, "file2.txt"));
+                File.Delete(Path.Combine(localFilePath, "file4.txt"));
+
+                // Add a file
+                TestHelpers.CreateFileWithInitialVersion(localFilePath, "file5.txt");
+
+                // Verify the set of files after the additions/deletions
+                Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 2));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file5.txt", 1));
+
+                // This restore operates on the same tag, so we expect it to _properly keep the changes around_
+                await _defaultStore.Restore(jsonFileLocation);
+
+                // Verify that the same set of 3 files is still present!
+                Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 1));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file5.txt", 1));
+                await TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
+            }
+            finally
+            {
+                DirectoryHelper.DeleteGitDirectory(testFolder);
+            }
+        }
+
+
+        [EnvironmentConditionalSkipTheory]
+        [InlineData(
+        @"{
+              ""AssetsRepo"": ""Azure/azure-sdk-assets-integration"",
+              ""AssetsRepoPrefixPath"": ""pull/scenarios"",
+              ""AssetsRepoId"": """",
+              ""TagPrefix"": ""main"",
               ""Tag"": ""language/tables_bb2223""
         }")]
         [Trait("Category", "Integration")]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/IntegrationTests/GitStoreIntegrationRestoreTests.cs
@@ -464,7 +464,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests.IntegrationTests
                 // Verify that the same set of 3 files is still present!
                 Assert.Equal(3, System.IO.Directory.EnumerateFiles(localFilePath).Count());
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file1.txt", 1));
-                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 1));
+                Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file3.txt", 2));
                 Assert.True(TestHelpers.VerifyFileVersion(localFilePath, "file5.txt", 1));
                 await TestHelpers.CheckBreadcrumbAgainstAssetsJsons(new string[] { jsonFileLocation });
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -737,11 +737,6 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 File.WriteAllText(config.AssetsJsonLocation.ToString(), content);
             }
         }
-
-        public Task SetContext(string targetDirectory)
-        {
-            throw new NotImplementedException();
-        }
         #endregion
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -64,15 +64,18 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         public GitStore()
         {
             _consoleWrapper = new ConsoleWrapper();
+            BreadCrumb.RefreshLocalCache(Assets);
         }
 
         public GitStore(IConsoleWrapper consoleWrapper)
         {
             _consoleWrapper = consoleWrapper;
+            BreadCrumb.RefreshLocalCache(Assets);
         }
 
         public GitStore(GitProcessHandler processHandler) {
             GitHandler = processHandler;
+            BreadCrumb.RefreshLocalCache(Assets);
         }
 
         #region push, reset, restore, and other asset repo implementations

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStoreBreadcrumb.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStoreBreadcrumb.cs
@@ -106,9 +106,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             });
         }
 
-        public void RefreshLocalCache(ConcurrentDictionary<string, string> localCache)
+        public void RefreshLocalCache(ConcurrentDictionary<string, string> localCache, GitAssetsConfiguration config)
         {
-            var breadLocation = GetBreadCrumbLocation(new GitAssetsConfiguration());
+            var breadLocation = GetBreadCrumbLocation(config);
 
             if (File.Exists(breadLocation))
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStoreBreadcrumb.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStoreBreadcrumb.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -70,6 +71,11 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
         public GitStoreBreadcrumb() { }
 
+        public string GetBreadCrumbLocation(GitAssetsConfiguration configuration)
+        {
+            return Path.Join(configuration.ResolveAssetsStoreLocation().ToString(), ".breadcrumb");
+        }
+
         /// <summary>
         /// Updates an existing breadcrumb file with an assets configuration. Add/Update only. Should never remove.
         /// </summary>
@@ -77,7 +83,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         /// <returns></returns>
         public async Task Update(GitAssetsConfiguration configuration)
         {
-            var breadcrumbFile = Path.Join(configuration.ResolveAssetsStoreLocation().ToString(), ".breadcrumb");
+            var breadcrumbFile = GetBreadCrumbLocation(configuration);
             var targetKey = configuration.AssetsJsonRelativeLocation.ToString();
 
             await BreadCrumbWorker.EnqueueAsync(async () =>
@@ -98,6 +104,18 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 
                 File.WriteAllLines(breadcrumbFile, linesForWriting, System.Text.Encoding.UTF8);
             });
+        }
+
+        public void RefreshLocalCache(ConcurrentDictionary<string, string> localCache)
+        {
+
+            var readLines = File.ReadAllLines(GetBreadCrumbLocation(new GitAssetsConfiguration()));
+            var lines = readLines.Select(x => new BreadcrumbLine(x)).ToDictionary(x => x.PathToAssetsJson, x => x);
+
+            foreach( var line in lines)
+            {
+                localCache.AddOrUpdate(line.Value.PathToAssetsJson, line.Value.Tag, (key, oldValue) => line.Value.Tag);
+            }
         }
     }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStoreBreadcrumb.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStoreBreadcrumb.cs
@@ -108,13 +108,17 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
         public void RefreshLocalCache(ConcurrentDictionary<string, string> localCache)
         {
+            var breadLocation = GetBreadCrumbLocation(new GitAssetsConfiguration());
 
-            var readLines = File.ReadAllLines(GetBreadCrumbLocation(new GitAssetsConfiguration()));
-            var lines = readLines.Select(x => new BreadcrumbLine(x)).ToDictionary(x => x.PathToAssetsJson, x => x);
-
-            foreach( var line in lines)
+            if (File.Exists(breadLocation))
             {
-                localCache.AddOrUpdate(line.Value.PathToAssetsJson, line.Value.Tag, (key, oldValue) => line.Value.Tag);
+                var readLines = File.ReadAllLines(breadLocation);
+                var lines = readLines.Select(x => new BreadcrumbLine(x)).ToDictionary(x => x.PathToAssetsJson, x => x);
+
+                foreach (var line in lines)
+                {
+                    localCache.AddOrUpdate(line.Value.PathToAssetsJson, line.Value.Tag, (key, oldValue) => line.Value.Tag);
+                }
             }
         }
     }


### PR DESCRIPTION
The proxy maintains a tiny dictionary of `<assets-json-location>: <target-tag>`

We use this little dictionary to [short circuit](https://github.com/Azure/azure-sdk-tools/blob/b14dd081686ceb639049a2e0a7762eb7d179da27/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs#L324) our checkout process. However, when I refactored to allow automatic checkout to discard pending changes, I didn't properly account for loading this dictionary into memory. This caused us to always treat even the same tag that was currently checked out as a `new` tag, which causes us to discard changes when `restoring`.

By refreshing this local cache once per object lifetime, we can avoid this "I didn't know it was there already" discard of pending changes.

todo:
- [x] add a CLI integration test that truly exercises this exact scenario in different proxy invocations.