### PR TITLE
Return correct URL when processing API review from spec

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -176,8 +176,7 @@ namespace APIViewWeb.Controllers
             await _pullRequestManager.UpsertPullRequestAsync(pullRequestModel);
 
             // Return review URL created for current package if exists
-            var pr = pullRequests.SingleOrDefault(r => r.PackageName == packageName && (r.Language == null || r.Language == language));
-            return pr == null ? "" : ManagerHelpers.ResolveReviewUrl(pullRequest: pr, hostName: hostName);
+            return string.IsNullOrEmpty(pullRequestModel.APIRevisionId)? "" : ManagerHelpers.ResolveReviewUrl(pullRequest: pullRequestModel, hostName: hostName);
 
         }
 


### PR DESCRIPTION
Spec review pipeline gets failure status if a PR generates more than one API review. FIx is to get the review ID from pull request model that already has the info.

