### PR TITLE
apiviewgo skips nested modules

### DIFF
--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -54,6 +54,21 @@ func TestInterface(t *testing.T) {
 	}
 }
 
+func TestMultiModule(t *testing.T) {
+	for _, path := range []string{
+		"testdata/test_multi_module",
+		"testdata/test_multi_module/A",
+		"testdata/test_multi_module/A/B",
+	} {
+		t.Run(path, func(t *testing.T) {
+			p, err := createReview(filepath.Clean(path))
+			require.NoError(t, err)
+			require.Equal(t, 1, len(p.Navigation), "review should include only one package")
+			require.Equal(t, filepath.Base(path), p.Navigation[0].Text, "review includes the wrong module")
+		})
+	}
+}
+
 func TestStruct(t *testing.T) {
 	p, err := createReview(filepath.Clean("testdata/test_struct"))
 	if err != nil {

--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -4,7 +4,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -18,16 +17,7 @@ func TestMain(m *testing.M) {
 }
 
 func TestFuncDecl(t *testing.T) {
-	err := CreateAPIView(filepath.Clean("testdata/test_func_decl"), "output")
-	if err != nil {
-		t.Fatal(err)
-	}
-	file, err := os.ReadFile("./output/test_func_decl.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	p := PackageReview{}
-	err = json.Unmarshal(file, &p)
+	p, err := createReview(filepath.Clean("testdata/test_func_decl"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,16 +36,7 @@ func TestFuncDecl(t *testing.T) {
 }
 
 func TestInterface(t *testing.T) {
-	err := CreateAPIView(filepath.Clean("testdata/test_interface"), "output")
-	if err != nil {
-		t.Fatal(err)
-	}
-	file, err := os.ReadFile("./output/test_interface.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	p := PackageReview{}
-	err = json.Unmarshal(file, &p)
+	p, err := createReview(filepath.Clean("testdata/test_interface"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,16 +55,7 @@ func TestInterface(t *testing.T) {
 }
 
 func TestStruct(t *testing.T) {
-	err := CreateAPIView(filepath.Clean("testdata/test_struct"), "output")
-	if err != nil {
-		t.Fatal(err)
-	}
-	file, err := os.ReadFile("./output/test_struct.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	p := PackageReview{}
-	err = json.Unmarshal(file, &p)
+	p, err := createReview(filepath.Clean("testdata/test_struct"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,16 +74,7 @@ func TestStruct(t *testing.T) {
 }
 
 func TestConst(t *testing.T) {
-	err := CreateAPIView(filepath.Clean("testdata/test_const"), "output")
-	if err != nil {
-		t.Fatal(err)
-	}
-	file, err := os.ReadFile("./output/test_const.json")
-	if err != nil {
-		t.Fatal(err)
-	}
-	p := PackageReview{}
-	err = json.Unmarshal(file, &p)
+	p, err := createReview(filepath.Clean("testdata/test_const"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -85,6 +85,14 @@ func NewModule(dir string) (*Module, error) {
 			if !indexTestdata && strings.Contains(path, "testdata") {
 				return filepath.SkipDir
 			}
+			if path != dir {
+				// This is a subdirectory of the module we're indexing. If it contains
+				// a go.mod, this subdirectory contains a separate module, not a package
+				// of the module we're indexing.
+				if _, err := os.Stat(filepath.Join(path, "go.mod")); err == nil {
+					return filepath.SkipDir
+				}
+			}
 			p, err := NewPkg(path, mf.Module.Mod.Path)
 			if err == nil {
 				m.packages[baseImportPath+p.Name()] = p

--- a/src/go/cmd/testdata/test_multi_module/A/B/go.mod
+++ b/src/go/cmd/testdata/test_multi_module/A/B/go.mod
@@ -1,0 +1,3 @@
+module test_multi_module/B
+
+go 1.13

--- a/src/go/cmd/testdata/test_multi_module/A/B/test.go
+++ b/src/go/cmd/testdata/test_multi_module/A/B/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package B
+
+type BStruct struct {}

--- a/src/go/cmd/testdata/test_multi_module/A/go.mod
+++ b/src/go/cmd/testdata/test_multi_module/A/go.mod
@@ -1,0 +1,3 @@
+module test_multi_module/A
+
+go 1.13

--- a/src/go/cmd/testdata/test_multi_module/A/test.go
+++ b/src/go/cmd/testdata/test_multi_module/A/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package A
+
+type AStruct struct {}

--- a/src/go/cmd/testdata/test_multi_module/go.mod
+++ b/src/go/cmd/testdata/test_multi_module/go.mod
@@ -1,0 +1,3 @@
+module test_multi_module
+
+go 1.13

--- a/src/go/cmd/testdata/test_multi_module/test.go
+++ b/src/go/cmd/testdata/test_multi_module/test.go
@@ -1,0 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package testmultimodule
+
+type Struct struct {}


### PR DESCRIPTION
A directory containing a go.mod is a module, even when below another directory containing a go.mod. For example:
```
Foo
├── Bar
│   └── go.mod
└── go.mod
```
Foo and Bar are separate modules--nothing in Bar is accessible through Foo--so when indexing Foo, apiviewgo mustn't include anything from Bar. This PR ensures it doesn't by having apiviewgo skip any subdirectory of the module it's indexing that contains a go.mod. Fixes #7520