### PR TITLE
Stress tests: Fix image tag for multiimage deployments

### DIFF
--- a/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
+++ b/eng/common/scripts/stress-testing/stress-test-deployment-lib.ps1
@@ -257,7 +257,7 @@ function DeployStressPackage(
     if ($pkg.Dockerfile -or $pkg.DockerBuildDir) {
         throw "The chart.yaml docker config is deprecated, please use the scenarios matrix instead."
     }
-    
+
 
     foreach ($dockerBuildConfig in $dockerBuildConfigs) {
         $dockerFilePath = $dockerBuildConfig.dockerFilePath
@@ -285,7 +285,7 @@ function DeployStressPackage(
             $dockerBuildCmd += $dockerBuildFolder
 
             Run @dockerBuildCmd
-            
+
             Write-Host "`nContainer image '$imageTag' successfully built. To run commands on the container locally:" -ForegroundColor Blue
             Write-Host "  docker run -it $imageTag" -ForegroundColor DarkBlue
             Write-Host "  docker run -it $imageTag <shell, e.g. 'bash' 'pwsh' 'sh'>" -ForegroundColor DarkBlue
@@ -302,7 +302,7 @@ function DeployStressPackage(
             }
         }
         $generatedHelmValues.scenarios = @( foreach ($scenario in $generatedHelmValues.scenarios) {
-            $dockerPath = if ("image" -notin $scenario) {
+            $dockerPath = if ("image" -notin $scenario.keys) {
                 $dockerFilePath
             } else {
                 Join-Path $pkg.Directory $scenario.image
@@ -476,7 +476,7 @@ function generateRetryTestsHelmValues ($pkg, $releaseName, $generatedHelmValues)
             $failedJobsScenario += $job.split("-$($pkg.ReleaseName)")[0]
         }
     }
-    
+
     $releaseName = "$($pkg.ReleaseName)-$revision-retry"
 
     $retryTestsHelmVal = @{"scenarios"=@()}


### PR DESCRIPTION
When multiple docker files are used, one `imageTag` value was incorrectly applied to all images

Before:

```yaml
scenarios:
- testScenario: httpget
  image: dockerfiles/java11
  imageBuildDir: ..\..\..\
  .....
- testScenario: httpget
  image: dockerfiles/java21
  imageBuildDir: ..\..\..\
```

resulted in followoing generated values
```yaml
scenarios:
- testScenario: httpget
  image: dockerfiles/java11
  imageBuildDir: ..\..\..\
  Scenario: default11get
  imageTag: stresspgs7b6dif73rup6.azurecr.io/limolkova/java-template2/java21:limolkova
- testScenario: httpget
  image: dockerfiles/java21
  imageBuildDir: ..\..\..\
  Scenario: default21get
  imageTag: stresspgs7b6dif73rup6.azurecr.io/limolkova/java-template2/java21:limolkova
```

Now proper `imageTag` is generated
