### PR TITLE
Update the team/user store to store additional information to be used in the upcoming CODEOWNERS linter

### DIFF
--- a/eng/pipelines/pipeline-owners-extraction.yml
+++ b/eng/pipelines/pipeline-owners-extraction.yml
@@ -21,6 +21,11 @@ stages:
       Project: internal
       DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
       OutputPath: '$(Agent.BuildDirectory)/pipelineOwners.json'
+      RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob?$(azuresdkartifacts-azure-sdk-write-teams-sas)"
+      TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob?$(azuresdkartifacts-azure-sdk-write-teams-sas)"
+      UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob?$(azuresdkartifacts-azure-sdk-write-teams-sas)"
+      RepoListFile: "$(Build.SourcesDirectory)/tools/github/data/repositories.txt"
+
     steps:
       - task: DotNetCoreCLI@2
         displayName: 'Install Pipeline Owners Extractor'
@@ -42,7 +47,7 @@ stages:
         condition: succeededOrFailed()
 
       - pwsh: |
-          dotnet run --blobStorageURI "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob?$(azuresdkartifacts-azure-sdk-write-teams-sas)"
+          dotnet run -rUri2 "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -rlFile "$(RepoListFile)"
         displayName: 'Fetch and store team/user data'
         workingDirectory: tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore
         env:

--- a/eng/pipelines/pipeline-owners-extraction.yml
+++ b/eng/pipelines/pipeline-owners-extraction.yml
@@ -47,7 +47,7 @@ stages:
         condition: succeededOrFailed()
 
       - pwsh: |
-          dotnet run -rUri2 "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -rlFile "$(RepoListFile)"
+          dotnet run -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -rlFile "$(RepoListFile)"
         displayName: 'Fetch and store team/user data'
         workingDirectory: tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore
         env:

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Constants/ProductAndTeamConstants.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Constants/ProductAndTeamConstants.cs
@@ -10,8 +10,11 @@ namespace GitHubTeamUserStore.Constants
     {
         // The ProductHeaderName is used to register the GitHubClient for this application
         public const string ProductHeaderName = "azure-sdk-github-team-user-store";
+
+        public const string Azure = "Azure";
         // Need to do this since Octokit doesn't expose the API to get team by name.
         // The team Id won't change even if the team name gets modified.
         public const int AzureSdkWriteTeamId = 3057675;
+        public const string AzureSdkWriteTeamName = "azure-sdk-write";
     }
 }

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Program.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Program.cs
@@ -71,14 +71,11 @@ namespace GitHubTeamUserStore
             bool success = false;
             // The team/user list needs to be generated before the user/org data. The reason being is that the User/Org
             // visibility data is generated for the azure-sdk-write team users.
-            if (await TeamUserGenerator.GenerateAndStoreTeamUserList(gitHubEventClient, teamUserBlobStorageUri))
+            if (await TeamUserGenerator.GenerateAndStoreTeamUserAndOrgData(gitHubEventClient, teamUserBlobStorageUri, userOrgVisibilityBlobStorageUri))
             {
-                if (await TeamUserGenerator.GenerateAndStoreUserOrgData(gitHubEventClient, userOrgVisibilityBlobStorageUri))
+                if (await RepositoryLabelGenerator.GenerateAndStoreRepositoryLabels(gitHubEventClient, repoLabelBlobStorageUri, repositoryListFile))
                 {
-                    if (await RepositoryLabelGenerator.GenerateAndStoreRepositoryLabels(gitHubEventClient, repoLabelBlobStorageUri, repositoryListFile))
-                    {
-                        success = true;
-                    }
+                    success = true;
                 }
             }
 

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Program.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Program.cs
@@ -1,5 +1,6 @@
 using System.CommandLine;
 using System.Diagnostics;
+using Azure.Storage.Blobs;
 using GitHubTeamUserStore.Constants;
 
 namespace GitHubTeamUserStore
@@ -8,24 +9,55 @@ namespace GitHubTeamUserStore
     {
         static async Task Main(string[] args)
         {
-            var blobStorageURIOption = new Option<string>
-                (name: "--blobStorageURI",
-                description: "The blob storage URI including the SAS.");
-            blobStorageURIOption.IsRequired = true;
+            var teamUserBlobStorageUriOption = new Option<string>
+                (name: "--teamUserBlobStorageURI", 
+                description: "The team/user blob storage URI including the SAS.");
+            teamUserBlobStorageUriOption.AddAlias("-tUri");
+            teamUserBlobStorageUriOption.IsRequired = true;
+
+            var userOrgVisibilityBlobStorageUriOption = new Option<string>
+                (name: "--userOrgVisibilityBlobStorageURI",
+                description: "The user/org blob storage URI including the SAS.");
+            userOrgVisibilityBlobStorageUriOption.AddAlias("-uUri");
+            userOrgVisibilityBlobStorageUriOption.IsRequired = true;
+
+            var repoLabelBlobStorageUriOption = new Option<string>
+                (name: "--repoLabelBlobStorageURI",
+                description: "The repo/label blob storage URI including the SAS.");
+            repoLabelBlobStorageUriOption.AddAlias("-rUri");
+            repoLabelBlobStorageUriOption.IsRequired = true;
+
+            // Since this will be running in the pipeline-owners-extraction, azure-sdk-tools
+            // will be there. The command line option should be
+            // --repositoryListFile "$(Build.SourcesDirectory)/tools/github/data/repositories.txt"
+            var repositoryListFileOption = new Option<string>
+                (name: "--repositoryListFile",
+                description: "The data file which contains the list of repositorys to get labels for.");
+            repositoryListFileOption.AddAlias("-rlFile");
+            repositoryListFileOption.IsRequired = true;
 
             var rootCommand = new RootCommand
             {
-                blobStorageURIOption,
+                teamUserBlobStorageUriOption,
+                userOrgVisibilityBlobStorageUriOption,
+                repoLabelBlobStorageUriOption,
+                repositoryListFileOption,
             };
             rootCommand.SetHandler(PopulateTeamUserData,
-                                   blobStorageURIOption);
+                                   teamUserBlobStorageUriOption,
+                                   userOrgVisibilityBlobStorageUriOption,
+                                   repoLabelBlobStorageUriOption,
+                                   repositoryListFileOption);
 
             int returnCode = await rootCommand.InvokeAsync(args);
             Console.WriteLine($"Exiting with return code {returnCode}");
             Environment.Exit(returnCode);
         }
 
-        private static async Task<int> PopulateTeamUserData(string blobStorageURI)
+        private static async Task<int> PopulateTeamUserData(string teamUserBlobStorageUri,
+                                                            string userOrgVisibilityBlobStorageUri,
+                                                            string repoLabelBlobStorageUri, 
+                                                            string repositoryListFile)
         {
 
             // Default the returnCode code to non-zero. If everything is successful it'll be set to 0
@@ -33,12 +65,24 @@ namespace GitHubTeamUserStore
             Stopwatch stopWatch = new Stopwatch();
             stopWatch.Start();
 
-            GitHubEventClient gitHubEventClient = new GitHubEventClient(ProductAndTeamConstants.ProductHeaderName, blobStorageURI);
+            GitHubEventClient gitHubEventClient = new GitHubEventClient(ProductAndTeamConstants.ProductHeaderName);
 
             await gitHubEventClient.WriteRateLimits("RateLimit at start of execution:");
-            await TeamUserGenerator.GenerateAndStoreTeamUserList(gitHubEventClient);
+            bool success = false;
+            // The team/user list needs to be generated before the user/org data. The reason being is that the User/Org
+            // visibility data is generated for the azure-sdk-write team users.
+            if (await TeamUserGenerator.GenerateAndStoreTeamUserList(gitHubEventClient, teamUserBlobStorageUri))
+            {
+                if (await TeamUserGenerator.GenerateAndStoreUserOrgData(gitHubEventClient, userOrgVisibilityBlobStorageUri))
+                {
+                    if (await RepositoryLabelGenerator.GenerateAndStoreRepositoryLabels(gitHubEventClient, repoLabelBlobStorageUri, repositoryListFile))
+                    {
+                        success = true;
+                    }
+                }
+            }
+
             await gitHubEventClient.WriteRateLimits("RateLimit at end of execution:");
-            bool storedEqualsGenerated = await TeamUserGenerator.VerifyStoredTeamUsers(gitHubEventClient);
 
             stopWatch.Stop();
             TimeSpan ts = stopWatch.Elapsed;
@@ -47,9 +91,9 @@ namespace GitHubTeamUserStore
                 ts.Milliseconds / 10);
             Console.WriteLine($"Total run time: {elapsedTime}");
 
-            if (storedEqualsGenerated)
+            if (success)
             {
-                Console.WriteLine("List stored successfully.");
+                Console.WriteLine("Data stored successfully.");
                 returnCode = 0;
             }
             else

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/RepositoryLabelGenerator.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/RepositoryLabelGenerator.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Azure.Storage.Blobs;
+using GitHubTeamUserStore.Constants;
+using Octokit;
+
+namespace GitHubTeamUserStore
+{
+    public class RepositoryLabelGenerator
+    {
+        // Repository name is the key, with the list of that repository's labels as the as the value
+        private static Dictionary<string, HashSet<string>> _repoLabelDict = new Dictionary<string, HashSet<string>>();
+
+        public static async Task<bool> GenerateAndStoreRepositoryLabels(GitHubEventClient gitHubEventClient, string repoLabelBlobStorageUri, string repositoryListFile)
+        {
+            Uri repoLabelBlobUri = new Uri(repoLabelBlobStorageUri);
+            BlobUriBuilder repoLabelBlobUriBuilder = new BlobUriBuilder(repoLabelBlobUri);
+
+            // Load the repostiory list file
+            string fullPath = Path.GetFullPath(repositoryListFile);
+            if (!File.Exists(fullPath))
+            {
+                throw new ArgumentException($"The path provided '{repositoryListFile}' does not exist");
+            }
+
+            var repositories = File.ReadAllLines(fullPath);
+            foreach (string repository in repositories)
+            {
+                if (string.IsNullOrWhiteSpace(repository))
+                {
+                    continue;
+                }
+                // The repositories in the file will all start with "Azure/" which is fine for storage considering
+                // that the $(Build.Repository.Name), in a pipeline, will also start with "Azure/" but "Azure/"
+                // needs to be stripped off for the GetRepositoryLabels call which requires the Org and repository
+                // be separate arguments. The dictionary key will be full repository name.
+                string repoWithoutOrg = repository;
+                if (repoWithoutOrg.StartsWith($"{ProductAndTeamConstants.Azure}/"))
+                {
+                    repoWithoutOrg = repoWithoutOrg.Replace($"{ProductAndTeamConstants.Azure}/", "");
+                }
+                var labelsHash = await gitHubEventClient.GetRepositoryLabels(repoWithoutOrg);
+                _repoLabelDict[repository] = labelsHash;
+            }
+            // Dictionary<string, HashSet<string>> will serialize as-is and doesn't need to be changed for serialization
+            string jsonString = JsonSerializer.Serialize(_repoLabelDict);
+            await gitHubEventClient.UploadDataToBlobStorage(jsonString, repoLabelBlobUriBuilder);
+            bool dataMatches = await VerifyStoredRepositoryLabelData(gitHubEventClient, repoLabelBlobUriBuilder);
+            if (dataMatches)
+            {
+                Console.WriteLine("repository/label data stored successfully.");
+            }
+            else
+            {
+                Console.WriteLine("There were issues with generated vs stored repository/label data. See above for specifics.");
+            }
+            return dataMatches;
+        }
+
+        public static async Task<bool> VerifyStoredRepositoryLabelData(GitHubEventClient gitHubEventClient, BlobUriBuilder blobUriBuilder)
+        {
+
+            string rawJson = await gitHubEventClient.GetBlobDataFromStorage(blobUriBuilder);
+            var storedRepoLabelDict = JsonSerializer.Deserialize<Dictionary<string, HashSet<string>>>(rawJson);
+            if (_repoLabelDict.Keys.Count != storedRepoLabelDict.Keys.Count)
+            {
+                Console.WriteLine($"Error! Created repo/label dictionary has {_repoLabelDict.Keys.Count} repositories and stored dictionary has {storedRepoLabelDict.Keys.Count} repositories.");
+                Console.WriteLine(string.Format("created list users {0}", string.Join(", ", _repoLabelDict.Keys)));
+                Console.WriteLine(string.Format("stored list users {0}", string.Join(", ", storedRepoLabelDict.Keys)));
+                return false;
+            }
+
+            // Verify that the _repoLabelDict and the storedRepoLabelDict both contain the same set of keys (repositories)
+            foreach (string repository in _repoLabelDict.Keys)
+            {
+                if (!storedRepoLabelDict.ContainsKey(repository))
+                {
+                    Console.WriteLine("Error! Created repo/label dictionary has different repositories than the stored dictionary.");
+                    Console.WriteLine(string.Format("created dictionary repositories {0}", string.Join(", ", _repoLabelDict.Keys)));
+                    Console.WriteLine(string.Format("stored dictionary repositories {0}", string.Join(", ", storedRepoLabelDict.Keys)));
+                    return false;
+                }
+            }
+
+            // A this point both dictionaries contain the same set of repositories, now verify that the labels for repository match
+            bool hasError = false;
+            foreach (string repository in _repoLabelDict.Keys)
+            {
+                if (_repoLabelDict[repository].Count != storedRepoLabelDict[repository].Count)
+                {
+                    hasError = true;
+                    Console.WriteLine($"The created dictionary entry for {repository} is has a different number of labels, {_repoLabelDict[repository].Count}, than the stored dictionary, {storedRepoLabelDict[repository].Count}.");
+                    Console.WriteLine(string.Format("created dictionary repositories {0}", string.Join(", ", _repoLabelDict[repository])));
+                    Console.WriteLine(string.Format("stored dictionary repositories {0}", string.Join(", ", storedRepoLabelDict[repository])));
+                    // If the number of labels differs, don't bother checking individual entries, move on to the next repository
+                    continue;
+                }
+
+                foreach (string label in _repoLabelDict[repository])
+                {
+                    if (!storedRepoLabelDict[repository].Contains(label))
+                    {
+                        hasError = true;
+                        Console.WriteLine($"The created entry for {repository} has the same number of entries but different labels than the stored diectionary");
+                        Console.WriteLine(string.Format("created dictionary label {0}", string.Join(", ", _repoLabelDict[repository])));
+                        Console.WriteLine(string.Format("stored dictionary label {0}", string.Join(", ", storedRepoLabelDict[repository])));
+                        // After the differences are reported for this repository entry, move on to the next outer loop iteration
+                        break;
+                    }
+                }
+            }
+            return !hasError;
+        }
+    }
+}

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/RepositoryLabelGenerator.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/RepositoryLabelGenerator.cs
@@ -12,11 +12,11 @@ namespace GitHubTeamUserStore
 {
     public class RepositoryLabelGenerator
     {
-        // Repository name is the key, with the list of that repository's labels as the as the value
-        private static Dictionary<string, HashSet<string>> _repoLabelDict = new Dictionary<string, HashSet<string>>();
 
         public static async Task<bool> GenerateAndStoreRepositoryLabels(GitHubEventClient gitHubEventClient, string repoLabelBlobStorageUri, string repositoryListFile)
         {
+            // Repository name is the key, with the list of that repository's labels as the as the value
+            Dictionary<string, HashSet<string>> repoLabelDict = new Dictionary<string, HashSet<string>>();
             Uri repoLabelBlobUri = new Uri(repoLabelBlobStorageUri);
             BlobUriBuilder repoLabelBlobUriBuilder = new BlobUriBuilder(repoLabelBlobUri);
 
@@ -44,12 +44,12 @@ namespace GitHubTeamUserStore
                     repoWithoutOrg = repoWithoutOrg.Replace($"{ProductAndTeamConstants.Azure}/", "");
                 }
                 var labelsHash = await gitHubEventClient.GetRepositoryLabels(repoWithoutOrg);
-                _repoLabelDict[repository] = labelsHash;
+                repoLabelDict[repository] = labelsHash;
             }
             // Dictionary<string, HashSet<string>> will serialize as-is and doesn't need to be changed for serialization
-            string jsonString = JsonSerializer.Serialize(_repoLabelDict);
+            string jsonString = JsonSerializer.Serialize(repoLabelDict);
             await gitHubEventClient.UploadDataToBlobStorage(jsonString, repoLabelBlobUriBuilder);
-            bool dataMatches = await VerifyStoredRepositoryLabelData(gitHubEventClient, repoLabelBlobUriBuilder);
+            bool dataMatches = await VerifyStoredRepositoryLabelData(gitHubEventClient, repoLabelBlobUriBuilder, repoLabelDict);
             if (dataMatches)
             {
                 Console.WriteLine("repository/label data stored successfully.");
@@ -61,26 +61,28 @@ namespace GitHubTeamUserStore
             return dataMatches;
         }
 
-        public static async Task<bool> VerifyStoredRepositoryLabelData(GitHubEventClient gitHubEventClient, BlobUriBuilder blobUriBuilder)
+        public static async Task<bool> VerifyStoredRepositoryLabelData(GitHubEventClient gitHubEventClient, 
+                                                                       BlobUriBuilder blobUriBuilder,
+                                                                       Dictionary<string, HashSet<string>> repoLabelDict)
         {
 
             string rawJson = await gitHubEventClient.GetBlobDataFromStorage(blobUriBuilder);
             var storedRepoLabelDict = JsonSerializer.Deserialize<Dictionary<string, HashSet<string>>>(rawJson);
-            if (_repoLabelDict.Keys.Count != storedRepoLabelDict.Keys.Count)
+            if (repoLabelDict.Keys.Count != storedRepoLabelDict.Keys.Count)
             {
-                Console.WriteLine($"Error! Created repo/label dictionary has {_repoLabelDict.Keys.Count} repositories and stored dictionary has {storedRepoLabelDict.Keys.Count} repositories.");
-                Console.WriteLine(string.Format("created list users {0}", string.Join(", ", _repoLabelDict.Keys)));
+                Console.WriteLine($"Error! Created repo/label dictionary has {repoLabelDict.Keys.Count} repositories and stored dictionary has {storedRepoLabelDict.Keys.Count} repositories.");
+                Console.WriteLine(string.Format("created list users {0}", string.Join(", ", repoLabelDict.Keys)));
                 Console.WriteLine(string.Format("stored list users {0}", string.Join(", ", storedRepoLabelDict.Keys)));
                 return false;
             }
 
             // Verify that the _repoLabelDict and the storedRepoLabelDict both contain the same set of keys (repositories)
-            foreach (string repository in _repoLabelDict.Keys)
+            foreach (string repository in repoLabelDict.Keys)
             {
                 if (!storedRepoLabelDict.ContainsKey(repository))
                 {
                     Console.WriteLine("Error! Created repo/label dictionary has different repositories than the stored dictionary.");
-                    Console.WriteLine(string.Format("created dictionary repositories {0}", string.Join(", ", _repoLabelDict.Keys)));
+                    Console.WriteLine(string.Format("created dictionary repositories {0}", string.Join(", ", repoLabelDict.Keys)));
                     Console.WriteLine(string.Format("stored dictionary repositories {0}", string.Join(", ", storedRepoLabelDict.Keys)));
                     return false;
                 }
@@ -88,25 +90,25 @@ namespace GitHubTeamUserStore
 
             // A this point both dictionaries contain the same set of repositories, now verify that the labels for repository match
             bool hasError = false;
-            foreach (string repository in _repoLabelDict.Keys)
+            foreach (string repository in repoLabelDict.Keys)
             {
-                if (_repoLabelDict[repository].Count != storedRepoLabelDict[repository].Count)
+                if (repoLabelDict[repository].Count != storedRepoLabelDict[repository].Count)
                 {
                     hasError = true;
-                    Console.WriteLine($"The created dictionary entry for {repository} is has a different number of labels, {_repoLabelDict[repository].Count}, than the stored dictionary, {storedRepoLabelDict[repository].Count}.");
-                    Console.WriteLine(string.Format("created dictionary repositories {0}", string.Join(", ", _repoLabelDict[repository])));
+                    Console.WriteLine($"The created dictionary entry for {repository} is has a different number of labels, {repoLabelDict[repository].Count}, than the stored dictionary, {storedRepoLabelDict[repository].Count}.");
+                    Console.WriteLine(string.Format("created dictionary repositories {0}", string.Join(", ", repoLabelDict[repository])));
                     Console.WriteLine(string.Format("stored dictionary repositories {0}", string.Join(", ", storedRepoLabelDict[repository])));
                     // If the number of labels differs, don't bother checking individual entries, move on to the next repository
                     continue;
                 }
 
-                foreach (string label in _repoLabelDict[repository])
+                foreach (string label in repoLabelDict[repository])
                 {
                     if (!storedRepoLabelDict[repository].Contains(label))
                     {
                         hasError = true;
                         Console.WriteLine($"The created entry for {repository} has the same number of entries but different labels than the stored diectionary");
-                        Console.WriteLine(string.Format("created dictionary label {0}", string.Join(", ", _repoLabelDict[repository])));
+                        Console.WriteLine(string.Format("created dictionary label {0}", string.Join(", ", repoLabelDict[repository])));
                         Console.WriteLine(string.Format("stored dictionary label {0}", string.Join(", ", storedRepoLabelDict[repository])));
                         // After the differences are reported for this repository entry, move on to the next outer loop iteration
                         break;

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/TeamUserGenerator.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/TeamUserGenerator.cs
@@ -6,6 +6,7 @@ using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
 using GitHubTeamUserStore.Constants;
+using Azure.Storage.Blobs;
 
 namespace GitHubTeamUserStore
 {
@@ -14,6 +15,10 @@ namespace GitHubTeamUserStore
         // Team/User dictionary where the team name is the key and the list users is the value. It's worth noting
         // that this is the list of Logins (Octokit.User.Login) which are what's used in CODEOWNERS, @mentions, etc.
         private static Dictionary<string, List<string>> _teamUserDict = new Dictionary<string, List<string>>();
+
+        // The user list of azure-sdk-write will contain a distinct list of all users from all child teams. For
+        // each one, check if they're a member of azure and store that in here.
+        private static Dictionary<string, bool> _userOrgDict = new Dictionary<string, bool>();
 
         /// <summary>
         /// Generate the team/user lists for each and every team under azure-sdk-write. Every team and user in a CODEOWNERS
@@ -24,16 +29,32 @@ namespace GitHubTeamUserStore
         /// teams is less than 1/10th of that. The team/user data is serialized into json and stored in azure blob storage.
         /// </summary>
         /// <param name="gitHubEventClient">Authenticated GitHubEventClient</param>
+        /// <param name="teamUserBlobStorageUri">team/user blob storage URI</param>
         /// <returns></returns>
-        public static async Task GenerateAndStoreTeamUserList(GitHubEventClient gitHubEventClient)
+        public static async Task<bool> GenerateAndStoreTeamUserList(GitHubEventClient gitHubEventClient,
+                                                                    string teamUserBlobStorageUri)
         {
+            // The BlobUriBuilder for team/user storage is stored for the verify call
+            Uri teamUserBlobUri = new Uri(teamUserBlobStorageUri);
+            BlobUriBuilder teamUserBlobUriBuilder = new BlobUriBuilder(teamUserBlobUri);
+
             Team azureSdkWrite = await gitHubEventClient.GetTeamById(ProductAndTeamConstants.AzureSdkWriteTeamId);
             await CreateTeamUserEntry(gitHubEventClient, azureSdkWrite);
             // Serializing the Dictionary<string, List<string>> directly won't work with the JsonSerializer but
             // a List<KeyValuePair<string, List<string>>> will and it's easy enough to convert to/from.
             var list = _teamUserDict.ToList();
             string jsonString = JsonSerializer.Serialize(list);
-            await gitHubEventClient.UploadToBlobStorage(jsonString);
+            await gitHubEventClient.UploadDataToBlobStorage(jsonString, teamUserBlobUriBuilder);
+            bool dataMatches = await VerifyStoredTeamUsers(gitHubEventClient, teamUserBlobUriBuilder);
+            if (dataMatches)
+            {
+                Console.WriteLine("team/user data stored successfully.");
+            }
+            else
+            {
+                Console.WriteLine("There were issues with generated vs stored data. See above for specifics.");
+            }
+            return dataMatches;
         }
 
         /// <summary>
@@ -77,11 +98,10 @@ namespace GitHubTeamUserStore
         /// team/user data from blob storage is the same as the in-memory data that was used to create the blob.
         /// </summary>
         /// <param name="gitHubEventClient">Authenticated GitHubEventClient</param>
-        /// <returns>True, if the team data in storage matches the in-memory data that was used to create the blob otherwise false.</returns>
-        public static async Task<bool> VerifyStoredTeamUsers(GitHubEventClient gitHubEventClient)
+        /// <returns>True, if the team data in storage matches the in-memory data that was used to create the blob, otherwise, false.</returns>
+        private static async Task<bool> VerifyStoredTeamUsers(GitHubEventClient gitHubEventClient, BlobUriBuilder blobUriBuilder)
         {
-            bool hasError = false;
-            string rawJson = await gitHubEventClient.GetTeamUserBlobFromStorage();
+            string rawJson = await gitHubEventClient.GetBlobDataFromStorage(blobUriBuilder);
             var list = JsonSerializer.Deserialize<List<KeyValuePair<string, List<string>>>>(rawJson);
             var storedDictionary = list.ToDictionary((keyItem) => keyItem.Key, (valueItem) => valueItem.Value);
 
@@ -92,9 +112,10 @@ namespace GitHubTeamUserStore
                 Console.WriteLine($"Error! Created dictionary has {_teamUserDict.Keys.Count} teams and stored dictionary has {storedDictionary.Keys.Count} teams.");
                 Console.WriteLine(string.Format("created list teams {0}", string.Join(", ", _teamUserDict.Keys)));
                 Console.WriteLine(string.Format("stored list teams {0}", string.Join(", ", storedDictionary.Keys)));
-                return !hasError;
+                return false;
             }
 
+            bool hasError = false;
             // If the number of teams in the dictionaries are equal, look at the users for every team.
             foreach (string key in _teamUserDict.Keys)
             {
@@ -125,6 +146,84 @@ namespace GitHubTeamUserStore
                             break;
                         }
                     }
+                }
+            }
+            return !hasError;
+        }
+
+        /// <summary>
+        /// This function requires that the team/user data is generated first. It'll use the users from
+        /// the azure-sdk-write group, which is the all inclusive list of users with write permissions,
+        /// to generate the org visibility data.
+        /// </summary>
+        /// <param name="gitHubEventClient">Authenticated GitHubEventClient</param>
+        /// <param name="userOrgVisibilityBlobStorageUri">The URI, including SAS, of the user/org visibility blob</param>
+        /// <returns></returns>
+        public static async Task<bool> GenerateAndStoreUserOrgData(GitHubEventClient gitHubEventClient,
+                                                                   string userOrgVisibilityBlobStorageUri)
+        {
+            Uri userOrgVisBlobUri = new Uri(userOrgVisibilityBlobStorageUri);
+            BlobUriBuilder userOrgVisBlobUriBuilder = new BlobUriBuilder(userOrgVisBlobUri);
+
+            // The user list of azure-sdk-write will be a distinct list of all users from all child teams. All
+            // users are Azure org members, otherwise they wouldn't be in there. Using the list, create a dictionary
+            // with the user as the key and the value, a boolean, true if they're public and false otherwise.
+            List<string> allWriteUsers = _teamUserDict[ProductAndTeamConstants.AzureSdkWriteTeamName];
+            foreach (var user in allWriteUsers)
+            {
+                _userOrgDict[user] = await gitHubEventClient.IsUserPublicMemberOfOrg(ProductAndTeamConstants.Azure, user);
+            }
+            // Dictionary<string, bool> will serialize as-is and doesn't need to be changed for serialization
+            string jsonString = JsonSerializer.Serialize(_userOrgDict);
+            await gitHubEventClient.UploadDataToBlobStorage(jsonString, userOrgVisBlobUriBuilder);
+            bool dataMatches = await VerifyStoredUserOrgData(gitHubEventClient, userOrgVisBlobUriBuilder);
+            if (dataMatches)
+            {
+                Console.WriteLine("user/org visibility data stored successfully.");
+            }
+            else
+            {
+                Console.WriteLine("There were issues with generated vs stored user/org visibility data. See above for specifics.");
+            }
+            return dataMatches;
+        }
+
+        public static async Task<bool> VerifyStoredUserOrgData(GitHubEventClient gitHubEventClient, BlobUriBuilder blobUriBuilder)
+        {
+
+            string rawJson = await gitHubEventClient.GetBlobDataFromStorage(blobUriBuilder);
+            var storedUserOrgDict = JsonSerializer.Deserialize<Dictionary<string, bool>>(rawJson);
+            if (_userOrgDict.Keys.Count != storedUserOrgDict.Keys.Count)
+            {
+                // At this point dictionaries are different, don't bother looking at org membership, output the strings of users (keys)
+                // so they can be compared.
+                Console.WriteLine($"Error! Created user/org dictionary has {_userOrgDict.Keys.Count} users and stored dictionary has {storedUserOrgDict.Keys.Count} users.");
+                Console.WriteLine(string.Format("created list users {0}", string.Join(", ", _userOrgDict.Keys)));
+                Console.WriteLine(string.Format("stored list users {0}", string.Join(", ", storedUserOrgDict.Keys)));
+                return false;
+            }
+
+            // Verify that the _userOrgDict and the storedUserOrgDict both contain the same set of keys
+            foreach (string user in _userOrgDict.Keys)
+            {
+                if (!storedUserOrgDict.ContainsKey(user))
+                {
+                    Console.WriteLine("Error! Created user/org dictionary has different users than the stored dictionary.");
+                    Console.WriteLine(string.Format("created list users {0}", string.Join(", ", _userOrgDict.Keys)));
+                    Console.WriteLine(string.Format("stored list users {0}", string.Join(", ", storedUserOrgDict.Keys)));
+                    return false;
+                }
+            }
+
+            // A this point both dictionaries contain the same set of keys, now verify that the org visibility data is the same.
+            // Look at every entry and report all of the errors
+            bool hasError = false;
+            foreach (string user in _userOrgDict.Keys)
+            {
+                if (_userOrgDict[user] != storedUserOrgDict[user])
+                {
+                    hasError = true;
+                    Console.WriteLine($"The created dictionary entry for {user} is '{_userOrgDict[user]}' and in stored it is '{storedUserOrgDict[user]}'");
                 }
             }
             return !hasError;

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/TeamUserGenerator.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/TeamUserGenerator.cs
@@ -12,13 +12,6 @@ namespace GitHubTeamUserStore
 {
     public class TeamUserGenerator
     {
-        // Team/User dictionary where the team name is the key and the list users is the value. It's worth noting
-        // that this is the list of Logins (Octokit.User.Login) which are what's used in CODEOWNERS, @mentions, etc.
-        private static Dictionary<string, List<string>> _teamUserDict = new Dictionary<string, List<string>>();
-
-        // The user list of azure-sdk-write will contain a distinct list of all users from all child teams. For
-        // each one, check if they're a member of azure and store that in here.
-        private static Dictionary<string, bool> _userOrgDict = new Dictionary<string, bool>();
 
         /// <summary>
         /// Generate the team/user lists for each and every team under azure-sdk-write. Every team and user in a CODEOWNERS
@@ -29,32 +22,38 @@ namespace GitHubTeamUserStore
         /// teams is less than 1/10th of that. The team/user data is serialized into json and stored in azure blob storage.
         /// </summary>
         /// <param name="gitHubEventClient">Authenticated GitHubEventClient</param>
-        /// <param name="teamUserBlobStorageUri">team/user blob storage URI</param>
-        /// <returns></returns>
-        public static async Task<bool> GenerateAndStoreTeamUserList(GitHubEventClient gitHubEventClient,
-                                                                    string teamUserBlobStorageUri)
+        /// <param name="teamUserBlobStorageUri">The URI, including SAS, of the team/user blob storage URI</param>
+        /// <param name="userOrgVisibilityBlobStorageUri">The URI, including SAS, of the user/org visibility blob</param>
+        /// <returns>true if everything stored successfully, false otherwise</returns>
+        public static async Task<bool> GenerateAndStoreTeamUserAndOrgData(GitHubEventClient gitHubEventClient,
+                                                                          string teamUserBlobStorageUri,
+                                                                          string userOrgVisibilityBlobStorageUri)
         {
+            // Team/User dictionary where the team name is the key and the list users is the value. It's worth noting
+            // that this is the list of Logins (Octokit.User.Login) which are what's used in CODEOWNERS, @mentions, etc.
+            Dictionary<string, List<string>> teamUserDict = new Dictionary<string, List<string>>();
             // The BlobUriBuilder for team/user storage is stored for the verify call
             Uri teamUserBlobUri = new Uri(teamUserBlobStorageUri);
             BlobUriBuilder teamUserBlobUriBuilder = new BlobUriBuilder(teamUserBlobUri);
 
             Team azureSdkWrite = await gitHubEventClient.GetTeamById(ProductAndTeamConstants.AzureSdkWriteTeamId);
-            await CreateTeamUserEntry(gitHubEventClient, azureSdkWrite);
+            await CreateTeamUserEntry(gitHubEventClient, azureSdkWrite, teamUserDict);
             // Serializing the Dictionary<string, List<string>> directly won't work with the JsonSerializer but
             // a List<KeyValuePair<string, List<string>>> will and it's easy enough to convert to/from.
-            var list = _teamUserDict.ToList();
+            var list = teamUserDict.ToList();
             string jsonString = JsonSerializer.Serialize(list);
             await gitHubEventClient.UploadDataToBlobStorage(jsonString, teamUserBlobUriBuilder);
-            bool dataMatches = await VerifyStoredTeamUsers(gitHubEventClient, teamUserBlobUriBuilder);
-            if (dataMatches)
+            if (await VerifyStoredTeamUsers(gitHubEventClient, teamUserBlobUriBuilder, teamUserDict))
             {
                 Console.WriteLine("team/user data stored successfully.");
+                // don't bother generating the data unless the team/user data stored
+                return await GenerateAndStoreUserOrgData(gitHubEventClient, userOrgVisibilityBlobStorageUri, teamUserDict);
             }
             else
             {
                 Console.WriteLine("There were issues with generated vs stored data. See above for specifics.");
+                return false;
             }
-            return dataMatches;
         }
 
         /// <summary>
@@ -64,11 +63,13 @@ namespace GitHubTeamUserStore
         /// </summary>
         /// <param name="gitHubEventClient">Authenticated GitHubEventClient</param>
         /// <param name="team">Octokit.Team to get users for.</param>
-        public static async Task CreateTeamUserEntry(GitHubEventClient gitHubEventClient, Team team)
+        public static async Task CreateTeamUserEntry(GitHubEventClient gitHubEventClient, 
+                                                     Team team, 
+                                                     Dictionary<string, List<string>> teamUserDict)
         {
             // If this team has already been added to the dictionary then there's nothing to do. This
             // should prevent any weirdness if there ends up being some kind of circular team reference
-            if (_teamUserDict.ContainsKey(team.Name))
+            if (teamUserDict.ContainsKey(team.Name))
             {
                 return;
             }
@@ -79,7 +80,7 @@ namespace GitHubTeamUserStore
                 // Just need a List<string> containing the logins from the returned
                 // list of users. The Login is what's used in @mentions, assignments etc
                 var members = teamMembers.Select(s => s.Login).ToList();
-                _teamUserDict.Add(team.Name, members);
+                teamUserDict.Add(team.Name, members);
             }
             else
             {
@@ -89,7 +90,7 @@ namespace GitHubTeamUserStore
             var childTeams = await gitHubEventClient.GetAllChildTeams(team);
             foreach (Team childTeam in childTeams)
             {
-                await CreateTeamUserEntry(gitHubEventClient, childTeam);
+                await CreateTeamUserEntry(gitHubEventClient, childTeam, teamUserDict);
             }
         }
 
@@ -99,27 +100,29 @@ namespace GitHubTeamUserStore
         /// </summary>
         /// <param name="gitHubEventClient">Authenticated GitHubEventClient</param>
         /// <returns>True, if the team data in storage matches the in-memory data that was used to create the blob, otherwise, false.</returns>
-        private static async Task<bool> VerifyStoredTeamUsers(GitHubEventClient gitHubEventClient, BlobUriBuilder blobUriBuilder)
+        private static async Task<bool> VerifyStoredTeamUsers(GitHubEventClient gitHubEventClient, 
+                                                              BlobUriBuilder blobUriBuilder, 
+                                                              Dictionary<string, List<string>> teamUserDict)
         {
             string rawJson = await gitHubEventClient.GetBlobDataFromStorage(blobUriBuilder);
             var list = JsonSerializer.Deserialize<List<KeyValuePair<string, List<string>>>>(rawJson);
             var storedDictionary = list.ToDictionary((keyItem) => keyItem.Key, (valueItem) => valueItem.Value);
 
-            // Verify the dictionary from storage contains everything from the _teamUserDict
-            if (_teamUserDict.Keys.Count != storedDictionary.Keys.Count)
+            // Verify the dictionary from storage contains everything from the teamUserDict
+            if (teamUserDict.Keys.Count != storedDictionary.Keys.Count)
             {
                 // At this point list the teams and return, don't bother looking at the users.
-                Console.WriteLine($"Error! Created dictionary has {_teamUserDict.Keys.Count} teams and stored dictionary has {storedDictionary.Keys.Count} teams.");
-                Console.WriteLine(string.Format("created list teams {0}", string.Join(", ", _teamUserDict.Keys)));
+                Console.WriteLine($"Error! Created dictionary has {teamUserDict.Keys.Count} teams and stored dictionary has {storedDictionary.Keys.Count} teams.");
+                Console.WriteLine(string.Format("created list teams {0}", string.Join(", ", teamUserDict.Keys)));
                 Console.WriteLine(string.Format("stored list teams {0}", string.Join(", ", storedDictionary.Keys)));
                 return false;
             }
 
             bool hasError = false;
             // If the number of teams in the dictionaries are equal, look at the users for every team.
-            foreach (string key in _teamUserDict.Keys)
+            foreach (string key in teamUserDict.Keys)
             {
-                var users = _teamUserDict[key];
+                var users = teamUserDict[key];
                 var storedUsers = storedDictionary[key];
                 // Since these are just lists of strings, calling sort will sort them in ascending order.
                 // This makes things easier to find differences if there's an error
@@ -160,23 +163,28 @@ namespace GitHubTeamUserStore
         /// <param name="userOrgVisibilityBlobStorageUri">The URI, including SAS, of the user/org visibility blob</param>
         /// <returns></returns>
         public static async Task<bool> GenerateAndStoreUserOrgData(GitHubEventClient gitHubEventClient,
-                                                                   string userOrgVisibilityBlobStorageUri)
+                                                                   string userOrgVisibilityBlobStorageUri,
+                                                                   Dictionary<string, List<string>> teamUserDict)
         {
+            // The user list of azure-sdk-write will contain a distinct list of all users from all child teams. For
+            // each one, check if they're a member of azure and store that in here.
+            Dictionary<string, bool> userOrgDict = new Dictionary<string, bool>();
+
             Uri userOrgVisBlobUri = new Uri(userOrgVisibilityBlobStorageUri);
             BlobUriBuilder userOrgVisBlobUriBuilder = new BlobUriBuilder(userOrgVisBlobUri);
 
             // The user list of azure-sdk-write will be a distinct list of all users from all child teams. All
             // users are Azure org members, otherwise they wouldn't be in there. Using the list, create a dictionary
             // with the user as the key and the value, a boolean, true if they're public and false otherwise.
-            List<string> allWriteUsers = _teamUserDict[ProductAndTeamConstants.AzureSdkWriteTeamName];
+            List<string> allWriteUsers = teamUserDict[ProductAndTeamConstants.AzureSdkWriteTeamName];
             foreach (var user in allWriteUsers)
             {
-                _userOrgDict[user] = await gitHubEventClient.IsUserPublicMemberOfOrg(ProductAndTeamConstants.Azure, user);
+                userOrgDict[user] = await gitHubEventClient.IsUserPublicMemberOfOrg(ProductAndTeamConstants.Azure, user);
             }
             // Dictionary<string, bool> will serialize as-is and doesn't need to be changed for serialization
-            string jsonString = JsonSerializer.Serialize(_userOrgDict);
+            string jsonString = JsonSerializer.Serialize(userOrgDict);
             await gitHubEventClient.UploadDataToBlobStorage(jsonString, userOrgVisBlobUriBuilder);
-            bool dataMatches = await VerifyStoredUserOrgData(gitHubEventClient, userOrgVisBlobUriBuilder);
+            bool dataMatches = await VerifyStoredUserOrgData(gitHubEventClient, userOrgVisBlobUriBuilder, userOrgDict);
             if (dataMatches)
             {
                 Console.WriteLine("user/org visibility data stored successfully.");
@@ -188,28 +196,30 @@ namespace GitHubTeamUserStore
             return dataMatches;
         }
 
-        public static async Task<bool> VerifyStoredUserOrgData(GitHubEventClient gitHubEventClient, BlobUriBuilder blobUriBuilder)
+        public static async Task<bool> VerifyStoredUserOrgData(GitHubEventClient gitHubEventClient, 
+                                                               BlobUriBuilder blobUriBuilder,
+                                                                Dictionary<string, bool> userOrgDict)
         {
 
             string rawJson = await gitHubEventClient.GetBlobDataFromStorage(blobUriBuilder);
             var storedUserOrgDict = JsonSerializer.Deserialize<Dictionary<string, bool>>(rawJson);
-            if (_userOrgDict.Keys.Count != storedUserOrgDict.Keys.Count)
+            if (userOrgDict.Keys.Count != storedUserOrgDict.Keys.Count)
             {
                 // At this point dictionaries are different, don't bother looking at org membership, output the strings of users (keys)
                 // so they can be compared.
-                Console.WriteLine($"Error! Created user/org dictionary has {_userOrgDict.Keys.Count} users and stored dictionary has {storedUserOrgDict.Keys.Count} users.");
-                Console.WriteLine(string.Format("created list users {0}", string.Join(", ", _userOrgDict.Keys)));
+                Console.WriteLine($"Error! Created user/org dictionary has {userOrgDict.Keys.Count} users and stored dictionary has {storedUserOrgDict.Keys.Count} users.");
+                Console.WriteLine(string.Format("created list users {0}", string.Join(", ", userOrgDict.Keys)));
                 Console.WriteLine(string.Format("stored list users {0}", string.Join(", ", storedUserOrgDict.Keys)));
                 return false;
             }
 
-            // Verify that the _userOrgDict and the storedUserOrgDict both contain the same set of keys
-            foreach (string user in _userOrgDict.Keys)
+            // Verify that the userOrgDict and the storedUserOrgDict both contain the same set of keys
+            foreach (string user in userOrgDict.Keys)
             {
                 if (!storedUserOrgDict.ContainsKey(user))
                 {
                     Console.WriteLine("Error! Created user/org dictionary has different users than the stored dictionary.");
-                    Console.WriteLine(string.Format("created list users {0}", string.Join(", ", _userOrgDict.Keys)));
+                    Console.WriteLine(string.Format("created list users {0}", string.Join(", ", userOrgDict.Keys)));
                     Console.WriteLine(string.Format("stored list users {0}", string.Join(", ", storedUserOrgDict.Keys)));
                     return false;
                 }
@@ -218,12 +228,12 @@ namespace GitHubTeamUserStore
             // A this point both dictionaries contain the same set of keys, now verify that the org visibility data is the same.
             // Look at every entry and report all of the errors
             bool hasError = false;
-            foreach (string user in _userOrgDict.Keys)
+            foreach (string user in userOrgDict.Keys)
             {
-                if (_userOrgDict[user] != storedUserOrgDict[user])
+                if (userOrgDict[user] != storedUserOrgDict[user])
                 {
                     hasError = true;
-                    Console.WriteLine($"The created dictionary entry for {user} is '{_userOrgDict[user]}' and in stored it is '{storedUserOrgDict[user]}'");
+                    Console.WriteLine($"The created dictionary entry for {user} is '{userOrgDict[user]}' and in stored it is '{storedUserOrgDict[user]}'");
                 }
             }
             return !hasError;


### PR DESCRIPTION
The team/user store used to only store team/user data for teams with write permissions (teams under, and including, azure-sdk-write). _This data is used to expand teams in CODEOWNERS files for Azure repositories._ During the analysis for the development of a CODEOWNERS linter, it was quickly discovered that we needed more than just the team/user data. We needed the following:

1. User/Org visibility data. Our [documentation](https://eng.ms/docs/products/azure-developer-experience/onboard/access-repos) states that user's Azure org membership must be public and this information was needed to detect this specific case. The fact is, even GitHub's CODEOWNERS verification (which only verifies owners on source path/owner lines) flags owners as invalid if their membership to Azure is private, regardless of whether or not the owner has write permission for the repository. This information is also not a security risk as anyone can look at a GitHub user and see what they're public members of. [This is underlying GitHub API call Octokit.Net is using](https://docs.github.com/en/rest/orgs/members?apiVersion=2022-11-28#check-public-organization-membership-for-a-user). Only the users that are part of azure-sdk-write are checked. The data is stored as a Dictionary<string, bool>
2. Repository Label data. There is metadata in our CODEOWNERS files that includes labels (PRLabel and ServiceLabel) which need to be verified. The [list of repositories](https://github.com/Azure/azure-sdk-tools/blob/main/tools/github/data/repositories.txt) that labels are being collected for is the same list of repositories that we sync a common set of labels to. The common list can't be used because it only contains the labels that are common to all of the repositories and each one has their repository specific labels. 

There was a secondary change that's not reflected in this PR. The GitHub PAT being used to collect this data had to be updated. Previously, the PAT only required Organization->Members:read-only to get the user/org data. The label data, specifically for our private repositories, required Repository->Issues:read-only and Repository->PullRequests:read-only permissions.

This does increate the number of calls made to the GitHub API, when the pipeline-owners-extraction pipeline runs, from roughly 200 to about 1500 which is still way under the 5000/hour limit. Given the pipeline only runs once daily, that's okay.

Q) Why do we need to get this data here, instead of having the linter get it?
A) The plan is to have the linter run in CI pipeline which means no secrets. While the data being stored in blob storage isn't a security risk, having a PAT in a CI pipeline most certainly would be.