### PR TITLE
Do not pull back locked issues/PRs in scheduled events queries

### DIFF
--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/ScheduledEventProcessing.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/ScheduledEventProcessing.cs
@@ -105,7 +105,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                                                                  IssueTypeQualifier.Issue,
                                                                  ItemState.Open,
                                                                  7, // more than 7 days old
-                                                                 null,
+                                                                 new List<IssueIsQualifier> { IssueIsQualifier.Unlocked },
                                                                  includeLabels);
                 // Need to stop updating when the we hit the limit but, until then, after exhausting every
                 // issue in the page returned, the query needs to be rerun to get the next page
@@ -185,7 +185,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                                                                  IssueTypeQualifier.Issue,
                                                                  ItemState.Open,
                                                                  14, // more than 14 days since last update
-                                                                 null,
+                                                                 new List<IssueIsQualifier> { IssueIsQualifier.Unlocked },
                                                                  includeLabels);
 
                 // Need to stop updating when the we hit the limit but, until then, after exhausting every
@@ -260,7 +260,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                                                                  IssueTypeQualifier.PullRequest,
                                                                  ItemState.Open,
                                                                  7, // more than 7 days old
-                                                                 null,
+                                                                 new List<IssueIsQualifier> { IssueIsQualifier.Unlocked },
                                                                  includeLabels);
                 // Need to stop updating when the we hit the limit but, until then, after exhausting every
                 // issue in the page returned, the query needs to be rerun to get the next page
@@ -339,7 +339,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                                                                  IssueTypeQualifier.PullRequest,
                                                                  ItemState.Open,
                                                                  60, // more than 60 days since last update
-                                                                 null,
+                                                                 new List<IssueIsQualifier> { IssueIsQualifier.Unlocked },
                                                                  null,
                                                                  excludeLabels);
                 // Need to stop updating when the we hit the limit but, until then, after exhausting every
@@ -424,7 +424,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                                                                  IssueTypeQualifier.Issue,
                                                                  ItemState.Open,
                                                                  7, // more than 7 days since the last update
-                                                                 null,
+                                                                 new List<IssueIsQualifier> { IssueIsQualifier.Unlocked },
                                                                  includeLabels,
                                                                  excludeLabels);
 


### PR DESCRIPTION
Locking the issues after 90 days is a brand new rule. It's also the end of a long path (requiring 90 days of inactivity after 7 and then 14 days of inactivity respectively). As it turns out, after an issue has been closed and locked someone can come back and reopen the issue but leave it locked. The problem with locked issues is comments can't be added which is what most of our scheduled tasks do. This was causing processing failures. The correct solution is to modify the query to omit locked issues from the results. It's also worth noting that these queries should have been omitting locked items from the query result to begin with. Notice that the LockClosedIssues only ever looks for issues that aren't already locked which is what the other queries should have been doing to begin with.