### PR TITLE
Filter packages at verify step

### DIFF
--- a/eng/common/scripts/create-tags-and-git-release.ps1
+++ b/eng/common/scripts/create-tags-and-git-release.ps1
@@ -25,12 +25,7 @@ $apiUrl = "https://api.github.com/repos/$repoId"
 Write-Host "Using API URL $apiUrl"
 
 # VERIFY PACKAGES
-$pkgList = VerifyPackages -artifactLocation $artifactLocation -workingDirectory $workingDirectory -apiUrl $apiUrl -releaseSha $releaseSha -continueOnError $continueOnError
-
-if ($packageFilter) {
-    Write-Host "Filtering discovered packages to '$packageFilter'"
-    [array]$pkgList = $pkgList | Where-Object { $_.PackageId -like $packageFilter }
-}
+$pkgList = VerifyPackages -artifactLocation $artifactLocation -workingDirectory $workingDirectory -apiUrl $apiUrl -releaseSha $releaseSha -packageFilter $packageFilter -continueOnError $continueOnError
 
 if ($pkgList) {
   Write-Host "Given the visible artifacts, github releases will be created for the following:"


### PR DESCRIPTION
VerifyPackages will also fail out in various scenarios, so moving the package filter into this function that generates the package list, instead of at the CreateRelease scope

