### PR TITLE
Add package filter parameter for release

### DIFF
--- a/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+++ b/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
@@ -1,6 +1,7 @@
 parameters:
   ArtifactLocation: 'not-specified'
   PackageRepository: 'not-specified'
+  PackageFilter: ''
   ReleaseSha: 'not-specified'
   RepoId: $(Build.Repository.Name)
   WorkingDirectory: ''
@@ -14,6 +15,7 @@ steps:
     arguments: >
       -artifactLocation ${{ parameters.ArtifactLocation }}
       -packageRepository ${{ parameters.PackageRepository }}
+      -packageFilter ${{ parameters.PackageFilter }}
       -releaseSha ${{ parameters.ReleaseSha }}
       -repoId ${{ parameters.RepoId }}
       -workingDirectory '${{ parameters.WorkingDirectory }}'

--- a/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
+++ b/eng/common/pipelines/templates/steps/create-tags-and-git-release.yml
@@ -15,7 +15,7 @@ steps:
     arguments: >
       -artifactLocation ${{ parameters.ArtifactLocation }}
       -packageRepository ${{ parameters.PackageRepository }}
-      -packageFilter ${{ parameters.PackageFilter }}
+      -packageFilter "${{ parameters.PackageFilter }}"
       -releaseSha ${{ parameters.ReleaseSha }}
       -repoId ${{ parameters.RepoId }}
       -workingDirectory '${{ parameters.WorkingDirectory }}'

--- a/eng/common/scripts/create-tags-and-git-release.ps1
+++ b/eng/common/scripts/create-tags-and-git-release.ps1
@@ -7,6 +7,7 @@ param (
   $artifactLocation, # the root of the artifact folder. DevOps $(System.ArtifactsDirectory)
   $workingDirectory, # directory that package artifacts will be extracted into for examination (if necessary)
   $packageRepository, # used to indicate destination against which we will check the existing version.
+  $packageFilter,
   # valid options: PyPI, Nuget, NPM, Maven, C, CPP
   # used by CreateTags
   $releaseSha, # the SHA for the artifacts. DevOps: $(Release.Artifacts.<artifactAlias>.SourceVersion) or $(Build.SourceVersion)
@@ -25,6 +26,11 @@ Write-Host "Using API URL $apiUrl"
 
 # VERIFY PACKAGES
 $pkgList = VerifyPackages -artifactLocation $artifactLocation -workingDirectory $workingDirectory -apiUrl $apiUrl -releaseSha $releaseSha -continueOnError $continueOnError
+
+if ($packageFilter) {
+    Write-Host "Filtering discovered packages to '$packageFilter'"
+    [array]$pkgList = $pkgList | Where-Object { $_.PackageId -like $packageFilter }
+}
 
 if ($pkgList) {
   Write-Host "Given the visible artifacts, github releases will be created for the following:"


### PR DESCRIPTION
By default we recursively discover packages in our release scripts. This is causing issues in the go repo where some packages have packages nested but that are represented in separate pipelines, namely `azidentity`. This PR adds a `-NoRecurse` option to the scripts and pipeline templates which changes our search depth to the artifact location only.

```
<package>/
  go.mod
  ci.yml
  CHANGELOG.md
  <sub package>/
    go.mod
    ci.yml
    CHANGELOG.md
```

Resolves https://github.com/Azure/azure-sdk-for-go/issues/21737
