### PR TITLE
[githubio-linkcheck] Reduce timeout from infinite to 6 hours

### DIFF
--- a/eng/pipelines/githubio-linkcheck.yml
+++ b/eng/pipelines/githubio-linkcheck.yml
@@ -11,7 +11,7 @@ variables:
 jobs:
 - job: CheckLinks
   displayName: Check and Cache Links
-  timeoutInMinutes: 0
+  timeoutInMinutes: 360
   steps:
   - task: PowerShell@2
     displayName: 'azure-sdk link check'


### PR DESCRIPTION
- Pipeline normally runs in 3 hours, so 6 hours is plenty of time
- We should not use infinite timeouts, to avoid blocking build agents indefinitely