### PR TITLE
Show enum members in JS API review

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaScriptLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaScriptLanguageService.cs
@@ -11,7 +11,7 @@ namespace APIViewWeb
         public override string Name { get; } = "JavaScript";
         public override string[] Extensions { get; } = { ".api.json" };
         public override string ProcessName { get; } = "node";
-        public override string VersionString { get; } = "1";
+        public override string VersionString { get; } = "1.0.5";
 
         public override string GetProcessorArguments(string originalName, string tempDirectory, string jsonFilePath)
         {

--- a/tools/apiview/parsers/js-api-parser/export.ts
+++ b/tools/apiview/parsers/js-api-parser/export.ts
@@ -49,6 +49,7 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
         case ApiItemKind.Interface:
         case ApiItemKind.Class:
         case ApiItemKind.Namespace:
+        case ApiItemKind.Enum:
             typeKind = item.kind.toLowerCase();
             break
         case ApiItemKind.TypeAlias:
@@ -71,7 +72,8 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
 
     if (item.kind === ApiItemKind.Interface ||
         item.kind === ApiItemKind.Class ||
-        item.kind === ApiItemKind.Namespace)
+        item.kind === ApiItemKind.Namespace ||
+        item.kind === ApiItemKind.Enum)
     {
         if (item.members.length > 0)
         {
@@ -146,7 +148,7 @@ var apiViewFile: IApiViewFile = {
     Navigation: navigation,
     Tokens: builder.tokens,
     PackageName: apiModel.packages[0].name,
-    VersionString: "1.0.4",
+    VersionString: "1.0.5",
     Language: "JavaScript"
 }
 

--- a/tools/apiview/parsers/js-api-parser/package.json
+++ b/tools/apiview/parsers/js-api-parser/package.json
@@ -1,19 +1,19 @@
 {
   "name": "@azure-tools/ts-genapi",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "main": "index.js",
   "publishConfig": {
     "registry": "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
   },
   "dependencies": {
-    "@microsoft/api-extractor-model": "^7.26.1",
-    "js-tokens": "^6.0.0"
+    "@microsoft/api-extractor-model": "^7.28.2",
+    "js-tokens": "^8.0.0"
   },
   "devDependencies": {
     "@types/node": "^12.20.55",
     "ts-node": "^10.0.0",
-    "typescript": "~4.8.0"
+    "typescript": "~5.2.0"
   },
   "scripts": {
     "build": "tsc -p ."

--- a/tools/apiview/parsers/js-api-parser/package.json
+++ b/tools/apiview/parsers/js-api-parser/package.json
@@ -11,7 +11,7 @@
     "js-tokens": "^8.0.0"
   },
   "devDependencies": {
-    "@types/node": "^12.20.55",
+    "@types/node": "^18.0.0",
     "ts-node": "^10.0.0",
     "typescript": "~5.2.0"
   },


### PR DESCRIPTION
JS API review is not showing Enum members and this causes insufficient diff even when public level Enums are changed. This PR also has the change to upgrade all existing JS reviews.

Thanks and regards,
Praveen