### PR TITLE
Serialize with depth

### DIFF
--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -205,7 +205,7 @@ function UpdateDocsMsMetadataForPackage($packageInfoJsonLocation) {
     Write-Host "The docs metadata json $packageMetadataName does not exist, creating a new one to docs repo..."
     New-Item -ItemType Directory -Path $packageInfoLocation -Force
   }
-  $packageInfoJson = ConvertTo-Json $packageInfo
+  $packageInfoJson = ConvertTo-Json $packageInfo -Depth 100
   Set-Content `
     -Path $packageInfoLocation/$packageMetadataName `
     -Value $packageInfoJson


### PR DESCRIPTION
When merging the releasing metadata JSON properties with the existing metadata JSON, the `Update-DocsMsMetadata.ps1` script calls `ConvertTo-Json` without specifying `-Depth`. The result is a string serialization at depths greater than 2 which results in unintended docs build configurations: 

Example:

The metadata pushed into the docs repo from [this build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3065250&view=logs&j=18993cac-9748-5722-f1d8-b9d5549e160d&t=24de96b9-eee4-58d6-0b41-e984f23dd609&l=53) 

Included [this change](https://github.com/MicrosoftDocs/azure-docs-sdk-python/commit/38fa6e430d0ba7e281a6b11fac3ea5197c323f84#diff-04f3acc8bc7d0652741c709defc1638f060237e93cad50b70b6c41caabf9438cL14-L17).

