### PR TITLE
Added doxygen comment support to C++ API Reviews.

### DIFF
--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.cpp
@@ -87,11 +87,22 @@ void AzureClassesDatabase::CreateApiViewMessage(
     }
     case ApiViewMessages::NonVirtualDestructor: {
       newMessage.DiagnosticId = "CPA000B";
-      newMessage.DiagnosticText = "Base class destructors should be public and virtual or protected and non-virtual. ";
-      newMessage.HelpLinkUri
-          = "https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#c35-a-base-class-destructor-should-be-either-public-and-virtual-or-protected-and-non-virtual";
+      newMessage.DiagnosticText
+          = "Base class destructors should be public and virtual or protected and non-virtual. ";
+      newMessage.HelpLinkUri = "https://isocpp.github.io/CppCoreGuidelines/"
+                               "CppCoreGuidelines#c35-a-base-class-destructor-should-be-either-"
+                               "public-and-virtual-or-protected-and-non-virtual";
       newMessage.Level = ApiViewMessage::MessageLevel::Error;
       break;
+    }
+
+    case ApiViewMessages::TypedefInGlobalNamespace: {
+      newMessage.DiagnosticId = "CPA000C";
+      newMessage.DiagnosticText
+          = "Types in the global namespace which are not builtin types should be avoided. This "
+            "especially applies to the int8_t, uint8_t, int16_t, uint16_t, int32_t, uint32_t, "
+            "int64_t, uint64_t types, all of which should be in the std namespace.";
+      newMessage.Level = ApiViewMessage::MessageLevel::Warning;
     }
   }
   newMessage.TargetId = targetId;

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewMessage.hpp
@@ -36,4 +36,5 @@ enum class ApiViewMessages
   UsingDirectiveFound, // "using namespace" directive found.
   ImplicitOverride, // Implicit override of virtual method.
   NonVirtualDestructor, // Destructor of non-final class is not virtual.
+  TypedefInGlobalNamespace, // A type contains a non-builtin value in the global namespace.
 };

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewProcessor.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ApiViewProcessor.hpp
@@ -79,6 +79,7 @@ public:
   ~AzureClassesDatabase();
 
   TypeHierarchy* GetTypeHierarchy() { return &m_typeHierarchy; }
+  ApiViewProcessorImpl const* GetProcessor() { return m_processor; }
 
   void CreateApiViewMessage(ApiViewMessages diagnostic, std::string_view const& targetId);
   void CreateAstNode(clang::NamedDecl* namedNode);

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstDumper.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstDumper.cpp
@@ -135,8 +135,16 @@ void AstDumper::SetNamespace(std::string_view const& newNamespace)
   }
 }
 
-void AstDumper::Newline() { InsertNewline(); }
+void AstDumper::Newline()
+{
+  InsertNewline();
+  m_currentCursor = 0;
+}
 
-void AstDumper::LeftAlign() { InsertWhitespace(m_indentationLevel); }
+void AstDumper::LeftAlign()
+{
+  InsertWhitespace(m_indentationLevel);
+  m_currentCursor = m_indentationLevel;
+}
 
 void AstDumper::AdjustIndent(int indentDelta) { m_indentationLevel += indentDelta; }

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstDumper.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstDumper.hpp
@@ -12,6 +12,7 @@ class AstDumper {
   std::string m_currentNamespace;
   std::vector<std::string> m_namespaceComponents;
   int m_indentationLevel{};
+  size_t m_currentCursor{};
 
   void OpenNamespace(std::string_view const& namespaceName);
   void OpenNamespaces(
@@ -22,6 +23,9 @@ class AstDumper {
       std::vector<std::string> const& namespaceComponents,
       std::vector<std::string>::iterator& current);
 
+protected:
+  void UpdateCursor(size_t cursorAdjustment) { m_currentCursor += cursorAdjustment; }
+
 public:
   // Note about the different functions.
   // Functions named "InsertXxx" and "AddXxx" are intended to insert elements into the output
@@ -30,6 +34,7 @@ public:
   void AdjustIndent(int indentDelta = 0);
   void LeftAlign();
   void Newline();
+  size_t GetCurrentCursor() { return m_currentCursor; }
   void SetNamespace(std::string_view const& currentNamespace);
 
   virtual void InsertNewline() = 0;
@@ -43,18 +48,21 @@ public:
       std::string_view const& type,
       std::string_view const& typeNavigationId)
       = 0;
-  virtual void InsertMemberName(std::string_view const& member, std::string_view const& memberFullName) = 0;
+  virtual void InsertMemberName(
+      std::string_view const& member,
+      std::string_view const& memberFullName)
+      = 0;
   virtual void InsertStringLiteral(std::string_view const& str) = 0;
   virtual void InsertLiteral(std::string_view const& str) = 0;
   virtual void InsertComment(std::string_view const& comment) = 0;
+  virtual void AddExternalLinkStart(std::string_view const& linkValue) = 0;
+  virtual void AddExternalLinkEnd() = 0;
   virtual void AddDocumentRangeStart() = 0;
   virtual void AddDocumentRangeEnd() = 0;
   virtual void AddDeprecatedRangeStart() = 0;
   virtual void AddDeprecatedRangeEnd() = 0;
   virtual void AddDiffRangeStart() = 0;
   virtual void AddDiffRangeEnd() = 0;
-  virtual void AddInheritanceInfoStart() = 0;
-  virtual void AddInheritanceInfoEnd() = 0;
 
   virtual void DumpTypeHierarchyNode(std::shared_ptr<TypeHierarchy::TypeHierarchyNode> const& node)
       = 0;

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstDumper.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstDumper.hpp
@@ -26,7 +26,6 @@ class AstDumper {
 protected:
   void UpdateCursor(size_t cursorAdjustment) {
       m_currentCursor += cursorAdjustment; 
-      assert(m_currentCursor >= 0);
   }
 
 public:

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstDumper.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstDumper.hpp
@@ -24,9 +24,7 @@ class AstDumper {
       std::vector<std::string>::iterator& current);
 
 protected:
-  void UpdateCursor(size_t cursorAdjustment) {
-      m_currentCursor += cursorAdjustment; 
-  }
+  void UpdateCursor(size_t cursorAdjustment) { m_currentCursor += cursorAdjustment; }
 
 public:
   // Note about the different functions.

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstDumper.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstDumper.hpp
@@ -24,7 +24,10 @@ class AstDumper {
       std::vector<std::string>::iterator& current);
 
 protected:
-  void UpdateCursor(size_t cursorAdjustment) { m_currentCursor += cursorAdjustment; }
+  void UpdateCursor(size_t cursorAdjustment) {
+      m_currentCursor += cursorAdjustment; 
+      assert(m_currentCursor >= 0);
+  }
 
 public:
   // Note about the different functions.

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.hpp
@@ -18,9 +18,12 @@ class Attr;
 enum AccessSpecifier : int;
 } // namespace clang
 
+class AstDocumentation;
+
 struct DumpNodeOptions
 {
   bool DumpListInitializer{false};
+  bool NeedsDocumentation{true};
   bool NeedsLeftAlign{true};
   bool NeedsLeadingNewline{true};
   bool NeedsTrailingNewline{true};
@@ -28,11 +31,13 @@ struct DumpNodeOptions
   bool NeedsNamespaceAdjustment{true};
   bool IncludeNamespace{false};
   bool IncludeContainingClass{false};
+  bool InlineBlockComment{false};
+  size_t RightMargin{80};   // Soft right margin for dumper.
 };
 
 class AstNode {
 protected:
-  explicit AstNode(clang::Decl const* decl);
+  explicit AstNode();
 
 public:
   // AstNode's don't have namespaces or names, so return something that would make callers happy.
@@ -41,8 +46,8 @@ public:
 
   virtual void DumpNode(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const = 0;
 
-  static std::string GetCommentForNode(clang::ASTContext& context, clang::Decl const* decl);
-  static std::string GetCommentForNode(clang::ASTContext& context, clang::Decl const& decl);
+  static std::unique_ptr<AstDocumentation> GetCommentForNode(clang::ASTContext& context, clang::Decl const* decl);
+  static std::unique_ptr<AstDocumentation> GetCommentForNode(clang::ASTContext& context, clang::Decl const& decl);
   static std::unique_ptr<AstNode> Create(
       clang::Decl const* decl,
       AzureClassesDatabase* const azureClassesDatabase,
@@ -59,7 +64,7 @@ class AstNamedNode : public AstNode {
 protected:
   AzureClassesDatabase* const m_classDatabase;
   std::string m_navigationId;
-  std::string m_nodeDocumentation;
+  std::unique_ptr<AstDocumentation> m_nodeDocumentation;
   clang::AccessSpecifier m_nodeAccess;
 
   explicit AstNamedNode(
@@ -69,6 +74,7 @@ protected:
 
 public:
   void DumpAttributes(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const;
+  void DumpDocumentation(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const;
   virtual void DumpNode(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const override
   {
     assert(!"Pure virtual base - missing implementation of DumpNode in derived class.");

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.hpp
@@ -24,6 +24,7 @@ struct DumpNodeOptions
 {
   bool DumpListInitializer{false};
   bool NeedsDocumentation{true};
+  bool NeedsSourceComment{true};
   bool NeedsLeftAlign{true};
   bool NeedsLeadingNewline{true};
   bool NeedsTrailingNewline{true};
@@ -47,7 +48,6 @@ public:
   virtual void DumpNode(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const = 0;
 
   static std::unique_ptr<AstDocumentation> GetCommentForNode(clang::ASTContext& context, clang::Decl const* decl);
-  static std::unique_ptr<AstDocumentation> GetCommentForNode(clang::ASTContext& context, clang::Decl const& decl);
   static std::unique_ptr<AstNode> Create(
       clang::Decl const* decl,
       AzureClassesDatabase* const azureClassesDatabase,

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/AstNode.hpp
@@ -59,6 +59,8 @@ public:
 class AstNamedNode : public AstNode {
   std::string m_namespace;
   std::string m_name;
+  std::string m_typeUrl;
+  std::string m_typeLocation;
   std::vector<std::unique_ptr<AstNode>> m_nodeAttributes;
 
 protected:
@@ -75,6 +77,7 @@ protected:
 public:
   void DumpAttributes(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const;
   void DumpDocumentation(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const;
+  void DumpSourceComment(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const;
   virtual void DumpNode(AstDumper* dumper, DumpNodeOptions const& dumpOptions) const override
   {
     assert(!"Pure virtual base - missing implementation of DumpNode in derived class.");

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CMakeLists.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CMakeLists.txt
@@ -22,7 +22,7 @@ include(HandleLLVMOptions)
 add_definitions(${LLVM_DEFINITIONS})
 
 add_compile_options(/EHsc)
-add_library(ApiViewProcessor STATIC AstNode.cpp ApiViewProcessor.cpp ProcessorImpl.cpp AstDumper.cpp  ApiViewMessage.cpp)
+add_library(ApiViewProcessor STATIC AstNode.cpp ApiViewProcessor.cpp ProcessorImpl.cpp AstDumper.cpp  ApiViewMessage.cpp CommentExtractor.cpp)
 
 
 target_include_directories(ApiViewProcessor PRIVATE ${LLVM_INCLUDE_DIRS})

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CommentExtractor.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CommentExtractor.cpp
@@ -1,0 +1,875 @@
+// Co pyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "CommentExtractor.hpp"
+#include <clang/AST/ASTContext.h>
+#include <clang/AST/Comment.h>
+#include <clang/AST/CommentVisitor.h>
+#include <iostream>
+#include <iterator>
+#include <list>
+#include <string>
+#include <vector>
+
+using namespace clang;
+
+struct AstComment : public AstDocumentation
+{
+  AstComment(comments::FullComment const* const comment) : AstDocumentation() {}
+
+  bool IsInlineComment() const override { return false; }
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    for (auto& child : m_children)
+    {
+      if (child)
+      {
+        child->DumpNode(dumper, options);
+      }
+    }
+  }
+};
+
+struct AstBlockCommandComment : public AstDocumentation
+{
+  AstBlockCommandComment(comments::BlockCommandComment const* const comment) : AstDocumentation()
+  {
+    std::string value;
+    value += GetCommandMarker(comment->getCommandMarker());
+    auto commandInfo{
+        clang::comments::CommandTraits::getBuiltinCommandInfo(comment->getCommandID())};
+    if (commandInfo->IsBriefCommand)
+    {
+      value += "brief";
+    }
+    else if (commandInfo->IsReturnsCommand)
+    {
+      value += "returns";
+    }
+    else if (commandInfo->IsThrowsCommand)
+    {
+      value += "throws";
+    }
+    else if (commandInfo->IsParamCommand)
+    {
+      throw std::runtime_error("Block command comment should never have a param command.");
+    }
+    else if (commandInfo->IsTParamCommand)
+    {
+      throw std::runtime_error("Block command comment should never have a tparam command.");
+    }
+    else if (commandInfo->IsVerbatimBlockCommand)
+    {
+      throw std::runtime_error("Block command comment should never have a verbatim command.");
+    }
+    else if (commandInfo->IsVerbatimLineCommand)
+    {
+      throw std::runtime_error("Block command comment should never have a verbatim line command.");
+    }
+    else
+    {
+      value += commandInfo->Name;
+    }
+    m_thisLine = value;
+  }
+
+  bool IsInlineComment() const override { return false; }
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    if (options.NeedsLeadingNewline)
+    {
+      dumper->Newline();
+    }
+    if (options.NeedsLeftAlign)
+    {
+      dumper->LeftAlign();
+    }
+    dumper->InsertWhitespace();
+    dumper->InsertPunctuation('*');
+    dumper->InsertWhitespace();
+    dumper->InsertComment(m_thisLine);
+
+    // The first child will be the first line of the brief description, it should be joined with the
+    // current line.
+    auto child{m_children.begin()};
+    if (child != m_children.end() && *child)
+    {
+      DumpNodeOptions innerOptions{options};
+      innerOptions.NeedsLeftAlign = false;
+      innerOptions.NeedsLeadingNewline = false;
+      innerOptions.NeedsTrailingNewline = true;
+      innerOptions.InlineBlockComment = true;
+      (*child)->DumpNode(dumper, innerOptions);
+      child++;
+    }
+
+    for (; child != m_children.end(); child++)
+    {
+      DumpNodeOptions innerOptions{options};
+      innerOptions.NeedsLeftAlign = true;
+      innerOptions.NeedsLeadingNewline = true;
+      innerOptions.NeedsTrailingNewline = false;
+      if (*child)
+      {
+        (*child)->DumpNode(dumper, options);
+      }
+    }
+
+    if (options.NeedsTrailingNewline)
+    {
+      dumper->Newline();
+    }
+  }
+};
+
+struct AstParamComment : public AstDocumentation
+{
+  AstParamComment(comments::ParamCommandComment const* comment) : AstDocumentation()
+  {
+    std::string thisLine;
+    thisLine += GetCommandMarker(comment->getCommandMarker());
+    auto commandInfo{
+        clang::comments::CommandTraits::getBuiltinCommandInfo(comment->getCommandID())};
+    if (commandInfo->IsParamCommand)
+    {
+      thisLine += "param";
+    }
+    else
+    {
+      thisLine += commandInfo->Name;
+    }
+    thisLine += " ";
+    // If the caller explicitly listed the direction, include that in the description.
+    if (comment->isDirectionExplicit())
+    {
+      thisLine += comment->getDirectionAsString(comment->getDirection());
+      thisLine += " ";
+    }
+    if (comment->hasParamName())
+    {
+      thisLine += comment->getParamNameAsWritten();
+      thisLine += " ";
+    }
+    m_thisLine = thisLine;
+  }
+
+  bool IsInlineComment() const override { return false; }
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    if (m_thisLine == "@param format")
+    {
+      std::cout << "@param[in] format";
+    }
+    if (options.NeedsLeadingNewline)
+    {
+      dumper->Newline();
+    }
+    if (options.NeedsLeftAlign)
+    {
+      dumper->LeftAlign();
+    }
+    dumper->InsertWhitespace();
+    dumper->InsertPunctuation('*');
+    dumper->InsertWhitespace();
+    dumper->InsertComment(m_thisLine);
+
+    // The first child will be the first line of the parameter documentation, it should be joined
+    // with the current line.
+    auto child{m_children.begin()};
+    if (child != m_children.end() && *child)
+    {
+      DumpNodeOptions innerOptions{options};
+      innerOptions.NeedsLeftAlign = false;
+      innerOptions.NeedsLeadingNewline = false;
+      innerOptions.NeedsTrailingNewline = true;
+      innerOptions.InlineBlockComment = true;
+      (*child)->DumpNode(dumper, innerOptions);
+      child++;
+    }
+
+    for (; child != m_children.end(); child++)
+    {
+      DumpNodeOptions innerOptions{options};
+      innerOptions.NeedsLeftAlign = true;
+      innerOptions.NeedsLeadingNewline = false;
+      innerOptions.NeedsTrailingNewline = true;
+      if (*child)
+      {
+        (*child)->DumpNode(dumper, options);
+      }
+    }
+
+    if (options.NeedsTrailingNewline)
+    {
+      dumper->Newline();
+    }
+  }
+};
+
+struct AstTParamComment : public AstDocumentation
+{
+  AstTParamComment(comments::TParamCommandComment const* comment) : AstDocumentation()
+  {
+    std::string thisLine;
+    thisLine += GetCommandMarker(comment->getCommandMarker());
+    auto commandInfo{
+        clang::comments::CommandTraits::getBuiltinCommandInfo(comment->getCommandID())};
+    if (commandInfo->IsTParamCommand)
+    {
+      thisLine += "tparam";
+    }
+    else
+    {
+      thisLine += commandInfo->Name;
+    }
+    thisLine += " ";
+
+    if (comment->hasParamName())
+    {
+      thisLine += comment->getParamNameAsWritten();
+      thisLine += " ";
+    }
+    m_thisLine = thisLine;
+  }
+  bool IsInlineComment() const override { return false; }
+
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    if (options.NeedsLeadingNewline)
+    {
+      dumper->Newline();
+    }
+    if (options.NeedsLeftAlign)
+    {
+      dumper->LeftAlign();
+    }
+    dumper->InsertWhitespace();
+    dumper->InsertPunctuation('*');
+    dumper->InsertWhitespace();
+    dumper->InsertComment(m_thisLine);
+
+    // The first child will be the first line of the parameter documentation, it should be joined
+    // with the current line.
+    auto child{m_children.begin()};
+    if (child != m_children.end() && *child)
+    {
+      DumpNodeOptions innerOptions{options};
+      innerOptions.NeedsLeftAlign = false;
+      innerOptions.NeedsLeadingNewline = false;
+      innerOptions.NeedsTrailingNewline = true;
+      innerOptions.InlineBlockComment = true;
+      (*child)->DumpNode(dumper, innerOptions);
+      child++;
+    }
+
+    for (; child != m_children.end(); child++)
+    {
+      DumpNodeOptions innerOptions{options};
+      innerOptions.NeedsLeftAlign = true;
+      innerOptions.NeedsLeadingNewline = true;
+      innerOptions.NeedsTrailingNewline = false;
+      if (*child)
+      {
+        (*child)->DumpNode(dumper, options);
+      }
+    }
+
+    if (options.NeedsTrailingNewline)
+    {
+      dumper->Newline();
+    }
+  }
+};
+
+struct AstVerbatimBlockComment : public AstDocumentation
+{
+  AstVerbatimBlockComment(comments::VerbatimBlockComment const* comment) : AstDocumentation()
+  {
+    std::string thisLine;
+    auto commandInfo{
+        clang::comments::CommandTraits::getBuiltinCommandInfo(comment->getCommandID())};
+
+    thisLine += GetCommandMarker(comment->getCommandMarker());
+    thisLine += commandInfo->Name;
+
+    auto it = comment->child_begin();
+    auto childLineComment = clang::dyn_cast<clang::comments::VerbatimBlockLineComment>(*it);
+    if (childLineComment)
+    {
+      std::string childText{childLineComment->getText()};
+      // If the first character of the 0th argument is a '{', then this is a code block. Append
+      // it to the name.
+      if ((childText[0] == '{') && (childText[(childText.size() - 1)] = '}'))
+      {
+        m_hasLanguageTag = true;
+      }
+    }
+    m_thisLine = thisLine;
+    m_endMarker += GetCommandMarker(comment->getCommandMarker());
+    m_endMarker += commandInfo->EndCommandName;
+  }
+
+  bool IsInlineComment() const override { return false; }
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    if (options.NeedsLeadingNewline)
+    {
+      dumper->Newline();
+    }
+    if (options.NeedsLeftAlign)
+    {
+      dumper->LeftAlign();
+    }
+    dumper->InsertWhitespace();
+    dumper->InsertComment("* ");
+    dumper->InsertWhitespace();
+    dumper->InsertComment(m_thisLine);
+
+    // The first child will be the first line of the parameter documentation, it should be joined
+    // with the current line.
+    auto child{m_children.begin()};
+    if (child != m_children.end() && *child)
+    {
+      DumpNodeOptions innerOptions{options};
+      if (m_hasLanguageTag)
+      {
+        innerOptions.NeedsLeftAlign = false;
+        innerOptions.NeedsLeadingNewline = false;
+        innerOptions.NeedsTrailingNewline = false;
+        innerOptions.InlineBlockComment = true;
+      }
+      (*child)->DumpNode(dumper, innerOptions);
+      child++;
+    }
+
+    for (; child != m_children.end(); child++)
+    {
+      DumpNodeOptions innerOptions{options};
+      innerOptions.NeedsLeftAlign = true;
+      innerOptions.NeedsLeadingNewline = true;
+      innerOptions.NeedsTrailingNewline = false;
+      if (*child)
+      {
+        (*child)->DumpNode(dumper, options);
+      }
+    }
+
+    if (!m_endMarker.empty())
+    {
+      dumper->Newline();
+
+      dumper->LeftAlign();
+      dumper->InsertWhitespace();
+      dumper->InsertComment("* ");
+      dumper->InsertWhitespace();
+      dumper->InsertComment(m_endMarker);
+    }
+
+    if (options.NeedsTrailingNewline)
+    {
+      dumper->Newline();
+    }
+  }
+
+private:
+  bool m_hasLanguageTag{false};
+  std::string m_endMarker;
+};
+
+// Represents an inline command marker. Examples include the \c in \c foo, or the \a in \a foo.
+// The marker is the \c or \a.
+//
+// \p or \c should be rendered in a fixed width font
+// \a or \e or \em should be rendered in a italic font
+// \b should be rendered in a bold font
+// \emoji should be rendered as an emoji (if possible - see
+// https://gist.github.com/rxaviers/7360908).
+struct AstInlineCommand : AstDocumentation
+{
+  AstInlineCommand(const comments::InlineCommandComment* comment) : AstDocumentation()
+  {
+    std::string thisLine;
+    std::string commandRenderMarkdownStart;
+    std::string commandRenderMarkdownEnd;
+    switch (comment->getRenderKind())
+    {
+      case clang::comments::InlineCommandComment::RenderKind::RenderNormal:
+        break;
+      case clang::comments::InlineCommandComment::RenderKind::RenderBold:
+        commandRenderMarkdownEnd = "**";
+        commandRenderMarkdownStart = "**";
+        break;
+      case clang::comments::InlineCommandComment::RenderKind::RenderEmphasized:
+        commandRenderMarkdownEnd = "*";
+        commandRenderMarkdownStart = "*";
+        break;
+      case clang::comments::InlineCommandComment::RenderKind::RenderMonospaced:
+        commandRenderMarkdownEnd = "`";
+        commandRenderMarkdownStart = "`";
+        break;
+      default:
+        throw std::runtime_error("Unknown inline command render kind.");
+    }
+    // Include the arguments to the command.
+    thisLine += commandRenderMarkdownStart;
+    for (unsigned i = 0u; i < comment->getNumArgs(); ++i)
+    {
+      thisLine += comment->getArgText(i);
+    }
+    thisLine += commandRenderMarkdownEnd;
+    m_thisLine = thisLine;
+  }
+  bool IsInlineComment() const override { return true; }
+
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    dumper->InsertComment(m_thisLine);
+    for (auto& child : m_children)
+    {
+      child->DumpNode(dumper, options);
+    }
+  }
+};
+
+// A paragraph represents a block of text. Typically this is a paragraph of text. The children of
+// the line are typically AstTextComment nodes, but they may also be AstInlineCommand nodes. If they
+// are AstInlineCommand nodes, we should just insert them with no separation, if they are
+// AstTextComment nodes, we should insert them with a new line and comment leader between them.
+struct AstParagraphComment : AstDocumentation
+{
+  AstParagraphComment(comments::ParagraphComment const* comment) : AstDocumentation() {}
+  bool IsInlineComment() const override { return false; }
+
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    if (!options.InlineBlockComment)
+    {
+      if (options.NeedsLeadingNewline)
+      {
+        dumper->Newline();
+      }
+      if (options.NeedsLeftAlign)
+      {
+        dumper->LeftAlign();
+      }
+      dumper->InsertWhitespace();
+      dumper->InsertPunctuation('*');
+      dumper->InsertWhitespace();
+
+      // Insert a blank line before the paragraph if the previous line was not an inline comment.
+      dumper->Newline();
+      dumper->LeftAlign();
+      dumper->InsertWhitespace();
+      dumper->InsertPunctuation('*');
+      dumper->InsertWhitespace();
+    }
+    bool insertLineBreak = false;
+    for (auto& child : m_children)
+    {
+      if (child)
+      {
+        if (insertLineBreak && !child->IsInlineComment())
+        {
+          dumper->Newline();
+          dumper->LeftAlign();
+          dumper->InsertWhitespace();
+          dumper->InsertPunctuation('*');
+        }
+        child->DumpNode(dumper, options);
+        if (child->IsInlineComment())
+        {
+          insertLineBreak = false;
+        }
+        else
+        {
+          insertLineBreak = true;
+        }
+      }
+    }
+  }
+};
+
+struct AstVerbatimBlockLineComment : AstDocumentation
+{
+  AstVerbatimBlockLineComment(comments::VerbatimBlockLineComment const* comment)
+      : AstDocumentation()
+  {
+    m_thisLine = comment->getText();
+  }
+
+  bool IsInlineComment() const override { return false; }
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    if (options.NeedsLeadingNewline)
+    {
+      dumper->Newline();
+    }
+    if (options.NeedsLeftAlign)
+    {
+      dumper->LeftAlign();
+    }
+    if (!options.InlineBlockComment)
+    {
+      dumper->InsertWhitespace();
+      dumper->InsertPunctuation('*');
+      dumper->InsertWhitespace();
+    }
+    dumper->InsertComment(m_thisLine);
+    for (auto& child : m_children)
+    {
+      child->DumpNode(dumper, options);
+    }
+    if (options.NeedsTrailingNewline)
+    {
+      dumper->Newline();
+    }
+  }
+};
+
+struct AstTextComment : AstDocumentation
+{
+  AstTextComment(comments::TextComment const* comment) : AstDocumentation()
+  {
+    m_thisLine = comment->getText();
+  }
+  bool IsInlineComment() const override { return false; }
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    dumper->InsertComment(m_thisLine);
+  }
+};
+
+struct AstVerbatimLineComment : AstDocumentation
+{
+  AstVerbatimLineComment(comments::VerbatimLineComment const* comment) : AstDocumentation()
+  {
+    auto commandInfo{
+        clang::comments::CommandTraits::getBuiltinCommandInfo(comment->getCommandID())};
+    m_thisLine += GetCommandMarker(comment->getCommandMarker());
+    m_thisLine += commandInfo->Name;
+    m_endMarker = commandInfo->EndCommandName;
+  }
+  bool IsInlineComment() const override { return true; }
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    dumper->InsertComment(m_thisLine);
+  }
+
+private:
+  std::string m_endMarker;
+};
+
+struct AstHtmlStartTagComment : AstDocumentation
+{
+  AstHtmlStartTagComment(comments::HTMLStartTagComment const* comment) : AstDocumentation()
+  {
+    if (comment->getTagName() == "a")
+    {
+      m_isLinkHref = true;
+      auto argCount = comment->getNumAttrs();
+      for (size_t i = 0; i < argCount; i += 1)
+      {
+        if (comment->getAttr(i).Name == "href")
+        {
+          m_linkTarget = comment->getAttr(i).Value;
+        }
+      }
+    }
+  }
+  bool IsInlineComment() const override { return true; }
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    // We only serialize the first link argument.
+    if (m_isLinkHref)
+    {
+      dumper->AddExternalLinkStart(m_linkTarget);
+    }
+  }
+
+private:
+  std::string m_linkTarget;
+  bool m_isLinkHref{false};
+};
+
+struct AstHtmlEndTagComment : AstDocumentation
+{
+  AstHtmlEndTagComment(comments::HTMLEndTagComment const* comment) : AstDocumentation()
+  {
+    if (comment->getTagName() == "a")
+    {
+      m_isLinkHref = true;
+    }
+  }
+  bool IsInlineComment() const override { return true; }
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    if (m_isLinkHref)
+    {
+      dumper->AddExternalLinkEnd();
+    }
+  }
+
+private:
+  bool m_isLinkHref{false};
+};
+
+std::unique_ptr<AstDocumentation> AstDocumentation::Create(const comments::Comment* comment)
+{
+  switch (comment->getCommentKind())
+  {
+    case comments::Comment::CommentKind::FullCommentKind:
+      return std::make_unique<AstComment>(cast<const comments::FullComment>(comment));
+    case comments::Comment::CommentKind::BlockCommandCommentKind:
+      return std::make_unique<AstBlockCommandComment>(
+          cast<const comments::BlockCommandComment>(comment));
+    case comments::Comment::CommentKind::ParamCommandCommentKind:
+      return std::make_unique<AstParamComment>(cast<const comments::ParamCommandComment>(comment));
+    case comments::Comment::CommentKind::TParamCommandCommentKind:
+      return std::make_unique<AstTParamComment>(
+          cast<const comments::TParamCommandComment>(comment));
+    case comments::Comment::CommentKind::VerbatimBlockCommentKind:
+      return std::make_unique<AstVerbatimBlockComment>(
+          cast<const comments::VerbatimBlockComment>(comment));
+    case comments::Comment::CommentKind::InlineCommandCommentKind:
+      return std::make_unique<AstInlineCommand>(
+          cast<const comments::InlineCommandComment>(comment));
+    case comments::Comment::ParagraphCommentKind:
+      return std::make_unique<AstParagraphComment>(cast<const comments::ParagraphComment>(comment));
+    case comments::Comment::TextCommentKind:
+      return std::make_unique<AstTextComment>(cast<const comments::TextComment>(comment));
+    case comments::Comment::VerbatimBlockLineCommentKind:
+      return std::make_unique<AstVerbatimBlockLineComment>(
+          cast<const comments::VerbatimBlockLineComment>(comment));
+    case comments::Comment::VerbatimLineCommentKind:
+      return std::make_unique<AstVerbatimLineComment>(
+          cast<const comments::VerbatimLineComment>(comment));
+
+    case comments::Comment::HTMLStartTagCommentKind:
+      return std::make_unique<AstHtmlStartTagComment>(
+          cast<const comments::HTMLStartTagComment>(comment));
+    case comments::Comment::HTMLEndTagCommentKind:
+      return std::make_unique<AstHtmlEndTagComment>(
+          cast<const comments::HTMLEndTagComment>(comment));
+
+    default:
+      llvm::errs() << "Unknown comment kind: " << comment->getCommentKindName() << "\n";
+      return nullptr;
+  }
+}
+
+class CommentVisitor
+    : public clang::comments::CommentVisitor<CommentVisitor, std::unique_ptr<AstDocumentation>> {
+public:
+  CommentVisitor(const clang::ASTContext& context)
+      : clang::comments::CommentVisitor<CommentVisitor, std::unique_ptr<AstDocumentation>>(),
+        m_context{context}
+  {
+  }
+
+  std::unique_ptr<AstDocumentation> visitComment(const clang::comments::Comment* comment)
+  {
+    std::unique_ptr<AstDocumentation> rv{AstDocumentation::Create(comment)};
+    for (auto child = comment->child_begin(); child != comment->child_end(); child++)
+    {
+      auto childNode = visit(*child);
+      if (childNode)
+      {
+        rv->AddChild(std::move(childNode));
+      }
+    }
+    return rv;
+  };
+
+  std::unique_ptr<AstDocumentation> visitFullComment(const clang::comments::FullComment* decl)
+  {
+    //    decl->dump(llvm::outs(), m_context);
+    std::unique_ptr<AstDocumentation> rv{AstDocumentation::Create(decl)};
+    for (auto child = decl->child_begin(); child != decl->child_end(); child++)
+    {
+      auto childNode = visit(*child);
+      if (childNode)
+      {
+        rv->AddChild(std::move(childNode));
+      }
+    }
+    return rv;
+  };
+
+  // std::unique_ptr<AstDocumentation> visitBlockCommandComment(
+  //     const clang::comments::BlockCommandComment* bc)
+  //{
+  //   auto rv{AstDocumentation::Create(bc)};
+  //   // Gather the text for the block command comment.
+  //   for (auto child = bc->child_begin(); child != bc->child_end(); child++)
+  //   {
+  //     rv->AddChild(visit(*child));
+  //   }
+  //   return rv;
+  // };
+
+  // std::unique_ptr<AstDocumentation> visitParamCommandComment(
+  //     const clang::comments::ParamCommandComment* paramComment)
+  //{
+  //   std::unique_ptr<AstDocumentation> rv{AstDocumentation::Create(paramComment)};
+  //   for (auto child = paramComment->child_begin(); child != paramComment->child_end(); child++)
+  //   {
+  //     rv->AddChild(visit(*child));
+  //   }
+  //   return rv;
+  // }
+  // std::unique_ptr<AstDocumentation> visitTParamCommandComment(
+  //     const clang::comments::TParamCommandComment* tparamComment)
+  //{
+  //   std::unique_ptr<AstDocumentation> rv{AstDocumentation::Create(tparamComment)};
+  //   for (auto child = tparamComment->child_begin(); child != tparamComment->child_end(); child++)
+  //   {
+  //     rv->AddChild(visit(*child));
+  //   }
+  //   return rv;
+  // }
+
+  // std::unique_ptr<AstDocumentation> visitInlineCommandComment(
+  //     const clang::comments::InlineCommandComment* inlineCommandComment)
+  //{
+  //   std::unique_ptr<AstDocumentation> rv{AstDocumentation::Create(inlineCommandComment)};
+  //   for (auto child = inlineCommandComment->child_begin();
+  //        child != inlineCommandComment->child_end();
+  //        child++)
+  //   {
+  //     rv->AddChild(visit(*child));
+  //   }
+  //   return rv;
+  // }
+  // std::unique_ptr<AstDocumentation> visitVerbatimBlockComment(
+  //     const clang::comments::VerbatimBlockComment* vbc)
+  //{
+  //   std::unique_ptr<AstDocumentation> rv{AstDocumentation::Create(vbc)};
+
+  //  for (auto child = vbc->child_begin(); child != vbc->child_end(); child++)
+  //  {
+  //    auto childNode = visit(*child);
+  //    rv->AddChild(std::move(childNode));
+  //  }
+  //  return rv;
+  //}
+
+  // std::unique_ptr<AstDocumentation> visitHTMLStartTagComment(
+  //     const clang::comments::HTMLStartTagComment* startTag)
+  //{
+  //   std::unique_ptr<AstDocumentation> node{AstDocumentation::Create(startTag)};
+  //   std::string rv = "<" + std::string(startTag->getTagName()) + " ";
+  //   auto attributeCount = startTag->getNumAttrs();
+  //   for (auto i = 0ul; i < attributeCount; i += 1)
+  //   {
+  //     auto& attribute{startTag->getAttr(i)};
+  //     rv += std::string(attribute.Name);
+  //     rv += "=";
+  //     rv += "'" + std::string(attribute.Value) + "'";
+  //   }
+  //   rv += ">";
+
+  //  //    node->SetLine(rv);
+
+  //  return node;
+  //}
+  // std::unique_ptr<AstDocumentation> visitHTMLEndTagComment(
+  //    const clang::comments::HTMLEndTagComment* endTag)
+  //{
+  //  std::unique_ptr<AstDocumentation> node{AstDocumentation::Create(endTag)};
+  //  std::string rv = "</" + std::string(endTag->getTagName()) + ">";
+  //  //    node->SetLine(rv);
+  //  return node;
+  //}
+  // std::unique_ptr<AstDocumentation> visitVerbatimBlockLineComment(
+  //    const clang::comments::VerbatimBlockLineComment* vbc)
+  //{
+  //  std::unique_ptr<AstDocumentation> node{AstDocumentation::Create(vbc)};
+
+  //  for (auto child = vbc->child_begin(); child != vbc->child_end(); child++)
+  //  {
+  //    node->AddChild(visit(*child));
+  //  }
+  //  return node;
+  //}
+
+  // We want to ignore empty paragraph comments, so we need to specialize the visitor for paragraph
+  // comments.
+  std::unique_ptr<AstDocumentation> visitParagraphComment(
+      const clang::comments::ParagraphComment* decl)
+  {
+    // Ignore empty paragraph clang::comments.
+    if (decl->isWhitespace())
+    {
+      return nullptr;
+    }
+    std::unique_ptr<AstDocumentation> node{AstDocumentation::Create(decl)};
+    for (auto child = decl->child_begin(); child != decl->child_end(); child++)
+    {
+      auto childNode = visit(*child);
+      if (childNode)
+      {
+        node->AddChild(std::move(childNode));
+      }
+    }
+
+    return node;
+  };
+
+  // We want to ignore empty text comments, so we need to specialize the visitor for text
+  // comments.
+  std::unique_ptr<AstDocumentation> visitTextComment(const clang::comments::TextComment* tc)
+  {
+    // Ignore text clang::comments which are whitespace.
+    if (tc->isWhitespace())
+    {
+      return nullptr;
+    }
+    std::unique_ptr<AstDocumentation> node{AstDocumentation::Create(tc)};
+    return node;
+  };
+
+  // std::unique_ptr<AstDocumentation> visitHTMLTagComment(const clang::comments::HTMLTagComment*
+  // tag)
+  //{
+  //   std::unique_ptr<AstDocumentation> node{AstDocumentation::Create(tag)};
+  //   //    node->SetLine("***HTMLTag Comment***");
+  //   return node;
+  // }
+  // std::unique_ptr<AstDocumentation> visitInlineContentComment(
+  //     const clang::comments::InlineContentComment* tag)
+  //{
+  //   std::unique_ptr<AstDocumentation> node{AstDocumentation::Create(tag)};
+  //   // node->SetLine("***HTML Content Comment***");
+  //   return node;
+  // }
+
+  // std::unique_ptr<AstDocumentation> visitVerbatimLineComment(
+  //     const clang::comments::VerbatimLineComment* tag)
+  //{
+  //   std::unique_ptr<AstDocumentation> node{AstDocumentation::Create(tag)};
+  //   // node->SetLine("***Verbatim Line Content ***");
+  //   return node;
+  // }
+
+private:
+  const clang::ASTContext& m_context;
+};
+
+std::unique_ptr<AstDocumentation> CommentExtractor::Extract(clang::comments::Comment* comment)
+{
+  CommentVisitor visitor{m_context};
+  auto doc{visitor.visit(comment)};
+  return doc;
+}
+
+std::string_view AstDocumentation::GetCommandMarker(clang::comments::CommandMarkerKind marker)
+{
+  switch (marker)
+  {
+    case clang::comments::CommandMarkerKind::CMK_At:
+      return "@";
+    case clang::comments::CommandMarkerKind::CMK_Backslash:
+      return "\\";
+  }
+  throw std::runtime_error("Unknown command marker kind.");
+}

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CommentExtractor.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CommentExtractor.hpp
@@ -10,16 +10,14 @@ namespace clang { namespace comments {
   enum CommandMarkerKind : int;
 }} // namespace clang::comments
 
+/** An AstDocumentation node represents a parsed comment. 
+ * It is a base class which will be
+ * specialized for different types of comments, loosely following the clang AST for comments.
+ */
 class AstDocumentation : public AstNode {
 public:
-  size_t GetChildCount() const { return m_children.size(); }
-  std::unique_ptr<AstDocumentation> const& GetChild(size_t index) const
-  {
-    return m_children[index];
-  }
-  std::string const& GetLine() const { return m_thisLine; }
-  void AddChild(std::unique_ptr<AstDocumentation>&& line) { m_children.push_back(std::move(line)); }
   virtual bool IsInlineComment() const = 0;
+  void AddChild(std::unique_ptr<AstDocumentation>&& line) { m_children.push_back(std::move(line)); }
   void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
   {
     if (options.NeedsLeadingNewline)
@@ -63,6 +61,10 @@ protected:
   std::string m_thisLine{};
 };
 
+/** Extract a comment from a comment node.
+ * This function iterates over a clang::comments::Comment
+ * node and retrieves all the information in the comment in a way which can later be dumped.
+ */
 class CommentExtractor {
 public:
   CommentExtractor(const clang::ASTContext& context) : m_context{context} {}

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CommentExtractor.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CommentExtractor.hpp
@@ -1,0 +1,74 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+#include "AstDumper.hpp"
+#include "AstNode.hpp"
+
+namespace clang { namespace comments {
+
+  class Comment;
+  enum CommandMarkerKind : int;
+}} // namespace clang::comments
+
+class AstDocumentation : public AstNode {
+public:
+  size_t GetChildCount() const { return m_children.size(); }
+  std::unique_ptr<AstDocumentation> const& GetChild(size_t index) const
+  {
+    return m_children[index];
+  }
+  std::string const& GetLine() const { return m_thisLine; }
+  void AddChild(std::unique_ptr<AstDocumentation>&& line) { m_children.push_back(std::move(line)); }
+  virtual bool IsInlineComment() const = 0;
+  void DumpNode(AstDumper* dumper, DumpNodeOptions const& options) const override
+  {
+    if (options.NeedsLeadingNewline)
+    {
+      dumper->Newline();
+    }
+    if (options.NeedsLeftAlign)
+    {
+      dumper->LeftAlign();
+    }
+    dumper->InsertWhitespace();
+    dumper->InsertComment("* ");
+    dumper->InsertWhitespace();
+    dumper->InsertComment(m_thisLine);
+
+    for (auto const& child : m_children)
+    {
+      DumpNodeOptions innerOptions{options};
+      innerOptions.NeedsLeftAlign = true;
+      innerOptions.NeedsLeadingNewline = true;
+      innerOptions.NeedsTrailingNewline = false;
+      if (child)
+      {
+        child->DumpNode(dumper, options);
+      }
+    }
+
+    if (options.NeedsTrailingNewline)
+    {
+      dumper->Newline();
+    }
+  }
+
+  static std::unique_ptr<AstDocumentation> Create(clang::comments::Comment const* comment);
+
+protected:
+  AstDocumentation() : AstNode(){};
+  std::string_view GetCommandMarker(clang::comments::CommandMarkerKind marker);
+
+  std::vector<std::unique_ptr<AstDocumentation>> m_children;
+  std::string m_thisLine{};
+};
+
+class CommentExtractor {
+public:
+  CommentExtractor(const clang::ASTContext& context) : m_context{context} {}
+
+  std::unique_ptr<AstDocumentation> Extract(clang::comments::Comment* comment);
+
+private:
+  const clang::ASTContext& m_context;
+};

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CommentExtractor.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/CommentExtractor.hpp
@@ -65,12 +65,6 @@ protected:
  * This function iterates over a clang::comments::Comment
  * node and retrieves all the information in the comment in a way which can later be dumped.
  */
-class CommentExtractor {
-public:
-  CommentExtractor(const clang::ASTContext& context) : m_context{context} {}
-
-  std::unique_ptr<AstDocumentation> Extract(clang::comments::Comment* comment);
-
-private:
-  const clang::ASTContext& m_context;
-};
+std::unique_ptr<AstDocumentation> ExtractCommentForDeclaration(
+    clang::ASTContext const& context,
+    clang::Decl const* declaration);

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/JsonDumper.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/JsonDumper.hpp
@@ -34,8 +34,21 @@ class JsonDumper : public AstDumper {
     DeprecatedRangeEnd = 14,
     SkipDiffRangeStart = 15,
     SkipDiffRangeEnd = 16,
-    InheritanceInfoStart = 17,
-    InheritanceInfoEnd = 18
+    FoldableSectionHeading = 17,
+    FoldableSectionContentStart = 18,
+    FoldableSectionContentEnd = 19,
+    TableBegin = 20,
+    TableEnd = 21,
+    TableRowCount = 22,
+    TableColumnCount = 23,
+    TableColumnName = 24,
+    TableCellBegin = 25,
+    TableCellEnd = 26,
+    LeafSectionPlaceholder = 27,
+    ExternalLinkStart = 28,
+    ExternalLinkEnd = 29,
+    HiddenApiRangeStart = 30,
+    HiddenApiRangeEnd = 31
   };
 
   // Validate that the json we've created won't cause problems for ApiView.
@@ -105,6 +118,7 @@ public:
          {"NavigateToId", nullptr},
          {"Value", whiteSpace},
          {"Kind", TokenKinds::Whitespace}});
+    UpdateCursor(count);
   }
   virtual void InsertNewline() override
   {
@@ -121,6 +135,7 @@ public:
          {"NavigateToId", nullptr},
          {"Value", keyword},
          {"Kind", TokenKinds::Keyword}});
+    UpdateCursor(keyword.size());
   }
   virtual void InsertText(std::string_view const& text) override
   {
@@ -129,6 +144,7 @@ public:
          {"NavigateToId", nullptr},
          {"Value", text},
          {"Kind", TokenKinds::Text}});
+    UpdateCursor(text.size());
   }
   virtual void InsertPunctuation(const char punctuation) override
   {
@@ -138,6 +154,7 @@ public:
          {"NavigateToId", nullptr},
          {"Value", punctuationString},
          {"Kind", TokenKinds::Punctuation}});
+    UpdateCursor(1);
   }
   virtual void InsertLineIdMarker() override
   {
@@ -154,6 +171,7 @@ public:
          {"NavigateToId", nullptr},
          {"Value", id},
          {"Kind", TokenKinds::TypeName}});
+    UpdateCursor(id.size());
   }
   virtual void InsertTypeName(std::string_view const& type, std::string_view const& navigationId)
       override
@@ -163,6 +181,7 @@ public:
          {"NavigateToId", navigationId},
          {"Value", type},
          {"Kind", TokenKinds::TypeName}});
+    UpdateCursor(type.size());
   }
   virtual void InsertMemberName(
       std::string_view const& member,
@@ -181,6 +200,7 @@ public:
          {"NavigateToId", nullptr},
          {"Value", str},
          {"Kind", TokenKinds::StringLiteral}});
+    UpdateCursor(str.size());
   }
   virtual void InsertLiteral(std::string_view const& str) override
   {
@@ -189,6 +209,7 @@ public:
          {"NavigateToId", nullptr},
          {"Value", str},
          {"Kind", TokenKinds::Literal}});
+    UpdateCursor(str.size());
   }
   virtual void InsertComment(std::string_view const& comment) override
   {
@@ -197,6 +218,7 @@ public:
          {"NavigateToId", nullptr},
          {"Value", comment},
          {"Kind", TokenKinds::Comment}});
+    UpdateCursor(comment.size());
   }
   virtual void AddDocumentRangeStart() override
   {
@@ -213,6 +235,23 @@ public:
          {"NavigateToId", nullptr},
          {"Value", nullptr},
          {"Kind", TokenKinds::DocumentRangeEnd}});
+  }
+  virtual void AddExternalLinkStart(const std::string_view& url) override
+  {
+    m_json["Tokens"].push_back(
+        {{"DefinitionId", nullptr},
+         {"NavigateToId", nullptr},
+         {"Value", url},
+         {"Kind", TokenKinds::ExternalLinkEnd}});
+
+  }
+  virtual void AddExternalLinkEnd()
+  {
+    m_json["Tokens"].push_back(
+        {{"DefinitionId", nullptr},
+         {"NavigateToId", nullptr},
+         {"Value", nullptr},
+         {"Kind", TokenKinds::ExternalLinkStart}});
   }
   virtual void AddDeprecatedRangeStart() override
   {
@@ -245,22 +284,6 @@ public:
          {"NavigateToId", nullptr},
          {"Value", nullptr},
          {"Kind", TokenKinds::SkipDiffRangeEnd}});
-  }
-  virtual void AddInheritanceInfoStart() override
-  {
-    m_json["Tokens"].push_back(
-        {{"DefinitionId", nullptr},
-         {"NavigateToId", nullptr},
-         {"Value", nullptr},
-         {"Kind", TokenKinds::InheritanceInfoStart}});
-  }
-  virtual void AddInheritanceInfoEnd() override
-  {
-    m_json["Tokens"].push_back(
-        {{"DefinitionId", nullptr},
-         {"NavigateToId", nullptr},
-         {"Value", nullptr},
-         {"Kind", TokenKinds::InheritanceInfoEnd}});
   }
 
   nlohmann::json DoDumpTypeHierarchyNode(

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ProcessorImpl.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ProcessorImpl.cpp
@@ -435,7 +435,6 @@ int ApiViewProcessorImpl::ProcessApiView()
     assert(file.u8string().find(m_currentSourceRoot.u8string()) == 0);
     auto relativeFile = static_cast<std::string>(
         stringFromU8string(file.u8string().erase(0, m_currentSourceRoot.u8string().size() + 1)));
- //   std::string quotedFile = replaceAll(relativeFile, "\\", "\\\\");
     std::string quotedFile = replaceAll(relativeFile, "\\", "/");
     sourceFileAggregate << "#include \"" << quotedFile << "\"" << std::endl;
   }

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ProcessorImpl.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ProcessorImpl.cpp
@@ -101,6 +101,7 @@ const std::vector<std::string_view> KnownSettings{
     "filterNamespace",
     "additionalCompilerSwitches",
     "additionalIncludeDirectories",
+    "sourceRootUrl",
     "reviewName",
     "serviceName",
     "packageName",
@@ -138,6 +139,10 @@ ApiViewProcessorImpl::ApiViewProcessorImpl(
   if (configurationJson.contains("includePrivate"))
   {
     m_includePrivate = configurationJson["includePrivate"];
+  }
+  if (configurationJson.contains("sourceRootUrl"))
+  {
+    m_repositoryRoot = configurationJson["sourceRootUrl"];
   }
   if (configurationJson.contains("filterNamespace")
       && !configurationJson["filterNamespace"].is_null())
@@ -430,7 +435,8 @@ int ApiViewProcessorImpl::ProcessApiView()
     assert(file.u8string().find(m_currentSourceRoot.u8string()) == 0);
     auto relativeFile = static_cast<std::string>(
         stringFromU8string(file.u8string().erase(0, m_currentSourceRoot.u8string().size() + 1)));
-    std::string quotedFile = replaceAll(relativeFile, "\\", "\\\\");
+ //   std::string quotedFile = replaceAll(relativeFile, "\\", "\\\\");
+    std::string quotedFile = replaceAll(relativeFile, "\\", "/");
     sourceFileAggregate << "#include \"" << quotedFile << "\"" << std::endl;
   }
 

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ProcessorImpl.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/ProcessorImpl.hpp
@@ -27,6 +27,8 @@ class ApiViewProcessorImpl {
   std::string m_reviewName;
   std::string m_serviceName;
   std::string m_packageName;
+  std::string m_repositoryRoot;
+  mutable std::string m_sourceRoot;
 
   bool m_allowInternal{false};
   bool m_includeDetail{false};
@@ -114,11 +116,20 @@ public:
 
   std::unique_ptr<AzureClassesDatabase> const& GetClassesDatabase() { return m_classDatabase; }
 
-  bool AllowInternal() { return m_allowInternal; }
-  bool IncludeDetail() { return m_includeDetail; }
-  bool IncludePrivate() { return m_includePrivate; }
-  std::string_view const ReviewName() { return m_reviewName; };
-  std::string_view const ServiceName() { return m_serviceName; };
-  std::string_view const PackageName() { return m_packageName; };
-  std::vector<std::string> const &FilterNamespaces() { return m_filterNamespaces; }
+  bool AllowInternal() const { return m_allowInternal; }
+  bool IncludeDetail() const { return m_includeDetail; }
+  bool IncludePrivate() const { return m_includePrivate; }
+  std::string_view const ReviewName() const { return m_reviewName; };
+  std::string_view const ServiceName() const { return m_serviceName; };
+  std::string_view const PackageName() const { return m_packageName; };
+  std::string_view const SourceRepository() const { return m_repositoryRoot; };
+  std::string_view const RootDirectory() const
+  {
+    if (m_sourceRoot.empty())
+    {
+      m_sourceRoot = m_currentSourceRoot.string();
+    }
+    return m_sourceRoot;
+  }
+  std::vector<std::string> const& FilterNamespaces() { return m_filterNamespaces; }
 };

--- a/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/TextDumper.hpp
+++ b/tools/apiview/parsers/cpp-api-parser/ApiViewProcessor/TextDumper.hpp
@@ -16,30 +16,73 @@ public:
 
   virtual void InsertWhitespace(int count) override { m_stream << std::string(count, ' '); }
   virtual void InsertNewline() override { m_stream << std::endl; }
-  virtual void InsertKeyword(std::string_view const& keyword) override { m_stream << keyword; }
-  virtual void InsertText(std::string_view const& text) override { m_stream << text; }
-  virtual void InsertPunctuation(const char punctuation) override { m_stream << punctuation; }
-  virtual void InsertLineIdMarker() override { m_stream << "// "; }
+  virtual void InsertKeyword(std::string_view const& keyword) override
+  {
+    m_stream << keyword;
+    UpdateCursor(keyword.size());
+  }
+  virtual void InsertText(std::string_view const& text) override
+  {
+    m_stream << text;
+    UpdateCursor(text.size());
+  }
+  virtual void InsertPunctuation(const char punctuation) override
+  {
+    m_stream << punctuation;
+    UpdateCursor(1);
+  }
+  virtual void InsertLineIdMarker() override
+  {
+    m_stream << "// ";
+    UpdateCursor(3);
+  }
   virtual void InsertTypeName(std::string_view const& type, std::string_view const&) override
   {
     m_stream << type;
+    UpdateCursor(type.size());
   }
   virtual void InsertMemberName(std::string_view const& member, std::string_view const&) override
   {
     m_stream << member;
+    UpdateCursor(member.size());
   }
-  virtual void InsertStringLiteral(std::string_view const& str) override { m_stream << str; }
-  virtual void InsertLiteral(std::string_view const& str) override { m_stream << str; }
-  virtual void InsertIdentifier(std::string_view const& str) override { m_stream << str; }
-  virtual void InsertComment(std::string_view const& comment) override { m_stream << comment; }
-  virtual void AddDocumentRangeStart() override { m_stream << "/*"; }
-  virtual void AddDocumentRangeEnd() override { m_stream << "*/"; }
+  virtual void InsertStringLiteral(std::string_view const& str) override
+  {
+    m_stream << str;
+    UpdateCursor(str.size());
+  }
+  virtual void InsertLiteral(std::string_view const& str) override
+  {
+    m_stream << str;
+    UpdateCursor(str.size());
+  }
+  virtual void InsertIdentifier(std::string_view const& str) override
+  {
+    m_stream << str;
+    UpdateCursor(str.size());
+  }
+  virtual void InsertComment(std::string_view const& comment) override
+  {
+    m_stream << comment;
+    UpdateCursor(comment.size());
+  }
+  virtual void AddDocumentRangeStart() override
+  {
+    m_stream << "/* ** START DOCUMENTATION RANGE ** */" << std::endl;
+  }
+  virtual void AddDocumentRangeEnd() override
+  {
+    m_stream << "/* ** END DOCUMENTATION RANGE ** */" << std::endl;
+  }
+  virtual void AddExternalLinkStart(std::string_view const& linkValue) override
+  {
+    m_stream << "**LINK** <a href=" << linkValue << "> ** LINK **";
+  }
+  virtual void AddExternalLinkEnd() override { m_stream << "**LINK**</a>**LINK**"; }
   virtual void AddDeprecatedRangeStart() override { m_stream << "/* ** DEPRECATED **"; }
   virtual void AddDeprecatedRangeEnd() override { m_stream << "/* ** DEPRECATED ** */"; }
   virtual void AddDiffRangeStart() override { m_stream << "/* ** DIFF **"; }
   virtual void AddDiffRangeEnd() override { m_stream << " ** DIFF ** */"; }
-  virtual void AddInheritanceInfoStart() override { m_stream << "/* ** INHERITANCE **"; }
-  virtual void AddInheritanceInfoEnd() override { m_stream << " ** INHERITANCE ** */"; }
 
   void DoDumpHierarchyNode(
       std::shared_ptr<TypeHierarchy::TypeHierarchyNode> const& node,

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/CMakeLists.txt
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/CMakeLists.txt
@@ -19,7 +19,7 @@ add_executable(parseTests
     TestCases/ExpressionTests.cpp
     TestCases/UsingNamespace.cpp
     TestCases/DestructorTests.cpp
-)
+    TestCases/DocumentationTests.cpp)
 add_dependencies(parseTests ApiViewProcessor)
 
 target_include_directories(parseTests PRIVATE ${ApiViewProcessor_SOURCE_DIR})

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/TestCases/DocumentationTests.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/TestCases/DocumentationTests.cpp
@@ -1,0 +1,151 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// SPDX-License-Identifier: MIT
+
+/**
+ * @file DoxygenDemo.hpp
+ * @brief A class skeleton which demonstrates all the doxygen special commands.
+ *
+ * This file contains the class skeleton which demonstrates all the doxygen special commands.
+ *
+ * @author [Azure SDK Tools]
+ *
+ */
+
+#ifndef DOXYGEN_DEMO_HPP
+#define DOXYGEN_DEMO_HPP
+
+#include <cerrno>
+#include <map>
+#include <string>
+
+/**
+ * Global integer value.
+ */
+extern int external;
+
+// A class which demontrates all the doxygen documentation features.
+
+/**
+ * @brief A class that demonstrates all the doxygen special commands.
+ *
+ * This class demonstrates all the doxygen special commands.
+ *
+ */
+class DoxygenDemo {
+public:
+  /**
+   * @brief A constructor.
+   *
+   * A more elaborate description of the constructor.
+   *
+   */
+  DoxygenDemo();
+
+  /**
+   * @brief A destructor.
+   *
+   * A more elaborate description of the destructor.
+   *
+   */
+  ~DoxygenDemo();
+
+  /**
+   * @brief A normal member taking two arguments and returning an integer value.
+   *
+   * This function takes two arguments and returns an integer value.
+   *
+   * @param a An integer argument.
+   * @param s A constant character pointer.
+   * @see DoxygenDemo()
+   * @see ~DoxygenDemo()
+   * @see testMeToo()
+   * @see publicVar()
+   * @return The test results.
+   */
+  int testMe(int a, const char* s);
+
+  /**
+   * @brief A normal member taking no arguments and returning nothing.
+   *
+   * This function takes no arguments and returns nothing.
+   *
+   * @return Nothing.
+   */
+  void testMeToo();
+
+  /**
+   * @brief A public variable.
+   *
+   * This is a public variable.
+   *
+   */
+  int publicVar;
+
+  /**
+   * @brief A normal member taking no arguments and returning nothing.
+   *
+   * This function takes no arguments and returns nothing.
+   *
+   * @return Nothing.
+   * @verbatim
+   * This is a verbatim directive.
+   * @endverbatim
+   * 
+   * \cond
+   * This is a set of documentation that should be excluded.
+   * \endcond
+   */
+  void verbatimDirective();
+
+  /**
+   * \brief A normal member taking no arguments and returning nothing.
+   *
+   * This function takes no @a arguments @p and returns @b nothing.
+   *
+   * \return Nothing.
+   * \code{.c}
+   * int x = 5;
+   * int y = 10;
+   * int z = x + y;
+   * \endcode
+   */
+  void codeDirective();
+
+  
+  /**
+   * @brief A normal member taking no arguments and returning nothing.
+   *
+   * This function takes no arguments and returns nothing. It is a multi-line paragraph ending on a \a break.
+   *
+   * This is what happens when you have a hypertext link: <a href="https://www.example.com">An
+   * example link.</a>
+   *
+   * @return \a Nothing.
+   * 
+   * @link https://www.example.com An example link. @endlink
+   */
+  void linkDirective();
+
+
+private:
+  /**
+   * @brief A private variable.
+   *
+   * This is a private variable.
+   *
+   */
+  int privateVar;
+
+  /**
+   * @brief \b A normal member taking no arguments and returning nothing.
+   *
+   * This function takes no arguments and returns nothing. It is a multi-line paragraph ending on a \a break.
+   * 
+   * This is what happens when you have a hypertext link: <a href=https://www.example.com'>An example link.</a>
+   *
+   * @return \a Nothing.
+   */
+  void privateFunction();
+};
+
+#endif /* DOXYGEN_DEMO_HPP */

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/tests.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/tests.cpp
@@ -263,8 +263,8 @@ struct NsDumper : AstDumper
   virtual void AddDeprecatedRangeEnd() override {}
   virtual void AddDiffRangeStart() override {}
   virtual void AddDiffRangeEnd() override {}
-  virtual void AddInheritanceInfoStart() override {}
-  virtual void AddInheritanceInfoEnd() override {}
+  virtual void AddExternalLinkStart(std::string_view const& url) override {}
+  virtual void AddExternalLinkEnd() override {}
   virtual void DumpTypeHierarchyNode(
       std::shared_ptr<TypeHierarchy::TypeHierarchyNode> const& node) override
   {
@@ -601,6 +601,32 @@ TEST_F(TestParser, TestDtors)
   }
   EXPECT_EQ(nonVirtualDestructor, 2ul);
 }
+
+TEST_F(TestParser, TestDocuments)
+{
+  ApiViewProcessor processor("tests", R"({
+  "sourceFilesToProcess": [
+    "DocumentationTests.cpp"
+  ],
+  "additionalIncludeDirectories": [],
+  "additionalCompilerSwitches": null,
+  "allowInternal": false,
+  "includeDetail": false,
+  "includePrivate": false,
+  "filterNamespace": null
+}
+)"_json);
+
+
+  EXPECT_EQ(processor.ProcessApiView(), 0);
+
+  auto& db = processor.GetClassesDatabase();
+  EXPECT_TRUE(SyntaxCheckClassDb(db, "DocumentationTests1.cpp"));
+
+  NsDumper dumper;
+  db->DumpClassDatabase(&dumper);
+}
+
 
 
 #if 0

--- a/tools/apiview/parsers/cpp-api-parser/ParseTests/tests.cpp
+++ b/tools/apiview/parsers/cpp-api-parser/ParseTests/tests.cpp
@@ -454,7 +454,7 @@ TEST_F(TestParser, Class1)
 
   NsDumper dumper;
   db->DumpClassDatabase(&dumper);
-  EXPECT_EQ(44ul, dumper.Messages.size());
+  EXPECT_EQ(55ul, dumper.Messages.size());
 
   size_t internalTypes = 0;
   for (const auto& msg : dumper.Messages)

--- a/tools/apiview/parsers/cpp-api-parser/README.md
+++ b/tools/apiview/parsers/cpp-api-parser/README.md
@@ -80,6 +80,8 @@ An ApiViewSettings.json file contains the following options:
 - "filterNamespace" - if present and non-null, represents a set of
   namespace prefixes which are expected in the package.
   Types which do not match the filter will generate a warning.
+- "sourceRootUrl" - if present and non-null represents the root URL for the ApiView directory.
+  This URL is used to generate source links in the ApiView tool.
 
 ## Implementation Details
 


### PR DESCRIPTION
This PR implements 3 new features to the C++ API View tool.

1. Enable comments in API Views.
2. Add a line to each type describing where the type is located in the source tree
3. Flag typedefs in the global namespace as being challenging. This raises the visibility of using types like uint8_t in the global namespace.
