### PR TITLE
Fail fast on variable conflicts with subscription config

### DIFF
--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -109,11 +109,17 @@ function SetSubscriptionConfiguration([object]$subscriptionConfiguration)
                 # Mark values as secret so we don't print json blobs containing secrets in the logs.
                 # Prepend underscore to the variable name, so we can still access the variable names via environment
                 # variables if they get set subsequently.
+                if ([Environment]::GetEnvironmentVariable($nestedPair.Name)) {
+                    throw "Environment variable '$($nestedPair.Name)' is already set. Check the tests.yml/ci.yml EnvVars parameter does not conflict with the subscription config json"
+                }
                 if (ShouldMarkValueAsSecret "AZURE_" $nestedPair.Name $nestedPair.Value) {
                     Write-Host "##vso[task.setvariable variable=_$($nestedPair.Name);issecret=true;]$($nestedPair.Value)"
                 }
             }
         } else {
+            if ([Environment]::GetEnvironmentVariable($pair.Name)) {
+                throw "Environment variable '$($pair.Name)' is already set. Check the tests.yml/ci.yml EnvVars parameter does not conflict with the subscription config json"
+            }
             if (ShouldMarkValueAsSecret "AZURE_" $pair.Name $pair.Value) {
                 Write-Host "##vso[task.setvariable variable=_$($pair.Name);issecret=true;]$($pair.Value)"
             }

--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -5,6 +5,10 @@ parameters:
   - name: SubscriptionConfigurations
     type: object
     default: null
+  # EnvVars is used to help diagnose variable conflict issues early
+  - name: EnvVars
+    type: object
+    default: null
 
 steps:
   - ${{ if parameters.SubscriptionConfiguration }}:
@@ -16,6 +20,8 @@ steps:
         . ./eng/common/TestResources/SubConfig-Helpers.ps1
         SetSubscriptionConfiguration $config
       displayName: Initialize SubscriptionConfiguration variable
+      ${{ if parameters.EnvVars }}:
+        env: ${{ parameters.EnvVars }}
 
   - ${{ if parameters.SubscriptionConfigurations }}:
     - pwsh: |
@@ -36,3 +42,5 @@ steps:
           UpdateSubscriptionConfiguration $configBase $config
 
         displayName: Merge Test Resource Configurations
+        ${{ if parameters.EnvVars }}:
+          env: ${{ parameters.EnvVars }}


### PR DESCRIPTION
We've run into this a couple times as teams migrate away from hardcoded keyvault secrets but have duplicates in the yaml, causing hard to find issues when updating values in the wrong place. The identity team, for example, has some of their core variables in our base config (which should be moved).

I'm going to update the language test pipelines to pass down `EnvVars` from the tests/ci.yml files just to fail fast on any conflicts.