### PR TITLE
Check for DocsMsPackagesAllValid before running validation step

### DIFF
--- a/eng/common/pipelines/templates/steps/docsms-ensure-validation.yml
+++ b/eng/common/pipelines/templates/steps/docsms-ensure-validation.yml
@@ -1,6 +1,6 @@
 steps:
 # Fail the build if any of the packages failed validation. Valid values are
-# "true" or "false"
+# "true" or "false". This step will skip if $(DocsMsPackagesAllValid) is not set
 - pwsh: |
     if ('$(DocsMsPackagesAllValid)' -eq 'true') {
       Write-Host "All packages passed validation."
@@ -9,3 +9,4 @@ steps:
       exit 1
     }
   displayName: Check package validation results
+  condition: and(succeeded(), ne(variables['DocsMsPackagesAllValid'], ''))


### PR DESCRIPTION
This fixes an issue discovered [in the spring pipelines for which no docs are published](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3034028&view=logs&j=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b&t=27412920-1ce6-5c15-b5b0-3baeb5d8a8ba&s=cc1c0c38-0f79-5da2-c09f-847e3abdf9ce). In that case, the Update-DocsMsMetadata.ps1 script [does not run](https://github.com/Azure/azure-sdk-for-java/blob/djurek/ignore-undocumentable-packages/eng/common/pipelines/templates/steps/update-docsms-metadata.yml#L36-L39) which means the `DocsMsPackagesAllValid` is not set. 

A couple of fixes are possible: 

1. Only check for valid docs if `DocsMsPackagesAllValid` variable is set
1. Ensure that `DocsMsPackagesAllValid` variable is always set by setting it in some prior step (drawbacks here include the fact that we have to change other job steps outside of the check template)

Tests: 

* Using the spring pipeline (note that the step was skipped): https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3038636&view=logs&j=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b&t=27412920-1ce6-5c15-b5b0-3baeb5d8a8ba
* Using the KV pipeline which has packages that are not skipped: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3038839&view=logs&j=f8e040b3-c0ff-5789-0eda-99daaaa3fc1b&t=72adc640-892e-556c-caf8-3d3401f18a55