### PR TITLE
[pylint] do not import legacy six

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/README.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/README.md
@@ -87,3 +87,4 @@ docstring-missing-type | pylint:disable=docstring-missing-type    |       Docstr
 docstring-missing-return | pylint:disable=docstring-missing-return    |       Docstring missing return.                        | [link](https://azure.github.io/azure-sdk/python_documentation.html#docstrings)           |
 docstring-missing-rtype | pylint:disable=docstring-missing-rtype    |       Docstring missing return type.                        | [link](https://azure.github.io/azure-sdk/python_documentation.html#docstrings)           |
 docstring-should-be-keyword | pylint:disable=docstring-should-be-keyword    |       Docstring should use keywords.                        | [link](https://azure.github.io/azure-sdk/python_documentation.html#docstrings)           |
+do-not-import-legacy-sxi | pylint:disable=do-not-import-legacy-six    |       Do not import six.                        | No Link.          |

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/README.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/README.md
@@ -87,4 +87,4 @@ docstring-missing-type | pylint:disable=docstring-missing-type    |       Docstr
 docstring-missing-return | pylint:disable=docstring-missing-return    |       Docstring missing return.                        | [link](https://azure.github.io/azure-sdk/python_documentation.html#docstrings)           |
 docstring-missing-rtype | pylint:disable=docstring-missing-rtype    |       Docstring missing return type.                        | [link](https://azure.github.io/azure-sdk/python_documentation.html#docstrings)           |
 docstring-should-be-keyword | pylint:disable=docstring-should-be-keyword    |       Docstring should use keywords.                        | [link](https://azure.github.io/azure-sdk/python_documentation.html#docstrings)           |
-do-not-import-legacy-sxi | pylint:disable=do-not-import-legacy-six    |       Do not import six.                        | No Link.          |
+do-not-import-legacy-six | pylint:disable=do-not-import-legacy-six    |       Do not import six.                        | No Link.          |

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -2196,6 +2196,39 @@ class DeleteOperationReturnStatement(BaseChecker):
         except:
             pass
 
+class DoNotImportLegacySix(BaseChecker):
+    __implements__ = IAstroidChecker
+
+    """Rule to check that libraries do not import the six package."""
+    name = "do-not-import-legacy-six"
+    priority = -1
+    msgs = {
+        "C4757": (
+            "Do not import the six package in your library. Six was used with python 3.6, which is no longer supported.",
+            "do-not-import-legacy-six",
+            "Do not import the six package in your library."
+        ),
+    }
+
+    def visit_importfrom(self, node):
+        """Check that we aren't importing from six."""
+        if node.modname == "six": 
+            self.add_message(
+                msgid=f"do-not-import-legacy-six",
+                node=node,
+                confidence=None,
+            )
+    
+    def visit_import(self, node):
+        """Check that we aren't importing six."""
+        for name, _ in node.names:
+            if name == "six":
+                self.add_message(
+                    msgid=f"do-not-import-legacy-six",
+                    node=node,
+                    confidence=None,
+                )
+
 # if a linter is registered in this function then it will be checked with pylint
 def register(linter):
     linter.register_checker(ClientsDoNotUseStaticMethods(linter))
@@ -2223,6 +2256,7 @@ def register(linter):
     linter.register_checker(NameExceedsStandardCharacterLength(linter))
     linter.register_checker(DeleteOperationReturnStatement(linter))
     linter.register_checker(ClientMethodsHaveTracingDecorators(linter))
+    linter.register_checker(DoNotImportLegacySix(linter))
 
     # disabled by default, use pylint --enable=check-docstrings if you want to use it
     linter.register_checker(CheckDocstringParameters(linter))

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -2204,7 +2204,7 @@ class DoNotImportLegacySix(BaseChecker):
     priority = -1
     msgs = {
         "C4757": (
-            "Do not import the six package in your library. Six was used with python 3.6, which is no longer supported.",
+            "Do not import the six package in your library. Six was used to work with python2, which is no longer supported.",
             "do-not-import-legacy-six",
             "Do not import the six package in your library."
         ),

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3534,3 +3534,51 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
         )
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
+
+class TestDoNotImportLegacySix(pylint.testutils.CheckerTestCase):
+    """Test that we are blocking disallowed imports and allowing allowed imports."""
+    CHECKER_CLASS = checker.DoNotImportLegacySix
+
+    def test_disallowed_import_from(self):
+        """Check that illegal imports raise warnings"""
+        importfrom_node = astroid.extract_node("from six import with_metaclass")
+        with self.assertAddsMessages(
+                pylint.testutils.MessageTest(
+                    msg_id="do-not-import-legacy-six",
+                    line=1,
+                    node=importfrom_node,
+                    col_offset=0,
+                )
+        ):
+            self.checker.visit_importfrom(importfrom_node)
+
+    def test_disallowed_import(self):
+        """Check that illegal imports raise warnings"""
+        importfrom_node = astroid.extract_node("import six")
+        with self.assertAddsMessages(
+                pylint.testutils.MessageTest(
+                    msg_id="do-not-import-legacy-six",
+                    line=1,
+                    node=importfrom_node,
+                    col_offset=0,
+                )
+        ):
+            self.checker.visit_import(importfrom_node)
+
+    def test_allowed_imports(self):
+        """Check that allowed imports don't raise warnings."""
+        # import not in the blocked list.
+        importfrom_node = astroid.extract_node("from math import PI")
+        with self.assertNoMessages():
+            self.checker.visit_importfrom(importfrom_node)
+
+        # from import not in the blocked list.
+        importfrom_node = astroid.extract_node("from azure.core.pipeline import Pipeline")
+        with self.assertNoMessages():
+            self.checker.visit_importfrom(importfrom_node)
+
+        # Import HttpResponse, but from in `azure.core`.
+        importfrom_node = astroid.extract_node("from .. import HttpResponse")
+        importfrom_node.root().name = "azure.core"
+        with self.assertNoMessages():
+            self.checker.visit_importfrom(importfrom_node)


### PR DESCRIPTION
fixes #30954