### PR TITLE
Set Samples page model and use correct property to find active revision

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Samples.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Samples.cshtml
@@ -40,7 +40,7 @@ else
         <div class="row mx-1 px-0 py-2">
             <div class="col-md-8">
                 <div class="input-group-sm input-group" id="review-info-bar">
-                    <partial name="Shared/_ReviewBadge" model="Model.Review" />
+                    <partial name="Shared/_ReviewBadge" model="(Model.Review, default(APIRevisionListItemModel))"/>
                     @if (Model.SampleContent.Length > 0)
                     {
                         <span class="input-group-text">Revision:</span>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Samples.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Samples.cshtml.cs
@@ -64,7 +64,7 @@ namespace APIViewWeb.Pages.Assemblies
                 {
                     if (revisionId != null)
                     {
-                        ActiveSampleRevision = SampleRevisions.Where(s => s.Id == revisionId).First();
+                        ActiveSampleRevision = SampleRevisions.Where(s => s.FileId == revisionId).First();
                     }
                     else
                     {


### PR DESCRIPTION
1. Samples page model is not set correctly and that causes issue to load samples.
2. Selecting a different revision throws error since it's compared against wrong samples revision property.