### PR TITLE
Emit the pushed commit sha as an output variable

### DIFF
--- a/eng/common/pipelines/templates/steps/git-push-changes.yml
+++ b/eng/common/pipelines/templates/steps/git-push-changes.yml
@@ -8,6 +8,7 @@ parameters:
   WorkingDirectory: $(System.DefaultWorkingDirectory)'
   ScriptDirectory: eng/common/scripts
   SkipCheckingForChanges: false
+  StepName: ''
 
 steps:
 - pwsh: |
@@ -40,6 +41,8 @@ steps:
   workingDirectory: ${{ parameters.WorkingDirectory }}
 
 - task: PowerShell@2
+  ${{ if ne(parameters.StepName, '') }}:
+    name: ${{ parameters.StepName }}
   displayName: Push changes
   condition: and(succeeded(), eq(variables['HasChanges'], 'true'))
   inputs:
@@ -52,3 +55,4 @@ steps:
       -GitUrl "https://$(azuresdk-github-pat)@github.com/${{ parameters.BaseRepoOwner }}/$(RepoNameWithoutOwner).git"
       -PushArgs "${{ parameters.PushArgs }}"
       -SkipCommit $${{ parameters.SkipCheckingForChanges }}
+      -CommitOutputVariable 'CommitId'

--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -12,6 +12,8 @@ The message for this particular commit
 The GitHub repository URL
 .PARAMETER PushArgs
 Optional arguments to the push command
+.PARAMETER CommitOutputVariable
+The name of the devops variable to set with the commit id of the pushed commit
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
@@ -34,7 +36,10 @@ param(
     [boolean] $SkipCommit = $false,
 
     [Parameter(Mandatory = $false)]
-    [boolean] $AmendCommit = $false
+    [boolean] $AmendCommit = $false,
+
+    [Parameter(Mandatory = $false)]
+    [string] $CommitOutputVariable = $null
 )
 
 # Explicit set arg parsing to Legacy mode because some of the git calls in this script depend on empty strings being empty and not passing a "" git.
@@ -173,6 +178,12 @@ do
             {
                 Write-Error "Unable to commit LASTEXITCODE=$($LASTEXITCODE), see command output above."
                 continue
+            }
+
+            if ($CommitOutputVariable) {
+              $commitId = git rev-parse HEAD
+              Write-Host "Setting output variable $CommitOutputVariable to $commitId"
+              Write-Host "##vso[task.setvariable variable=$CommitOutputVariable;IsOutput=true]$commitId"
             }
         }
         finally


### PR DESCRIPTION
Allow the devops pipeline to use the published commit id via output variable

git-branch-push.ps1 is variable on the output varable name

git-push-changes.yml is variable on the step name with a consistent output variable name 'CommitId'