### PR TITLE
update the document for semicolon in `TypeSpec-Project-Generate.ps1`

### DIFF
--- a/eng/common/scripts/TypeSpec-Project-Generate.ps1
+++ b/eng/common/scripts/TypeSpec-Project-Generate.ps1
@@ -5,7 +5,7 @@ param (
     [Parameter(Position=0)]
     [ValidateNotNullOrEmpty()]
     [string] $ProjectDirectory,
-    [string] $TypespecAdditionalOptions = $null, ## addtional typespec emitter options, separated by semicolon if more than one, e.g. option1=value1;option2=value2
+    [string] $TypespecAdditionalOptions = $null, ## addtional typespec emitter options, separated by escaped semicolon %3B if more than one, e.g. option1=value1%3Boption2=value2
     [switch] $SaveInputs = $false ## saves the temporary files during execution, default false
 )
 


### PR DESCRIPTION
Despite the document says we could use semicolon to separate multiple options in this parameter, but it will not work if we just do this:
```
dotnet build /t:GenerateCode /p:typespecAdditionalOptions="csharpGeneratorPath=./autorest.csharp/artifacts/bin/AutoRest.CSharp/Debug/net6.0/AutoRest.CSharp.dll;debug=true"
```
which eventually calls the `TypeSpec-Project-Generate.ps1` script.

The option after the semicolon is somehow discarded. But if we escape this semicolon, everything works fine
```
dotnet build /t:GenerateCode /p:typespecAdditionalOptions="csharpGeneratorPath=./autorest.csharp/artifacts/bin/AutoRest.CSharp/Debug/net6.0/AutoRest.CSharp.dll%3Bdebug=true"
```

Fixes https://github.com/Azure/autorest.csharp/issues/3362