### PR TITLE
[pylint] Bump 3.0 checker

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/dev_requirements.txt
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/dev_requirements.txt
@@ -1,3 +1,3 @@
-pylint==2.15.8
+pylint==3.0.3
 azure-core==1.23.1
 pytest==7.1.1

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -9,14 +9,18 @@ Pylint custom checkers for SDK guidelines: C4717 - C4758
 
 import logging
 import astroid
+from astroid import nodes
+from typing import TYPE_CHECKING, Optional
+
 from pylint.checkers import BaseChecker
-from pylint.interfaces import IAstroidChecker
+
+if TYPE_CHECKING:
+    from pylint.lint import PyLinter
+
 logger = logging.getLogger(__name__)
 
 
 class ClientConstructorTakesCorrectParameters(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-constructor"
     priority = -1
     msgs = {
@@ -31,7 +35,7 @@ class ClientConstructorTakesCorrectParameters(BaseChecker):
             " https://azure.github.io/azure-sdk/python_design.html#client-configuration",
             "missing-client-constructor-parameter-kwargs",
             "All client types should accept a **kwargs parameter.",
-        )
+        ),
     }
     options = (
         (
@@ -53,7 +57,12 @@ class ClientConstructorTakesCorrectParameters(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientConstructorTakesCorrectParameters, self).__init__(linter)
@@ -67,25 +76,32 @@ class ClientConstructorTakesCorrectParameters(BaseChecker):
         :return: None
         """
         try:
-            if node.name == "__init__" and node.parent.name.endswith("Client") and \
-                    node.parent.name not in self.ignore_clients:
+            if (
+                node.name == "__init__"
+                and node.parent.name.endswith("Client")
+                and node.parent.name not in self.ignore_clients
+            ):
                 arg_names = [argument.name for argument in node.args.args]
                 if "credential" not in arg_names:
                     self.add_message(
-                        msgid="missing-client-constructor-parameter-credential", node=node, confidence=None
+                        msgid="missing-client-constructor-parameter-credential",
+                        node=node,
+                        confidence=None,
                     )
                 if not node.args.kwarg:
                     self.add_message(
-                        msgid="missing-client-constructor-parameter-kwargs", node=node, confidence=None
+                        msgid="missing-client-constructor-parameter-kwargs",
+                        node=node,
+                        confidence=None,
                     )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if constructor has correct parameters.")
+            logger.debug(
+                "Pylint custom checker failed to check if constructor has correct parameters."
+            )
             pass
 
 
 class ClientHasKwargsInPoliciesForCreateConfigurationMethod(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "configuration-policies-kwargs"
     priority = -1
     msgs = {
@@ -109,7 +125,9 @@ class ClientHasKwargsInPoliciesForCreateConfigurationMethod(BaseChecker):
     )
 
     def __init__(self, linter=None):
-        super(ClientHasKwargsInPoliciesForCreateConfigurationMethod, self).__init__(linter)
+        super(ClientHasKwargsInPoliciesForCreateConfigurationMethod, self).__init__(
+            linter
+        )
 
     def visit_functiondef(self, node):
         """Visits the any method called `create_configuration` or `create_config` and checks
@@ -130,16 +148,16 @@ class ClientHasKwargsInPoliciesForCreateConfigurationMethod(BaseChecker):
                             self.add_message(
                                 msgid="config-missing-kwargs-in-policy",
                                 node=list(node.get_children())[idx],
-                                confidence=None
+                                confidence=None,
                             )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if kwargs parameter in policies.")
+            logger.debug(
+                "Pylint custom checker failed to check if kwargs parameter in policies."
+            )
             pass
 
 
 class ClientHasApprovedMethodNamePrefix(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-approved-method-name-prefix"
     priority = -1
     msgs = {
@@ -162,7 +180,12 @@ class ClientHasApprovedMethodNamePrefix(BaseChecker):
         ),
     )
 
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientHasApprovedMethodNamePrefix, self).__init__(linter)
@@ -177,29 +200,47 @@ class ClientHasApprovedMethodNamePrefix(BaseChecker):
         """
         try:
             if node.name.endswith("Client") and node.name not in self.ignore_clients:
-                client_methods = [child for child in node.get_children() if child.is_function]
+                client_methods = [
+                    child for child in node.get_children() if child.is_function
+                ]
 
-                approved_prefixes = ["get", "list", "create", "upsert", "set", "update", "replace", "append", "add",
-                                     "delete", "remove", "begin"]
+                approved_prefixes = [
+                    "get",
+                    "list",
+                    "create",
+                    "upsert",
+                    "set",
+                    "update",
+                    "replace",
+                    "append",
+                    "add",
+                    "delete",
+                    "remove",
+                    "begin",
+                ]
                 for idx, method in enumerate(client_methods):
-                    if method.name.startswith("__") or "_exists" in method.name or method.name.startswith("_") \
-                            or method.name.startswith("from"):
+                    if (
+                        method.name.startswith("__")
+                        or "_exists" in method.name
+                        or method.name.startswith("_")
+                        or method.name.startswith("from")
+                    ):
                         continue
                     prefix = method.name.split("_")[0]
                     if prefix.lower() not in approved_prefixes:
                         self.add_message(
                             msgid="unapproved-client-method-name-prefix",
                             node=client_methods[idx],
-                            confidence=None
+                            confidence=None,
                         )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client has approved method name prefix.")
+            logger.debug(
+                "Pylint custom checker failed to check if client has approved method name prefix."
+            )
             pass
 
 
 class ClientMethodsUseKwargsWithMultipleParameters(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-method-multiple-parameters"
     priority = -1
     msgs = {
@@ -222,7 +263,12 @@ class ClientMethodsUseKwargsWithMultipleParameters(BaseChecker):
         ),
     )
 
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientMethodsUseKwargsWithMultipleParameters, self).__init__(linter)
@@ -236,24 +282,30 @@ class ClientMethodsUseKwargsWithMultipleParameters(BaseChecker):
         :return: None
         """
         try:
-            if node.parent.name.endswith("Client") and node.is_method() and node.parent.name not in self.ignore_clients:
+            if (
+                node.parent.name.endswith("Client")
+                and node.is_method()
+                and node.parent.name not in self.ignore_clients
+            ):
                 # Only bother checking method signatures with > 6 parameters (don't include self/cls/etc)
                 if len(node.args.args) > 6:
                     positional_args = len(node.args.args) - len(node.args.defaults)
                     if positional_args > 6:
                         self.add_message(
-                            msgid="client-method-has-more-than-5-positional-arguments", node=node, confidence=None
+                            msgid="client-method-has-more-than-5-positional-arguments",
+                            node=node,
+                            confidence=None,
                         )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if kwargs is used for multiple parameters.")
+            logger.debug(
+                "Pylint custom checker failed to check if kwargs is used for multiple parameters."
+            )
             pass
 
     visit_asyncfunctiondef = visit_functiondef
 
 
 class ClientMethodsHaveTypeAnnotations(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-method-type-annotations"
     priority = -1
     msgs = {
@@ -276,7 +328,12 @@ class ClientMethodsHaveTypeAnnotations(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientMethodsHaveTypeAnnotations, self).__init__(linter)
@@ -290,36 +347,50 @@ class ClientMethodsHaveTypeAnnotations(BaseChecker):
         :return: None
         """
         try:
-            if node.parent.name.endswith("Client") and node.is_method() and node.parent.name not in self.ignore_clients:
+            if (
+                node.parent.name.endswith("Client")
+                and node.is_method()
+                and node.parent.name not in self.ignore_clients
+            ):
                 if not node.name.startswith("_") or node.name == "__init__":
                     # Checks that method has python 2/3 type comments or annotations as shown here:
                     # https://www.python.org/dev/peps/pep-0484/#suggested-syntax-for-python-2-7-and-straddling-code
 
                     # check for type comments
-                    if node.type_comment_args is None or node.type_comment_returns is None:
-
+                    if (
+                        node.type_comment_args is None
+                        or node.type_comment_returns is None
+                    ):
                         # type annotations default to a list of None when not present,
                         # so need extra logic here to check for any hints that may be present
-                        type_annotations = [type_hint for type_hint in node.args.annotations if type_hint is not None]
+                        type_annotations = [
+                            type_hint
+                            for type_hint in node.args.annotations
+                            if type_hint is not None
+                        ]
 
                         # check for type annotations
                         # node.args.args is a list of ast.AssignName arguments
                         # node.returns is the type annotation return
                         # Note that if the method returns nothing it will be of type ast.Const.NoneType
-                        if (type_annotations == [] and len(node.args.args) > 1) or node.returns is None:
+                        if (
+                            type_annotations == [] and len(node.args.args) > 1
+                        ) or node.returns is None:
                             self.add_message(
-                                msgid="client-method-missing-type-annotations", node=node, confidence=None
+                                msgid="client-method-missing-type-annotations",
+                                node=node,
+                                confidence=None,
                             )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client methods missing type annotations.")
+            logger.debug(
+                "Pylint custom checker failed to check if client methods missing type annotations."
+            )
             pass
 
     visit_asyncfunctiondef = visit_functiondef
 
 
 class ClientMethodsHaveTracingDecorators(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-method-has-tracing-decorator"
     priority = -1
     msgs = {
@@ -358,9 +429,14 @@ class ClientMethodsHaveTracingDecorators(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
     ignore_functions = ["send_request"]
-    ignore_decorators = {"typing.overload", "builtins.classmethod"} 
+    ignore_decorators = {"typing.overload", "builtins.classmethod"}
 
     def __init__(self, linter=None):
         super(ClientMethodsHaveTracingDecorators, self).__init__(linter)
@@ -378,16 +454,29 @@ class ClientMethodsHaveTracingDecorators(BaseChecker):
         try:
             path = node.root().name
             split_path = path.split(".")
-            new_path = ".".join(split_path[:len(split_path)-1])
+            new_path = ".".join(split_path[: len(split_path) - 1])
             if new_path.count("_") == 0:
-                if node.parent.name.endswith("Client") and node.is_method() and not node.name.startswith("_") and \
-                        node.parent.name not in self.ignore_clients:
-                    if node.args.kwarg and node.name not in self.ignore_functions and not node.name.endswith("client") \
-                        and not self.ignore_decorators.intersection(node.decoratornames()) and \
-                            "azure.core.tracing.decorator.distributed_trace" not in node.decoratornames():
-                                    self.add_message(
-                                        msgid="client-method-missing-tracing-decorator", node=node, confidence=None
-                                    )
+                if (
+                    node.parent.name.endswith("Client")
+                    and node.is_method()
+                    and not node.name.startswith("_")
+                    and node.parent.name not in self.ignore_clients
+                ):
+                    if (
+                        node.args.kwarg
+                        and node.name not in self.ignore_functions
+                        and not node.name.endswith("client")
+                        and not self.ignore_decorators.intersection(
+                            node.decoratornames()
+                        )
+                        and "azure.core.tracing.decorator.distributed_trace"
+                        not in node.decoratornames()
+                    ):
+                        self.add_message(
+                            msgid="client-method-missing-tracing-decorator",
+                            node=node,
+                            confidence=None,
+                        )
         except:
             pass
 
@@ -404,24 +493,34 @@ class ClientMethodsHaveTracingDecorators(BaseChecker):
         try:
             path = node.root().name
             split_path = path.split(".")
-            new_path = ".".join(split_path[:len(split_path)-1])
+            new_path = ".".join(split_path[: len(split_path) - 1])
             if new_path.count("_") == 0:
-                if node.parent.name.endswith("Client") and node.is_method() and not node.name.startswith("_") and \
-                        node.parent.name not in self.ignore_clients:
-                    if node.args.kwarg and node.name not in self.ignore_functions and not node.name.endswith("client") \
-                        and not self.ignore_decorators.intersection(node.decoratornames()) and \
-                            "azure.core.tracing.decorator_async.distributed_trace_async" not in node.decoratornames():
-
+                if (
+                    node.parent.name.endswith("Client")
+                    and node.is_method()
+                    and not node.name.startswith("_")
+                    and node.parent.name not in self.ignore_clients
+                ):
+                    if (
+                        node.args.kwarg
+                        and node.name not in self.ignore_functions
+                        and not node.name.endswith("client")
+                        and not self.ignore_decorators.intersection(
+                            node.decoratornames()
+                        )
+                        and "azure.core.tracing.decorator_async.distributed_trace_async"
+                        not in node.decoratornames()
+                    ):
                         self.add_message(
-                            msgid="client-method-missing-tracing-decorator-async", node=node, confidence=None
+                            msgid="client-method-missing-tracing-decorator-async",
+                            node=node,
+                            confidence=None,
                         )
         except:
             pass
 
 
 class ClientsDoNotUseStaticMethods(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-does-not-use-static-methods"
     priority = -1
     msgs = {
@@ -443,7 +542,12 @@ class ClientsDoNotUseStaticMethods(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientsDoNotUseStaticMethods, self).__init__(linter)
@@ -456,23 +560,29 @@ class ClientsDoNotUseStaticMethods(BaseChecker):
         :return: None
         """
         try:
-            if node.parent.name.endswith("Client") and node.is_method() and node.parent.name not in self.ignore_clients:
+            if (
+                node.parent.name.endswith("Client")
+                and node.is_method()
+                and node.parent.name not in self.ignore_clients
+            ):
                 # ignores private methods or methods that don't have any decorators
                 if not node.name.startswith("_") and node.decorators is not None:
                     if "builtins.staticmethod" in node.decoratornames():
                         self.add_message(
-                            msgid="client-method-should-not-use-static-method", node=node, confidence=None
+                            msgid="client-method-should-not-use-static-method",
+                            node=node,
+                            confidence=None,
                         )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client methods do not use staticmethods.")
+            logger.debug(
+                "Pylint custom checker failed to check if client methods do not use staticmethods."
+            )
             pass
 
     visit_asyncfunctiondef = visit_functiondef
 
 
 class FileHasCopyrightHeader(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "file-has-copyright-header"
     priority = -1
     msgs = {
@@ -508,18 +618,18 @@ class FileHasCopyrightHeader(BaseChecker):
         try:
             if not node.package:  # don't throw an error on an __init__.py file
                 header = node.stream().read(200).lower()
-                if header.find(b'copyright') == -1:
+                if header.find(b"copyright") == -1:
                     self.add_message(
-                                msgid="file-needs-copyright-header", node=node, confidence=None
-                            )
+                        msgid="file-needs-copyright-header", node=node, confidence=None
+                    )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if file is missing a copyright header.")
+            logger.debug(
+                "Pylint custom checker failed to check if file is missing a copyright header."
+            )
             pass
 
 
 class ClientUsesCorrectNamingConventions(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-naming-conventions"
     priority = -1
     msgs = {
@@ -541,7 +651,12 @@ class ClientUsesCorrectNamingConventions(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientUsesCorrectNamingConventions, self).__init__(linter)
@@ -556,10 +671,16 @@ class ClientUsesCorrectNamingConventions(BaseChecker):
         :return: None
         """
         # check for correct capitalization for "Client" and whatever the first letter of the prefix is
-        if "_" in node.name or node.name.endswith("client") or node.name[0] != node.name[0].upper():
+        if (
+            "_" in node.name
+            or node.name.endswith("client")
+            or node.name[0] != node.name[0].upper()
+        ):
             if not node.name.startswith("_") and node.name not in self.ignore_clients:
                 self.add_message(
-                    msgid="client-incorrect-naming-convention", node=node, confidence=None
+                    msgid="client-incorrect-naming-convention",
+                    node=node,
+                    confidence=None,
                 )
 
         # check for correct naming convention in any class constants
@@ -569,10 +690,14 @@ class ClientUsesCorrectNamingConventions(BaseChecker):
                     const_name = node.body[idx].targets[0].name
                     if const_name != const_name.upper():
                         self.add_message(
-                            msgid="client-incorrect-naming-convention", node=node.body[idx], confidence=None
+                            msgid="client-incorrect-naming-convention",
+                            node=node.body[idx],
+                            confidence=None,
                         )
                 except AttributeError:
-                    logger.debug("Pylint custom checker failed to check if client uses correct naming conventions.")
+                    logger.debug(
+                        "Pylint custom checker failed to check if client uses correct naming conventions."
+                    )
                     pass
 
             # check that methods in client class do not use camelcase
@@ -580,16 +705,18 @@ class ClientUsesCorrectNamingConventions(BaseChecker):
                 for func in node.body:
                     if func.name != func.name.lower() and not func.name.startswith("_"):
                         self.add_message(
-                            msgid="client-incorrect-naming-convention", node=func, confidence=None
+                            msgid="client-incorrect-naming-convention",
+                            node=func,
+                            confidence=None,
                         )
             except AttributeError:
-                logger.debug("Pylint custom checker failed to check if client uses correct naming conventions.")
+                logger.debug(
+                    "Pylint custom checker failed to check if client uses correct naming conventions."
+                )
                 pass
 
 
 class ClientMethodsHaveKwargsParameter(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-methods-have-kwargs"
     priority = -1
     msgs = {
@@ -611,7 +738,12 @@ class ClientMethodsHaveKwargsParameter(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientMethodsHaveKwargsParameter, self).__init__(linter)
@@ -624,28 +756,37 @@ class ClientMethodsHaveKwargsParameter(BaseChecker):
         :return: None
         """
         try:
-            if node.parent.name.endswith("Client") and node.is_method() and node.parent.name not in self.ignore_clients:
+            if (
+                node.parent.name.endswith("Client")
+                and node.is_method()
+                and node.parent.name not in self.ignore_clients
+            ):
                 # avoid false positive with @property
                 if node.decorators is not None:
                     if "builtins.property" in node.decoratornames():
                         return
-                    if not node.name.startswith("_") and \
-                            ("azure.core.tracing.decorator.distributed_trace" in node.decoratornames() or
-                             "azure.core.tracing.decorator_async.distributed_trace_async" in node.decoratornames()):
+                    if not node.name.startswith("_") and (
+                        "azure.core.tracing.decorator.distributed_trace"
+                        in node.decoratornames()
+                        or "azure.core.tracing.decorator_async.distributed_trace_async"
+                        in node.decoratornames()
+                    ):
                         if not node.args.kwarg:
                             self.add_message(
-                                msgid="client-method-missing-kwargs", node=node, confidence=None
+                                msgid="client-method-missing-kwargs",
+                                node=node,
+                                confidence=None,
                             )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client uses kwargs parameter in method.")
+            logger.debug(
+                "Pylint custom checker failed to check if client uses kwargs parameter in method."
+            )
             pass
 
     visit_asyncfunctiondef = visit_functiondef
 
 
 class ClientMethodNamesDoNotUseDoubleUnderscorePrefix(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-methods-no-double-underscore"
     priority = -1
     msgs = {
@@ -667,8 +808,20 @@ class ClientMethodNamesDoNotUseDoubleUnderscorePrefix(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
-    acceptable_names = ["__init__", "__enter__", "__exit__", "__aenter__", "__aexit__", "__repr__"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
+    acceptable_names = [
+        "__init__",
+        "__enter__",
+        "__exit__",
+        "__aenter__",
+        "__aexit__",
+        "__repr__",
+    ]
 
     def __init__(self, linter=None):
         super(ClientMethodNamesDoNotUseDoubleUnderscorePrefix, self).__init__(linter)
@@ -681,21 +834,30 @@ class ClientMethodNamesDoNotUseDoubleUnderscorePrefix(BaseChecker):
         :return: None
         """
         try:
-            if node.parent.name.endswith("Client") and node.is_method() and node.parent.name not in self.ignore_clients:
-                if node.name.startswith("__") and node.name not in self.acceptable_names:
+            if (
+                node.parent.name.endswith("Client")
+                and node.is_method()
+                and node.parent.name not in self.ignore_clients
+            ):
+                if (
+                    node.name.startswith("__")
+                    and node.name not in self.acceptable_names
+                ):
                     self.add_message(
-                        msgid="client-method-name-no-double-underscore", node=node, confidence=None
+                        msgid="client-method-name-no-double-underscore",
+                        node=node,
+                        confidence=None,
                     )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client method name does not use double underscore prefix.")
+            logger.debug(
+                "Pylint custom checker failed to check if client method name does not use double underscore prefix."
+            )
             pass
 
     visit_asyncfunctiondef = visit_functiondef
 
 
 class ClientDocstringUsesLiteralIncludeForCodeExample(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-docstring-literal-include"
     priority = -1
     msgs = {
@@ -718,7 +880,12 @@ class ClientDocstringUsesLiteralIncludeForCodeExample(BaseChecker):
         ),
     )
 
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientDocstringUsesLiteralIncludeForCodeExample, self).__init__(linter)
@@ -735,10 +902,14 @@ class ClientDocstringUsesLiteralIncludeForCodeExample(BaseChecker):
             if node.name.endswith("Client") and node.name not in self.ignore_clients:
                 if node.doc.find("code-block") != -1:
                     self.add_message(
-                        msgid="client-docstring-use-literal-include", node=node, confidence=None
+                        msgid="client-docstring-use-literal-include",
+                        node=node,
+                        confidence=None,
                     )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client uses literalinclude over code-block.")
+            logger.debug(
+                "Pylint custom checker failed to check if client uses literalinclude over code-block."
+            )
             pass
 
     def visit_functiondef(self, node):
@@ -750,21 +921,27 @@ class ClientDocstringUsesLiteralIncludeForCodeExample(BaseChecker):
         :return: None
         """
         try:
-            if node.parent.name.endswith("Client") and node.parent.name not in self.ignore_clients and node.is_method():
+            if (
+                node.parent.name.endswith("Client")
+                and node.parent.name not in self.ignore_clients
+                and node.is_method()
+            ):
                 if node.doc.find("code-block") != -1:
                     self.add_message(
-                        msgid="client-docstring-use-literal-include", node=node, confidence=None
+                        msgid="client-docstring-use-literal-include",
+                        node=node,
+                        confidence=None,
                     )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client uses literalinclude over code-block.")
+            logger.debug(
+                "Pylint custom checker failed to check if client uses literalinclude over code-block."
+            )
             pass
 
     visit_asyncfunctiondef = visit_functiondef
 
 
 class AsyncClientCorrectNaming(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "async-client-correct-naming"
     priority = -1
     msgs = {
@@ -786,7 +963,12 @@ class AsyncClientCorrectNaming(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(AsyncClientCorrectNaming, self).__init__(linter)
@@ -801,19 +983,26 @@ class AsyncClientCorrectNaming(BaseChecker):
         """
         try:
             # avoid false positive when async name is used with a base class.
-            if node.name.endswith("Client") and "async" in node.name.lower() and "base" not in node.name.lower():
-                if not node.name.startswith("_") and node.name not in self.ignore_clients:
+            if (
+                node.name.endswith("Client")
+                and "async" in node.name.lower()
+                and "base" not in node.name.lower()
+            ):
+                if (
+                    not node.name.startswith("_")
+                    and node.name not in self.ignore_clients
+                ):
                     self.add_message(
                         msgid="async-client-bad-name", node=node, confidence=None
                     )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if async client uses correct naming.")
+            logger.debug(
+                "Pylint custom checker failed to check if async client uses correct naming."
+            )
             pass
 
 
 class SpecifyParameterNamesInCall(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "specify-parameter-names"
     priority = -1
     msgs = {
@@ -835,7 +1024,12 @@ class SpecifyParameterNamesInCall(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(SpecifyParameterNamesInCall, self).__init__(linter)
@@ -851,20 +1045,26 @@ class SpecifyParameterNamesInCall(BaseChecker):
         try:
             klass = node.parent.parent.parent
             function = node.parent.parent
-            if klass.name.endswith("Client") and klass.name not in self.ignore_clients and function.is_method():
+            if (
+                klass.name.endswith("Client")
+                and klass.name not in self.ignore_clients
+                and function.is_method()
+            ):
                 # node.args represent positional arguments
                 if len(node.args) > 2 and node.func.attrname != "format":
                     self.add_message(
-                        msgid="specify-parameter-names-in-call", node=node, confidence=None
+                        msgid="specify-parameter-names-in-call",
+                        node=node,
+                        confidence=None,
                     )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client methods specify parameters name in call.")
+            logger.debug(
+                "Pylint custom checker failed to check if client methods specify parameters name in call."
+            )
             pass
 
 
 class ClientListMethodsUseCorePaging(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-paging-methods-use-list"
     priority = -1
     msgs = {
@@ -886,11 +1086,16 @@ class ClientListMethodsUseCorePaging(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientListMethodsUseCorePaging, self).__init__(linter)
-    
+
     def visit_return(self, node):
         """Visits every method in the client and checks that any list methods return
         an ItemPaged or AsyncItemPaged value. Also, checks that if a method returns an iterable value
@@ -903,29 +1108,48 @@ class ClientListMethodsUseCorePaging(BaseChecker):
         try:
             iterable_return = False
             paging_method = False
-            if node.parent.parent.name.endswith("Client") and node.parent.parent.name not in self.ignore_clients and node.parent.is_method():
+            if (
+                node.parent.parent.name.endswith("Client")
+                and node.parent.parent.name not in self.ignore_clients
+                and node.parent.is_method()
+            ):
                 try:
-                    if any(v for v in node.value.infer() if "def by_page" in v.as_string()):
+                    if any(
+                        v for v in node.value.infer() if "def by_page" in v.as_string()
+                    ):
                         iterable_return = True
-                except (astroid.exceptions.InferenceError, AttributeError, TypeError): # astroid can't always infer the return
-                    logger.debug("Pylint custom checker failed to check if client list method uses core paging.")
-                    return 
+                except (
+                    astroid.exceptions.InferenceError,
+                    AttributeError,
+                    TypeError,
+                ):  # astroid can't always infer the return
+                    logger.debug(
+                        "Pylint custom checker failed to check if client list method uses core paging."
+                    )
+                    return
 
-                if node.parent.name.startswith("list") or node.parent.name.startswith("_list"):
+                if node.parent.name.startswith("list") or node.parent.name.startswith(
+                    "_list"
+                ):
                     paging_method = True
 
-                if (not paging_method and iterable_return) or (paging_method and not iterable_return):
+                if (not paging_method and iterable_return) or (
+                    paging_method and not iterable_return
+                ):
                     self.add_message(
-                        msgid="client-paging-methods-use-list", node=node.parent, confidence=None
+                        msgid="client-paging-methods-use-list",
+                        node=node.parent,
+                        confidence=None,
                     )
-                
+
         except (AttributeError, TypeError):
-            logger.debug("Pylint custom checker failed to check if client list method uses core paging.")
+            logger.debug(
+                "Pylint custom checker failed to check if client list method uses core paging."
+            )
             pass
 
-class ClientLROMethodsUseCorePolling(BaseChecker):
-    __implements__ = IAstroidChecker
 
+class ClientLROMethodsUseCorePolling(BaseChecker):
     name = "client-lro-methods-use-polling"
     priority = -1
     msgs = {
@@ -947,7 +1171,12 @@ class ClientLROMethodsUseCorePolling(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientLROMethodsUseCorePolling, self).__init__(linter)
@@ -961,26 +1190,37 @@ class ClientLROMethodsUseCorePolling(BaseChecker):
         :return: None
         """
         try:
-            if node.parent.name.endswith("Client") and node.parent.name not in self.ignore_clients and node.is_method():
+            if (
+                node.parent.name.endswith("Client")
+                and node.parent.name not in self.ignore_clients
+                and node.is_method()
+            ):
                 if node.name.startswith("begin"):
                     try:
                         # infer_call_result gives the method return value as a string
                         returns = next(node.infer_call_result()).as_string()
                         if returns.find("LROPoller") == -1:
                             self.add_message(
-                                msgid="client-lro-methods-use-polling", node=node, confidence=None
+                                msgid="client-lro-methods-use-polling",
+                                node=node,
+                                confidence=None,
                             )
-                    except (astroid.exceptions.InferenceError, AttributeError): # astroid can't always infer the return
-                        logger.debug("Pylint custom checker failed to check if client begin method uses core polling.")
+                    except (
+                        astroid.exceptions.InferenceError,
+                        AttributeError,
+                    ):  # astroid can't always infer the return
+                        logger.debug(
+                            "Pylint custom checker failed to check if client begin method uses core polling."
+                        )
                         pass
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client begin method uses core polling.")
+            logger.debug(
+                "Pylint custom checker failed to check if client begin method uses core polling."
+            )
             pass
 
 
 class ClientLROMethodsUseCorrectNaming(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-lro-methods-use-correct-naming"
     priority = -1
     msgs = {
@@ -1002,7 +1242,12 @@ class ClientLROMethodsUseCorrectNaming(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientLROMethodsUseCorrectNaming, self).__init__(linter)
@@ -1027,18 +1272,22 @@ class ClientLROMethodsUseCorrectNaming(BaseChecker):
                 if node.value.func.name == "LROPoller":
                     # get the method in which LROPoller is returned
                     method = node.value.func.scope()
-                    if not method.name.startswith("begin") and not method.name.startswith("_"):
+                    if not method.name.startswith(
+                        "begin"
+                    ) and not method.name.startswith("_"):
                         self.add_message(
-                            msgid="lro-methods-use-correct-naming", node=method, confidence=None
+                            msgid="lro-methods-use-correct-naming",
+                            node=method,
+                            confidence=None,
                         )
             except AttributeError:
-                logger.debug("Pylint custom checker failed to check if client method with polling uses correct naming.")
+                logger.debug(
+                    "Pylint custom checker failed to check if client method with polling uses correct naming."
+                )
                 pass
 
 
 class ClientConstructorDoesNotHaveConnectionStringParam(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-conn-str-not-in-constructor"
     priority = -1
     msgs = {
@@ -1060,7 +1309,12 @@ class ClientConstructorDoesNotHaveConnectionStringParam(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
         super(ClientConstructorDoesNotHaveConnectionStringParam, self).__init__(linter)
@@ -1078,18 +1332,23 @@ class ClientConstructorDoesNotHaveConnectionStringParam(BaseChecker):
                 for func in node.body:
                     if func.name == "__init__":
                         for argument in func.args.args:
-                            if argument.name == "connection_string" or argument.name == "conn_str":
+                            if (
+                                argument.name == "connection_string"
+                                or argument.name == "conn_str"
+                            ):
                                 self.add_message(
-                                    msgid="connection-string-should-not-be-constructor-param", node=node, confidence=None
+                                    msgid="connection-string-should-not-be-constructor-param",
+                                    node=node,
+                                    confidence=None,
                                 )
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client uses connection string param in constructor.")
+            logger.debug(
+                "Pylint custom checker failed to check if client uses connection string param in constructor."
+            )
             pass
 
 
 class PackageNameDoesNotUseUnderscoreOrPeriod(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "package-name-incorrect"
     priority = -1
     msgs = {
@@ -1128,18 +1387,23 @@ class PackageNameDoesNotUseUnderscoreOrPeriod(BaseChecker):
                     if isinstance(nod, astroid.Assign):
                         if nod.targets[0].name == "PACKAGE_NAME":
                             package = nod.value
-                            if package.value.find(".") != -1 or package.value.find("_") != -1:
+                            if (
+                                package.value.find(".") != -1
+                                or package.value.find("_") != -1
+                            ):
                                 self.add_message(
-                                    msgid="package-name-incorrect", node=node, confidence=None
+                                    msgid="package-name-incorrect",
+                                    node=node,
+                                    confidence=None,
                                 )
         except Exception:
-            logger.debug("Pylint custom checker failed to check if package name is correct.")
+            logger.debug(
+                "Pylint custom checker failed to check if package name is correct."
+            )
             pass
 
 
 class ServiceClientUsesNameWithClientSuffix(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "client-name-incorrect"
     priority = -1
     msgs = {
@@ -1175,7 +1439,9 @@ class ServiceClientUsesNameWithClientSuffix(BaseChecker):
         """
         try:
             # ignore base clients
-            if node.file.endswith("base_client.py") or node.file.endswith("base_client_async.py"):
+            if node.file.endswith("base_client.py") or node.file.endswith(
+                "base_client_async.py"
+            ):
                 return
             if node.file.endswith("client.py") or node.file.endswith("client_async.py"):
                 has_client_suffix = False
@@ -1188,25 +1454,25 @@ class ServiceClientUsesNameWithClientSuffix(BaseChecker):
                         msgid="client-suffix-needed", node=node, confidence=None
                     )
         except Exception:
-            logger.debug("Pylint custom checker failed to check if service client has a client suffix.")
+            logger.debug(
+                "Pylint custom checker failed to check if service client has a client suffix."
+            )
             pass
 
 
 class CheckDocstringParameters(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "check-docstrings"
     priority = -1
     msgs = {
         "C4739": (
             'Params missing in docstring: "%s". See details: '
-            'https://azure.github.io/azure-sdk/python_documentation.html#docstrings',
+            "https://azure.github.io/azure-sdk/python_documentation.html#docstrings",
             "docstring-missing-param",
             "Docstring missing for param.",
         ),
         "C4740": (
             'Param types missing in docstring: "%s". See details: '
-            'https://azure.github.io/azure-sdk/python_documentation.html#docstrings',
+            "https://azure.github.io/azure-sdk/python_documentation.html#docstrings",
             "docstring-missing-type",
             "Docstring missing for param type.",
         ),
@@ -1224,19 +1490,19 @@ class CheckDocstringParameters(BaseChecker):
         ),
         "C4743": (
             '"%s" not found as a parameter. Use :keyword type myarg: if a keyword argument. See details: '
-            'https://azure.github.io/azure-sdk/python_documentation.html#docstrings',
+            "https://azure.github.io/azure-sdk/python_documentation.html#docstrings",
             "docstring-should-be-keyword",
             "Docstring should use keywords.",
         ),
         "C4758": (
             '"%s" missing in docstring or in method signature. There should be a direct correlation between :keyword: arguments in the docstring and keyword-only arguments in method signature. See details: '
-            'https://azure.github.io/azure-sdk/python_documentation.html#docstrings',
+            "https://azure.github.io/azure-sdk/python_documentation.html#docstrings",
             "docstring-keyword-should-match-keyword-only",
             "Docstring keyword arguments and keyword-only method arguments should match.",
         ),
         "C4759": (
             '"%s" type formatted incorrectly. Do not use `:class` in docstring type. See details: '
-            'https://azure.github.io/azure-sdk/python_documentation.html#docstrings',
+            "https://azure.github.io/azure-sdk/python_documentation.html#docstrings",
             "docstring-type-do-not-use-class",
             "Docstring type is formatted incorrectly. Do not use `:class` in docstring type.",
         ),
@@ -1289,7 +1555,6 @@ class CheckDocstringParameters(BaseChecker):
         ),
     )
 
-
     def __init__(self, linter=None):
         super(CheckDocstringParameters, self).__init__(linter)
 
@@ -1311,8 +1576,8 @@ class CheckDocstringParameters(BaseChecker):
         if line.startswith("paramtype"):
             param = line.split("paramtype ")[1]
             if param in keyword_args:
-                keyword_args[param] = docstring[idx+1]
-        
+                keyword_args[param] = docstring[idx + 1]
+
         return keyword_args
 
     def _find_param(self, line, docstring, idx, docparams):
@@ -1332,8 +1597,8 @@ class CheckDocstringParameters(BaseChecker):
         if line.startswith("type"):
             param = line.split("type ")[1]
             if param in docparams:
-                docparams[param] = docstring[idx+1]
-        
+                docparams[param] = docstring[idx + 1]
+
         return docparams
 
     def check_parameters(self, node):
@@ -1357,9 +1622,14 @@ class CheckDocstringParameters(BaseChecker):
         # specific case for constructor where docstring found in class def
         if isinstance(node, astroid.ClassDef):
             for constructor in node.body:
-                if isinstance(constructor, astroid.FunctionDef) and constructor.name == "__init__":
+                if (
+                    isinstance(constructor, astroid.FunctionDef)
+                    and constructor.name == "__init__"
+                ):
                     arg_names = [arg.name for arg in constructor.args.args]
-                    method_keyword_only_args = [arg.name for arg in constructor.args.kwonlyargs]
+                    method_keyword_only_args = [
+                        arg.name for arg in constructor.args.kwonlyargs
+                    ]
                     vararg_name = node.args.vararg
                     break
 
@@ -1375,7 +1645,7 @@ class CheckDocstringParameters(BaseChecker):
             docstring = docstring.split(":")
         except AttributeError:
             return
-        
+
         # If there is a vararg, treat it as a param
         if vararg_name:
             arg_names.append(vararg_name)
@@ -1384,11 +1654,13 @@ class CheckDocstringParameters(BaseChecker):
         docstring_keyword_args = {}
         for idx, line in enumerate(docstring):
             # check for keyword args in docstring
-            docstring_keyword_args.update(self._find_keyword(line, docstring, idx, docstring_keyword_args))
+            docstring_keyword_args.update(
+                self._find_keyword(line, docstring, idx, docstring_keyword_args)
+            )
 
             # check for params in docstring
             docparams.update(self._find_param(line, docstring, idx, docparams))
-           
+
         # check that all params are documented
         missing_params = []
         for param in arg_names:
@@ -1398,26 +1670,52 @@ class CheckDocstringParameters(BaseChecker):
                 missing_params.append(param)
 
         # check that all keyword-only args are documented
-        missing_kwonly_args = list(set(docstring_keyword_args) ^ set(method_keyword_only_args))
+        missing_kwonly_args = list(
+            set(docstring_keyword_args) ^ set(method_keyword_only_args)
+        )
 
         if missing_params:
             self.add_message(
-                msgid="docstring-missing-param", args=(", ".join(missing_params)), node=node, confidence=None
+                msgid="docstring-missing-param",
+                args=(", ".join(missing_params)),
+                node=node,
+                confidence=None,
             )
 
         if missing_kwonly_args:
             self.add_message(
-                msgid="docstring-keyword-should-match-keyword-only", args=(", ".join(missing_kwonly_args)), node=node, confidence=None
+                msgid="docstring-keyword-should-match-keyword-only",
+                args=(", ".join(missing_kwonly_args)),
+                node=node,
+                confidence=None,
             )
 
         # check that all types are formatted correctly
-        add_keyword_type_warnings = [keyword for keyword, doc_type in docstring_keyword_args.items() if doc_type and "CLASS" in doc_type]
+        add_keyword_type_warnings = [
+            keyword
+            for keyword, doc_type in docstring_keyword_args.items()
+            if doc_type and "CLASS" in doc_type
+        ]
         if len(add_keyword_type_warnings) > 0:
-            self.add_message(msgid="docstring-type-do-not-use-class", args=(", ".join(add_keyword_type_warnings)), node=node, confidence=None)
+            self.add_message(
+                msgid="docstring-type-do-not-use-class",
+                args=(", ".join(add_keyword_type_warnings)),
+                node=node,
+                confidence=None,
+            )
 
-        add_docparams_type_warnings = [param for param, doc_type in docparams.items() if doc_type and "CLASS" in doc_type]
+        add_docparams_type_warnings = [
+            param
+            for param, doc_type in docparams.items()
+            if doc_type and "CLASS" in doc_type
+        ]
         if len(add_docparams_type_warnings) > 0:
-            self.add_message(msgid="docstring-type-do-not-use-class", args=(", ".join(add_docparams_type_warnings)), node=node, confidence=None)
+            self.add_message(
+                msgid="docstring-type-do-not-use-class",
+                args=(", ".join(add_docparams_type_warnings)),
+                node=node,
+                confidence=None,
+            )
 
         # check if we have a type for each param and check if documented params that should be keywords
         missing_types = []
@@ -1430,7 +1728,10 @@ class CheckDocstringParameters(BaseChecker):
 
         if missing_types:
             self.add_message(
-                msgid="docstring-missing-type", args=(", ".join(missing_types)), node=node, confidence=None
+                msgid="docstring-missing-type",
+                args=(", ".join(missing_types)),
+                node=node,
+                confidence=None,
             )
 
         if should_be_keywords:
@@ -1438,7 +1739,7 @@ class CheckDocstringParameters(BaseChecker):
                 msgid="docstring-should-be-keyword",
                 args=(", ".join(should_be_keywords)),
                 node=node,
-                confidence=None
+                confidence=None,
             )
 
     def check_return(self, node):
@@ -1458,7 +1759,7 @@ class CheckDocstringParameters(BaseChecker):
             docstring = docstring.split(":")
         except AttributeError:
             return
-    
+
         has_return, has_rtype = False, False
         for line in docstring:
             if line.startswith("return"):
@@ -1467,9 +1768,12 @@ class CheckDocstringParameters(BaseChecker):
                 has_rtype = True
                 try:
                     if "CLASS" in docstring[docstring.index("rtype") + 1]:
-                            self.add_message(
-                                msgid="docstring-type-do-not-use-class", args="rtype", node=node, confidence=None
-                            )
+                        self.add_message(
+                            msgid="docstring-type-do-not-use-class",
+                            args="rtype",
+                            node=node,
+                            confidence=None,
+                        )
                 except:
                     pass
 
@@ -1530,8 +1834,6 @@ class CheckDocstringParameters(BaseChecker):
 
 
 class CheckForPolicyUse(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "check-for-policies"
     priority = -1
     msgs = {
@@ -1659,10 +1961,11 @@ class CheckForPolicyUse(BaseChecker):
         """
         # only throw the error if pylint was run at package level since it needs to check all the files
         # infer run location based on the location of the init file highest in dir hierarchy
-        if node.package: # the init file
+        if node.package:  # the init file
             count = node.file.split("azure-sdk-for-python")[1].count("-")
-            if node.file.split("azure-sdk-for-python")[1].count("\\") <= (5 + count) and \
-                    node.file.split("azure-sdk-for-python")[1].count("/") <= (5 + count):
+            if node.file.split("azure-sdk-for-python")[1].count("\\") <= (
+                5 + count
+            ) and node.file.split("azure-sdk-for-python")[1].count("/") <= (5 + count):
                 self.ran_at_package_level = True
 
         # not really a good place to throw the pylint error, so we'll do it on the init file.
@@ -1670,14 +1973,14 @@ class CheckForPolicyUse(BaseChecker):
         # done manually for some reason
         if node.file.endswith("__init__.py") and self.node_to_use is None:
             header = node.stream().read(200).lower()
-            if header.find(b'disable') != -1:
-                if header.find(b'missing-logging-policy') != -1:
+            if header.find(b"disable") != -1:
+                if header.find(b"missing-logging-policy") != -1:
                     self.disable_logging_error = True
-                if header.find(b'missing-user-agent-policy') != -1:
+                if header.find(b"missing-user-agent-policy") != -1:
                     self.disable_user_agent_error = True
-                if header.find(b'missing-distributed-tracing-policy') != -1:
+                if header.find(b"missing-distributed-tracing-policy") != -1:
                     self.disable_tracing_error = True
-                if header.find(b'missing-retry-policy') != -1:
+                if header.find(b"missing-retry-policy") != -1:
                     self.disable_retry_error = True
             self.node_to_use = node
 
@@ -1689,7 +1992,10 @@ class CheckForPolicyUse(BaseChecker):
                     self.has_policies.add("NetworkTraceLoggingPolicy")
                 if node.body[idx].name.find("LoggingPolicy") != -1:
                     self.has_policies.add("NetworkTraceLoggingPolicy")
-                if "RetryPolicy" in node.body[idx].basenames or "AsyncRetryPolicy" in node.body[idx].basenames:
+                if (
+                    "RetryPolicy" in node.body[idx].basenames
+                    or "AsyncRetryPolicy" in node.body[idx].basenames
+                ):
                     self.has_policies.add("RetryPolicy")
                 if node.body[idx].name.find("RetryPolicy") != -1:
                     self.has_policies.add("RetryPolicy")
@@ -1705,8 +2011,10 @@ class CheckForPolicyUse(BaseChecker):
             # policy is imported in this file, let's check that it gets used in the code
             if isinstance(node.body[idx], astroid.ImportFrom):
                 for imp, pol in enumerate(node.body[idx].names):
-                    if node.body[idx].names[imp][0].endswith("Policy") and \
-                            node.body[idx].names[imp][0] not in self.has_policies:
+                    if (
+                        node.body[idx].names[imp][0].endswith("Policy")
+                        and node.body[idx].names[imp][0] not in self.has_policies
+                    ):
                         self.visit_class(node.body, node.body[idx].names[imp][0])
 
     def close(self):
@@ -1719,28 +2027,34 @@ class CheckForPolicyUse(BaseChecker):
             if self.disable_logging_error is False:
                 if "NetworkTraceLoggingPolicy" not in self.has_policies:
                     self.add_message(
-                        msgid="missing-logging-policy", node=self.node_to_use, confidence=None
+                        msgid="missing-logging-policy",
+                        node=self.node_to_use,
+                        confidence=None,
                     )
             if self.disable_retry_error is False:
                 if "RetryPolicy" not in self.has_policies:
                     self.add_message(
-                        msgid="missing-retry-policy", node=self.node_to_use, confidence=None
+                        msgid="missing-retry-policy",
+                        node=self.node_to_use,
+                        confidence=None,
                     )
             if self.disable_user_agent_error is False:
                 if "UserAgentPolicy" not in self.has_policies:
                     self.add_message(
-                        msgid="missing-user-agent-policy", node=self.node_to_use, confidence=None
+                        msgid="missing-user-agent-policy",
+                        node=self.node_to_use,
+                        confidence=None,
                     )
             if self.disable_tracing_error is False:
                 if "DistributedTracingPolicy" not in self.has_policies:
                     self.add_message(
-                        msgid="missing-distributed-tracing-policy", node=self.node_to_use, confidence=None
+                        msgid="missing-distributed-tracing-policy",
+                        node=self.node_to_use,
+                        confidence=None,
                     )
 
 
 class CheckDocstringAdmonitionNewline(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "check-admonition"
     priority = -1
     msgs = {
@@ -1776,16 +2090,21 @@ class CheckDocstringAdmonitionNewline(BaseChecker):
 
         try:
             # not every class/method will have a docstring so don't crash here, just return
-            if node.doc.find("admonition") != -1 and node.doc.find(".. literalinclude") != -1:
+            if (
+                node.doc.find("admonition") != -1
+                and node.doc.find(".. literalinclude") != -1
+            ):
                 literal_include = node.doc.split(".. literalinclude")[0]
                 chars_list = list(reversed(literal_include))
                 for idx, char in enumerate(chars_list):
-                    if char == '\n':
-                        if chars_list[idx+1] == '\n':
+                    if char == "\n":
+                        if chars_list[idx + 1] == "\n":
                             break
                         else:
                             self.add_message(
-                                "docstring-admonition-needs-newline", node=node, confidence=None
+                                "docstring-admonition-needs-newline",
+                                node=node,
+                                confidence=None,
                             )
                             break
         except Exception:
@@ -1824,8 +2143,6 @@ class CheckDocstringAdmonitionNewline(BaseChecker):
 
 
 class CheckEnum(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "check-enum"
     priority = -1
     msgs = {
@@ -1835,7 +2152,7 @@ class CheckEnum(BaseChecker):
             "enum-must-be-uppercase",
             "Capitalize enum name.",
         ),
-        "C4747":(
+        "C4747": (
             "The enum must inherit from CaseInsensitiveEnumMeta. See details: "
             "https://azure.github.io/azure-sdk/python_implementation.html#extensible-enumerations",
             "enum-must-inherit-case-insensitive-enum-meta",
@@ -1873,23 +2190,24 @@ class CheckEnum(BaseChecker):
         :return: None
         """
         try:
-            
             # If it has a metaclass, and is an enum class, check the capitalization
             if node.declared_metaclass():
                 if node.declared_metaclass().name == "CaseInsensitiveEnumMeta":
-                    self._enum_uppercase(node)   
+                    self._enum_uppercase(node)
             # Else if it does not have a metaclass, but it is an enum class
             # Check both capitalization and throw pylint error for metaclass
             elif node.bases[0].name == "str" and node.bases[1].name == "Enum":
                 self.add_message(
-                    "enum-must-inherit-case-insensitive-enum-meta", node=node, confidence=None
+                    "enum-must-inherit-case-insensitive-enum-meta",
+                    node=node,
+                    confidence=None,
                 )
-                self._enum_uppercase(node)  
+                self._enum_uppercase(node)
 
         except Exception:
             logger.debug("Pylint custom checker failed to check enum.")
             pass
-    
+
     def _enum_uppercase(self, node):
         """Visits every enum within the class.
         Checks if the enum is uppercase, if it isn't it
@@ -1909,8 +2227,6 @@ class CheckEnum(BaseChecker):
 
 
 class CheckAPIVersion(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "check-api-version-kwarg"
     priority = -1
     msgs = {
@@ -1932,10 +2248,15 @@ class CheckAPIVersion(BaseChecker):
             },
         ),
     )
-    ignore_clients = ["PipelineClient", "AsyncPipelineClient", "ARMPipelineClient", "AsyncARMPipelineClient"]
+    ignore_clients = [
+        "PipelineClient",
+        "AsyncPipelineClient",
+        "ARMPipelineClient",
+        "AsyncARMPipelineClient",
+    ]
 
     def __init__(self, linter=None):
-        super(CheckAPIVersion, self).__init__(linter)             
+        super(CheckAPIVersion, self).__init__(linter)
 
     def visit_classdef(self, node):
         """Visits every class in file and checks if it is a client.
@@ -1948,32 +2269,39 @@ class CheckAPIVersion(BaseChecker):
 
         try:
             api_version = False
-            
+
             if node.name.endswith("Client") and node.name not in self.ignore_clients:
                 if node.doc:
-                    if ":keyword api_version:" in node.doc or ":keyword str api_version:" in node.doc:
+                    if (
+                        ":keyword api_version:" in node.doc
+                        or ":keyword str api_version:" in node.doc
+                    ):
                         api_version = True
-                if not api_version:    
+                if not api_version:
                     for func in node.body:
                         if isinstance(func, astroid.FunctionDef):
-                            if func.name == '__init__':
-                                if func.doc: 
-                                    if ":keyword api_version:" in func.doc or ":keyword str api_version:" in func.doc:
+                            if func.name == "__init__":
+                                if func.doc:
+                                    if (
+                                        ":keyword api_version:" in func.doc
+                                        or ":keyword str api_version:" in func.doc
+                                    ):
                                         api_version = True
                                 if not api_version:
                                     self.add_message(
-                                        msgid="client-accepts-api-version-keyword", node=node, confidence=None
-                                    )   
-    
-      
+                                        msgid="client-accepts-api-version-keyword",
+                                        node=node,
+                                        confidence=None,
+                                    )
+
         except AttributeError:
-            logger.debug("Pylint custom checker failed to check if client takes in an optional keyword-only api_version argument.")
-            pass                                                                                    
+            logger.debug(
+                "Pylint custom checker failed to check if client takes in an optional keyword-only api_version argument."
+            )
+            pass
 
 
 class CheckNamingMismatchGeneratedCode(BaseChecker):
-    __implements__ = IAstroidChecker
-
     name = "check-naming-mismatch"
     priority = -1
     msgs = {
@@ -2011,9 +2339,11 @@ class CheckNamingMismatchGeneratedCode(BaseChecker):
         try:
             if node.file.endswith("__init__.py"):
                 aliased = []
-            
+
                 for nod in node.body:
-                    if isinstance(nod, astroid.ImportFrom) or isinstance(nod, astroid.Import):
+                    if isinstance(nod, astroid.ImportFrom) or isinstance(
+                        nod, astroid.Import
+                    ):
                         # If the model has been aliased
                         for name in nod.names:
                             if name[1] is not None:
@@ -2026,17 +2356,21 @@ class CheckNamingMismatchGeneratedCode(BaseChecker):
                                 for model_name in models.elts:
                                     if model_name.value in aliased:
                                         self.add_message(
-                                            msgid="naming-mismatch", node=model_name, confidence=None
+                                            msgid="naming-mismatch",
+                                            node=model_name,
+                                            confidence=None,
                                         )
-    
+
         except Exception:
-                logger.debug("Pylint custom checker failed to check if model is aliased.")
+            logger.debug("Pylint custom checker failed to check if model is aliased.")
+
 
 class NonCoreNetworkImport(BaseChecker):
     """There are certain imports that should only occur in the core package.
     For example, instead of using `requests` to make requests, clients should
     take a `azure.core.pipeline.Pipeline` as input to make requests.
     """
+
     name = "networking-import-outside-azure-core-transport"
     priority = -1
     msgs = {
@@ -2059,22 +2393,26 @@ class NonCoreNetworkImport(BaseChecker):
 
     def visit_importfrom(self, node):
         """Check that we aren't importing from a blocked package."""
-        if node.root().name.startswith(self.AZURE_CORE_TRANSPORT_NAME): 
+        if node.root().name.startswith(self.AZURE_CORE_TRANSPORT_NAME):
             return
         self._check_import(node.modname, node)
-    
+
     def _check_import(self, name, node):
         """Check if an import is blocked."""
         for blocked in self.BLOCKED_MODULES:
             if name.startswith(blocked):
                 self.add_message(
-                    msgid=f"networking-import-outside-azure-core-transport", node=node, confidence=None
+                    msgid=f"networking-import-outside-azure-core-transport",
+                    node=node,
+                    confidence=None,
                 )
+
 
 class NonAbstractTransportImport(BaseChecker):
     """Rule to check that we aren't importing transports outside of `azure.core.pipeline.transport`.
     Transport selection should be up to `azure.core` or the end-user, not individual SDKs.
     """
+
     name = "non-abstract-transport-import"
     priority = -1
     msgs = {
@@ -2085,13 +2423,19 @@ class NonAbstractTransportImport(BaseChecker):
         ),
     }
     AZURE_CORE_TRANSPORT_NAME = "azure.core.pipeline.transport"
-    ABSTRACT_CLASSES = {"HttpTransport", "HttpRequest", "HttpResponse", "AsyncHttpTransport", "AsyncHttpResponse"}
+    ABSTRACT_CLASSES = {
+        "HttpTransport",
+        "HttpRequest",
+        "HttpResponse",
+        "AsyncHttpTransport",
+        "AsyncHttpResponse",
+    }
 
     def visit_importfrom(self, node):
         """Check that we aren't importing from a blocked package."""
-        if node.root().name.startswith(self.AZURE_CORE_TRANSPORT_NAME): 
+        if node.root().name.startswith(self.AZURE_CORE_TRANSPORT_NAME):
             return
-        if node.modname == self.AZURE_CORE_TRANSPORT_NAME: 
+        if node.modname == self.AZURE_CORE_TRANSPORT_NAME:
             for name, _ in node.names:
                 if name not in self.ABSTRACT_CLASSES:
                     self.add_message(
@@ -2100,22 +2444,23 @@ class NonAbstractTransportImport(BaseChecker):
                         confidence=None,
                     )
 
+
 class NoAzureCoreTracebackUseRaiseFrom(BaseChecker):
-    __implements__ = IAstroidChecker
 
     """Rule to check that we don't use raise_with_traceback from azure core."""
+
     name = "no-raise-with-traceback"
     priority = -1
     msgs = {
         "C4754": (
             "Don't use raise_with_traceback, use python 3 'raise from' syntax.",
             "no-raise-with-traceback",
-            "Don't use raise_with_traceback instead use python 3 'raise from' syntax."
+            "Don't use raise_with_traceback instead use python 3 'raise from' syntax.",
         ),
     }
 
     def visit_import(self, node):
-        """Checks all imports to make sure we are 
+        """Checks all imports to make sure we are
         not using raise_with_traceback from azure core."""
         try:
             if node.modname == "azure.core.exceptions":
@@ -2125,7 +2470,7 @@ class NoAzureCoreTracebackUseRaiseFrom(BaseChecker):
             pass
 
     def visit_importfrom(self, node):
-        """Checks all `from` imports to make sure we are 
+        """Checks all `from` imports to make sure we are
         not using raise_with_traceback from azure core."""
 
         try:
@@ -2133,7 +2478,7 @@ class NoAzureCoreTracebackUseRaiseFrom(BaseChecker):
                 for import_, _ in node.names:
                     self._check_import(import_, node)
         except:
-            pass 
+            pass
 
     def _check_import(self, name, node):
         """Raises message if raise_with_traceback is found."""
@@ -2143,62 +2488,64 @@ class NoAzureCoreTracebackUseRaiseFrom(BaseChecker):
                 msgid="no-raise-with-traceback", node=node, confidence=None
             )
 
+
 class NameExceedsStandardCharacterLength(BaseChecker):
-    __implements__ = IAstroidChecker
 
     """Rule to check that the character length of type and property names are not over 40 characters."""
+
     name = "name-too-long"
     priority = -1
     msgs = {
         "C4751": (
             "Name is over standard character length of 40.",
             "name-too-long",
-            "Only use names that are less than 40 characters."
+            "Only use names that are less than 40 characters.",
         ),
     }
 
     STANDARD_CHARACTER_LENGTH = 40
 
-    def visit_classdef(self,node):
+    def visit_classdef(self, node):
         """Visit every class and check that the
          class name is within the character length limit.
 
         :param node: node
         :type node: ast.ClassDef
-         
-         """
+
+        """
 
         try:
-            self.iterate_through_names(node, True)    
+            self.iterate_through_names(node, True)
         except:
-            pass   
-
+            pass
 
     def visit_functiondef(self, node):
-        """Visit every function and check that the function and 
+        """Visit every function and check that the function and
         its variable names are within the character length limit.
-        
+
         :param node: node
         :type node: ast.FunctionDef
-        
+
         """
         try:
-            self.iterate_through_names(node, False)    
+            self.iterate_through_names(node, False)
         except:
-            pass      
+            pass
 
     def iterate_through_names(self, node, ignore_function):
         """Helper function to iterate through names.
 
-            :param node: node
-            :type node: ast.ClassDef or ast.FunctionDef
-            :param ignore_function: Whether the function is being called 
-             from `visit_classdef` or not. If it is called from `visit_classdef`
-             ignore_function should be `True` to avoid repeat warnings on functions. 
-            :type ignore_function: bool
-            :return: None
+        :param node: node
+        :type node: ast.ClassDef or ast.FunctionDef
+        :param ignore_function: Whether the function is being called
+         from `visit_classdef` or not. If it is called from `visit_classdef`
+         ignore_function should be `True` to avoid repeat warnings on functions.
+        :type ignore_function: bool
+        :return: None
         """
-        if len(node.name) > self.STANDARD_CHARACTER_LENGTH and not node.name.startswith("_"):
+        if len(node.name) > self.STANDARD_CHARACTER_LENGTH and not node.name.startswith(
+            "_"
+        ):
             self.add_message(
                 msgid="name-too-long",
                 node=node,
@@ -2206,52 +2553,69 @@ class NameExceedsStandardCharacterLength(BaseChecker):
             )
 
         for i in node.body:
-            if not (isinstance(i, astroid.FunctionDef) or isinstance(i, astroid.AsyncFunctionDef)) and not ignore_function:
+            if (
+                not (
+                    isinstance(i, astroid.FunctionDef)
+                    or isinstance(i, astroid.AsyncFunctionDef)
+                )
+                and not ignore_function
+            ):
                 try:
-                    if len(i.name) > self.STANDARD_CHARACTER_LENGTH and not i.name.startswith("_"):
+                    if len(
+                        i.name
+                    ) > self.STANDARD_CHARACTER_LENGTH and not i.name.startswith("_"):
                         self.add_message(
                             msgid="name-too-long",
                             node=i,
                             confidence=None,
-                        )        
+                        )
                 except:
                     # Gets the names of ast.Assign statements
                     for j in i.targets:
                         if isinstance(j, astroid.AssignName):
-                            if len(j.name) > self.STANDARD_CHARACTER_LENGTH and not j.name.startswith("_"):
+                            if len(
+                                j.name
+                            ) > self.STANDARD_CHARACTER_LENGTH and not j.name.startswith(
+                                "_"
+                            ):
                                 self.add_message(
                                     msgid="name-too-long",
                                     node=j,
                                     confidence=None,
-                                )  
+                                )
                         elif isinstance(j, astroid.AssignAttr):
                             # for self.names
-                            if len(j.attrname) > self.STANDARD_CHARACTER_LENGTH and not j.attrname.startswith("_"):
+                            if len(
+                                j.attrname
+                            ) > self.STANDARD_CHARACTER_LENGTH and not j.attrname.startswith(
+                                "_"
+                            ):
                                 self.add_message(
                                     msgid="name-too-long",
                                     node=j,
                                     confidence=None,
-                                )  
+                                )
 
-    visit_asyncfunctiondef = visit_functiondef    
+    visit_asyncfunctiondef = visit_functiondef
+
 
 class DeleteOperationReturnStatement(BaseChecker):
-    __implements__ = IAstroidChecker
 
     """Rule to check that delete* or begin_delete* return None or LROPoller[None], respectively."""
+
     name = "delete-operation-wrong-return-type"
     priority = -1
     msgs = {
         "C4752": (
             "delete* or begin_delete* should return None or LROPoller[None], respectively.",
             "delete-operation-wrong-return-type",
-            "delete* or begin_delete* functions should return None or LROPoller[None]."
+            "delete* or begin_delete* functions should return None or LROPoller[None].",
         ),
     }
 
-    def visit_functiondef(self,node):
+    def visit_functiondef(self, node):
         """Visits all delete functions and checks that their return types
-        are LROPoller or None. """
+        are LROPoller or None."""
         try:
             if node.returns.as_string() == "None":
                 # If there are residual comment typehints or no return value,
@@ -2263,40 +2627,46 @@ class DeleteOperationReturnStatement(BaseChecker):
                         msgid="delete-operation-wrong-return-type",
                         node=node,
                         confidence=None,
-                    )   
-            if node.name.startswith("begin_delete") and node.parent.name.endswith("Client"):
-                if node.returns.as_string() != "LROPoller[None]" and node.returns.as_string() != "AsyncLROPoller[None]":
+                    )
+            if node.name.startswith("begin_delete") and node.parent.name.endswith(
+                "Client"
+            ):
+                if (
+                    node.returns.as_string() != "LROPoller[None]"
+                    and node.returns.as_string() != "AsyncLROPoller[None]"
+                ):
                     self.add_message(
                         msgid="delete-operation-wrong-return-type",
                         node=node,
                         confidence=None,
-                    )   
+                    )
         except:
             pass
 
+
 class DoNotImportLegacySix(BaseChecker):
-    __implements__ = IAstroidChecker
 
     """Rule to check that libraries do not import the six package."""
+
     name = "do-not-import-legacy-six"
     priority = -1
     msgs = {
         "C4757": (
             "Do not import the six package in your library. Six was used to work with python2, which is no longer supported.",
             "do-not-import-legacy-six",
-            "Do not import the six package in your library."
+            "Do not import the six package in your library.",
         ),
     }
 
     def visit_importfrom(self, node):
         """Check that we aren't importing from six."""
-        if node.modname == "six": 
+        if node.modname == "six":
             self.add_message(
                 msgid=f"do-not-import-legacy-six",
                 node=node,
                 confidence=None,
             )
-    
+
     def visit_import(self, node):
         """Check that we aren't importing six."""
         for name, _ in node.names:
@@ -2307,17 +2677,18 @@ class DoNotImportLegacySix(BaseChecker):
                     confidence=None,
                 )
 
+
 class NoLegacyAzureCoreHttpResponseImport(BaseChecker):
-    __implements__ = IAstroidChecker
 
     """Rule to check that we aren't importing azure.core.pipeline.transport.HttpResponse outside of Azure Core."""
+
     name = "no-legacy-azure-core-http-response-import"
     priority = -1
     msgs = {
         "C4756": (
             "Do not import HttpResponse from azure.core.pipeline.transport outside of Azure Core.",
             "no-legacy-azure-core-http-response-import",
-            "Do not import HttpResponse from azure.core.pipeline.transport outside of Azure Core. You can import HttpResponse from azure.core.rest instead."
+            "Do not import HttpResponse from azure.core.pipeline.transport outside of Azure Core. You can import HttpResponse from azure.core.rest instead.",
         ),
     }
 
@@ -2328,9 +2699,11 @@ class NoLegacyAzureCoreHttpResponseImport(BaseChecker):
 
     def visit_importfrom(self, node):
         """Check that we aren't importing from azure.core.pipeline.transport import HttpResponse."""
-        if node.root().name.startswith(self.AZURE_CORE_NAME) or node.root().name.startswith(self.AZURE_MGMT_CORE): 
+        if node.root().name.startswith(
+            self.AZURE_CORE_NAME
+        ) or node.root().name.startswith(self.AZURE_MGMT_CORE):
             return
-        if node.modname == self.AZURE_CORE_TRANSPORT_NAME: 
+        if node.modname == self.AZURE_CORE_TRANSPORT_NAME:
             for name, _ in node.names:
                 if name in self.RESPONSE_CLASSES:
                     self.add_message(
@@ -2338,6 +2711,7 @@ class NoLegacyAzureCoreHttpResponseImport(BaseChecker):
                         node=node,
                         confidence=None,
                     )
+
 
 # if a linter is registered in this function then it will be checked with pylint
 def register(linter):
@@ -2347,7 +2721,9 @@ def register(linter):
     linter.register_checker(ClientMethodsHaveTypeAnnotations(linter))
     linter.register_checker(ClientUsesCorrectNamingConventions(linter))
     linter.register_checker(ClientMethodsHaveKwargsParameter(linter))
-    linter.register_checker(ClientHasKwargsInPoliciesForCreateConfigurationMethod(linter))
+    linter.register_checker(
+        ClientHasKwargsInPoliciesForCreateConfigurationMethod(linter)
+    )
     linter.register_checker(AsyncClientCorrectNaming(linter))
     linter.register_checker(FileHasCopyrightHeader(linter))
     linter.register_checker(ClientMethodNamesDoNotUseDoubleUnderscorePrefix(linter))
@@ -2375,7 +2751,7 @@ def register(linter):
     # Rules are disabled until false positive rate improved
     # linter.register_checker(CheckForPolicyUse(linter))
     # linter.register_checker(ClientHasApprovedMethodNamePrefix(linter))
-    
+
     # linter.register_checker(ClientDocstringUsesLiteralIncludeForCodeExample(linter))
     # linter.register_checker(ClientLROMethodsUseCorePolling(linter))
     # linter.register_checker(ClientLROMethodsUseCorrectNaming(linter))

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -900,7 +900,7 @@ class ClientDocstringUsesLiteralIncludeForCodeExample(BaseChecker):
         """
         try:
             if node.name.endswith("Client") and node.name not in self.ignore_clients:
-                if node.doc.find("code-block") != -1:
+                if node.doc_node.value.find("code-block") != -1:
                     self.add_message(
                         msgid="client-docstring-use-literal-include",
                         node=node,
@@ -926,7 +926,7 @@ class ClientDocstringUsesLiteralIncludeForCodeExample(BaseChecker):
                 and node.parent.name not in self.ignore_clients
                 and node.is_method()
             ):
-                if node.doc.find("code-block") != -1:
+                if node.doc_node.value.find("code-block") != -1:
                     self.add_message(
                         msgid="client-docstring-use-literal-include",
                         node=node,
@@ -1198,7 +1198,7 @@ class ClientLROMethodsUseCorePolling(BaseChecker):
                 if node.name.startswith("begin"):
                     try:
                         # infer_call_result gives the method return value as a string
-                        returns = next(node.infer_call_result()).as_string()
+                        returns = next(node.infer_call_result(caller=node)).as_string()
                         if returns.find("LROPoller") == -1:
                             self.add_message(
                                 msgid="client-lro-methods-use-polling",
@@ -1640,7 +1640,7 @@ class CheckDocstringParameters(BaseChecker):
 
         try:
             # check for incorrect type :class to prevent splitting
-            docstring = node.doc.replace(":class:", "CLASS ")
+            docstring = node.doc_node.value.replace(":class:", "CLASS ")
             # not every method will have a docstring so don't crash here, just return
             docstring = docstring.split(":")
         except AttributeError:
@@ -1754,7 +1754,7 @@ class CheckDocstringParameters(BaseChecker):
 
         try:
             # check for incorrect type :class to prevent splitting
-            docstring = node.doc.replace(":class:", "CLASS ")
+            docstring = node.doc_node.value.replace(":class:", "CLASS ")
             # not every method will have a docstring so don't crash here, just return
             docstring = docstring.split(":")
         except AttributeError:
@@ -1780,7 +1780,7 @@ class CheckDocstringParameters(BaseChecker):
         # Get decorators on the function
         function_decorators = node.decoratornames()
         try:
-            returns = next(node.infer_call_result()).as_string()
+            returns = next(node.infer_call_result(caller=node)).as_string()
             # If returns None ignore
             if returns == "None":
                 return
@@ -2091,10 +2091,10 @@ class CheckDocstringAdmonitionNewline(BaseChecker):
         try:
             # not every class/method will have a docstring so don't crash here, just return
             if (
-                node.doc.find("admonition") != -1
-                and node.doc.find(".. literalinclude") != -1
+                node.doc_node.value.find("admonition") != -1
+                and node.doc_node.value.find(".. literalinclude") != -1
             ):
-                literal_include = node.doc.split(".. literalinclude")[0]
+                literal_include = node.doc_node.value.split(".. literalinclude")[0]
                 chars_list = list(reversed(literal_include))
                 for idx, char in enumerate(chars_list):
                     if char == "\n":
@@ -2271,20 +2271,20 @@ class CheckAPIVersion(BaseChecker):
             api_version = False
 
             if node.name.endswith("Client") and node.name not in self.ignore_clients:
-                if node.doc:
+                if node.doc_node:
                     if (
-                        ":keyword api_version:" in node.doc
-                        or ":keyword str api_version:" in node.doc
+                        ":keyword api_version:" in node.doc_node.value
+                        or ":keyword str api_version:" in node.doc_node.value
                     ):
                         api_version = True
                 if not api_version:
                     for func in node.body:
                         if isinstance(func, astroid.FunctionDef):
                             if func.name == "__init__":
-                                if func.doc:
+                                if func.doc_node:
                                     if (
-                                        ":keyword api_version:" in func.doc
-                                        or ":keyword str api_version:" in func.doc
+                                        ":keyword api_version:" in func.doc_node.value
+                                        or ":keyword str api_version:" in func.doc_node.value
                                     ):
                                         api_version = True
                                 if not api_version:

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -9,13 +9,8 @@ Pylint custom checkers for SDK guidelines: C4717 - C4758
 
 import logging
 import astroid
-from astroid import nodes
-from typing import TYPE_CHECKING, Optional
-
 from pylint.checkers import BaseChecker
 
-if TYPE_CHECKING:
-    from pylint.lint import PyLinter
 
 logger = logging.getLogger(__name__)
 

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/setup.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/setup.py
@@ -15,5 +15,5 @@ setup(
     py_modules=["pylint_guidelines_checker"],
     long_description=readme,
     long_description_content_type="text/markdown",
-    python_requires=">=3.7",
+    python_requires=">=3.8",
 )

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/setup.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/setup.py
@@ -1,19 +1,19 @@
 from setuptools import setup
 
 
-with open('README.md', encoding='utf-8') as f:
+with open("README.md", encoding="utf-8") as f:
     readme = f.read()
 
 setup(
     name="azure-pylint-guidelines-checker",
     version="0.2.0",
-    url='http://github.com/Azure/azure-sdk-for-python',
-    license='MIT License',
+    url="http://github.com/Azure/azure-sdk-for-python",
+    license="MIT License",
     description="A pylint plugin which enforces azure sdk guidelines.",
-    author='Microsoft Corporation',
-    author_email='azpysdkhelp@microsoft.com',
-    py_modules=['pylint_guidelines_checker'],
+    author="Microsoft Corporation",
+    author_email="azpysdkhelp@microsoft.com",
+    py_modules=["pylint_guidelines_checker"],
     long_description=readme,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     python_requires=">=3.7",
 )

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/__init__.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/__init__.py
@@ -5,5 +5,5 @@ from something2 import something2 as somethingTwo
 
 __all__ = (
     Something,
-    somethingTwo, #pylint: disable=naming-mismatch
+    somethingTwo,  # pylint: disable=naming-mismatch
 )

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/api_version_checker_acceptable_class.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/api_version_checker_acceptable_class.py
@@ -1,7 +1,7 @@
-#Test file for api_verison checker 
+# Test file for api_verison checker
 
 
-class SomeClient():
+class SomeClient:
 
     """
     :param str endpoint: Something.
@@ -9,16 +9,13 @@ class SomeClient():
         The API version of the service to use for requests. It defaults to API version v2.1.
         Setting to an older version may result in reduced feature compatibility. To use the
         latest supported API version and features, instantiate a DocumentAnalysisClient instead.
-    :paramtype api_version: str 
+    :paramtype api_version: str
     :param credential: Something.
     :type credential: : TokenCredential.
     :keyword key : Something2.
-    
-     
+
+
     """
 
     def __init__(self, endpoint, credential, **kwargs):
         pass
-
-
-

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/api_version_checker_acceptable_init.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/api_version_checker_acceptable_init.py
@@ -1,7 +1,7 @@
-#Test file for api_verison checker 
+# Test file for api_verison checker
 
-class SomeClient():
 
+class SomeClient:
     def __init__(self, endpoint, credential, **kwargs):
         """
         :param str endpoint: Something.
@@ -11,7 +11,7 @@ class SomeClient():
             The API version of the service to use for requests. It defaults to API version v2.1.
             Setting to an older version may result in reduced feature compatibility. To use the
             latest supported API version and features, instantiate a DocumentAnalysisClient instead.
-        :paramtype api_version: str 
-        
+        :paramtype api_version: str
+
         """
         pass

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/api_version_checker_violation.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/api_version_checker_violation.py
@@ -1,13 +1,12 @@
 # Test file for api version checker
 
 
-class SomeClient():
-
+class SomeClient:
     def __init__(self, endpoint, credential, **kwargs):
         """
         :param str endpoint: Something.
         :param credential: Something.
         :type credential: TokenCredential.
-        
+
         """
         pass

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/copyright_header_acceptable.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/copyright_header_acceptable.py
@@ -4,6 +4,6 @@
 # ------------------------------------
 
 
-class Something():
+class Something:
     def __init__(self):
         pass

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/copyright_header_violation.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/copyright_header_violation.py
@@ -1,3 +1,3 @@
-class Something():
+class Something:
     def __init__(self):
         pass

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/core_paging_acceptable.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/core_paging_acceptable.py
@@ -1,21 +1,27 @@
 from azure.core.paging import ItemPaged
 
-class CosmosClient():
+
+class CosmosClient:
     def __init__(self, url, credential, consistency_level=None, **kwargs):
         auth = credential
         connection_policy = "connection_policy"
         self.client_connection = CosmosClientConnection(
-            url, auth=auth, consistency_level=consistency_level, connection_policy=connection_policy, **kwargs
+            url,
+            auth=auth,
+            consistency_level=consistency_level,
+            connection_policy=connection_policy,
+            **kwargs
         )
 
     def list_databases(self, **kwargs):
         result = self.client_connection.ReadDatabases(options="", **kwargs)
         return result
 
+
 class CosmosClientConnection(object):
     def ReadDatabases(self, options=None, **kwargs):
-         return self.QueryDatabases(None, options, **kwargs)
-         
+        return self.QueryDatabases(None, options, **kwargs)
+
     def QueryDatabases(self, query, options=None, **kwargs):
         return ItemPaged(
             self, query, options, fetch_function="fetch", page_iterator_class=query

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/core_paging_acceptable_and_violation.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/core_paging_acceptable_and_violation.py
@@ -1,33 +1,32 @@
 import azure
 
-class SearchQuery():
+
+class SearchQuery:
     """Represent a rich search query again an Azure Search index."""
 
     def order_by(self, *fields):
         pass
 
-class SearchItemPaged():
+
+class SearchItemPaged:
     def __init__(self, *args, **kwargs):
         super(SearchItemPaged, self).__init__(*args, **kwargs)
         self._first_page_iterator_instance = None
 
     def by_page():
-       pass
+        pass
 
-class SearchClient(): #@
-    def list_search(self, search_text, **kwargs): # pylint:disable=too-many-locals
+
+class SearchClient:  # @
+    def list_search(self, search_text, **kwargs):  # pylint:disable=too-many-locals
         # type: (str, **Any) -> SearchItemPaged[dict]
-        """Search the Azure search index for documents.
-
-        """
+        """Search the Azure search index for documents."""
         self._client = None
         query = None
-        return SearchItemPaged(
-            self._client, query, kwargs, page_iterator_class=None
-        )
-    
+        return SearchItemPaged(self._client, query, kwargs, page_iterator_class=None)
+
     def list_this(self):
         return azure.core.paging.ItemPaged()
-    
+
     def list_something(self):
         return None

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/core_paging_violation.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/core_paging_violation.py
@@ -1,12 +1,14 @@
 from azure.core.paging import ItemPaged
 
-class CustomClass():
+
+class CustomClass:
     def not_right(self):
         pass
 
-class SomeClient(): #@
-    def list_thing(self): #@
-        '''
+
+class SomeClient:  # @
+    def list_thing(self):  # @
+        """
         :rtype: CustomClass()
-        '''
+        """
         return CustomClass()

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/enum_checker_acceptable.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/enum_checker_acceptable.py
@@ -3,6 +3,7 @@ from enum import Enum
 from six import with_metaclass
 from azure.core import CaseInsensitiveEnumMeta
 
+
 class EnumPython2(with_metaclass(CaseInsensitiveEnumMeta, str, Enum)):
     ONE = "one"
     TWO = "two"

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/enum_checker_violation.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/enum_checker_violation.py
@@ -1,5 +1,6 @@
 # Test file for enum checker
 from enum import Enum
 
+
 class EnumPython(str, Enum):
     One = "one"

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -14,41 +14,49 @@ import pylint_guidelines_checker as checker
 
 TEST_FOLDER = os.path.abspath(os.path.join(__file__, ".."))
 
+
 class TestClientMethodsHaveTracingDecorators(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.ClientMethodsHaveTracingDecorators
 
     def test_ignores_constructor(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_private_method(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def _private_method(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_private_method_async(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             async def _private_method(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(function_node)
 
     def test_ignores_methods_with_decorators(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         from azure.core.tracing.decorator import distributed_trace
         class SomeClient(): #@
             @distributed_trace
@@ -60,7 +68,8 @@ class TestClientMethodsHaveTracingDecorators(pylint.testutils.CheckerTestCase):
             @distributed_trace
             def list_thing(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(func_node_a)
@@ -68,7 +77,8 @@ class TestClientMethodsHaveTracingDecorators(pylint.testutils.CheckerTestCase):
             self.checker.visit_functiondef(func_node_c)
 
     def test_ignores_async_methods_with_decorators(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         from azure.core.tracing.decorator_async import distributed_trace_async
         class SomeClient(): #@
             @distributed_trace_async
@@ -80,7 +90,8 @@ class TestClientMethodsHaveTracingDecorators(pylint.testutils.CheckerTestCase):
             @distributed_trace_async
             async def list_thing(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(func_node_a)
@@ -88,7 +99,8 @@ class TestClientMethodsHaveTracingDecorators(pylint.testutils.CheckerTestCase):
             self.checker.visit_asyncfunctiondef(func_node_c)
 
     def test_finds_sync_decorator_on_async_method(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         from azure.core.tracing.decorator import distributed_trace
         class SomeClient(): #@
             @distributed_trace
@@ -100,16 +112,32 @@ class TestClientMethodsHaveTracingDecorators(pylint.testutils.CheckerTestCase):
             @distributed_trace
             async def list_thing(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-tracing-decorator-async", line=5, node=func_node_a, col_offset=4, end_line=5, end_col_offset=34
+                msg_id="client-method-missing-tracing-decorator-async",
+                line=5,
+                node=func_node_a,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=34,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-tracing-decorator-async", line=8, node=func_node_b, col_offset=4, end_line=8, end_col_offset=23
+                msg_id="client-method-missing-tracing-decorator-async",
+                line=8,
+                node=func_node_b,
+                col_offset=4,
+                end_line=8,
+                end_col_offset=23,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-tracing-decorator-async", line=11, node=func_node_c, col_offset=4, end_line=11, end_col_offset=24
+                msg_id="client-method-missing-tracing-decorator-async",
+                line=11,
+                node=func_node_c,
+                col_offset=4,
+                end_line=11,
+                end_col_offset=24,
             ),
         ):
             self.checker.visit_asyncfunctiondef(func_node_a)
@@ -117,7 +145,8 @@ class TestClientMethodsHaveTracingDecorators(pylint.testutils.CheckerTestCase):
             self.checker.visit_asyncfunctiondef(func_node_c)
 
     def test_finds_async_decorator_on_sync_method(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         from azure.core.tracing.decorator_async import distributed_trace_async
         class SomeClient(): #@
             @distributed_trace_async
@@ -129,16 +158,32 @@ class TestClientMethodsHaveTracingDecorators(pylint.testutils.CheckerTestCase):
             @distributed_trace_async
             def list_thing(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-tracing-decorator", line=5, node=func_node_a, col_offset=4, end_line=5, end_col_offset=28
+                msg_id="client-method-missing-tracing-decorator",
+                line=5,
+                node=func_node_a,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=28,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-tracing-decorator", line=8, node=func_node_b, col_offset=4, end_line=8, end_col_offset=17
+                msg_id="client-method-missing-tracing-decorator",
+                line=8,
+                node=func_node_b,
+                col_offset=4,
+                end_line=8,
+                end_col_offset=17,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-tracing-decorator", line=11, node=func_node_c, col_offset=4, end_line=11, end_col_offset=18
+                msg_id="client-method-missing-tracing-decorator",
+                line=11,
+                node=func_node_c,
+                col_offset=4,
+                end_line=11,
+                end_col_offset=18,
             ),
         ):
             self.checker.visit_functiondef(func_node_a)
@@ -217,39 +262,46 @@ class TestClientsDoNotUseStaticMethods(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.ClientsDoNotUseStaticMethods
 
     def test_ignores_constructor(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_private_method(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             @staticmethod
             def _private_method(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_private_method_async(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             @staticmethod
             async def _private_method(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(function_node)
 
     def test_ignores_methods_with_other_decorators(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         class SomeClient(): #@
             @distributed_trace
             def create_configuration(self): #@
@@ -260,7 +312,8 @@ class TestClientsDoNotUseStaticMethods(pylint.testutils.CheckerTestCase):
             @distributed_trace
             def list_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(func_node_a)
@@ -268,7 +321,8 @@ class TestClientsDoNotUseStaticMethods(pylint.testutils.CheckerTestCase):
             self.checker.visit_functiondef(func_node_c)
 
     def test_ignores_async_methods_with_other_decorators(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         class SomeClient(): #@
             @distributed_trace_async
             async def create_configuration(self): #@
@@ -279,7 +333,8 @@ class TestClientsDoNotUseStaticMethods(pylint.testutils.CheckerTestCase):
             @distributed_trace_async
             async def list_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(func_node_a)
@@ -287,7 +342,8 @@ class TestClientsDoNotUseStaticMethods(pylint.testutils.CheckerTestCase):
             self.checker.visit_asyncfunctiondef(func_node_c)
 
     def test_finds_staticmethod_on_async_method(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         class SomeClient(): #@
             @staticmethod
             async def create_configuration(self): #@
@@ -298,24 +354,41 @@ class TestClientsDoNotUseStaticMethods(pylint.testutils.CheckerTestCase):
             @staticmethod
             async def list_thing(self): #@
                 pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-should-not-use-static-method", line=4, node=func_node_a, col_offset=4, end_line=4, end_col_offset=34
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-should-not-use-static-method", line=7, node=func_node_b, col_offset=4, end_line=7, end_col_offset=23
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-should-not-use-static-method", line=10, node=func_node_c, col_offset=4, end_line=10, end_col_offset=24
-                ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-should-not-use-static-method",
+                line=4,
+                node=func_node_a,
+                col_offset=4,
+                end_line=4,
+                end_col_offset=34,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-should-not-use-static-method",
+                line=7,
+                node=func_node_b,
+                col_offset=4,
+                end_line=7,
+                end_col_offset=23,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-should-not-use-static-method",
+                line=10,
+                node=func_node_c,
+                col_offset=4,
+                end_line=10,
+                end_col_offset=24,
+            ),
         ):
             self.checker.visit_asyncfunctiondef(func_node_a)
             self.checker.visit_asyncfunctiondef(func_node_b)
             self.checker.visit_asyncfunctiondef(func_node_c)
 
     def test_finds_staticmethod_on_sync_method(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         class SomeClient(): #@
             @staticmethod
             def create_configuration(self): #@
@@ -326,17 +399,33 @@ class TestClientsDoNotUseStaticMethods(pylint.testutils.CheckerTestCase):
             @staticmethod
             def list_thing(self): #@
                 pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-should-not-use-static-method", line=4, node=func_node_a, col_offset=4, end_line=4, end_col_offset=28
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-should-not-use-static-method", line=7, node=func_node_b, col_offset=4, end_line=7, end_col_offset=17
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-should-not-use-static-method", line=10, node=func_node_c, col_offset=4, end_line=10, end_col_offset=18
-                ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-should-not-use-static-method",
+                line=4,
+                node=func_node_a,
+                col_offset=4,
+                end_line=4,
+                end_col_offset=28,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-should-not-use-static-method",
+                line=7,
+                node=func_node_b,
+                col_offset=4,
+                end_line=7,
+                end_col_offset=17,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-should-not-use-static-method",
+                line=10,
+                node=func_node_c,
+                col_offset=4,
+                end_line=10,
+                end_col_offset=18,
+            ),
         ):
             self.checker.visit_functiondef(func_node_a)
             self.checker.visit_functiondef(func_node_b)
@@ -413,48 +502,70 @@ class TestClientHasApprovedMethodNamePrefix(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.ClientHasApprovedMethodNamePrefix
 
     def test_ignores_constructor(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_private_method(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def _private_method(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_if_exists_suffix(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def check_if_exists(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_from_prefix(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def from_connection_string(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_approved_prefix_names(self):
-        class_node, func_node_a, func_node_b, func_node_c, func_node_d, func_node_e, func_node_f, func_node_g, \
-            func_node_h, func_node_i, func_node_j, func_node_k, func_node_l = astroid.extract_node("""
+        (
+            class_node,
+            func_node_a,
+            func_node_b,
+            func_node_c,
+            func_node_d,
+            func_node_e,
+            func_node_f,
+            func_node_g,
+            func_node_h,
+            func_node_i,
+            func_node_j,
+            func_node_k,
+            func_node_l,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             def create_configuration(self): #@
                 pass
@@ -480,7 +591,8 @@ class TestClientHasApprovedMethodNamePrefix(pylint.testutils.CheckerTestCase):
                 pass
             def begin_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
@@ -511,9 +623,26 @@ class TestClientHasApprovedMethodNamePrefix(pylint.testutils.CheckerTestCase):
             self.checker.visit_classdef(class_node)
 
     def test_finds_unapproved_prefix_names(self):
-        class_node, func_node_a, func_node_b, func_node_c, func_node_d, func_node_e, func_node_f, func_node_g, \
-            func_node_h, func_node_i, func_node_j, func_node_k, func_node_l, func_node_m, func_node_n, func_node_o, \
-            func_node_p = astroid.extract_node("""
+        (
+            class_node,
+            func_node_a,
+            func_node_b,
+            func_node_c,
+            func_node_d,
+            func_node_e,
+            func_node_f,
+            func_node_g,
+            func_node_h,
+            func_node_i,
+            func_node_j,
+            func_node_k,
+            func_node_l,
+            func_node_m,
+            func_node_n,
+            func_node_o,
+            func_node_p,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             @distributed_trace
             def build_configuration(self): #@
@@ -548,57 +677,138 @@ class TestClientHasApprovedMethodNamePrefix(pylint.testutils.CheckerTestCase):
                 pass
             def removes_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=4, node=func_node_a, col_offset=4, end_line=4, end_col_offset=27
+                msg_id="unapproved-client-method-name-prefix",
+                line=4,
+                node=func_node_a,
+                col_offset=4,
+                end_line=4,
+                end_col_offset=27,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=6, node=func_node_b, col_offset=4, end_line=6, end_col_offset=22
+                msg_id="unapproved-client-method-name-prefix",
+                line=6,
+                node=func_node_b,
+                col_offset=4,
+                end_line=6,
+                end_col_offset=22,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=8, node=func_node_c, col_offset=4, end_line=8, end_col_offset=18
+                msg_id="unapproved-client-method-name-prefix",
+                line=8,
+                node=func_node_c,
+                col_offset=4,
+                end_line=8,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=10, node=func_node_d, col_offset=4, end_line=10, end_col_offset=20
+                msg_id="unapproved-client-method-name-prefix",
+                line=10,
+                node=func_node_d,
+                col_offset=4,
+                end_line=10,
+                end_col_offset=20,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=12, node=func_node_e, col_offset=4, end_line=12, end_col_offset=17
+                msg_id="unapproved-client-method-name-prefix",
+                line=12,
+                node=func_node_e,
+                col_offset=4,
+                end_line=12,
+                end_col_offset=17,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=14, node=func_node_f, col_offset=4, end_line=14, end_col_offset=29
+                msg_id="unapproved-client-method-name-prefix",
+                line=14,
+                node=func_node_f,
+                col_offset=4,
+                end_line=14,
+                end_col_offset=29,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=16, node=func_node_g, col_offset=4, end_line=16, end_col_offset=18
+                msg_id="unapproved-client-method-name-prefix",
+                line=16,
+                node=func_node_g,
+                col_offset=4,
+                end_line=16,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=18, node=func_node_h, col_offset=4, end_line=18, end_col_offset=19
+                msg_id="unapproved-client-method-name-prefix",
+                line=18,
+                node=func_node_h,
+                col_offset=4,
+                end_line=18,
+                end_col_offset=19,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=20, node=func_node_i, col_offset=4, end_line=20, end_col_offset=21
+                msg_id="unapproved-client-method-name-prefix",
+                line=20,
+                node=func_node_i,
+                col_offset=4,
+                end_line=20,
+                end_col_offset=21,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=22, node=func_node_j, col_offset=4, end_line=22, end_col_offset=18
+                msg_id="unapproved-client-method-name-prefix",
+                line=22,
+                node=func_node_j,
+                col_offset=4,
+                end_line=22,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=24, node=func_node_k, col_offset=4, end_line=24, end_col_offset=21
+                msg_id="unapproved-client-method-name-prefix",
+                line=24,
+                node=func_node_k,
+                col_offset=4,
+                end_line=24,
+                end_col_offset=21,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=26, node=func_node_l, col_offset=4, end_line=26, end_col_offset=22
+                msg_id="unapproved-client-method-name-prefix",
+                line=26,
+                node=func_node_l,
+                col_offset=4,
+                end_line=26,
+                end_col_offset=22,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=28, node=func_node_m, col_offset=4, end_line=28, end_col_offset=21
+                msg_id="unapproved-client-method-name-prefix",
+                line=28,
+                node=func_node_m,
+                col_offset=4,
+                end_line=28,
+                end_col_offset=21,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=30, node=func_node_n, col_offset=4, end_line=30, end_col_offset=18
+                msg_id="unapproved-client-method-name-prefix",
+                line=30,
+                node=func_node_n,
+                col_offset=4,
+                end_line=30,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=32, node=func_node_o, col_offset=4, end_line=32, end_col_offset=21
+                msg_id="unapproved-client-method-name-prefix",
+                line=32,
+                node=func_node_o,
+                col_offset=4,
+                end_line=32,
+                end_col_offset=21,
             ),
             pylint.testutils.MessageTest(
-                msg_id="unapproved-client-method-name-prefix", line=34, node=func_node_p, col_offset=4, end_line=34, end_col_offset=21
-            )
+                msg_id="unapproved-client-method-name-prefix",
+                line=34,
+                node=func_node_p,
+                col_offset=4,
+                end_line=34,
+                end_col_offset=21,
+            ),
         ):
             self.checker.visit_classdef(class_node)
 
@@ -615,82 +825,116 @@ class TestClientConstructorTakesCorrectParameters(pylint.testutils.CheckerTestCa
     CHECKER_CLASS = checker.ClientConstructorTakesCorrectParameters
 
     def test_finds_correct_params(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, thing_url, credential, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_non_constructor_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def create_configuration(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_non_client_constructor_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def __init__(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_finds_constructor_without_kwargs(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, thing_url, credential=None): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="missing-client-constructor-parameter-kwargs", line=3, node=function_node, col_offset=4, end_line=3, end_col_offset=16
+                msg_id="missing-client-constructor-parameter-kwargs",
+                line=3,
+                node=function_node,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=16,
             )
         ):
             self.checker.visit_functiondef(function_node)
 
     def test_finds_constructor_without_credentials(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, thing_url, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="missing-client-constructor-parameter-credential", line=3, node=function_node, col_offset=4, end_line=3, end_col_offset=16
+                msg_id="missing-client-constructor-parameter-credential",
+                line=3,
+                node=function_node,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=16,
             )
         ):
             self.checker.visit_functiondef(function_node)
 
     def test_finds_constructor_with_no_params(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="missing-client-constructor-parameter-credential", line=3, node=function_node, col_offset=4, end_line=3, end_col_offset=16
+                msg_id="missing-client-constructor-parameter-credential",
+                line=3,
+                node=function_node,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=16,
             ),
             pylint.testutils.MessageTest(
-                msg_id="missing-client-constructor-parameter-kwargs", line=3, node=function_node, col_offset=4, end_line=3, end_col_offset=16
-            )
+                msg_id="missing-client-constructor-parameter-kwargs",
+                line=3,
+                node=function_node,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=16,
+            ),
         ):
             self.checker.visit_functiondef(function_node)
 
     def test_guidelines_link_active(self):
-        url = "https://azure.github.io/azure-sdk/python_design.html#client-configuration"
+        url = (
+            "https://azure.github.io/azure-sdk/python_design.html#client-configuration"
+        )
         config = Configuration()
         client = PipelineClient(url, config=config)
         request = client.get(url)
@@ -698,13 +942,30 @@ class TestClientConstructorTakesCorrectParameters(pylint.testutils.CheckerTestCa
         assert response.http_response.status_code == 200
 
 
-class TestClientMethodsUseKwargsWithMultipleParameters(pylint.testutils.CheckerTestCase):
+class TestClientMethodsUseKwargsWithMultipleParameters(
+    pylint.testutils.CheckerTestCase
+):
     CHECKER_CLASS = checker.ClientMethodsUseKwargsWithMultipleParameters
 
     def test_ignores_method_abiding_to_guidelines(self):
-        class_node, function_node, function_node_a, function_node_b, function_node_c, function_node_d, \
-            function_node_e, function_node_f, function_node_g, function_node_h, function_node_i, function_node_j, \
-            function_node_k, function_node_l, function_node_m = astroid.extract_node("""
+        (
+            class_node,
+            function_node,
+            function_node_a,
+            function_node_b,
+            function_node_c,
+            function_node_d,
+            function_node_e,
+            function_node_f,
+            function_node_g,
+            function_node_h,
+            function_node_i,
+            function_node_j,
+            function_node_k,
+            function_node_l,
+            function_node_m,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             @distributed_trace
             def do_thing(): #@
@@ -735,7 +996,8 @@ class TestClientMethodsUseKwargsWithMultipleParameters(pylint.testutils.CheckerT
                 pass
             def do_thing_m(self, one, two, three, four, five, *args, six, seven=7, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
@@ -754,9 +1016,24 @@ class TestClientMethodsUseKwargsWithMultipleParameters(pylint.testutils.CheckerT
             self.checker.visit_functiondef(function_node_m)
 
     def test_ignores_method_abiding_to_guidelines_async(self):
-        class_node, function_node, function_node_a, function_node_b, function_node_c, function_node_d, \
-            function_node_e, function_node_f, function_node_g, function_node_h, function_node_i, function_node_j, \
-            function_node_k, function_node_l, function_node_m = astroid.extract_node("""
+        (
+            class_node,
+            function_node,
+            function_node_a,
+            function_node_b,
+            function_node_c,
+            function_node_d,
+            function_node_e,
+            function_node_f,
+            function_node_g,
+            function_node_h,
+            function_node_i,
+            function_node_j,
+            function_node_k,
+            function_node_l,
+            function_node_m,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             @distributed_trace_async
             async def do_thing(): #@
@@ -787,7 +1064,8 @@ class TestClientMethodsUseKwargsWithMultipleParameters(pylint.testutils.CheckerT
                 pass
             async def do_thing_m(self, one, two, three, four, five, *args, six, seven=7, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(function_node)
@@ -806,8 +1084,17 @@ class TestClientMethodsUseKwargsWithMultipleParameters(pylint.testutils.CheckerT
             self.checker.visit_asyncfunctiondef(function_node_m)
 
     def test_finds_methods_with_too_many_positional_args(self):
-        class_node, function_node, function_node_a, function_node_b, function_node_c, function_node_d, \
-            function_node_e, function_node_f = astroid.extract_node("""
+        (
+            class_node,
+            function_node,
+            function_node_a,
+            function_node_b,
+            function_node_c,
+            function_node_d,
+            function_node_e,
+            function_node_f,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             @distributed_trace
             def do_thing(self, one, two, three, four, five, six): #@
@@ -824,30 +1111,66 @@ class TestClientMethodsUseKwargsWithMultipleParameters(pylint.testutils.CheckerT
                 pass
             def do_thing_f(self, one, two, three, four, five, six, *args, seven=7, eight=8, nine=9): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=4, node=function_node, col_offset=4, end_line=4, end_col_offset=16
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=4,
+                node=function_node,
+                col_offset=4,
+                end_line=4,
+                end_col_offset=16,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=6, node=function_node_a, col_offset=4, end_line=6, end_col_offset=18
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=6,
+                node=function_node_a,
+                col_offset=4,
+                end_line=6,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=8, node=function_node_b, col_offset=4, end_line=8, end_col_offset=18
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=8,
+                node=function_node_b,
+                col_offset=4,
+                end_line=8,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=10, node=function_node_c, col_offset=4, end_line=10, end_col_offset=18
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=10,
+                node=function_node_c,
+                col_offset=4,
+                end_line=10,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=12, node=function_node_d, col_offset=4, end_line=12, end_col_offset=18
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=12,
+                node=function_node_d,
+                col_offset=4,
+                end_line=12,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=14, node=function_node_e, col_offset=4, end_line=14, end_col_offset=18
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=14,
+                node=function_node_e,
+                col_offset=4,
+                end_line=14,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=16, node=function_node_f, col_offset=4, end_line=16, end_col_offset=18
-            )
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=16,
+                node=function_node_f,
+                col_offset=4,
+                end_line=16,
+                end_col_offset=18,
+            ),
         ):
             self.checker.visit_functiondef(function_node)
             self.checker.visit_functiondef(function_node_a)
@@ -858,8 +1181,17 @@ class TestClientMethodsUseKwargsWithMultipleParameters(pylint.testutils.CheckerT
             self.checker.visit_functiondef(function_node_f)
 
     def test_finds_methods_with_too_many_positional_args_async(self):
-        class_node, function_node, function_node_a, function_node_b, function_node_c, function_node_d, \
-            function_node_e, function_node_f = astroid.extract_node("""
+        (
+            class_node,
+            function_node,
+            function_node_a,
+            function_node_b,
+            function_node_c,
+            function_node_d,
+            function_node_e,
+            function_node_f,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             @distributed_trace_async
             async def do_thing(self, one, two, three, four, five, six): #@
@@ -876,30 +1208,66 @@ class TestClientMethodsUseKwargsWithMultipleParameters(pylint.testutils.CheckerT
                 pass
             async def do_thing_f(self, one, two, three, four, five, six, *args, seven=7, eight=8, nine=9): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=4, node=function_node, col_offset=4, end_line=4, end_col_offset=22
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=4,
+                node=function_node,
+                col_offset=4,
+                end_line=4,
+                end_col_offset=22,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=6, node=function_node_a, col_offset=4, end_line=6, end_col_offset=24
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=6,
+                node=function_node_a,
+                col_offset=4,
+                end_line=6,
+                end_col_offset=24,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=8, node=function_node_b, col_offset=4, end_line=8, end_col_offset=24
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=8,
+                node=function_node_b,
+                col_offset=4,
+                end_line=8,
+                end_col_offset=24,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=10, node=function_node_c, col_offset=4, end_line=10, end_col_offset=24
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=10,
+                node=function_node_c,
+                col_offset=4,
+                end_line=10,
+                end_col_offset=24,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=12, node=function_node_d, col_offset=4, end_line=12, end_col_offset=24
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=12,
+                node=function_node_d,
+                col_offset=4,
+                end_line=12,
+                end_col_offset=24,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=14, node=function_node_e, col_offset=4, end_line=14, end_col_offset=24
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=14,
+                node=function_node_e,
+                col_offset=4,
+                end_line=14,
+                end_col_offset=24,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-has-more-than-5-positional-arguments", line=16, node=function_node_f, col_offset=4, end_line=16, end_col_offset=24
-            )
+                msg_id="client-method-has-more-than-5-positional-arguments",
+                line=16,
+                node=function_node_f,
+                col_offset=4,
+                end_line=16,
+                end_col_offset=24,
+            ),
         ):
             self.checker.visit_asyncfunctiondef(function_node)
             self.checker.visit_asyncfunctiondef(function_node_a)
@@ -910,7 +1278,8 @@ class TestClientMethodsUseKwargsWithMultipleParameters(pylint.testutils.CheckerT
             self.checker.visit_asyncfunctiondef(function_node_f)
 
     def test_ignores_non_client_methods(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def do_thing(self, one, two, three, four, five, six): #@
                 pass
@@ -918,7 +1287,8 @@ class TestClientMethodsUseKwargsWithMultipleParameters(pylint.testutils.CheckerT
             @distributed_trace_async
             async def do_thing(self, one, two, three, four, five, six): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node_a)
@@ -937,20 +1307,28 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.ClientMethodsHaveTypeAnnotations
 
     def test_ignores_correct_type_annotations(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing(self, one: str, two: int, three: bool, four: Union[str, thing], five: dict) -> int: #@
                 pass
             async def do_thing(self, one: str, two: int, three: bool, four: Union[str, thing], five: dict) -> int: #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_asyncfunctiondef(function_node_b)
 
     def test_ignores_correct_type_comments(self):
-        class_node, function_node_a, function_node_b, function_node_c = astroid.extract_node("""
+        (
+            class_node,
+            function_node_a,
+            function_node_b,
+            function_node_c,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing_a(self, one, two, three, four, five): #@
                 # type: (str, str, str, str, str) -> None
@@ -968,7 +1346,8 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
                            ):
                 # type: (...) -> int
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node_a)
@@ -976,7 +1355,13 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
             self.checker.visit_functiondef(function_node_c)
 
     def test_ignores_correct_type_comments_async(self):
-        class_node, function_node_a, function_node_b, function_node_c = astroid.extract_node("""
+        (
+            class_node,
+            function_node_a,
+            function_node_b,
+            function_node_c,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             async def do_thing_a(self, one, two, three, four, five): #@
                 # type: (str, str, str, str, str) -> None
@@ -994,7 +1379,8 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
                            ):
                 # type: (...) -> int
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(function_node_a)
@@ -1002,7 +1388,8 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
             self.checker.visit_asyncfunctiondef(function_node_c)
 
     def test_ignores_no_parameter_method_with_annotations(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing_a(self): #@
                 # type: () -> None
@@ -1010,14 +1397,16 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
 
             def do_thing_b(self) -> None: #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
 
     def test_ignores_no_parameter_method_with_annotations_async(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             async def do_thing_a(self): #@
                 # type: () -> None
@@ -1025,76 +1414,111 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
 
             async def do_thing_b(self) -> None: #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(function_node_a)
             self.checker.visit_asyncfunctiondef(function_node_b)
 
     def test_finds_no_parameter_method_without_annotations(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing(self): #@
                 pass
             async def do_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-missing-type-annotations", line=3, node=function_node_a, col_offset=4, end_line=3, end_col_offset=16
-                ),
-                pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=5, node=function_node_b, col_offset=4, end_line=5, end_col_offset=22
-                ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-missing-type-annotations",
+                line=3,
+                node=function_node_a,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=16,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-missing-type-annotations",
+                line=5,
+                node=function_node_b,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=22,
+            ),
         ):
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
 
     def test_finds_method_missing_annotations(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing(self, one, two, three): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=3, node=function_node, col_offset=4, end_line=3, end_col_offset=16
+                msg_id="client-method-missing-type-annotations",
+                line=3,
+                node=function_node,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=16,
             )
         ):
             self.checker.visit_functiondef(function_node)
 
     def test_finds_method_missing_annotations_async(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             async def do_thing(self, one, two, three): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=3, node=function_node, col_offset=4, end_line=3, end_col_offset=22
+                msg_id="client-method-missing-type-annotations",
+                line=3,
+                node=function_node,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=22,
             )
         ):
             self.checker.visit_asyncfunctiondef(function_node)
 
     def test_finds_constructor_without_annotations(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, one, two, three, four, five): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-missing-type-annotations", line=3, node=function_node, col_offset=4, end_line=3, end_col_offset=16
-                )
+            pylint.testutils.MessageTest(
+                msg_id="client-method-missing-type-annotations",
+                line=3,
+                node=function_node,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=16,
+            )
         ):
             self.checker.visit_functiondef(function_node)
 
     def test_finds_missing_return_annotation_but_has_type_hints(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing_a(self, one: str, two: int, three: bool, four: Union[str, thing], five: dict): #@
                 pass
@@ -1102,21 +1526,33 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
             def do_thing_b(self, one, two, three, four, five): #@
                 # type: (str, str, str, str, str)
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=3, node=function_node_a, col_offset=4, end_line=3, end_col_offset=18
+                msg_id="client-method-missing-type-annotations",
+                line=3,
+                node=function_node_a,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=6, node=function_node_b, col_offset=4, end_line=6, end_col_offset=18
+                msg_id="client-method-missing-type-annotations",
+                line=6,
+                node=function_node_b,
+                col_offset=4,
+                end_line=6,
+                end_col_offset=18,
             ),
         ):
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
 
     def test_finds_missing_return_annotation_but_has_type_hints_async(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             async def do_thing_a(self, one: str, two: int, three: bool, four: Union[str, thing], five: dict): #@
                 pass
@@ -1124,21 +1560,33 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
             async def do_thing_b(self, one, two, three, four, five): #@
                 # type: (str, str, str, str, str)
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=3, node=function_node_a, col_offset=4, end_line=3, end_col_offset=24
+                msg_id="client-method-missing-type-annotations",
+                line=3,
+                node=function_node_a,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=24,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=6, node=function_node_b, col_offset=4, end_line=6, end_col_offset=24
+                msg_id="client-method-missing-type-annotations",
+                line=6,
+                node=function_node_b,
+                col_offset=4,
+                end_line=6,
+                end_col_offset=24,
             ),
         ):
             self.checker.visit_asyncfunctiondef(function_node_a)
             self.checker.visit_asyncfunctiondef(function_node_b)
 
     def test_finds_missing_annotations_but_has_return_hint(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing_a(self, one, two, three, four, five) -> None: #@
                 pass
@@ -1146,21 +1594,33 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
             def do_thing_b(self, one, two, three, four, five): #@
                 # type: -> None
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=3, node=function_node_a,  col_offset=4, end_line=3, end_col_offset=18
+                msg_id="client-method-missing-type-annotations",
+                line=3,
+                node=function_node_a,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=6, node=function_node_b, col_offset=4, end_line=6, end_col_offset=18
-            )
+                msg_id="client-method-missing-type-annotations",
+                line=6,
+                node=function_node_b,
+                col_offset=4,
+                end_line=6,
+                end_col_offset=18,
+            ),
         ):
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
 
     def test_finds_missing_annotations_but_has_return_hint_async(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             async def do_thing_a(self, one, two, three, four, five) -> None: #@
                 pass
@@ -1168,41 +1628,58 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
             async def do_thing_b(self, one, two, three, four, five): #@
                 # type: -> None
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=3, node=function_node_a, col_offset=4, end_line=3, end_col_offset=24
+                msg_id="client-method-missing-type-annotations",
+                line=3,
+                node=function_node_a,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=24,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-type-annotations", line=6, node=function_node_b, col_offset=4, end_line=6, end_col_offset=24
-            )
+                msg_id="client-method-missing-type-annotations",
+                line=6,
+                node=function_node_b,
+                col_offset=4,
+                end_line=6,
+                end_col_offset=24,
+            ),
         ):
             self.checker.visit_asyncfunctiondef(function_node_a)
             self.checker.visit_asyncfunctiondef(function_node_b)
 
     def test_ignores_non_client_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def do_thing(self, one, two, three, four, five, six): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_private_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def _do_thing(self, one, two, three, four, five, six): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_guidelines_link_active(self):
-        url = "https://azure.github.io/azure-sdk/python_implementation.html#types-or-not"
+        url = (
+            "https://azure.github.io/azure-sdk/python_implementation.html#types-or-not"
+        )
         config = Configuration()
         client = PipelineClient(url, config=config)
         request = client.get(url)
@@ -1210,11 +1687,14 @@ class TestClientMethodsHaveTypeAnnotations(pylint.testutils.CheckerTestCase):
         assert response.http_response.status_code == 200
 
 
-class TestClientHasKwargsInPoliciesForCreateConfigurationMethod(pylint.testutils.CheckerTestCase):
+class TestClientHasKwargsInPoliciesForCreateConfigurationMethod(
+    pylint.testutils.CheckerTestCase
+):
     CHECKER_CLASS = checker.ClientHasKwargsInPoliciesForCreateConfigurationMethod
 
     def test_ignores_config_policies_with_kwargs(self):
-        function_node_a, function_node_b = astroid.extract_node("""
+        function_node_a, function_node_b = astroid.extract_node(
+            """
         def create_configuration(self, **kwargs): #@
             config = Configuration(**kwargs)
             config.headers_policy = StorageHeadersPolicy(**kwargs)
@@ -1233,14 +1713,23 @@ class TestClientHasKwargsInPoliciesForCreateConfigurationMethod(pylint.testutils
             config = KeyVaultClient.get_configuration_class(api_version, aio=False)(credential, **kwargs)
             config.authentication_policy = ChallengeAuthPolicy(credential, **kwargs)
             return config
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
 
     def test_finds_config_policies_without_kwargs(self):
-        function_node_a, policy_a, policy_b, policy_c, function_node_b, policy_d = astroid.extract_node("""
+        (
+            function_node_a,
+            policy_a,
+            policy_b,
+            policy_c,
+            function_node_b,
+            policy_d,
+        ) = astroid.extract_node(
+            """
         def create_configuration(self, **kwargs): #@
             config = Configuration(**kwargs)
             config.headers_policy = StorageHeadersPolicy(**kwargs)
@@ -1259,27 +1748,49 @@ class TestClientHasKwargsInPoliciesForCreateConfigurationMethod(pylint.testutils
             config = KeyVaultClient.get_configuration_class(api_version, aio=False)(credential, **kwargs)
             config.authentication_policy = ChallengeAuthPolicy(credential) #@
             return config
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="config-missing-kwargs-in-policy", line=5, node=policy_a, col_offset=4, end_line=5, end_col_offset=55
+                msg_id="config-missing-kwargs-in-policy",
+                line=5,
+                node=policy_a,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=55,
             ),
             pylint.testutils.MessageTest(
-                msg_id="config-missing-kwargs-in-policy", line=8, node=policy_b, col_offset=4, end_line=8, end_col_offset=50
+                msg_id="config-missing-kwargs-in-policy",
+                line=8,
+                node=policy_b,
+                col_offset=4,
+                end_line=8,
+                end_col_offset=50,
             ),
             pylint.testutils.MessageTest(
-                msg_id="config-missing-kwargs-in-policy", line=9, node=policy_c, col_offset=4, end_line=9, end_col_offset=39
+                msg_id="config-missing-kwargs-in-policy",
+                line=9,
+                node=policy_c,
+                col_offset=4,
+                end_line=9,
+                end_col_offset=39,
             ),
             pylint.testutils.MessageTest(
-                msg_id="config-missing-kwargs-in-policy", line=18, node=policy_d,  col_offset=4, end_line=18, end_col_offset=66
-            )
+                msg_id="config-missing-kwargs-in-policy",
+                line=18,
+                node=policy_d,
+                col_offset=4,
+                end_line=18,
+                end_col_offset=66,
+            ),
         ):
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
 
     def test_ignores_policies_outside_create_config(self):
-        function_node_a, function_node_b = astroid.extract_node("""
+        function_node_a, function_node_b = astroid.extract_node(
+            """
         def _configuration(self, **kwargs): #@
             config = Configuration(**kwargs)
             config.headers_policy = StorageHeadersPolicy(**kwargs)
@@ -1298,14 +1809,17 @@ class TestClientHasKwargsInPoliciesForCreateConfigurationMethod(pylint.testutils
             config = KeyVaultClient.get_configuration_class(api_version, aio=False)(credential)
             config.authentication_policy = ChallengeAuthPolicy(credential)
             return config
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
 
     def test_guidelines_link_active(self):
-        url = "https://azure.github.io/azure-sdk/python_design.html#client-configuration"
+        url = (
+            "https://azure.github.io/azure-sdk/python_design.html#client-configuration"
+        )
         config = Configuration()
         client = PipelineClient(url, config=config)
         request = client.get(url)
@@ -1317,42 +1831,50 @@ class TestClientUsesCorrectNamingConventions(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.ClientUsesCorrectNamingConventions
 
     def test_ignores_constructor(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_internal_client(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class _BaseSomeClient(): #@
             def __init__(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_private_method(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             def _private_method(self, **kwargs): #@
                 pass
             async def _another_private_method(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_correct_client(self):
-        class_node = astroid.extract_node("""
+        class_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
@@ -1370,7 +1892,13 @@ class TestClientUsesCorrectNamingConventions(pylint.testutils.CheckerTestCase):
             self.checker.visit_classdef(class_node)
 
     def test_ignores_correct_method_names(self):
-        class_node, function_node_a, function_node_b, function_node_c = astroid.extract_node("""
+        (
+            class_node,
+            function_node_a,
+            function_node_b,
+            function_node_c,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             def from_connection_string(self, **kwargs): #@
                 pass
@@ -1378,13 +1906,20 @@ class TestClientUsesCorrectNamingConventions(pylint.testutils.CheckerTestCase):
                 pass
             def delete_thing(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_correct_method_names_async(self):
-        class_node, function_node_a, function_node_b, function_node_c = astroid.extract_node("""
+        (
+            class_node,
+            function_node_a,
+            function_node_b,
+            function_node_c,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             def from_connection_string(self, **kwargs): #@
                 pass
@@ -1392,40 +1927,60 @@ class TestClientUsesCorrectNamingConventions(pylint.testutils.CheckerTestCase):
                 pass
             def delete_thing(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_correct_class_constant(self):
-        class_node = astroid.extract_node("""
+        class_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             MAX_SIZE = 14
             MIN_SIZE = 2
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_finds_incorrectly_named_client(self):
-        class_node_a, class_node_b, class_node_c = astroid.extract_node("""
+        class_node_a, class_node_b, class_node_c = astroid.extract_node(
+            """
         class some_client(): #@
             pass
         class Some_Client(): #@
             pass
         class someClient(): #@
             pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=2, node=class_node_a, col_offset=0, end_line=2, end_col_offset=17
+                msg_id="client-incorrect-naming-convention",
+                line=2,
+                node=class_node_a,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=17,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=4, node=class_node_b, col_offset=0, end_line=4, end_col_offset=17
+                msg_id="client-incorrect-naming-convention",
+                line=4,
+                node=class_node_b,
+                col_offset=0,
+                end_line=4,
+                end_col_offset=17,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=6, node=class_node_c, col_offset=0, end_line=6, end_col_offset=16
+                msg_id="client-incorrect-naming-convention",
+                line=6,
+                node=class_node_c,
+                col_offset=0,
+                end_line=6,
+                end_col_offset=16,
             ),
         ):
             self.checker.visit_classdef(class_node_a)
@@ -1433,8 +1988,16 @@ class TestClientUsesCorrectNamingConventions(pylint.testutils.CheckerTestCase):
             self.checker.visit_classdef(class_node_c)
 
     def test_finds_incorrectly_named_methods(self):
-        class_node, func_node_a, func_node_b, func_node_c, func_node_d, func_node_e, func_node_f \
-            = astroid.extract_node("""
+        (
+            class_node,
+            func_node_a,
+            func_node_b,
+            func_node_c,
+            func_node_d,
+            func_node_e,
+            func_node_f,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             def Create_Config(self): #@
                 pass
@@ -1448,33 +2011,72 @@ class TestClientUsesCorrectNamingConventions(pylint.testutils.CheckerTestCase):
                 pass
             def Updatething(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=3, node=func_node_a,  col_offset=4, end_line=3, end_col_offset=21
+                msg_id="client-incorrect-naming-convention",
+                line=3,
+                node=func_node_a,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=21,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=5, node=func_node_b, col_offset=4, end_line=5, end_col_offset=16
+                msg_id="client-incorrect-naming-convention",
+                line=5,
+                node=func_node_b,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=16,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=7, node=func_node_c, col_offset=4, end_line=7, end_col_offset=18
+                msg_id="client-incorrect-naming-convention",
+                line=7,
+                node=func_node_c,
+                col_offset=4,
+                end_line=7,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=9, node=func_node_d, col_offset=4, end_line=9, end_col_offset=19
+                msg_id="client-incorrect-naming-convention",
+                line=9,
+                node=func_node_d,
+                col_offset=4,
+                end_line=9,
+                end_col_offset=19,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=11, node=func_node_e, col_offset=4, end_line=11, end_col_offset=17
+                msg_id="client-incorrect-naming-convention",
+                line=11,
+                node=func_node_e,
+                col_offset=4,
+                end_line=11,
+                end_col_offset=17,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=13, node=func_node_f, col_offset=4, end_line=13, end_col_offset=19
+                msg_id="client-incorrect-naming-convention",
+                line=13,
+                node=func_node_f,
+                col_offset=4,
+                end_line=13,
+                end_col_offset=19,
             ),
         ):
             self.checker.visit_classdef(class_node)
 
     def test_finds_incorrectly_named_methods_async(self):
-        class_node, func_node_a, func_node_b, func_node_c, func_node_d, func_node_e, func_node_f \
-            = astroid.extract_node("""
+        (
+            class_node,
+            func_node_a,
+            func_node_b,
+            func_node_c,
+            func_node_d,
+            func_node_e,
+            func_node_f,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             async def Create_Config(self): #@
                 pass
@@ -1488,43 +2090,86 @@ class TestClientUsesCorrectNamingConventions(pylint.testutils.CheckerTestCase):
                 pass
             async def Updatething(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=3, node=func_node_a, col_offset=4, end_line=3, end_col_offset=27
+                msg_id="client-incorrect-naming-convention",
+                line=3,
+                node=func_node_a,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=27,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=5, node=func_node_b, col_offset=4, end_line=5, end_col_offset=22
+                msg_id="client-incorrect-naming-convention",
+                line=5,
+                node=func_node_b,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=22,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=7, node=func_node_c,col_offset=4, end_line=7, end_col_offset=24
+                msg_id="client-incorrect-naming-convention",
+                line=7,
+                node=func_node_c,
+                col_offset=4,
+                end_line=7,
+                end_col_offset=24,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=9, node=func_node_d, col_offset=4, end_line=9, end_col_offset=25
+                msg_id="client-incorrect-naming-convention",
+                line=9,
+                node=func_node_d,
+                col_offset=4,
+                end_line=9,
+                end_col_offset=25,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=11, node=func_node_e, col_offset=4, end_line=11, end_col_offset=23
+                msg_id="client-incorrect-naming-convention",
+                line=11,
+                node=func_node_e,
+                col_offset=4,
+                end_line=11,
+                end_col_offset=23,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=13, node=func_node_f, col_offset=4, end_line=13, end_col_offset=25
+                msg_id="client-incorrect-naming-convention",
+                line=13,
+                node=func_node_f,
+                col_offset=4,
+                end_line=13,
+                end_col_offset=25,
             ),
         ):
             self.checker.visit_classdef(class_node)
 
     def test_finds_incorrectly_named_class_constant(self):
-        class_node, const_a, const_b = astroid.extract_node("""
+        class_node, const_a, const_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             max_size = 14 #@
             min_size = 2 #@
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=3, node=const_a, col_offset=4, end_line=3, end_col_offset=17
+                msg_id="client-incorrect-naming-convention",
+                line=3,
+                node=const_a,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=17,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-incorrect-naming-convention", line=4,node=const_b, col_offset=4, end_line=4, end_col_offset=16
+                msg_id="client-incorrect-naming-convention",
+                line=4,
+                node=const_b,
+                col_offset=4,
+                end_line=4,
+                end_col_offset=16,
             ),
         ):
             self.checker.visit_classdef(class_node)
@@ -1542,63 +2187,74 @@ class TestClientMethodsHaveKwargsParameter(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.ClientMethodsHaveKwargsParameter
 
     def test_ignores_private_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def _create_configuration(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_properties(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             @property
             def key_id(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_properties_async(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             @property
             async def key_id(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(function_node)
 
     def test_ignores_non_client_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def create_configuration(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_methods_with_kwargs(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             def get_thing(self, **kwargs): #@
                 pass
             @distributed_trace
             def remove_thing(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
 
     def test_finds_missing_kwargs(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         from azure.core.tracing.decorator import distributed_trace
         
         class SomeClient(): #@
@@ -1608,34 +2264,48 @@ class TestClientMethodsHaveKwargsParameter(pylint.testutils.CheckerTestCase):
             @distributed_trace
             def remove_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-kwargs", line=6, node=function_node_a, col_offset=4, end_line=6, end_col_offset=17
+                msg_id="client-method-missing-kwargs",
+                line=6,
+                node=function_node_a,
+                col_offset=4,
+                end_line=6,
+                end_col_offset=17,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-kwargs", line=9, node=function_node_b, col_offset=4, end_line=9, end_col_offset=20
+                msg_id="client-method-missing-kwargs",
+                line=9,
+                node=function_node_b,
+                col_offset=4,
+                end_line=9,
+                end_col_offset=20,
             ),
         ):
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
 
     def test_ignores_methods_with_kwargs_async(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             async def get_thing(self, **kwargs): #@
                 pass
             async def remove_thing(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(function_node_a)
             self.checker.visit_asyncfunctiondef(function_node_b)
 
     def test_finds_missing_kwargs_async(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         from azure.core.tracing.decorator_async import distributed_trace_async
         
         class SomeClient(): #@
@@ -1645,14 +2315,25 @@ class TestClientMethodsHaveKwargsParameter(pylint.testutils.CheckerTestCase):
             @distributed_trace_async
             async def remove_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-kwargs", line=6, node=function_node_a, col_offset=4, end_line=6, end_col_offset=23
+                msg_id="client-method-missing-kwargs",
+                line=6,
+                node=function_node_a,
+                col_offset=4,
+                end_line=6,
+                end_col_offset=23,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-method-missing-kwargs", line=9, node=function_node_b, col_offset=4, end_line=9, end_col_offset=26
+                msg_id="client-method-missing-kwargs",
+                line=9,
+                node=function_node_b,
+                col_offset=4,
+                end_line=9,
+                end_col_offset=26,
             ),
         ):
             self.checker.visit_asyncfunctiondef(function_node_a)
@@ -1671,55 +2352,70 @@ class TestAsyncClientCorrectNaming(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.AsyncClientCorrectNaming
 
     def test_ignores_private_client(self):
-        class_node = astroid.extract_node("""
+        class_node = astroid.extract_node(
+            """
         class _AsyncBaseSomeClient(): #@
             def create_configuration(self):
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_correct_client(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def create_configuration(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_async_base_named_client(self):
-        class_node_a = astroid.extract_node("""
+        class_node_a = astroid.extract_node(
+            """
         class AsyncSomeClientBase(): #@
             def get_thing(self, **kwargs):
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node_a)
 
     def test_finds_incorrectly_named_client(self):
-        class_node_a = astroid.extract_node("""
+        class_node_a = astroid.extract_node(
+            """
         class AsyncSomeClient(): #@
             def get_thing(self, **kwargs):
                 pass
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="async-client-bad-name", line=2, node=class_node_a, col_offset=0, end_line=2, end_col_offset=21
+                msg_id="async-client-bad-name",
+                line=2,
+                node=class_node_a,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=21,
             ),
         ):
             self.checker.visit_classdef(class_node_a)
 
     def test_ignores_non_client(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def create_configuration(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
@@ -1737,7 +2433,9 @@ class TestFileHasCopyrightHeader(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.FileHasCopyrightHeader
 
     def test_copyright_header_acceptable(self):
-        file = open(os.path.join(TEST_FOLDER, "test_files", "copyright_header_acceptable.py"))
+        file = open(
+            os.path.join(TEST_FOLDER, "test_files", "copyright_header_acceptable.py")
+        )
         node = astroid.parse(file.read())
         file.close()
 
@@ -1745,14 +2443,16 @@ class TestFileHasCopyrightHeader(pylint.testutils.CheckerTestCase):
             self.checker.visit_module(node)
 
     def test_copyright_header_violation(self):
-        file = open(os.path.join(TEST_FOLDER, "test_files", "copyright_header_violation.py"))
+        file = open(
+            os.path.join(TEST_FOLDER, "test_files", "copyright_header_violation.py")
+        )
         node = astroid.parse(file.read())
         file.close()
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="file-needs-copyright-header", line=0, node=node
-                )
+            pylint.testutils.MessageTest(
+                msg_id="file-needs-copyright-header", line=0, node=node
+            )
         ):
             self.checker.visit_module(node)
 
@@ -1769,37 +2469,44 @@ class TestSpecifyParameterNamesInCall(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.SpecifyParameterNamesInCall
 
     def test_ignores_call_with_only_two_unnamed_params(self):
-        class_node, call_node = astroid.extract_node("""
+        class_node, call_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing(self):
                 self._client.thing(one, two) #@
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_call(call_node)
 
     def test_ignores_call_with_two_unnamed_params_and_one_named(self):
-        class_node, call_node = astroid.extract_node("""
+        class_node, call_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing(self):
                 self._client.thing(one, two, three=3) #@
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_call(call_node)
 
     def test_ignores_call_from_non_client(self):
-        class_node, call_node = astroid.extract_node("""
+        class_node, call_node = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def do_thing(self):
                 self._other.thing(one, two, three) #@
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_call(call_node)
 
     def test_ignores_call_with_named_params(self):
-        class_node, call_node_a, call_node_b, call_node_c = astroid.extract_node("""
+        class_node, call_node_a, call_node_b, call_node_c = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def do_thing_a(self):
                 self._other.thing(one=one, two=two, three=three) #@
@@ -1807,7 +2514,8 @@ class TestSpecifyParameterNamesInCall(pylint.testutils.CheckerTestCase):
                 self._other.thing(zero, number, one=one, two=two, three=three) #@
             def do_thing_c(self):
                 self._other.thing(zero, one=one, two=two, three=three) #@      
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_call(call_node_a)
@@ -1815,38 +2523,54 @@ class TestSpecifyParameterNamesInCall(pylint.testutils.CheckerTestCase):
             self.checker.visit_call(call_node_c)
 
     def test_ignores_non_client_function_call(self):
-        call_node = astroid.extract_node("""
+        call_node = astroid.extract_node(
+            """
         def do_thing():
             self._client.thing(one, two, three) #@
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_call(call_node)
 
     def test_finds_call_with_more_than_two_unnamed_params(self):
-        class_node, call_node = astroid.extract_node("""
+        class_node, call_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing(self):
                 self._client.thing(one, two, three) #@
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="specify-parameter-names-in-call", line=4, node=call_node, col_offset=8, end_line=4, end_col_offset=43
+                msg_id="specify-parameter-names-in-call",
+                line=4,
+                node=call_node,
+                col_offset=8,
+                end_line=4,
+                end_col_offset=43,
             ),
         ):
             self.checker.visit_call(call_node)
 
     def test_finds_call_with_more_than_two_unnamed_params_and_some_named(self):
-        class_node, call_node = astroid.extract_node("""
+        class_node, call_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def do_thing(self):
                 self._client.thing(one, two, three, four=4, five=5) #@
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="specify-parameter-names-in-call", line=4, node=call_node, col_offset=8, end_line=4, end_col_offset=59
+                msg_id="specify-parameter-names-in-call",
+                line=4,
+                node=call_node,
+                col_offset=8,
+                end_line=4,
+                end_col_offset=59,
             ),
         ):
             self.checker.visit_call(call_node)
@@ -1864,27 +2588,32 @@ class TestClientListMethodsUseCorePaging(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.ClientListMethodsUseCorePaging
 
     def test_ignores_private_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def _list_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_return(function_node.body[0])
 
     def test_ignores_non_client_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def list_things(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_return(function_node.body[0])
 
     def test_ignores_methods_return_ItemPaged(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         from azure.core.paging import ItemPaged
         
         class SomeClient(): #@
@@ -1895,14 +2624,16 @@ class TestClientListMethodsUseCorePaging(pylint.testutils.CheckerTestCase):
                 return ItemPaged(
                     command, prefix=name_starts_with, results_per_page=results_per_page,
                     page_iterator_class=BlobPropertiesPaged)
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_return(function_node_a.body[0])
             self.checker.visit_return(function_node_b.body[0])
 
     def test_ignores_methods_return_AsyncItemPaged(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         from azure.core.async_paging import AsyncItemPaged
         
         class SomeClient(): #@
@@ -1913,14 +2644,16 @@ class TestClientListMethodsUseCorePaging(pylint.testutils.CheckerTestCase):
                 return AsyncItemPaged(
                     command, prefix=name_starts_with, results_per_page=results_per_page,
                     page_iterator_class=BlobPropertiesPaged)
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_return(function_node_a.body[0])
             self.checker.visit_return(function_node_b.body[0])
 
     def test_finds_method_returning_something_else(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         from azure.core.polling import LROPoller
         
         class SomeClient(): #@
@@ -1928,21 +2661,33 @@ class TestClientListMethodsUseCorePaging(pylint.testutils.CheckerTestCase):
                 return list()
             def list_thing2(self): #@
                 return LROPoller()
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-paging-methods-use-list", line=5, node=function_node_a, col_offset=4, end_line=5, end_col_offset=18
+                msg_id="client-paging-methods-use-list",
+                line=5,
+                node=function_node_a,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=18,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-paging-methods-use-list", line=7, node=function_node_b, col_offset=4, end_line=7, end_col_offset=19
+                msg_id="client-paging-methods-use-list",
+                line=7,
+                node=function_node_b,
+                col_offset=4,
+                end_line=7,
+                end_col_offset=19,
             ),
         ):
             self.checker.visit_return(function_node_a.body[0])
             self.checker.visit_return(function_node_b.body[0])
 
     def test_finds_method_returning_something_else_async(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         from azure.core.polling import LROPoller
         from typing import list
         
@@ -1951,69 +2696,103 @@ class TestClientListMethodsUseCorePaging(pylint.testutils.CheckerTestCase):
                 return list()
             async def list_thing2(self, **kwargs): #@
                 return LROPoller()
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-paging-methods-use-list", line=6, node=function_node_a, col_offset=4, end_line=6, end_col_offset=24
+                msg_id="client-paging-methods-use-list",
+                line=6,
+                node=function_node_a,
+                col_offset=4,
+                end_line=6,
+                end_col_offset=24,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-paging-methods-use-list", line=8, node=function_node_b,  col_offset=4, end_line=8, end_col_offset=25
+                msg_id="client-paging-methods-use-list",
+                line=8,
+                node=function_node_b,
+                col_offset=4,
+                end_line=8,
+                end_col_offset=25,
             ),
         ):
             self.checker.visit_return(function_node_a.body[0])
             self.checker.visit_return(function_node_b.body[0])
 
     def test_finds_return_ItemPaged_not_list(self):
-        class_node, function_node_a = astroid.extract_node("""
+        class_node, function_node_a = astroid.extract_node(
+            """
         from azure.core.paging import ItemPaged
         
         class SomeClient(): #@
             def some_thing(self): #@
                 return ItemPaged()
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-paging-methods-use-list", line=5, node=function_node_a, col_offset=4, end_line=5, end_col_offset=18
+                msg_id="client-paging-methods-use-list",
+                line=5,
+                node=function_node_a,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=18,
             ),
         ):
             self.checker.visit_return(function_node_a.body[0])
 
     def test_finds_return_AsyncItemPaged_not_list(self):
-        class_node, function_node_a = astroid.extract_node("""
+        class_node, function_node_a = astroid.extract_node(
+            """
         from azure.core.async_paging import AsyncItemPaged
         
         class SomeClient(): #@
             async def some_thing(self): #@
                 return AsyncItemPaged()
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-paging-methods-use-list", line=5, node=function_node_a, col_offset=4, end_line=5, end_col_offset=18
+                msg_id="client-paging-methods-use-list",
+                line=5,
+                node=function_node_a,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=18,
             ),
         ):
             self.checker.visit_return(function_node_a.body[0])
 
     def test_core_paging_file_custom_class_acceptable_and_violation(self):
-        file = open(os.path.join(TEST_FOLDER, "test_files", "core_paging_acceptable_and_violation.py"))
+        file = open(
+            os.path.join(
+                TEST_FOLDER, "test_files", "core_paging_acceptable_and_violation.py"
+            )
+        )
         node = astroid.parse(file.read())
         file.close()
 
         function_node = node.body[3].body[0]
         function_node_a = node.body[3].body[1]
         function_node_b = node.body[3].body[2]
-       
+
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-paging-methods-use-list", line=32, node=function_node_b, col_offset=4, end_line=32, end_col_offset=32
+                msg_id="client-paging-methods-use-list",
+                line=32,
+                node=function_node_b,
+                col_offset=4,
+                end_line=32,
+                end_col_offset=32,
             )
         ):
             self.checker.visit_return(function_node.body[2])
             self.checker.visit_return(function_node_a.body[0])
             self.checker.visit_return(function_node_b.body[0])
-     
+
     def test_core_paging_file_custom_class_violation(self):
         file = open(os.path.join(TEST_FOLDER, "test_files", "core_paging_violation.py"))
         node = astroid.parse(file.read())
@@ -2021,25 +2800,29 @@ class TestClientListMethodsUseCorePaging(pylint.testutils.CheckerTestCase):
 
         function_node = node.body[2].body[0]
 
-   
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-paging-methods-use-list", line=8, node=function_node, col_offset=4, end_line=8, end_col_offset=18
+                msg_id="client-paging-methods-use-list",
+                line=8,
+                node=function_node,
+                col_offset=4,
+                end_line=8,
+                end_col_offset=18,
             )
         ):
             self.checker.visit_return(function_node.body[0])
-    
+
     def test_core_paging_file_custom_class_acceptable(self):
-        file = open(os.path.join(TEST_FOLDER, "test_files", "core_paging_acceptable.py"))
+        file = open(
+            os.path.join(TEST_FOLDER, "test_files", "core_paging_acceptable.py")
+        )
         node = astroid.parse(file.read())
         file.close()
 
         function_node = node.body[2].body[0]
 
-   
         with self.assertNoMessages():
             self.checker.visit_return(function_node.body[0])
-          
 
     def test_guidelines_link_active(self):
         url = "https://azure.github.io/azure-sdk/python_design.html#response-formats"
@@ -2054,27 +2837,32 @@ class TestClientLROMethodsUseCorePolling(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.ClientLROMethodsUseCorePolling
 
     def test_ignores_private_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def _begin_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_non_client_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def begin_things(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_methods_return_LROPoller(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         from azure.core.polling import LROPoller
         
         class SomeClient(): #@
@@ -2083,32 +2871,44 @@ class TestClientLROMethodsUseCorePolling(pylint.testutils.CheckerTestCase):
             @distributed_trace
             def begin_thing2(self): #@
                 return LROPoller(self._client, raw_result, get_long_running_output, polling_method)
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
 
     def test_finds_method_returning_something_else(self):
-        class_node, function_node_a, function_node_b = astroid.extract_node("""
+        class_node, function_node_a, function_node_b = astroid.extract_node(
+            """
         class SomeClient(): #@
             def begin_thing(self): #@
                 return list()
             def begin_thing2(self): #@
                 return {}
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-lro-methods-use-polling", line=3, node=function_node_a,  col_offset=4, end_line=3, end_col_offset=19
+                msg_id="client-lro-methods-use-polling",
+                line=3,
+                node=function_node_a,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=19,
             ),
             pylint.testutils.MessageTest(
-                msg_id="client-lro-methods-use-polling", line=5, node=function_node_b,  col_offset=4, end_line=5, end_col_offset=20
+                msg_id="client-lro-methods-use-polling",
+                line=5,
+                node=function_node_b,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=20,
             ),
         ):
             self.checker.visit_functiondef(function_node_a)
             self.checker.visit_functiondef(function_node_b)
-    
 
     def test_guidelines_link_active(self):
         url = "https://azure.github.io/azure-sdk/python_design.html#response-formats"
@@ -2123,33 +2923,38 @@ class TestClientLROMethodsUseCorrectNaming(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.ClientLROMethodsUseCorrectNaming
 
     def test_ignores_private_methods(self):
-        class_node, return_node = astroid.extract_node("""
+        class_node, return_node = astroid.extract_node(
+            """
         from azure.core.polling import LROPoller
         
         class SomeClient(): #@
             def _do_thing(self): 
                 return LROPoller(self._client, raw_result, get_long_running_output, polling_method) #@
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
             self.checker.visit_return(return_node)
 
     def test_ignores_non_client_methods(self):
-        class_node, return_node = astroid.extract_node("""
+        class_node, return_node = astroid.extract_node(
+            """
         from azure.core.polling import LROPoller
         
         class SomethingElse(): #@
             def begin_things(self):
                 return LROPoller(self._client, raw_result, get_long_running_output, polling_method) #@
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
             self.checker.visit_return(return_node)
 
     def test_ignores_methods_return_LROPoller_and_correctly_named(self):
-        class_node, return_node_a, return_node_b = astroid.extract_node("""
+        class_node, return_node_a, return_node_b = astroid.extract_node(
+            """
         from azure.core.polling import LROPoller
         
         class SomeClient(): #@
@@ -2158,7 +2963,8 @@ class TestClientLROMethodsUseCorrectNaming(pylint.testutils.CheckerTestCase):
             @distributed_trace
             def begin_thing2(self):
                 return LROPoller(self._client, raw_result, get_long_running_output, polling_method) #@
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
@@ -2166,7 +2972,14 @@ class TestClientLROMethodsUseCorrectNaming(pylint.testutils.CheckerTestCase):
             self.checker.visit_return(return_node_b)
 
     def test_finds_incorrectly_named_method_returning_LROPoller(self):
-        class_node, function_node_a, return_node_a, function_node_b, return_node_b = astroid.extract_node("""
+        (
+            class_node,
+            function_node_a,
+            return_node_a,
+            function_node_b,
+            return_node_b,
+        ) = astroid.extract_node(
+            """
         from azure.core.polling import LROPoller
         
         class SomeClient(): #@
@@ -2175,14 +2988,25 @@ class TestClientLROMethodsUseCorrectNaming(pylint.testutils.CheckerTestCase):
             @distributed_trace
             def start_thing2(self): #@
                 return LROPoller(self._client, raw_result, get_long_running_output, polling_method) #@
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="lro-methods-use-correct-naming", line=5, node=function_node_a,  col_offset=4, end_line=5, end_col_offset=20
+                msg_id="lro-methods-use-correct-naming",
+                line=5,
+                node=function_node_a,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=20,
             ),
             pylint.testutils.MessageTest(
-                msg_id="lro-methods-use-correct-naming", line=8, node=function_node_b, col_offset=4, end_line=8, end_col_offset=20
+                msg_id="lro-methods-use-correct-naming",
+                line=8,
+                node=function_node_b,
+                col_offset=4,
+                end_line=8,
+                end_col_offset=20,
             ),
         ):
             self.checker.visit_classdef(class_node)
@@ -2198,54 +3022,74 @@ class TestClientLROMethodsUseCorrectNaming(pylint.testutils.CheckerTestCase):
         assert response.http_response.status_code == 200
 
 
-class TestClientConstructorDoesNotHaveConnectionStringParam(pylint.testutils.CheckerTestCase):
+class TestClientConstructorDoesNotHaveConnectionStringParam(
+    pylint.testutils.CheckerTestCase
+):
     CHECKER_CLASS = checker.ClientConstructorDoesNotHaveConnectionStringParam
 
     def test_ignores_client_with_no_conn_str_in_constructor(self):
-        class_node = astroid.extract_node("""
+        class_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self): 
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_ignores_non_client_methods(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomethingElse(): #@
             def __init__(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
 
     def test_finds_client_method_using_conn_str_in_constructor_a(self):
-        class_node = astroid.extract_node("""
+        class_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, connection_string):
                 return list()
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="connection-string-should-not-be-constructor-param", line=2, node=class_node, col_offset=0, end_line=2, end_col_offset=16
-                ),
+            pylint.testutils.MessageTest(
+                msg_id="connection-string-should-not-be-constructor-param",
+                line=2,
+                node=class_node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=16,
+            ),
         ):
             self.checker.visit_classdef(class_node)
 
     def test_finds_client_method_using_conn_str_in_constructor_b(self):
-        class_node = astroid.extract_node("""
+        class_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, conn_str):
                 return list()
-        """)
+        """
+        )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="connection-string-should-not-be-constructor-param", line=2, node=class_node, col_offset=0, end_line=2, end_col_offset=16
-                ),
+            pylint.testutils.MessageTest(
+                msg_id="connection-string-should-not-be-constructor-param",
+                line=2,
+                node=class_node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=16,
+            ),
         ):
             self.checker.visit_classdef(class_node)
 
@@ -2257,39 +3101,38 @@ class TestClientConstructorDoesNotHaveConnectionStringParam(pylint.testutils.Che
         response = client._pipeline.run(request)
         assert response.http_response.status_code == 200
 
+
 class TestPackageNameDoesNotUseUnderscoreOrPeriod(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.PackageNameDoesNotUseUnderscoreOrPeriod
 
     def test_package_name_acceptable(self):
-
-        package_name =  astroid.extract_node(
-        """
+        package_name = astroid.extract_node(
+            """
         PACKAGE_NAME = "correct-package-name"        
-        """ 
+        """
         )
-        module_node = astroid.Module(name = "node", file="setup.py", doc = """ """)
+        module_node = astroid.Module(name="node", file="setup.py", doc=""" """)
         module_node.body = [package_name]
 
         with self.assertNoMessages():
             self.checker.visit_module(module_node)
 
     def test_package_name_violation(self):
-
-        package_name =  astroid.extract_node(
-        """
+        package_name = astroid.extract_node(
+            """
         PACKAGE_NAME = "incorrect.package-name"        
-        """ 
+        """
         )
-        module_node = astroid.Module(name = "node", file="setup.py", doc = """ """)
+        module_node = astroid.Module(name="node", file="setup.py", doc=""" """)
         module_node.body = [package_name]
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="package-name-incorrect", line=0, node=module_node
-                )
+            pylint.testutils.MessageTest(
+                msg_id="package-name-incorrect", line=0, node=module_node
+            )
         ):
             self.checker.visit_module(module_node)
-    
+
     def test_guidelines_link_active(self):
         url = "https://azure.github.io/azure-sdk/python_design.html#packaging"
         config = Configuration()
@@ -2298,40 +3141,41 @@ class TestPackageNameDoesNotUseUnderscoreOrPeriod(pylint.testutils.CheckerTestCa
         response = client._pipeline.run(request)
         assert response.http_response.status_code == 200
 
+
 class TestServiceClientUsesNameWithClientSuffix(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.ServiceClientUsesNameWithClientSuffix
 
     def test_client_suffix_acceptable(self):
-        client_node =  astroid.extract_node(
-        """
+        client_node = astroid.extract_node(
+            """
         class MyClient():
             def __init__(self):
                 pass       
-        """ 
+        """
         )
-        module_node = astroid.Module(name = "node", file="_my_client.py", doc = """ """)
+        module_node = astroid.Module(name="node", file="_my_client.py", doc=""" """)
         module_node.body = [client_node]
 
         with self.assertNoMessages():
             self.checker.visit_module(module_node)
-    
+
     def test_client_suffix_violation(self):
-        client_node =  astroid.extract_node(
-        """
+        client_node = astroid.extract_node(
+            """
         class Violation():
             def __init__(self):
                 pass       
-        """ 
+        """
         )
-        module_node = astroid.Module(name = "node", file="_my_client.py", doc = """ """)
+        module_node = astroid.Module(name="node", file="_my_client.py", doc=""" """)
         module_node.body = [client_node]
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="client-suffix-needed", line=0, node=module_node
-                )
+            pylint.testutils.MessageTest(
+                msg_id="client-suffix-needed", line=0, node=module_node
+            )
         ):
             self.checker.visit_module(module_node)
-    
+
     def test_guidelines_link_active(self):
         url = "https://azure.github.io/azure-sdk/python_design.html#service-client"
         config = Configuration()
@@ -2341,31 +3185,44 @@ class TestServiceClientUsesNameWithClientSuffix(pylint.testutils.CheckerTestCase
         assert response.http_response.status_code == 200
 
 
-class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(pylint.testutils.CheckerTestCase):
+class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(
+    pylint.testutils.CheckerTestCase
+):
     CHECKER_CLASS = checker.ClientMethodNamesDoNotUseDoubleUnderscorePrefix
 
     def test_ignores_repr(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __repr__(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_constructor(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __init__(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_other_dunder(self):
-        class_node, function_node_a, function_node_b, function_node_c, function_node_d = astroid.extract_node("""
+        (
+            class_node,
+            function_node_a,
+            function_node_b,
+            function_node_c,
+            function_node_d,
+        ) = astroid.extract_node(
+            """
         class SomeClient(): #@
             def __enter__(self): #@
                 pass
@@ -2375,7 +3232,8 @@ class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(pylint.testutils.Check
                 pass
             def __aexit__(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node_a)
@@ -2384,29 +3242,34 @@ class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(pylint.testutils.Check
             self.checker.visit_functiondef(function_node_d)
 
     def test_ignores_private_method(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             @staticmethod
             def _private_method(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
     def test_ignores_private_method_async(self):
-        class_node, function_node = astroid.extract_node("""
+        class_node, function_node = astroid.extract_node(
+            """
         class SomeClient(): #@
             @staticmethod
             async def _private_method(self, **kwargs): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(function_node)
 
     def test_ignores_methods_with_decorators(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         class SomeClient(): #@
             @distributed_trace
             def create_configuration(self): #@
@@ -2417,7 +3280,8 @@ class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(pylint.testutils.Check
             @distributed_trace
             def list_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_functiondef(func_node_a)
@@ -2425,7 +3289,8 @@ class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(pylint.testutils.Check
             self.checker.visit_functiondef(func_node_c)
 
     def test_ignores_async_methods_with_decorators(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         class SomeClient(): #@
             @distributed_trace_async
             async def create_configuration(self): #@
@@ -2436,7 +3301,8 @@ class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(pylint.testutils.Check
             @distributed_trace_async
             async def list_thing(self): #@
                 pass
-        """)
+        """
+        )
 
         with self.assertNoMessages():
             self.checker.visit_asyncfunctiondef(func_node_a)
@@ -2444,7 +3310,8 @@ class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(pylint.testutils.Check
             self.checker.visit_asyncfunctiondef(func_node_c)
 
     def test_finds_double_underscore_on_async_method(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         class SomeClient(): #@
             @staticmethod
             async def __create_configuration(self): #@
@@ -2455,24 +3322,41 @@ class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(pylint.testutils.Check
             @staticmethod
             async def __list_thing(self): #@
                 pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-name-no-double-underscore", line=4, node=func_node_a, col_offset=4, end_line=4, end_col_offset=36
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-name-no-double-underscore", line=7, node=func_node_b, col_offset=4, end_line=7, end_col_offset=25
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-name-no-double-underscore", line=10, node=func_node_c, col_offset=4, end_line=10, end_col_offset=26
-                ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-name-no-double-underscore",
+                line=4,
+                node=func_node_a,
+                col_offset=4,
+                end_line=4,
+                end_col_offset=36,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-name-no-double-underscore",
+                line=7,
+                node=func_node_b,
+                col_offset=4,
+                end_line=7,
+                end_col_offset=25,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-name-no-double-underscore",
+                line=10,
+                node=func_node_c,
+                col_offset=4,
+                end_line=10,
+                end_col_offset=26,
+            ),
         ):
             self.checker.visit_asyncfunctiondef(func_node_a)
             self.checker.visit_asyncfunctiondef(func_node_b)
             self.checker.visit_asyncfunctiondef(func_node_c)
 
     def test_finds_double_underscore_on_sync_method(self):
-        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node("""
+        class_node, func_node_a, func_node_b, func_node_c = astroid.extract_node(
+            """
         class SomeClient(): #@
             @staticmethod
             def __create_configuration(self): #@
@@ -2483,17 +3367,33 @@ class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(pylint.testutils.Check
             @staticmethod
             def __list_thing(self): #@
                 pass
-        """)
+        """
+        )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-name-no-double-underscore", line=4, node=func_node_a, col_offset=4, end_line=4, end_col_offset=30
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-name-no-double-underscore", line=7, node=func_node_b, col_offset=4, end_line=7, end_col_offset=19
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="client-method-name-no-double-underscore", line=10, node=func_node_c, col_offset=4, end_line=10, end_col_offset=2
-                ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-name-no-double-underscore",
+                line=4,
+                node=func_node_a,
+                col_offset=4,
+                end_line=4,
+                end_col_offset=30,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-name-no-double-underscore",
+                line=7,
+                node=func_node_b,
+                col_offset=4,
+                end_line=7,
+                end_col_offset=19,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="client-method-name-no-double-underscore",
+                line=10,
+                node=func_node_c,
+                col_offset=4,
+                end_line=10,
+                end_col_offset=2,
+            ),
         ):
             self.checker.visit_functiondef(func_node_a)
             self.checker.visit_functiondef(func_node_b)
@@ -2523,6 +3423,7 @@ class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(pylint.testutils.Check
         request = client.get(url)
         response = client._pipeline.run(request)
         assert response.http_response.status_code == 200
+
 
 class TestCheckDocstringAdmonitionNewline(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.CheckDocstringAdmonitionNewline
@@ -2572,9 +3473,14 @@ class TestCheckDocstringAdmonitionNewline(pylint.testutils.CheckerTestCase):
         )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-admonition-needs-newline", line=2, node=function_node, col_offset=0, end_line=2, end_col_offset=16
-                )
+            pylint.testutils.MessageTest(
+                msg_id="docstring-admonition-needs-newline",
+                line=2,
+                node=function_node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=16,
+            )
         ):
             self.checker.visit_functiondef(function_node)
 
@@ -2593,9 +3499,14 @@ class TestCheckDocstringAdmonitionNewline(pylint.testutils.CheckerTestCase):
         )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-admonition-needs-newline", line=2, node=function_node, col_offset=0, end_line=2, end_col_offset=16
-                )
+            pylint.testutils.MessageTest(
+                msg_id="docstring-admonition-needs-newline",
+                line=2,
+                node=function_node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=16,
+            )
         ):
             self.checker.visit_functiondef(function_node)
 
@@ -2644,9 +3555,14 @@ class TestCheckDocstringAdmonitionNewline(pylint.testutils.CheckerTestCase):
         )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-admonition-needs-newline", line=2, node=function_node, col_offset=0, end_line=2, end_col_offset=22
-                )
+            pylint.testutils.MessageTest(
+                msg_id="docstring-admonition-needs-newline",
+                line=2,
+                node=function_node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=22,
+            )
         ):
             self.checker.visit_asyncfunctiondef(function_node)
 
@@ -2665,9 +3581,14 @@ class TestCheckDocstringAdmonitionNewline(pylint.testutils.CheckerTestCase):
         )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-admonition-needs-newline", line=2, node=function_node, col_offset=0, end_line=2, end_col_offset=22
-                )
+            pylint.testutils.MessageTest(
+                msg_id="docstring-admonition-needs-newline",
+                line=2,
+                node=function_node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=22,
+            )
         ):
             self.checker.visit_asyncfunctiondef(function_node)
 
@@ -2722,9 +3643,14 @@ class TestCheckDocstringAdmonitionNewline(pylint.testutils.CheckerTestCase):
         )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-admonition-needs-newline", line=2, node=class_node, col_offset=0, end_line=2, end_col_offset=16
-                )
+            pylint.testutils.MessageTest(
+                msg_id="docstring-admonition-needs-newline",
+                line=2,
+                node=class_node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=16,
+            )
         ):
             self.checker.visit_classdef(class_node)
 
@@ -2745,102 +3671,101 @@ class TestCheckDocstringAdmonitionNewline(pylint.testutils.CheckerTestCase):
         )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-admonition-needs-newline", line=2, node=class_node,  col_offset=0, end_line=2, end_col_offset=16
-                )
+            pylint.testutils.MessageTest(
+                msg_id="docstring-admonition-needs-newline",
+                line=2,
+                node=class_node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=16,
+            )
         ):
-            self.checker.visit_classdef(class_node)        
-    
-    
+            self.checker.visit_classdef(class_node)
+
+
 class TestCheckNamingMismatchGeneratedCode(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.CheckNamingMismatchGeneratedCode
 
     def test_import_naming_mismatch_violation(self):
-        import_one = astroid.extract_node(
-            'import Something'
-           
-        )
-        import_two =  astroid.extract_node(
-            'import Something2 as SomethingTwo'
-           
-        )
+        import_one = astroid.extract_node("import Something")
+        import_two = astroid.extract_node("import Something2 as SomethingTwo")
         assign_one = astroid.extract_node(
-        """
+            """
             __all__ =(
             "Something",
             "SomethingTwo", 
             ) 
           """
         )
-      
-        module_node = astroid.Module(name = "node", file="__init__.py", doc = """ """)
-        module_node.body = [import_one,import_two,assign_one]
+
+        module_node = astroid.Module(name="node", file="__init__.py", doc=""" """)
+        module_node.body = [import_one, import_two, assign_one]
 
         for name in module_node.body[-1].assigned_stmts():
             err_node = name.elts[1]
-     
+
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="naming-mismatch", line=4, node=err_node ,col_offset=0, end_line=4, end_col_offset=14
-                )
+            pylint.testutils.MessageTest(
+                msg_id="naming-mismatch",
+                line=4,
+                node=err_node,
+                col_offset=0,
+                end_line=4,
+                end_col_offset=14,
+            )
         ):
             self.checker.visit_module(module_node)
 
     def test_import_from_naming_mismatch_violation(self):
-        import_one = astroid.extract_node(
-            'import Something'
-           
-        )
-        import_two =  astroid.extract_node(
-            'from Something2 import SomethingToo as SomethingTwo'
-           
+        import_one = astroid.extract_node("import Something")
+        import_two = astroid.extract_node(
+            "from Something2 import SomethingToo as SomethingTwo"
         )
         assign_one = astroid.extract_node(
-        """
+            """
             __all__ =(
             "Something",
             "SomethingTwo", 
             ) 
           """
         )
-      
-        module_node = astroid.Module(name = "node", file="__init__.py", doc = """ """)
-        module_node.body = [import_one,import_two,assign_one]
+
+        module_node = astroid.Module(name="node", file="__init__.py", doc=""" """)
+        module_node.body = [import_one, import_two, assign_one]
 
         for name in module_node.body[-1].assigned_stmts():
             err_node = name.elts[1]
-     
+
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="naming-mismatch", line=4, node=err_node, col_offset=0, end_line=4, end_col_offset=14
-                )
+            pylint.testutils.MessageTest(
+                msg_id="naming-mismatch",
+                line=4,
+                node=err_node,
+                col_offset=0,
+                end_line=4,
+                end_col_offset=14,
+            )
         ):
             self.checker.visit_module(module_node)
 
     def test_naming_mismatch_acceptable(self):
-        import_one = astroid.extract_node(
-            'import Something'
-           
-        )
-        import_two =  astroid.extract_node(
-            'import Something2 as SomethingTwo'
-           
-        )
+        import_one = astroid.extract_node("import Something")
+        import_two = astroid.extract_node("import Something2 as SomethingTwo")
         assign_one = astroid.extract_node(
-        """
+            """
             __all__ =(
             "Something",
             "Something2", 
             ) 
           """
         )
-      
-        module_node = astroid.Module(name = "node", file="__init__.py", doc = """ """)
-        module_node.body = [import_one,import_two,assign_one]
+
+        module_node = astroid.Module(name="node", file="__init__.py", doc=""" """)
+        module_node.body = [import_one, import_two, assign_one]
 
         with self.assertNoMessages():
             self.checker.visit_module(module_node)
-    
+
     def test_naming_mismatch_pylint_disable(self):
         file = open(os.path.join(TEST_FOLDER, "test_files", "__init__.py"))
         node = astroid.parse(file.read())
@@ -2856,6 +3781,7 @@ class TestCheckNamingMismatchGeneratedCode(pylint.testutils.CheckerTestCase):
         request = client.get(url)
         response = client._pipeline.run(request)
         assert response.http_response.status_code == 200
+
 
 class TestCheckEnum(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.CheckEnum
@@ -2884,12 +3810,17 @@ class TestCheckEnum(pylint.testutils.CheckerTestCase):
         )
 
         with self.assertAddsMessages(
-             pylint.testutils.MessageTest(
-                msg_id="enum-must-be-uppercase", line=7, node=class_node.body[0].targets[0], col_offset=4, end_line=7, end_col_offset=7
+            pylint.testutils.MessageTest(
+                msg_id="enum-must-be-uppercase",
+                line=7,
+                node=class_node.body[0].targets[0],
+                col_offset=4,
+                end_line=7,
+                end_col_offset=7,
             )
         ):
             self.checker.visit_classdef(class_node)
-    
+
     def test_enum_capitalized_violation_python_three(self):
         class_node = astroid.extract_node(
             """
@@ -2901,14 +3832,19 @@ class TestCheckEnum(pylint.testutils.CheckerTestCase):
             
             """
         )
- 
+
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="enum-must-be-uppercase", line=6, node=class_node.body[0].targets[0], col_offset=4, end_line=6, end_col_offset=7
+                msg_id="enum-must-be-uppercase",
+                line=6,
+                node=class_node.body[0].targets[0],
+                col_offset=4,
+                end_line=6,
+                end_col_offset=7,
             )
         ):
             self.checker.visit_classdef(class_node)
-    
+
     def test_inheriting_case_insensitive_violation(self):
         class_node = astroid.extract_node(
             """
@@ -2921,7 +3857,13 @@ class TestCheckEnum(pylint.testutils.CheckerTestCase):
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="enum-must-inherit-case-insensitive-enum-meta", line=4, node=class_node,  col_offset=0, end_line=4, end_col_offset=16 )
+                msg_id="enum-must-inherit-case-insensitive-enum-meta",
+                line=4,
+                node=class_node,
+                col_offset=0,
+                end_line=4,
+                end_col_offset=16,
+            )
         ):
             self.checker.visit_classdef(class_node)
 
@@ -2934,46 +3876,61 @@ class TestCheckEnum(pylint.testutils.CheckerTestCase):
             class MyGoodEnum(str, Enum, metaclass=CaseInsensitiveEnumMeta): 
                 ONE = "one"
             """
-        )         
+        )
 
         with self.assertNoMessages():
-            self.checker.visit_classdef(class_node)   
+            self.checker.visit_classdef(class_node)
 
     def test_enum_file_acceptable_python_two(self):
-        file = open(os.path.join(TEST_FOLDER, "test_files", "enum_checker_acceptable.py"))
+        file = open(
+            os.path.join(TEST_FOLDER, "test_files", "enum_checker_acceptable.py")
+        )
         node = astroid.parse(file.read())
         file.close()
-        
+
         with self.assertNoMessages():
-            self.checker.visit_classdef(node.body[3])        
-    
+            self.checker.visit_classdef(node.body[3])
+
     def test_enum_file_both_violation(self):
-        file = open(os.path.join(TEST_FOLDER, "test_files", "enum_checker_violation.py"))
+        file = open(
+            os.path.join(TEST_FOLDER, "test_files", "enum_checker_violation.py")
+        )
         node = astroid.parse(file.read())
         file.close()
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="enum-must-inherit-case-insensitive-enum-meta", line=4, node=node.body[1], col_offset=0, end_line=4, end_col_offset=16
+                msg_id="enum-must-inherit-case-insensitive-enum-meta",
+                line=4,
+                node=node.body[1],
+                col_offset=0,
+                end_line=4,
+                end_col_offset=16,
             ),
             pylint.testutils.MessageTest(
-                msg_id="enum-must-be-uppercase", line=5, node=node.body[1].body[0].targets[0], col_offset=4, end_line=5, end_col_offset=7
-            )
+                msg_id="enum-must-be-uppercase",
+                line=5,
+                node=node.body[1].body[0].targets[0],
+                col_offset=4,
+                end_line=5,
+                end_col_offset=7,
+            ),
         ):
-
             self.checker.visit_classdef(node.body[1])
 
     def test_guidelines_link_active(self):
-        self._create_url_pipeline("https://azure.github.io/azure-sdk/python_design.html#enumerations")
-        self._create_url_pipeline("https://azure.github.io/azure-sdk/python_implementation.html#extensible-enumerations")
-        
-    
-    def _create_url_pipeline(self,url):
+        self._create_url_pipeline(
+            "https://azure.github.io/azure-sdk/python_design.html#enumerations"
+        )
+        self._create_url_pipeline(
+            "https://azure.github.io/azure-sdk/python_implementation.html#extensible-enumerations"
+        )
+
+    def _create_url_pipeline(self, url):
         resp = requests.get(url)
         assert resp.status_code == 200
-        
-        
-            
+
+
 class TestCheckAPIVersion(pylint.testutils.CheckerTestCase):
     CHECKER_CLASS = checker.CheckAPIVersion
 
@@ -2990,9 +3947,14 @@ class TestCheckAPIVersion(pylint.testutils.CheckerTestCase):
         )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="client-accepts-api-version-keyword", col_offset=0, line=2, node=class_node, end_line=2, end_col_offset=16
-                )
+            pylint.testutils.MessageTest(
+                msg_id="client-accepts-api-version-keyword",
+                col_offset=0,
+                line=2,
+                node=class_node,
+                end_line=2,
+                end_col_offset=16,
+            )
         ):
             self.checker.visit_classdef(class_node)
 
@@ -3008,36 +3970,50 @@ class TestCheckAPIVersion(pylint.testutils.CheckerTestCase):
                     pass
             """
         )
-    
+
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
-    
+
     def test_api_version_file_class_acceptable(self):
-        file = open(os.path.join(TEST_FOLDER, "test_files", "api_version_checker_acceptable_class.py"))
+        file = open(
+            os.path.join(
+                TEST_FOLDER, "test_files", "api_version_checker_acceptable_class.py"
+            )
+        )
         node = astroid.parse(file.read())
         file.close()
-    
+
         with self.assertNoMessages():
             self.checker.visit_classdef(node.body[0])
 
     def test_api_version_file_init_acceptable(self):
-        file = open(os.path.join(TEST_FOLDER, "test_files", "api_version_checker_acceptable_init.py"))
+        file = open(
+            os.path.join(
+                TEST_FOLDER, "test_files", "api_version_checker_acceptable_init.py"
+            )
+        )
         node = astroid.parse(file.read())
         file.close()
 
         with self.assertNoMessages():
             self.checker.visit_classdef(node.body[0])
 
-
     def test_api_version_file_violation(self):
-        file = open(os.path.join(TEST_FOLDER, "test_files", "api_version_checker_violation.py"))
+        file = open(
+            os.path.join(TEST_FOLDER, "test_files", "api_version_checker_violation.py")
+        )
         node = astroid.parse(file.read())
         file.close()
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="client-accepts-api-version-keyword", line=4, node=node.body[0], col_offset=0, end_line=4, end_col_offset=16
-                )
+            pylint.testutils.MessageTest(
+                msg_id="client-accepts-api-version-keyword",
+                line=4,
+                node=node.body[0],
+                col_offset=0,
+                end_line=4,
+                end_col_offset=16,
+            )
         ):
             self.checker.visit_classdef(node.body[0])
 
@@ -3052,6 +4028,7 @@ class TestCheckAPIVersion(pylint.testutils.CheckerTestCase):
 
 class TestCheckNonCoreNetworkImport(pylint.testutils.CheckerTestCase):
     """Test that we are blocking disallowed imports and allowing allowed imports."""
+
     CHECKER_CLASS = checker.NonCoreNetworkImport
 
     def test_disallowed_imports(self):
@@ -3059,27 +4036,26 @@ class TestCheckNonCoreNetworkImport(pylint.testutils.CheckerTestCase):
         # Blocked import ouside of core.
         import_node = astroid.extract_node("import requests")
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="networking-import-outside-azure-core-transport",
-                    line=1,
-                    node=import_node,
-                    col_offset=0,
-                )
+            pylint.testutils.MessageTest(
+                msg_id="networking-import-outside-azure-core-transport",
+                line=1,
+                node=import_node,
+                col_offset=0,
+            )
         ):
             self.checker.visit_import(import_node)
 
         # blocked import from outside of core.
         importfrom_node = astroid.extract_node("from aiohttp import get")
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="networking-import-outside-azure-core-transport",
-                    line=1,
-                    node=importfrom_node,
-                    col_offset=0,
-                )
+            pylint.testutils.MessageTest(
+                msg_id="networking-import-outside-azure-core-transport",
+                line=1,
+                node=importfrom_node,
+                col_offset=0,
+            )
         ):
             self.checker.visit_importfrom(importfrom_node)
-
 
     def test_allowed_imports(self):
         """Check that allowed imports don't raise warnings."""
@@ -3089,7 +4065,9 @@ class TestCheckNonCoreNetworkImport(pylint.testutils.CheckerTestCase):
             self.checker.visit_import(import_node)
 
         # from import not in the blocked list.
-        importfrom_node = astroid.extract_node("from azure.core.pipeline import Pipeline")
+        importfrom_node = astroid.extract_node(
+            "from azure.core.pipeline import Pipeline"
+        )
         with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)
 
@@ -3100,7 +4078,9 @@ class TestCheckNonCoreNetworkImport(pylint.testutils.CheckerTestCase):
             self.checker.visit_import(import_node)
 
         # blocked from import, but in core.
-        importfrom_node = astroid.extract_node("from requests.exceptions import HttpException")
+        importfrom_node = astroid.extract_node(
+            "from requests.exceptions import HttpException"
+        )
         importfrom_node.root().name = "azure.core.pipeline.transport._private_module"
         with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)
@@ -3108,18 +4088,21 @@ class TestCheckNonCoreNetworkImport(pylint.testutils.CheckerTestCase):
 
 class TestCheckNonAbstractTransportImport(pylint.testutils.CheckerTestCase):
     """Test that we are blocking disallowed imports and allowing allowed imports."""
+
     CHECKER_CLASS = checker.NonAbstractTransportImport
 
     def test_disallowed_imports(self):
         """Check that illegal imports raise warnings"""
-        importfrom_node = astroid.extract_node("from azure.core.pipeline.transport import RequestsTransport")
+        importfrom_node = astroid.extract_node(
+            "from azure.core.pipeline.transport import RequestsTransport"
+        )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="non-abstract-transport-import",
-                    line=1,
-                    node=importfrom_node,
-                    col_offset=0,
-                )
+            pylint.testutils.MessageTest(
+                msg_id="non-abstract-transport-import",
+                line=1,
+                node=importfrom_node,
+                col_offset=0,
+            )
         ):
             self.checker.visit_importfrom(importfrom_node)
 
@@ -3131,71 +4114,81 @@ class TestCheckNonAbstractTransportImport(pylint.testutils.CheckerTestCase):
             self.checker.visit_importfrom(importfrom_node)
 
         # from import not in the blocked list.
-        importfrom_node = astroid.extract_node("from azure.core.pipeline import Pipeline")
+        importfrom_node = astroid.extract_node(
+            "from azure.core.pipeline import Pipeline"
+        )
         with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)
 
         # Import abstract classes
-        importfrom_node = astroid.extract_node("from azure.core.pipeline.transport import HttpTransport, HttpRequest, HttpResponse, AsyncHttpTransport, AsyncHttpResponse")
+        importfrom_node = astroid.extract_node(
+            "from azure.core.pipeline.transport import HttpTransport, HttpRequest, HttpResponse, AsyncHttpTransport, AsyncHttpResponse"
+        )
         with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)
 
         # Import non-abstract classes, but from in `azure.core.pipeline.transport`.
-        importfrom_node = astroid.extract_node("from azure.core.pipeline.transport import RequestsTransport, AioHttpTransport, AioHttpTransportResponse")
+        importfrom_node = astroid.extract_node(
+            "from azure.core.pipeline.transport import RequestsTransport, AioHttpTransport, AioHttpTransportResponse"
+        )
         importfrom_node.root().name = "azure.core.pipeline.transport._private_module"
         with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)
 
+
 class TestRaiseWithTraceback(pylint.testutils.CheckerTestCase):
     """Test that we don't use raise with traceback"""
+
     CHECKER_CLASS = checker.NoAzureCoreTracebackUseRaiseFrom
 
     def test_raise_traceback(self):
         node = astroid.extract_node(
-        """
+            """
         from azure.core.exceptions import DeserializationError, SerializationError, raise_with_traceback
         """
         )
 
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="no-raise-with-traceback",
-                    line=2,
-                    node=node,
-                    col_offset=0, 
-                    end_line=2, 
-                    end_col_offset=96
-                )
+            pylint.testutils.MessageTest(
+                msg_id="no-raise-with-traceback",
+                line=2,
+                node=node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=96,
+            )
         ):
             self.checker.visit_importfrom(node)
 
+
 class TestTypePropertyNameLength(pylint.testutils.CheckerTestCase):
     """Test that we are checking the type and property name lengths"""
+
     CHECKER_CLASS = checker.NameExceedsStandardCharacterLength
 
     def test_class_name_too_long(self):
         class_node = astroid.extract_node(
-        """
+            """
             class ThisClassNameShouldEndUpBeingTooLongForAClient():
                 def __init__(self, **kwargs):
                     pass
         """
         )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="name-too-long",
-                    line=2,
-                    node=class_node,
-                    col_offset=0, 
-                    end_line=2, 
-                    end_col_offset=52
-                )
+            pylint.testutils.MessageTest(
+                msg_id="name-too-long",
+                line=2,
+                node=class_node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=52,
+            )
         ):
             self.checker.visit_classdef(class_node)
 
     def test_function_name_too_long(self):
         class_node, function_node = astroid.extract_node(
-        """
+            """
             class ClassNameGoodClient(): #@
                 def this_function_name_should_be_too_long_for_rule(self, **kwargs): #@
                     pass
@@ -3204,20 +4197,20 @@ class TestTypePropertyNameLength(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="name-too-long",
-                    line=3,
-                    node=function_node,
-                    col_offset=4, 
-                    end_line=3, 
-                    end_col_offset=54
-                )
+            pylint.testutils.MessageTest(
+                msg_id="name-too-long",
+                line=3,
+                node=function_node,
+                col_offset=4,
+                end_line=3,
+                end_col_offset=54,
+            )
         ):
             self.checker.visit_functiondef(function_node)
 
     def test_variable_name_too_long(self):
         class_node, function_node, property_node = astroid.extract_node(
-        """
+            """
             class ClassNameGoodClient(): #@
                 def this_function_good(self, **kwargs): #@
                     this_lists_name_is_too_long_to_work_with_linter_rule = [] #@
@@ -3226,20 +4219,20 @@ class TestTypePropertyNameLength(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="name-too-long",
-                    line=4,
-                    node=property_node.targets[0],
-                    col_offset=8, 
-                    end_line=4, 
-                    end_col_offset=65
-                )
+            pylint.testutils.MessageTest(
+                msg_id="name-too-long",
+                line=4,
+                node=property_node.targets[0],
+                col_offset=8,
+                end_line=4,
+                end_col_offset=65,
+            )
         ):
             self.checker.visit_functiondef(function_node)
 
     def test_private_name_too_long(self):
         class_node, function_node, property_node = astroid.extract_node(
-        """
+            """
             class ClassNameGoodClient(): #@
                 def _this_function_is_private_but_over_length_reqs(self, **kwargs): #@
                     this_lists_name = [] #@
@@ -3251,7 +4244,7 @@ class TestTypePropertyNameLength(pylint.testutils.CheckerTestCase):
 
     def test_instance_attr_name_too_long(self):
         class_node, function_node, property_node = astroid.extract_node(
-        """
+            """
             class ClassNameGoodClient(): #@
                 def __init__(self, this_name_is_too_long_to_use_anymore_reqs, **kwargs): #@
                     self.this_name_is_too_long_to_use_anymore_reqs = 10 #@
@@ -3260,20 +4253,20 @@ class TestTypePropertyNameLength(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_classdef(class_node)
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="name-too-long",
-                    line=4,
-                    node=property_node.targets[0],
-                    col_offset=8, 
-                    end_line=4, 
-                    end_col_offset=65
-                )
+            pylint.testutils.MessageTest(
+                msg_id="name-too-long",
+                line=4,
+                node=property_node.targets[0],
+                col_offset=8,
+                end_line=4,
+                end_col_offset=65,
+            )
         ):
             self.checker.visit_functiondef(function_node)
 
     def test_class_var_name_too_long(self):
         class_node, class_var_node, function_node, property_node = astroid.extract_node(
-        """
+            """
             class ClassNameGoodClient(): #@
                 this_name_is_too_long_to_use_anymore_reqs = 10 #@
                 def __init__(self, dog, **kwargs): #@
@@ -3281,27 +4274,29 @@ class TestTypePropertyNameLength(pylint.testutils.CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="name-too-long",
-                    line=3,
-                    node=class_node.body[0].targets[0],
-                    col_offset=4, 
-                    end_line=3, 
-                    end_col_offset=45
-                )
+            pylint.testutils.MessageTest(
+                msg_id="name-too-long",
+                line=3,
+                node=class_node.body[0].targets[0],
+                col_offset=4,
+                end_line=3,
+                end_col_offset=45,
+            )
         ):
             self.checker.visit_functiondef(class_node)
         with self.assertNoMessages():
             self.checker.visit_functiondef(function_node)
 
+
 class TestDeleteOperationReturnType(pylint.testutils.CheckerTestCase):
 
     """Test that we are checking the return type of delete functions is correct"""
+
     CHECKER_CLASS = checker.DeleteOperationReturnStatement
 
     def test_begin_delete_operation_incorrect_return(self):
         node = astroid.extract_node(
-        """
+            """
             from azure.core.polling import LROPoller 
             from typing import Any
             class MyClient():
@@ -3310,20 +4305,20 @@ class TestDeleteOperationReturnType(pylint.testutils.CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="delete-operation-wrong-return-type",
-                    line=5,
-                    node=node,
-                    col_offset=4, 
-                    end_line=5, 
-                    end_col_offset=24
-                )
+            pylint.testutils.MessageTest(
+                msg_id="delete-operation-wrong-return-type",
+                line=5,
+                node=node,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=24,
+            )
         ):
             self.checker.visit_functiondef(node)
 
     def test_delete_operation_incorrect_return(self):
         node = astroid.extract_node(
-        """
+            """
             from azure.core.polling import LROPoller 
             from typing import Any
             class MyClient():
@@ -3332,20 +4327,20 @@ class TestDeleteOperationReturnType(pylint.testutils.CheckerTestCase):
         """
         )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="delete-operation-wrong-return-type",
-                    line=5,
-                    node=node,
-                    col_offset=4, 
-                    end_line=5, 
-                    end_col_offset=24
-                )
+            pylint.testutils.MessageTest(
+                msg_id="delete-operation-wrong-return-type",
+                line=5,
+                node=node,
+                col_offset=4,
+                end_line=5,
+                end_col_offset=24,
+            )
         ):
             self.checker.visit_functiondef(node)
 
     def test_delete_operation_correct_return(self):
         node = astroid.extract_node(
-        """
+            """
             from azure.core.polling import LROPoller 
             from typing import Any
             class MyClient():
@@ -3357,9 +4352,8 @@ class TestDeleteOperationReturnType(pylint.testutils.CheckerTestCase):
             self.checker.visit_functiondef(node)
 
     def test_begin_delete_operation_correct_return(self):
-
         node = astroid.extract_node(
-        """
+            """
             from azure.core.polling import LROPoller 
             from typing import Any
             class MyClient():
@@ -3370,9 +4364,11 @@ class TestDeleteOperationReturnType(pylint.testutils.CheckerTestCase):
         with self.assertNoMessages():
             self.checker.visit_functiondef(node)
 
+
 class TestDocstringParameters(pylint.testutils.CheckerTestCase):
 
     """Test that we are checking the docstring is correct"""
+
     CHECKER_CLASS = checker.CheckDocstringParameters
 
     def test_docstring_vararg(self):
@@ -3422,33 +4418,33 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
             """
         )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id='docstring-keyword-should-match-keyword-only',
-                    line=2,
-                    node=node,
-                    args='y, z',
-                    col_offset=0,
-                    end_line=2,
-                    end_col_offset=16
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-missing-type",
-                    line=2,
-                    args='x',
-                    node=node,
-                    col_offset=0, 
-                    end_line=2, 
-                    end_col_offset=16
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-should-be-keyword",
-                    line=2,
-                    args='y, z',
-                    node=node,
-                    col_offset=0, 
-                    end_line=2, 
-                    end_col_offset=16
-                ),
+            pylint.testutils.MessageTest(
+                msg_id="docstring-keyword-should-match-keyword-only",
+                line=2,
+                node=node,
+                args="y, z",
+                col_offset=0,
+                end_line=2,
+                end_col_offset=16,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="docstring-missing-type",
+                line=2,
+                args="x",
+                node=node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=16,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="docstring-should-be-keyword",
+                line=2,
+                args="y, z",
+                node=node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=16,
+            ),
         ):
             self.checker.visit_functiondef(node)
 
@@ -3480,15 +4476,15 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
             """
         )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-missing-return",
-                    line=3,
-                    args=None,
-                    node=node,
-                    col_offset=0, 
-                    end_line=3, 
-                    end_col_offset=16
-                ),
+            pylint.testutils.MessageTest(
+                msg_id="docstring-missing-return",
+                line=3,
+                args=None,
+                node=node,
+                col_offset=0,
+                end_line=3,
+                end_col_offset=16,
+            ),
         ):
             self.checker.visit_functiondef(node)
 
@@ -3580,42 +4576,43 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
             """
         )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-type-do-not-use-class",
-                    line=2,
-                    args="x",
-                    node=node,
-                    col_offset=0, 
-                    end_line=3, 
-                    end_col_offset=16
-                ),
-                pylint.testutils.MessageTest(
-                    msg_id="docstring-type-do-not-use-class",
-                    line=2,
-                    args="rtype",
-                    node=node,
-                    col_offset=0, 
-                    end_line=2, 
-                    end_col_offset=16
-                ),
+            pylint.testutils.MessageTest(
+                msg_id="docstring-type-do-not-use-class",
+                line=2,
+                args="x",
+                node=node,
+                col_offset=0,
+                end_line=3,
+                end_col_offset=16,
+            ),
+            pylint.testutils.MessageTest(
+                msg_id="docstring-type-do-not-use-class",
+                line=2,
+                args="rtype",
+                node=node,
+                col_offset=0,
+                end_line=2,
+                end_col_offset=16,
+            ),
         ):
             self.checker.visit_functiondef(node)
 
 
 class TestDoNotImportLegacySix(pylint.testutils.CheckerTestCase):
     """Test that we are blocking disallowed imports and allowing allowed imports."""
+
     CHECKER_CLASS = checker.DoNotImportLegacySix
 
     def test_disallowed_import_from(self):
         """Check that illegal imports raise warnings"""
         importfrom_node = astroid.extract_node("from six import with_metaclass")
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="do-not-import-legacy-six",
-                    line=1,
-                    node=importfrom_node,
-                    col_offset=0,
-                )
+            pylint.testutils.MessageTest(
+                msg_id="do-not-import-legacy-six",
+                line=1,
+                node=importfrom_node,
+                col_offset=0,
+            )
         ):
             self.checker.visit_importfrom(importfrom_node)
 
@@ -3623,12 +4620,12 @@ class TestDoNotImportLegacySix(pylint.testutils.CheckerTestCase):
         """Check that illegal imports raise warnings"""
         importfrom_node = astroid.extract_node("import six")
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="do-not-import-legacy-six",
-                    line=1,
-                    node=importfrom_node,
-                    col_offset=0,
-                )
+            pylint.testutils.MessageTest(
+                msg_id="do-not-import-legacy-six",
+                line=1,
+                node=importfrom_node,
+                col_offset=0,
+            )
         ):
             self.checker.visit_import(importfrom_node)
 
@@ -3640,24 +4637,30 @@ class TestDoNotImportLegacySix(pylint.testutils.CheckerTestCase):
             self.checker.visit_importfrom(importfrom_node)
 
         # from import not in the blocked list.
-        importfrom_node = astroid.extract_node("from azure.core.pipeline import Pipeline")
+        importfrom_node = astroid.extract_node(
+            "from azure.core.pipeline import Pipeline"
+        )
         with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)
 
+
 class TestCheckNoLegacyAzureCoreHttpResponseImport(pylint.testutils.CheckerTestCase):
     """Test that we are blocking disallowed imports and allowing allowed imports."""
+
     CHECKER_CLASS = checker.NoLegacyAzureCoreHttpResponseImport
 
     def test_disallowed_import_from(self):
         """Check that illegal imports raise warnings"""
-        importfrom_node = astroid.extract_node("from azure.core.pipeline.transport import HttpResponse")
+        importfrom_node = astroid.extract_node(
+            "from azure.core.pipeline.transport import HttpResponse"
+        )
         with self.assertAddsMessages(
-                pylint.testutils.MessageTest(
-                    msg_id="no-legacy-azure-core-http-response-import",
-                    line=1,
-                    node=importfrom_node,
-                    col_offset=0,
-                )
+            pylint.testutils.MessageTest(
+                msg_id="no-legacy-azure-core-http-response-import",
+                line=1,
+                node=importfrom_node,
+                col_offset=0,
+            )
         ):
             self.checker.visit_importfrom(importfrom_node)
 
@@ -3669,7 +4672,9 @@ class TestCheckNoLegacyAzureCoreHttpResponseImport(pylint.testutils.CheckerTestC
             self.checker.visit_importfrom(importfrom_node)
 
         # from import not in the blocked list.
-        importfrom_node = astroid.extract_node("from azure.core.pipeline import Pipeline")
+        importfrom_node = astroid.extract_node(
+            "from azure.core.pipeline import Pipeline"
+        )
         with self.assertNoMessages():
             self.checker.visit_importfrom(importfrom_node)
 

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -4435,7 +4435,7 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
                 msg_id="docstring-keyword-should-match-keyword-only",
                 line=2,
                 node=node,
-                args="y, z",
+                args="z, y",
                 col_offset=0,
                 end_line=2,
                 end_col_offset=16,

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -2451,7 +2451,7 @@ class TestFileHasCopyrightHeader(pylint.testutils.CheckerTestCase):
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="file-needs-copyright-header", line=0, node=node
+                msg_id="file-needs-copyright-header", line=0, node=node, col_offset=0
             )
         ):
             self.checker.visit_module(node)
@@ -2761,7 +2761,7 @@ class TestClientListMethodsUseCorePaging(pylint.testutils.CheckerTestCase):
                 node=function_node_a,
                 col_offset=4,
                 end_line=5,
-                end_col_offset=18,
+                end_col_offset=24,
             ),
         ):
             self.checker.visit_return(function_node_a.body[0])
@@ -2782,11 +2782,11 @@ class TestClientListMethodsUseCorePaging(pylint.testutils.CheckerTestCase):
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
                 msg_id="client-paging-methods-use-list",
-                line=32,
+                line=31,
                 node=function_node_b,
                 col_offset=4,
-                end_line=32,
-                end_col_offset=32,
+                end_line=31,
+                end_col_offset=22,
             )
         ):
             self.checker.visit_return(function_node.body[2])
@@ -2803,10 +2803,10 @@ class TestClientListMethodsUseCorePaging(pylint.testutils.CheckerTestCase):
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
                 msg_id="client-paging-methods-use-list",
-                line=8,
+                line=10,
                 node=function_node,
                 col_offset=4,
-                end_line=8,
+                end_line=10,
                 end_col_offset=18,
             )
         ):
@@ -3111,7 +3111,8 @@ class TestPackageNameDoesNotUseUnderscoreOrPeriod(pylint.testutils.CheckerTestCa
         PACKAGE_NAME = "correct-package-name"        
         """
         )
-        module_node = astroid.Module(name="node", file="setup.py", doc=""" """)
+        module_node = astroid.Module(name="node", file="setup.py")
+        module_node.doc_node = """ """
         module_node.body = [package_name]
 
         with self.assertNoMessages():
@@ -3123,12 +3124,13 @@ class TestPackageNameDoesNotUseUnderscoreOrPeriod(pylint.testutils.CheckerTestCa
         PACKAGE_NAME = "incorrect.package-name"        
         """
         )
-        module_node = astroid.Module(name="node", file="setup.py", doc=""" """)
+        module_node = astroid.Module(name="node", file="setup.py")
+        module_node.doc_node = """ """
         module_node.body = [package_name]
 
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="package-name-incorrect", line=0, node=module_node
+                msg_id="package-name-incorrect", line=0, node=module_node, col_offset=0,
             )
         ):
             self.checker.visit_module(module_node)
@@ -3153,7 +3155,8 @@ class TestServiceClientUsesNameWithClientSuffix(pylint.testutils.CheckerTestCase
                 pass       
         """
         )
-        module_node = astroid.Module(name="node", file="_my_client.py", doc=""" """)
+        module_node = astroid.Module(name="node", file="_my_client.py")
+        module_node.doc_node = """ """
         module_node.body = [client_node]
 
         with self.assertNoMessages():
@@ -3167,11 +3170,12 @@ class TestServiceClientUsesNameWithClientSuffix(pylint.testutils.CheckerTestCase
                 pass       
         """
         )
-        module_node = astroid.Module(name="node", file="_my_client.py", doc=""" """)
+        module_node = astroid.Module(name="node", file="_my_client.py")
+        module_node.doc_node = """ """
         module_node.body = [client_node]
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
-                msg_id="client-suffix-needed", line=0, node=module_node
+                msg_id="client-suffix-needed", line=0, node=module_node, col_offset=0,
             )
         ):
             self.checker.visit_module(module_node)
@@ -3392,7 +3396,7 @@ class TestClientMethodNamesDoNotUseDoubleUnderscorePrefix(
                 node=func_node_c,
                 col_offset=4,
                 end_line=10,
-                end_col_offset=2,
+                end_col_offset=20,
             ),
         ):
             self.checker.visit_functiondef(func_node_a)
@@ -3698,7 +3702,8 @@ class TestCheckNamingMismatchGeneratedCode(pylint.testutils.CheckerTestCase):
           """
         )
 
-        module_node = astroid.Module(name="node", file="__init__.py", doc=""" """)
+        module_node = astroid.Module(name="node", file="__init__.py")
+        module_node.doc_node = """ """
         module_node.body = [import_one, import_two, assign_one]
 
         for name in module_node.body[-1].assigned_stmts():
@@ -3730,7 +3735,8 @@ class TestCheckNamingMismatchGeneratedCode(pylint.testutils.CheckerTestCase):
           """
         )
 
-        module_node = astroid.Module(name="node", file="__init__.py", doc=""" """)
+        module_node = astroid.Module(name="node", file="__init__.py")
+        module_node.doc_node = """ """
         module_node.body = [import_one, import_two, assign_one]
 
         for name in module_node.body[-1].assigned_stmts():
@@ -3760,7 +3766,8 @@ class TestCheckNamingMismatchGeneratedCode(pylint.testutils.CheckerTestCase):
           """
         )
 
-        module_node = astroid.Module(name="node", file="__init__.py", doc=""" """)
+        module_node = astroid.Module(name="node", file="__init__.py")
+        module_node.doc_node = """ """
         module_node.body = [import_one, import_two, assign_one]
 
         with self.assertNoMessages():
@@ -3901,18 +3908,18 @@ class TestCheckEnum(pylint.testutils.CheckerTestCase):
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
                 msg_id="enum-must-inherit-case-insensitive-enum-meta",
-                line=4,
+                line=5,
                 node=node.body[1],
                 col_offset=0,
-                end_line=4,
+                end_line=5,
                 end_col_offset=16,
             ),
             pylint.testutils.MessageTest(
                 msg_id="enum-must-be-uppercase",
-                line=5,
+                line=6,
                 node=node.body[1].body[0].targets[0],
                 col_offset=4,
-                end_line=5,
+                end_line=6,
                 end_col_offset=7,
             ),
         ):
@@ -4041,6 +4048,8 @@ class TestCheckNonCoreNetworkImport(pylint.testutils.CheckerTestCase):
                 line=1,
                 node=import_node,
                 col_offset=0,
+                end_line=1,
+                end_col_offset=15,
             )
         ):
             self.checker.visit_import(import_node)
@@ -4053,6 +4062,8 @@ class TestCheckNonCoreNetworkImport(pylint.testutils.CheckerTestCase):
                 line=1,
                 node=importfrom_node,
                 col_offset=0,
+                end_line=1,
+                end_col_offset=23,
             )
         ):
             self.checker.visit_importfrom(importfrom_node)
@@ -4102,6 +4113,8 @@ class TestCheckNonAbstractTransportImport(pylint.testutils.CheckerTestCase):
                 line=1,
                 node=importfrom_node,
                 col_offset=0,
+                end_line=1,
+                end_col_offset=59,
             )
         ):
             self.checker.visit_importfrom(importfrom_node)
@@ -4225,7 +4238,7 @@ class TestTypePropertyNameLength(pylint.testutils.CheckerTestCase):
                 node=property_node.targets[0],
                 col_offset=8,
                 end_line=4,
-                end_col_offset=65,
+                end_col_offset=60,
             )
         ):
             self.checker.visit_functiondef(function_node)
@@ -4259,7 +4272,7 @@ class TestTypePropertyNameLength(pylint.testutils.CheckerTestCase):
                 node=property_node.targets[0],
                 col_offset=8,
                 end_line=4,
-                end_col_offset=65,
+                end_col_offset=54,
             )
         ):
             self.checker.visit_functiondef(function_node)
@@ -4311,7 +4324,7 @@ class TestDeleteOperationReturnType(pylint.testutils.CheckerTestCase):
                 node=node,
                 col_offset=4,
                 end_line=5,
-                end_col_offset=24,
+                end_col_offset=34,
             )
         ):
             self.checker.visit_functiondef(node)
@@ -4333,7 +4346,7 @@ class TestDeleteOperationReturnType(pylint.testutils.CheckerTestCase):
                 node=node,
                 col_offset=4,
                 end_line=5,
-                end_col_offset=24,
+                end_col_offset=28,
             )
         ):
             self.checker.visit_functiondef(node)
@@ -4582,7 +4595,7 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
                 args="x",
                 node=node,
                 col_offset=0,
-                end_line=3,
+                end_line=2,
                 end_col_offset=16,
             ),
             pylint.testutils.MessageTest(
@@ -4612,6 +4625,8 @@ class TestDoNotImportLegacySix(pylint.testutils.CheckerTestCase):
                 line=1,
                 node=importfrom_node,
                 col_offset=0,
+                end_line=1,
+                end_col_offset=30,
             )
         ):
             self.checker.visit_importfrom(importfrom_node)
@@ -4625,6 +4640,8 @@ class TestDoNotImportLegacySix(pylint.testutils.CheckerTestCase):
                 line=1,
                 node=importfrom_node,
                 col_offset=0,
+                end_line=1,
+                end_col_offset=10,
             )
         ):
             self.checker.visit_import(importfrom_node)
@@ -4660,6 +4677,8 @@ class TestCheckNoLegacyAzureCoreHttpResponseImport(pylint.testutils.CheckerTestC
                 line=1,
                 node=importfrom_node,
                 col_offset=0,
+                end_line=1,
+                end_col_offset=54,
             )
         ):
             self.checker.visit_importfrom(importfrom_node)


### PR DESCRIPTION
Ran black

Fixed pylint 3.0 breaking changes (node.doc = node.node_doc, infer_call_result on FunctionDef takes a caller positional arg)