### PR TITLE
[JimBot] Update package version in use

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -55,7 +55,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230713.2
+          --version 1.0.0-dev.20230929.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -34,7 +34,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230713.2
+          --version 1.0.0-dev.20230929.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/tools/github-event-processor/YmlAndConfigFiles/event-processor.yml
+++ b/tools/github-event-processor/YmlAndConfigFiles/event-processor.yml
@@ -59,7 +59,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230313.4
+          --version 1.0.0-dev.20230929.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         working-directory: .github/workflows

--- a/tools/github-event-processor/YmlAndConfigFiles/scheduled-event-processor.yml
+++ b/tools/github-event-processor/YmlAndConfigFiles/scheduled-event-processor.yml
@@ -36,7 +36,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230313.4
+          --version 1.0.0-dev.20230929.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         working-directory: .github/workflows


### PR DESCRIPTION
# Summary

The focus of these changes is to update the version of the package used by Actions to deploy the changes recently made to remove the "CXP Attention" rule and tweak the "needs-team-triage" criteria to ignore issues with an assignment already made.