### PR TITLE
[js-api-parser] don't add members as types

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaScriptLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaScriptLanguageService.cs
@@ -11,7 +11,7 @@ namespace APIViewWeb
         public override string Name { get; } = "JavaScript";
         public override string[] Extensions { get; } = { ".api.json" };
         public override string ProcessName { get; } = "node";
-        public override string VersionString { get; } = "1.0.7";
+        public override string VersionString { get; } = "1.0.8";
 
         public override string GetProcessorArguments(string originalName, string tempDirectory, string jsonFilePath)
         {

--- a/tools/apiview/parsers/js-api-parser/export.ts
+++ b/tools/apiview/parsers/js-api-parser/export.ts
@@ -24,7 +24,7 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
         }
         builder.annotate(releaseTag);
     }
-    
+
     if (item instanceof ApiDeclaredItem) {
         if ( item.kind === ApiItemKind.Namespace) {
             builder.splitAppend(`declare namespace ${item.displayName} `, item.canonicalReference.toString(), item.displayName);
@@ -81,7 +81,7 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
                 .punct("{")
                 .newline()
                 .incIndent()
-    
+
             for (const member of item.members) {
                 appendMembers(builder,navigationItem.ChildItems, member);
             }
@@ -102,7 +102,7 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
         }
     }
     else
-    { 
+    {
         builder.newline();
     }
 }
@@ -130,7 +130,7 @@ apiModel.loadPackage(fileName);
 var navigation: IApiViewNavItem[] = [];
 var builder = new TokensBuilder();
 
-for (const modelPackage of apiModel.packages) {    
+for (const modelPackage of apiModel.packages) {
     for (const entryPoint of modelPackage.entryPoints) {
         for (const member of entryPoint.members) {
             appendMembers(builder, navigation, member);
@@ -148,7 +148,7 @@ var apiViewFile: IApiViewFile = {
     Navigation: navigation,
     Tokens: builder.tokens,
     PackageName: apiModel.packages[0].name,
-    VersionString: "1.0.7",
+    VersionString: "1.0.8",
     Language: "JavaScript",
     PackageVersion: PackageversionString
 }

--- a/tools/apiview/parsers/js-api-parser/package.json
+++ b/tools/apiview/parsers/js-api-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/ts-genapi",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "",
   "main": "index.js",
   "publishConfig": {

--- a/tools/apiview/parsers/js-api-parser/tokensBuilder.ts
+++ b/tools/apiview/parsers/js-api-parser/tokensBuilder.ts
@@ -94,13 +94,13 @@ export class TokensBuilder
 
     incIndent(): TokensBuilder
     {
-        this.indentString = ' '.repeat(this.indentString.length + 4); 
+        this.indentString = ' '.repeat(this.indentString.length + 4);
         return this;
     }
 
     decIndent(): TokensBuilder
     {
-        this.indentString = ' '.repeat(this.indentString.length - 4); 
+        this.indentString = ' '.repeat(this.indentString.length - 4);
         return this;
     }
 
@@ -185,7 +185,7 @@ export class TokensBuilder
             }
 
             var tokens: any[] = Array.from(jsTokens(line));
-            tokens.forEach(token => 
+            tokens.forEach(token =>
             {
                 if (this.keywords.indexOf(token.value) > 0)
                 {
@@ -193,7 +193,19 @@ export class TokensBuilder
                 }
                 else if (token.value === currentTypeName)
                 {
-                    this.tokens.push({ Kind: ApiViewTokenKind.TypeName, DefinitionId: currentTypeId, Value: token.value });
+                    if (currentTypeId.match(/.*:member(\(\d+\))*$/)) {
+                        this.tokens.push({
+                            Kind: ApiViewTokenKind.MemberName,
+                            DefinitionId: currentTypeId,
+                            Value: token.value,
+                        });
+                    } else {
+                        this.tokens.push({
+                            Kind: ApiViewTokenKind.TypeName,
+                            DefinitionId: currentTypeId,
+                            Value: token.value,
+                        });
+                    }
                 }
                 else if (token.type === "StringLiteral")
                 {
@@ -212,7 +224,7 @@ export class TokensBuilder
                     this.text(token.value);
                 }
             });
-            
+
             if (index < array.length - 1)
             {
                 this.newline();


### PR DESCRIPTION
This PR uses the id of the token to determine whether it should be added as a member or a type.