### PR TITLE
Correct the variable name in spec location validation script

### DIFF
--- a/eng/common/scripts/Verify-RestApiSpecLocation.ps1
+++ b/eng/common/scripts/Verify-RestApiSpecLocation.ps1
@@ -210,7 +210,7 @@ function Verify-PackageVersion() {
 
         # Ignore the validation if the package is not GA version
         if ($version.IsPrerelease) {
-          Write-Host "ServiceDir:$ServiceDirectory, Package $($parsedPackage.PackageId) is marked with version $($parsedPackage.PackageVersion), the version is a prerelease version and the validation of spec location is ignored."
+          Write-Host "ServiceDir:$ServiceDirectory, Package $PackageName is marked with version $version, the version is a prerelease version and the validation of spec location is ignored."
           exit 0
         }
         $continueValidation = $true


### PR DESCRIPTION
Fixed the variable name in an output message.