### PR TITLE
Resolve APIView Issues Identified during Manual Testing

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
@@ -1,0 +1,89 @@
+using APIViewWeb;
+using Xunit;
+using APIViewWeb.Repositories;
+using Moq;
+using System.IO;
+using APIViewWeb.Managers.Interfaces;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.SignalR;
+using APIViewWeb.Hubs;
+using System.Collections;
+using System.Collections.Generic;
+using APIViewWeb.Managers;
+using System;
+using System.Threading.Tasks;
+using APIViewWeb.LeanModels;
+
+namespace APIViewUnitTests
+{
+    public class APIRevisionsManagerTests
+    {
+        private readonly IAPIRevisionsManager _apiRevisionsManager;
+
+        public APIRevisionsManagerTests()
+        {
+            IAuthorizationService authorizationService = new Mock<IAuthorizationService>().Object;
+            ICosmosReviewRepository cosmosReviewRepository = new Mock<ICosmosReviewRepository>().Object;
+            ICosmosAPIRevisionsRepository cosmosAPIRevisionsRepository = new Mock<ICosmosAPIRevisionsRepository>().Object;
+            IHubContext<SignalRHub> signalRHub = new Mock<IHubContext<SignalRHub>>().Object;
+            IEnumerable<LanguageService> languageServices = new List<LanguageService>();
+            IDevopsArtifactRepository devopsArtifactRepository = new Mock<IDevopsArtifactRepository>().Object;
+            ICodeFileManager codeFileManager = new Mock<ICodeFileManager>().Object;
+            IBlobCodeFileRepository blobCodeFileRepository = new Mock<IBlobCodeFileRepository>().Object;
+            IBlobOriginalsRepository blobOriginalRepository = new Mock<IBlobOriginalsRepository>().Object;
+            INotificationManager notificationManager = new Mock<INotificationManager>().Object;
+            
+            _apiRevisionsManager = new APIRevisionsManager(
+                authorizationService: authorizationService, reviewsRepository: cosmosReviewRepository,
+                apiRevisionsRepository: cosmosAPIRevisionsRepository, signalRHubContext: signalRHub,
+                languageServices: languageServices, devopsArtifactRepository: devopsArtifactRepository,
+                codeFileManager: codeFileManager, codeFileRepository: blobCodeFileRepository,
+                originalsRepository: blobOriginalRepository, notificationManager: notificationManager);    
+        }
+
+        // GetLatestAPIRevisionsAsync
+
+        [Fact]
+        public async Task GetLatestAPIRevisionsAsyncThrowsExceptionWhenReviewIdAndAPIRevisionsAreAbsent()
+        {
+            await Assert.ThrowsAsync<ArgumentException>(async () => await _apiRevisionsManager.GetLatestAPIRevisionsAsync(null, null));
+        }
+
+        [Fact]
+        public async Task GetLatestAPIRevisionsAsyncReturnsDefaultIfNoLatestAPIRevisionIsFound()
+        {
+            var latest = await _apiRevisionsManager.GetLatestAPIRevisionsAsync(apiRevisions: new List<APIRevisionListItemModel>());
+            Assert.Equal(default(APIRevisionListItemModel), latest);
+        }
+
+        [Fact]
+        public async Task GetLatestAPIRevisionsAsyncReturnsCorrectLatestWithAllTypesPresent()
+        {
+            var apiRevisions = new List<APIRevisionListItemModel>()
+            {
+                new APIRevisionListItemModel() { Id ="A", APIRevisionType = APIRevisionType.Manual, CreatedOn = DateTime.Now.AddMinutes(5) },
+                new APIRevisionListItemModel() { Id ="B", APIRevisionType = APIRevisionType.Automatic, CreatedOn = DateTime.Now.AddMinutes(10) },
+                new APIRevisionListItemModel() { Id ="C", APIRevisionType = APIRevisionType.PullRequest, CreatedOn = DateTime.Now.AddMinutes(15) },
+            };
+            var latest = await _apiRevisionsManager.GetLatestAPIRevisionsAsync(apiRevisions: apiRevisions);
+            Assert.Equal("C", latest.Id);
+
+            var latestAutomatic = await _apiRevisionsManager.GetLatestAPIRevisionsAsync(apiRevisions: apiRevisions, apiRevisionType: APIRevisionType.Automatic);
+            Assert.Equal("B", latestAutomatic.Id);
+        }
+
+        [Fact]
+        public async Task GetLatestAPIRevisionsAsyncReturnsCorrectLatestWhenSpecifiedTypeIsAbsent()
+        {
+            var apiRevisions = new List<APIRevisionListItemModel>()
+            {
+                new APIRevisionListItemModel() { Id ="A", APIRevisionType = APIRevisionType.Manual, CreatedOn = DateTime.Now.AddMinutes(5) },
+                new APIRevisionListItemModel() { Id ="B", APIRevisionType = APIRevisionType.Automatic, CreatedOn = DateTime.Now.AddMinutes(10) },
+            };
+
+            var latest = await _apiRevisionsManager.GetLatestAPIRevisionsAsync(apiRevisions: apiRevisions, apiRevisionType: APIRevisionType.PullRequest);
+            Assert.Equal("B", latest.Id);
+        }
+
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
@@ -82,7 +82,7 @@ namespace APIViewWeb.Controllers
                 APIRevisionListItemModel latestAutomaticApiRevisions = await _apiRevisionsManager.GetLatestAPIRevisionsAsync(reviewId: review.Id, apiRevisionType: APIRevisionType.Automatic);
                 
                 // Return 200 OK for approved review and 201 for review in pending status
-                if (firstReleaseStatusOnly != true && latestAutomaticApiRevisions.IsApproved)
+                if (firstReleaseStatusOnly != true && latestAutomaticApiRevisions != null && latestAutomaticApiRevisions.IsApproved)
                 {
                     return Ok();
                 }

--- a/src/dotnet/APIView/APIViewWeb/Controllers/ReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/ReviewController.cs
@@ -48,11 +48,14 @@ namespace APIViewWeb.Controllers
         {
             var review = await _reviewManager.GetReviewAsync(User, reviewId);
             var latestAPIRevision = await _apiRevisionManager.GetLatestAPIRevisionsAsync(reviewId: review.Id);
+            var apiRevison = latestAPIRevision;
 
-            if (string.IsNullOrEmpty(revisionId))
-                revisionId = latestAPIRevision.Id;
+            if (!string.IsNullOrEmpty(revisionId))
+            {
+                apiRevison = await _apiRevisionManager.GetAPIRevisionAsync(user: User, apiRevisionId: revisionId);
+            }
 
-            var isLatestAPIRevision = (revisionId == latestAPIRevision.Id);
+            var isLatestAPIRevision = (apiRevison.Id == latestAPIRevision.Id);
 
             await SendAIReviewGenerationStatus(review, reviewId, revisionId, AIReviewGenerationStatus.Generating, isLatestAPIRevision);
 

--- a/src/dotnet/APIView/APIViewWeb/Helpers/PageModelHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/PageModelHelpers.cs
@@ -250,12 +250,12 @@ namespace APIViewWeb.Helpers
 
             var apiRevisions = await reviewRevisionsManager.GetAPIRevisionsAsync(reviewId);
 
-            // Try getting latest Automatic Revision
+            // Try getting latest Automatic Revision, otherwise get latest of any type or default
             var activeRevision = await reviewRevisionsManager.GetLatestAPIRevisionsAsync(reviewId, apiRevisions, APIRevisionType.Automatic);
             if (activeRevision == null)
             {
-                // Get latest of any type
-                activeRevision = await reviewRevisionsManager.GetLatestAPIRevisionsAsync(reviewId, apiRevisions);
+                var notifcation = new NotificationModel() { Message = $"This review has no valid apiRevisons", Level = NotificatonLevel.Warning };
+                await signalRHubContext.Clients.Group(userId).SendAsync("RecieveNotification", notifcation);
             }
 
             APIRevisionListItemModel diffRevision = null;
@@ -381,7 +381,7 @@ namespace APIViewWeb.Helpers
         /// <param name="sectionKeyA"></param>
         /// <param name="sectionKeyB"></param>
         /// <returns></returns>
-        public static async Task<CodeLineModel[]> GetCodeLineSection(ClaimsPrincipal user, IReviewManager reviewManager,
+        public static async Task<CodeLineModel[]> GetCodeLineSectionAsync(ClaimsPrincipal user, IReviewManager reviewManager,
             IAPIRevisionsManager apiRevisionsManager, ICommentsManager commentManager,
             IBlobCodeFileRepository codeFileRepository, string reviewId, int sectionKey, string revisionId = null,
             string diffRevisionId = null, int diffContextSize = 3, string diffContextSeperator = "<br><span>.....</span><br>",

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -17,7 +17,7 @@ namespace APIViewWeb.Managers.Interfaces
         public Task<PagedList<APIRevisionListItemModel>> GetAPIRevisionsAsync(PageParams pageParams, APIRevisionsFilterAndSortParams filterAndSortParams);
         public Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAsync(string reviewId);
         public Task<APIRevisionListItemModel> GetLatestAPIRevisionsAsync(string reviewId = null, IEnumerable<APIRevisionListItemModel> apiRevisions = null, APIRevisionType apiRevisionType = APIRevisionType.All);
-        public Task<APIRevisionListItemModel> GetAPIRevisionAsync(ClaimsPrincipal user, string revisionId);
+        public Task<APIRevisionListItemModel> GetAPIRevisionAsync(ClaimsPrincipal user, string apiRevisionId);
         public APIRevisionListItemModel GetNewAPIRevisionAsync(APIRevisionType apiRevisionType, string reviewId = null, string packageName = null, string language = null,
             string label = null, int? prNumber = null, string createdBy = "azure-sdk");
         public Task<bool> ToggleAPIRevisionApprovalAsync(ClaimsPrincipal user, string id, string revisionId = null, APIRevisionListItemModel apiRevision = null, string notes = "");

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml
@@ -52,12 +52,15 @@
                 <partial name="_SelectPickerPartial" model="Model.ReviewsProperties.State" />
             </select>
         </div>
+        @*
+        Disabling Approval since it has no benefit to users at this point
         <div class="input-group input-group-sm mb-2">
             <span class="input-group-text">Status</span>
             <select multiple id="status-filter-select" aria-label="Status Filter">
                 <partial name="_SelectPickerPartial" model="Model.ReviewsProperties.Status" />
             </select>
         </div>
+        *@
  
         <button type="button" class="btn btn-outline-primary btn-sm mt-2" id="reset-filter-button"><i class="fa-solid fa-xmark"></i>&nbsp;&nbsp;Reset Filters</button>
         <hr class="border">

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml.cs
@@ -25,7 +25,7 @@ namespace APIViewWeb.Pages.Assemblies
         public readonly UserPreferenceCache _preferenceCache;
         public readonly IUserProfileManager _userProfileManager;
         public const int _defaultPageSize = 50;
-        public const string _defaultSortField = "LastUpdated";
+        public const string _defaultSortField = "LastUpdatedOn";
 
         public IndexPageModel(IReviewManager reviewManager, IUserProfileManager userProfileManager, UserPreferenceCache preferenceCache, IHubContext<SignalRHub> notificationHub)
         {

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -46,7 +46,8 @@
                         {
                             @if (Model.ReviewContent.ActiveConversationsInActiveAPIRevision > 0 
                                 && Model.ReviewContent.ActiveConversationsInSampleRevisions > 0
-                                && Model.ReviewContent.PreferredApprovers.Contains(User.GetGitHubLogin()))
+                                && Model.ReviewContent.PreferredApprovers.Contains(User.GetGitHubLogin())
+                                && Model.ReviewContent.ActiveAPIRevision.CreatedOn > Model.ReviewContent.DiffAPIRevision.CreatedOn)
                             {
                                 <span class="small text-muted">Approves the current revision of the API</span>
                                 <div class="d-grid gap-2">
@@ -57,7 +58,8 @@
                             }
                             else
                             {
-                                @if (Model.ReviewContent.PreferredApprovers.Contains(User.GetGitHubLogin()))
+                                @if (Model.ReviewContent.PreferredApprovers.Contains(User.GetGitHubLogin())
+                                    && Model.ReviewContent.ActiveAPIRevision.CreatedOn > Model.ReviewContent.DiffAPIRevision.CreatedOn)
                                 {
                                     <span class="small text-muted">Approves the current revision of the API</span>
                                     <div class="d-grid gap-2">
@@ -534,7 +536,7 @@
                     </select>
                     <select id="diff-select" aria-label="Diff Select">
                         @{
-                            var diffRevisionsToSelectFrom = Model.ReviewContent.APIRevisionsGrouped[diffRevisionType];
+                            var diffRevisionsToSelectFrom = Model.ReviewContent.APIRevisionsGrouped[diffRevisionType].Where(r => r.Id!= Model.ReviewContent.ActiveAPIRevision.Id);
                             (IEnumerable<APIRevisionListItemModel> revisions, APIRevisionListItemModel activeRevision, APIRevisionListItemModel diffRevision, bool forDiff, bool showDocumentation, bool showDiffOnly) diffRevisionSelectModel = (
                             revisions: diffRevisionsToSelectFrom,
                             activeRevision: Model.ReviewContent.ActiveAPIRevision,

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -155,7 +155,7 @@
                     @{
                         var iconCommentClass = "icon-comments invisible";
                         var comments = TempData["Comments"] as ReviewCommentsModel;
-                        if (sectionKey != null && comments.Threads.Count() > 0)
+                        if (sectionKey != null && comments != null && comments.Threads.Count() > 0)
                         {
                             if (comments.Threads.Any(c => c.LineClass != null && c.LineClass.Contains($"code-line-section-content-{sectionKey}")))
                             {

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewsPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewsPartial.cshtml
@@ -30,10 +30,13 @@
                                     <span role="img" class="mx-1 icon icon-language @iconClassName" aria-label="@review.Language"></span>
                                 }
                                 <a class="review-name align-middle" asp-page="./Review" asp-route-id="@review.Id">@review.PackageName.Substring(0, @truncationIndex)</a>
+                                @*
+                                Disabling approval (first release / Package name approval) for now as it is of no benefit to users
                                 @if (review.IsApproved == true)
                                 {
                                     <i class="fas fa-check-circle text-success ml-2"></i>
                                 }
+                                *@
                             </td>
                             <td class="align-middle cst-bdr-left ps-3">
                                 <a username="@review.CreatedBy">@review.CreatedBy</a>


### PR DESCRIPTION
- Add APIRevisionsManager Tests
- Some rename of `revisionId` to `apiRevisionId`.
- Prevent Diffing between the exact same apiRevision
- Remove approve filter and checkmark on review page.
- Only allow approval when activeRevision is ahead (created after) diffRevision