### PR TITLE
Allow overrides when creating emitter package json

### DIFF
--- a/eng/pipelines/templates/stages/archetype-autorest-preview.yml
+++ b/eng/pipelines/templates/stages/archetype-autorest-preview.yml
@@ -1,6 +1,6 @@
 parameters:
 # Whether to build alpha versions of the packages. This is passed as a flag to the build script.
-- name: BuildAlphaVersion
+- name: BuildPrereleaseVersion
   type: boolean
 
 # Whether to use the `next` version of TypeSpec. This is passed as a flag to the init script.
@@ -94,7 +94,8 @@ stages:
       
       - script: >
           npm run ci-build --
-          --buildAlphaVersion ${{ parameters.BuildAlphaVersion }}
+          --publishTarget ${{ parameters.PublishTarget }}
+          --buildPrereleaseVersion ${{ parameters.BuildPrereleaseVersion }}
           --buildNumber $(Build.BuildNumber)
           --output $(Build.ArtifactStagingDirectory)
         displayName: 'Run build script'
@@ -109,6 +110,7 @@ stages:
           filePath: $(toolsRepositoryPath)/eng/scripts/autorest/New-EmitterPackageJson.ps1
           arguments: >
             -PackageJsonPath '${{ parameters.EmitterPackageJsonPath }}'
+            -OverridesPath $(Build.ArtifactStagingDirectory)/overrides.json
             -OutputDirectory '$(Build.ArtifactStagingDirectory)'
           workingDirectory: $(autorestRepositoryPath)
 
@@ -147,15 +149,11 @@ stages:
 - stage: Publish
   dependsOn: Build
   variables:
-    autorestRepositoryPath: $(Build.SourcesDirectory)/autorest
-    toolsRepositoryPath: $(Build.SourcesDirectory)/azure-sdk-tools
-    sdkRepositoryPath: $(Build.SourcesDirectory)/azure-sdk
+    toolsRepositoryPath: $(Build.SourcesDirectory)
     buildArtifactsPath: $(Pipeline.Workspace)/build_artifacts
   jobs:
   - job: Publish
     steps:
-    - checkout: self
-      path: s/autorest
     - checkout: azure-sdk-tools
 
     - download: current
@@ -189,9 +187,8 @@ stages:
           inputs:
             command: 'push'
             packagesToPush: $(buildArtifactsPath)/packages/${{ package.file }}
-            # Nuget packages are always published to the same internal feed. PublishTarget doesn't affect this.
+            # Nuget packages are always published to the same internal feed https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
             nuGetFeedType: 'internal'
-            # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
             publishVstsFeed: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
 
     - ${{ if ne(parameters.EmitterPackageJsonPath, 'not-specified') }}:
@@ -200,15 +197,9 @@ stages:
         inputs:
           pwsh: true
           filePath: $(toolsRepositoryPath)/eng/scripts/autorest/New-EmitterPackageLock.ps1
-          ${{ if eq(parameters.PublishTarget, 'internal') }}:
-            arguments: >
-              -EmitterPackageJsonPath "$(buildArtifactsPath)/emitter-package.json"
-              -OutputDirectory "$(Build.ArtifactStagingDirectory)"
-              -NpmrcPath "$(buildArtifactsPath)/packages/.npmrc"
-          ${{ elseif eq(parameters.PublishTarget, 'public') }}:
-            arguments: >
-              -EmitterPackageJsonPath "$(buildArtifactsPath)/emitter-package.json"
-              -OutputDirectory "$(Build.ArtifactStagingDirectory)"
+          arguments: >
+            -EmitterPackageJsonPath "$(buildArtifactsPath)/emitter-package.json"
+            -OutputDirectory "$(Build.ArtifactStagingDirectory)"
 
     - publish: $(Build.ArtifactStagingDirectory)
       artifact: publish_artifacts

--- a/eng/scripts/autorest/New-EmitterPackageJson.ps1
+++ b/eng/scripts/autorest/New-EmitterPackageJson.ps1
@@ -1,7 +1,12 @@
 [CmdletBinding()]
 param (
     [parameter(Mandatory = $true)]
+    [ValidateScript({ Test-Path $_ })]
     [string]$PackageJsonPath,
+
+    [parameter(Mandatory = $false)]
+    [ValidateScript({ Test-Path $_ })]
+    [string]$OverridesPath,
 
     [parameter(Mandatory = $true)]
     [string]$OutputDirectory,
@@ -10,41 +15,59 @@ param (
     [string]$PackageJsonFileName = "emitter-package.json"
 )
 
-$knownPackages = @(
-    "@azure-tools/typespec-azure-core"
-    "@azure-tools/typespec-client-generator-core"
-    "@typespec/compiler"
-    "@typespec/eslint-config-typespec"
-    "@typespec/http"
-    "@typespec/rest"
-    "@typespec/versioning"
-)
+$packageJson = Get-Content $PackageJsonPath | ConvertFrom-Json -AsHashtable
 
-$packageJson = Get-Content $PackageJsonPath | ConvertFrom-Json
+# If we provide OverridesPath, use that to load a hashtable of version overrides
+$overrides = @{}
+
+if ($OverridesPath) {
+    Write-Host "Using overrides from $OverridesPath`:`n"
+    $overrides = Get-Content $OverridesPath | ConvertFrom-Json -AsHashtable
+    Write-Host ($overrides | ConvertTo-Json)
+    Write-Host ""
+}
+
+
+# If there's a peer dependency and a dev dependency for the same package, carry the
+# dev dependency forward into emitter-package.json
 
 $devDependencies = @{}
 
-foreach ($package in $knownPackages) {
-    $pinnedVersion = $packageJson.devDependencies.$package
-    if ($pinnedVersion) {
+foreach ($package in $packageJson.peerDependencies.Keys) {
+    $pinnedVersion = $packageJson.devDependencies[$package]
+    if ($pinnedVersion -and -not $overrides[$package]) {
+        Write-Host "Pinning $package to $pinnedVersion"
         $devDependencies[$package] = $pinnedVersion
     }
 }
 
 $emitterPackageJson = [ordered]@{
-    "main" = "dist/src/index.js"
-    "dependencies" = @{
-        $packageJson.name = $packageJson.version
-    }
+  "main" = "dist/src/index.js"
+  "dependencies" = @{
+      $packageJson.name = $overrides[$packageJson.name] ?? $packageJson.version
+  }
 }
 
+# you shouldn't specify the same package in both dependencies and overrides
+$overrides.Remove($packageJson.name)
+
+# Avoid adding an empty devDependencies section
 if($devDependencies.Keys.Count -gt 0) {
-    $emitterPackageJson["devDependencies"] = $devDependencies
+  $emitterPackageJson["devDependencies"] = $devDependencies
+}
+
+# Avoid adding an empty overrides section
+if($overrides.Keys.Count -gt 0) {
+    $emitterPackageJson["overrides"] = $overrides
 }
 
 New-Item $OutputDirectory -ItemType Directory -ErrorAction SilentlyContinue | Out-Null
 $OutputDirectory = Resolve-Path $OutputDirectory
 
 $dest = Join-Path $OutputDirectory $PackageJsonFileName
+$destJson = $emitterPackageJson | ConvertTo-Json -Depth 100
+
 Write-Host "Generating $dest"
-$emitterPackageJson | ConvertTo-Json -Depth 100 | Out-File $dest
+$destJson | Out-File $dest
+
+Write-Host $destJson

--- a/eng/scripts/autorest/New-EmitterPackageLock.ps1
+++ b/eng/scripts/autorest/New-EmitterPackageLock.ps1
@@ -42,8 +42,8 @@ try {
       exit $LASTEXITCODE
     }
 
-    Write-Host '##[group]npm list --all --package-lock-only'
-    npm list --all --package-lock-only
+    Write-Host '##[group]npm list --all'
+    npm list --all
     Write-Host '##[endgroup]'
 
     $dest = Join-Path $OutputDirectory $LockFileName


### PR DESCRIPTION
Stop using internal feed for npmrc and instead use URL based version overrides