### PR TITLE
Set IsPackable for CodeownersUtils to false

### DIFF
--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Azure.Sdk.Tools.CodeownersUtils.csproj
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Azure.Sdk.Tools.CodeownersUtils.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
+    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Set IsPackable to false for the CodeownersUtils project as the library isn't supposed to be being published to nuget. This caused failures in the publishing for the projects that depend on the utils because it was trying to publish the same version of CodeownersUtils in multiple pipelines when it shouldn't have been published to begin with.