### PR TITLE
Always pull chaos images

### DIFF
--- a/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/values.yaml
+++ b/tools/stress-cluster/cluster/kubernetes/stress-infrastructure/values.yaml
@@ -5,6 +5,10 @@ chaos-mesh:
     registry: azsdkengsys.azurecr.io/mirror
   dashboard:
     securityMode: false
+    imagePullPolicy: Always
   chaosDaemon:
     runtime: containerd
     socketPath: /run/containerd/containerd.sock
+    imagePullPolicy: Always
+  controllerManager:
+    imagePullPolicy: Always


### PR DESCRIPTION
This makes it easier to bounce the containers and pull in newly published images with up to date packages.