### PR TITLE
[tsp-client] Fix typespec compiler usage

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release
 
+## Unreleased - 0.2.1
+
+- Fix TypeSpec compilation issue with module-resolver.
+- Use `resolveCompilerOptions` to get emitter configurations from tspconfig.yaml.
+- Remove unused functions: `getEmitterOptions()`, `resolveCliOptions()`, `resolveImports()`.
+
 ## 2023-12-8 - 0.2.0
 
 - Use the `@typespec/compiler` module installed locally in the `TempTypeSpecFiles/` directory.

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release
 
-## Unreleased - 0.2.1
+## Unreleased - 0.3.0
 
 - Fix TypeSpec compilation issue with module-resolver.
 - Use `resolveCompilerOptions` to get emitter configurations from tspconfig.yaml.

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -151,9 +151,11 @@ async function syncTspFiles(outputDir: string, localSpecRepo?: string) {
 async function generate({
   rootUrl,
   noCleanup,
+  additionalEmitterOptions,
 }: {
   rootUrl: string;
   noCleanup: boolean;
+  additionalEmitterOptions?: string;
 }) {
   const tempRoot = path.join(rootUrl, "TempTypeSpecFiles");
   const tspLocation = await readTspLocation(rootUrl);
@@ -172,7 +174,7 @@ async function generate({
   Logger.info("Installing dependencies from npm...");
   await installDependencies(srcDir);
 
-  await compileTsp({ emitterPackage: emitter, outputPath: rootUrl, resolvedMainFilePath, saveInputs: noCleanup });
+  await compileTsp({ emitterPackage: emitter, outputPath: rootUrl, resolvedMainFilePath, saveInputs: noCleanup, additionalEmitterOptions });
 
   if (noCleanup) {
     Logger.debug(`Skipping cleanup of temp directory: ${tempRoot}`);
@@ -205,14 +207,14 @@ async function main() {
         Logger.info(`SDK initialized in ${outputDir}`);
         if (!options.skipSyncAndGenerate) {
           await syncTspFiles(outputDir);
-          await generate({ rootUrl: outputDir, noCleanup: options.noCleanup});
+          await generate({ rootUrl: outputDir, noCleanup: options.noCleanup, additionalEmitterOptions: options.emitterOptions});
         }
         break;
       case "sync":
         await syncTspFiles(rootUrl, options.localSpecRepo);
         break;
       case "generate":
-        await generate({ rootUrl, noCleanup: options.noCleanup});
+        await generate({ rootUrl, noCleanup: options.noCleanup, additionalEmitterOptions: options.emitterOptions});
         break;
       case "update":
         if (options.repo && !options.commit) {
@@ -231,7 +233,7 @@ async function main() {
           await writeFile(path.join(rootUrl, "tsp-location.yaml"), `directory: ${tspLocation.directory}\ncommit: ${tspLocation.commit}\nrepo: ${tspLocation.repo}\nadditionalDirectories: ${tspLocation.additionalDirectories}`);
         }
         await syncTspFiles(rootUrl);
-        await generate({ rootUrl, noCleanup: options.noCleanup});
+        await generate({ rootUrl, noCleanup: options.noCleanup, additionalEmitterOptions: options.emitterOptions});
         break;
       default:
         Logger.error(`Unknown command: ${options.command}`);

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -9,6 +9,7 @@ import { mkdir, writeFile, cp, readFile } from "node:fs/promises";
 import { addSpecFiles, checkoutCommit, cloneRepo, getRepoRoot, sparseCheckout } from "./git.js";
 import { fetch } from "./network.js";
 import { parse as parseYaml } from "yaml";
+import { joinPaths } from "@typespec/compiler";
 
 
 async function sdkInit(
@@ -170,7 +171,7 @@ async function generate({
     throw new Error("emitter is undefined");
   }
   const mainFilePath = await discoverMainFile(srcDir);
-  const resolvedMainFilePath = path.join(srcDir, mainFilePath);
+  const resolvedMainFilePath = joinPaths(srcDir, mainFilePath);
   Logger.info("Installing dependencies from npm...");
   await installDependencies(srcDir);
 

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -129,11 +129,13 @@ export async function compileTsp({
   emitterPackage,
   outputPath,
   resolvedMainFilePath,
+  additionalEmitterOptions,
   saveInputs,
 }: {
   emitterPackage: string;
   outputPath: string;
   resolvedMainFilePath: string;
+  additionalEmitterOptions?: string;
   saveInputs?: boolean;
 }) {
   const parsedEntrypoint = getDirectoryPath(resolvedMainFilePath);
@@ -144,6 +146,14 @@ export async function compileTsp({
   overrideOptions[emitterPackage] = {"emitter-output-dir": outputDir}
   if (saveInputs) {
     overrideOptions[emitterPackage]!["save-inputs"] = "true";
+  }
+  if (additionalEmitterOptions) {
+    additionalEmitterOptions.split(";").forEach((option) => {
+      const [key, value] = option.split("=");
+      if (key && value) {
+        overrideOptions[emitterPackage]![key] = value;
+      }
+    });
   }
   const overrides: Partial<ResolveCompilerOptionsOptions["overrides"]> = {
     outputDir,
@@ -156,7 +166,7 @@ export async function compileTsp({
     entrypoint: resolvedMainFilePath,
     overrides,
   });
-
+  Logger.debug(`Compiler options: ${JSON.stringify(options)}`);
   if (diagnostics.length > 0) {
     // This should not happen, but if it does, we should log it.
     Logger.debug(`Compiler options diagnostic information: ${JSON.stringify(diagnostics)}`);

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -69,16 +69,20 @@ export async function compileTsp({
   const { compile, NodeHost, getSourceLocation, resolveCompilerOptions } = await importTsp(parsedEntrypoint);
 
   const outputDir = resolvePath(outputPath);
-  const overrideOptions: Record<string, Record<string, string>> = {};
-  overrideOptions[emitterPackage] = {"emitter-output-dir": outputDir}
+  const overrideOptions: Record<string, Record<string, string>> = {
+    [emitterPackage]: {
+      "emitter-output-dir": outputDir,
+    },
+  };
+  const emitterOverrideOptions = overrideOptions[emitterPackage] ?? {[emitterPackage]: {}};
   if (saveInputs) {
-    overrideOptions[emitterPackage]!["save-inputs"] = "true";
+    emitterOverrideOptions["save-inputs"] = "true";
   }
   if (additionalEmitterOptions) {
     additionalEmitterOptions.split(";").forEach((option) => {
       const [key, value] = option.split("=");
       if (key && value) {
-        overrideOptions[emitterPackage]![key] = value;
+        emitterOverrideOptions[key] = value;
       }
     });
   }


### PR DESCRIPTION
Use functions provided by `@typespec/compiler` to resolve emitter options and paths passed into the `compile()` call. 

Issues to be addressed in a follow up PR: #7124 , https://github.com/Azure/azure-sdk-tools/issues/7472 <-- will do a wider pass through all of the path operations we do in the tool and update to using the functions provided by typespec/compiler