### PR TITLE
Process swagger file cross reference when generating API review

### DIFF
--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/CHANGELOG
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/CHANGELOG
@@ -1,5 +1,8 @@
 # Release History
 
+## 1.3.0 (12-12-2023)
++ Support local schema reference in another referred swagger file
+
 ## 1.2.0 (11-29-2023)
 + Added API version as PackageVersion in code file.
 

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerAPIViewGenerator.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerAPIViewGenerator.cs
@@ -173,6 +173,7 @@ namespace SwaggerApiParser
                     {
                         var resp = response;
                         var referenceSwaggerFilePath = swaggerFilePath;
+                        string referencePath = "";
 
                         if (response.IsRefObject())
                         {
@@ -180,11 +181,14 @@ namespace SwaggerApiParser
                             if (resp == null)
                             {
                                 resp = (Response)schemaCache.GetResponseFromCache(response.@ref, swaggerFilePath);
+                                // Update reference path if referenced object is in another swagger file
+                                if (response.IsRefObject() && !response.@ref.StartsWith("#"))
+                                    referencePath = response.@ref;
                             }
 
                             if (resp == null)
                             {
-                                var referencePath = response.@ref;
+                                referencePath = response.@ref;
                                 do
                                 {
                                     if (!Path.IsPathFullyQualified(referencePath))
@@ -216,7 +220,13 @@ namespace SwaggerApiParser
                         {
                             if (schema.IsRefObject())
                             {
-                                var referencePath = schema.@ref;
+                                // Update swagger file path to correct file if schema reference is local but parent itself is in another swagger file
+                                if (schema.@ref.StartsWith("#") && !string.IsNullOrEmpty(referencePath))
+                                {
+                                    referenceSwaggerFilePath = Utils.GetReferencedSwaggerFile(referencePath, referenceSwaggerFilePath);
+                                }
+                                
+                                referencePath = schema.@ref;
                                 do
                                 {
                                     referenceSwaggerFilePath = Utils.GetReferencedSwaggerFile(referencePath, referenceSwaggerFilePath);

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiParser.csproj
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/SwaggerApiParser.csproj
@@ -6,7 +6,7 @@
     <ToolCommandName>swaggerAPIParser</ToolCommandName>
     <TargetFramework>net7.0</TargetFramework>
     <RootNamespace>SwaggerApiParser</RootNamespace>
-    <VersionPrefix>1.2.0</VersionPrefix>
+    <VersionPrefix>1.3.0</VersionPrefix>
     <AssemblyName>Azure.Sdk.Tools.SwaggerApiParser</AssemblyName>
     <SignAssembly>True</SignAssembly>
     <InformationalVersion>$(OfficialBuildId)</InformationalVersion>


### PR DESCRIPTION
Swagger file refers to a definition in another swagger file and sometimes this definition in second swagger file might have a schema reference to another definition within same file and this reference will be a local reference. API review parser incorrectly searches for this local reference in first swagger file instead of second file where it's defined.

PR has the fix to correctly refer the swagger file based on the parent reference if current reference path is local.

For e.g. data.json has a reference to 202response definition which is in common.json and 202response has a reference to longrunningoperationresult schema using local reference `#LongRunningOperationResult` and it's defined in common.json. We need to make sure parser refers common.json when processing `#LongRunningOperationResult` schema instead of data.json.