### PR TITLE
Temporarily disable ACS dogfood cleanup

### DIFF
--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -35,9 +35,10 @@ parameters:
       - DisplayName: Dogfood Translation - Resource Cleanup
         SubscriptionConfigurations:
           - $(sub-config-translation-int-test-resources)
-      - DisplayName: Dogfood ACS - Resource Cleanup
-        SubscriptionConfigurations:
-          - $(sub-config-communication-int-test-resources-common)
+      # TODO: re-enable dogfood cleanup after resource deletion issues are solved, to avoid pipeline timeouts
+      # - DisplayName: Dogfood ACS - Resource Cleanup
+      #   SubscriptionConfigurations:
+      #     - $(sub-config-communication-int-test-resources-common)
       - DisplayName: AzureCloud ACS - Resource Cleanup
         SubscriptionConfigurations:
           - $(sub-config-azure-cloud-test-resources)


### PR DESCRIPTION
We are seeing pipeline timeouts and getting email spam due to resource group build-up and deletion prevention in dogfood. Temporarily disabling cleanup to get things green again.
