### PR TITLE
Empty package models don't throw error

### DIFF
--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -101,34 +101,36 @@ if ($allPackageProperties)
     }
     foreach($pkg in $allPackageProperties)
     {
-        Write-Host "Package Name: $($pkg.Name)"
-        Write-Host "Package Version: $($pkg.Version)"
-        Write-Host "Package SDK Type: $($pkg.SdkType)"
-        Write-Host "Artifact Name: $($pkg.ArtifactName)"
-        Write-Host "Release date: $($pkg.ReleaseStatus)"
-        $configFilePrefix = $pkg.Name
-        if ($pkg.ArtifactName)
-        {
-          $configFilePrefix = $pkg.ArtifactName
-        }
-        $outputPath = Join-Path -Path $outDirectory "$configFilePrefix.json"
-        Write-Host "Output path of json file: $outputPath"
-        $outDir = Split-Path $outputPath -parent
-        if (-not (Test-Path -path $outDir))
-        {
-          Write-Host "Creating directory $($outDir) for json property file"
-          New-Item -ItemType Directory -Path $outDir
-        }
+        if ($pkg.Name) {
+          Write-Host "Package Name: $($pkg.Name)"
+          Write-Host "Package Version: $($pkg.Version)"
+          Write-Host "Package SDK Type: $($pkg.SdkType)"
+          Write-Host "Artifact Name: $($pkg.ArtifactName)"
+          Write-Host "Release date: $($pkg.ReleaseStatus)"
+          $configFilePrefix = $pkg.Name
+          if ($pkg.ArtifactName)
+          {
+            $configFilePrefix = $pkg.ArtifactName
+          }
+          $outputPath = Join-Path -Path $outDirectory "$configFilePrefix.json"
+          Write-Host "Output path of json file: $outputPath"
+          $outDir = Split-Path $outputPath -parent
+          if (-not (Test-Path -path $outDir))
+          {
+            Write-Host "Creating directory $($outDir) for json property file"
+            New-Item -ItemType Directory -Path $outDir
+          }
 
-        # If package properties for a track 2 (IsNewSdk = true) package has
-        # already been written, skip writing to that same path.
-        if ($exportedPaths.ContainsKey($outputPath) -and $exportedPaths[$outputPath].IsNewSdk -eq $true) {
-          Write-Host "Track 2 package info with file name $($outputPath) already exported. Skipping export."
-          continue
-        }
-        $exportedPaths[$outputPath] = $pkg
+          # If package properties for a track 2 (IsNewSdk = true) package has
+          # already been written, skip writing to that same path.
+          if ($exportedPaths.ContainsKey($outputPath) -and $exportedPaths[$outputPath].IsNewSdk -eq $true) {
+            Write-Host "Track 2 package info with file name $($outputPath) already exported. Skipping export."
+            continue
+          }
+          $exportedPaths[$outputPath] = $pkg
 
-        SetOutput $outputPath $pkg
+          SetOutput $outputPath $pkg
+        }
     }
 
     Get-ChildItem -Path $outDirectory


### PR DESCRIPTION
On `python` `pypy39` platform, this script runs into a [weird problem.](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3209852&view=logs&j=8e5196d1-9c2a-56bb-41fd-e329e85c48fa&t=6cc1318c-0278-53f9-9f83-99109e387aaa)

The linked build isolates the error, along with a bunch of debug output showing where stuff is going wrong.

On this `pypy39` platform image, we are getting 2 _extra_ "blank" pkg props. That looks like this for the template project:

![image](https://github.com/Azure/azure-sdk-tools/assets/45376673/84f578d6-93f4-4022-ba73-f2da6529e6e4)

Here's the thing, these are _magically_ showing up. In the same build that produces this error for review, you can see clearly that the _actual_ `Language-Settings.ps1` function that is retrieving the package list, is **getting the correct list**. It just magically gets another two blank objects. I'm almost positive that we're probably leaking two objects from previous commands, but honestly, I've dug at this for a while and I haven't seen it yet.

The fix [proves working](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3209898&view=results) in this build. 

