### PR TITLE
[Perf][Python] Don't install package in editable mode

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Python.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Python.cs
@@ -57,7 +57,7 @@ namespace Azure.Sdk.Tools.PerfAutomation
                 {
                     if (packageName == primaryPackage)
                     {
-                        await Util.RunAsync(pip, "install -e .", projectDirectory, outputBuilder: outputBuilder, errorBuilder: errorBuilder);
+                        await Util.RunAsync(pip, "install .", projectDirectory, outputBuilder: outputBuilder, errorBuilder: errorBuilder);
                     }
                     // TODO: Consider installing source versions of non-primary packages.  Would require finding package in source tree.
                     //       So far, this seems unnecessary, since dev-requirements.txt usually includes core.


### PR DESCRIPTION
The package doesn't need to be in editable mode, and we found that this can cause issues when dev dependencies that share the same namespace are installed alongside the main package.