### PR TITLE
Use better description for single repo sparse checkout

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -17,7 +17,10 @@ steps:
       - checkout: none
 
   - task: PowerShell@2
-    displayName: 'Sparse checkout repositories'
+    ${{ if eq(length(parameters.Repositories), 1) }}:
+      displayName: 'Sparse checkout ${{ parameters.Repositories[0].Name }}'
+    ${{ else }}:
+      displayName: 'Sparse checkout repositories'
     inputs:
       targetType: inline
       # Define this inline, because of the chicken/egg problem with loading a script when nothing


### PR DESCRIPTION
This will use the repository name in the step display name for single repo sparse checkouts:
![image](https://github.com/Azure/azure-sdk-tools/assets/1291634/a77b9dac-828b-4dff-aa7e-4d5f836d5b6c)
