### PR TITLE
Create tool tsp-client

### DIFF
--- a/tools/tsp-client/.gitignore
+++ b/tools/tsp-client/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+*.env
+dist
+types
+temp

--- a/tools/tsp-client/.prettierrc.json
+++ b/tools/tsp-client/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "arrowParens": "always",
+  "bracketSpacing": true,
+  "endOfLine": "lf",
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": false,
+  "tabWidth": 2
+}

--- a/tools/tsp-client/README.md
+++ b/tools/tsp-client/README.md
@@ -1,0 +1,46 @@
+# tsp-client
+
+A simple command line tool for generating TypeSpec clients.
+
+### Usage
+```
+tsp-client [options] <outputDir>
+```
+
+## Options
+
+### <outputDir> (required)
+
+The only positional parameter. Specifies the directory to pass to the language emitter.
+
+### --emitter, -e (required)
+
+Specifies which language emitter to use. Current choices are "csharp", "java", "javascript", "python", "openapi".
+
+Aliases are also available, such as cs, js, py, and ts.
+
+### --mainFile, -m
+
+Used when specifying a URL to a TSP file directly. Not required if using a `tsp-location.yaml`
+
+### --debug, -d
+
+Enables verbose debug logging to the console.
+
+### --no-cleanup
+
+Disables automatic cleanup of the temporary directory where the TSP is written and referenced npm modules are installed.
+
+## Examples
+
+Generating from a TSP file to a particular directory:
+
+```
+tsp-client -e openapi -m https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cognitiveservices/OpenAI.Inference/main.tsp ./temp
+```
+
+Generating in a directory that contains a `tsp-location.yaml`:
+
+```
+tsp-client sdk/openai/openai
+```

--- a/tools/tsp-client/cmd/tsp-client.js
+++ b/tools/tsp-client/cmd/tsp-client.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+await import("../dist/index.js");

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -10,7 +10,7 @@
     "example": "npx ts-node src/index.ts -e openapi -m https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cognitiveservices/OpenAI.Inference/main.tsp ./temp",
     "test": "mocha"
   },
-  "author": "Jeff Fisher <jeffish@microsoft.com>",
+  "author": "Microsoft Corporation",
   "license": "MIT",
   "type": "module",
   "engines": {

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -25,6 +25,7 @@
     "@types/chai": "^4.3.5",
     "@types/mocha": "^10.0.1",
     "@types/node": "^20.4.8",
+    "@types/prompt-sync": "^4.2.1",
     "chai": "^4.3.7",
     "mocha": "^10.2.0",
     "prettier": "^3.0.1",
@@ -38,7 +39,7 @@
     "yaml": "^2.3.1"
   },
   "peerDependencies": {
-    "@typespec/compiler": "^0.47.1"
+    "@typespec/compiler": ">=0.47.1 <1.0.0"
   },
   "mocha": {
     "extension": [

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,0 +1,50 @@
+{
+  "name": "@azure-tools/tsp-client",
+  "version": "1.0.0",
+  "description": "A tool to generate Azure SDKs from TypeSpec",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "npm run clean && npm run build:tsc",
+    "build:tsc": "tsc",
+    "clean": "rimraf ./dist ./types",
+    "example": "npx ts-node src/index.ts -e openapi -m https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cognitiveservices/OpenAI.Inference/main.tsp ./temp",
+    "test": "mocha"
+  },
+  "author": "Jeff Fisher <jeffish@microsoft.com>",
+  "license": "MIT",
+  "type": "module",
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "bin": "cmd/tsp-client.js",
+  "files": [
+    "dist",
+    "cmd/tsp-client.js"
+  ],
+  "devDependencies": {
+    "@types/chai": "^4.3.5",
+    "@types/mocha": "^10.0.1",
+    "@types/node": "^20.4.8",
+    "chai": "^4.3.7",
+    "mocha": "^10.2.0",
+    "prettier": "^3.0.1",
+    "rimraf": "^5.0.1",
+    "ts-node": "^10.9.1",
+    "typescript": "^5.1.6"
+  },
+  "dependencies": {
+    "@azure/core-rest-pipeline": "^1.12.0",
+    "chalk": "^5.3.0",
+    "yaml": "^2.3.1"
+  },
+  "peerDependencies": {
+    "@typespec/compiler": "^0.47.1"
+  },
+  "mocha": {
+    "extension": [
+      "ts"
+    ],
+    "spec": "test/**/*.spec.ts",
+    "loader": "ts-node/esm"
+  }
+}

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@azure-tools/tsp-client",
-  "version": "1.0.0",
+  "version": "0.0.1",
+  "private": "true",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "scripts": {
@@ -16,7 +17,9 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "bin": "cmd/tsp-client.js",
+  "bin": {
+    "tsp-client": "cmd/tsp-client.js"
+  },
   "files": [
     "dist",
     "cmd/tsp-client.js"

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -36,10 +36,11 @@
   "dependencies": {
     "@azure/core-rest-pipeline": "^1.12.0",
     "chalk": "^5.3.0",
+    "prompt-sync": "^4.2.0",
     "yaml": "^2.3.1"
   },
   "peerDependencies": {
-    "@typespec/compiler": ">=0.47.1 <1.0.0"
+    "@typespec/compiler": ">=0.48.1 <1.0.0"
   },
   "mocha": {
     "extension": [

--- a/tools/tsp-client/src/fileTree.ts
+++ b/tools/tsp-client/src/fileTree.ts
@@ -1,0 +1,79 @@
+export function createFileTree(url: string): FileTree {
+  const rootUrl = url;
+  const fileMap = new Map<string, string>();
+
+  function longestCommonPrefix(a: string, b: string): string {
+    if (a === b) {
+      return a;
+    }
+    let lastCommonSlash = -1;
+    for (let i = 0; i < Math.min(a.length, b.length); i++) {
+      if (a[i] === b[i]) {
+        if (a[i] === "/") {
+          lastCommonSlash = i;
+        }
+      } else {
+        break;
+      }
+    }
+    if (lastCommonSlash === -1) {
+      throw new Error("no common prefix found");
+    }
+    return a.slice(0, lastCommonSlash + 1);
+  }
+
+  function findCommonRoot(): string {
+    let candidate = "";
+    for (const fileUrl of fileMap.keys()) {
+      const lastSlashIndex = fileUrl.lastIndexOf("/");
+      const dirUrl = fileUrl.slice(0, lastSlashIndex + 1);
+      if (!candidate) {
+        candidate = dirUrl;
+      } else {
+        candidate = longestCommonPrefix(candidate, dirUrl);
+      }
+    }
+    return candidate;
+  }
+
+  return {
+    addFile(url: string, contents: string): void {
+      if (fileMap.has(url)) {
+        throw new Error(`file already parsed: ${url}`);
+      }
+      fileMap.set(url, contents);
+    },
+    async createTree(): Promise<FileTreeResult> {
+      const outputFiles = new Map<string, string>();
+      // calculate the highest common root
+      const root = findCommonRoot();
+      let mainFilePath = "";
+      for (const [url, contents] of fileMap.entries()) {
+        const relativePath = url.slice(root.length);
+        outputFiles.set(relativePath, contents);
+        if (url === rootUrl) {
+          mainFilePath = relativePath;
+        }
+      }
+      if (!mainFilePath) {
+        throw new RangeError(
+          `Main file ${rootUrl} not added to FileTree. Did you forget to add it?`,
+        );
+      }
+      return {
+        mainFilePath,
+        files: outputFiles,
+      };
+    },
+  };
+}
+
+export interface FileTreeResult {
+  mainFilePath: string;
+  files: Map<string, string>;
+}
+
+export interface FileTree {
+  addFile(url: string, contents: string): void;
+  createTree(): Promise<FileTreeResult>;
+}

--- a/tools/tsp-client/src/fs.ts
+++ b/tools/tsp-client/src/fs.ts
@@ -65,14 +65,15 @@ export async function readTspLocation(rootDir: string): Promise<[string, string,
       }
       return [ directory, commit, repo, additionalDirectories ];
     }
+    throw new Error("Could not find tsp-location.yaml");
   } catch (e) {
     Logger.error(`Error reading tsp-location.yaml: ${e}`);
+    throw e;
   }
-  throw new Error("Could not find tsp-location.yaml");
 }
 
 
-export async function getEmitterFromRepoConfig(emitterPath: string): Promise<string | undefined> {
+export async function getEmitterFromRepoConfig(emitterPath: string): Promise<string> {
   await access(emitterPath);
   const data = await readFile(emitterPath, 'utf8');
   const obj = JSON.parse(data);

--- a/tools/tsp-client/src/fs.ts
+++ b/tools/tsp-client/src/fs.ts
@@ -82,8 +82,10 @@ export async function getEmitterFromRepoConfig(emitterPath: string): Promise<str
   const languages: string[] = ["@azure-tools/typespec-", "@typespec/openapi3"];
   for (const lang of languages) {
     const emitter = Object.keys(obj.dependencies).find((dep: string) => dep.startsWith(lang));
-    Logger.info(`Found emitter package ${emitter}`);
-    return emitter;
+    if (emitter) {
+      Logger.info(`Found emitter package ${emitter}`);
+      return emitter;
+    }
   }
   throw new Error("Could not find emitter package");
 }

--- a/tools/tsp-client/src/fs.ts
+++ b/tools/tsp-client/src/fs.ts
@@ -1,0 +1,49 @@
+import { mkdir, rm, writeFile, mkdtemp, stat, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { FileTreeResult } from "./fileTree.js";
+import * as path from "node:path";
+import { Logger } from "./log.js";
+import { parse as parseYaml } from "yaml";
+
+export async function ensureDirectory(path: string) {
+  await mkdir(path, { recursive: true });
+}
+
+export async function removeDirectory(path: string) {
+  await rm(path, { recursive: true, force: true });
+}
+
+export async function createTempDirectory(): Promise<string> {
+  const tempRoot = await mkdtemp(path.join(tmpdir(), "tsp-client-"));
+  Logger.debug(`Created temporary working directory ${tempRoot}`);
+  return tempRoot;
+}
+
+export async function writeFileTree(rootDir: string, files: FileTreeResult["files"]) {
+  for (const [relativeFilePath, contents] of files) {
+    const filePath = path.join(rootDir, relativeFilePath);
+    await ensureDirectory(path.dirname(filePath));
+    Logger.debug(`writing ${filePath}`);
+    await writeFile(filePath, contents);
+  }
+}
+
+export async function tryReadTspLocation(rootDir: string): Promise<string | undefined> {
+  try {
+    const yamlPath = path.resolve(rootDir, "tsp-location.yaml");
+    const fileStat = await stat(yamlPath);
+    if (fileStat.isFile()) {
+      const fileContents = await readFile(yamlPath, "utf8");
+      const locationYaml = parseYaml(fileContents);
+      const { directory, commit, repo } = locationYaml;
+      if (!directory || !commit || !repo) {
+        throw new Error("Invalid tsp-location.yaml");
+      }
+      // make GitHub URL
+      return `https://raw.githubusercontent.com/${repo}/${commit}/${directory}/`;
+    }
+  } catch (e) {
+    Logger.error(`Error reading tsp-location.yaml: ${e}`);
+  }
+  return undefined;
+}

--- a/tools/tsp-client/src/git.ts
+++ b/tools/tsp-client/src/git.ts
@@ -1,0 +1,82 @@
+import { execSync, spawn } from "child_process";
+
+export function getRepoRoot(): string {
+    return execSync('git rev-parse --show-toplevel').toString().trim();
+}
+  
+export async function cloneRepo(rootUrl: string, cloneDir: string, repo: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const git = spawn("git", ["clone", "--no-checkout", "--filter=tree:0", repo, cloneDir], {
+        cwd: rootUrl,
+        stdio: "inherit",
+      });
+      git.once("exit", (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`git clone failed exited with code ${code}`));
+        }
+      });
+      git.once("error", (err) => {
+        reject(new Error(`git clone failed with error: ${err}`));
+      });
+    });
+  }
+  
+  
+  export async function sparseCheckout(cloneDir: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const git = spawn("git", ["sparse-checkout", "init"], {
+        cwd: cloneDir,
+        stdio: "inherit",
+      });
+      git.once("exit", (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`git sparse-checkout failed exited with code ${code}`));
+        }
+      });
+      git.once("error", (err) => {
+        reject(new Error(`git sparse-checkout failed with error: ${err}`));
+      });
+    });
+  }
+  
+  export async function addSpecFiles(cloneDir: string, subDir: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const git = spawn("git", ["sparse-checkout", "add", subDir], {
+        cwd: cloneDir,
+        stdio: "inherit",
+      });
+      git.once("exit", (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`git sparse-checkout add failed exited with code ${code}`));
+        }
+      });
+      git.once("error", (err) => {
+        reject(new Error(`git sparse-checkout add failed with error: ${err}`));
+      });
+    });
+  }
+  
+  export async function checkoutCommit(cloneDir: string, commit: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      const git = spawn("git", ["checkout", commit], {
+        cwd: cloneDir,
+        stdio: "inherit",
+      });
+      git.once("exit", (code) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          reject(new Error(`git checkout failed exited with code ${code}`));
+        }
+      });
+      git.once("error", (err) => {
+        reject(new Error(`git checkout failed with error: ${err}`));
+      });
+    });
+  }

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -29,7 +29,7 @@ async function sdkInit(
   }): Promise<string> {
   if (isUrl) {
     // URL scenario
-    const resolvedConfigUrl = await resolveTspConfigUrl(config);
+    const resolvedConfigUrl = resolveTspConfigUrl(config);
     Logger.debug(`Resolved config url: ${resolvedConfigUrl.resolvedUrl}`)
     const tspConfig = await fetch(resolvedConfigUrl.resolvedUrl);
     const configYaml = parseYaml(tspConfig);
@@ -257,7 +257,7 @@ async function main() {
         }
         if (options.tspConfig) {
           let [ directory, commit, repo, additionalDirectories ] = await readTspLocation(rootUrl);
-          let tspConfig = await resolveTspConfigUrl(options.tspConfig);
+          let tspConfig = resolveTspConfigUrl(options.tspConfig);
           commit = tspConfig.commit ?? commit;
           repo = tspConfig.repo ?? repo;
           await writeFile(path.join(rootUrl, "tsp-location.yaml"), `directory: ${directory}\ncommit: ${commit}\nrepo: ${repo}\nadditionalDirectories: ${additionalDirectories}`);

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -1,0 +1,104 @@
+import * as path from "node:path";
+
+import { createPackageJson, installDependencies } from "./npm.js";
+import { createTempDirectory, removeDirectory, tryReadTspLocation, writeFileTree } from "./fs.js";
+import { Logger, printBanner, enableDebug, printVersion } from "./log.js";
+import { doesFileExist, downloadTsp, isValidUrl, rewriteGitHubUrl } from "./network.js";
+import { compileTsp } from "./typespec.js";
+import { getEmitterPackage } from "./languageSettings.js";
+import { getOptions } from "./options.js";
+
+async function discoverMainFileUrl(outputDir: string): Promise<string> {
+  const tspUrl = await tryReadTspLocation(outputDir);
+  if (!tspUrl) {
+    throw new Error("No tsp-location.yaml found, and no main file specified");
+  }
+  Logger.debug(`Using base url from  tsp-location.yaml: ${tspUrl}`);
+  for (const mainFile of ["client.tsp", "main.tsp"]) {
+    let url = new URL(mainFile, tspUrl).toString();
+    Logger.debug(`Checking for file: ${url}`);
+    if (await doesFileExist(url)) {
+      Logger.debug(`Found main file: ${url}`);
+      return url;
+    }
+  }
+  throw new Error(`No main.tsp or client.tsp found for base url ${tspUrl}`);
+}
+
+async function downloadAndCompile({
+  rootUrl,
+  emitter,
+  noCleanup,
+  emitterOutputPath,
+}: {
+  rootUrl: string;
+  emitter: string;
+  noCleanup: boolean;
+  emitterOutputPath: string;
+}) {
+  const { moduleImports, fileTree } = await downloadTsp(rootUrl);
+  const { mainFilePath, files } = await fileTree.createTree();
+  const tempRoot = await createTempDirectory();
+  const srcDir = path.join(tempRoot, "src");
+  await writeFileTree(srcDir, files);
+
+  const emitterPackage = getEmitterPackage(emitter);
+  moduleImports.add(emitterPackage);
+  await createPackageJson(tempRoot, moduleImports);
+  Logger.info("Installing dependencies from npm...");
+  await installDependencies(tempRoot);
+  const resolvedMainFilePath = path.join(srcDir, mainFilePath);
+  // todo: allow extra emitter options for debugging
+  Logger.info(`Compiling tsp using ${emitterPackage}...`);
+  await compileTsp({
+    language: emitter,
+    emitterPackage,
+    resolvedMainFilePath,
+    tempRoot,
+    emitterOutputPath,
+  });
+
+  if (noCleanup) {
+    Logger.debug(`Skipping cleanup of temp directory: ${tempRoot}`);
+  } else {
+    Logger.debug("Cleaning up temp directory");
+    await removeDirectory(tempRoot);
+  }
+}
+
+async function main() {
+  const options = await getOptions();
+  if (options.debug) {
+    enableDebug();
+  }
+  printBanner();
+  await printVersion();
+  let rootUrl: string;
+  if (options.mainFile) {
+    Logger.debug(`Using main file: ${options.mainFile}`);
+    if (!isValidUrl(options.mainFile)) {
+      Logger.error(`Invalid url passed to command: ${options.mainFile}`);
+      return;
+    }
+    if (!options.mainFile.endsWith(".tsp")) {
+      Logger.error(`Expected url to end in 'tsp': ${options.mainFile}`);
+      return;
+    }
+    rootUrl = rewriteGitHubUrl(options.mainFile);
+  } else {
+    // check for tsp-location.yaml
+    rootUrl = await discoverMainFileUrl(options.outputDir);
+  }
+
+  await downloadAndCompile({
+    rootUrl,
+    emitter: options.emitter,
+    noCleanup: options.noCleanup,
+    emitterOutputPath: options.outputDir,
+  });
+}
+
+main().catch((err) => {
+  Logger.error(err);
+  process.exit(1);
+});

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -39,18 +39,12 @@ async function sdkInit(
         Logger.error(`Parameter service-dir is not defined correctly in tspconfig.yaml. Please refer to https://github.com/Azure/azure-rest-api-specs/blob/main/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml for the right schema.`)
       }
       Logger.debug(`Service directory: ${serviceDir}`)
-      let additionalDirs: string[] = [];
-      if (configYaml["parameters"]["dependencies"] && configYaml["parameters"]["dependencies"]["additionalDirectories"]) {
-        additionalDirs = configYaml["parameters"]["dependencies"]["additionalDirectories"];
-      }
-      let packageDir;
-      if (configYaml["options"][emitter] && configYaml["options"][emitter]["package-dir"]) {
-        packageDir = configYaml["options"][emitter]["package-dir"];
-      }
-      if (packageDir === undefined) {
+      const additionalDirs: string[] = configYaml?.parameters?.dependencies?.additionalDirectories ?? [];
+      const packageDir: string | undefined = configYaml?.options?.[emitter]?.["package-dir"];
+      if (!packageDir) {
         Logger.error(`Missing package-dir in ${emitter} options of tspconfig.yaml. Please refer to https://github.com/Azure/azure-rest-api-specs/blob/main/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml for the right schema.`);
       }
-      const newPackageDir = path.join(outputDir, serviceDir, packageDir)
+      const newPackageDir = path.join(outputDir, serviceDir, packageDir!)
       await mkdir(newPackageDir, { recursive: true });
       await writeFile(
         path.join(newPackageDir, "tsp-location.yaml"),

--- a/tools/tsp-client/src/languageSettings.ts
+++ b/tools/tsp-client/src/languageSettings.ts
@@ -1,0 +1,61 @@
+import { join } from "node:path";
+
+interface LanguageEmitterSettings {
+  emitterName: string;
+  emitterOptions: Record<string, string>;
+}
+
+export const knownLanguages = ["csharp", "java", "javascript", "python", "openapi"] as const;
+export type KnownLanguage = (typeof knownLanguages)[number];
+export const languageAliases: Record<string, KnownLanguage> = {
+  cs: "csharp",
+  js: "javascript",
+  ts: "javascript",
+  typescript: "javascript",
+  py: "python",
+};
+
+export function getEmitterPackage(language: string): string {
+  if (language in languageEmitterSettings) {
+    return languageEmitterSettings[language as KnownLanguage].emitterName;
+  }
+  throw new Error(`Unknown language ${language}`);
+}
+
+export function getEmitterOutputPath(language: string, projectDirectory: string): string {
+  if (language === "csharp") {
+    return join(projectDirectory, "src");
+  }
+  return projectDirectory;
+}
+
+const languageEmitterSettings: Record<KnownLanguage, LanguageEmitterSettings> = {
+  csharp: {
+    emitterName: "@azure-tools/typespec-csharp",
+    emitterOptions: {
+      "emitter-output-dir": "$projectDirectory/src",
+    },
+  },
+  java: {
+    emitterName: "@azure-tools/typespec-java",
+    emitterOptions: {
+      "emitter-output-dir": "$projectDirectory",
+    },
+  },
+  javascript: {
+    emitterName: "@azure-tools/typespec-ts",
+    emitterOptions: {
+      "emitter-output-dir": "$projectDirectory",
+    },
+  },
+  python: {
+    emitterName: "@azure-tools/typespec-python",
+    emitterOptions: {
+      "emitter-output-dir": "$projectDirectory",
+    },
+  },
+  openapi: {
+    emitterName: "@typespec/openapi3",
+    emitterOptions: {},
+  },
+};

--- a/tools/tsp-client/src/log.ts
+++ b/tools/tsp-client/src/log.ts
@@ -1,0 +1,82 @@
+import chalk from "chalk";
+import { getPackageVersion } from "./npm.js";
+
+const logSink = {
+  log: console.log,
+  info: console.info,
+  warn: console.warn,
+  error: console.error,
+  debug: (..._args: unknown[]) => {
+    /* no-op */
+  },
+};
+
+export interface Logger {
+  info(message: string): void;
+  warn(message: string): void;
+  error(message: string): void;
+  debug(message: string): void;
+  success(message: string): void;
+  (message: string): void;
+}
+
+function createLogger(): Logger {
+  const direct = (...values: unknown[]) => logSink.log(chalk.reset(...values));
+  direct.info = (...values: unknown[]) => logSink.info(chalk.blueBright(...values));
+  direct.warn = (...values: unknown[]) => logSink.warn(chalk.yellow(...values));
+  direct.error = (...values: unknown[]) => logSink.error(chalk.red(...values));
+  direct.debug = (...values: unknown[]) => logSink.debug(chalk.magenta(...values));
+  direct.success = (...values: unknown[]) => logSink.info(chalk.green(...values));
+
+  return direct;
+}
+
+export function enableDebug(): void {
+  logSink.debug = console.debug;
+}
+
+export const Logger = createLogger();
+
+const bannerText = `
+888                                      888 d8b                   888    
+888                                      888 Y8P                   888    
+888                                      888                       888    
+888888 .d8888b  88888b.          .d8888b 888 888  .d88b.  88888b.  888888 
+888    88K      888 "88b        d88P"    888 888 d8P  Y8b 888 "88b 888    
+888    "Y8888b. 888  888 888888 888      888 888 88888888 888  888 888    
+Y88b.       X88 888 d88P        Y88b.    888 888 Y8b.     888  888 Y88b.  
+ "Y888  88888P' 88888P"          "Y8888P 888 888  "Y8888  888  888  "Y888 
+                888                                                       
+                888                                                       
+                888                                                       
+`;
+export function printBanner() {
+  Logger.info(bannerText);
+}
+
+const usageText = `
+Usage: tsp-client [options] <outputDir>
+
+Generate from a tsp file using --mainFile or use tsp-location.yaml inside 
+the outputDir.
+
+Positionals:
+  outputDir  The output directory for the emitter                       [string]
+
+Options:
+  -d, --debug      Enable debug logging                                [boolean]
+  -e, --emitter    Which language emitter to use             [required] [string]
+                  [choices: "csharp", "java", "javascript", "python", "openapi"]
+  -m, --mainFile   The url of the main tsp file to generate from        [string]
+      --noCleanup  Don't clean up the temp directory after generation  [boolean]
+  -h, --help       Show help                                           [boolean]
+  -v, --version    Show version number                                 [boolean]
+`;
+export function printUsage() {
+  Logger(usageText);
+}
+
+export async function printVersion() {
+  const version = await getPackageVersion();
+  Logger(`tsp-client version: ${version}`);
+}

--- a/tools/tsp-client/src/log.ts
+++ b/tools/tsp-client/src/log.ts
@@ -55,13 +55,16 @@ export function printBanner() {
 }
 
 const usageText = `
-Usage: tsp-client [options] <outputDir>
+Usage: tsp-client [options]
 
 Generate from a tsp file using --mainFile or use tsp-location.yaml inside 
 the outputDir.
 
 Positionals:
-  outputDir  The output directory for the emitter                       [string]
+  init        Initialize the SDK project folder from a tspconfig.yaml   [string]
+  sync        Sync tsp files using tsp-location.yaml                    [string]
+  generate    Generate from a tsp project                               [string]
+  update      Sync and generate from a tsp project                      [string]
 
 Options:
   -d, --debug      Enable debug logging                                [boolean]
@@ -71,6 +74,7 @@ Options:
       --noCleanup  Don't clean up the temp directory after generation  [boolean]
   -h, --help       Show help                                           [boolean]
   -v, --version    Show version number                                 [boolean]
+  -o, --outputDir  The output directory for the emitter
 `;
 export function printUsage() {
   Logger(usageText);

--- a/tools/tsp-client/src/network.ts
+++ b/tools/tsp-client/src/network.ts
@@ -5,7 +5,7 @@ import { Logger } from "./log.js";
 
 const httpClient = createDefaultHttpClient();
 
-async function fetch(url: string, method: "GET" | "HEAD" = "GET"): Promise<string> {
+export async function fetch(url: string, method: "GET" | "HEAD" = "GET"): Promise<string> {
   const result = await httpClient.sendRequest(createPipelineRequest({ url, method }));
   if (result.status !== 200) {
     throw new Error(`failed to fetch ${url}: ${result.status}`);

--- a/tools/tsp-client/src/network.ts
+++ b/tools/tsp-client/src/network.ts
@@ -1,0 +1,92 @@
+import { createDefaultHttpClient, createPipelineRequest } from "@azure/core-rest-pipeline";
+import { createFileTree } from "./fileTree.js";
+import { resolveImports } from "./typespec.js";
+import { Logger } from "./log.js";
+
+const httpClient = createDefaultHttpClient();
+
+async function fetch(url: string, method: "GET" | "HEAD" = "GET"): Promise<string> {
+  const result = await httpClient.sendRequest(createPipelineRequest({ url, method }));
+  if (result.status !== 200) {
+    throw new Error(`failed to fetch ${url}: ${result.status}`);
+  }
+  return String(result.bodyAsText);
+}
+
+export function isValidUrl(url: string) {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function doesFileExist(url: string): Promise<boolean> {
+  return fetch(url, "HEAD")
+    .then(() => true)
+    .catch(() => false);
+}
+
+export function rewriteGitHubUrl(url: string): string {
+  if (url.includes("github.com")) {
+    const result = url.replace("github.com", "raw.githubusercontent.com");
+    Logger.debug(`rewriting github url to direct link: ${result}`);
+    return result;
+  }
+  return url;
+}
+
+export async function downloadTsp(rootUrl: string) {
+  const seenFiles = new Set<string>();
+  const moduleImports = new Set<string>();
+  // fetch the root file
+  const filesToProcess = [rootUrl];
+  seenFiles.add(rootUrl);
+  const fileTree = createFileTree(rootUrl);
+
+  while (filesToProcess.length > 0) {
+    const url = filesToProcess.shift()!;
+    const sourceFile = await fetch(url);
+    fileTree.addFile(url, sourceFile);
+    // process imports, fetching any relatively referenced files
+    const imports = await resolveImports(sourceFile);
+    for (const fileImport of imports) {
+      // Check if the module name is referencing a path(./foo, /foo, file:/foo)
+      if (/^(?:\.\.?(?:\/|$)|\/|([A-Za-z]:)?[/\\])/.test(fileImport)) {
+        if (fileImport.startsWith("file:")) {
+          throw new Error(`file protocol imports are not supported: ${fileImport}`);
+        }
+        let resolvedImport: string;
+        if (fileImport.startsWith("http:")) {
+          throw new Error(`absolute url imports are not supported: ${fileImport}`);
+        } else {
+          resolvedImport = new URL(fileImport, url).toString();
+        }
+        if (!seenFiles.has(resolvedImport)) {
+          Logger.debug(`discovered import ${resolvedImport}`);
+          filesToProcess.push(resolvedImport);
+          seenFiles.add(resolvedImport);
+        }
+      } else {
+        Logger.debug(`discovered module import ${fileImport}`);
+        moduleImports.add(fileImport);
+      }
+    }
+  }
+
+  // look for a tspconfig.yaml next to the root
+  try {
+    const tspConfigUrl = new URL("tspconfig.yaml", rootUrl).toString();
+    const tspConfig = await fetch(tspConfigUrl);
+    Logger.debug("found tspconfig.yaml");
+    fileTree.addFile(tspConfigUrl, tspConfig);
+  } catch (e) {
+    Logger.debug("no tspconfig.yaml found");
+  }
+
+  return {
+    moduleImports,
+    fileTree,
+  };
+}

--- a/tools/tsp-client/src/npm.ts
+++ b/tools/tsp-client/src/npm.ts
@@ -1,0 +1,51 @@
+import * as path from "node:path";
+import { readFile, writeFile } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+export async function createPackageJson(rootPath: string, deps: Set<string>): Promise<void> {
+  const dependencies: Record<string, string> = {};
+
+  for (const dep of deps) {
+    dependencies[dep] = "latest";
+  }
+
+  const packageJson = JSON.stringify({
+    dependencies,
+  });
+
+  const filePath = path.join(rootPath, "package.json");
+  await writeFile(filePath, packageJson);
+}
+
+export function installDependencies(workingDir: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const npm = spawn("npm", ["install", "--no-lock-file"], {
+      cwd: workingDir,
+      stdio: "inherit",
+      shell: true,
+    });
+    npm.once("exit", (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`npm failed exited with code ${code}`));
+      }
+    });
+    npm.once("error", (err) => {
+      reject(new Error(`npm install failed with error: ${err}`));
+    });
+  });
+}
+
+let packageVersion: string;
+export async function getPackageVersion(): Promise<string> {
+  if (!packageVersion) {
+    const __dirname = path.dirname(fileURLToPath(import.meta.url));
+    const packageJson = JSON.parse(
+      await readFile(path.join(__dirname, "..", "package.json"), "utf-8"),
+    );
+    packageVersion = packageJson.version ?? "unknown";
+  }
+  return packageVersion;
+}

--- a/tools/tsp-client/src/options.ts
+++ b/tools/tsp-client/src/options.ts
@@ -2,13 +2,23 @@ import { parseArgs } from "node:util";
 import { Logger, printUsage, printVersion } from "./log.js";
 import * as path from "node:path";
 import { knownLanguages, languageAliases } from "./languageSettings.js";
+import { doesFileExist } from "./network.js";
+import PromptSync from "prompt-sync";
 
 export interface Options {
   debug: boolean;
-  emitter: string;
+  command: string;
+  tspConfig?: string;
+  emitter?: string;
   mainFile?: string;
   outputDir: string;
   noCleanup: boolean;
+  skipSyncAndGenerate: boolean;
+  commit?: string;
+  repo?: string;
+  isUrl: boolean;
+  localSpecRepo?: string;
+  emitterOptions?: string;
 }
 
 export async function getOptions(): Promise<Options> {
@@ -35,9 +45,34 @@ export async function getOptions(): Promise<Options> {
         type: "string",
         short: "m",
       },
-      ["no-cleanup"]: {
+      outputDir: {
+        type: "string",
+        short: "o",
+      },
+      tspConfig: {
+        type: "string",
+        short: "c",
+      },
+      commit: {
+        type: "string",
+        short: "C",
+      },
+      repo: {
+        type: "string",
+        short: "R",
+      },
+      ["emitter-options"]: {
+        type: "string",
+      },
+      ["local-spec-repo"]: {
+        type: "string",
+      },
+      ["save-inputs"]: {
         type: "boolean",
       },
+      ["skip-sync-and-generate"]: {
+        type: "boolean",
+      }
     },
   });
   if (values.help) {
@@ -50,35 +85,84 @@ export async function getOptions(): Promise<Options> {
     process.exit(0);
   }
 
-  if (!values.emitter) {
-    Logger.error("Option --emitter/-e is required");
+  if (values.emitter) {
+    let emitter = values.emitter.toLowerCase();
+    if (emitter in languageAliases) {
+      emitter = languageAliases[emitter]!;
+    }
+    if (!(knownLanguages as readonly string[]).includes(emitter)) {
+      Logger.error(`Unknown language ${values.emitter}`);
+      Logger.error(`Valid languages are: ${knownLanguages.join(", ")}`);
+      printUsage();
+      process.exit(1);
+    }
+  }
+
+  if (positionals.length === 0) {
+    Logger.error("Command is required");
     printUsage();
     process.exit(1);
   }
 
-  let emitter = values.emitter.toLowerCase();
-  if (emitter in languageAliases) {
-    emitter = languageAliases[emitter]!;
-  }
-  if (!(knownLanguages as readonly string[]).includes(emitter)) {
-    Logger.error(`Unknown language ${values.emitter}`);
-    Logger.error(`Valid languages are: ${knownLanguages.join(", ")}`);
+  if (positionals[0] !== "sync" && positionals[0] !== "generate" && positionals[0] !== "update" && positionals[0] !== "init") {
+    Logger.error(`Unknown command ${positionals[0]}`);
     printUsage();
     process.exit(1);
   }
 
-  if (positionals.length === 0 || !positionals[0]) {
-    Logger.error("Output directory is required");
-    printUsage();
-    process.exit(1);
+  let isUrl = false;
+  if (positionals[0] === "init") {
+    if (!values.tspConfig) {
+      Logger.error("tspConfig is required");
+      printUsage();
+      process.exit(1);
+    }
+    if (await doesFileExist(values.tspConfig)) {
+      isUrl = true;
+    }
+    if (!isUrl) {
+      if (values.commit === undefined || values.repo === undefined) {
+        Logger.error("The commit and repo options are required when tspConfig is a local directory");
+        printUsage();
+        process.exit(1);
+      }
+    }
   }
-  const outputDir = path.resolve(path.normalize(positionals[0]));
+  // By default, assume that the command is run from the output directory
+  let outputDir = ".";
+  if (values.outputDir) {
+    outputDir = values.outputDir;
+  }
+  outputDir = path.resolve(path.normalize(outputDir));
+
+  // Ask user is this is the correct output directory
+  const prompt = PromptSync();
+  let useOutputDir = prompt("Use output directory '" + outputDir + "'? (y/n) ", "y");
+
+  if (useOutputDir.toLowerCase() === "n") {
+    const newOutputDir = prompt("Enter output directory: ");
+    if (!newOutputDir) {
+      Logger.error("Output directory is required");
+      printUsage();
+      process.exit(1);
+    }
+    outputDir = path.resolve(path.normalize(newOutputDir));
+  }
+  Logger.info("Using output directory '" + outputDir + "'");
 
   return {
     debug: values.debug ?? false,
+    command: positionals[0],
+    tspConfig: values.tspConfig,
     emitter: values.emitter,
     mainFile: values.mainFile,
-    noCleanup: values["no-cleanup"] ?? false,
+    noCleanup: values["save-inputs"] ?? false,
+    skipSyncAndGenerate: values["skip-sync-and-generate"] ?? false,
     outputDir: outputDir,
+    commit: values.commit,
+    repo: values.repo,
+    isUrl: isUrl,
+    localSpecRepo: values["local-spec-repo"],
+    emitterOptions: values["emitter-options"],
   };
 }

--- a/tools/tsp-client/src/options.ts
+++ b/tools/tsp-client/src/options.ts
@@ -1,0 +1,84 @@
+import { parseArgs } from "node:util";
+import { Logger, printUsage, printVersion } from "./log.js";
+import * as path from "node:path";
+import { knownLanguages, languageAliases } from "./languageSettings.js";
+
+export interface Options {
+  debug: boolean;
+  emitter: string;
+  mainFile?: string;
+  outputDir: string;
+  noCleanup: boolean;
+}
+
+export async function getOptions(): Promise<Options> {
+  const { values, positionals } = parseArgs({
+    allowPositionals: true,
+    options: {
+      help: {
+        type: "boolean",
+        short: "h",
+      },
+      version: {
+        type: "boolean",
+        short: "v",
+      },
+      debug: {
+        type: "boolean",
+        short: "d",
+      },
+      emitter: {
+        type: "string",
+        short: "e",
+      },
+      mainFile: {
+        type: "string",
+        short: "m",
+      },
+      ["no-cleanup"]: {
+        type: "boolean",
+      },
+    },
+  });
+  if (values.help) {
+    printUsage();
+    process.exit(0);
+  }
+
+  if (values.version) {
+    await printVersion();
+    process.exit(0);
+  }
+
+  if (!values.emitter) {
+    Logger.error("Option --emitter/-e is required");
+    printUsage();
+    process.exit(1);
+  }
+
+  let emitter = values.emitter.toLowerCase();
+  if (emitter in languageAliases) {
+    emitter = languageAliases[emitter]!;
+  }
+  if (!(knownLanguages as readonly string[]).includes(emitter)) {
+    Logger.error(`Unknown language ${values.emitter}`);
+    Logger.error(`Valid languages are: ${knownLanguages.join(", ")}`);
+    printUsage();
+    process.exit(1);
+  }
+
+  if (positionals.length === 0 || !positionals[0]) {
+    Logger.error("Output directory is required");
+    printUsage();
+    process.exit(1);
+  }
+  const outputDir = path.resolve(path.normalize(positionals[0]));
+
+  return {
+    debug: values.debug ?? false,
+    emitter: values.emitter,
+    mainFile: values.mainFile,
+    noCleanup: values["no-cleanup"] ?? false,
+    outputDir: outputDir,
+  };
+}

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -1,0 +1,55 @@
+import { NodeHost, compile, getSourceLocation } from "@typespec/compiler";
+import { parse, isImportStatement } from "@typespec/compiler";
+import * as path from "node:path";
+import { Logger } from "./log.js";
+import { getEmitterOutputPath } from "./languageSettings.js";
+
+export async function resolveImports(file: string): Promise<string[]> {
+  const imports: string[] = [];
+  const node = await parse(file);
+  for (const statement of node.statements) {
+    if (isImportStatement(statement)) {
+      imports.push(statement.path.value);
+    }
+  }
+  return imports;
+}
+
+export async function compileTsp({
+  language,
+  emitterPackage,
+  emitterOutputPath,
+  resolvedMainFilePath,
+  tempRoot,
+}: {
+  language: string;
+  emitterPackage: string;
+  emitterOutputPath: string;
+  resolvedMainFilePath: string;
+  tempRoot: string;
+}) {
+  const emitterOutputDir = getEmitterOutputPath(language, emitterOutputPath);
+  Logger.debug(`Using emitter output dir: ${emitterOutputDir}`);
+  // compile the local copy of the root file
+  const program = await compile(NodeHost, resolvedMainFilePath, {
+    outputDir: path.join(tempRoot, "output"),
+    emit: [emitterPackage],
+    options: {
+      [emitterPackage]: {
+        "emitter-output-dir": emitterOutputDir,
+      },
+    },
+  });
+
+  if (program.diagnostics.length > 0) {
+    for (const diagnostic of program.diagnostics) {
+      const location = getSourceLocation(diagnostic.target);
+      const source = location ? location.file.path : "unknown";
+      console.error(
+        `${diagnostic.severity}: ${diagnostic.code} - ${diagnostic.message} @ ${source}`,
+      );
+    }
+  } else {
+    Logger.success("generation complete");
+  }
+}

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -70,12 +70,12 @@ export function resolveCliOptions(opts: string[]): Record<string, Record<string,
 }
 
 
-export async function resolveTspConfigUrl(configUrl: string): Promise<{
+export function resolveTspConfigUrl(configUrl: string): {
   resolvedUrl: string;
   commit: string;
   repo: string;
   path: string;
-}> {
+} {
   let resolvedConfigUrl = configUrl;
 
   const res = configUrl.match('^https://(?<urlRoot>github|raw.githubusercontent).com/(?<repo>[^/]*/azure-rest-api-specs(-pr)?)/(tree/|blob/)?(?<commit>[0-9a-f]{40})/(?<path>.*)/tspconfig.yaml$')

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -15,20 +15,16 @@ export async function getEmitterOptions(rootUrl: string, tempRoot: string, emitt
   } else {
     const configData = await readFile(path.join(tempRoot, "tspconfig.yaml"), "utf8");
     const configYaml = parseYaml(configData);
-  
-    if (configYaml["options"] && configYaml["options"][emitter]){
-      emitterOptions[emitter] = configYaml["options"][emitter];
-      for (const key in emitterOptions[emitter]!) {
-        Object.keys(emitterOptions![emitter]!).forEach(
-          (k) => {
-            if (`{${k}}` === emitterOptions[emitter]![key]) {
-              emitterOptions[emitter]![key] = emitterOptions[emitter]![k];
-            }
-          });
+    emitterOptions[emitter] = configYaml?.options?.[emitter];
+    // TODO: This accounts for a very specific and common configuration in the tspconfig.yaml files,
+    // we should consider making this more generic.
+    Object.keys(emitterOptions[emitter]!).forEach((key) => {
+      if (emitterOptions![emitter]![key] === "{package-dir}") {
+        emitterOptions![emitter]![key] = emitterOptions![emitter]!["package-dir"];
       }
-    }
+    });
   }
-  if (emitterOptions[emitter] && !emitterOptions[emitter]!["emitter-output-dir"]) {
+  if (!emitterOptions?.[emitter]?.["emitter-output-dir"]) {
     emitterOptions[emitter]!["emitter-output-dir"] = rootUrl;
   }
   if (saveInputs) {

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -1,8 +1,114 @@
 import { NodeHost, compile, getSourceLocation } from "@typespec/compiler";
 import { parse, isImportStatement } from "@typespec/compiler";
-import * as path from "node:path";
 import { Logger } from "./log.js";
-import { getEmitterOutputPath } from "./languageSettings.js";
+import { readFile, readdir } from "fs/promises";
+import * as path from "node:path";
+import { parse as parseYaml } from "yaml";
+
+
+export async function getEmitterOptions(rootUrl: string, tempRoot: string, emitter: string, saveInputs: boolean, additionalOptions?: string): Promise<Record<string, any>> {
+  // TODO: Add a way to specify emitter options like Language-Settings.ps1, could be a languageSettings.ts file
+  let emitterOptions: Record<string, Record<string, unknown>> = {};
+  emitterOptions[emitter] = {};
+  if (additionalOptions) {
+    emitterOptions = resolveCliOptions(additionalOptions.split(","));
+  } else {
+    const configData = await readFile(path.join(tempRoot, "tspconfig.yaml"), "utf8");
+    const configYaml = parseYaml(configData);
+  
+    if (configYaml["options"] && configYaml["options"][emitter]){
+      emitterOptions[emitter] = configYaml["options"][emitter];
+      for (const key in emitterOptions[emitter]!) {
+        Object.keys(emitterOptions![emitter]!).forEach(
+          (k) => {
+            if (`{${k}}` === emitterOptions[emitter]![key]) {
+              emitterOptions[emitter]![key] = emitterOptions[emitter]![k];
+            }
+          });
+      }
+    }
+  }
+  if (emitterOptions[emitter] && !emitterOptions[emitter]!["emitter-output-dir"]) {
+    emitterOptions[emitter]!["emitter-output-dir"] = rootUrl;
+  }
+  if (saveInputs) {
+    if (emitterOptions[emitter] === undefined) {
+      emitterOptions[emitter] = {};
+    }
+    emitterOptions[emitter]!["save-inputs"] = true;
+  }
+  Logger.debug(`Using emitter options: ${JSON.stringify(emitterOptions)}`);
+  return emitterOptions;
+}
+
+export function resolveCliOptions(opts: string[]): Record<string, Record<string, unknown>> {
+  const options: Record<string, Record<string, string>> = {};
+  for (const option of opts ?? []) {
+    const optionParts = option.split("=");
+    if (optionParts.length !== 2) {
+      throw new Error(
+        `The --option parameter value "${option}" must be in the format: <emitterName>.some-options=value`
+      );
+    }
+    let optionKeyParts = optionParts[0]!.split(".");
+    if (optionKeyParts.length > 2) {
+      // support emitter/path/file.js.option=xyz
+      optionKeyParts = [
+        optionKeyParts.slice(0, -1).join("."),
+        optionKeyParts[optionKeyParts.length - 1]!,
+      ];
+    }
+    let emitterName = optionKeyParts[0];
+    emitterName = emitterName?.replace(".", "/")
+    const key = optionKeyParts[1];
+    if (!(emitterName! in options)) {
+      options[emitterName!] = {};
+    }
+    options[emitterName!]![key!] = optionParts[1]!;
+  }
+  return options;
+}
+
+
+export async function resolveTspConfigUrl(configUrl: string): Promise<{
+  resolvedUrl: string;
+  commit: string;
+  repo: string;
+  path: string;
+}> {
+  let resolvedConfigUrl = configUrl;
+
+  const res = configUrl.match('^https://(?<urlRoot>github|raw.githubusercontent).com/(?<repo>[^/]*/azure-rest-api-specs(-pr)?)/(tree/|blob/)?(?<commit>[0-9a-f]{40})/(?<path>.*)/tspconfig.yaml$')
+  if (res && res.groups) {
+    if (res.groups["urlRoot"]! === "github") {
+      resolvedConfigUrl = configUrl.replace("github.com", "raw.githubusercontent.com");
+      resolvedConfigUrl = resolvedConfigUrl.replace("/blob/", "/");
+    }
+    return {
+      resolvedUrl: resolvedConfigUrl,
+      commit: res.groups!["commit"]!,
+      repo: res.groups!["repo"]!,
+      path: res.groups!["path"]!,
+    }
+  } else {
+    throw new Error(`Invalid tspconfig.yaml url: ${configUrl}`);
+  }
+}
+
+
+export async function discoverMainFile(srcDir: string): Promise<string> {
+  Logger.debug(`Discovering entry file in ${srcDir}`)
+  let entryTsp = "";
+  const files = await readdir(srcDir, {recursive: true });
+  for (const file of files) {
+    if (file.includes("client.tsp") || file.includes("main.tsp")) {
+      entryTsp = file;
+      Logger.debug(`Found entry file: ${entryTsp}`);
+      return entryTsp;
+    }
+  };
+  throw new Error(`No main.tsp or client.tsp found`);
+}
 
 export async function resolveImports(file: string): Promise<string[]> {
   const imports: string[] = [];
@@ -16,29 +122,22 @@ export async function resolveImports(file: string): Promise<string[]> {
 }
 
 export async function compileTsp({
-  language,
   emitterPackage,
-  emitterOutputPath,
+  outputPath,
   resolvedMainFilePath,
-  tempRoot,
+  options,
 }: {
-  language: string;
   emitterPackage: string;
-  emitterOutputPath: string;
+  outputPath: string;
   resolvedMainFilePath: string;
-  tempRoot: string;
+  options: Record<string, Record<string, unknown>>;
 }) {
-  const emitterOutputDir = getEmitterOutputPath(language, emitterOutputPath);
-  Logger.debug(`Using emitter output dir: ${emitterOutputDir}`);
+  Logger.debug(`Using emitter output dir: ${outputPath}`);
   // compile the local copy of the root file
   const program = await compile(NodeHost, resolvedMainFilePath, {
-    outputDir: path.join(tempRoot, "output"),
+    outputDir: outputPath,
     emit: [emitterPackage],
-    options: {
-      [emitterPackage]: {
-        "emitter-output-dir": emitterOutputDir,
-      },
-    },
+    options: options,
   });
 
   if (program.diagnostics.length > 0) {

--- a/tools/tsp-client/test/fileTree.spec.ts
+++ b/tools/tsp-client/test/fileTree.spec.ts
@@ -1,0 +1,21 @@
+import { assert } from "chai";
+import { createFileTree } from "../src/fileTree.js";
+
+describe("FileTree", function () {
+  it("handles basic tree", async function () {
+    const tree = createFileTree("http://example.com/foo/bar/baz.tsp");
+    tree.addFile("http://example.com/foo/bar/baz.tsp", "text");
+    tree.addFile("http://example.com/foo/buzz/foo.tsp", "text");
+    tree.addFile("http://example.com/foo/bar/qux.tsp", "text");
+    const result = await tree.createTree();
+    assert.strictEqual(result.mainFilePath, "bar/baz.tsp");
+    assert.strictEqual(result.files.size, 3);
+    const resultPaths = new Set(result.files.keys());
+    assert.isTrue(resultPaths.has("bar/baz.tsp"));
+    assert.isTrue(resultPaths.has("bar/qux.tsp"));
+    assert.isTrue(resultPaths.has("buzz/foo.tsp"));
+    for (const contents of result.files.values()) {
+      assert.strictEqual(contents, "text");
+    }
+  });
+});

--- a/tools/tsp-client/test/network.spec.ts
+++ b/tools/tsp-client/test/network.spec.ts
@@ -1,0 +1,13 @@
+import { assert } from "chai";
+import { rewriteGitHubUrl } from "../src/network.js";
+
+describe("Network", function () {
+  it("rewriteGitHubUrl", function () {
+    const initial =
+      "https://github.com/Azure/azure-rest-api-specs/blob/main/specification/cognitiveservices/OpenAI.Inference/main.tsp";
+    const expected =
+      "https://raw.githubusercontent.com/Azure/azure-rest-api-specs/main/specification/cognitiveservices/OpenAI.Inference/main.tsp";
+    const actual = rewriteGitHubUrl(initial);
+    assert.strictEqual(actual, expected);
+  });
+});

--- a/tools/tsp-client/tsconfig.json
+++ b/tools/tsp-client/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "outDir": "dist",
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "node16",
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noImplicitThis": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"],
+  "ts-node": {
+    "esm": true
+  }
+}


### PR DESCRIPTION
Per Issue #6838, this PR scaffolds out a new tool to invoke the TypeSpec compiler using Node/npm.

The largest enhancement is avoiding the need to clone the specs repository as URLs are supported as entrypoints rather than requiring the TSP files all be locally available.

Eventually this tool will grow to support all of the scenarios covered in https://github.com/Azure/azure-sdk-tools/blob/main/doc/common/TypeSpec-Project-Scripts.md 