### PR TITLE
[mirror-repos] Mirror azure-rest-api-specs before other repos

### DIFF
--- a/eng/pipelines/mirror-repos.yml
+++ b/eng/pipelines/mirror-repos.yml
@@ -22,6 +22,41 @@ jobs:
               Azure/azure-rest-api-specs-pr:
               azure-sdk/azure-rest-api-specs:
 
+
+    - template: ./templates/steps/sync-repo-merge-branch.yml
+      parameters:
+        GH_TOKEN: $(azuresdk-github-pat)
+        Repos:
+
+          Azure/azure-rest-api-specs-pr:
+            Branch: main
+            TargetBranches:
+              RPSaaSMaster:
+                Theirs: '@("**")'
+                Ours: '@("specification", "custom-words.txt")'
+                Merge: '@("specification/common-types")'
+                AcceptTheirsForFinalMerge: true
+              RPSaaSDev:
+                Theirs: '@("**")'
+                Ours: '@("specification", "custom-words.txt")'
+                Merge: '@("specification/common-types")'
+                AcceptTheirsForFinalMerge: true
+              ARMCoreRPDev:
+                Theirs: '@("**")'
+                Ours: '@("specification", "custom-words.txt")'
+                Merge: '@("specification/common-types")'
+                AcceptTheirsForFinalMerge: true
+              InternalARMContracts:
+                Theirs: '@("**")'
+                Ours: '@("specification", "custom-words.txt")'
+                Merge: '@("specification/common-types")'
+                AcceptTheirsForFinalMerge: true
+
+    - template: ./templates/steps/sync-repo-branch.yml
+      parameters:
+        GH_TOKEN: $(azuresdk-github-pat)
+        Repos:
+
           Azure/azure-sdk-for-cpp:
             TargetRepos:
               Azure/azure-sdk-for-cpp-pr:
@@ -102,32 +137,3 @@ jobs:
               Azure/azure-sdk-for-python-pr:
               azure-sdk/azure-sdk-for-python:
               azure-sdk/azure-sdk-for-python-pr:
-
-    - template: ./templates/steps/sync-repo-merge-branch.yml
-      parameters:
-        GH_TOKEN: $(azuresdk-github-pat)
-        Repos:
-          Azure/azure-rest-api-specs-pr:
-            Branch: main
-            TargetBranches:
-              RPSaaSMaster:
-                Theirs: '@("**")'
-                Ours: '@("specification", "custom-words.txt")'
-                Merge: '@("specification/common-types")'
-                AcceptTheirsForFinalMerge: true
-              RPSaaSDev:
-                Theirs: '@("**")'
-                Ours: '@("specification", "custom-words.txt")'
-                Merge: '@("specification/common-types")'
-                AcceptTheirsForFinalMerge: true
-              ARMCoreRPDev:
-                Theirs: '@("**")'
-                Ours: '@("specification", "custom-words.txt")'
-                Merge: '@("specification/common-types")'
-                AcceptTheirsForFinalMerge: true
-              InternalARMContracts:
-                Theirs: '@("**")'
-                Ours: '@("specification", "custom-words.txt")'
-                Merge: '@("specification/common-types")'
-                AcceptTheirsForFinalMerge: true
-


### PR DESCRIPTION
- We are frequently manually running this pipeline to mirror azure-rest-api-specs
- Only changes order repos/branches are mirrored, no repos/branches were added or removed