### PR TITLE
Revert "Strong name sign Sodium.Core in secret library"

### DIFF
--- a/tools/secret-management/Azure.Sdk.Tools.AccessManagement/Azure.Sdk.Tools.AccessManagement.csproj
+++ b/tools/secret-management/Azure.Sdk.Tools.AccessManagement/Azure.Sdk.Tools.AccessManagement.csproj
@@ -7,8 +7,6 @@
     <PackageReference Include="Microsoft.Graph" Version="5.4.0" />
     <PackageReference Include="Octokit" Version="5.0.3" />
     <PackageReference Include="Sodium.Core" Version="1.3.3" />
-    <!-- Add this to strong name sign Sodium.Core as a requirement for internal sign/release -->
-    <PackageReference Include="StrongNamer" Version="0.2.5" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/tools/secret-management/Directory.Build.props
+++ b/tools/secret-management/Directory.Build.props
@@ -6,6 +6,7 @@
         <IsPackable>false</IsPackable>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <NoWarn>$(NoWarn);CS8002</NoWarn>
     </PropertyGroup>
 
     <Import Project="../../Directory.Build.props" />


### PR DESCRIPTION
Reverts Azure/azure-sdk-tools#6854

This didn't solve our problem, so we're going to go with an internal skip instead. Removing the strong name lib dependency in favor of the old NoWarn approach.