### PR TITLE
Add new property in CodeFile model to get package version from parser

### DIFF
--- a/src/dotnet/APIView/APIView/Model/CodeFile.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFile.cs
@@ -46,6 +46,8 @@ namespace ApiView
 
         public string PackageDisplayName { get; set; }
 
+        public string PackageVersion { get; set; }
+
         public CodeFileToken[] Tokens { get; set; } = Array.Empty<CodeFileToken>();
 
         public List<CodeFileToken[]> LeafSections { get; set; }

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -864,6 +864,7 @@ namespace APIViewWeb.Managers
             file.VersionString = codeFile.VersionString;
             file.Name = codeFile.Name;
             file.PackageName = codeFile.PackageName;
+            file.PackageVersion = codeFile.PackageVersion;
         }
 
         private LanguageService GetLanguageService(string language)

--- a/src/dotnet/APIView/APIViewWeb/Models/ReviewCodeFileModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/ReviewCodeFileModel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System;
@@ -36,5 +36,6 @@ namespace APIViewWeb
 
         // This field stores original file name uploaded to create review
         public string FileName { get; set; }
+        public string PackageVersion { get; set; }
     }
 }


### PR DESCRIPTION
Parser needs a property in CodeFile to send package version to APIView so each revision can be tagged with a package version.