### PR TITLE
Update GitHubEventProcessor to 1.0.0-dev.20231114.3

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -55,7 +55,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20231010.2
+          --version 1.0.0-dev.20231114.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -34,7 +34,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20231010.2
+          --version 1.0.0-dev.20231114.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash


### PR DESCRIPTION
Update the version of GitHubEventProcessor so it uses the new CodeownersUtils to parse CODEOWNERS files. This is an interim change before updating the new InitialIssueTriage rule which requires metadata that isn't in the CODEOWNERS files yet.