### PR TITLE
Swagger API review parser changes to add package version in code file

### DIFF
--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/CHANGELOG
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/CHANGELOG
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.2.0 (11-29-2023)
++ Added API version as PackageVersion in code file.
+
 ## 1.1.0 (6-26-2023)
 + Disabled flatteneing of nested model.
 + Updated definitions to include models all referenced models

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerAPIViewGenerator.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerAPIViewGenerator.cs
@@ -32,7 +32,8 @@ namespace SwaggerApiParser
                     swaggerFilePath = swaggerFilePath
                 },
                 fileName = Path.GetFileName(swaggerFilePath),
-                packageName = packageName
+                packageName = packageName,
+                APIVersion = swaggerSpec.info.version
             };
 
             AddDefinitionsToCache(swaggerSpec, swaggerFilePath, schemaCache);

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiParser.csproj
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiParser.csproj
@@ -6,7 +6,7 @@
     <ToolCommandName>swaggerAPIParser</ToolCommandName>
     <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>SwaggerApiParser</RootNamespace>
-    <VersionPrefix>1.1.0</VersionPrefix>
+    <VersionPrefix>1.2.0</VersionPrefix>
     <AssemblyName>Azure.Sdk.Tools.SwaggerApiParser</AssemblyName>
     <SignAssembly>True</SignAssembly>
     <InformationalVersion>$(OfficialBuildId)</InformationalVersion>

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiView/CodeFile.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiView/CodeFile.cs
@@ -28,6 +28,8 @@ namespace SwaggerApiParser.SwaggerApiView
 
         public string PackageDisplayName { get; set; }
 
+        public string PackageVersion { get; set; }
+
         public CodeFileToken[] Tokens { get; set; } = Array.Empty<CodeFileToken>();
 
         public List<CodeFileToken[]> LeafSections { get; set; }

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiView/SwaggerApiViewRoot.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiView/SwaggerApiViewRoot.cs
@@ -13,6 +13,7 @@ namespace SwaggerApiParser.SwaggerApiView
         public String PackageName;
         public Dictionary<String, SwaggerApiViewSpec> SwaggerApiViewSpecs;
         public SchemaCache schemaCache;
+        public String APIVersion;
 
         public SwaggerApiViewRoot(string resourceProvider, string packageName)
         {
@@ -29,6 +30,7 @@ namespace SwaggerApiParser.SwaggerApiView
             if (swaggerApiViewSpec != null)
             {
                 this.SwaggerApiViewSpecs.Add(swaggerFilePath, swaggerApiViewSpec);
+                APIVersion = swaggerApiViewSpec.APIVersion;
             }
         }
 
@@ -47,6 +49,7 @@ namespace SwaggerApiParser.SwaggerApiView
                 VersionString = "0",
                 Name = this.ResourceProvider,
                 PackageName = this.PackageName,
+                PackageVersion = this.APIVersion,
                 Navigation = this.BuildNavigationItems()
             };
 

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiView/SwaggerApiViewSpec.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiView/SwaggerApiViewSpec.cs
@@ -17,6 +17,7 @@ namespace SwaggerApiParser.SwaggerApiView
 
         public string fileName;
         public string packageName;
+        public string APIVersion;
 
 
         public SwaggerApiViewSpec()
@@ -100,6 +101,7 @@ namespace SwaggerApiParser.SwaggerApiView
                 VersionString = "0",
                 Name = this.fileName,
                 PackageName = this.packageName,
+                PackageVersion = this.APIVersion,
                 Navigation = new NavigationItem[] { this.BuildNavigationItem() }
             };
             return ret;

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParserTest/SwaggerAPIViewTest.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParserTest/SwaggerAPIViewTest.cs
@@ -278,4 +278,17 @@ public class SwaggerApiViewTest
         await codeFile.SerializeAsync(writer);
         
     }
+
+    [Fact]
+    public async Task TestCodeFilePackageVersion()
+    {
+        const string runCommandFilePath = "./fixtures/runCommands.json";
+        var swaggerSpec = await SwaggerDeserializer.Deserialize(runCommandFilePath);
+
+        SwaggerApiViewRoot root = new SwaggerApiViewRoot("Microsoft.Compute", "Microsoft.Compute");
+        await root.AddSwaggerSpec(swaggerSpec, Path.GetFullPath(runCommandFilePath), "Microsoft.Compute");
+
+        var codeFile = root.GenerateCodeFile();
+        Assert.Equal("2021-11-01", codeFile.PackageVersion);
+    }
 }


### PR DESCRIPTION
Changes to include API-version in API review code file for Swagger API review. Package version is consumed by API review to generate revision label.