### PR TITLE
[Pylint] Add bug fix for mgmt-core 

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 0.2.0 (Unreleased)
 
 - Checker to enforce docstring keywords being keyword-only in method signature.
+- Fixed a bug in `no-legacy-azure-core-http-response-import` that was throwing warnings for azure-mgmt-core.
 
 ## 0.1.0 (2023-08-02)
 

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -2288,12 +2288,13 @@ class NoLegacyAzureCoreHttpResponseImport(BaseChecker):
     }
 
     AZURE_CORE_NAME = "azure.core"
+    AZURE_MGMT_CORE = "azure.mgmt.core"
     AZURE_CORE_TRANSPORT_NAME = "azure.core.pipeline.transport"
     RESPONSE_CLASSES = ["HttpResponse", "AsyncHttpResponse"]
 
     def visit_importfrom(self, node):
         """Check that we aren't importing from azure.core.pipeline.transport import HttpResponse."""
-        if node.root().name.startswith(self.AZURE_CORE_NAME): 
+        if node.root().name.startswith(self.AZURE_CORE_NAME) or node.root().name.startswith(self.AZURE_MGMT_CORE): 
             return
         if node.modname == self.AZURE_CORE_TRANSPORT_NAME: 
             for name, _ in node.names:


### PR DESCRIPTION
Ignore mgmt-core for no legacy import check -- when bumping versions will bump version universal and disable the needed checkers so that this fix goes through