### PR TITLE
Update Exception Logging

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -24,6 +24,7 @@ using Azure.Sdk.Tools.TestProxy.CommandOptions;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using System.Text.Json;
+using Microsoft.Extensions.Logging.Console;
 
 namespace Azure.Sdk.Tools.TestProxy
 {
@@ -147,9 +148,10 @@ namespace Azure.Sdk.Tools.TestProxy
                     {
                         loggingBuilder.ClearProviders();
                         loggingBuilder.AddConfiguration(hostBuilder.Configuration.GetSection("Logging"));
-                        loggingBuilder.AddSimpleConsole(formatterOptions =>
+                        loggingBuilder.AddConsole(options =>
                         {
-                            formatterOptions.TimestampFormat = "[HH:mm:ss] ";
+                            options.LogToStandardErrorThreshold = LogLevel.Error;
+                            options.TimestampFormat = "";
                         });
                         loggingBuilder.AddDebug();
                         loggingBuilder.AddEventSourceLogger();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -21,10 +21,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.CommandLine;
 using Azure.Sdk.Tools.TestProxy.CommandOptions;
-using Microsoft.AspNetCore.Identity;
-using Microsoft.CodeAnalysis.VisualBasic.Syntax;
 using System.Text.Json;
 using Microsoft.Extensions.Logging.Console;
+using Microsoft.Extensions.Options;
 
 namespace Azure.Sdk.Tools.TestProxy
 {
@@ -151,7 +150,9 @@ namespace Azure.Sdk.Tools.TestProxy
                         loggingBuilder.AddConsole(options =>
                         {
                             options.LogToStandardErrorThreshold = LogLevel.Error;
-                            options.TimestampFormat = "";
+                        }).AddSimpleConsole(options =>
+                        {
+                            options.TimestampFormat = "[HH:mm:ss] ";
                         });
                         loggingBuilder.AddDebug();
                         loggingBuilder.AddEventSourceLogger();


### PR DESCRIPTION
Lower the StdErrErrorThreshold to `Error` so that `Logging.Error` show up on stderr.

Resolves #6563 so that the .NET framework will actually see the stderr output when collecting it for the error.