### PR TITLE
FaultInjector: stream response instead of buffering

### DIFF
--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Program.cs
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Program.cs
@@ -376,8 +376,8 @@ namespace Azure.Sdk.Tools.HttpFaultInjector
 
         private class UpstreamResponse : IDisposable
         {
-            private readonly HttpContent? _content = null;
-            private readonly Stream? _contentStream = null;
+            private readonly HttpContent _content = null;
+            private readonly Stream _contentStream = null;
             private UpstreamResponse(HttpContent content)
             {
                 _content = content;

--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Program.cs
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Program.cs
@@ -82,8 +82,7 @@ namespace Azure.Sdk.Tools.HttpFaultInjector
                 _httpClient = new HttpClient(new HttpClientHandler()
                 {
                     // Allow insecure SSL certs
-                    ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true,
-                    
+                    ServerCertificateCustomValidationCallback = (message, cert, chain, errors) => true
                 });
             }
             else


### PR DESCRIPTION
Fixes #7463

Tried with storage stress tests  under load:
- no new issues
- OOM no longer happens
- memory utilization is 10x lower
- throghput in stress test went up ~5x times

![image](https://github.com/Azure/azure-sdk-tools/assets/2347409/4a78dc91-acd7-472a-b048-e3d26a913c02)
(fault-injector is now at 200MB, used to be > 2GB)

