### PR TITLE
Disable symbol publishing for tool

### DIFF
--- a/tools/secret-management/ci.yml
+++ b/tools/secret-management/ci.yml
@@ -27,3 +27,5 @@ extends:
     ToolDirectory: tools/secret-management
     # Sodium.Core dependency is not strong name signed. Skip validation in order to sign secret cli.
     RequireStrongNames: false
+    # This tool contains native binaries that cause sybmol publishing to fail so disable the symbols for this tool package
+    ShouldPublishSymbols: false


### PR DESCRIPTION
This tool contains native binaries that cause symbol publishing to fail so disable the symbols for this tool package

I've tried to update the symbol publishing tool but it doesn't like the native 3rd party *.so files and the symbols for our internal tools aren't that interesting so just disabling the publishing for this tool.