### PR TITLE
Allowing a bit more of a grace period on slow requests

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -160,6 +160,8 @@ namespace Azure.Sdk.Tools.TestProxy
                     .ConfigureKestrel(kestrelServerOptions =>
                     {
                         kestrelServerOptions.ConfigureEndpointDefaults(lo => lo.Protocols = HttpProtocols.Http1);
+                        // default minimum rate is 240 bytes per second with 5 second grace period. Bumping to 50bps with a graceperiod of 20 seconds.
+                        kestrelServerOptions.Limits.MinRequestBodyDataRate = new MinDataRate(bytesPerSecond: 50, gracePeriod: TimeSpan.FromSeconds(20));
                     })
                 );
 


### PR DESCRIPTION
This is an attempt at resolving Azure/azure-sdk-for-java#36669

I saw the following in a failed startPlayback request:

@samvaity FYI

```
[19:41:40] dbug: Microsoft.AspNetCore.Server.Kestrel.Connections[9]
      Connection id "0HMTFR2OL71BA" completed keep alive response.
[19:41:40] info: Microsoft.AspNetCore.Hosting.Diagnostics[2]
      Request finished HTTP/1.1 POST http://localhost:5000/v2.1/track - 342 - 500 - application/json 5299.1726ms
[19:41:40] dbug: Microsoft.AspNetCore.Server.Kestrel.BadRequests[17]
      Connection id "0HMTFR2OL71BA" bad request data: "Reading the request body timed out due to data arriving too slowly. See MinRequestBodyDataRate."
      Microsoft.AspNetCore.Server.Kestrel.Core.BadHttpRequestException: Reading the request body timed out due to data arriving too slowly. See MinRequestBodyDataRate.
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1ContentLengthMessageBody.TryReadInternal(ReadResult& readResult)
         at Microsoft.AspNetCore.Server.Kestrel.Core.Internal.Http.Http1MessageBody.OnConsumeAsync()
```

So let's see if we can make the proxy a bit more flexible on this point.