### PR TITLE
Fix Linter tool publish

### DIFF
--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter/Azure.Sdk.Tools.CodeownersLinter.csproj
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter/Azure.Sdk.Tools.CodeownersLinter.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
+    <PackAsTool>true</PackAsTool>
     <ToolCommandName>codeowners-linter</ToolCommandName>
   </PropertyGroup>
 


### PR DESCRIPTION
The CodeownersLinter project, part of the CodeownersUtils solution, didn't have PackAsTool set to true which means that it published the executable which wasn't all inclusive and lacked the CodeownersUtils library inclusion. Because of this, trying to install CodeownersLinter was failing because it couldn't find Azure.Sdk.Tools.CodeownersUtils which shouldn't be being published.