### PR TITLE
Fix analyzer issues

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0002Tests.cs
@@ -298,5 +298,24 @@ namespace RandomNamespace
             await Verifier.CreateAnalyzer(code)
                 .RunAsync();
         }
+
+        [Fact]
+        public async Task AZC0002NotProducedForGetSubClientMethods()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public class Operation {}
+        public virtual Operation GetOperationClient(string apiVersion = ""1.0.0"")
+        {
+            return new Operation();
+        }
+    }
+}";
+            await Verifier.CreateAnalyzer(code)
+                .RunAsync();
+        }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0006Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0006Tests.cs
@@ -93,5 +93,23 @@ namespace RandomNamespace
 }";
             await Verifier.VerifyAnalyzerAsync(code);
         }
+
+        [Fact]
+        public async Task AZC0006NotProducedForClientsWithStaticProperties()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        public static int a = 1;
+        public SomeClient() {}
+        public SomeClient(SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0018Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0018Tests.cs
@@ -89,6 +89,43 @@ namespace RandomNamespace
         }
 
         [Fact]
+        public async Task AZC0018NotProducedForExtendedReturnType()
+        {
+            const string code = @"
+using Azure;
+using Azure.Core;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Arbitrary
+{
+    public class ExtendedBinaryData : BinaryData
+    {
+        public ExtendedBinaryData(string data): base(data){}
+    }
+}
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public virtual AsyncPageable<Arbitrary.ExtendedBinaryData> GetPageableAsync(string s, RequestContext context)
+        {
+            return null;
+        }
+
+        public virtual Pageable<Arbitrary.ExtendedBinaryData> GetPageable(string s, RequestContext context)
+        {
+            return null;
+        }
+    }
+}";
+            await Verifier.CreateAnalyzer(code)
+                .RunAsync();
+        }
+
+        [Fact]
         public async Task AZC0018ProducedForMethodsWithGenericResponseOfPrimitive()
         {
             const string code = @"

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0018Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0018Tests.cs
@@ -126,6 +126,43 @@ namespace RandomNamespace
         }
 
         [Fact]
+        public async Task AZC0018ProducedForCustomTypeWithSystemName()
+        {
+            const string code = @"
+using Azure;
+using Azure.Core;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Custom
+{
+    namespace System
+    {
+        public class BinaryData {}
+    }
+}
+
+namespace RandomNamespace
+{
+    using Custom.System;
+    public class SomeClient
+    {
+        public virtual AsyncPageable<BinaryData> {|AZC0018:GetPageableAsync|}(string s, RequestContext context)
+        {
+            return null;
+        }
+
+        public virtual Pageable<BinaryData> {|AZC0018:GetPageable|}(string s, RequestContext context)
+        {
+            return null;
+        }
+    }
+}";
+            await Verifier.CreateAnalyzer(code)
+                .RunAsync();
+        }
+
+        [Fact]
         public async Task AZC0018ProducedForMethodsWithGenericResponseOfPrimitive()
         {
             const string code = @"

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAnalyzerBase.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAnalyzerBase.cs
@@ -79,9 +79,10 @@ namespace Azure.ClientSdk.Analyzers
             }
         }
 
-        protected static IMethodSymbol FindMethod(IEnumerable<IMethodSymbol> methodSymbols, ImmutableArray<ITypeParameterSymbol> genericParameters, ImmutableArray<IParameterSymbol> parameters)
+        protected static IMethodSymbol FindMethod(IEnumerable<IMethodSymbol> methodSymbols, ImmutableArray<ITypeParameterSymbol> genericParameters, ImmutableArray<IParameterSymbol> parameters, bool ignoreStatic = false)
         {
             return methodSymbols.SingleOrDefault(symbol =>
+                (!ignoreStatic || !symbol.IsStatic) &&
                 genericParameters.SequenceEqual(symbol.TypeParameters, ParameterEquivalenceComparer.Default) &&
                 parameters.SequenceEqual(symbol.Parameters, ParameterEquivalenceComparer.Default));
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientConstructorAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientConstructorAnalyzer.cs
@@ -40,8 +40,9 @@ namespace Azure.ClientSdk.Analyzers
                         // Allow optional options parameters
                         if (lastParameter.IsOptional) continue;
 
+                        // When there are static properties in client, there would be static constructor implicitly added
                         var nonOptionsMethod = FindMethod(
-                            type.Constructors, constructor.TypeParameters, constructor.Parameters.RemoveAt(constructor.Parameters.Length - 1));
+                            type.Constructors, constructor.TypeParameters, constructor.Parameters.RemoveAt(constructor.Parameters.Length - 1), true);
 
                         if (nonOptionsMethod == null || nonOptionsMethod.DeclaredAccessibility != Accessibility.Public)
                         {

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -15,6 +15,7 @@ namespace Azure.ClientSdk.Analyzers
         private const string AsyncSuffix = "Async";
 
         private const string AzureNamespace = "Azure";
+        private const string SystemNamespace = "System";
         private const string PageableTypeName = "Pageable";
         private const string AsyncPageableTypeName = "AsyncPageable";
         private const string BinaryDataTypeName = "BinaryData";
@@ -157,7 +158,7 @@ namespace Azure.ClientSdk.Analyzers
                 }
 
                 var pageableReturn = pageableTypeSymbol.TypeArguments.Single();
-                if (!IsOrImplements(pageableReturn, BinaryDataTypeName, AzureNamespace))
+                if (!IsOrImplements(pageableReturn, BinaryDataTypeName, SystemNamespace))
                 {
                     return false;
                 }
@@ -201,7 +202,7 @@ namespace Azure.ClientSdk.Analyzers
                         return;
                     }
 
-                    if (!IsOrImplements(operationReturn, BinaryDataTypeName, AzureNamespace))
+                    if (!IsOrImplements(operationReturn, BinaryDataTypeName, SystemNamespace))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0018, method.Locations.FirstOrDefault()), method);
                     }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -233,7 +233,7 @@ namespace Azure.ClientSdk.Analyzers
 
         private static bool IsOrImplements(ITypeSymbol typeSymbol, string typeName, string namespaceName)
         {
-            if (typeSymbol.Name == typeName && typeSymbol.ContainingNamespace.Name == namespaceName)
+            if (typeSymbol.Name == typeName && typeSymbol.ContainingNamespace.Name == namespaceName && typeSymbol.ContainingNamespace.ContainingNamespace.Name == "")
             {
                 return true;
             }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -14,6 +14,7 @@ namespace Azure.ClientSdk.Analyzers
     {
         private const string AsyncSuffix = "Async";
 
+        private const string AzureNamespace = "Azure";
         private const string PageableTypeName = "Pageable";
         private const string AsyncPageableTypeName = "AsyncPageable";
         private const string BinaryDataTypeName = "BinaryData";
@@ -156,7 +157,7 @@ namespace Azure.ClientSdk.Analyzers
                 }
 
                 var pageableReturn = pageableTypeSymbol.TypeArguments.Single();
-                if (!IsOrImplements(pageableReturn, BinaryDataTypeName))
+                if (!IsOrImplements(pageableReturn, BinaryDataTypeName, AzureNamespace))
                 {
                     return false;
                 }
@@ -174,7 +175,7 @@ namespace Azure.ClientSdk.Analyzers
                 unwrappedType = namedTypeSymbol.TypeArguments.Single();
             }
 
-            if (IsOrImplements(unwrappedType, ResponseTypeName))
+            if (IsOrImplements(unwrappedType, ResponseTypeName, AzureNamespace))
             {
                 if (unwrappedType is INamedTypeSymbol responseTypeSymbol && responseTypeSymbol.IsGenericType)
                 {
@@ -186,12 +187,12 @@ namespace Azure.ClientSdk.Analyzers
                 }
                 return;
             }
-            else if (IsOrImplements(unwrappedType, OperationTypeName))
+            else if (IsOrImplements(unwrappedType, OperationTypeName, AzureNamespace))
             {
                 if (unwrappedType is INamedTypeSymbol operationTypeSymbol && operationTypeSymbol.IsGenericType)
                 {
                     var operationReturn = operationTypeSymbol.TypeArguments.Single();
-                    if (IsOrImplements(operationReturn, PageableTypeName) || IsOrImplements(operationReturn, AsyncPageableTypeName))
+                    if (IsOrImplements(operationReturn, PageableTypeName, AzureNamespace) || IsOrImplements(operationReturn, AsyncPageableTypeName, AzureNamespace))
                     {
                         if (!IsValidPageable(operationReturn))
                         {
@@ -200,14 +201,14 @@ namespace Azure.ClientSdk.Analyzers
                         return;
                     }
 
-                    if (!IsOrImplements(operationReturn, BinaryDataTypeName))
+                    if (!IsOrImplements(operationReturn, BinaryDataTypeName, AzureNamespace))
                     {
                         context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0018, method.Locations.FirstOrDefault()), method);
                     }
                 }
                 return;
             }
-            else if (IsOrImplements(originalType, PageableTypeName) || IsOrImplements(originalType, AsyncPageableTypeName))
+            else if (IsOrImplements(originalType, PageableTypeName, AzureNamespace) || IsOrImplements(originalType, AsyncPageableTypeName, AzureNamespace))
             {
                 if (!IsValidPageable(originalType))
                 {
@@ -229,16 +230,16 @@ namespace Azure.ClientSdk.Analyzers
             }
         }
 
-        private static bool IsOrImplements(ITypeSymbol typeSymbol, string typeName)
+        private static bool IsOrImplements(ITypeSymbol typeSymbol, string typeName, string namespaceName)
         {
-            if (typeSymbol.Name == typeName)
+            if (typeSymbol.Name == typeName && typeSymbol.ContainingNamespace.Name == namespaceName)
             {
                 return true;
             }
 
             if (typeSymbol.BaseType != null)
             {
-                return IsOrImplements(typeSymbol.BaseType, typeName);
+                return IsOrImplements(typeSymbol.BaseType, typeName, namespaceName);
             }
 
             return false;
@@ -261,11 +262,11 @@ namespace Azure.ClientSdk.Analyzers
                 unwrappedType = namedTypeSymbol.TypeArguments.Single();
             }
 
-            if (IsOrImplements(unwrappedType, ResponseTypeName) ||
-                IsOrImplements(unwrappedType, NullableResponseTypeName) ||
-                IsOrImplements(unwrappedType, OperationTypeName) ||
-                IsOrImplements(originalType, PageableTypeName) ||
-                IsOrImplements(originalType, AsyncPageableTypeName))
+            if (IsOrImplements(unwrappedType, ResponseTypeName, AzureNamespace) ||
+                IsOrImplements(unwrappedType, NullableResponseTypeName, AzureNamespace) ||
+                IsOrImplements(unwrappedType, OperationTypeName, AzureNamespace) ||
+                IsOrImplements(originalType, PageableTypeName, AzureNamespace) ||
+                IsOrImplements(originalType, AsyncPageableTypeName, AzureNamespace))
             {
                 return true;
             }


### PR DESCRIPTION
Fix https://github.com/Azure/autorest.csharp/issues/3710
Root cause: https://github.com/Azure/autorest.csharp/issues/3710#issuecomment-1707840791
Quote here:
> The get sub client method returns the sub client called `Operation`, which is a criterion of a service method in analyzer
> ```C#
> public virtual Operation GetOperationClient(string apiVersion = "1.0.0")
> {
>     Argument.AssertNotNull(apiVersion, nameof(apiVersion));
> 
>     return new Operation(ClientDiagnostics, _pipeline, _endpoint, apiVersion);
> }
> ```
Solution: When checking whether a method is a service method, not just checking the type name, but also checking the namespace name.


Fix https://github.com/Azure/autorest.csharp/issues/3708
Root cause: https://github.com/Azure/autorest.csharp/issues/3708#issuecomment-1788716281
Quote here: 

> We generate static properties in clients, so there will be a static constructor without any parameters implicitly added, which should not be in the searching scope of a constructor equivalent.

Solution: exclude static constructor when looking for a equivalent constructor method, because we only care about the constructors explicitly written by generator or customization.

Preview in azure-sdk-for-net: https://github.com/Azure/azure-sdk-for-net/pull/39672