### PR TITLE
Add recording file location

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -37,7 +37,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await controller.Start();
 
             var value = httpContext.Response.Headers["x-recording-id"].ToString();
+            var path = httpContext.Response.Headers["x-recording-file-location"].ToString();
             Assert.NotNull(value);
+            Assert.NotNull(path);
             Assert.True(testRecordingHandler.PlaybackSessions.ContainsKey(value));
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -37,7 +37,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await controller.Start();
 
             var value = httpContext.Response.Headers["x-recording-id"].ToString();
-            var recordLocation = httpContext.Response.Headers["x-recording-f3le-location"].ToString();
+            var recordLocation = httpContext.Response.Headers["x-recording-file-location"].ToString();
             Assert.False(String.IsNullOrEmpty(value));
             Assert.False(String.IsNullOrEmpty(recordLocation));
             Assert.True(testRecordingHandler.PlaybackSessions.ContainsKey(value));

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -37,9 +37,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await controller.Start();
 
             var value = httpContext.Response.Headers["x-recording-id"].ToString();
-            var path = httpContext.Response.Headers["x-recording-file-location"].ToString();
-            Assert.NotNull(value);
-            Assert.NotNull(path);
+            var recordLocation = httpContext.Response.Headers["x-recording-f3le-location"].ToString();
+            Assert.False(String.IsNullOrEmpty(value));
+            Assert.False(String.IsNullOrEmpty(recordLocation));
             Assert.True(testRecordingHandler.PlaybackSessions.ContainsKey(value));
         }
 
@@ -76,8 +76,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await playbackController.Start();
 
             var value = playbackContext.Response.Headers["x-recording-id"].ToString();
-            Assert.NotNull(value);
-            // Ensure in-memory recordings don't return this header.
+            var recordLocation = playbackContext.Response.Headers["x-recording-file-location"].ToString();
+            Assert.False(String.IsNullOrEmpty(value));
             Assert.True(String.IsNullOrEmpty(recordLocation));
             Assert.True(testRecordingHandler.PlaybackSessions.ContainsKey(value));
             Assert.True(testRecordingHandler.InMemorySessions.Count() == 1);
@@ -210,7 +210,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await controller.Start();
 
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
-            Assert.NotNull(recordingId);
+            Assert.False(String.IsNullOrEmpty(recordingId));
             Assert.True(testRecordingHandler.PlaybackSessions.ContainsKey(recordingId));
             var entry = testRecordingHandler.PlaybackSessions[recordingId].Session.Entries[0];
             HttpRequest request = TestHelpers.CreateRequestFromEntry(entry);
@@ -245,7 +245,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await controller.Start();
 
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
-            Assert.NotNull(recordingId);
+            Assert.False(String.IsNullOrEmpty(recordingId));
             Assert.True(testRecordingHandler.PlaybackSessions.ContainsKey(recordingId));
             var entry = testRecordingHandler.PlaybackSessions[recordingId].Session.Entries[0];
             HttpRequest request = TestHelpers.CreateRequestFromEntry(entry);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -77,6 +77,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             var value = playbackContext.Response.Headers["x-recording-id"].ToString();
             Assert.NotNull(value);
+            // Ensure in-memory recordings don't return this header.
+            Assert.True(String.IsNullOrEmpty(recordLocation));
             Assert.True(testRecordingHandler.PlaybackSessions.ContainsKey(value));
             Assert.True(testRecordingHandler.InMemorySessions.Count() == 1);
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -35,7 +35,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             await controller.Start();
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
-            Assert.NotNull(recordingId);
+            Assert.False(string.IsNullOrEmpty(recordingId));
             Assert.True(testRecordingHandler.RecordingSessions.ContainsKey(recordingId));
         }
 
@@ -62,9 +62,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
         [Theory]
         [InlineData("recordings/TestStartRecordSimple_nosave.json", "request-response")]
-        [InlineData("recordings/TestStartRecordSimplé_nosave.json", "request-response")]
+        [InlineData("recordings/TestStartRecordSimplÃ©_nosave.json", "request-response")]
         [InlineData("recordings/TestStartRecordSimple.json", "")]
-        [InlineData("recordings/TestStartRecordSimplé.json", "")]
+        [InlineData("recordings/TestStartRecordSimplÃ©.json", "")]
         public async Task TestStopRecordingSimple(string targetFile, string additionalEntryModeHeader)
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -351,6 +351,8 @@ To start an individual test recording or playback, users will POST to a route on
 
 You will receive a recordingId in the reponse under header `x-recording-id`. This value should be included under header `x-recording-id` in all further requests.
 
+For playback, you will receive the location of the recording file (if it is on disk) in the header `x-recording-file-location`.
+
 ### Run your tests
 
 The implicit assumption about this proxy is that you as a dev have _some way_ to reroute your existing requests (with some header additions) to the test-proxy.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -372,7 +372,7 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 await RestoreAssetsJson(assetsPath, true);
                 var path = await GetRecordingPath(sessionId, assetsPath);
-
+                outgoingResponse.Headers.Add("x-recording-file-location", path);
                 if (!File.Exists(path))
                 {
                     throw new TestRecordingMismatchException($"Recording file path {path} does not exist.");


### PR DESCRIPTION
There are tests in the Java repo which parse the recording files for various reasons. Add a header on the response of playback start to share that location.

I also noticed that the tests were using the wrong assertion for headers, so I changed it to check for string empty/null. (Even null is unnecessary - could be a test against `String.Empty` if you prefer.)