### PR TITLE
Switch signalR group name to github Identity

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/CommentsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/CommentsController.cs
@@ -31,7 +31,7 @@ namespace APIViewWeb.Controllers
             if (string.IsNullOrEmpty(commentText))
             {
                 var notifcation = new NotificationModel() { Message = "Comment Text cannot be empty. Please type your comment entry and try again.", Level = NotificatonLevel.Error };
-                await _signalRHubContext.Clients.Group(User.Identity.Name).SendAsync("RecieveNotification", notifcation);
+                await _signalRHubContext.Clients.Group(User.GetGitHubLogin()).SendAsync("RecieveNotification", notifcation);
                 return new BadRequestResult();
             }
 

--- a/src/dotnet/APIView/APIViewWeb/Controllers/ReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/ReviewController.cs
@@ -95,7 +95,7 @@ namespace APIViewWeb.Controllers
                     notification.Level = NotificatonLevel.Error;
                     break;
             }
-            await _signalRHubContext.Clients.Group(User.Identity.Name).SendAsync("RecieveAIReviewGenerationStatus", notification);
+            await _signalRHubContext.Clients.Group(User.GetGitHubLogin()).SendAsync("RecieveAIReviewGenerationStatus", notification);
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Hubs/SignalRHub.cs
+++ b/src/dotnet/APIView/APIViewWeb/Hubs/SignalRHub.cs
@@ -1,8 +1,6 @@
 using System.Threading.Tasks;
-using APIViewWeb.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Azure;
 using Microsoft.Extensions.Logging;
 
 namespace APIViewWeb.Hubs
@@ -17,7 +15,7 @@ namespace APIViewWeb.Hubs
 
         public override Task OnConnectedAsync()
         {
-            string name = Context.User.Identity.Name;
+            string name = Context.User.GetGitHubLogin();
             if (!string.IsNullOrEmpty(name))
             {
                 Groups.AddToGroupAsync(Context.ConnectionId, name);

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -314,7 +314,7 @@ namespace APIViewWeb.Managers
                 review.ApprovalDate = DateTime.Now;
                 approvalStatus = true;
             }
-            await _signalRHubContext.Clients.Group(user.Identity.Name).SendAsync("ReceiveApprovalSelf", review.ReviewId, revisionId, approvalStatus);
+            await _signalRHubContext.Clients.Group(user.GetGitHubLogin()).SendAsync("ReceiveApprovalSelf", review.ReviewId, revisionId, approvalStatus);
             await _signalRHubContext.Clients.All.SendAsync("ReceiveApproval", review.ReviewId, revisionId, userId, approvalStatus);
             await _reviewsRepository.UpsertReviewAsync(review);
         }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml.cs
@@ -85,7 +85,7 @@ namespace APIViewWeb.Pages.Assemblies
                     }
                 }
                 var notifcation = new NotificationModel() { Message = errors.ToString(), Level = NotificatonLevel.Error };
-                await _notificationHubContext.Clients.Group(User.Identity.Name).SendAsync("RecieveNotification", notifcation);
+                await _notificationHubContext.Clients.Group(User.GetGitHubLogin()).SendAsync("RecieveNotification", notifcation);
                 return new NoContentResult();
             }
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
@@ -126,7 +126,7 @@ namespace APIViewWeb.Pages.Assemblies
                 if (Lines.Length == 0)
                 {
                     var notifcation = new NotificationModel() { Message = "There is no diff between the two revisions.", Level = NotificatonLevel.Info };
-                    await _signalRHubContext.Clients.Group(User.Identity.Name).SendAsync("RecieveNotification", notifcation);
+                    await _signalRHubContext.Clients.Group(User.GetGitHubLogin()).SendAsync("RecieveNotification", notifcation);
                     return Redirect(Request.Headers["referer"]);
                 }
             }
@@ -298,7 +298,7 @@ namespace APIViewWeb.Pages.Assemblies
                 else 
                 {
                     var notifcation = new NotificationModel() { Message = $"A revision with ID {revisionId} does not exist for this review.", Level = NotificatonLevel.Warning };
-                    await _signalRHubContext.Clients.Group(User.Identity.Name).SendAsync("RecieveNotification", notifcation);
+                    await _signalRHubContext.Clients.Group(User.GetGitHubLogin()).SendAsync("RecieveNotification", notifcation);
                 }
 
             }


### PR DESCRIPTION
`Claims.Identity.Name` is returning null in some cases. This PR is intended to unblock the issue while we investigate.