### PR TITLE
[eng/common] Update-DocsMsMetadata.ps1 can fail the build on invalid packages

### DIFF
--- a/eng/common/pipelines/templates/steps/docsms-ensure-validation.yml
+++ b/eng/common/pipelines/templates/steps/docsms-ensure-validation.yml
@@ -13,8 +13,9 @@ steps:
         }
 
         Write-Host "All packages passed validation"
-    } catch {
-        Write-Error "Failed to parse DocsMsPackagesAllValid value '$value' as a boolean."
+    } catch [FormatException] {
+        Write-Host "Failed to parse DocsMsPackagesAllValid value '$value' as a boolean."
+        Write-Error $_
         exit 1
     }
   displayName: Check package validation results

--- a/eng/common/pipelines/templates/steps/docsms-ensure-validation.yml
+++ b/eng/common/pipelines/templates/steps/docsms-ensure-validation.yml
@@ -1,0 +1,20 @@
+steps:
+# Fail the build if any of the packages failed validation. Valid values are
+# "true" or "false" though some attempt is made to parse the boolean value from
+# the string.
+- pwsh: |
+    $value = '$(DocsMsPackagesAllValid)'
+
+    try {
+        $result = [System.Convert]::ToBoolean($value)
+        if (!$result) {
+            Write-Error "Some packages failed validation"
+            exit 1
+        }
+
+        Write-Host "All packages passed validation"
+    } catch {
+        Write-Error "Failed to parse DocsMsPackagesAllValid value '$value' as a boolean."
+        exit 1
+    }
+  displayName: Check package validation results

--- a/eng/common/pipelines/templates/steps/docsms-ensure-validation.yml
+++ b/eng/common/pipelines/templates/steps/docsms-ensure-validation.yml
@@ -1,21 +1,11 @@
 steps:
 # Fail the build if any of the packages failed validation. Valid values are
-# "true" or "false" though some attempt is made to parse the boolean value from
-# the string.
+# "true" or "false"
 - pwsh: |
-    $value = '$(DocsMsPackagesAllValid)'
-
-    try {
-        $result = [System.Convert]::ToBoolean($value)
-        if (!$result) {
-            Write-Error "Some packages failed validation"
-            exit 1
-        }
-
-        Write-Host "All packages passed validation"
-    } catch [FormatException] {
-        Write-Host "Failed to parse DocsMsPackagesAllValid value '$value' as a boolean."
-        Write-Error $_
-        exit 1
+    if ('$(DocsMsPackagesAllValid)' -eq 'true') {
+      Write-Host "All packages passed validation."
+    } else {
+      Write-Error "Some packages failed validation."
+      exit 1
     }
   displayName: Check package validation results

--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -237,7 +237,8 @@ foreach ($packageInfoLocation in $PackageInfoJsonLocations) {
     Write-Host "Validating the packages..."
 
     $packageInfo =  GetPackageInfoJson $packageInfoLocation
-    # "Validate-${Language}-DocMsPackages"
+    # This calls a function named "Validate-${Language}-DocMsPackages" 
+    # declared in common.ps1, implemented in Language-Settings.ps1
     $isValid = &$ValidateDocsMsPackagesFn `
       -PackageInfos $packageInfo `
       -PackageSourceOverride $PackageSourceOverride `


### PR DESCRIPTION
This PR adds the ability to fail nightly docs builds if validation fails. This capability is not active in this PR as these need to be individually wired up in `docindex.yml`

Example builds: 
* .NET 
    * https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2928742&view=results
    * https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2928743&view=results
* JS
    * https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2928744&view=results
    * https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2928746&view=results
* Python 
    * https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2928748&view=results
    * https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2928751&view=results

* Java
  * Example build showing expected failure when wired up -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=2928681&view=logs&s=cc1c0c38-0f79-5da2-c09f-847e3abdf9ce&j=bd8e6c55-eb1f-54f4-a38a-6cffe78ea5a1 