### PR TITLE
Updates to github-event-processor

### DIFF
--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Azure.Sdk.Tools.GitHubEventProcessor.Tests.csproj
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Azure.Sdk.Tools.GitHubEventProcessor.Tests.csproj
@@ -31,4 +31,10 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="Tests.FakeCodeowners\InitialIssueTriage_CODEOWNERS">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
 </Project>

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Azure.Sdk.Tools.GitHubEventProcessor.Tests.csproj
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Azure.Sdk.Tools.GitHubEventProcessor.Tests.csproj
@@ -31,10 +31,4 @@
     </None>
   </ItemGroup>
 
-  <ItemGroup>
-    <None Update="Tests.FakeCodeowners\InitialIssueTriage_CODEOWNERS">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
 </Project>

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Static/IssueProcessingTests.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Static/IssueProcessingTests.cs
@@ -15,7 +15,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
     [Parallelizable(ParallelScope.Children)]
     public class IssueProcessingTests : ProcessingTestBase
     {
-        // JRS - With the updated Initial Triage rule I need to be able to set the following information in order to test
+        // With the updated Initial Triage rule I need to be able to set the following information in order to test
         // all of the code paths.
         // 1. mockGitHubEventClient.UserHasPermissionsReturn - whether or not the user has write or admin permissions
         // 2. mockGitHubEventClient.IsUserMemberOfOrgReturn - whether or not the user is a member of the Azure org

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Static/IssueProcessingTests.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Static/IssueProcessingTests.cs
@@ -15,74 +15,297 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
     [Parallelizable(ParallelScope.Children)]
     public class IssueProcessingTests : ProcessingTestBase
     {
+        // JRS - With the updated Initial Triage rule I need to be able to set the following information in order to test
+        // all of the code paths.
+        // 1. mockGitHubEventClient.UserHasPermissionsReturn - whether or not the user has write or admin permissions
+        // 2. mockGitHubEventClient.IsUserMemberOfOrgReturn - whether or not the user is a member of the Azure org
+        // 3. mockGitHubEventClient.OwnerCanBeAssignedToIssueInRepoReturn - whether or not a given owner can be assigned to an issue
+        // 4. AIReturnLabels - change to string, if null no labels returned otherwise split string into a list
+        // 5. RuleState ruleState - Whether or not the InitialIssueAssignment rule is on or off
+        // 6. RuleState ruleStateServiceAttention - Whether or not the ServiceAttention rule is on or off
+        //
+        // CODEOWNERS changes necessary to test
+        // The CODEOWNERS file needs entries that match the AIReturnLabels, in theory the AI Label Service will return one
+        // ServiceLabel and one other label. If the rule is going to process the Service Label returned needs to match one
+        // entry in the CODEOWNERS file. The AzureSdkOwners for that CODEOWNERS entry will need to have
+        // OwnerCanBeAssignedToIssueInRepoReturn set. Some entries will need AzureSdkOwners with and without assignment permission
+        // and other entries will be without AzureSdkOwners entirely.
+        //
+        // Labels being added (this entire thing only matters if there are no assinees, no labels and the AI Label Service returns
+        // labels)
+        // If there are no valid AzureSdkOwners (meaning there are none or none of the AzureSdkOwners can be assigned to an issue)
+        // AND there are ServiceOwners for the ServiceLabel
+        // AND the ServiceAttention rule is enabled
+        // add ServiceAttention label, process ServiceAttention rule and add NeedsTeamAttention label
+        // ELSE
+        // add NeedsTeamTriage label
+        //
+        // If the creator of the Issue is not a member of the Azure org and does not have write or admin permissions
+        // add CustomerReported and Question labels
+        //
+        // The ServiceAttention just adds a comment @ mentioning everyone on the ServiceOwners list from CODEOWNERS that
+        // matches the ServiceLabel entry returned from the AI Label Service.
+        // 
+
         /// <summary>
-        /// TBD: InitialIssueTriage rule is not yet complete as it requires a CODEOWNERS overhaul that is not complete.
-        /// The payload for this rule to process requires an issues opened event with no assignee and no labels.
-        /// Until the CODEOWNERS changes are complete, processing is as follows:
-        /// Trigger: issues opened
-        /// Conditions: Issue has no assignee
-        ///             Issue has no labels
-        /// Resulting Action:Query the AI Service
-        ///     If the AI Service
+        /// Note: FakeUser1 is the owner that submitted issue in InitialIssueTriage_issue_opened_no_labels_no_assignee.json
         /// </summary>
         /// <param name="rule">String, RulesConstants for the rule being tested</param>
         /// <param name="payloadFile">JSon payload file for the event being tested</param>
-        /// <param name="ruleState">Whether or not the rule is on/off</param>
-        /// <param name="AIServiceReturnsLabels">Whether or not the AI Service should return labels</param>
+        /// <param name="ruleState">Whether or not the InitialIssueTriage rule is on/off</param>
+        /// <param name="serviceAttentionRuleState">Whether or not the ServiceAttention rule is on/off</param>
+        /// <param name="AIServiceReturnsLabels">The label(s) for the AI Label service to "return"or null if none</param>
+        /// <param name="ownersWithAssignPermission">The owners, from the appropriate CODEOWNERS entry, with assign permission or null if none</param>
+        /// <param name="hasCodeownersEntry">Whether or not to expect a codeowners entry for the labels returned.</param>
+        /// <param name="isMemberOfOrg">Whether or not the owner that created the issue is a member of Azure</param>
+        /// <param name="hasWriteOrAdmin">Whether or not the owner that created the issue has write or admin</param>
         [Category("static")]
-        [TestCase(RulesConstants.InitialIssueTriage, "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json", RuleState.On, true, true, true)]
-        [TestCase(RulesConstants.InitialIssueTriage, "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json", RuleState.On, false, true, true)]
-        [TestCase(RulesConstants.InitialIssueTriage, "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json", RuleState.Off, false, false, false)]
-        [TestCase(RulesConstants.InitialIssueTriage, "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json", RuleState.On, false, false, true)]
-        [TestCase(RulesConstants.InitialIssueTriage, "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json", RuleState.On, false, true, false)]
-        [TestCase(RulesConstants.InitialIssueTriage, "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json", RuleState.On, false, false, false)]
-        public async Task TestInitialIssueTriage(string rule, string payloadFile, RuleState ruleState, bool AIServiceReturnsLabels, bool isMemberOfOrg, bool hasWriteOrAdmin)
+        [NonParallelizable] // All the tests use the same CODEOWNERS file
+        // Scenario: Everything turned off, nothing should process
+        // Expected: There should be no updates
+        [TestCase(RulesConstants.InitialIssueTriage, 
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.Off,
+                  RuleState.Off,
+                  null, // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  false,
+                  false, 
+                  false)]
+        // Scenario: No labels returned from AI Label service
+        //           isMemberOfOrg and hasWriteOrAdmin both set to false.
+        // Expected: NeedsTriage, CustomerReported and Question labels added to the Issue
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  null, // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  false,
+                  false,
+                  false)]
+        // Scenario: No labels returned from AI Label service
+        //           isMemberOfOrg is true and hasWriteOrAdmin is false
+        // Expected: Only NeedsTriage label added to the Issue
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  null, // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  false,
+                  true,
+                  false)]
+        // Scenario: No labels returned from AI Label service
+        //           isMemberOfOrg is false and hasWriteOrAdmin is true
+        // Expected: Only NeedsTriage label added to the Issue
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  null, // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  false,
+                  false,
+                  true)]
+        /* From here on out, the creator will have isMemberOfOrg and hasWriteOrAdmin set to true. Those scenarios were already tested */
+        // Scenario: The AI label doesn't have a matching CODEOWNERS entry
+        // Expected: The label is added to the issue along with NeedsTeamTriage
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  "FakeLabel666", // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  false, // Has CODEOWNERS entry
+                  true,
+                  true)]
+        // Scenario: The AI label has a matching CODEOWNERS entry with no AzureSdkOwners.
+        //           ServiceAttention rule is Off.
+        // Expected: The label is added to the issue along with NeedsTeamTriage
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.Off,
+                  "FakeLabel1", // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  true, // Has CODEOWNERS entry
+                  true,
+                  true)]
+        // Scenario: The AI label has a matching CODEOWNERS entry with a single AzureSdkOwner.
+        //           ServiceAttention rule is Off.
+        //           The AzureSdkOwner does not have issue assignment permissions.
+        // Expected: The label is added to the issue along with NeedsTeamTriage
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.Off,
+                  "FakeLabel2", // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  true, // Has CODEOWNERS entry
+                  true,
+                  true)]
+        // Scenario: The AI label has a matching CODEOWNERS entry with a single AzureSdkOwner.
+        //           ServiceAttention rule is On.
+        //           The AzureSdkOwner does not have issue assignment permissions.
+        // Expected: The label is added to the issue.
+        //           ServiceAttention is added to the issue and the ServiceAttention rule executed.
+        //           A comment is created via running the ServiceAttention rule.
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  "FakeLabel2", // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  true, // Has CODEOWNERS entry
+                  true,
+                  true)]
+        // Scenario: The AI label has a matching CODEOWNERS entry with a single AzureSdkOwner.
+        //           ServiceAttention rule is On (doesn't matter when there's an AzureSdkOwner valid for assignment).
+        //           The AzureSdkOwner has issue assignment permissions.
+        // Expected: The label is added to the issue.
+        //           The AzureSdkOwner, FakeUser1, is assigned to the issue
+        //           NeedsTeamAttention is added to the issue since there is a valid owner
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  "FakeLabel2", // labels returned from the AI Label service
+                  "FakeUser1", // owners with permission to be assigned to issues
+                  true, // Has CODEOWNERS entry
+                  true,
+                  true)]
+        // Scenario: The AI label has a matching CODEOWNERS entry with a multiple AzureSdkOwners.
+        //           ServiceAttention rule is Off.
+        //           None of the AzureSdkOwners have issue assignment permissions.
+        // Expected: The label is added to the issue
+        //           NeedsTeamTriage is added to the issue since there is no a valid owner and ServiceAttention isn't On
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.Off,
+                  "FakeLabel3", // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  true, // Has CODEOWNERS entry
+                  true,
+                  true)]
+        // Scenario: The AI label has a matching CODEOWNERS entry with a multiple AzureSdkOwners.
+        //           ServiceAttention rule is On.
+        //           None of the AzureSdkOwners have issue assignment permissions.
+        // Expected: The label is added to the issue
+        //           ServiceAttention is added to the issue and the ServiceAttention rule processed.
+        //           ServiceAttention rule adds a comment to the issue.
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  "FakeLabel3", // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  true, // Has CODEOWNERS entry
+                  true,
+                  true)]
+        // Scenario: The AI label has a matching CODEOWNERS entry with a multiple AzureSdkOwners.
+        //           ServiceAttention rule is On.
+        //           Only one of the AzureSdkOwners have issue assignment permissions.
+        // Expected: The label is added to the issue
+        //           The AzureSdkOwner with permission is assigned to the issue
+        //           A comment is added @ mentioning all of the AzureSdkOwners
+        //           A second comment is added thanking the creator, tagging and routing to the team
+        //           NeedsTeamTriage is added to the issue
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  "FakeLabel3", // labels returned from the AI Label service
+                  "FakeUser5", // owners with permission to be assigned to issues
+                  true, // Has CODEOWNERS entry
+                  true,
+                  true)]
+        // Scenario: The AI label has a matching CODEOWNERS entry with multiple AzureSdkOwners which
+        //           are pulled from source path/owners.
+        //           Both AzureSdkOwners have assignment permissions.
+        // Expected: The label is added to the issue.
+        //           One of the AzureSdkOWners with permission is assigned to the issue
+        //           A comment is added @ mentioning all of the AzureSdkOwners
+        //           A second comment is added thanking the creator, tagging and routing to the team
+        //           NeedsTeamTriage is added to the issue
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  "FakeLabel4", // labels returned from the AI Label service
+                  "FakeUser5,FakeUser6", // owners with permission to be assigned to issues
+                  true, // Has CODEOWNERS entry
+                  true,
+                  true)]
+        // Scenario: The AI label has a matching CODEOWNERS entry with multiple AzureSdkOwners which
+        //           are pulled from source path/owners.
+        //           None of AzureSdkOwners have assignment permissions.
+        // Expected: The label is added to the issue
+        //           ServiceAttention is added to the issue and the ServiceAttention rule processed.
+        //           ServiceAttention rule adds a comment to the issue.
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  "FakeLabel4", // labels returned from the AI Label service
+                  null, // owners with permission to be assigned to issues
+                  true, // Has CODEOWNERS entry
+                  true,
+                  true)]
+        public async Task TestInitialIssueTriage(string rule, 
+                                                 string payloadFile,
+                                                 RuleState ruleState, 
+                                                 RuleState serviceAttentionRuleState,
+                                                 string AIServiceReturnsLabels,
+                                                 string ownersWithAssignPermission,
+                                                 bool hasCodeownersEntry,
+                                                 bool isMemberOfOrg, 
+                                                 bool hasWriteOrAdmin)
         {
+            // CODEOWNERS has blocks setup for different scenarios. The ServiceLabel to return from the AI Service needs
+            // to be a parameter so the correct block is selected.
+            CodeOwnerUtils.ResetCodeOwnerEntries();
+            CodeOwnerUtils.codeOwnersFilePathOverride = "Tests.FakeCodeowners/InitialIssueTriage_CODEOWNERS";
+
             var mockGitHubEventClient = new MockGitHubEventClient(OrgConstants.ProductHeaderName);
             mockGitHubEventClient.RulesConfiguration.Rules[rule] = ruleState;
+            mockGitHubEventClient.RulesConfiguration.Rules[RulesConstants.ServiceAttention] = serviceAttentionRuleState;
             mockGitHubEventClient.UserHasPermissionsReturn = hasWriteOrAdmin;
             mockGitHubEventClient.IsUserMemberOfOrgReturn = isMemberOfOrg;
             var rawJson = TestHelpers.GetTestEventPayload(payloadFile);
             var issueEventPayload = SimpleJsonSerializer.Deserialize<IssueEventGitHubPayload>(rawJson);
-            List<string> expectedLabels = new List<string>
-                {
-                    "FakeLabel1",
-                    "FakeLabel2"
-                };
 
-            if (AIServiceReturnsLabels)
+            // If there are labels to be returned from the AI Label service, parse them and ensure the mock's
+            // AILabelServiceReturn is set. Each label gets added to the issue which means each label = 1 update.
+            List<string> expectedLabels = new List<string>();
+            if (AIServiceReturnsLabels != null)
             {
-                foreach (string label in expectedLabels)
-                {
-                    mockGitHubEventClient.AILabelServiceReturn.Add(label);
-                }
+                expectedLabels.AddRange(AIServiceReturnsLabels.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList());
+                mockGitHubEventClient.AILabelServiceReturn.AddRange(expectedLabels);
             }
+            // Set the owners with assign permission. If there are none, and there are ServiceOwners, then the
+            // ServiceAttention label will get added and the rule executed if it's turned on for the repository.
+            if (ownersWithAssignPermission != null)
+            {
+                mockGitHubEventClient.OwnersWithAssignPermission.AddRange(ownersWithAssignPermission.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList());
+            }
+
             await IssueProcessing.InitialIssueTriage(mockGitHubEventClient, issueEventPayload);
             var totalUpdates = await mockGitHubEventClient.ProcessPendingUpdates(issueEventPayload.Repository.Id, issueEventPayload.Issue.Number);
-            // Verify the RuleCheck
-            Assert.AreEqual(ruleState == RuleState.On, mockGitHubEventClient.RulesConfiguration.RuleEnabled(rule), $"Rule '{rule}' enabled should have been {ruleState == RuleState.On} but RuleEnabled returned {ruleState != RuleState.On}.'");
-            if (RuleState.On == ruleState)
-            {
-                // The only update is labels being added, the number of which depends on the AI label serice returning labels
-                // and whether the user's org and collaborator permissions
-                Assert.AreEqual(1, totalUpdates, $"The number of updates should have been 1 but was instead, {totalUpdates}");
-                if (AIServiceReturnsLabels)
-                {
-                    Assert.True(mockGitHubEventClient.GetLabelsToAdd().Contains(LabelConstants.NeedsTeamTriage), $"Labels to add should contain {LabelConstants.NeedsTeamTriage} which should have been added when labels were predicted.");
-                    // Verify the labels returned by the AI service have been added
-                    foreach (string label in expectedLabels)
-                    {
-                        Assert.True(mockGitHubEventClient.GetLabelsToAdd().Contains(label), $"Labels to add should contain {label} which was returned by the AI service and should have been added.");
-                    }
-                }
-                else
-                {
-                    // If the AI Label service doesn't predict labels, the label added is NeedsTriage
-                    Assert.True(mockGitHubEventClient.GetLabelsToAdd().Contains(LabelConstants.NeedsTriage), $"Labels to add should contain {LabelConstants.NeedsTriage} which should have been added when no labels were predicted.");
-                }
 
+            // Verify the RuleChecks
+            Assert.AreEqual(ruleState == RuleState.On, mockGitHubEventClient.RulesConfiguration.RuleEnabled(rule), $"Rule '{rule}' enabled should have been {ruleState == RuleState.On} but RuleEnabled returned {ruleState != RuleState.On}.'");
+            Assert.AreEqual(serviceAttentionRuleState == RuleState.On, mockGitHubEventClient.RulesConfiguration.RuleEnabled(RulesConstants.ServiceAttention), $"Rule '{RulesConstants.ServiceAttention}' enabled should have been {serviceAttentionRuleState == RuleState.On} but RuleEnabled returned {serviceAttentionRuleState != RuleState.On}.'");
+            if (ruleState == RuleState.Off)
+            {
+                Assert.AreEqual(0, totalUpdates, $"{rule} is {ruleState} and should not have produced any updates but had {totalUpdates} updates.");
+            }
+            else
+            {
+                // The creator org/permission check is done regardless of whether or not the AI Label service returnes labels.
                 // If the user is not part of the Azure org AND they don't have write or admin collaborator permissions
-                // then customer-reported and question labels should be added to the issue
+                // then customer-reported and question labels should be added to the issue.
                 if (!isMemberOfOrg && !hasWriteOrAdmin)
                 {
                     Assert.True(mockGitHubEventClient.GetLabelsToAdd().Contains(LabelConstants.CustomerReported), $"Labels to add should contain {LabelConstants.CustomerReported} which it should when the user is not part of the org and doesn't have write/admin collaborator permissions.");
@@ -93,10 +316,86 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
                     Assert.False(mockGitHubEventClient.GetLabelsToAdd().Contains(LabelConstants.CustomerReported), $"Labels to add contains {LabelConstants.CustomerReported} and shouldn't when the user is part of the org or has write/admin collaborator permissions.");
                     Assert.False(mockGitHubEventClient.GetLabelsToAdd().Contains(LabelConstants.Question), $"Labels to add contains {LabelConstants.Question} and shouldn't when the user is part of the org or has write/admin collaborator permissions.");
                 }
-            }
-            else
-            {
-                Assert.AreEqual(0, totalUpdates, $"{rule} is {ruleState} and should not have produced any updates.");
+
+                // If there are no labels being returned from the AI Label service, the only processing is whether or not the creator
+                // is a member of the Azure org or has Write or Admin permissions
+                if (expectedLabels.Count == 0)
+                {
+                    Assert.True(mockGitHubEventClient.GetLabelsToAdd().Contains(LabelConstants.NeedsTriage), $"Labels to add should contain {LabelConstants.NeedsTriage} when the AI Label service has no suggested labels.");
+                }
+                // else the AI Label Service returned labels to add
+                else
+                {
+                    // Verify the labels returned by the AI service have been added to the issue
+                    foreach (string label in expectedLabels)
+                    {
+                        Assert.True(mockGitHubEventClient.GetLabelsToAdd().Contains(label), $"Labels to add should contain {label} which was returned by the AI service and should have been added.");
+                    }
+
+                    // If there is no CODEOWNERS entry there will be no AzureSdkOwners or ServiceOwners which means
+                    // that LabelConstants.NeedsTeamTriage should be on the issue. In theory, this is the only path
+                    // that should add NeedsTeamTriage. The reason being is that this will only happen if there are
+                    // no ServiceOwners and no AzureSdkOwners which can only happen if there's no entry. A metadata
+                    // block with a ServiceLabel needs to have ServiceOwners directly or end in a source path/owners
+                    // line otherwise the block is malformed and will get thrown away. 
+                    if (!hasCodeownersEntry)
+                    {
+                        Assert.True(mockGitHubEventClient.GetLabelsToAdd().Contains(LabelConstants.NeedsTeamTriage), $"With no CODEOWNERS entry {LabelConstants.NeedsTeamTriage} should have been added to the issue.");
+                    }
+                    // There is a CODEOWNERS entry for the ServiceLabel returned from the AI Label service
+                    else
+                    {
+                        // First, check whether or not there are AzureSdkOwners with assign permissions. If so,
+                        // then one of them needs to be assigned as the owner of the issue. Verify that only
+                        // one owner is being assigned to the issue and it's one of the ones in the list of
+                        // owners with issue assign permission.
+                        if (mockGitHubEventClient.OwnersWithAssignPermission.Count > 0)
+                        {
+                            var githubIssueAssignment = mockGitHubEventClient.GetGitHubIssueAssignment();
+                            Assert.AreEqual(1, githubIssueAssignment.Assignees.Count, $"There should only be a single owner assigned to an issue but {githubIssueAssignment.Assignees.Count} owners were assigned. Assignees={string.Join(",", githubIssueAssignment.Assignees)}.");
+                            // Verify that the assignee is one of the owners from the list with assign permissions.
+                            bool ownerFromOwnersWithPermList = mockGitHubEventClient.OwnersWithAssignPermission.Contains(githubIssueAssignment.Assignees[0], StringComparer.OrdinalIgnoreCase);
+                            Assert.True(ownerFromOwnersWithPermList, $"The owner assigned to the issue, {githubIssueAssignment.Assignees[0]}, was not in the list of owners with assign permission, {string.Join(",", mockGitHubEventClient.OwnersWithAssignPermission)}");
+
+                            Assert.True(mockGitHubEventClient.GetLabelsToAdd().Contains(LabelConstants.NeedsTeamAttention), $"With a valid AzureSdkOwner to assign to the issue the {LabelConstants.NeedsTeamAttention} should have been added to the issue.");
+
+                            // If there is more than one AzureSdkOwner, a comment will also be created to @ mention all of the owners
+                            // and a second comment will be created thanking the issue creator for their feedback.
+                            var azureSdkOwners = CodeOwnerUtils.GetAzureSdkOwnersForServiceLabels(expectedLabels);
+                            // With a single AzureSdkOwner there should only be one comment thanking the creator for feedback and tagging and routing the issue
+                            if (azureSdkOwners.Count == 1)
+                            {
+                                Assert.AreEqual(1, mockGitHubEventClient.GetComments().Count, $"With only one AzureSdkOwner there should only be one comment thanking the creator, tagging and routing but {mockGitHubEventClient.GetComments().Count} comments were created.");
+                            }
+                            // With more than one AzureSdkOWner there should be two comments. The first is an @ metion and the second is the same one thanking the creator
+                            else if (azureSdkOwners.Count > 1)
+                            {
+                                Assert.AreEqual(2, mockGitHubEventClient.GetComments().Count, $"With multiple AzureSdkOwners there should only be two comments. One @ mentioning everyone on the list and the other thanking the creator, tagging and routing but {mockGitHubEventClient.GetComments().Count} comments were created.");
+                            }
+                            // If there are OwnersWithAssignPermission but no AzureSdkOwners then the test scenario wasn't written correctly.
+                            else
+                            {
+                                Assert.Fail($"OwnersWithAssignPermission was > 0 but the label(s), {string.Join(",", expectedLabels)}, has no AzureSdkOwners in it's CODEOWNERS entry. Please verify the test was written correctly.");
+                            }
+                        }
+                        // No AzureSdkOwners with assign permission means that there's no valid assignees and if there are ServiceOwners (which their has to be
+                        // at this point since the no CODEOWNERS entry case is checked first) it'll run the ServiceAttention rule if its enabled.
+                        else
+                        {
+                            if (serviceAttentionRuleState == RuleState.Off)
+                            {
+                                Assert.True(mockGitHubEventClient.GetLabelsToAdd().Contains(LabelConstants.NeedsTeamTriage), $"With no valid AzureSdkOwners and the ServiceAttention rule being disabled, {LabelConstants.NeedsTeamTriage} should have been added to the issue.");
+                            }
+                            // else, the ServiceAttention rule will which creates a comment that ends with @ mentioning the service owners
+                            // and NeedsTeamAttention is added to the issue
+                            else
+                            {
+                                Assert.True(mockGitHubEventClient.GetLabelsToAdd().Contains(LabelConstants.NeedsTeamAttention), $"With no valid AzureSdkOwners but valid ServiceOwners and ServiceAttention rule being enabled, {LabelConstants.NeedsTeamAttention} should have been added to the issue.");
+                                Assert.AreEqual(1, mockGitHubEventClient.GetComments().Count, $"With no AzureSdkOwners and the ServiceAttention rule being enabled, there should only be one comment created by the ServiceAttention rule but {mockGitHubEventClient.GetComments().Count} comments were created.");
+                            }
+                        }
+                    }
+                }
             }
         }
 
@@ -170,7 +469,6 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
         [TestCase(RulesConstants.ServiceAttention, "Tests.JsonEventPayloads/ServiceAttention_issue_labeled.json", RuleState.Off, true)]
         [TestCase(RulesConstants.ServiceAttention, "Tests.JsonEventPayloads/ServiceAttention_issue_labeled.json", RuleState.On, true)]
         [TestCase(RulesConstants.ServiceAttention, "Tests.JsonEventPayloads/ServiceAttention_issue_labeled.json", RuleState.On, false)]
-
         public async Task TestServiceAttention(string rule, string payloadFile, RuleState ruleState, bool hasPartiesToMentionForServiceAttention)
         {
             var mockGitHubEventClient = new MockGitHubEventClient(OrgConstants.ProductHeaderName);
@@ -199,7 +497,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
             {
                 if (hasPartiesToMentionForServiceAttention)
                 {
-                    string expectedNames = "@FakeUser1 @FakeUser11 @FakeUser4 @FakeUser14 @FakeUser24 @FakeUser9";
+                    string expectedNames = "@FakeUser1 @FakeUser11 @FakeUser14 @FakeUser24 @FakeUser4 @FakeUser9";
                     // "Thanks for the feedback! We are routing this to the appropriate team for follow-up. cc @FakeUser1 @FakeUser11 @FakeUser4 @FakeUser14 @FakeUser24 @FakeUser9."
                     // There should be one update, a comment
                     Assert.AreEqual(1, totalUpdates, $"The number of updates should have been 1 but was instead, {totalUpdates}");
@@ -218,6 +516,43 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
             {
                 Assert.AreEqual(0, totalUpdates, $"{rule} is {ruleState} and should not have produced any updates.");
             }
+        }
+
+        /// <summary>
+        /// This is for testing an update to the Service Attention rule. If Service Attention is already on the rule and the rule
+        /// is labled, then that label's people are @ mentioned.
+        /// Trigger: issue labeled
+        /// Conditions: Issue is open
+        ///             "Service Attention" is already on the issue
+        ///             The label has a CODEOWNERS entry with ServiceOwners
+        /// Resulting Action: Add issue comment "Thanks for the feedback! We are routing this to the appropriate team for follow-up. cc ${mentionees}."
+        /// </summary>
+        /// <param name="rule">String, RulesConstants for the rule being tested</param>
+        /// <param name="payloadFile">JSon payload file for the event being tested</param>
+        /// <param name="expectedOwners">The expected owners to be @ mentioned for the label being added. This needs to be ordered as the API getting the owners orders them.</param>
+        [Category("static")]
+        [NonParallelizable]
+        [TestCase(RulesConstants.ServiceAttention, "Tests.JsonEventPayloads/ServiceAttention_issue_labeled_already_has_ServiceAttention.json", "@FakeUser14 @FakeUser24 @FakeUser4")]
+        public async Task TestServiceAttentionAlreadyOnIssue(string rule, string payloadFile, string expectedOwners)
+        {
+            var mockGitHubEventClient = new MockGitHubEventClient(OrgConstants.ProductHeaderName);
+            mockGitHubEventClient.RulesConfiguration.Rules[rule] = RuleState.On;
+            var rawJson = TestHelpers.GetTestEventPayload(payloadFile);
+            var issueEventPayload = SimpleJsonSerializer.Deserialize<IssueEventGitHubPayload>(rawJson);
+
+            CodeOwnerUtils.ResetCodeOwnerEntries();
+            CodeOwnerUtils.codeOwnersFilePathOverride = "Tests.FakeCodeowners/ServiceAttention_has_CODEOWNERS";
+
+            IssueProcessing.ServiceAttention(mockGitHubEventClient, issueEventPayload);
+            var totalUpdates = await mockGitHubEventClient.ProcessPendingUpdates(issueEventPayload.Repository.Id, issueEventPayload.Issue.Number);
+            // "Thanks for the feedback! We are routing this to the appropriate team for follow-up. cc @FakeUser1 @FakeUser11 @FakeUser4 @FakeUser14 @FakeUser24 @FakeUser9."
+            // There should be one update, a comment
+            Assert.AreEqual(1, totalUpdates, $"The number of updates should have been 1 but was instead, {totalUpdates}");
+
+            // Verify that a single comment was created
+            Assert.AreEqual(1, mockGitHubEventClient.GetComments().Count, $"{rule} should have produced a single comment.");
+            string comment = mockGitHubEventClient.GetComments()[0].Comment;
+            Assert.True(comment.Contains(expectedOwners), $"Comment should have contained expected names {expectedOwners} but did not. Full comment={comment}");
         }
 
         /// <summary>

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Tests.FakeCodeowners/InitialIssueTriage_CODEOWNERS
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Tests.FakeCodeowners/InitialIssueTriage_CODEOWNERS
@@ -1,0 +1,41 @@
+################
+# FAKE Codeowners file for InitialIssueTriage testing. Each metadata block has a unique ServiceLabel for
+# testing different scenarios. The ServiceLabel needs to be returned from the AI Label service mock in order
+# for a particular block to be selected.
+# Note: FakeUser1 is the owner that opened the issue in the 
+# Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json file.
+################
+
+# This scenario is a ServiceOwners block with no AzureSdkOwners
+# ServiceLabel: %FakeLabel1
+# ServiceOwners: @FakeUser7 @FakeUser8
+
+# The scenarios here are a ServiceOwners block with a single AzureSdkOwner.
+# The first scenario will be that the AzureSdkOwner doesn't have issue assignment permissions
+# and the ServiceAttention rule is turned off. The ServiceLabel and NeedsTeamTriage will be added to the issue.
+# The second scenario will be that the AzureSdkOwner doesn't have issue assignment permissions
+# meaning that the ServiceOwners/ServiceAttention fallback will be executed.
+# The third scenario will be that the AzureSdkOwner has issue assignment permissions. This
+# will cause the owner to be assigned to the issue without a comment mentioning all AzureSdkOwners
+# ServiceLabel: %FakeLabel2
+# ServiceOwners: @FakeUser0 @FakeUser9
+# AzureSdkOwners: @FakeUser1
+
+# The scenarios here are a ServiceOwners block with a multiple AzureSdkOwners.
+# The first scenario is that none of the AzureSdkOwners will have issue assignment permissions
+# meaning that the ServiceOwners/ServiceAttention fallback will be executed.
+# The second scenario is that only 1 of the AzureSdkOwners will have issue assignment permissions.
+# This will cause the owner with permissions to be assigned to the issue and both owners will be
+# in the at mention.
+# ServiceOwners block with multiple AzureSdkOwners
+# ServiceLabel: %FakeLabel3
+# ServiceOwners: @FakeUser3 @FakeUser4
+# AzureSdkOwners: @FakeUser1 @FakeUser5
+
+# AzureSdkOwners and ServiceOwners pulled from source path/owners. 
+# The first scenario will test with both AzureSdkOwners having issue assignment permission 
+# The second scenario will test both AzureSdkOwners not having issue assignment permission
+# ServiceLabel: %FakeLabel4
+# AzureSdkOwners:
+/files/filePath0/           @FakeUser5 @FakeUser6
+

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Tests.JsonEventPayloads/ServiceAttention_issue_labeled_already_has_ServiceAttention.json
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Tests.JsonEventPayloads/ServiceAttention_issue_labeled_already_has_ServiceAttention.json
@@ -1,24 +1,101 @@
 {
-  "action": "opened",
+  "action": "labeled",
   "issue": {
     "active_lock_reason": null,
-    "assignee": null,
-    "assignees": [],
+    "assignee": {
+      "avatar_url": "https://avatars.githubusercontent.com/u/13556087?v=4",
+      "events_url": "https://api.github.com/users/FakeUser1/events{/privacy}",
+      "followers_url": "https://api.github.com/users/FakeUser1/followers",
+      "following_url": "https://api.github.com/users/FakeUser1/following{/other_user}",
+      "gists_url": "https://api.github.com/users/FakeUser1/gists{/gist_id}",
+      "gravatar_id": "",
+      "html_url": "https://github.com/FakeUser1",
+      "id": 13556087,
+      "login": "FakeUser1",
+      "node_id": "MDQ6VXNlcjEzNTU2MDg3",
+      "organizations_url": "https://api.github.com/users/FakeUser1/orgs",
+      "received_events_url": "https://api.github.com/users/FakeUser1/received_events",
+      "repos_url": "https://api.github.com/users/FakeUser1/repos",
+      "site_admin": false,
+      "starred_url": "https://api.github.com/users/FakeUser1/starred{/owner}{/repo}",
+      "subscriptions_url": "https://api.github.com/users/FakeUser1/subscriptions",
+      "type": "User",
+      "url": "https://api.github.com/users/FakeUser1"
+    },
+    "assignees": [
+      {
+        "avatar_url": "https://avatars.githubusercontent.com/u/13556087?v=4",
+        "events_url": "https://api.github.com/users/FakeUser1/events{/privacy}",
+        "followers_url": "https://api.github.com/users/FakeUser1/followers",
+        "following_url": "https://api.github.com/users/FakeUser1/following{/other_user}",
+        "gists_url": "https://api.github.com/users/FakeUser1/gists{/gist_id}",
+        "gravatar_id": "",
+        "html_url": "https://github.com/FakeUser1",
+        "id": 13556087,
+        "login": "FakeUser1",
+        "node_id": "MDQ6VXNlcjEzNTU2MDg3",
+        "organizations_url": "https://api.github.com/users/FakeUser1/orgs",
+        "received_events_url": "https://api.github.com/users/FakeUser1/received_events",
+        "repos_url": "https://api.github.com/users/FakeUser1/repos",
+        "site_admin": false,
+        "starred_url": "https://api.github.com/users/FakeUser1/starred{/owner}{/repo}",
+        "subscriptions_url": "https://api.github.com/users/FakeUser1/subscriptions",
+        "type": "User",
+        "url": "https://api.github.com/users/FakeUser1"
+      }
+    ],
     "author_association": "OWNER",
     "body": null,
     "closed_at": null,
     "comments": 0,
-    "comments_url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/15/comments",
-    "created_at": "2023-01-30T18:59:03Z",
-    "events_url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/15/events",
-    "html_url": "https://github.com/Azure/azure-sdk-fake/issues/15",
-    "id": 1563022437,
-    "labels": [],
-    "labels_url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/15/labels{/name}",
+    "comments_url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/14/comments",
+    "created_at": "2023-01-27T17:01:30Z",
+    "events_url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/14/events",
+    "html_url": "https://github.com/Azure/azure-sdk-fake/issues/14",
+    "id": 1560095682,
+    "labels": [
+      {
+        "color": "d73a4a",
+        "default": true,
+        "description": "Something isn't working",
+        "id": 4273699693,
+        "name": "bug",
+        "node_id": "LA_kwDOHkcrQs7-u3tt",
+        "url": "https://api.github.com/repos/Azure/azure-sdk-fake/labels/bug"
+      },
+      {
+        "color": "F75BB2",
+        "default": false,
+        "description": "",
+        "id": 5095715984,
+        "name": "Service Attention",
+        "node_id": "LA_kwDOHkcrQs8AAAABL7p0kA",
+        "url": "https://api.github.com/repos/Azure/azure-sdk-fake/labels/Service%20Attention"
+      },
+      {
+        "color": "9C7082",
+        "default": false,
+        "description": "fake label for testing",
+        "id": 5095712487,
+        "name": "FakeLabel1",
+        "node_id": "LA_kwDOHkcrQs8AAAABL7pm5w",
+        "url": "https://api.github.com/repos/Azure/azure-sdk-fake/labels/FakeLabel1"
+      },
+      {
+        "color": "9C7082",
+        "default": false,
+        "description": "fake label for testing",
+        "id": 5095712487,
+        "name": "FakeLabel9",
+        "node_id": "LA_kwDOHkcrQs8AAAABL7pm5w",
+        "url": "https://api.github.com/repos/Azure/azure-sdk-fake/labels/FakeLabel9"
+      }
+    ],
+    "labels_url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/14/labels{/name}",
     "locked": false,
     "milestone": null,
-    "node_id": "I_kwDOHkcrQs5dKdRl",
-    "number": 15,
+    "node_id": "I_kwDOHkcrQs5c_SvC",
+    "number": 14,
     "performed_via_github_app": null,
     "reactions": {
       "+1": 0,
@@ -30,15 +107,15 @@
       "laugh": 0,
       "rocket": 0,
       "total_count": 0,
-      "url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/15/reactions"
+      "url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/14/reactions"
     },
     "repository_url": "https://api.github.com/repos/Azure/azure-sdk-fake",
     "state": "open",
     "state_reason": null,
-    "timeline_url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/15/timeline",
-    "title": "Another new issue to generate test payloads",
-    "updated_at": "2023-01-30T18:59:03Z",
-    "url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/15",
+    "timeline_url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/14/timeline",
+    "title": "New test issue to generate event payloads",
+    "updated_at": "2023-01-30T16:16:54Z",
+    "url": "https://api.github.com/repos/Azure/azure-sdk-fake/issues/14",
     "user": {
       "avatar_url": "https://avatars.githubusercontent.com/u/13556087?v=4",
       "events_url": "https://api.github.com/users/FakeUser1/events{/privacy}",
@@ -59,6 +136,15 @@
       "type": "User",
       "url": "https://api.github.com/users/FakeUser1"
     }
+  },
+  "label": {
+    "color": "9C7082",
+    "default": false,
+    "description": "fake label for testing",
+    "id": 5095712487,
+    "name": "FakeLabel4",
+    "node_id": "LA_kwDOHkcrQs8AAAABL7pm5w",
+    "url": "https://api.github.com/repos/Azure/azure-sdk-fake/labels/FakeLabel4"
   },
   "repository": {
     "allow_forking": true,
@@ -121,8 +207,8 @@
     "name": "azure-sdk-fake",
     "node_id": "R_kgDOHkcrQg",
     "notifications_url": "https://api.github.com/repos/Azure/azure-sdk-fake/notifications{?since,all,participating}",
-    "open_issues": 7,
-    "open_issues_count": 7,
+    "open_issues": 6,
+    "open_issues_count": 6,
     "owner": {
       "avatar_url": "https://avatars.githubusercontent.com/u/13556087?v=4",
       "events_url": "https://api.github.com/users/FakeUser1/events{/privacy}",

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Azure.Sdk.Tools.GitHubEventProcessor.csproj
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Azure.Sdk.Tools.GitHubEventProcessor.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\code-owners-parser\CodeOwnersParser\Azure.Sdk.Tools.CodeOwnersParser.csproj" />
+    <ProjectReference Include="..\..\codeowners-utils\Azure.Sdk.Tools.CodeownersUtils\Azure.Sdk.Tools.CodeownersUtils.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Threading.Tasks;
+using Azure.Sdk.Tools.CodeownersUtils.Constants;
 using Azure.Sdk.Tools.GitHubEventProcessor.Constants;
 using Azure.Sdk.Tools.GitHubEventProcessor.GitHubPayload;
 using Azure.Sdk.Tools.GitHubEventProcessor.Utils;
@@ -23,6 +24,8 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
         // Exception string partial from the call to GitHubClient.Repository.Collaborator.ReviewPermission
         // used to determine if the call threw because the user being checked was a bot or didn't exist.
         private static readonly string NotAUserPartial = "is not a user";
+
+        private static readonly int MaxIssueAssignees = 10;
 
         /// <summary>
         /// Class to store the information needed to create a GitHub Comment on an Issue or PullRequest.
@@ -112,6 +115,26 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
             }
         }
 
+        /// <summary>
+        /// This class is necessary to assign owners to an issue. The reason this class is necessary is
+        /// becuase unlike every other issue update call, which only requires the repositoryId and issueId,
+        /// this underlying API call needs the repo owner and repo name. Thanks GitHub!
+        /// </summary>
+        public class GitHubIssueAssignment
+        {
+            private string _repoName;
+            private string _repoOwner;
+            private List<string> _assignees = new List<string>();
+            public string RepositoryName { get { return _repoName; } }
+            public string RepositoryOwner { get { return _repoOwner; } }
+            public List<string> Assignees { get { return _assignees; } }
+
+            public GitHubIssueAssignment(string repoOwner, string repoName)
+            {
+                _repoOwner = repoOwner;
+                _repoName = repoName;
+            }
+        }
 
         private GitHubClient _gitHubClient = null;
         private RulesConfiguration _rulesConfiguration = null;
@@ -126,6 +149,9 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
         // Scheduled event processing can process multiple issues, this list will not be used
         // for action processing which uses a shared event.
         protected List<GitHubIssueToUpdate> _gitHubIssuesToUpdate = new List<GitHubIssueToUpdate>();
+        // Necessary for issue assignment which requires the repository owner/name to set instead of just
+        // the Id.
+        protected GitHubIssueAssignment _gitHubIssueAssignment = null;
 
         public int CoreRateLimit { get; set; } = 0;
 
@@ -168,6 +194,18 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
                     await _gitHubClient.Issue.Update(repositoryId, 
                                                      issueOrPullRequestNumber, 
                                                      _issueUpdate);
+                }
+
+                // The issue is being assigned. Note, this can only happen for issues, the issueOrPullRequestNumber
+                // in this case will always be an issue with the way events are processed.
+                if (_gitHubIssueAssignment != null)
+                {
+                    numUpdates++;
+                    AssigneesUpdate assigneesUpdate = new AssigneesUpdate(_gitHubIssueAssignment.Assignees);
+                    await _gitHubClient.Issue.Assignee.AddAssignees(_gitHubIssueAssignment.RepositoryOwner,
+                                                                    _gitHubIssueAssignment.RepositoryName,
+                                                                    issueOrPullRequestNumber,
+                                                                    assigneesUpdate);
                 }
 
                 // Process the labels to add. They're all added as a single call and are additive, not replacement 
@@ -270,6 +308,13 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
                 Console.WriteLine("Common IssueUpdate from rules processing will be updated.");
                 numUpdates++;
             }
+
+            if (_gitHubIssueAssignment != null)
+            {
+                Console.WriteLine($"IssueAssignment is being made to (1 call)");
+                numUpdates++;
+            }
+
             if (_labelsToAdd.Count > 0)
             {
                 Console.WriteLine($"There are {_labelsToAdd.Count} labels being added (1 call)");
@@ -300,6 +345,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
                 Console.WriteLine($"Number of IssuesUpdates (only applicable for Scheduled events) {_gitHubIssuesToUpdate.Count}");
                 numUpdates += _gitHubIssuesToUpdate.Count;
             }
+
             return numUpdates;
         }
 
@@ -309,17 +355,44 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
         /// <param name="prependMessage">Optional message to prepend to the rate limit message.</param>
         public async Task WriteRateLimits(string prependMessage = null)
         {
-            var miscRateLimit = await GetRateLimits();
-            CoreRateLimit = miscRateLimit.Resources.Core.Limit;
-            // Get the Minutes till reset.
-            TimeSpan span = miscRateLimit.Resources.Core.Reset.UtcDateTime.Subtract(DateTime.UtcNow);
-            // In the message, cast TotalMinutes to an int to get a whole number of minutes.
-            string rateLimitMessage = $"Limit={miscRateLimit.Resources.Core.Limit}, Remaining={miscRateLimit.Resources.Core.Remaining}, Limit Reset in {(int)span.TotalMinutes} minutes.";
-            if (prependMessage != null)
+            int maxTries = 5;
+            // 200 ms. If the rate limits cannot be fetched in 1 second, there's a problem with GitHub.
+            // Unlike scheduled events which have a longer back off period, normal event processing cannot
+            // delay that long before retrying.
+            int sleepDuration = 200;
+
+            for (int tryNumber = 1; tryNumber <= maxTries; tryNumber++)
             {
-                rateLimitMessage = $"{prependMessage} {rateLimitMessage}";
+                try
+                {
+                    var miscRateLimit = await GetRateLimits();
+                    CoreRateLimit = miscRateLimit.Resources.Core.Limit;
+                    // Get the Minutes till reset.
+                    TimeSpan span = miscRateLimit.Resources.Core.Reset.UtcDateTime.Subtract(DateTime.UtcNow);
+                    // In the message, cast TotalMinutes to an int to get a whole number of minutes.
+                    string rateLimitMessage = $"Limit={miscRateLimit.Resources.Core.Limit}, Remaining={miscRateLimit.Resources.Core.Remaining}, Limit Reset in {(int)span.TotalMinutes} minutes.";
+                    if (prependMessage != null)
+                    {
+                        rateLimitMessage = $"{prependMessage} {rateLimitMessage}";
+                    }
+                    Console.WriteLine(rateLimitMessage);
+                    return;
+                }
+                catch (Exception ex)
+                {
+                    if (tryNumber == maxTries)
+                    {
+                        Console.WriteLine($"Exception trying to get RateLimit from GitHub. Number of attempts, {maxTries}, exhausted. Rethrowing.");
+                        throw;
+                    }
+                    else
+                    {
+                        Console.WriteLine($"Exception trying to get RateLimit from GitHub, attempt number: {tryNumber} of {maxTries}. Waiting {sleepDuration}ms before trying again.");
+                        Console.WriteLine($"Exception: {ex}");
+                        await Task.Delay(sleepDuration);
+                    }
+                }
             }
-            Console.WriteLine(rateLimitMessage);
         }
 
         /// <summary>
@@ -376,12 +449,6 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
             return await _gitHubClient.RateLimit.GetRateLimits();
         }
 
-        // JRS - Remove
-        public void SetIssueUpdate(IssueUpdate issueUpdate)
-        {
-            _issueUpdate = issueUpdate;
-        }
-
         /// <summary>
         /// Store the label to add on the list of labels to add to an issue. This is only used by Actions
         /// and not Scheduled events
@@ -389,7 +456,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
         /// <param name="labelToAdd">string, the label to add to the issue</param>
         public void AddLabel(string labelToAdd)
         {
-            if (_labelsToRemove.Contains(labelToAdd))
+            if (_labelsToRemove.Contains(labelToAdd, StringComparer.OrdinalIgnoreCase))
             {
                 Console.WriteLine($"Label to add {labelToAdd} is currently on the remove list and will not be added.");
             }
@@ -406,7 +473,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
         /// <param name="labelToRemove">string, the label to remove from the issue</param>
         public void RemoveLabel(string labelToRemove)
         {
-            if (_labelsToAdd.Contains(labelToRemove))
+            if (_labelsToRemove.Contains(labelToRemove, StringComparer.OrdinalIgnoreCase))
             {
                 Console.WriteLine($"Label to remove {labelToRemove} is currently on the add list and will not be added");
             }
@@ -667,6 +734,75 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
                 permission
             };
             return await DoesUserHavePermissions(repositoryId, user, permissionList);
+        }
+
+        /// <summary>
+        /// Before assigning an owner to an issue they need to be checked to see if they're a valid assignee for
+        /// that repository. Also, unlike PRs, issues cannot be assigned to teams. Unfortunately, unlike most other
+        /// APIs that manipulate issues, this particular API requires the repoOwner and repoName instead of just the
+        /// repositoryId (note: Azure/azure-sdk-for-whatever is actually repoOwner/repoName). The repository is in
+        /// payload contains this information which will be Repository.Owner.Name for the owner and Repository.Name
+        /// for the name.
+        /// </summary>
+        /// <param name="repoOwner">The repository owner, found in the Repository.Owner.Name of the payload.</param>
+        /// <param name="repoName">The repository name, found in the Repository.Name of the payload.</param>
+        /// <param name="assignee">The owner to check.</param>
+        /// <returns>True if the owner can be assigned to issues within the repository, false otherwise.</returns>
+        public virtual async Task<bool> OwnerCanBeAssignedToIssuesInRepo(string repoOwner, string repoName, string assignee)
+        {
+            if (string.IsNullOrWhiteSpace(repoOwner))
+            {
+                return false;
+            }
+            // Issues cannot be assigned to teams, only PRs
+            if (assignee.Contains(SeparatorConstants.Team))
+            {
+                return false;
+            }
+            return await _gitHubClient.Issue.Assignee.CheckAssignee(repoOwner, repoName, assignee);
+        }
+
+        /// <summary>
+        /// This function is only valid for issue processing, scheduled events do not assign issue.
+        /// </summary>
+        /// <param name="repoOwner">The repository owner, found in the Repository.Owner.Name of the payload.</param>
+        /// <param name="repoName">The repository name, found in the Repository.Name of the payload.</param>
+        /// <param name="assignee">The owner to assign to an issue. Note, this cannot be a team.</param>
+        public void AssignOwnerToIssue(string repoOwner, string repoName, string assignee)
+        {
+
+            if (assignee == null)
+            {
+                Console.WriteLine("Issue assignee cannot be null.");
+                return;
+            }
+
+            if (assignee.Contains(SeparatorConstants.Team))
+            {
+                Console.WriteLine($"Assignee, {assignee}, is a team. Issues cannot be assigned to a team.");
+                return;
+            }
+
+            if (null == _gitHubIssueAssignment)
+            {
+                _gitHubIssueAssignment = new GitHubIssueAssignment(repoOwner, repoName);
+            }
+
+            if (_gitHubIssueAssignment.Assignees.Contains(assignee, StringComparer.OrdinalIgnoreCase))
+            {
+                Console.WriteLine($"Issue assignee {assignee} is already on the list of assignees for the issue.");
+            }
+            else
+            {
+                if (_gitHubIssueAssignment.Assignees.Count < MaxIssueAssignees)
+                {
+                    _gitHubIssueAssignment.Assignees.Add(assignee);
+                }
+                else
+                {
+                    Console.WriteLine($"The max number of Issue assignees (10) has been reached. {assignee} will not be assigned to the issue.");
+                }
+            }
         }
 
         /// <summary>

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
@@ -473,7 +473,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
         /// <param name="labelToRemove">string, the label to remove from the issue</param>
         public void RemoveLabel(string labelToRemove)
         {
-            if (_labelsToRemove.Contains(labelToRemove, StringComparer.OrdinalIgnoreCase))
+            if (_labelsToAdd.Contains(labelToRemove, StringComparer.OrdinalIgnoreCase))
             {
                 Console.WriteLine($"Label to remove {labelToRemove} is currently on the add list and will not be added");
             }

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Utils/LabelUtils.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Utils/LabelUtils.cs
@@ -1,5 +1,6 @@
 using Octokit;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using System.Text;
 
@@ -8,22 +9,31 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Utils
     public class LabelUtils
     {
         /// <summary>
-        /// Check whether or not an label exists in a list of labels. This will be used on issues,
-        /// and PRs, both of which contain a list of labels
+        /// Overload that takes the Octokit's IReadOnlyList of Labels and converts it
+        /// to a string list.
         /// </summary>
         /// <param name="labels">IReadOnlyList of labels</param>
         /// <param name="labelToCheck">The label to look for on the issue</param>
         /// <returns>true if the label exists, false otherwise</returns>
         public static bool HasLabel(IReadOnlyList<Label> labels, string labelToCheck)
         {
+            return HasLabel(labels.Select(l => l.Name).ToList(), labelToCheck);
+        }
+
+        /// <summary>
+        /// Check whether or not an label exists in a list of labels. This will be used on issues,
+        /// and PRs, both of which contain a list of labels
+        /// </summary>
+        /// <param name="labels">List of labels</param>
+        /// <param name="labelToCheck">The label to look for in the list</param>
+        /// <returns>true if the label exists, false otherwise</returns>
+        public static bool HasLabel(List<string> labels, string labelToCheck)
+        {
             if (labels != null)
             {
-                foreach (Label label in labels)
+                if (labels.Contains(labelToCheck, StringComparer.OrdinalIgnoreCase))
                 {
-                    if (label.Name.Equals(labelToCheck, StringComparison.OrdinalIgnoreCase))
-                    {
-                        return true;
-                    }
+                    return true;
                 }
             }
             return false;

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Utils/RulesConfiguration.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Utils/RulesConfiguration.cs
@@ -6,7 +6,7 @@ using System.Text.Json;
 using System.Text.Json.Serialization;
 using Azure.Sdk.Tools.GitHubEventProcessor.Constants;
 using System.IO;
-using Azure.Sdk.Tools.CodeOwnersParser;
+using Azure.Sdk.Tools.CodeownersUtils.Utils;
 
 namespace Azure.Sdk.Tools.GitHubEventProcessor.Utils
 {
@@ -92,21 +92,32 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Utils
         /// Check whether or not a given rule is enabled, disabled or missing.
         /// </summary>
         /// <param name="rule">String, rule to check. This string should be from RulesConstants.</param>
+        /// <param name="outputRunLogMessages">Boolean to determine whether or not to put log messages, default is true. This is necessary because we have a case where one rule runs another's processing but we only want the log outputting when the specific rule is being executed to avoid confusion.</param>
         /// <returns>True if enabled, False if disabled or missing from the configuration file.</returns>
-        public bool RuleEnabled(string rule)
+        public bool RuleEnabled(string rule, bool outputRunLogMessages = true)
         {
             if (Rules.ContainsKey(rule))
             {
                 if (Rules[rule] == RuleState.On)
                 {
-                    Console.WriteLine($"Rule, {rule}, is {Rules[rule]}. Processing...");
+                    if (outputRunLogMessages)
+                    {
+                        Console.WriteLine($"Rule, {rule}, is {Rules[rule]}. Processing...");
+                    }
                     return true;
                 }
-                Console.WriteLine($"Rule, {rule}, is {Rules[rule]}. Not processing...");
+
+                if (outputRunLogMessages)
+                {
+                    Console.WriteLine($"Rule, {rule}, is {Rules[rule]}. Not processing...");
+                }
             }
             else
             {
-                Console.WriteLine($"Rule, {rule}, is not in the repository config file and will not run.");
+                if (outputRunLogMessages)
+                {
+                    Console.WriteLine($"Rule, {rule}, is not in the repository config file and will not run.");
+                }
             }
             return false;
         }

--- a/tools/github-event-processor/GitHubEventProcessor.sln
+++ b/tools/github-event-processor/GitHubEventProcessor.sln
@@ -5,9 +5,9 @@ VisualStudioVersion = 17.3.32929.385
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.GitHubEventProcessor", "Azure.Sdk.Tools.GitHubEventProcessor\Azure.Sdk.Tools.GitHubEventProcessor.csproj", "{CF5AED50-110D-401B-9557-DD7EFE095BD1}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CodeOwnersParser", "..\code-owners-parser\CodeOwnersParser\Azure.Sdk.Tools.CodeOwnersParser.csproj", "{D4B02A7A-425E-4BC7-8820-924AC6BB181F}"
-EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.GitHubEventProcessor.Tests", "Azure.Sdk.Tools.GitHubEventProcessor.Tests\Azure.Sdk.Tools.GitHubEventProcessor.Tests.csproj", "{7BB40AA1-FEC1-44E4-AB17-962859BB69C9}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Azure.Sdk.Tools.CodeownersUtils", "..\codeowners-utils\Azure.Sdk.Tools.CodeownersUtils\Azure.Sdk.Tools.CodeownersUtils.csproj", "{D0BC4510-08B6-4401-BC03-ED3674C1082D}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -19,14 +19,14 @@ Global
 		{CF5AED50-110D-401B-9557-DD7EFE095BD1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{CF5AED50-110D-401B-9557-DD7EFE095BD1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{CF5AED50-110D-401B-9557-DD7EFE095BD1}.Release|Any CPU.Build.0 = Release|Any CPU
-		{D4B02A7A-425E-4BC7-8820-924AC6BB181F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D4B02A7A-425E-4BC7-8820-924AC6BB181F}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D4B02A7A-425E-4BC7-8820-924AC6BB181F}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D4B02A7A-425E-4BC7-8820-924AC6BB181F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{7BB40AA1-FEC1-44E4-AB17-962859BB69C9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{7BB40AA1-FEC1-44E4-AB17-962859BB69C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7BB40AA1-FEC1-44E4-AB17-962859BB69C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7BB40AA1-FEC1-44E4-AB17-962859BB69C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0BC4510-08B6-4401-BC03-ED3674C1082D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0BC4510-08B6-4401-BC03-ED3674C1082D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0BC4510-08B6-4401-BC03-ED3674C1082D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0BC4510-08B6-4401-BC03-ED3674C1082D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/tools/github-event-processor/RULES.md
+++ b/tools/github-event-processor/RULES.md
@@ -104,56 +104,52 @@ This is a stand-alone service providing a REST API which requires a service key 
 
 ### Actions
 
+- Query AI label service for suggestions:
+
+```text
+IF labels were predicted:
+    - Assign returned labels to the issue
+
+    IF service and category labels have AzureSdkOwners (in CODEOWNERS):
+        IF a single AzureSdkOwner:
+            - Assign the AzureSdkOwner issue
+        ELSE
+            - Assign a random AzureSdkOwner from the set to the issue
+            - Create the following comment, mentioning all AzureSdkOwners from the set
+                 "@{person1} @{person2}...${personX}"
+
+        - Create the following comment
+             "Thank you for your feedback.  Tagging and routing to the team member best able to assist."
+
+    # Note: No valid AzureSdkOwners means there were no CODEOWNERS entries for the service label OR no
+    # CODEOWNERS entries for the service label with AzureSdkOwners OR there is a CODEOWNERS entry with
+    # AzureSdkOwners but none of them have permissions to be assigned to an issue for the repository.
+    IF there are no valid AzureSdkOwners, but there are ServiceOwners, and the ServiceAttention rule is enabled
+    for the repository
+        - Add "Service Attention" label to the issue and apply the logic from the "Service Attention" rule
+    ELSE
+        - Add "needs-team-triage" (at this point it owners cannot be determined for this issue)
+
+    IF "needs-team-triage" is not being added to the issue
+         - Add "needs-team-attention" label to the issue
+
+ELSE
+    - Add "needs-triage" label to the issue
+
+```
+
 - Evaluate the user that created the issue:
 
-    ```text
-    IF creator is NOT an Azure SDK team owner
-      IF the user is NOT a member of the Azure Org
-        IF the user does not have Admin or Write Collaborator permission
-          - Add "customer-reported" label to the issue
-          - Add "question" label to the issue
-    ```
-
-- Query AI label service for suggestions:
-  - _This is what we have today_
-
-    ```text
-    IF labels were predicted
-        - Assign returned labels to the issue
-        - Add "needs-team-triage" label to the issue
-    ELSE
-        - Add "needs-triage" label to the issue
-
-    IF the user is NOT a member of the Azure Org
-      IF the user does not have Admin or Write Collaborator permission
+```text
+IF the user is NOT a member of the Azure Org
+  IF the user does not have Admin or Write Collaborator permission
         - Add "customer-reported" label to the issue
         - Add "question" label to the issue
-    ```
+```
 
-  - _This is what we'd like to get to. It requires changes to the CODEOWNERS file structure which have not been done yet_
-
-    ```text
-    IF labels were predicted:
-        - Assign returned labels to the issue
-        - Add "needs-team-attention" label to the issue
-
-        IF service and category labels are associated with an Azure SDK team member:
-            IF a single team member:
-                - Assign team member to the issue
-            ELSE
-                - Assign a random team member from the set to the issue
-                - Create the following comment, mentioning other team members from the set
-                  - "@{person1} @{person2}...${personX}"
-
-            - Create the following comment
-              "Thank you for your feedback.  Tagging and routing to the team member best able to assist."
-        ELSE
-            - Add "Service Attention" label to the issue and apply the logic from the "Service Attention" rule
-            - Create the following comment
-              - "Thank you for your feedback.  This has been routed to the support team for assistance."
-    ELSE
-        - Add "needs-triage" label to the issue
-    ```
+Note: Users are supposed to be **public** members of Azure. This is very clearly stated in the
+the [onboarding docs](https://eng.ms/docs/products/azure-developer-experience/onboard/access). If a user's
+Azure membership is private, API call to check Azure membership will return false which can result in "customer-reported" and "question" labels being added to an issue for someone that is a private member of Azure.
 
 ## Manual issue triage
 


### PR DESCRIPTION
The following updates have been made in this PR.
1. The primary change was to swap out the old CodeownersParser for the CodeownersUtils which will parse the new moniker, AzureSdkOwners, from CODEOWNERS files. 
2. With the updated parsing the InitialIssueTriage rule has been rewritten, updated to definition provided by @jsquire. The exact rule's processing can be found in the updated Rules.md file which part of this PR. Fixes #5743 
4. The ServiceAttention rule now checks every label added. If ServiceAttention is already on the Issue and a service label is added it'll perform the rule's actions. Fixes #6480 
5. The rate limit API call now has retries. Because this is called at the start/end of processing, there is no backoff and the time in between attempts is 200ms, for a total wait time of 800ms over 5 attempts which is because we really can't afford a long delay when processing an Action. Fixes #6524 


As part of these updates, tests had to be added, or in the case of InitialIssueTriage, fully rewritten and new APIs had to be plumbed through the mock. The InitialIssueTriage can now assign someone to an issue which required new API calls. The first is the check to see if the owner has issue assignment permissions and, the second, is doing the assignment which requires the owner/repo name (part of the repository payload). This differs from other APIs that update Issues which only required the repository ID and is the reason for the GitHubIssueAssignment being added to the GitHubEventProcessor class. 

Because InitialIssueTriage will now add ServiceAttention and execute that rule, if certain conditions are met, the RuleEnabled API now has a silent mode. When checking whether not a rule is turned on, the output in the logs indicates that a rule is on and will run and anything until the next rule checkout output line is that rule running. In the case of ServiceAttention being run as part of InitialIssueTriage, it's only run if the rule is enabled for the repository. I didn't want the output going into the logs for the check done as part of the InitialIssueTriage because it's not explicitly running that rule and there's processing for the InitialIssueTriage that happens after that and anything in the output needs to be attributed to the rule that's actually running.

There were some refactors/overloads that had to be written since, ServiceAttention can be run from InitialIssueTriage which means that it's not getting the labels from the payload (a list of Octokit.Labels) but rather a list of string. Things had to handle both and the easiest way to do this was to boil everything down to the common denominator, a list of strings.


