### PR TITLE
Update APIView documentation

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/README.md
+++ b/src/dotnet/APIView/APIViewWeb/README.md
@@ -1,24 +1,14 @@
 # APIView
 
-APIView tool is used by archboard reviewers to review API signatures of all public APIs available in Azure SDK packages. This tool generates public API surface level review which shows all publicly available classes, methods, properties etc. This makes it easier to identify if there are any breaking changes. Currently APIView tool supports following languages:
+APIView tool is used by archboard reviewers to review API signatures of all public APIs available in Azure SDK packages. This tool generates public API surface level revisions which shows all publicly available classes, methods, properties etc. This makes it easier to identify if there are any breaking changes.
 
-- C#
-- C
-- C++
-- Java
-- JS/TS
-- Python
-- Go
-- Swift
+## How does it retrieve public API information
 
-## Why do we need APIView
+Developers can upload package or an abstract file generated based on each language into APIView tool. APIView tool has a language processor for each language it supports and these individual language processor extracts API stub information and create json APIView file that is processed by tool. APIView tool stores original uploaded file and generated json file in its data store. Revision pages are rendered using this generated json file which contains tokens to present language keywords, links etc. Tool also allows user to recreate review json from stored original file if language package processor itself is updated.
 
-APIView tool allows to see only stub version of classes, methods, properties, method signatures available in each Azure SDK. This helps architects to review an Azure SDK and helps to identify any potential change that can impact consumers of an Azure SDK. APIView is also used as an enforcing tool to make sure we release a GA version of Azure SDK package only after it is approved by an architect. APIView is also utlized to identify any change at API level in a pull request.
+## How to create an API revision manually
 
-
-## How to create an API review manually
-
-API review can be created by uploading an artifact to APIView tool. Type of the artifact is different across each language. Some language, for e.g., Swift requires developer to run parser tool locally to generate stub file and upload json stub file instead of any artifact. Following are the detailed instructions on how to create review for each language. 
+API revisions can be created by uploading an artifact to APIView tool. Type of the artifact is different across each language. Some language, for e.g., Swift requires developer to run parser tool locally to generate stub file and upload json stub file instead of any artifact. Following are the detailed instructions on how to create revisions for each language.
 
 ### C#
 Run `dotnet pack` for the required package to generate Nuget file. Upload the resulting .nupkg file using `Create Review` link in APIView.
@@ -54,38 +44,13 @@ Run `dotnet pack` for the required package to generate Nuget file. Upload the re
 2. Upload generated whl file
 
 ### Swagger
-Swagger API review can be generated manually by uploading swagger file to APIView if you are trying to generate API review for a single swagger file. Swagger API review is automatically generated when swagger files are modified in a pull request and pull request comment shows a link to generated API review. Automatically generated API review from pull request creates a diff using existing swagger files in the target branch as baseline to show API level changes in pull request. 
+Swagger API revisions can be generated manually by uploading swagger file to APIView if you are trying to generate API revision for a single swagger file. Swagger API revision is automatically generated when swagger files are modified in a pull request and pull request comment shows a link to generated APIView. Automatically generated API revision from pull request creates a diff using existing swagger files in the target branch as baseline to show API level changes in pull request.
 
-You can rename a swagger file as mentioned below and upload it to APIView in case if you need to generate an API review manually from swagger.
+You can rename a swagger file as mentioned below and upload it to APIView if you need to generate an API revision manually from swagger.
 1. Rename swagger json to replace file extension to .swagger `Rename-Item PetSwagger.json -NewName PetSwagger.swagger`
 2. Upload renamed `.swagger` file
 
 ### TypeSpec
-TypeSpec API review is generated automatically from a pull request and this should be good enough in most scenarios. You can also generate API review manually for a TypeSpec package by providing URL path to TypeSpec package specification root path.
+TypeSpec API revision is generated automatically from a pull request and this should be good enough in most scenarios. You can also generate API revision manually for a TypeSpec package by providing URL path to TypeSpec package specification root path.
 1. Click and `Create Review` and select TypeSpec from language dropdown.
 2. Provide URL to typespec project root path.
-
-
-## How does it retrieve public API information
-
-Developers can upload package or an abstract file generated based on each language into API View tool. APIView tool has a language processor for each language it supports and these individual language processor extracts API stub information and create json APIView file that is processed by tool. API review tool stores original uploaded file and generated json file in its data store. Review pages are rendered using this generated json file which contains tokens to present language keywords, links etc. Tool also allows user to recreate review json from stored original file if language package processor itself is updated.
-
-## Types of API reviews
-
-APIView tool shows three different types of reviews based on how it is generated.
-- Manual
-- Automatic
-- Pull request reviews
-
-### Manual
-Manual reviews are created by developers by uploading artifact as per the instructions given above. This will allow developers to review API changes if API review is not available from PR branch.
-
-### Automatic
-API review tool has a master version of API review created automatically by azure-sdk bot as part of our scheduled CI pipelines in Azure Devops internal project. CI will check for any new change in public API surface level as part of every scheduled run and create a new revision if it finds any difference. These reviews cannot be deleted or updated with new revisions manually , in other words, this is a locked version of API reviews. Only actions that are allowed on master review is Add/update/remove/Resolve comment and Approve API reviews.
-
-As part of build and release pipelines, we will enforce API approval by architect or deputy architect if package version is GA which means we need to ensure latest revision of automatically created review is approved in API review tool to release a GA version package. This is applicable for any package ( both data plane and management plane) that is listed as an artifact in CI yaml.
-
-Automatic API reviews are not listed by default when you login to API review tool. You can view automatic reviews by clicking on "Automatic" button in top right corner in the main page.
-
-### API reviews from pull requests
-PR pipeline for Java, C#, JS and Python sends a request to APIView tool to identify if there are any changes made at API level as part of the PR it is processing. APIView tool compared the stub file from PR pipeline against API review revision created from main branch and creates a new review if there is any change. APIView will also add a comment to GitHub PR with a link to API review if there is any change detected. APIView will not create any review for a PR if it does not have any API level change.


### PR DESCRIPTION
Removing user facing information from here that will live now in Eng Hub. (PR https://dev.azure.com/azure-sdk/internal/_git/azure-sdk-docs-eng.ms/pullrequest/875)

For remaining tool information I have updated the review/revision concept for consistency with latest changes