### PR TITLE
Fix automatic review exception

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
@@ -120,7 +120,7 @@ namespace APIViewWeb.Controllers
 
             if (codeFile == null)
             {
-                return StatusCode(statusCode: StatusCodes.Status404NotFound, $"API review code file for package {packageName} is not found in DevOps pipeline artifacts.");
+                return StatusCode(statusCode: StatusCodes.Status204NoContent, $"API review code file for package {packageName} is not found in DevOps pipeline artifacts.");
             }
             var apiRevision = await CreateAutomaticRevisionAsync(codeFile: codeFile, label: label, originalName: originalFilePath, memoryStream: memoryStream, compareAllRevisions);
             if (apiRevision != null)

--- a/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
@@ -118,6 +118,10 @@ namespace APIViewWeb.Controllers
                 packageName: packageName, originalFileName: originalFilePath, codeFileName: reviewFilePath, originalFileStream: memoryStream,
                 project: project);
 
+            if (codeFile == null)
+            {
+                return StatusCode(statusCode: StatusCodes.Status404NotFound, $"API review code file for package {packageName} is not found in DevOps pipeline artifacts.");
+            }
             var apiRevision = await CreateAutomaticRevisionAsync(codeFile: codeFile, label: label, originalName: originalFilePath, memoryStream: memoryStream, compareAllRevisions);
             if (apiRevision != null)
             {


### PR DESCRIPTION
Handle null pointer exception to avoid invalid exceptions when processing automatic API reviews. Too many exceptions logged in app insights, makes the monitoring difficult.