### PR TITLE
Enable continue on error for our mirror steps

### DIFF
--- a/eng/pipelines/templates/steps/sync-repo-branch.yml
+++ b/eng/pipelines/templates/steps/sync-repo-branch.yml
@@ -26,11 +26,10 @@ parameters:
 steps:
 
 - ${{ each repo in parameters.Repos }}:
-
   - ${{ each target in repo.value.TargetRepos }}:
-
     - task: PowerShell@2
       displayName: Sync Repo from ${{ repo.key }} to ${{ target.key }}
+      continueOnError: true
       inputs:
         pwsh: true
         workingDirectory: ${{ parameters.WorkingDirectory }}

--- a/eng/pipelines/templates/steps/sync-repo-merge-branch.yml
+++ b/eng/pipelines/templates/steps/sync-repo-merge-branch.yml
@@ -44,6 +44,7 @@ steps:
 
     - task: PowerShell@2
       displayName: Merge branch from ${{ repo.value.Branch }} into ${{ target.key }}
+      continueOnError: true
       inputs:
         pwsh: true
         workingDirectory: ${{ parameters.WorkingDirectory }}/${{ repo.key }}
@@ -79,6 +80,7 @@ steps:
         Write-Host "gh pr merge $mergeBranch --auto --merge --repo ${{ repo.key }}"
         gh pr merge $mergeBranch --auto --merge --repo ${{ repo.key }}
       displayName: Create Pull Request for merge
+      continueOnError: true
       workingDirectory: ${{ parameters.WorkingDirectory }}/${{ repo.key }}
       env:
         GH_TOKEN: $(azuresdk-github-pat)

--- a/eng/scripts/Merge-Branch.ps1
+++ b/eng/scripts/Merge-Branch.ps1
@@ -56,8 +56,8 @@ if ($LASTEXITCODE -and -not $mergeOutput.EndsWith('Automatic merge failed; fix c
 
 # update paths matching "theirs", except for "ours" and "merge", to the state in $SourceBranch
 if ($Theirs.Length) {
-    Write-Verbose "git restore -s $SourceBranch --worktree --theirs -- $theirIncludes $ourExcludes $mergeExcludes"
-    git restore -s $SourceBranch --worktree --theirs -- $theirIncludes $ourExcludes $mergeExcludes
+    Write-Verbose "git restore -s $SourceBranch --worktree --ignore-unmerged -- $theirIncludes $ourExcludes $mergeExcludes"
+    git restore -s $SourceBranch --worktree --ignore-unmerged -- $theirIncludes $ourExcludes $mergeExcludes
     if ($LASTEXITCODE) { ErrorExit $LASTEXITCODE }
     Write-Verbose "git add -A"
     git add -A
@@ -66,8 +66,8 @@ if ($Theirs.Length) {
 
 # update paths matching "ours", except for "merge", to their pre-merge state
 if ($Ours.Length) {
-    Write-Verbose "git restore -s (git rev-parse HEAD) --worktree --theirs -- $ourIncludes $mergeExcludes"
-    git restore -s (git rev-parse HEAD) --worktree --theirs -- $ourIncludes $mergeExcludes
+    Write-Verbose "git restore -s (git rev-parse HEAD) --worktree --ignore-unmerged -- $ourIncludes $mergeExcludes"
+    git restore -s (git rev-parse HEAD) --worktree --ignore-unmerged -- $ourIncludes $mergeExcludes
     if ($LASTEXITCODE) { ErrorExit $LASTEXITCODE }
     Write-Verbose "git add -A"
     git add -A
@@ -75,8 +75,8 @@ if ($Ours.Length) {
 }
 
 if ($AcceptTheirsForFinalMerge) {
-    Write-Verbose "git restore -s $SourceBranch --worktree --theirs -- $mergeIncludes"
-    git restore -s $SourceBranch --worktree --theirs -- $mergeIncludes
+    Write-Verbose "git restore -s $SourceBranch --worktree --ignore-unmerged -- $mergeIncludes"
+    git restore -s $SourceBranch --worktree --ignore-unmerged -- $mergeIncludes
     if ($LASTEXITCODE) { ErrorExit $LASTEXITCODE }
     Write-Verbose "git add -A"
     git add -A


### PR DESCRIPTION
- Enable continueonerror for our mirroring steps so one bad repo doesn't stop the others from mirroring
- React to recent change to git cli https://github.com/git/git/commit/54f98fee5069f50c6e96687504b82a7695c8648a Instead of passing --theirs we can get away with --ignore-unmerged given we are trying to avoid any merge conflicts at all and want to simply pick and choose which files we want to include from which branches