### PR TITLE
Base64 encode path

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -351,7 +351,7 @@ To start an individual test recording or playback, users will POST to a route on
 
 You will receive a recordingId in the reponse under header `x-recording-id`. This value should be included under header `x-recording-id` in all further requests.
 
-For playback, you will receive the location of the recording file (if it is on disk) in the header `x-recording-file-location`.
+For playback, you will receive the location of the recording file (if it is on disk) in the header `x-base64-recording-file-location`. This will be a base64 encoded string, as it can contain characters that are not allowed in header values.
 
 ### Run your tests
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -372,7 +372,8 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 await RestoreAssetsJson(assetsPath, true);
                 var path = await GetRecordingPath(sessionId, assetsPath);
-                outgoingResponse.Headers.Add("x-recording-file-location", path);
+                var base64path = Convert.ToBase64String(Encoding.UTF8.GetBytes(path));
+                outgoingResponse.Headers.Add("x-base64-recording-file-location", base64path);
                 if (!File.Exists(path))
                 {
                     throw new TestRecordingMismatchException($"Recording file path {path} does not exist.");


### PR DESCRIPTION
Paths can have characters that are illegal for header values. Base64 encoding the path will prevent issues here.