### PR TITLE
[live-test-cleanup] Reduce timeout from infinite to default (60 minutes)

### DIFF
--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -62,7 +62,6 @@ stages:
 
   jobs:
   - job: Run
-    timeoutInMinutes: 0
     pool:
       name: azsdk-pool-mms-ubuntu-2204-general
       vmImage: ubuntu-22.04


### PR DESCRIPTION
- Pipeline normally runs in 15 minutes, so 60 minutes is plenty of time
- We should not use infinite timeouts, to avoid blocking build agents indefinitely