### PR TITLE
Fix typos in ps1 scripts

### DIFF
--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -8,7 +8,7 @@ $CHANGELOG_UNRELEASED_STATUS = "(Unreleased)"
 $CHANGELOG_DATE_FORMAT = "yyyy-MM-dd"
 $RecommendedSectionHeaders = @("Features Added", "Breaking Changes", "Bugs Fixed", "Other Changes")
 
-# Returns a Collection of changeLogEntry object containing changelog info for all version present in the gived CHANGELOG
+# Returns a Collection of changeLogEntry object containing changelog info for all versions present in the gived CHANGELOG
 function Get-ChangeLogEntries {
   param (
     [Parameter(Mandatory = $true)]
@@ -109,7 +109,7 @@ function Get-ChangeLogEntry {
   return $null
 }
 
-#Returns the changelog for a particular version as string
+#Returns the changelog for a particular version as a string
 function Get-ChangeLogEntryAsString {
   param (
     [Parameter(Mandatory = $true)]
@@ -175,7 +175,7 @@ function Confirm-ChangeLogEntry {
   $status = $changeLogEntry.ReleaseStatus.Trim().Trim("()")
   if ($status -as [DateTime])
   {
-    LogDebug "Verifying like it's a release build because the changelog entry has a valid date."
+    LogDebug "Verifying as a release build because the changelog entry has a valid date."
     return Confirm-ChangeLogForRelease -changeLogEntry $changeLogEntry -changeLogEntries $changeLogEntries
   }
 

--- a/eng/common/scripts/Invoke-DevOpsAPI.ps1
+++ b/eng/common/scripts/Invoke-DevOpsAPI.ps1
@@ -85,7 +85,7 @@ function Get-DevOpsBuilds {
   param (
     $Organization="azure-sdk",
     $Project="internal",
-    $BranchName, #Should start with 'refs/heads/'
+    $BranchName, # Should start with 'refs/heads/'
     $Definitions, # Comma seperated string of definition IDs
     $StatusFilter, # Comma seperated string 'cancelling, completed, inProgress, notStarted'
     [ValidateNotNullOrEmpty()]

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -77,7 +77,7 @@ class PackageProps
 }
 
 # Takes package name and service Name
-# Returns important properties of the package as related to the language repo
+# Returns important properties of the package relative to the language repo
 # Returns a PS Object with properties @ { pkgName, pkgVersion, pkgDirectoryPath, pkgReadMePath, pkgChangeLogPath }
 # Note: python is required for parsing python package properties.
 function Get-PkgProperties
@@ -107,7 +107,7 @@ function Get-PkgProperties
 
 # Takes ServiceName and Repo Root Directory
 # Returns important properties for each package in the specified service, or entire repo if the serviceName is not specified
-# Returns an Table of service key to array values of PS Object with properties @ { pkgName, pkgVersion, pkgDirectoryPath, pkgReadMePath, pkgChangeLogPath }
+# Returns a Table of service key to array values of PS Object with properties @ { pkgName, pkgVersion, pkgDirectoryPath, pkgReadMePath, pkgChangeLogPath }
 function Get-AllPkgProperties ([string]$ServiceDirectory = $null)
 {
     $pkgPropsResult = @()
@@ -135,7 +135,7 @@ function Get-AllPkgProperties ([string]$ServiceDirectory = $null)
 }
 
 # Given the metadata url under https://github.com/Azure/azure-sdk/tree/main/_data/releases/latest,
-# the function will return the csv metadata back as part of response.
+# the function will return the csv metadata back as part of the response.
 function Get-CSVMetadata ([string]$MetadataUri=$MetadataUri)
 {
     $metadataResponse = Invoke-RestMethod -Uri $MetadataUri -method "GET" -MaximumRetryCount 3 -RetryIntervalSec 10 | ConvertFrom-Csv
@@ -144,7 +144,7 @@ function Get-CSVMetadata ([string]$MetadataUri=$MetadataUri)
 
 function Get-PkgPropsForEntireService ($serviceDirectoryPath)
 {
-    $projectProps = @() # Properties from very project inthe service
+    $projectProps = @() # Properties from every project in the service
     $serviceDirectory = $serviceDirectoryPath -replace '^.*[\\/]+sdk[\\/]+([^\\/]+).*$', '$1'
 
     if (!$GetPackageInfoFromRepoFn -or !(Test-Path "Function:$GetPackageInfoFromRepoFn"))

--- a/eng/common/scripts/Update-ChangeLog.ps1
+++ b/eng/common/scripts/Update-ChangeLog.ps1
@@ -75,7 +75,7 @@ if ($ChangeLogEntries.Contains($Version))
 {
     if ($ChangeLogEntries[$Version].ReleaseStatus -eq $ReleaseStatus)
     {
-        LogDebug "Version [$Version] is already present in change log with specificed ReleaseStatus [$ReleaseStatus]. No Change made."
+        LogDebug "Version [$Version] is already present in change log with specified ReleaseStatus [$ReleaseStatus]. No Change made."
         exit(0)
     }
 
@@ -102,7 +102,7 @@ LogDebug "The latest release note entry in the changelog is for version [$($Late
 
 $LatestsSorted = [AzureEngSemanticVersion]::SortVersionStrings(@($LatestVersion, $Version))
 if ($LatestsSorted[0] -ne $Version) {
-    LogWarning "Version [$Version] is older than the latestversion [$LatestVersion] in the changelog. Consider using a more recent version."
+    LogWarning "Version [$Version] is older than the latest version [$LatestVersion] in the changelog. Consider using a more recent version."
 }
 
 if ($ReplaceLatestEntryTitle)

--- a/eng/common/scripts/artifact-metadata-parsing.ps1
+++ b/eng/common/scripts/artifact-metadata-parsing.ps1
@@ -2,7 +2,7 @@
 
 $SDIST_PACKAGE_REGEX = "^(?<package>.*)\-(?<versionstring>$([AzureEngSemanticVersion]::SEMVER_REGEX))"
 
-# Posts a github release for each item of the pkgList variable. SilentlyContinue
+# Posts a github release for each item of the pkgList variable. Silently continue
 function CreateReleases($pkgList, $releaseApiUrl, $releaseSha) {
   foreach ($pkgInfo in $pkgList) {
     Write-Host "Creating release $($pkgInfo.Tag)"
@@ -11,7 +11,7 @@ function CreateReleases($pkgList, $releaseApiUrl, $releaseSha) {
     if ($pkgInfo.ReleaseNotes -ne $null) {
       $releaseNotes = $pkgInfo.ReleaseNotes
     }
-    # As github api limit the body param length with 125000 characters, we have to truncate the release note if needed.
+    # As github api limits the body param length to 125000 characters, we have to truncate the release note if needed.
     if ($releaseNotes.Length -gt 124996) {
       $releaseNotes = $releaseNotes.SubString(0, 124996) + " ..."
     }
@@ -170,7 +170,7 @@ function VerifyPackages($artifactLocation, $workingDirectory, $apiUrl, $releaseS
   return $results
 }
 
-# given a set of tags that we want to release, we need to ensure that if they already DO exist.
+# given a set of tags that we want to release, we need to ensure they DO already exist.
 # if they DO exist, quietly exit if the commit sha of the artifact matches that of the tag
 # if the commit sha does not match, exit with error and report both problem shas
 function CheckArtifactShaAgainstTagsList($priorExistingTagList, $releaseSha, $apiUrl, $continueOnError) {

--- a/eng/common/scripts/git-branch-push.ps1
+++ b/eng/common/scripts/git-branch-push.ps1
@@ -66,7 +66,7 @@ else
     exit $LASTEXITCODE
   }
 }
-# Checkout to $PRBranch, create new one if not exists.
+# Checkout to $PRBranch, create new one if it does not exist.
 git show-ref --verify --quiet refs/heads/$PRBranchName
 if ($LASTEXITCODE -eq 0) {
   Write-Host "git checkout $PRBranchName."


### PR DESCRIPTION
During Hacktober, @LukaszKokot discovered these typos is some scripts checked into `azure/azure-dev`.  He raised a PR against us to fix, them but they should actually be fixed here, since they are part of the common engineering system.

I offered to move his patch over here on his behalf (since we dropped the ball a little on getting back to him).

This change brings over what was in https://github.com/Azure/azure-dev/pull/2881, to here, which is where these file ultimately live.