### PR TITLE
Global `Restore` queue -> per asset restore

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -172,7 +172,8 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         public async Task<string> Restore(string pathToAssetsJson) {
             var config = await ParseConfigurationFile(pathToAssetsJson);
 
-            var restoreQueue = InitTasks.GetOrAdd("restore", new TaskQueue());
+            var restoreQueue = InitTasks.GetOrAdd(config.AssetsJsonRelativeLocation, new TaskQueue());
+
             await restoreQueue.EnqueueAsync(async () =>
             {
                 var initialized = IsAssetsRepoInitialized(config);


### PR DESCRIPTION
We should never have an issue with multiple startPlayback for the same assets.json, which would apply here.

