### PR TITLE
Prefer PackageName in Code file to find existing PR reviews

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/CodeFileManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/CodeFileManager.cs
@@ -188,12 +188,15 @@ namespace APIViewWeb.Managers
 
         public bool AreCodeFilesTheSame(CodeFile codeFileA, CodeFile codeFileB)
         {
+            if( codeFileA == null || codeFileB == null )
+                return false;
+
             bool result = true;
 
-            if (!codeFileA.Tokens.SequenceEqual(codeFileB.Tokens))
+            if (codeFileA.Tokens == null || codeFileB.Tokens == null || !codeFileA.Tokens.SequenceEqual(codeFileB.Tokens))
                 result = false;
 
-            if (!codeFileA.LeafSections.SequenceEqual(codeFileB.LeafSections))
+            if (codeFileA.LeafSections == null || codeFileB.LeafSections == null || !codeFileA.LeafSections.SequenceEqual(codeFileB.LeafSections))
                 result = false;
 
             return result;


### PR DESCRIPTION
1. Fix null pointer exception when baseline is not present in PR api change detection request
2. Prefer package name in CodeFile when it's present
3. Null check when comparing code file