### PR TITLE
Allow tsp-client to be run in non-interactive sessions

### DIFF
--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@azure/core-rest-pipeline": "^1.12.0",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "scripts": {

--- a/tools/tsp-client/src/options.ts
+++ b/tools/tsp-client/src/options.ts
@@ -1,6 +1,7 @@
 import { parseArgs } from "node:util";
 import { Logger, printUsage, printVersion } from "./log.js";
 import * as path from "node:path";
+import process from  "node:process";
 import { doesFileExist } from "./network.js";
 import PromptSync from "prompt-sync";
 
@@ -109,10 +110,16 @@ export async function getOptions(): Promise<Options> {
   }
   outputDir = path.resolve(path.normalize(outputDir));
 
-  // Ask user is this is the correct output directory
-  const prompt = PromptSync();
-  let useOutputDir = prompt("Use output directory '" + outputDir + "'? (y/n) ", "y");
-
+  let useOutputDir;
+  if (process.stdin.isTTY) {
+    // Ask user is this is the correct output directory
+    const prompt = PromptSync();
+    useOutputDir = prompt("Use output directory '" + outputDir + "'? (y/n) ", "y");
+  } else {
+    // There is no user to ask, so assume yes
+    useOutputDir = 'y';
+  }
+  
   if (useOutputDir.toLowerCase() === "n") {
     const newOutputDir = prompt("Enter output directory: ");
     if (!newOutputDir) {


### PR DESCRIPTION
tsp-client prompts the user for output directory confirmation.  In noninteractive sessions like CI builds, this causes an error like `ENXIO: no such device or address, open '/dev/tty'`.  This change only prompts for confirmation if the stdin stream is connected to a TTY context (has a user with a keyboard that can answer the prompt).