### PR TITLE
Add CODEOWNERS linter yml file to eng/common/pipelines

### DIFF
--- a/.github/CODEOWNERS_baseline_errors.txt
+++ b/.github/CODEOWNERS_baseline_errors.txt
@@ -1,0 +1,1 @@
+MaryGao is not a public member of Azure.

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -29,7 +29,7 @@ stages:
       vmImage: ubuntu-22.04
 
     variables:
-      CodeownersLinterVersion: '1.0.0-dev.20231023.2'
+      CodeownersLinterVersion: '1.0.0-dev.20231107.2'
       DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
       RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
       TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -43,5 +43,5 @@ stages:
           custom: 'tool'
           arguments: 'install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"'
       - pwsh: |
-          codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)"
+          codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -fbl -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)"
         displayName: 'Lint CODEOWNERS and filter using baseline'

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -1,0 +1,47 @@
+# Lint the CODEOWNERS file for a given repository and filter out baseline errors
+# Note: Due to the nature of the verifications, which includes source paths/globs
+# for the repository, this pipeline cannot use sparse-checkout.
+trigger: none
+
+pr:
+  branches:
+    include:
+      - main
+      - feature/*
+      - hotfix/*
+      - release/*
+  paths:
+    include:
+      - .github/CODEOWNERS
+      - .github/CODEOWNERS_baseline_errors.txt
+      - eng/common/pipelines/codeowners-linter.yml
+
+stages:
+- stage: Run
+  variables:
+    skipComponentGovernanceDetection: true
+
+  jobs:
+  - job: Run
+    timeoutInMinutes: 120
+    pool:
+      name: azsdk-pool-mms-ubuntu-2204-general
+      vmImage: ubuntu-22.04
+
+    variables:
+      CodeownersLinterVersion: '1.0.0-dev.20231023.2'
+      DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
+      RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
+      TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"
+      UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
+
+    steps:
+      - task: DotNetCoreCLI@2
+        displayName: 'Install CodeownersLinter'
+        inputs:
+          command: custom
+          custom: 'tool'
+          arguments: 'install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"'
+      - pwsh: |
+          codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)"
+        displayName: 'Lint CODEOWNERS and filter using baseline'


### PR DESCRIPTION
**codeowners-linter.yml** is going to be the pipeline yml file that'll run the linter. This is a unique pipeline in that it's the only yml file in eng/common that is a fully contained pipeline instead of a template that's included in other pipelines. This needs to be in common because, like github-actions, it needs to set the version of the CodeownersLinter to install in a common place that gets pushed out to the other repositories. 
Because the trigger is set to none, this shouldn't get picked up by pipeline generation which is we want. Once this is pushed out to the other repositories I'll need to do the following:
1. Create their baseline files and get those checked in.
2. Create the pipeline for that repository. The pipeline will run daily and the triggers are setup to run when there are changes to the CODEOWNERS or baseline files as part of PRs. Since the linter requires data that's produced as part of the pipeline-owners-extractor run, the pipelines will be scheduled to run daily _after_ that pipeline runs (which is 4am PST).

CODEOWNERS_baseline_errors.txt - This is baseline of deduped existing errors. The pipeline uses the baseline file to filter out existing errors otherwise it would start out failing. The baseline file is effectively there to prevent further bleeding but wouldn't prevent the same error from being added again (the unfortunate side effect of having to dedupe since we can't actually rely on errors per line number for obvious reasons).