### PR TITLE
[CODEOWNERS] Remove automation section

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,10 +15,6 @@
 # Git Hub integration
 /.github/CODEOWNERS                    @azure/azure-sdk-eng
 
-# Repository tooling
-/tools/github                          @jsquire @ronniegeraghty
-/tools/github-issues                   @jsquire @ronniegeraghty
-
 ###########
 # Eng Sys
 ###########


### PR DESCRIPTION
The focus of these changes is to remove the automation section, as CODEOWNERS changes no longer require manual syncing.