### PR TITLE
Reduce APIView search query cost when searching without filters

### DIFF
--- a/src/dotnet/APIView/APIView/APIView.csproj
+++ b/src/dotnet/APIView/APIView/APIView.csproj
@@ -15,8 +15,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.4.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
     <PackageReference Include="System.Text.Json" Version="4.6.0-preview9.19421.4" />
   </ItemGroup>

--- a/src/dotnet/APIView/APIView/APIView.csproj
+++ b/src/dotnet/APIView/APIView/APIView.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="1.1.0" />
+    <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="7.0.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.4.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosReviewRepository.cs
@@ -207,15 +207,13 @@ namespace APIViewWeb
                 }
                 else
                 {
-                    queryStringBuilder.Append($" AND (r.Author IN {searchAsQueryStr}");
+                    queryStringBuilder.Append($" AND (");
                     foreach (var item in search) 
                     {
                         var query = '"' + $"{item}" + '"';
-                        queryStringBuilder.Append($" OR CONTAINS(ARRAY_SLICE(r.Revisions, -1)[0].Name, {query}, true)");
-                        queryStringBuilder.Append($" OR CONTAINS(r.Name, {query}, true)");
+                        queryStringBuilder.Append($" CONTAINS(r.Name, {query}, true)");
                         queryStringBuilder.Append($" OR CONTAINS(r.ServiceName, {query}, true)");
                         queryStringBuilder.Append($" OR CONTAINS(r.PackageDisplayName, {query}, true)");
-                        queryStringBuilder.Append($" OR CONTAINS(ARRAY_SLICE(r.Revisions, -1)[0].Label, {query}, true)");
                     }
                     queryStringBuilder.Append($")");
                 }


### PR DESCRIPTION
APIView search without any filters is taking around 6-7 seconds to find the records due to search against revision properties.

This change is to improve search performance to few milli seconds when searching without any filters by checking against review properties only.

Search query cost is reduced to 30 RUs from 2800 RUs and response time is few ms instead of 6 seconds with this change.