### PR TITLE
Update tools for new Codeowners utils

### DIFF
--- a/tools/identity-resolution/Services/GitHubService.cs
+++ b/tools/identity-resolution/Services/GitHubService.cs
@@ -5,7 +5,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using Azure.Sdk.Tools.CodeOwnersParser;
+using Azure.Sdk.Tools.CodeownersUtils.Parsing;
+using System.IO;
 
 namespace Azure.Sdk.Tools.NotificationConfiguration
 {
@@ -14,10 +15,9 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
     /// </summary>
     public class GitHubService
     {
-        private static readonly HttpClient httpClient = new HttpClient();
 
         private static readonly ConcurrentDictionary<string, List<CodeownersEntry>>
-            codeownersFileCache = new ConcurrentDictionary<string, List<CodeownersEntry>>();
+            codeownersFileCache = new();
 
         private readonly ILogger<GitHubService> logger;
 
@@ -35,7 +35,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
         /// </summary>
         /// <param name="repoUrl">GitHub repository URL</param>
         /// <returns>Contents fo the located CODEOWNERS file</returns>
-        public async Task<List<CodeownersEntry>> GetCodeownersFileEntries(Uri repoUrl)
+        public List<CodeownersEntry> GetCodeownersFileEntries(Uri repoUrl)
         {
             List<CodeownersEntry> result;
             if (codeownersFileCache.TryGetValue(repoUrl.ToString(), out result))
@@ -43,7 +43,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
                 return result;
             }
 
-            result = await GetCodeownersFileImpl(repoUrl);
+            result = GetCodeownersFileImpl(repoUrl);
             codeownersFileCache.TryAdd(repoUrl.ToString(), result);
             return result;
         }
@@ -53,21 +53,31 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
         /// </summary>
         /// <param name="repoUrl"></param>
         /// <returns></returns>
-        private async Task<List<CodeownersEntry>> GetCodeownersFileImpl(Uri repoUrl)
+        private List<CodeownersEntry> GetCodeownersFileImpl(Uri repoUrl)
         {
             // Gets the repo path from the URL
             var relevantPathParts = repoUrl.Segments.Skip(1).Take(2);
             var repoPath = string.Join("", relevantPathParts);
 
             var codeOwnersUrl = $"https://raw.githubusercontent.com/{repoPath}/main/.github/CODEOWNERS";
-            var result = await httpClient.GetAsync(codeOwnersUrl);
-            if (result.IsSuccessStatusCode)
+
+            try
             {
-                logger.LogInformation("Retrieved CODEOWNERS file URL = {0}", codeOwnersUrl);
-                return CodeownersFile.GetCodeownersEntries(await result.Content.ReadAsStringAsync());
+                this.logger.LogInformation("Parsing CodeownersEntries from CODEOWNERS file URL = {0}", codeOwnersUrl);
+                return CodeownersParser.ParseCodeownersFile(codeOwnersUrl);
+            }
+            // Thrown by FileHelpers if there was the codeOwnersUrl doesn't point to a valid URL or local file.
+            catch (ArgumentException)
+            {
+                this.logger.LogWarning("Unable to retrieve contents from codeOwnersUrl {0}. Please ensure that the file exists.", codeOwnersUrl);
+            }
+            // Thrown by FileHelpers if the codeOwnersUrl was good but was unable to be fetched with retries.
+            // This is the condition where GitHub is having issues.
+            catch (FileLoadException fle)
+            {
+                this.logger.LogWarning("{0}", fle.Message);
             }
 
-            logger.LogWarning("Could not retrieve CODEOWNERS file URL = {0} ResponseCode = {1}", codeOwnersUrl, result.StatusCode);
             return null;
         }
 

--- a/tools/identity-resolution/ci.yml
+++ b/tools/identity-resolution/ci.yml
@@ -9,6 +9,7 @@ trigger:
   paths:
     include:
       - tools/identity-resolution
+      - tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils
 
 pr:
   branches:
@@ -20,6 +21,7 @@ pr:
   paths:
     include:
       - tools/identity-resolution
+      - tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml

--- a/tools/identity-resolution/identity-resolution.csproj
+++ b/tools/identity-resolution/identity-resolution.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="YamlDotNet" Version="6.1.1" />
     <PackageReference Include="Azure.Identity" Version="1.10.2" />
   </ItemGroup>
-  
-   <ItemGroup>
-    <ProjectReference Include="../code-owners-parser/CodeOwnersParser/Azure.Sdk.Tools.CodeOwnersParser.csproj" />
+
+  <ItemGroup>
+    <ProjectReference Include="..\codeowners-utils\Azure.Sdk.Tools.CodeownersUtils\Azure.Sdk.Tools.CodeownersUtils.csproj" />
   </ItemGroup>
 
 

--- a/tools/identity-resolution/identity-resolution.sln
+++ b/tools/identity-resolution/identity-resolution.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.7.34202.233
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "identity-resolution", "identity-resolution.csproj", "{9BD15934-C50E-4E33-92C7-56FA60BB20F8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{9BD15934-C50E-4E33-92C7-56FA60BB20F8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9BD15934-C50E-4E33-92C7-56FA60BB20F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9BD15934-C50E-4E33-92C7-56FA60BB20F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9BD15934-C50E-4E33-92C7-56FA60BB20F8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {3D8B639A-3BC6-4B18-974F-D413F644F371}
+	EndGlobalSection
+EndGlobal

--- a/tools/notification-configuration/ci.yml
+++ b/tools/notification-configuration/ci.yml
@@ -9,7 +9,7 @@ trigger:
   paths:
     include:
       - tools/notification-configuration
-      - tools/code-owners-parser/CodeOwnersParser
+      - tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils
       - tools/identity-resolution/identity-resolution
 
 pr:
@@ -22,7 +22,7 @@ pr:
   paths:
     include:
       - tools/notification-configuration
-      - tools/code-owners-parser/CodeOwnersParser
+      - tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils
       - tools/identity-resolution/identity-resolution
 
 extends:

--- a/tools/notification-configuration/notification-configuration.sln
+++ b/tools/notification-configuration/notification-configuration.sln
@@ -4,12 +4,11 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 VisualStudioVersion = 17.5.33103.201
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.NotificationConfiguration", "notification-creator\Azure.Sdk.Tools.NotificationConfiguration.csproj", "{5759063D-A7B3-4D36-ACF4-5595C2789D27}"
+	ProjectSection(ProjectDependencies) = postProject
+		{0B5FEC08-8553-4267-B533-47D498A1B910} = {0B5FEC08-8553-4267-B533-47D498A1B910}
+	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.NotificationConfiguration.Tests", "notification-creator.Tests\Azure.Sdk.Tools.NotificationConfiguration.Tests.csproj", "{3097CBB4-ED3C-4273-AC67-F5D189CB94BA}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CodeOwnersParser", "..\code-owners-parser\CodeOwnersParser\Azure.Sdk.Tools.CodeOwnersParser.csproj", "{A9826C8B-85DF-48DB-8A05-40FB04833C42}"
-EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CodeOwnersParser.Tests", "..\code-owners-parser\Azure.Sdk.Tools.CodeOwnersParser.Tests\Azure.Sdk.Tools.CodeOwnersParser.Tests.csproj", "{2146E1FF-04D1-4B19-9767-C011A73CB40D}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "identity-resolution", "..\identity-resolution\identity-resolution.csproj", "{9805B503-5469-412C-9A0C-F09F504F0ED8}"
 EndProject
@@ -18,6 +17,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		ci.yml = ci.yml
 		README.md = README.md
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CodeownersUtils", "..\codeowners-utils\Azure.Sdk.Tools.CodeownersUtils\Azure.Sdk.Tools.CodeownersUtils.csproj", "{0B5FEC08-8553-4267-B533-47D498A1B910}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -33,18 +34,14 @@ Global
 		{3097CBB4-ED3C-4273-AC67-F5D189CB94BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3097CBB4-ED3C-4273-AC67-F5D189CB94BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3097CBB4-ED3C-4273-AC67-F5D189CB94BA}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A9826C8B-85DF-48DB-8A05-40FB04833C42}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A9826C8B-85DF-48DB-8A05-40FB04833C42}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A9826C8B-85DF-48DB-8A05-40FB04833C42}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A9826C8B-85DF-48DB-8A05-40FB04833C42}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2146E1FF-04D1-4B19-9767-C011A73CB40D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2146E1FF-04D1-4B19-9767-C011A73CB40D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{2146E1FF-04D1-4B19-9767-C011A73CB40D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{2146E1FF-04D1-4B19-9767-C011A73CB40D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9805B503-5469-412C-9A0C-F09F504F0ED8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9805B503-5469-412C-9A0C-F09F504F0ED8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9805B503-5469-412C-9A0C-F09F504F0ED8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9805B503-5469-412C-9A0C-F09F504F0ED8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0B5FEC08-8553-4267-B533-47D498A1B910}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0B5FEC08-8553-4267-B533-47D498A1B910}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0B5FEC08-8553-4267-B533-47D498A1B910}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0B5FEC08-8553-4267-B533-47D498A1B910}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/notification-configuration/notification-creator/Contacts.cs
+++ b/tools/notification-configuration/notification-creator/Contacts.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Azure.Sdk.Tools.CodeOwnersParser;
+using Azure.Sdk.Tools.CodeownersUtils.Parsing;
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Build.WebApi;
 
@@ -38,7 +38,7 @@ internal class Contacts
     /// <summary>
     /// See the class comment.
     /// </summary>
-    public async Task<List<string>> GetFromBuildDefinitionRepoCodeowners(BuildDefinition buildDefinition)
+    public List<string> GetFromBuildDefinitionRepoCodeowners(BuildDefinition buildDefinition)
     {
         if (buildDefinition.Process.Type != BuildDefinitionYamlProcessType)
         {
@@ -60,7 +60,7 @@ internal class Contacts
             return null;
         }
 
-        List<CodeownersEntry> codeownersEntries = await gitHubService.GetCodeownersFileEntries(repoUrl);
+        List<CodeownersEntry> codeownersEntries = gitHubService.GetCodeownersFileEntries(repoUrl);
         if (codeownersEntries == null)
         {
             this.log.LogInformation("CODEOWNERS file in '{repoUrl}' not found. Skipping sync.", repoUrl);
@@ -79,7 +79,7 @@ internal class Contacts
             yamlProcess,
             codeownersEntries,
             repoUrl.ToString());
-        List<string> contacts = matchingCodeownersEntry.Owners;
+        List<string> contacts = matchingCodeownersEntry.SourceOwners;
 
         this.log.LogInformation(
             "Found matching contacts (owners) in CODEOWNERS. " +
@@ -118,7 +118,7 @@ internal class Contacts
         string repoUrl)
     {
         CodeownersEntry matchingCodeownersEntry =
-            CodeownersFile.GetMatchingCodeownersEntry(
+            CodeownersParser.GetMatchingCodeownersEntry(
                 process.YamlFilename,
                 codeownersEntries);
 

--- a/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
+++ b/tools/notification-configuration/notification-creator/NotificationConfigurator.cs
@@ -182,7 +182,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration
             using (logger.BeginScope("Team Name = {0}", team.Name))
             {
                 List<string> contacts =
-                    await new Contacts(gitHubService, logger).GetFromBuildDefinitionRepoCodeowners(buildDefinition);
+                    new Contacts(gitHubService, logger).GetFromBuildDefinitionRepoCodeowners(buildDefinition);
                 if (contacts == null)
                 {
                     // assert: the reason for why contacts is null has been already logged.

--- a/tools/pipeline-owners-extractor/Azure.Sdk.Tools.PipelineOwnersExtractor/Azure.Sdk.Tools.PipelineOwnersExtractor.csproj
+++ b/tools/pipeline-owners-extractor/Azure.Sdk.Tools.PipelineOwnersExtractor/Azure.Sdk.Tools.PipelineOwnersExtractor.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -13,6 +13,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\..\codeowners-utils\Azure.Sdk.Tools.CodeownersUtils\Azure.Sdk.Tools.CodeownersUtils.csproj" />
     <ProjectReference Include="..\..\identity-resolution\identity-resolution.csproj" />
   </ItemGroup>
 

--- a/tools/pipeline-owners-extractor/PipelineOwnersExtractor.sln
+++ b/tools/pipeline-owners-extractor/PipelineOwnersExtractor.sln
@@ -5,9 +5,9 @@ VisualStudioVersion = 17.2.32602.215
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "identity-resolution", "..\identity-resolution\identity-resolution.csproj", "{54513498-7FA1-4525-915B-405746FBDDF5}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CodeOwnersParser", "..\code-owners-parser\CodeOwnersParser\Azure.Sdk.Tools.CodeOwnersParser.csproj", "{F0516B1D-037F-4096-9932-ED8F180EBC5D}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.PipelineOwnersExtractor", "Azure.Sdk.Tools.PipelineOwnersExtractor\Azure.Sdk.Tools.PipelineOwnersExtractor.csproj", "{4813A8E4-BC83-4F2D-8C87-F9AAAA11B207}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CodeownersUtils", "..\codeowners-utils\Azure.Sdk.Tools.CodeownersUtils\Azure.Sdk.Tools.CodeownersUtils.csproj", "{E6FEA30D-55B7-4C04-AC15-1FB7FBED6664}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,14 +19,14 @@ Global
 		{54513498-7FA1-4525-915B-405746FBDDF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{54513498-7FA1-4525-915B-405746FBDDF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{54513498-7FA1-4525-915B-405746FBDDF5}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F0516B1D-037F-4096-9932-ED8F180EBC5D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F0516B1D-037F-4096-9932-ED8F180EBC5D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F0516B1D-037F-4096-9932-ED8F180EBC5D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F0516B1D-037F-4096-9932-ED8F180EBC5D}.Release|Any CPU.Build.0 = Release|Any CPU
 		{4813A8E4-BC83-4F2D-8C87-F9AAAA11B207}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{4813A8E4-BC83-4F2D-8C87-F9AAAA11B207}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{4813A8E4-BC83-4F2D-8C87-F9AAAA11B207}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{4813A8E4-BC83-4F2D-8C87-F9AAAA11B207}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6FEA30D-55B7-4C04-AC15-1FB7FBED6664}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6FEA30D-55B7-4C04-AC15-1FB7FBED6664}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6FEA30D-55B7-4C04-AC15-1FB7FBED6664}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6FEA30D-55B7-4C04-AC15-1FB7FBED6664}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/pipeline-owners-extractor/ci.yml
+++ b/tools/pipeline-owners-extractor/ci.yml
@@ -9,6 +9,8 @@ trigger:
   paths:
     include:
       - tools/pipeline-owners-extractor
+      - tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils
+      - tools/identity-resolution
 
 pr:
   branches:
@@ -20,6 +22,8 @@ pr:
   paths:
     include:
       - tools/pipeline-owners-extractor
+      - tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils
+      - tools/identity-resolution
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml


### PR DESCRIPTION
Update identity-resolution, notification-configuration and pipeline-owners-extractor to use the new CodeownersUtils instead of CodeownersParser.

identity-resolution never had a solution, Visual Studio kept creating one every time the project was loaded and wanted to save it off. I relented and I'm checking that in here.

I also fixed the ci.yml files that didn't correctly the original parser as part of their include paths. This is reason that pipeline-owners-extractor want's expanding teams when that functionality was added months ago.
