### PR TITLE
Update CodeownersLinter to 1.0.0-dev.20231120.3

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -30,7 +30,7 @@ stages:
       vmImage: ubuntu-22.04
 
     variables:
-      CodeownersLinterVersion: '1.0.0-dev.20231107.2'
+      CodeownersLinterVersion: '1.0.0-dev.20231120.3'
       DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
       RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
       TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"


### PR DESCRIPTION
The CodeownersLinter had two minor updates:
1. Added an AKA link into the output, when there's errors, that links to the [Linter errors and how to deal with them](https://github.com/Azure/azure-sdk-tools/blob/main/tools/codeowners-utils/README.md#linter-errors-and-how-to-deal-with-them) section of the tool's README doc.
2. If there's a CODEOWNERS baseline file, but no linting errors, it'll output a warning indicating that if the errors have been fixed that the file should be deleted.