### PR TITLE
Fixed several ApiView parser issues.

### DIFF
--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.cpp
@@ -71,7 +71,7 @@ void AzureClassesDatabase::CreateApiViewMessage(
       newMessage.DiagnosticId = "CPA0009";
       newMessage.DiagnosticText = "Implicit override of virtual method. Consider using the "
                                   "'override' keyword to make the override semantics explicit.";
-      newMessage.Level = ApiViewMessage::MessageLevel::Error;
+      newMessage.Level = ApiViewMessage::MessageLevel::Info;
       newMessage.HelpLinkUri = "https://isocpp.github.io/CppCoreGuidelines/"
                                "CppCoreGuidelines#c128-virtual-functions-should-specify-exactly-"
                                "one-of-virtual-override-or-final";

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.cpp
@@ -67,11 +67,29 @@ void AzureClassesDatabase::CreateApiViewMessage(
       newMessage.Level = ApiViewMessage::MessageLevel::Info;
       break;
     }
-    case ApiViewMessages::UsingDirectiveFound: {
+    case ApiViewMessages::ImplicitOverride: {
       newMessage.DiagnosticId = "CPA0009";
+      newMessage.DiagnosticText = "Implicit override of virtual method. Consider using the "
+                                  "'override' keyword to make the override semantics explicit.";
+      newMessage.Level = ApiViewMessage::MessageLevel::Error;
+      newMessage.HelpLinkUri = "https://isocpp.github.io/CppCoreGuidelines/"
+                               "CppCoreGuidelines#c128-virtual-functions-should-specify-exactly-"
+                               "one-of-virtual-override-or-final";
+      break;
+    }
+    case ApiViewMessages::UsingDirectiveFound: {
+      newMessage.DiagnosticId = "CPA000A";
       newMessage.DiagnosticText = "Using Namespace directive found in header file. ";
       newMessage.HelpLinkUri
           = "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#Rs-using-directive";
+      newMessage.Level = ApiViewMessage::MessageLevel::Error;
+      break;
+    }
+    case ApiViewMessages::NonVirtualDestructor: {
+      newMessage.DiagnosticId = "CPA000B";
+      newMessage.DiagnosticText = "Base class destructors should be public and virtual or protected and non-virtual. ";
+      newMessage.HelpLinkUri
+          = "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual";
       newMessage.Level = ApiViewMessage::MessageLevel::Error;
       break;
     }

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.hpp
@@ -34,4 +34,6 @@ enum class ApiViewMessages
   InternalTypesInNonCorePackage, // Internal types in a non-core package
   ImplicitConstructor, // Constructor for a type is not marked "explicit".
   UsingDirectiveFound, // "using namespace" directive found.
+  ImplicitOverride, // Implicit override of virtual method.
+  NonVirtualDestructor, // Destructor of non-final class is not virtual.
 };

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.cpp
@@ -1487,7 +1487,7 @@ public:
 
     if (templateParam->hasDefaultArgument())
     {
-      auto const&defaultArg = templateParam->getDefaultArgument().getArgument();
+      auto const& defaultArg = templateParam->getDefaultArgument().getArgument();
       switch (defaultArg.getKind())
       {
 
@@ -1833,7 +1833,12 @@ public:
     // We assume that this is an implicit override if there are overriden methods. If we later find
     // an override attribute, we know it's not an implicit override.
     //
-    // Note that we don't do this for destructors, because they don't have an override attribute.
+    // Note that we don't do this for destructors, because they typically won't have an override
+    // attribute.
+    //
+    // Also note that if size_overriden_methods is non-zero, it means that the base class method is
+    // already virtual.
+    //
     if (method->getKind() == Decl::Kind::CXXMethod)
     {
       if (method->size_overridden_methods() > 0)

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.cpp
@@ -573,8 +573,8 @@ class AstDeclRefExpr : public AstExpr {
 
 public:
   AstDeclRefExpr(DeclRefExpr const* expression, ASTContext& context)
-      : AstExpr(expression, context), m_referencedName{
-                                          expression->getFoundDecl()->getQualifiedNameAsString()}
+      : AstExpr(expression, context),
+        m_referencedName{expression->getFoundDecl()->getQualifiedNameAsString()}
   {
   }
   virtual void Dump(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const override
@@ -1106,9 +1106,9 @@ AstNamedNode::AstNamedNode(
     NamedDecl const* namedDecl,
     AzureClassesDatabase* const database,
     std::shared_ptr<TypeHierarchy::TypeHierarchyNode> parentNode)
-    : AstNode(namedDecl),
-      m_namespace{AstNode::GetNamespaceForDecl(namedDecl)}, m_name{namedDecl->getNameAsString()},
-      m_classDatabase(database), m_navigationId{namedDecl->getQualifiedNameAsString()},
+    : AstNode(namedDecl), m_namespace{AstNode::GetNamespaceForDecl(namedDecl)},
+      m_name{namedDecl->getNameAsString()}, m_classDatabase(database),
+      m_navigationId{namedDecl->getQualifiedNameAsString()},
       m_nodeDocumentation{AstNode::GetCommentForNode(namedDecl->getASTContext(), namedDecl)},
       m_nodeAccess{namedDecl->getAccess()}
 {
@@ -1472,8 +1472,8 @@ public:
       AzureClassesDatabase* const database,
       std::shared_ptr<TypeHierarchy::TypeHierarchyNode> parentNode)
       : AstNamedNode(templateParam, database, parentNode),
-        m_paramName{templateParam->getNameAsString()}, m_isParameterPack{
-                                                           templateParam->isParameterPack()}
+        m_paramName{templateParam->getNameAsString()},
+        m_isParameterPack{templateParam->isParameterPack()}
   {
     for (auto attr : templateParam->attrs())
     {
@@ -1487,7 +1487,7 @@ public:
 
     if (templateParam->hasDefaultArgument())
     {
-      auto defaultArg = templateParam->getDefaultArgument().getArgument();
+      auto const&defaultArg = templateParam->getDefaultArgument().getArgument();
       switch (defaultArg.getKind())
       {
 
@@ -1813,9 +1813,13 @@ public:
 
 class AstMethod : public AstFunction {
 protected:
-  bool m_isVirtual;
-  bool m_isConst;
-  bool m_isPure;
+  bool m_isVirtual{};
+  bool m_isConst{};
+  bool m_isPure{};
+  bool m_isOverride{};
+  bool m_isImplicitOverride{};
+  bool m_isFinal{};
+  bool m_isImplicitFinal{};
   RefQualifierKind m_refQualifier;
 
 public:
@@ -1826,6 +1830,55 @@ public:
       : AstFunction(method, database, parentNode), m_isVirtual(method->isVirtual()),
         m_isPure(method->isPure()), m_isConst(method->isConst())
   {
+    // We assume that this is an implicit override if there are overriden methods. If we later find
+    // an override attribute, we know it's not an implicit override.
+    //
+    // Note that we don't do this for destructors, because they don't have an override attribute.
+    if (method->getKind() == Decl::Kind::CXXMethod)
+    {
+      if (method->size_overridden_methods() > 0)
+      {
+        m_isOverride = true;
+        m_isImplicitOverride = true;
+      }
+    }
+
+    for (auto& attr : method->attrs())
+    {
+      auto location{attr->getLocation()};
+      switch (attr->getKind())
+      {
+        case attr::Override:
+          m_isImplicitOverride = false;
+          break;
+        case attr::Final:
+          if (attr->isImplicit())
+          {
+            method->dump(llvm::outs());
+            //            database->CreateApiViewMessage(ApiViewMessages::ImplicitOverride,
+            //            m_navigationId);
+
+            m_isImplicitFinal = true;
+          }
+          else
+          {
+            m_isFinal = true;
+          }
+          break;
+        case attr::Deprecated:
+          break;
+        default:
+          llvm::outs() << "Unknown Method Attribute: ";
+          attr->printPretty(llvm::outs(), LangOptions());
+          llvm::outs() << "\n";
+          break;
+      }
+    }
+    if (m_isOverride && m_isImplicitOverride)
+    {
+      database->CreateApiViewMessage(ApiViewMessages::ImplicitOverride, m_navigationId);
+    }
+
     auto typePtr = method->getType().getTypePtr()->castAs<FunctionProtoType>();
     m_refQualifier = typePtr->getRefQualifier();
     m_parentClass = method->getParent()->getNameAsString();
@@ -1875,6 +1928,16 @@ public:
       dumper->InsertPunctuation('=');
       dumper->InsertWhitespace();
       dumper->InsertLiteral("0");
+    }
+    if (m_isOverride)
+    {
+      dumper->InsertWhitespace();
+      dumper->InsertKeyword("override");
+    }
+    if (m_isFinal)
+    {
+      dumper->InsertWhitespace();
+      dumper->InsertKeyword("final");
     }
     if (dumpOptions.NeedsTrailingSemi)
     {
@@ -1963,6 +2026,7 @@ class AstDestructor : public AstMethod {
   bool m_isDefault{false};
   bool m_isDeleted{false};
   bool m_isExplicitlyDefaulted{false};
+  bool m_isVirtual{false};
 
 public:
   AstDestructor(
@@ -1970,8 +2034,37 @@ public:
       AzureClassesDatabase* const database,
       std::shared_ptr<TypeHierarchy::TypeHierarchyNode> parentNode)
       : AstMethod(dtor, database, parentNode), m_isDefault{dtor->isDefaulted()},
-        m_isDeleted{dtor->isDeleted()}, m_isExplicitlyDefaulted{dtor->isExplicitlyDefaulted()}
+        m_isDeleted{dtor->isDeleted()}, m_isExplicitlyDefaulted{dtor->isExplicitlyDefaulted()},
+        m_isVirtual{dtor->isVirtual()}
   {
+    bool isBaseClassDtor{true};
+    // If this destructor overrides a base class destructor, it's not a base class destructor.
+    if (dtor->size_overridden_methods() != 0)
+    {
+      isBaseClassDtor = false;
+    }
+    if (dtor->getAccess() == AS_protected)
+    {
+      if (dtor->isVirtual())
+      {
+        database->CreateApiViewMessage(ApiViewMessages::NonVirtualDestructor, m_navigationId);
+      }
+    }
+    else if (dtor->getAccess() == AS_public)
+    {
+      if (!dtor->isVirtual())
+      {
+        auto parentClass = dtor->getParent();
+        if (!parentClass->isEffectivelyFinal())
+        {
+          database->CreateApiViewMessage(ApiViewMessages::NonVirtualDestructor, m_navigationId);
+        }
+      }
+    }
+    else
+    {
+      database->CreateApiViewMessage(ApiViewMessages::NonVirtualDestructor, m_navigationId);
+    }
   }
   void DumpNode(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const override
   {
@@ -2380,9 +2473,9 @@ public:
       AzureClassesDatabase* const azureClassesDatabase,
       std::shared_ptr<TypeHierarchy::TypeHierarchyNode> parentNode)
       : AstNamedNode(fieldDecl, azureClassesDatabase, parentNode),
-        m_fieldType{fieldDecl->getType()}, m_initializer{AstExpr::Create(
-                                               fieldDecl->getInClassInitializer(),
-                                               fieldDecl->getASTContext())},
+        m_fieldType{fieldDecl->getType()},
+        m_initializer{
+            AstExpr::Create(fieldDecl->getInClassInitializer(), fieldDecl->getASTContext())},
         m_classInitializerStyle{fieldDecl->getInClassInitStyle()},
         m_hasDefaultMemberInitializer{fieldDecl->hasInClassInitializer()},
         m_isMutable{fieldDecl->isMutable()}, m_isConst{fieldDecl->getType().isConstQualified()}
@@ -2453,8 +2546,9 @@ public:
       UsingDirectiveDecl const* usingDirective,
       AzureClassesDatabase* const azureClassesDatabase,
       std::shared_ptr<TypeHierarchy::TypeHierarchyNode> parentNode)
-      : AstNode(usingDirective), m_namedNamespace{usingDirective->getNominatedNamespaceAsWritten()
-                                                      ->getQualifiedNameAsString()}
+      : AstNode(usingDirective),
+        m_namedNamespace{
+            usingDirective->getNominatedNamespaceAsWritten()->getQualifiedNameAsString()}
   {
     azureClassesDatabase->CreateApiViewMessage(
         ApiViewMessages::UsingDirectiveFound, m_namedNamespace);
@@ -2572,8 +2666,8 @@ public:
       : AstNamedNode(enumDecl, azureClassesDatabase, parentNode),
         m_underlyingType{enumDecl->getIntegerType().getAsString()},
         m_isScoped{enumDecl->isScoped()}, m_isScopedWithClass{enumDecl->isScopedUsingClassTag()},
-        m_isFixed{enumDecl->isFixed()}, m_isForwardDeclaration{
-                                            enumDecl != enumDecl->getDefinition()}
+        m_isFixed{enumDecl->isFixed()},
+        m_isForwardDeclaration{enumDecl != enumDecl->getDefinition()}
   {
     if (!m_isScoped)
     {

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ProcessorImpl.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ProcessorImpl.cpp
@@ -156,11 +156,25 @@ ApiViewProcessorImpl::ApiViewProcessorImpl(
           "Configuration element `filterNamespace` is neither a string or an array of strings.");
     }
   }
-  if (configurationJson.contains("additionalCompilerSwitches")
-      && configurationJson["additionalIncludeDirectories"].is_array()
-      && configurationJson["additionalIncludeDirectories"].size() != 0)
+  if (configurationJson.contains("additionalCompilerSwitches"))
   {
-    m_additionalCompilerArguments = configurationJson["additionalCompilerSwitches"];
+    if (configurationJson["additionalCompilerSwitches"].is_array())
+    {
+      if (configurationJson["additionalCompilerSwitches"].size() != 0)
+      {
+        m_additionalCompilerArguments = configurationJson["additionalCompilerSwitches"];
+      }
+    }
+    else if (configurationJson["additionalCompilerSwitches"].is_string())
+    {
+      m_additionalCompilerArguments.push_back(
+          configurationJson["additionalCompilerSwitches"].get<std::string>());
+    }
+    else if (!configurationJson["additionalCompilerSwitches"].is_null())
+    {
+      throw std::runtime_error(
+          "Configuration element `additionalCompilerSwitches` is not an array or is empty.");
+    }
   }
   if (configurationJson.contains("additionalIncludeDirectories")
       && configurationJson["additionalIncludeDirectories"].is_array())
@@ -323,7 +337,10 @@ class ApiViewCompilationDatabase : public CompilationDatabase {
       "-c",
       "-std=c++14",
       "-Wall",
-      "-Werror"};
+      "-Werror",
+      // Work around Microsoft STL requiring clang 16.0.0 or later.
+      "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH",
+  };
 
 public:
   ApiViewCompilationDatabase(
@@ -331,8 +348,8 @@ public:
       std::filesystem::path const& sourceLocation,
       std::vector<std::filesystem::path> const& additionalIncludePaths,
       std::vector<std::string> const& additionalArguments)
-      : CompilationDatabase(), m_filesToCompile(filesToCompile),
-        m_sourceLocation(sourceLocation), m_additionalIncludePaths{additionalIncludePaths}
+      : CompilationDatabase(), m_filesToCompile(filesToCompile), m_sourceLocation(sourceLocation),
+        m_additionalIncludePaths{additionalIncludePaths}
   {
     for (auto const& arg : additionalArguments)
     {
@@ -363,6 +380,7 @@ public:
         {
           commandLine.push_back(arg);
         }
+
         commandLine.push_back(std::string(stringFromU8string(file.u8string())));
 
         std::vector<CompileCommand> rv;
@@ -417,8 +435,6 @@ int ApiViewProcessorImpl::ProcessApiView()
   }
 
   // Create a compilation database consisting of the source root and source file.
-  auto absTemp = m_currentSourceRoot;
-
   ApiViewCompilationDatabase compileDb(
       {std::filesystem::absolute(tempFile)},
       m_currentSourceRoot,

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/CMakeLists.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/CMakeLists.txt
@@ -17,7 +17,9 @@ add_executable(parseTests
     TestCases/TemplateTests.cpp
     TestCases/ClassesWithInternalAndDetail.cpp 
     TestCases/ExpressionTests.cpp
-     TestCases/UsingNamespace.cpp )
+    TestCases/UsingNamespace.cpp
+    TestCases/DestructorTests.cpp
+)
 add_dependencies(parseTests ApiViewProcessor)
 
 target_include_directories(parseTests PRIVATE ${ApiViewProcessor_SOURCE_DIR})

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/TestCases/DestructorTests.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/TestCases/DestructorTests.cpp
@@ -116,25 +116,25 @@ protected:
 };
 
 class FinalClassWithPrivateDestructor final {
-    int* member{};
-    ~FinalClassWithPrivateDestructor()
+  int* member{};
+  ~FinalClassWithPrivateDestructor()
+  {
+    if (member)
     {
-        if (member)
-        {
-        delete member;
-      }
-    };
+      delete member;
+    }
+  };
 };
 
 class ClassWithPrivateDestructor {
-    int* member{};
-    ~ClassWithPrivateDestructor()
+  int* member{};
+  ~ClassWithPrivateDestructor()
+  {
+    if (member)
     {
-      if (member)
-      {
-        delete member;
-      }
-    };
+      delete member;
+    }
+  };
 };
 
 } // namespace Test

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/TestCases/DestructorTests.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/TestCases/DestructorTests.cpp
@@ -1,0 +1,140 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+namespace Test {
+
+class BaseClassWithVirtualDestructor {
+  int* member{};
+
+public:
+  virtual ~BaseClassWithVirtualDestructor()
+  {
+    if (member)
+    {
+      delete member;
+    }
+  };
+};
+
+class FinalBaseClassWithVirtualDestructor final {
+  int* member{};
+
+public:
+  virtual ~FinalBaseClassWithVirtualDestructor()
+  {
+    if (member)
+    {
+      delete member;
+    }
+  };
+};
+
+class BaseClassWithNonVirtualDestructor {
+  int* member{};
+
+public:
+  ~BaseClassWithNonVirtualDestructor()
+  {
+    if (member)
+    {
+      delete member;
+    }
+  };
+};
+
+class FinalBaseClassWithNonVirtualDestructor final {
+  int* member{};
+
+public:
+  ~FinalBaseClassWithNonVirtualDestructor()
+  {
+    if (member)
+    {
+      delete member;
+    }
+  };
+};
+
+class BaseClassWithProtectedDestructor {
+  int* member{};
+
+protected:
+  ~BaseClassWithProtectedDestructor()
+  {
+    if (member)
+    {
+      delete member;
+    }
+  };
+};
+class FinalBaseClassWithProtectedDestructor final {
+  int* member{};
+
+protected:
+  ~FinalBaseClassWithProtectedDestructor()
+  {
+    if (member)
+    {
+      delete member;
+    }
+  };
+};
+
+class DerivedClassWithVirtualDestructor : public BaseClassWithVirtualDestructor {
+  int* member{};
+  ~DerivedClassWithVirtualDestructor()
+  {
+    if (member)
+    {
+      delete member;
+    }
+  };
+};
+
+class DerivedClassWithNonVirtualDestructor : public BaseClassWithNonVirtualDestructor {
+  int* member{};
+  ~DerivedClassWithNonVirtualDestructor()
+  {
+    if (member)
+    {
+      delete member;
+    }
+  };
+};
+
+class DerivedClassWithProtectedDestructor : public BaseClassWithProtectedDestructor {
+  int* member{};
+
+protected:
+  virtual ~DerivedClassWithProtectedDestructor()
+  {
+    if (member)
+    {
+      delete member;
+    }
+  };
+};
+
+class FinalClassWithPrivateDestructor final {
+    int* member{};
+    ~FinalClassWithPrivateDestructor()
+    {
+        if (member)
+        {
+        delete member;
+      }
+    };
+};
+
+class ClassWithPrivateDestructor {
+    int* member{};
+    ~ClassWithPrivateDestructor()
+    {
+      if (member)
+      {
+        delete member;
+      }
+    };
+};
+
+} // namespace Test

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/tests.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/tests.cpp
@@ -108,7 +108,7 @@ private:
       }
     }
     std::vector<std::string>
-        defaultCommandLine{"clang++.exe", "-DAZ_RTTI", "-fcxx-exceptions", "-c", "-std=c++14"};
+        defaultCommandLine{"clang++.exe", "-DAZ_RTTI", "-fcxx-exceptions", "-c", "-std=c++14", "-D_ALLOW_COMPILER_AND_STL_VERSION_MISMATCH"};
     // Inherited via CompilationDatabase
     virtual std::vector<CompileCommand> getCompileCommands(llvm::StringRef FilePath) const override
     {
@@ -454,7 +454,7 @@ TEST_F(TestParser, Class1)
 
   NsDumper dumper;
   db->DumpClassDatabase(&dumper);
-  EXPECT_EQ(31ul, dumper.Messages.size());
+  EXPECT_EQ(44ul, dumper.Messages.size());
 
   size_t internalTypes = 0;
   for (const auto& msg : dumper.Messages)
@@ -559,13 +559,49 @@ TEST_F(TestParser, UsingNamespace)
   size_t usingNamespaces = 0;
   for (const auto& msg : dumper.Messages)
   {
-    if (msg.DiagnosticId == "CPA0009")
+    if (msg.DiagnosticId == "CPA000A")
     {
       usingNamespaces += 1;
     }
   }
   EXPECT_EQ(usingNamespaces, 1ul);
 }
+
+TEST_F(TestParser, TestDtors)
+{
+  ApiViewProcessor processor("tests", R"({
+  "sourceFilesToProcess": [
+    "DestructorTests.cpp"
+  ],
+  "additionalIncludeDirectories": [],
+  "additionalCompilerSwitches": null,
+  "allowInternal": false,
+  "includeDetail": false,
+  "includePrivate": false,
+  "filterNamespace": null
+}
+)"_json);
+
+  EXPECT_EQ(processor.ProcessApiView(), 0);
+
+  auto& db = processor.GetClassesDatabase();
+  EXPECT_TRUE(SyntaxCheckClassDb(db, "DestructorTests1.cpp"));
+
+  NsDumper dumper;
+  db->DumpClassDatabase(&dumper);
+  EXPECT_EQ(2ul, dumper.Messages.size());
+
+  size_t nonVirtualDestructor= 0;
+  for (const auto& msg : dumper.Messages)
+  {
+    if (msg.DiagnosticId == "CPA000B")
+    {
+      nonVirtualDestructor+= 1;
+    }
+  }
+  EXPECT_EQ(nonVirtualDestructor, 2ul);
+}
+
 
 #if 0
 TEST_F(TestParser, AzureCore1)


### PR DESCRIPTION
- Fixed issue creating ApiView for azure core
- Added output for override and final attributes
- Added diagnostics for the following cases:
  - [destructors that aren't virtual](https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual).
  - method overrides without the override keyword.
