### PR TITLE
Eliminate `*` is not a valid pathspec on non-windows machines

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -246,7 +246,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         {
             try
             {
-                GitHandler.Run("checkout *", config);
+                GitHandler.Run("checkout .", config);
                 GitHandler.Run("clean -xdf", config);
             }
             catch (GitProcessException e)


### PR DESCRIPTION
I truly don't understand why we don't see this consistently.

[Example error](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2905364&view=logs&j=c80ec937-014a-532d-a6f0-bd9912040eb3&t=a2f2a75c-2929-5547-c2c1-26b2dae91467&l=178)