### PR TITLE
Fix the support of generating Example Model of DataFactoryKeyVaultReference type of DataFactoryElement

### DIFF
--- a/tools/sdk-testgen/packages/autorest.testmodeler/CHANGELOG.json
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/CHANGELOG.json
@@ -2,6 +2,18 @@
   "name": "@autorest/testmodeler",
   "entries": [
     {
+      "version": "2.6.1",
+      "tag": "@autorest/testmodeler_v2.6.1",
+      "date": "Fri, 21 Jul 2023 08:36:29 GMT",
+      "comments": {
+        "patch": [
+          {
+            "comment": "Support DataFactoryKeyVaultSecretReference of DataFactoryElement"
+          }
+        ]
+      }
+    },
+    {
       "version": "2.6.0",
       "tag": "@autorest/testmodeler_v2.6.0",
       "date": "Mon, 19 Jun 2023 08:50:04 GMT",

--- a/tools/sdk-testgen/packages/autorest.testmodeler/CHANGELOG.md
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Change Log - @autorest/testmodeler
 
-This log was last generated on Mon, 19 Jun 2023 08:50:04 GMT and should not be manually modified.
+This log was last generated on Fri, 21 Jul 2023 08:36:29 GMT and should not be manually modified.
+
+## 2.6.1
+Fri, 21 Jul 2023 08:36:29 GMT
+
+### Patches
+
+- Support DataFactoryKeyVaultSecretReference of DataFactoryElement
 
 ## 2.6.0
 Mon, 19 Jun 2023 08:50:04 GMT

--- a/tools/sdk-testgen/packages/autorest.testmodeler/package.json
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@autorest/testmodeler",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "description": "Autorest extension for testmodeler",
     "main": "dist/index.js",
     "scripts": {

--- a/tools/sdk-testgen/packages/autorest.testmodeler/src/core/model.ts
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/src/core/model.ts
@@ -234,7 +234,6 @@ export class ExampleValue {
     private static createSchemaForDfeObject(session: Session<TestCodeModel>, raw: any, dfeFormat: string): ObjectSchema | undefined {
         const dfeObjectType = 'type';
         const dfeObjectValue = 'value';
-        const dfeObjectTypeValues = ['Expression', 'SecureString', 'AzureKeyVaultSecretReference'];
         const dfeObjectSchemaPrefix = 'DataFactoryElement-';
 
         if (Object(raw) && raw[dfeObjectType] && raw[dfeObjectValue]) {
@@ -245,12 +244,14 @@ export class ExampleValue {
                 case 'SecureString':
                     r.addProperty(new Property(dfeObjectValue, '', new StringSchema(`${dfeFormat}-${dfeObjectValue}`, '')));
                     return r;
-                case 'AzureKeyVaultSecretReference':
-                    const valueSchema = session.model.schemas.objects.find((s) => s.language.default.name === "AzureKeyVaultSecretReference");
-                    if (!valueSchema)
+                case 'AzureKeyVaultSecretReference': {
+                    const valueSchema = session.model.schemas.objects.find((s) => s.language.default.name === `AzureKeyVaultSecretReference`);
+                    if (!valueSchema) {
                         throw new Error('Cant find schema for the value of DataFactoryElement KeyVaultSecret Reference');
+                    }
                     r.addProperty(new Property(dfeObjectValue, '', valueSchema));
                     return r;
+                }
                 default:
                     return undefined;
             }

--- a/tools/sdk-testgen/packages/autorest.testmodeler/src/core/model.ts
+++ b/tools/sdk-testgen/packages/autorest.testmodeler/src/core/model.ts
@@ -218,7 +218,7 @@ export class ExampleValue {
             const format = extensions[xMsFormat];
             const elementFormat = extensions[xMsFormatElementType];
 
-            const dfeObjSchema = ExampleValue.createSchemaForDfeObject(rawValue, format);
+            const dfeObjSchema = ExampleValue.createSchemaForDfeObject(session, rawValue, format);
             if (dfeObjSchema) {
                 return this.createInstance(session, rawValue, usedProperties, dfeObjSchema, language, undefined, searchDescents);
             } else {
@@ -231,17 +231,29 @@ export class ExampleValue {
         return instance;
     }
 
-    private static createSchemaForDfeObject(raw: any, dfeFormat: string): ObjectSchema | undefined {
+    private static createSchemaForDfeObject(session: Session<TestCodeModel>, raw: any, dfeFormat: string): ObjectSchema | undefined {
         const dfeObjectType = 'type';
         const dfeObjectValue = 'value';
         const dfeObjectTypeValues = ['Expression', 'SecureString', 'AzureKeyVaultSecretReference'];
         const dfeObjectSchemaPrefix = 'DataFactoryElement-';
 
-        if (Object(raw) && raw[dfeObjectType] && raw[dfeObjectValue] && dfeObjectTypeValues.includes(raw[dfeObjectType])) {
+        if (Object(raw) && raw[dfeObjectType] && raw[dfeObjectValue]) {
             const r = new ObjectSchema(dfeObjectSchemaPrefix + raw[dfeObjectType], '');
             r.addProperty(new Property(dfeObjectType, '', new StringSchema(`${dfeFormat}-${dfeObjectType}`, '')));
-            r.addProperty(new Property(dfeObjectValue, '', new StringSchema(`${dfeFormat}-${dfeObjectValue}`, '')));
-            return r;
+            switch (raw[dfeObjectType]) {
+                case 'Expression':
+                case 'SecureString':
+                    r.addProperty(new Property(dfeObjectValue, '', new StringSchema(`${dfeFormat}-${dfeObjectValue}`, '')));
+                    return r;
+                case 'AzureKeyVaultSecretReference':
+                    const valueSchema = session.model.schemas.objects.find((s) => s.language.default.name === "AzureKeyVaultSecretReference");
+                    if (!valueSchema)
+                        throw new Error('Cant find schema for the value of DataFactoryElement KeyVaultSecret Reference');
+                    r.addProperty(new Property(dfeObjectValue, '', valueSchema));
+                    return r;
+                default:
+                    return undefined;
+            }
         }
         return undefined;
     }


### PR DESCRIPTION
Fix the support of generating Example Model of DataFactoryKeyVaultReference type of DataFactoryElement according to the change in Azure.Core.Expression.DataFactory