### PR TITLE
Enable ManualIssueTriage for azure-sdk-tools

### DIFF
--- a/.github/event-processor.config
+++ b/.github/event-processor.config
@@ -1,6 +1,6 @@
 {
   "InitialIssueTriage": "On",
-  "ManualIssueTriage": "Off",
+  "ManualIssueTriage": "On",
   "ServiceAttention": "Off",
   "CXPAttention": "Off",
   "ManualTriageAfterExternalAssignment": "Off",


### PR DESCRIPTION
Enable the ManualIssueTriage rule for azure-sdk-tools.