### PR TITLE
[JS] Fix perf pipelines - "fix build cache error"

### DIFF
--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -27,6 +27,11 @@ namespace Azure.Sdk.Tools.PerfAutomation
             var outputBuilder = new StringBuilder();
             var errorBuilder = new StringBuilder();
 
+            // Prerequisite: delete build cache file to avoid the following error
+            //   "Error: Build cache is only supported if running in a Git repository. Either disable the build cache or run Rush in a Git repository."
+            var buildCacheFile = Path.Combine(WorkingDirectory, "common", "config", "rush", "build-cache.json");
+            File.Delete(buildCacheFile);
+
             var commonVersionsFile = Path.Combine(WorkingDirectory, "common", "config", "rush", "common-versions.json");
             var commonVersionsJson = JObject.Parse(File.ReadAllText(commonVersionsFile));
 

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/JavaScript.cs
@@ -27,7 +27,10 @@ namespace Azure.Sdk.Tools.PerfAutomation
             var outputBuilder = new StringBuilder();
             var errorBuilder = new StringBuilder();
 
-            // Prerequisite: delete build cache file to avoid the following error
+            // JS repo introduced build caching
+            // Build caching has to be disabled to appropriately do "rush build" following a "sparse checkout"
+            // Deleting "build-cache.json" would disable build caching
+            // ...avoids the following error
             //   "Error: Build cache is only supported if running in a Git repository. Either disable the build cache or run Rush in a Git repository."
             var buildCacheFile = Path.Combine(WorkingDirectory, "common", "config", "rush", "build-cache.json");
             File.Delete(buildCacheFile);


### PR DESCRIPTION
## Issue
In the recent updates to the JS repository, "build caching for @microsoft/rush" step has been introduced, to expedite the build process, thereby enhancing build efficiency.
However, an unforeseen complication has arisen due to this update. The “build caching” mechanism appears to be incompatible with the sparse checkout procedure that is currently employed in our automation workflow for the perf pipelines.

## Solution
To mitigate this issue, in this PR, adding a snippet to delete the "build cache" file in the JS repo prior to initiating the build process. This effectively disables the build caching feature, thereby allowing the sparse checkout to operate in conjunction with the “rush build” process without any conflicts. This restores the system/pipelines to previous behavior.

**This change is required to rectify all existing JS perf pipelines**