### PR TITLE
Scheduled autorest preview builds should reuse the branch and pr

### DIFF
--- a/eng/pipelines/templates/stages/archetype-autorest-preview.yml
+++ b/eng/pipelines/templates/stages/archetype-autorest-preview.yml
@@ -294,9 +294,9 @@ stages:
     buildArtifactsPath: $(Pipeline.Workspace)/build_artifacts
     publishArtifactsPath: $(Pipeline.Workspace)/publish_artifacts
     ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
-      branchName: auto-update-autorest-alpha-scheduled
+      branchName: auto-update-autorest-scheduled
     ${{ else }}:
-      branchName: auto-update-autorest-alpha-$(Build.BuildNumber)
+      branchName: auto-update-autorest-$(Build.BuildNumber)
   jobs:
   - job: Initialize
     steps:
@@ -428,27 +428,28 @@ stages:
         $reason = '$(Build.Reason)'
         $preRelease = '${{ parameters.BuildPrereleaseVersion }}' -eq 'true'
 
-        $source = "[$sourceBranch]($repoUrl/tree/$sourceBranch)" 
         if ($sourceBranch -match "^refs/heads/(.+)$") {
-            $source = "branch: [$($Matches[1])]($repoUrl/tree/$sourceBranch)"
+          $prBody = "Triggered from branch: [$($Matches[1])]($repoUrl/tree/$sourceBranch)"
         } elseif ($sourceBranch -match "^refs/tags/(.+)$") {
-            $source = "tag: [$($Matches[1])]($repoUrl/tree/$sourceBranch)"
+          $prBody = "Triggered from tag: [$($Matches[1])]($repoUrl/tree/$sourceBranch)"
         } elseif ($sourceBranch -match "^refs/pull/(\d+)/(head|merge)$") {
-            $source = "pull request: $repoUrl/pull/$($Matches[1])"
-        }
-
-        $prBody = "Triggered from $source"
-
-        $prTitle =  if ($reason -eq 'Schedule') {
-          "Scheduled autorest prerelease test"
-        } elseif ($preRelease) {
-          "Update autorest version to prerelease $generatorVersion" `
+          $prBody = "Triggered from pull request: $repoUrl/pull/$($Matches[1])"
         } else {
-          "Update autorest version to $generatorVersion"
+          $prBody = "Triggered from [$sourceBranch]($repoUrl/tree/$sourceBranch)"
         }
 
-        if ($generateJobResult -ne 'Succeeded') {
-          $prTitle = "Failed: $prTitle"
+        if ($reason -eq 'Schedule') {
+          $prTitle = "Scheduled code regeneration test"
+        } else {
+          if ($preRelease) {
+            $prTitle = "Update autorest version to prerelease $generatorVersion"
+          } else {
+            $prTitle = "Update autorest version to $generatorVersion"
+          }
+
+          if ($generateJobResult -ne 'Succeeded') {
+            $prTitle = "Failed: $prTitle"
+          }
         }
 
         Write-Host "Setting variable 'PullRequestTitle' to '$prTitle'"

--- a/eng/pipelines/templates/stages/archetype-autorest-preview.yml
+++ b/eng/pipelines/templates/stages/archetype-autorest-preview.yml
@@ -341,7 +341,7 @@ stages:
         CommitMsg: Initialize repository for autorest build $(Build.BuildNumber)
         WorkingDirectory: $(sdkRepositoryPath)
         ScriptDirectory: $(toolsRepositoryPath)/eng/common/scripts
-        # To accomodate scheduled runs and retries, we want to overwrite and existing changes on the branch
+        # To accomodate scheduled runs and retries, we want to overwrite any existing changes on the branch
         PushArgs: --force
 
     - task: PowerShell@2

--- a/eng/pipelines/templates/stages/archetype-autorest-preview.yml
+++ b/eng/pipelines/templates/stages/archetype-autorest-preview.yml
@@ -280,7 +280,6 @@ stages:
           artifactName: test_artifacts_$(System.JobName)
           artifactPath: $(Build.ArtifactStagingDirectory)
 
-
 - stage: Regenerate
   dependsOn:
   - Build
@@ -294,7 +293,10 @@ stages:
     sdkRepositoryCommitSha: $[stageDependencies.Build.Build.outputs['repositories.sdk-repository.version']]
     buildArtifactsPath: $(Pipeline.Workspace)/build_artifacts
     publishArtifactsPath: $(Pipeline.Workspace)/publish_artifacts
-    branchName: auto-update-autorest-alpha-$(Build.BuildNumber)
+    ${{ if eq(variables['Build.Reason'], 'Schedule') }}:
+      branchName: auto-update-autorest-alpha-scheduled
+    ${{ else }}:
+      branchName: auto-update-autorest-alpha-$(Build.BuildNumber)
   jobs:
   - job: Initialize
     steps:
@@ -339,6 +341,8 @@ stages:
         CommitMsg: Initialize repository for autorest build $(Build.BuildNumber)
         WorkingDirectory: $(sdkRepositoryPath)
         ScriptDirectory: $(toolsRepositoryPath)/eng/common/scripts
+        # To accomodate scheduled runs and retries, we want to overwrite and existing changes on the branch
+        PushArgs: --force
 
     - task: PowerShell@2
       displayName: Get generation job matrix
@@ -421,6 +425,7 @@ stages:
         $sourceBranch = '$(Build.SourceBranch)'
         $buildNumber = '$(Build.SourceBranch)'
         $queuedBy = '$(Build.SourceBranch)'
+        $reason = '$(Build.Reason)'
         $preRelease = '${{ parameters.BuildPrereleaseVersion }}' -eq 'true'
 
         $source = "[$sourceBranch]($repoUrl/tree/$sourceBranch)" 
@@ -434,9 +439,13 @@ stages:
 
         $prBody = "Triggered from $source"
 
-        $prTitle = $preRelease `
-          ? "Update autorest version to prerelease $generatorVersion" `
-          : "Update autorest version to $generatorVersion"
+        $prTitle =  if ($reason -eq 'Schedule') {
+          "Scheduled autorest prerelease test"
+        } elseif ($preRelease) {
+          "Update autorest version to prerelease $generatorVersion" `
+        } else {
+          "Update autorest version to $generatorVersion"
+        }
 
         if ($generateJobResult -ne 'Succeeded') {
           $prTitle = "Failed: $prTitle"


### PR DESCRIPTION
To prevent nightly autorest/typespec preview pipelines from creating a new draft PRs on every run, we want to reuse the branch and PR.

For this to work, we need to use a static PR title and force push when initializing the source branch to remove any changes from a previous scheduled run.