### PR TITLE
Use sparse-checkout to do a faster, shallow clone

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -36,6 +36,14 @@ stages:
       UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
 
     steps:
+      # Skip sparse checkout for the `azure-sdk-for-<lang>-pr` private mirrored repositories
+      # as we require the github service connection to be loaded.
+      - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
+        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+          parameters:
+            Paths:
+              - '/*'
+
       - task: DotNetCoreCLI@2
         displayName: 'Install CodeownersLinter'
         inputs:


### PR DESCRIPTION
@benbp and I chatted briefly after standup. The linter needs the full repository but not the full history. azure-sdk-for-net's clone was taking 4 1/2-6 minutes because it was grabbing the history which we don't need. Flipping over to a shallow clone dropped the clone time down to 1m 1s. I'd grabbed the build definition check directly from net's [ci.tests.yml ](https://github.com/Azure/azure-sdk-for-net/blob/main/eng/pipelines/templates/jobs/ci.tests.yml#L43) since that could eventually be a gotcha.