### PR TITLE
Lets not treat https code 401 as broken link

### DIFF
--- a/eng/common/scripts/Verify-Links.ps1
+++ b/eng/common/scripts/Verify-Links.ps1
@@ -25,7 +25,7 @@
   Path to the root of the site for resolving rooted relative links, defaults to host root for http and file directory for local files.
 
   .PARAMETER errorStatusCodes
-  List of http status codes that count as broken links. Defaults to 400, 401, 404, SocketError.HostNotFound = 11001, SocketError.NoData = 11004.
+  List of http status codes that count as broken links. Defaults to 400, 404, SocketError.HostNotFound = 11001, SocketError.NoData = 11004.
 
   .PARAMETER branchReplaceRegex
   Regex to check if the link needs to be replaced. E.g. ^(https://github.com/.*/(?:blob|tree)/)main(/.*)$
@@ -65,7 +65,7 @@ param (
   [switch] $recursive = $true,
   [string] $baseUrl = "",
   [string] $rootUrl = "",
-  [array] $errorStatusCodes = @(400, 401, 404, 11001, 11004),
+  [array] $errorStatusCodes = @(400, 404, 11001, 11004),
   [string] $branchReplaceRegex = "",
   [string] $branchReplacementName = "",
   [bool] $checkLinkGuidance = $false,


### PR DESCRIPTION
Http Status code 401 just means unauthorized and not necessarily that the link isn't valid. Removing this from the list of codes to error from.