### PR TITLE
Force entire `Restore` operation to enqueued

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -172,15 +172,19 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         public async Task<string> Restore(string pathToAssetsJson) {
             var config = await ParseConfigurationFile(pathToAssetsJson);
 
-            var initialized = IsAssetsRepoInitialized(config);
-
-            if (!initialized)
+            var restoreQueue = InitTasks.GetOrAdd("restore", new TaskQueue());
+            restoreQueue.Enqueue(async () =>
             {
-                InitializeAssetsRepo(config);
-            }
+                var initialized = IsAssetsRepoInitialized(config);
 
-            CheckoutRepoAtConfig(config, cleanEnabled: true);
-            await BreadCrumb.Update(config);
+                if (!initialized)
+                {
+                    InitializeAssetsRepo(config);
+                }
+
+                CheckoutRepoAtConfig(config, cleanEnabled: true);
+                await BreadCrumb.Update(config);
+            });
 
             return config.AssetsRepoLocation.ToString();
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -173,7 +173,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
             var config = await ParseConfigurationFile(pathToAssetsJson);
 
             var restoreQueue = InitTasks.GetOrAdd("restore", new TaskQueue());
-            restoreQueue.Enqueue(async () =>
+            await restoreQueue.EnqueueAsync(async () =>
             {
                 var initialized = IsAssetsRepoInitialized(config);
 


### PR DESCRIPTION
Resolves Azure/azure-sdk-for-java#36669 and Azure/azure-sdk-for-java#36655

Here's the conflict.

When the proxy finishes restoring a test in playback, it updates a local ConcurrentDictionary with the checkout status. When that is matching what we expect, it exits early and returns.

> we're at where we need to be. no work to be done.

The problem is that in some circumstances with the `azure-resourcemanager-compute` tests all invoking in parallel. We're ending up in the situation where multiple tests are all starting at the same time. This is due to the fact that all of these are not yet "cached", so they all have to invoke the "fetch and clean" operation _additionally_. This additional operation is what is causing our timeouts in some cases.

We can avoid this by forcing the _entire_ `restore` operation to a single set of enqueued work. Given that `restore` should only be run _a single time_ with full workload on each test run, this is a cost we can pay in interests of stability.

CC @billwert @samvaity @alzimmermsft 