### PR TITLE
Change logging category to include TestProxy

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
@@ -34,7 +34,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         {
             if (Logger == null && factory != null)
             {
-                Logger = factory.CreateLogger("TestProxy");
+                Logger = factory.CreateLogger("Azure.Sdk.Tools.TestProxy");
             }
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
@@ -1,15 +1,9 @@
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Http;
-using System.Threading.Tasks;
 using System.Text;
-using System.IO;
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Text.Json;
-using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Configuration;
 
 namespace Azure.Sdk.Tools.TestProxy.Common
 {
@@ -40,7 +34,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         {
             if (Logger == null && factory != null)
             {
-                Logger = factory.CreateLogger("DebugLogging");
+                Logger = factory.CreateLogger("TestProxy");
             }
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -269,12 +269,14 @@ test-proxy -- --urls "http://localhost:9000;https://localhost:9001"
 
 The test-proxy is integrated with the following environment variables.
 
-| Variable | Usage |
-|---|---|
-| `TEST_PROXY_FOLDER` | if command-line argument `storage-location` is not provided when invoking the proxy, this environment variable is also checked for a valid directory to use as test-proxy context. |
-| `Logging__LogLevel__Default` | Defaults to `Information`. Possible valid values are `Information`, `Warning`, `Error`, `Critical`.  |
+| Variable                       | Usage |
+|--------------------------------|---|
+| `TEST_PROXY_FOLDER`            | if command-line argument `storage-location` is not provided when invoking the proxy, this environment variable is also checked for a valid directory to use as test-proxy context. |
+| `Logging__LogLevel__TestProxy` | Defaults to `Information`. Possible valid values are <br/><br/>`Information`, `Warning`, `Error`, `Critical`.  |
 
-Both of the above variables can be set in the `docker` runtime by providing additional arguments EG: `docker run -e Logging__LogLevel__Default=Warning azsdkengsys.azurecr.io/engsys/test-proxy:latest`. For multiple environment variables, just use multiple `-e` provisions.
+Both of the above variables can be set in the `docker` runtime by providing additional arguments 
+EG: `docker run -e Logging__LogLevel__TestProxy=Warning azsdkengsys.azurecr.
+io/engsys/test-proxy:latest`. For multiple environment variables, just use multiple `-e` provisions.
 
 ## How do I use the test-proxy to get a recording?
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -272,7 +272,8 @@ The test-proxy is integrated with the following environment variables.
 | Variable                       | Usage                                                                                                                                                                              |
 |--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `TEST_PROXY_FOLDER`            | if command-line argument `storage-location` is not provided when invoking the proxy, this environment variable is also checked for a valid directory to use as test-proxy context. |
-| `Logging__LogLevel__TestProxy` | Defaults to `Information`. Possible valid values are <br/><br/>`Debug`, `Information`, `Warning`, `Error`, `Critical`.                                          |
+| `Logging__LogLevel__Default` | Defaults to `Information`. Possible valid values are <br/><br/>`Debug`, `Information`, `Warning`, `Error`, `Critical`.|
+| `Logging__LogLevel__Azure.Sdk.Tools.TestProxy`| Set to `Debug` to see request level logs emitted by the Test Proxy.|
 
 Both of the above variables can be set in the `docker` runtime by providing additional arguments 
 EG: `docker run -e Logging__LogLevel__TestProxy=Warning azsdkengsys.azurecr.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -275,9 +275,7 @@ The test-proxy is integrated with the following environment variables.
 | `Logging__LogLevel__Default` | Defaults to `Information`. Possible valid values are <br/><br/>`Debug`, `Information`, `Warning`, `Error`, `Critical`.|
 | `Logging__LogLevel__Azure.Sdk.Tools.TestProxy`| Set to `Debug` to see request level logs emitted by the Test Proxy.|
 
-Both of the above variables can be set in the `docker` runtime by providing additional arguments 
-EG: `docker run -e Logging__LogLevel__Default=Warning azsdkengsys.azurecr.
-io/engsys/test-proxy:latest`. For multiple environment variables, just use multiple `-e` provisions.
+Both of the above variables can be set in the `docker` runtime by providing additional arguments EG: `docker run -e Logging__LogLevel__Default=Warning azsdkengsys.azurecr.io/engsys/test-proxy:latest`. For multiple environment variables, just use multiple `-e` provisions.
 
 ## How do I use the test-proxy to get a recording?
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -272,7 +272,7 @@ The test-proxy is integrated with the following environment variables.
 | Variable                       | Usage                                                                                                                                                                              |
 |--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `TEST_PROXY_FOLDER`            | if command-line argument `storage-location` is not provided when invoking the proxy, this environment variable is also checked for a valid directory to use as test-proxy context. |
-| `Logging__LogLevel__Default` | Defaults to `Information`. Possible valid values are <br/><br/>`Debug`, `Information`, `Warning`, `Error`, `Critical`.|
+| `Logging__LogLevel__Default` | Defaults to `Information`. Possible valid values are <br/><br/>`Debug`, `Information`, `Warning`, `Error`, `Critical`.<br><br>Do not set for .NET test runs as it would cause the tests *themselves* to start emitting logs.|
 | `Logging__LogLevel__Azure.Sdk.Tools.TestProxy`| Set to `Debug` to see request level logs emitted by the Test Proxy.|
 
 Both of the above variables can be set in the `docker` runtime by providing additional arguments EG: `docker run -e Logging__LogLevel__Default=Warning azsdkengsys.azurecr.io/engsys/test-proxy:latest`. For multiple environment variables, just use multiple `-e` provisions.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -269,10 +269,10 @@ test-proxy -- --urls "http://localhost:9000;https://localhost:9001"
 
 The test-proxy is integrated with the following environment variables.
 
-| Variable                       | Usage |
-|--------------------------------|---|
+| Variable                       | Usage                                                                                                                                                                              |
+|--------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `TEST_PROXY_FOLDER`            | if command-line argument `storage-location` is not provided when invoking the proxy, this environment variable is also checked for a valid directory to use as test-proxy context. |
-| `Logging__LogLevel__TestProxy` | Defaults to `Information`. Possible valid values are <br/><br/>`Information`, `Warning`, `Error`, `Critical`.  |
+| `Logging__LogLevel__TestProxy` | Defaults to `Information`. Possible valid values are <br/><br/>`Debug`, `Information`, `Warning`, `Error`, `Critical`.                                          |
 
 Both of the above variables can be set in the `docker` runtime by providing additional arguments 
 EG: `docker run -e Logging__LogLevel__TestProxy=Warning azsdkengsys.azurecr.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -276,7 +276,7 @@ The test-proxy is integrated with the following environment variables.
 | `Logging__LogLevel__Azure.Sdk.Tools.TestProxy`| Set to `Debug` to see request level logs emitted by the Test Proxy.|
 
 Both of the above variables can be set in the `docker` runtime by providing additional arguments 
-EG: `docker run -e Logging__LogLevel__TestProxy=Warning azsdkengsys.azurecr.
+EG: `docker run -e Logging__LogLevel__Default=Warning azsdkengsys.azurecr.
 io/engsys/test-proxy:latest`. For multiple environment variables, just use multiple `-e` provisions.
 
 ## How do I use the test-proxy to get a recording?


### PR DESCRIPTION
This will allow users to set an env var Logging__LogLevel__Azure.Sdk.Tools.TestProxy = "Debug" instead of changing the Default or DebugLogging category. _Note changing Default will still work in the same way and I don't think we advertised "DebugLogging" to anyone so it hopefully won't break anyone._ However, changing the Default log level would break tests in .NET since it would cause tests to start emitting logs. 

By introducing a specific logging category (or more accurately renaming the specific logging category), we can let it still be configurable for users without requiring users to change the Default level.
