### PR TITLE
Add script which generates a changeset for pipelinev3

### DIFF
--- a/eng/common/scripts/Generate-PR-Diff.ps1
+++ b/eng/common/scripts/Generate-PR-Diff.ps1
@@ -1,0 +1,51 @@
+<#
+.SYNOPSIS
+Script used to generate the diff.json file for a PR. Explicitly intended to work in a PR context.
+
+.DESCRIPTION
+Combines the result of git diff, some parsed details from the diff, and the PR number into a single JSON file. This JSON file is intended for use further along the pipeline.
+
+.PARAMETER ArtifactPath
+The folder in which the result will be written.
+
+.PARAMETER TargetPath
+The path under which changes will be detected.
+#>
+[CmdletBinding()]
+Param (
+  [Parameter(Mandatory=$True)]
+  [string] $ArtifactPath,
+  [Parameter(Mandatory=$True)]
+  [string] $TargetPath
+)
+
+. (Join-Path $PSScriptRoot "Helpers" git-helpers.ps1)
+
+function Get-ChangedServices {
+    Param (
+        [Parameter(Mandatory=$True)]
+        [string[]] $ChangedFiles
+    )
+    
+    $changedServices = $ChangedFiles | Foreach-Object { if ($_ -match "sdk/([a-zA-Z\-]+)") { $matches[1] } } | Sort-Object -Unique
+
+    return $changedServices
+}
+
+if (!(Test-Path $ArtifactPath)) {
+    New-Item -ItemType Directory -Path $ArtifactPath | Out-Null
+}
+
+$ArtifactPath = Resolve-Path $ArtifactPath
+$ArtifactName = Join-Path $ArtifactPath "diff.json"
+
+$changedFiles = Get-ChangedFiles -DiffPath $TargetPath
+$changedServices = Get-ChangedServices -ChangedFiles $changedFiles
+
+$result = [PSCustomObject]@{
+    "ChangedFiles" = $changedFiles
+    "ChangedServices" = $changedServices
+    "PRNumber" = $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
+}
+
+$result | ConvertTo-Json | Out-File $ArtifactName

--- a/eng/common/scripts/Generate-PR-Diff.ps1
+++ b/eng/common/scripts/Generate-PR-Diff.ps1
@@ -27,7 +27,7 @@ function Get-ChangedServices {
         [string[]] $ChangedFiles
     )
     
-    $changedServices = $ChangedFiles | Foreach-Object { if ($_ -match "sdk/([a-zA-Z\-]+)") { $matches[1] } } | Sort-Object -Unique
+    $changedServices = $ChangedFiles | Foreach-Object { if ($_ -match "sdk/([^/]+)") { $matches[1] } } | Sort-Object -Unique
 
     return $changedServices
 }


### PR DESCRIPTION
Using `git-helpers` `Get-ChangedFiles`

Resolves #7504 

This will be used as the first step of a common build pipeline which we will add to all our repos.

![image](https://github.com/Azure/azure-sdk-tools/assets/45376673/f942f9bd-4ecf-46cb-8a29-70529bb0519d)
