### PR TITLE
Ensure `linux` instance handles `windows-style` path incoming

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -998,28 +998,29 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public async Task<string> GetRecordingPath(string file, string assetsPath = null)
         {
-            var normalizedFileName = file.Replace('\\', '/');
-
             if (String.IsNullOrWhiteSpace(file))
             {
                 throw new HttpException(HttpStatusCode.BadRequest, $"Recording file value of {file} is invalid. Try again with a populated filename.");
             }
 
-            var path = file;
+
+            // a properly escaped windows path should be encoded in the json file as \\\\
+            // handle that possiblility here.
+            var path = file.Replace("\\\\", "/").Replace('\\', '/');
 
             // if an assets.json is provided, we have a bit of work to do here.
             if (!string.IsNullOrWhiteSpace(assetsPath))
             {
                 var contextDirectory = await Store.GetPath(assetsPath);
 
-                path = Path.Join(contextDirectory, file);
+                path = Path.Join(contextDirectory, path);
             }
             // otherwise, it's a basic restore like we're used to
             else
             {
                 if (!Path.IsPathFullyQualified(file))
                 {
-                    path = Path.Join(ContextDirectory, file);
+                    path = Path.Join(ContextDirectory, path);
                 }
             }
 


### PR DESCRIPTION
Resolves #7109 

We already normalize all our strings (around assets, etc) using the `NormalizedString` type. Unfortunately, the issue here is that the  incoming file path needs to be in `json`. I'm honestly not quite sure how we've gotten this far without someone else hitting this.

Windows-style paths and `json` don't work well together, as aside from a couple specific, one cannot use escape characters in json strings. The json has gotta be quadruple escaped. If it's _not_, then `\\recordings\network` actually becomes `\r` `ecordings\network`.

When a customer discovered this issue, they were running tests against a linux docker proxy, hence the weirdness in the paths.