### PR TITLE
Update github-event-processor version to 1.0.0-dev.20231010.2

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -55,7 +55,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230929.3
+          --version 1.0.0-dev.20231010.2
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -34,7 +34,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20230929.3
+          --version 1.0.0-dev.20231010.2
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash


### PR DESCRIPTION
github-event-processor was recently updated to remove the CXPAttention rule but the Rules constant was left in the code.  The constant was removed with this [PR](https://github.com/Azure/azure-sdk-tools/pull/7092) which, after merging, runs the pipeline and publishes the tool to the NET dev feed. This PR simply updates the version being installed and will push the changes out to the other repositories.