### PR TITLE
Add option to allow single-log output for test-proxy

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/OptionsGenerator.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/OptionsGenerator.cs
@@ -49,6 +49,13 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
                 getDefaultValue: () => false);
             dumpOption.AddAlias("-d");
 
+            var universalOption = new Option<bool>(
+                name: "--universalOutput",
+                description: "Flag; Redirect all logs to stdout, including what would normally be showing up on stderr.",
+                getDefaultValue: () => false);
+            dumpOption.AddAlias("-u");
+
+
             var collectedArgs = new Argument<string[]>("args")
             {
                 Arity = ArgumentArity.ZeroOrMore,
@@ -77,8 +84,9 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
             startCommand.AddOption(insecureOption);
             startCommand.AddOption(dumpOption);
             startCommand.AddArgument(collectedArgs);
+
             startCommand.SetHandler(async (startOpts) => await callback(startOpts),
-                new StartOptionsBinder(storageLocationOption, storagePluginOption, insecureOption, dumpOption, collectedArgs)
+                new StartOptionsBinder(storageLocationOption, storagePluginOption, insecureOption, dumpOption, universalOption, collectedArgs)
             );
             root.Add(startCommand);
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/StartOptions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/StartOptions.cs
@@ -8,6 +8,7 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
     {
         public bool Insecure { get; set; }
         public bool Dump { get; set; }
+        public bool UniversalOutput { get; set; }
 
         // On the command line, use -- and everything after that becomes arguments to Host.CreateDefaultBuilder
         // For example Test-Proxy start -i -d -- --urls https://localhost:8002 would set AdditionaArgs to a list containing
@@ -21,16 +22,17 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
         private readonly Option<string> _storagePluginOption;
         private readonly Option<bool> _insecureOption;
         private readonly Option<bool> _dumpOption;
+        private readonly Option<bool> _univeralOutputOption;
         private readonly Argument<string[]> _additionalArgs;
 
-        public StartOptionsBinder(Option<string> storageLocationOption, Option<string> storagePluginOption, Option<bool> insecureOption, Option<bool> dumpOption, Argument<string[]> additionalArgs)
+        public StartOptionsBinder(Option<string> storageLocationOption, Option<string> storagePluginOption, Option<bool> insecureOption, Option<bool> dumpOption, Option<bool> universalOutput, Argument<string[]> additionalArgs)
         {
             _storageLocationOption = storageLocationOption;
             _storagePluginOption = storagePluginOption;
             _insecureOption = insecureOption;
             _dumpOption = dumpOption;
+            _univeralOutputOption = universalOutput;
             _additionalArgs = additionalArgs;
-
         }
 
         protected override StartOptions GetBoundValue(BindingContext bindingContext) =>
@@ -40,6 +42,7 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
                 StoragePlugin = bindingContext.ParseResult.GetValueForOption(_storagePluginOption),
                 Insecure = bindingContext.ParseResult.GetValueForOption(_insecureOption),
                 Dump = bindingContext.ParseResult.GetValueForOption(_dumpOption),
+                UniversalOutput = bindingContext.ParseResult.GetValueForOption(_univeralOutputOption),
                 AdditionalArgs = bindingContext.ParseResult.GetValueForArgument(_additionalArgs)
             };
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -149,7 +149,7 @@ namespace Azure.Sdk.Tools.TestProxy
                         loggingBuilder.AddConfiguration(hostBuilder.Configuration.GetSection("Logging"));
                         loggingBuilder.AddConsole(options =>
                         {
-                            options.LogToStandardErrorThreshold = LogLevel.Error;
+                            options.LogToStandardErrorThreshold = startOptions.UniversalOutput ? LogLevel.None : LogLevel.Error;
                         }).AddSimpleConsole(options =>
                         {
                             options.TimestampFormat = "[HH:mm:ss] ";


### PR DESCRIPTION
Addressing #7190 in a different way. Going to enable this new version of the proxy, then adjust `test-proxy-tool` to run with this new flag.

This is much much less hacky than just uploading the `stderr` output as a different file, and allows the proxy log to show up in a useful format, where errors are right next to the `info` logs that they are correlated with.
