### PR TITLE
Remove CXPAttention rules constant

### DIFF
--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Constants/RulesConstants.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Constants/RulesConstants.cs
@@ -16,7 +16,6 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Constants
         public const string InitialIssueTriage = "InitialIssueTriage";
         public const string ManualIssueTriage = "ManualIssueTriage";
         public const string ServiceAttention = "ServiceAttention";
-        public const string CXPAttention = "CXPAttention";
         public const string ManualTriageAfterExternalAssignment = "ManualTriageAfterExternalAssignment";
         public const string RequireAttentionForNonMilestone = "RequireAttentionForNonMilestone";
         public const string AuthorFeedbackNeeded = "AuthorFeedbackNeeded";


### PR DESCRIPTION
The CXPAttention rule and processing was removed from github-event-processor and the event-processor.config files but the rules constant was still there. Nothing bad happens, or will happen, but the logic that detects missing rules from the config file outputs the following informational message whenever it loads a config file. 
`CXPAttention was not in the rules config file. Missing rules default to Off.`

Since the rule, itself, is gone, the rules constant needs to go away as well.