### PR TITLE
Remove default value for pipeline picklist params

### DIFF
--- a/eng/pipelines/devops-create-package-workitem.yml
+++ b/eng/pipelines/devops-create-package-workitem.yml
@@ -58,13 +58,13 @@ steps:
     pwsh: true
     filePath: $(Build.SourcesDirectory)/eng/common/scripts/Update-DevOps-Release-WorkItem.ps1
     arguments: >
-      -language "${{parameters.Language}}"
-      -serviceName "${{parameters.ServiceName}}"
-      -packageDisplayName "${{parameters.PackageDisplayName}}"
-      -packageType "${{parameters.PackageType}}"
-      -packageName "${{parameters.PackageName}}"
-      -version "${{parameters.PackageVersion}}"
-      -plannedDate "${{parameters.ReleaseDate}}"
-      -relatedWorkItemId ${{parameters.RelatedWorkItemId}}
-      -tag "${{parameters.Tag}}"
+      -language "${{ parameters.Language }}"
+      -serviceName "${{ parameters.ServiceName }}"
+      -packageDisplayName "${{ parameters.PackageDisplayName }}"
+      -packageType "${{ parameters.PackageType }}"
+      -packageName "${{ parameters.PackageName }}"
+      -version "${{ parameters.PackageVersion }}"
+      -plannedDate "${{ parameters.ReleaseDate }}"
+      -relatedWorkItemId "${{ parameters.RelatedWorkItemId }}"
+      -tag "${{ parameters.Tag }}"
       -devops_pat "$(azuresdk-azure-sdk-devops-release-work-item-pat)"

--- a/eng/pipelines/devops-create-package-workitem.yml
+++ b/eng/pipelines/devops-create-package-workitem.yml
@@ -5,7 +5,6 @@ pool:
 parameters:
 - name: Language
   type: string
-  default: ''
   values:
   - .NET
   - Java
@@ -24,7 +23,6 @@ parameters:
   default: ''
 - name: PackageType
   type: string
-  default: ''
   values:
   - Client
   - mgmt

--- a/eng/pipelines/devops-create-package-workitem.yml
+++ b/eng/pipelines/devops-create-package-workitem.yml
@@ -5,6 +5,7 @@ pool:
 parameters:
 - name: Language
   type: string
+  default: '.NET'
   values:
   - .NET
   - Java
@@ -23,6 +24,7 @@ parameters:
   default: ''
 - name: PackageType
   type: string
+  default: 'Client'
   values:
   - Client
   - mgmt

--- a/eng/pipelines/devops-create-package-workitem.yml
+++ b/eng/pipelines/devops-create-package-workitem.yml
@@ -58,13 +58,13 @@ steps:
     pwsh: true
     filePath: $(Build.SourcesDirectory)/eng/common/scripts/Update-DevOps-Release-WorkItem.ps1
     arguments: >
-      -language "${{ parameters.Language }}"
-      -serviceName "${{ parameters.ServiceName }}"
-      -packageDisplayName "${{ parameters.PackageDisplayName }}"
-      -packageType "${{ parameters.PackageType }}"
-      -packageName "${{ parameters.PackageName }}"
-      -version "${{ parameters.PackageVersion }}"
-      -plannedDate "${{ parameters.ReleaseDate }}"
-      -relatedWorkItemId "${{ parameters.RelatedWorkItemId }}"
-      -tag "${{ parameters.Tag }}"
+      -language "$(Language)"
+      -serviceName "$(ServiceName)"
+      -packageDisplayName "$(PackageDisplayName)"
+      -packageType "$(PackageType)"
+      -packageName "$(PackageName)"
+      -version "$(PackageVersion)"
+      -plannedDate "$(ReleaseDate)"
+      -relatedWorkItemId "$(RelatedWorkItemId)"
+      -tag "$(Tag)"
       -devops_pat "$(azuresdk-azure-sdk-devops-release-work-item-pat)"


### PR DESCRIPTION
Update pipeline parameters so it can be triggered from powerapps. Pipeline cannot be executed from powerapps without setting a default value from one of the options. Also, parameter values supplied to DevOps request is processed as run time variables, not parameters.