### PR TITLE
Add newly created aka.ms link for guidance on dealing with linter errors

### DIFF
--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter/Program.cs
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter/Program.cs
@@ -14,6 +14,7 @@ namespace Azure.Sdk.Tools.CodeownersLinter
 {
     internal class Program
     {
+        const string linterErrorsHelpLink = "https://aka.ms/azsdk/codeownersLinterErrors";
         static void Main(string[] args)
         {
             Stopwatch stopWatch = new Stopwatch();
@@ -224,6 +225,8 @@ namespace Azure.Sdk.Tools.CodeownersLinter
                 {
                     Console.WriteLine(error + Environment.NewLine);
                 }
+
+                Console.WriteLine($"There were linter errors. Please visit {linterErrorsHelpLink} for guidance on how to handle them.");
             }
             return returnCode;
         }

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter/Program.cs
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter/Program.cs
@@ -205,8 +205,15 @@ namespace Azure.Sdk.Tools.CodeownersLinter
                 // above and doesn't need to be reported here.
                 if (codeownersBaselineFileExists)
                 {
-                    BaselineUtils baselineUtils = new BaselineUtils(codeownersBaselineFile);
-                    errors = baselineUtils.FilterErrorsUsingBaseline(errors);
+                    if (errors.Count == 0)
+                    {
+                        Console.WriteLine($"##vso[task.LogIssue type=warning;]There were no CODEOWNERS parsing errors but there is a baseline file {codeownersBaselineFile} for filtering. If the file is empty, or all errors have been fixed, then it should be deleted.");
+                    }
+                    else
+                    {
+                        BaselineUtils baselineUtils = new BaselineUtils(codeownersBaselineFile);
+                        errors = baselineUtils.FilterErrorsUsingBaseline(errors);
+                    }
                 }
             }
 


### PR DESCRIPTION
When the linter runs and encounters errors, after the errors are output, add one additional line which contains the aka.ms link on how to handle them. The exact line is:
`There were linter errors. Please visit https://aka.ms/azsdk/codeownersLinterErrors for guidance on how to handle them.`

There was one more piece I added. If there's a baseline file for the repository and no linter errors, it'll print a warning. If CODEOWNERS has been cleaned up to the point where there's no linting errors then there shouldn't be a baseline file.