### PR TITLE
Show model properties in response body

### DIFF
--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/Specs/Schema.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/Specs/Schema.cs
@@ -37,9 +37,9 @@ namespace SwaggerApiParser.Specs
             tableItems = this.TokenSerializePropertyIntoTableItems(context, this.tableItems);
             var tableRet = new List<CodeFileToken>();
             var tableRows = new List<CodeFileToken>();
-            if (tableItems.Count > 0)
+            foreach (var tableItem in this.tableItems)
             {
-                tableRows.AddRange(tableItems[0].TokenSerialize(context)); // Serialize only first row to avoid flattened properties
+                tableRows.AddRange(tableItem.TokenSerialize(context));
             }
             if (tableRows.Count > 0)
             {


### PR DESCRIPTION
Show the first level properties of Models in Swagger response without showing nested models.
Example https://apiviewuat.azurewebsites.net/Assemblies/Review/a71b14f76bb9432bb56d22b98d43e103#-billingSubscription.json-Definitions-MoveEligibilityResult