### PR TITLE
Avoid caching code file when running background task

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -273,7 +273,7 @@ namespace APIViewWeb.Managers
             {
                 apiRevisions = await _apiRevisionsRepository.GetAPIRevisionsAsync(reviewId);
             } 
-            var RevisionACodeFile = await _codeFileRepository.GetCodeFileAsync(apiRevision, true);
+            var RevisionACodeFile = await _codeFileRepository.GetCodeFileAsync(apiRevision, false);
             var RevisionAHtmlLines = RevisionACodeFile.Render(false);
             var RevisionATextLines = RevisionACodeFile.RenderText(false);
 
@@ -283,7 +283,7 @@ namespace APIViewWeb.Managers
                 if (rev.Id != apiRevision.Id)
                 {
                     var lineNumbersForHeadingOfSectionWithDiff = new HashSet<int>();
-                    var RevisionBCodeFile = await _codeFileRepository.GetCodeFileAsync(rev, true);
+                    var RevisionBCodeFile = await _codeFileRepository.GetCodeFileAsync(rev, false);
                     var RevisionBHtmlLines = RevisionBCodeFile.RenderReadOnly(false);
                     var RevisionBTextLines = RevisionBCodeFile.RenderText(false);
 

--- a/src/dotnet/APIView/APIViewWeb/Repositories/BlobCodeFileRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/BlobCodeFileRepository.cs
@@ -47,7 +47,7 @@ namespace APIViewWeb
             if (updateCache)
             {
                 using var _ = _cache.CreateEntry(key)
-                .SetSlidingExpiration(TimeSpan.FromHours(2))
+                .SetSlidingExpiration(TimeSpan.FromMinutes(10))
                 .SetValue(codeFile);
             }            
 


### PR DESCRIPTION
Disable code file caching when computing swagger diff. Also reduce cache time to 10 minutes.