### PR TITLE
Pipeline Witness logs trigger event

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildCompleteQueueWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Services/BuildCompleteQueueWorker.cs
@@ -42,7 +42,7 @@ namespace Azure.Sdk.Tools.PipelineWitness.Services
 
         internal override async Task ProcessMessageAsync(QueueMessage message, CancellationToken cancellationToken)
         {
-            this.logger.LogInformation("Processing build.complete event.");
+            this.logger.LogInformation($"Processing build.complete event: { message.MessageText }");
 
             var devopsEvent = JObject.Parse(message.MessageText);
 


### PR DESCRIPTION
Right now, we only log that we're processing **a** build.complete event, not the actual event itself.

This update can be almost thoughtlessly deployed.