### PR TITLE
[APIView] Add support for CrossLanguageDefinitionIds

### DIFF
--- a/packages/python-packages/apiview-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/apiview-stub-generator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## Version 0.3.9 (TBD)
+Improve support for "CrossLanguageDefinitionId".
+
 ## Version 0.3.8 (2023-07-06)
 Display `--source-url` as an actual clickable link.
 Fix issue with line ids in diffs so that the entire signature doesn't turn red if something is changed. 

--- a/packages/python-packages/apiview-stub-generator/apistub/_metadata_map.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_metadata_map.py
@@ -8,7 +8,7 @@
 import json
 import os
 
-MAPPING_FILE_NAME = "apiview_mapping.json"
+MAPPING_FILE_NAME = "apiview_mapping_python.json"
 
 """
 Loads metadata from the mapping file for use

--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -54,7 +54,7 @@ class StubGenerator:
             parser.add_argument(
                 "--mapping-path",
                 default=None,
-                help=("Path to an 'apiview_mapping.json' file that supplies cross-langauge definition IDs.")
+                help=("Path to an 'apiview_mapping_python.json' file that supplies cross-language definition IDs.")
             )
             parser.add_argument(
                 "--verbose",

--- a/packages/python-packages/apiview-stub-generator/apistub/_version.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.3.8"
+VERSION = "0.3.9"

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_class_node.py
@@ -319,9 +319,9 @@ class ClassNode(NodeEntityBase):
             apiview.add_newline()
 
         apiview.add_whitespace()
-        apiview.add_line_marker(self.namespace_id)
+        apiview.add_line_marker(self.namespace_id, add_cross_language_id=True)
         apiview.add_keyword("class", False, True)
-        apiview.add_text(self.full_name, definition_id=self.namespace_id, add_cross_language_id=True)
+        apiview.add_text(self.full_name, definition_id=self.namespace_id)
         for err in self.pylint_errors:
             err.generate_tokens(apiview, self.namespace_id)
 

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_function_node.py
@@ -252,7 +252,7 @@ class FunctionNode(NodeEntityBase):
             apiview.add_newline()
 
         apiview.add_whitespace()
-        apiview.add_line_marker(self.namespace_id)
+        apiview.add_line_marker(self.namespace_id, add_cross_language_id=True)
         if self.is_async:
             apiview.add_keyword("async", False, True)
 
@@ -260,8 +260,7 @@ class FunctionNode(NodeEntityBase):
         # Show fully qualified name for module level function and short name for instance functions
         apiview.add_text(
             self.full_name if self.is_module_level else self.name,
-            definition_id=self.namespace_id,
-            add_cross_language_id=True
+            definition_id=self.namespace_id
         )
         # Add parameters
         self._generate_signature_token(apiview, use_multi_line)

--- a/tools/apiview/emitters/typespec-apiview/package.json
+++ b/tools/apiview/emitters/typespec-apiview/package.json
@@ -87,6 +87,6 @@
     "prettier": "^2.7.1",
     "rimraf": "^3.0.2",
     "source-map-support": "^0.5.19",
-    "typescript": "^4.8.3"
+    "typescript": "^5.0"
   }
 }

--- a/tools/apiview/emitters/typespec-apiview/package.json
+++ b/tools/apiview/emitters/typespec-apiview/package.json
@@ -54,31 +54,31 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@typespec/compiler": ">=0.40 <1.0",
-    "@typespec/versioning": ">=0.40 <1.0"
+    "@typespec/compiler": ">=0.43 <1.0",
+    "@typespec/versioning": ">=0.43 <1.0"
   },
   "devDependencies": {
-    "@azure-tools/typespec-azure-core": "0.29.0",
-    "@typespec/http": "0.43.1",
-    "@typespec/rest": "0.43.0",
-    "@typespec/eslint-plugin": ">=0.40 <1.0",
-    "@typespec/library-linter": ">=0.40 <1.0",
-    "@typespec/prettier-plugin-typespec": ">=0.40 <1.0",
-    "@typespec/eslint-config-typespec": ">=0.6.0 <1.0",
+    "@azure-tools/typespec-azure-core": "~0.33",
+    "@changesets/cli": "^2.24.4",
     "@types/mocha": "~9.1.0",
     "@types/node": "~16.0.3",
-    "@changesets/cli": "^2.24.4",
+    "@typespec/eslint-config-typespec": ">=0.6.0 <1.0",
+    "@typespec/eslint-plugin": ">=0.43 <1.0",
+    "@typespec/http": ">=0.43 <1.0",
+    "@typespec/library-linter": ">=0.43 <1.0",
+    "@typespec/prettier-plugin-typespec": ">=0.43 <1.0",
+    "@typespec/rest": ">=0.43 <1.0",
     "c8": "~7.11.0",
     "cspell": "^6.8.1",
     "eslint": "^8.23.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-unicorn": "^43.0.2",
-    "prettier": "^2.7.1",
-    "rimraf": "^3.0.2",
-    "typescript": "^4.8.3",
     "mocha": "~9.2.0",
     "mocha-junit-reporter": "~2.0.2",
     "mocha-multi-reporters": "~1.5.1",
-    "source-map-support": "^0.5.19"
+    "prettier": "^2.7.1",
+    "rimraf": "^3.0.2",
+    "source-map-support": "^0.5.19",
+    "typescript": "^4.8.3"
   }
 }

--- a/tools/apiview/emitters/typespec-apiview/src/apiview.ts
+++ b/tools/apiview/emitters/typespec-apiview/src/apiview.ts
@@ -34,6 +34,7 @@ import {
   UnionExpressionNode,
   UnionStatementNode,
   UnionVariantNode,
+  ValueOfExpressionNode,
 } from "@typespec/compiler";
 import { ApiViewDiagnostic, ApiViewDiagnosticLevel } from "./diagnostic.js";
 import { ApiViewNavigation } from "./navigation.js";
@@ -599,6 +600,10 @@ export class ApiView {
         break;
       case SyntaxKind.UsingStatement:
         throw new Error(`Case "UsingStatement" not implemented`);
+      case SyntaxKind.ValueOfExpression:
+        this.keyword("valueof", true, true);
+        this.tokenize((node as ValueOfExpressionNode).target);
+        break;
       case SyntaxKind.VoidKeyword:
         this.keyword("void", true, true);
         break;

--- a/tools/apiview/emitters/typespec-apiview/src/emitter.ts
+++ b/tools/apiview/emitters/typespec-apiview/src/emitter.ts
@@ -22,7 +22,6 @@ export interface ResolvedApiViewEmitterOptions {
   service?: string;
   version?: string;
   includeGlobalNamespace: boolean;
-  mappingPath?: string;
 }
 
 export async function $onEmit(context: EmitContext<ApiViewEmitterOptions>) {
@@ -40,7 +39,6 @@ export function resolveOptions(context: EmitContext<ApiViewEmitterOptions>): Res
     service: resolvedOptions["service"],
     version: resolvedOptions["version"],
     includeGlobalNamespace: resolvedOptions["include-global-namespace"] ?? false,
-    mappingPath: resolvedOptions["mapping-path"],
   };
 }
 
@@ -143,26 +141,6 @@ function applyServiceFilter(program: Program, services: Service[], options: Reso
   return filtered;
 }
 
-async function loadMappingFile(program: Program, mappingPath?: string): Promise<any | undefined> {
-  if (mappingPath === undefined) {
-    return undefined;
-  }
-  const resolvedPath = resolvePath(mappingPath);
-  try {
-    const mappingFile = await program.host.readFile(resolvedPath);
-    return mappingFile;
-  } catch (error) {
-    reportDiagnostic(program, {
-      code: "mapping-file-not-found",
-      target: NoTarget,
-      format: {
-        value: mappingPath
-      }
-    });
-    return undefined;
-  }
-}
-
 function createApiViewEmitter(program: Program, options: ResolvedApiViewEmitterOptions) {
   return { emitApiView };
 
@@ -202,7 +180,6 @@ function createApiViewEmitter(program: Program, options: ResolvedApiViewEmitterO
         }  
       }      
       const resolvedProgram = resolveProgramForVersion(program, service.type, versionString);
-      const mapping = await loadMappingFile(program, options.mappingPath);
   
       const apiview = new ApiView(serviceTitle, namespaceString, versionString, options.includeGlobalNamespace);
       apiview.emit(resolvedProgram);

--- a/tools/apiview/emitters/typespec-apiview/src/lib.ts
+++ b/tools/apiview/emitters/typespec-apiview/src/lib.ts
@@ -4,7 +4,8 @@ export interface ApiViewEmitterOptions {
   "output-file"?: string;
   "service"?: string;
   "version"?: string;
-  "include-global-namespace"?: boolean
+  "include-global-namespace"?: boolean,
+  "mapping-path"?: string;
 }
 
 const ApiViewEmitterOptionsSchema: JSONSchemaType<ApiViewEmitterOptions> = {
@@ -14,7 +15,8 @@ const ApiViewEmitterOptionsSchema: JSONSchemaType<ApiViewEmitterOptions> = {
     "output-file": { type: "string", nullable: true },
     "service": { type: "string", nullable: true },
     "version": {type: "string", nullable: true },
-    "include-global-namespace": {type: "boolean", nullable: true}
+    "include-global-namespace": {type: "boolean", nullable: true},
+    "mapping-path": { type: "string", nullable: true },
   },
   required: [],
 };
@@ -45,6 +47,12 @@ export const $lib = createTypeSpecLibrary({
       severity: "error",
       messages: {
         default: paramMessage`Version "${"version"}" not found for service "${"serviceName"}". Allowed values: ${"allowed"}.`,
+      }
+    },
+    "mapping-file-not-found": {
+      severity: "error",
+      messages: {
+        default: paramMessage`Mapping file "${"mappingPath"}" not found.`,
       }
     },
   },

--- a/tools/apiview/emitters/typespec-apiview/src/lib.ts
+++ b/tools/apiview/emitters/typespec-apiview/src/lib.ts
@@ -49,12 +49,6 @@ export const $lib = createTypeSpecLibrary({
         default: paramMessage`Version "${"version"}" not found for service "${"serviceName"}". Allowed values: ${"allowed"}.`,
       }
     },
-    "mapping-file-not-found": {
-      severity: "error",
-      messages: {
-        default: paramMessage`Mapping file "${"mappingPath"}" not found.`,
-      }
-    },
   },
   emitter: {
     options: ApiViewEmitterOptionsSchema,

--- a/tools/apiview/emitters/typespec-apiview/src/version.ts
+++ b/tools/apiview/emitters/typespec-apiview/src/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "0.4.4";
+export const LIB_VERSION = "0.4.5";

--- a/tools/apiview/emitters/typespec-apiview/test/apiview.test.ts
+++ b/tools/apiview/emitters/typespec-apiview/test/apiview.test.ts
@@ -204,13 +204,13 @@ describe("apiview: tests", () => {
       @TypeSpec.service( { title: "Test", version: "1" } )
       namespace Azure.Test {
         @doc(T)
-        scalar Unreal<T extends string>;
+        scalar Unreal<T extends valueof string>;
       }
       `;
       const expect = `
       namespace Azure.Test {
         @doc(T)
-        scalar Unreal<T extends string>
+        scalar Unreal<T extends valueof string>
       }
       `;
       const apiview = await apiViewFor(input, {});

--- a/tools/stress-cluster/services/Stress.Watcher/Dockerfile
+++ b/tools/stress-cluster/services/Stress.Watcher/Dockerfile
@@ -1,10 +1,10 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0 AS build
 
 COPY ./src /src
 
 RUN cd /src && dotnet publish -c Release -o /stresswatcher -f net6.0
 
-FROM mcr.microsoft.com/dotnet/runtime:6.0
+FROM mcr.microsoft.com/dotnet/runtime:6.0-cbl-mariner2.0
 
 COPY --from=build /stresswatcher /stresswatcher
 


### PR DESCRIPTION
**TypeSpec:** Also adds support for unnamed unions and the valueof keyword.

**Python:** Updates the default file to `apiview_mapping_python.json` so as not to conflict with other languages. 