### PR TITLE
Disable folder check

### DIFF
--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "description": "",
   "scripts": {
     "start": "node dist/changelogToolCli.js",

--- a/tools/js-sdk-release-tools/src/utils/git.ts
+++ b/tools/js-sdk-release-tools/src/utils/git.ts
@@ -11,8 +11,11 @@ export async function getChangedPackageDirectory(throwErrorWhenFindingUnexpected
     const files = gitStatus.files;
     for (const file of files) {
         const filePath = file.path;
-        if (filePath.match(/sdk\/[^\/]*\/(arm-.*)|(.*-rest)/)) {
-            const packageDirectory = /sdk\/[^\/]*\/(arm-[^\/]*)|(.*-rest)/.exec(filePath);
+        // TODO: Temporarily disable the check for file folder, re-enable the check for file folder if necessary
+        // if (filePath.match(/sdk\/[^\/]*\/(arm-.*)|(.*-rest)/)) {
+        if (filePath.match(/sdk\/[^\/]*\/([^\/]*)/)) {
+            // const packageDirectory = /sdk\/[^\/]*\/(arm-[^\/]*)|(.*-rest)/.exec(filePath);
+            const packageDirectory = /sdk\/[^\/]*\/([^\/]*)/.exec(filePath);
             if (packageDirectory) {
                 changedPackageDirectories.add(packageDirectory[0]);
             }


### PR DESCRIPTION
fixes the failure https://github.com/Azure/azure-rest-api-specs/pull/26146/checks?check_run_id=18103044311

```
cmderr	[automation_generate.sh] [ERROR] Error:
cmderr	[automation_generate.sh] [ERROR] An error occurred while run build for typespec project: "specification/cognitiveservices/Vision.ImageAnalysis":
cmderr	[automation_generate.sh] [ERROR] Err: Error: Find unexpected generated file: sdk/vision/imageAnalysis/src/ImageAnalysisClient.ts. Please confirm whether the output-folder is correct.
cmderr	[automation_generate.sh] [ERROR] Stderr: "undefined"
cmderr	[automation_generate.sh] [ERROR] Stdout: "undefined"
cmderr	[automation_generate.sh] [ERROR] ErrorStack: "Error: Find unexpected generated file: sdk/vision/imageAnalysis/src/ImageAnalysisClient.ts. Please confirm whether the output-folder is correct.
cmderr	[automation_generate.sh] [ERROR]     at Object.<anonymous> (/opt/hostedtoolcache/node/16.20.2/x64/lib/node_modules/@azure-tools/js-sdk-release-tools/dist/utils/git.js:24:23)
cmderr	[automation_generate.sh] [ERROR]     at Generator.next (<anonymous>)
cmderr	[automation_generate.sh] [ERROR]     at fulfilled (/opt/hostedtoolcache/node/16.20.2/x64/lib/node_modules/@azure-tools/js-sdk-release-tools/node_modules/tslib/tslib.js:112:62)"
the given reference name 'refs/heads/sdkAuto/26146/' is not valid
```