### PR TITLE
Adding automatic reset on failed push

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -160,7 +160,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     // - ls-remote origin
                     // - push
                     // if we have a failure on either of these, we need to unstage our changes for an easy re-attempt at pushing.
-                    GitHandler.TryRun("git reset --soft HEAD^", config.AssetsRepoLocation.ToString(), out CommandResult ResetResult);
+                    GitHandler.TryRun("reset --soft HEAD^", config.AssetsRepoLocation.ToString(), out CommandResult ResetResult);
 
                     throw GenerateInvokeException(e.Result);
                 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -155,11 +155,21 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 catch(GitProcessException e)
                 {
                     HideOrigin(config);
+
+                    // the only executions that have a real chance of failing are
+                    // - ls-remote origin
+                    // - push
+                    // if we have a failure on either of these, we need to unstage our changes for an easy re-attempt at pushing.
+                    GitHandler.TryRun("git reset --soft HEAD^", config.AssetsRepoLocation.ToString(), out CommandResult ResetResult);
+
                     throw GenerateInvokeException(e.Result);
                 }
                 await UpdateAssetsJson(generatedTagName, config);
                 await BreadCrumb.Update(config);
             }
+            // can we detect that we have unpushed commits?
+            else if
+
 
             HideOrigin(config);
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -167,9 +167,6 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                 await UpdateAssetsJson(generatedTagName, config);
                 await BreadCrumb.Update(config);
             }
-            // can we detect that we have unpushed commits?
-            else if
-
 
             HideOrigin(config);
         }

--- a/tools/test-proxy/scripts/test-scripts/CLIIntegration.Tests.ps1
+++ b/tools/test-proxy/scripts/test-scripts/CLIIntegration.Tests.ps1
@@ -650,7 +650,7 @@ Describe "AssetsModuleTests" {
                 $original_value = $env:GIT_TOKEN
                 $env:GIT_TOKEN = "An Invalid Git Token"
 
-                # Push the changes
+                # Push the changes, this should fail due to currupted git token
                 $CommandArgs = "push --assets-json-path $assetsJsonRelativePath"
                 Invoke-ProxyCommand -TestProxyExe $TestProxyExe -CommandArgs $CommandArgs -MountDirectory $testFolder
                 $LASTEXITCODE | Should -Not -Be 0

--- a/tools/test-proxy/scripts/test-scripts/CLIIntegration.Tests.ps1
+++ b/tools/test-proxy/scripts/test-scripts/CLIIntegration.Tests.ps1
@@ -641,14 +641,12 @@ Describe "AssetsModuleTests" {
                 Test-FileVersion -FilePath $localAssetsFilePath -FileName "file4.txt" -ExpectedVersion 1
                 Test-FileVersion -FilePath $localAssetsFilePath -FileName "file5.txt" -ExpectedVersion 1
 
-                # Create a new file
-                Edit-FileVersion -FilePath $localAssetsFilePath -FileName "file6.txt" -Version 1
                 # Update the version on an existing file
                 Edit-FileVersion -FilePath $localAssetsFilePath -FileName "file2.txt" -Version 3
                 $assetsFile = Join-Path $testFolder "assets.json"
 
                 $original_value = $env:GIT_TOKEN
-                $env:GIT_TOKEN = "An Invalid Git Token"
+                $env:GIT_TOKEN = "InvalidGitToken"
 
                 # Push the changes, this should fail due to currupted git token
                 $CommandArgs = "push --assets-json-path $assetsJsonRelativePath"
@@ -665,7 +663,7 @@ Describe "AssetsModuleTests" {
                 Test-DirectoryFileCount -Directory $localAssetsFilePath -ExpectedNumberOfFiles 3
                 Test-FileVersion -FilePath $localAssetsFilePath -FileName "file2.txt" -ExpectedVersion 3
                 Test-FileVersion -FilePath $localAssetsFilePath -FileName "file4.txt" -ExpectedVersion 1
-                Test-FileVersion -FilePath $localAssetsFilePath -FileName "file6.txt" -ExpectedVersion 1
+                Test-FileVersion -FilePath $localAssetsFilePath -FileName "file5.txt" -ExpectedVersion 1
 
                 $updatedAssets = Update-AssetsFromFile -AssetsJsonContent $assetsFile
                 Write-Host "updatedAssets.Tag=$($updatedAssets.Tag), originalAssets.Tag=$($recordingJson.Tag)"

--- a/tools/test-proxy/scripts/test-scripts/CLIIntegration.Tests.ps1
+++ b/tools/test-proxy/scripts/test-scripts/CLIIntegration.Tests.ps1
@@ -608,6 +608,73 @@ Describe "AssetsModuleTests" {
                 Test-Path -Path (Join-Path $assetsFolder $file3) | Should -Be $false
             }
         }
+        It "Should restore, make a change, attempt a push with corrupted env key (to force error), then _successfully_ push after fixing the env key." {
+            if ($env:CLI_TEST_WITH_DOCKER) {
+                Set-ItResult -Skipped
+            }
+            else {
+                $recordingJson = [PSCustomObject]@{
+                    AssetsRepo           = "Azure/azure-sdk-assets-integration"
+                    AssetsRepoPrefixPath = "pull/scenarios"
+                    AssetsRepoId         = ""
+                    TagPrefix            = "language/tables"
+                    Tag                  = "language/tables_bb2223"
+                }
+
+                $files = @(
+                    "assets.json"
+                )
+                $originalTagPrefix = $recordingJson.TagPrefix
+                $testFolder = Describe-TestFolder -AssetsJsonContent $recordingJson -Files $files -IsPushTest $true
+                # Ensure that the TagPrefix was updated for testing
+                $originalTagPrefix | Should -not -Be $recordingJson.TagPrefix
+                $assetsFile = Join-Path $testFolder "assets.json"
+                $assetsJsonRelativePath = [System.IO.Path]::GetRelativePath($testFolder, $assetsFile)
+                $CommandArgs = "restore --assets-json-path $assetsJsonRelativePath"
+
+                # The initial restore/verification
+                Invoke-ProxyCommand -TestProxyExe $TestProxyExe -CommandArgs $CommandArgs -MountDirectory $testFolder
+                $LASTEXITCODE | Should -Be 0
+                $localAssetsFilePath = Get-AssetsFilePath -AssetsJsonContent $recordingJson -AssetsJsonFile $assetsFile
+                Test-DirectoryFileCount -Directory $localAssetsFilePath -ExpectedNumberOfFiles 3
+                Test-FileVersion -FilePath $localAssetsFilePath -FileName "file2.txt" -ExpectedVersion 2
+                Test-FileVersion -FilePath $localAssetsFilePath -FileName "file4.txt" -ExpectedVersion 1
+                Test-FileVersion -FilePath $localAssetsFilePath -FileName "file5.txt" -ExpectedVersion 1
+
+                # Create a new file
+                Edit-FileVersion -FilePath $localAssetsFilePath -FileName "file6.txt" -Version 1
+                # Update the version on an existing file
+                Edit-FileVersion -FilePath $localAssetsFilePath -FileName "file2.txt" -Version 3
+                $assetsFile = Join-Path $testFolder "assets.json"
+
+                $original_value = $env:GIT_TOKEN
+                $env:GIT_TOKEN = "An Invalid Git Token"
+
+                # Push the changes
+                $CommandArgs = "push --assets-json-path $assetsJsonRelativePath"
+                Invoke-ProxyCommand -TestProxyExe $TestProxyExe -CommandArgs $CommandArgs -MountDirectory $testFolder
+                $LASTEXITCODE | Should -Not -Be 0
+
+                # attempt to push the changes for real this time
+                $env:GIT_TOKEN = $original_value
+                $CommandArgs = "push --assets-json-path $assetsJsonRelativePath"
+                Invoke-ProxyCommand -TestProxyExe $TestProxyExe -CommandArgs $CommandArgs -MountDirectory $testFolder
+                $LASTEXITCODE | Should -Be 0
+
+                # Verify that after the push the directory still contains our updated files
+                Test-DirectoryFileCount -Directory $localAssetsFilePath -ExpectedNumberOfFiles 3
+                Test-FileVersion -FilePath $localAssetsFilePath -FileName "file2.txt" -ExpectedVersion 3
+                Test-FileVersion -FilePath $localAssetsFilePath -FileName "file4.txt" -ExpectedVersion 1
+                Test-FileVersion -FilePath $localAssetsFilePath -FileName "file6.txt" -ExpectedVersion 1
+
+                $updatedAssets = Update-AssetsFromFile -AssetsJsonContent $assetsFile
+                Write-Host "updatedAssets.Tag=$($updatedAssets.Tag), originalAssets.Tag=$($recordingJson.Tag)"
+                $updatedAssets.Tag | Should -not -Be $recordingJson.Tag
+
+                $exists = Test-TagExists -AssetsJsonContent $updatedAssets -WorkingDirectory $localAssetsFilePath
+                $exists | Should -Be $true
+            }
+        }
         AfterEach {
             Remove-Test-Folder $testFolder
             Remove-Integration-Tag $updatedAssets


### PR DESCRIPTION
Resolves #6664  

For the most part, users are entirely self-service on the test-proxy, except for one common situation. This one:

1. User is onboarding to proxy for the first time
2. User records new recordings successfully
3. User attempts to `push` the new recordings. They fail with 403. They join the appropriate group.
4. User re-attempts `push`. `Push` silently just does nothing.

The origin of this is because we only `push` when there uncommitted changes _to be pushed_. There's nothing handling when a push fails.

By resetting the changes, users are unblocked from this common scenario, and a re-entry to the `push` function will act as if the failed push never happened. 


~~TODO:~~

- [x] Add integration test, We can "fake" this scenario by restoring from public, then deliberately corrupting the github API token secret, then restoring it, and committing again.