### PR TITLE
Feature/app insights monitoring

### DIFF
--- a/src/dotnet/APIView/APIViewIntegrationTests/APIViewIntegrationTests.csproj
+++ b/src/dotnet/APIView/APIViewIntegrationTests/APIViewIntegrationTests.csproj
@@ -12,19 +12,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.26.1" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="6.0.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/APIView/APIViewIntegrationTests/TestsBaseFixture.cs
+++ b/src/dotnet/APIView/APIViewIntegrationTests/TestsBaseFixture.cs
@@ -21,6 +21,7 @@ using Microsoft.AspNetCore.SignalR;
 using APIViewWeb.Managers.Interfaces;
 using Microsoft.CodeAnalysis.Host;
 using Microsoft.Extensions.Options;
+using Microsoft.ApplicationInsights;
 
 namespace APIViewIntegrationTests
 {
@@ -94,7 +95,9 @@ namespace APIViewIntegrationTests
             authorizationServiceMoq.Setup(_ => _.AuthorizeAsync(It.IsAny<ClaimsPrincipal>(), It.IsAny<Object>(), It.IsAny<IEnumerable<IAuthorizationRequirement>>()))
                 .ReturnsAsync(AuthorizationResult.Success);
 
-            var notificationManager = new NotificationManager(config, ReviewRepository, cosmosUserProfileRepository);
+            var telemetryClient = new Mock<TelemetryClient>();
+
+            var notificationManager = new NotificationManager(config, ReviewRepository, cosmosUserProfileRepository, telemetryClient.Object);
 
             var devopsArtifactRepositoryMoq = new Mock<IDevopsArtifactRepository>();
             devopsArtifactRepositoryMoq.Setup(_ => _.DownloadPackageArtifact(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>()))
@@ -118,13 +121,15 @@ namespace APIViewIntegrationTests
                 authorizationService: authorizationServiceMoq.Object, reviewsRepository: ReviewRepository,
                 languageServices: languageService, devopsArtifactRepository: devopsArtifactRepositoryMoq.Object,
                 codeFileManager: CodeFileManager, codeFileRepository: BlobCodeFileRepository, apiRevisionsRepository: APIRevisionRepository,
-                originalsRepository: blobOriginalsRepository, notificationManager: notificationManager, signalRHubContext: signalRHubContextMoq.Object);
+                originalsRepository: blobOriginalsRepository, notificationManager: notificationManager, signalRHubContext: signalRHubContextMoq.Object,
+                telemetryClient: telemetryClient.Object);
 
 
             ReviewManager = new ReviewManager(
                 authorizationService: authorizationServiceMoq.Object, reviewsRepository: ReviewRepository,
                 apiRevisionsManager: APIRevisionManager, commentManager: CommentsManager, codeFileRepository: BlobCodeFileRepository,
-                commentsRepository: CommentRepository, languageServices: languageService, signalRHubContext: signalRHubContextMoq.Object);
+                commentsRepository: CommentRepository, languageServices: languageService, signalRHubContext: signalRHubContextMoq.Object,
+                telemetryClient: telemetryClient.Object);
 
             TestDataPath = config["TestPkgPath"];
         }

--- a/src/dotnet/APIView/APIViewUITests/APIViewUITests.csproj
+++ b/src/dotnet/APIView/APIViewUITests/APIViewUITests.csproj
@@ -10,19 +10,25 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.14.1" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.31.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="7.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0-release-23619-01" />
     <PackageReference Include="Selenium.Support" Version="4.10.0" />
     <PackageReference Include="Selenium.WebDriver" Version="4.10.0" />
     <PackageReference Include="Selenium.WebDriver.ChromeDriver" Version="118.0.5993.7000" />
     <PackageReference Include="SeleniumExtras.WaitHelpers" Version="1.0.2" />
-    <PackageReference Include="xunit" Version="2.4.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
-    <PackageReference Include="coverlet.collector" Version="1.2.0" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
 </Project>

--- a/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/APIRevisionsManagerTests.cs
@@ -2,17 +2,16 @@ using APIViewWeb;
 using Xunit;
 using APIViewWeb.Repositories;
 using Moq;
-using System.IO;
 using APIViewWeb.Managers.Interfaces;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using APIViewWeb.Hubs;
-using System.Collections;
 using System.Collections.Generic;
 using APIViewWeb.Managers;
 using System;
 using System.Threading.Tasks;
 using APIViewWeb.LeanModels;
+using Microsoft.ApplicationInsights;
 
 namespace APIViewUnitTests
 {
@@ -32,13 +31,14 @@ namespace APIViewUnitTests
             IBlobCodeFileRepository blobCodeFileRepository = new Mock<IBlobCodeFileRepository>().Object;
             IBlobOriginalsRepository blobOriginalRepository = new Mock<IBlobOriginalsRepository>().Object;
             INotificationManager notificationManager = new Mock<INotificationManager>().Object;
+            TelemetryClient telemetryClient = new Mock<TelemetryClient>().Object;
             
             _apiRevisionsManager = new APIRevisionsManager(
                 authorizationService: authorizationService, reviewsRepository: cosmosReviewRepository,
                 apiRevisionsRepository: cosmosAPIRevisionsRepository, signalRHubContext: signalRHub,
                 languageServices: languageServices, devopsArtifactRepository: devopsArtifactRepository,
                 codeFileManager: codeFileManager, codeFileRepository: blobCodeFileRepository,
-                originalsRepository: blobOriginalRepository, notificationManager: notificationManager);    
+                originalsRepository: blobOriginalRepository, notificationManager: notificationManager, telemetryClient: telemetryClient);    
         }
 
         // GetLatestAPIRevisionsAsync

--- a/src/dotnet/APIView/APIViewUnitTests/APIViewUnitTests.csproj
+++ b/src/dotnet/APIView/APIViewUnitTests/APIViewUnitTests.csproj
@@ -18,14 +18,14 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.26.1" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />
-    <PackageReference Include="Moq" Version="4.18.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" PrivateAssets="All" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="xunit" Version="2.6.6" />
+    <PackageReference Include="coverlet.collector" Version="6.0.0" PrivateAssets="All" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.6">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/dotnet/APIView/APIViewUnitTests/LanguageServiceTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/LanguageServiceTests.cs
@@ -3,6 +3,8 @@ using APIViewWeb.Helpers;
 using Microsoft.Extensions.Configuration;
 using Xunit;
 using FluentAssertions;
+using Moq;
+using Microsoft.ApplicationInsights;
 
 namespace APIViewUnitTests
 {
@@ -11,7 +13,8 @@ namespace APIViewUnitTests
         [Fact]
         public void TypeSpectLanguageService_Supports_Multiple_Extensions()
         {
-            var languageService = new TypeSpecLanguageService(new ConfigurationBuilder().Build());
+            var telemetryClient = new Mock<TelemetryClient>().Object;
+            var languageService = new TypeSpecLanguageService(new ConfigurationBuilder().Build(), telemetryClient);
             Assert.True(languageService.IsSupportedFile("specification/cognitiveservices/HealthInsights/healthinsights.common/primitives.cadl"));
             Assert.True(languageService.IsSupportedFile("specification/cognitiveservices/HealthInsights/healthinsights.common/primitives.tsp"));
             Assert.False(languageService.IsSupportedFile("specification/cognitiveservices/HealthInsights/healthinsights.common/primitives.json"));

--- a/src/dotnet/APIView/APIViewUnitTests/ProgramTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/ProgramTests.cs
@@ -32,7 +32,7 @@ namespace APIViewUnitTests
         [InlineData(0)]
         [InlineData(1)]
         [InlineData(3)]
-        public void RunAsyncThrowsWithIncorrectNumberOfArgs(int length)
+        public async Task RunAsyncThrowsWithIncorrectNumberOfArgs(int length)
         {
             var args = new string[length];
 
@@ -41,11 +41,11 @@ namespace APIViewUnitTests
                 args[i] = InputPath;
             }
 
-            Assert.ThrowsAsync<ArgumentException>(async () => await Program.RunAsync(args));
+            await Assert.ThrowsAsync<ArgumentException>(async () => await Program.RunAsync(args));
         }
 
         [Fact]
-        public void RunAsyncThrowsWithMissingInputFile()
+        public async Task RunAsyncThrowsWithMissingInputFile()
         {
             var args = new string[]
             {
@@ -53,11 +53,11 @@ namespace APIViewUnitTests
                 OutputPath
             };
 
-            Assert.ThrowsAsync<FileNotFoundException>(async () => await Program.RunAsync(args));
+            await Assert.ThrowsAsync<FileNotFoundException>(async () => await Program.RunAsync(args));
         }
 
         [Fact]
-        public void RunAsyncThrowsWithMissingOutputFolder()
+        public async Task RunAsyncThrowsWithMissingOutputFolder()
         {
             var args = new string[]
             {
@@ -65,7 +65,7 @@ namespace APIViewUnitTests
                 Path.Combine("missing_folder", "output.json")
             };
 
-            Assert.ThrowsAsync<FolderNotFoundException>(async () => await Program.RunAsync(args));
+            await Assert.ThrowsAsync<FolderNotFoundException>(async () => await Program.RunAsync(args));
         }
 
         [Theory]

--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -41,6 +41,7 @@
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.5" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.15" />

--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -23,15 +23,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="11.0.0" />
+    <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.1" />
     <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.6" />
-    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.2.0" />
-    <PackageReference Include="Azure.Identity" Version="1.10.2" />
+    <PackageReference Include="Azure.Data.AppConfiguration" Version="1.3.0" />
+    <PackageReference Include="Azure.Identity" Version="1.10.4" />
     <PackageReference Include="Azure.Search.Documents" Version="11.5.0-beta.4" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
-    <PackageReference Include="CsvHelper" Version="27.2.1" />
+    <PackageReference Include="CsvHelper" Version="30.0.1" />
     <!-- Adding NU1701 suppression as these three libraries have not updated to more modern versions of .net, although in testing they work as required. -->
-    <PackageReference Include="Markdig" Version="0.30.3">
+    <PackageReference Include="Markdig" Version="0.34.0">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Markdig.SyntaxHighlighting" Version="1.1.7">
@@ -40,20 +40,21 @@
     <PackageReference Include="ColorCode.Portable" Version="1.0.3">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="5.2.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.26.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.0" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
-    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="4.7.2">
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+    <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.15" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.205.1" />
+    <PackageReference Include="Microsoft.TypeScript.MSBuild" Version="5.3.3">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.170.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.1.9" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.205.1" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.11" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19367-01" PrivateAssets="All" />
-    <PackageReference Include="MongoDB.Driver" Version="2.20.0" />
-    <PackageReference Include="Octokit" Version="3.0.0" />
+    <PackageReference Include="MongoDB.Driver" Version="2.23.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Octokit" Version="9.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 

--- a/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
@@ -1,13 +1,10 @@
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
-using Amazon.Util;
 using ApiView;
 using APIViewWeb.Filters;
-using APIViewWeb.Helpers;
 using APIViewWeb.LeanModels;
 using APIViewWeb.Managers;
 using APIViewWeb.Managers.Interfaces;
@@ -15,10 +12,6 @@ using APIViewWeb.Models;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.Extensions.Logging;
-using Microsoft.TeamFoundation.SourceControl.WebApi;
-using Microsoft.VisualStudio.Services.Account;
-using Octokit;
 
 namespace APIViewWeb.Controllers
 {

--- a/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
@@ -30,18 +30,15 @@ namespace APIViewWeb.Controllers
         private readonly IReviewManager _reviewManager;
         private readonly IAPIRevisionsManager _apiRevisionsManager;
         private readonly ICommentsManager _commentsManager;
-        private readonly ILogger<AutoReviewController> _logger;
 
         public AutoReviewController(IAuthorizationService authorizationService, ICodeFileManager codeFileManager,
-            IReviewManager reviewManager, IAPIRevisionsManager apiRevisionManager, ICommentsManager commentsManager,
-            ILogger<AutoReviewController> logger)
+            IReviewManager reviewManager, IAPIRevisionsManager apiRevisionManager, ICommentsManager commentsManager)
         {
             _authorizationService = authorizationService;
             _codeFileManager = codeFileManager;
             _apiRevisionsManager = apiRevisionManager;
             _commentsManager = commentsManager;
             _reviewManager = reviewManager;
-            _logger = logger;
         }
 
         [HttpPost]

--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -14,13 +14,8 @@ using Microsoft.Extensions.Configuration;
 using System.IO;
 using APIViewWeb.Managers.Interfaces;
 using ApiView;
-using System;
 using APIViewWeb.Models;
 using APIViewWeb.LeanModels;
-using Microsoft.VisualStudio.Services.DelegatedAuthorization;
-using Octokit;
-using static Microsoft.VisualStudio.Services.Graph.Constants;
-using Microsoft.AspNetCore.Mvc.ViewEngines;
 
 namespace APIViewWeb.Controllers
 {
@@ -28,29 +23,26 @@ namespace APIViewWeb.Controllers
     {
         private readonly ICodeFileManager _codeFileManager;
         private readonly IPullRequestManager _pullRequestManager;
-        private readonly IBlobCodeFileRepository _codeFileRepository;
         private readonly IReviewManager _reviewManager;
         private readonly IAPIRevisionsManager _apiRevisionsManager;
-        private readonly ILogger<PullRequestController> _logger;
         private readonly IConfiguration _configuration;
         private readonly IOpenSourceRequestManager _openSourceManager;
-        private readonly TelemetryClient _telemetryClient = new TelemetryClient(TelemetryConfiguration.CreateDefault());
+        private readonly TelemetryClient _telemetryClient;
         private HashSet<string> _allowedListBotAccounts = new HashSet<string>();
 
         string[] VALID_EXTENSIONS = new string[] { ".whl", ".api.json", ".nupkg", "-sources.jar", ".gosource" };
         
         public PullRequestController(ICodeFileManager codeFileManager, IPullRequestManager pullRequestManager,
-            IBlobCodeFileRepository codeFileRepository, IAPIRevisionsManager apiRevisionsManager, IReviewManager reviewManager, ILogger<PullRequestController> logger,
-            IConfiguration configuration, IOpenSourceRequestManager openSourceRequestManager)
+            IAPIRevisionsManager apiRevisionsManager, IReviewManager reviewManager,
+            IConfiguration configuration, IOpenSourceRequestManager openSourceRequestManager, TelemetryClient telemetryClient)
         {
             _codeFileManager = codeFileManager;
             _pullRequestManager = pullRequestManager;
-            _codeFileRepository = codeFileRepository;
             _reviewManager = reviewManager;
             _apiRevisionsManager = apiRevisionsManager;
-            _logger = logger;
             _configuration = configuration;
             _openSourceManager = openSourceRequestManager;
+            _telemetryClient = telemetryClient;
 
             var botAllowedList = _configuration["allowedList-bot-github-accounts"];
             if (!string.IsNullOrEmpty(botAllowedList))

--- a/src/dotnet/APIView/APIViewWeb/Controllers/ReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/ReviewController.cs
@@ -6,12 +6,11 @@ using APIViewWeb.LeanModels;
 using APIViewWeb.Managers;
 using APIViewWeb.Managers.Interfaces;
 using APIViewWeb.Models;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Logging;
 using System;
-using System.Linq;
-using System.Security.Claims;
 using System.Threading.Tasks;
 
 namespace APIViewWeb.Controllers
@@ -21,17 +20,16 @@ namespace APIViewWeb.Controllers
         private readonly IReviewManager _reviewManager;
         private readonly IAPIRevisionsManager _apiRevisionManager;
         private readonly IHubContext<SignalRHub> _signalRHubContext;
-
-        private readonly ILogger _logger;
+        private readonly TelemetryClient _telemetryClient;
 
         public ReviewController(IReviewManager reviewManager,
             IAPIRevisionsManager apiRevisionManager, IHubContext<SignalRHub> signalRHubContext,
-            ILogger<ReviewController> logger)
+            TelemetryClient telemetryClient)
         {
             _reviewManager = reviewManager;
             _apiRevisionManager = apiRevisionManager;
             _signalRHubContext = signalRHubContext;
-            _logger = logger;
+            _telemetryClient = telemetryClient;
         }
 
         [HttpGet]
@@ -65,7 +63,7 @@ namespace APIViewWeb.Controllers
             }
             catch (Exception ex)
             {
-                _logger.LogError(ex, "Error generating AI review");
+                _telemetryClient.TrackTrace("Error generating AI review" + ex.Message, SeverityLevel.Error);
                 await SendAIReviewGenerationStatus(review, reviewId, revisionId, AIReviewGenerationStatus.Error, isLatestAPIRevision, errorMessage: ex.Message);
             }
         }

--- a/src/dotnet/APIView/APIViewWeb/HostedServices/LinesWithDiffBackgroundHostedService.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/LinesWithDiffBackgroundHostedService.cs
@@ -19,13 +19,15 @@ namespace APIViewWeb.HostedServices
         private readonly bool _isDisabled;
         private readonly IReviewManager _reviewManager;
         private readonly IAPIRevisionsManager _apiRevisionManager;
+        private readonly TelemetryClient _telemetryClient;
 
-        static TelemetryClient _telemetryClient = new(TelemetryConfiguration.CreateDefault());
-
-        public LinesWithDiffBackgroundHostedService(IReviewManager reviewManager, IAPIRevisionsManager apiRevisionManager, IConfiguration configuration)
+        public LinesWithDiffBackgroundHostedService(IReviewManager reviewManager, 
+            IAPIRevisionsManager apiRevisionManager, IConfiguration configuration,
+            TelemetryClient telemetryClient)
         {
             _reviewManager = reviewManager;
             _apiRevisionManager = apiRevisionManager;
+            _telemetryClient = telemetryClient;
 
             if (bool.TryParse(configuration["LinesWithDiffBackgroundTaskDisabled"], out bool taskDisabled))
             {

--- a/src/dotnet/APIView/APIViewWeb/HostedServices/PullRequestBackgroundHostedService.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/PullRequestBackgroundHostedService.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using APIViewWeb.Managers;
 using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -15,12 +14,14 @@ namespace APIViewWeb.HostedServices
     {
         private bool _isDisabled = false;
         private IPullRequestManager _pullRequestManager;
+        private readonly TelemetryClient _telemetryClient;
 
-        static TelemetryClient _telemetryClient = new(TelemetryConfiguration.CreateDefault());
-
-        public PullRequestBackgroundHostedService(IPullRequestManager pullRequestManager, IConfiguration configuration)
+        public PullRequestBackgroundHostedService(IPullRequestManager pullRequestManager,
+            IConfiguration configuration, TelemetryClient telemetryClient)
         {
             _pullRequestManager = pullRequestManager;
+            _telemetryClient = telemetryClient;
+
             // We can disable background task using app settings if required
             var taskDisabled = configuration["PullRequestCleanupTaskDisabled"];
             if (!String.IsNullOrEmpty(taskDisabled) && taskDisabled == "true")

--- a/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using APIViewWeb.Managers;
 using APIViewWeb.Managers.Interfaces;
 using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Hosting;
 
@@ -21,13 +20,15 @@ namespace APIViewWeb.HostedServices
         private readonly int _autoArchiveInactiveGracePeriodMonths; // This is inactive duration in months
         private readonly HashSet<string> _upgradeDisabledLangs = new HashSet<string>();
         private readonly int _backgroundBatchProcessCount;
+        private readonly TelemetryClient _telemetryClient;
 
-        static TelemetryClient _telemetryClient = new(TelemetryConfiguration.CreateDefault());
-
-        public ReviewBackgroundHostedService(IReviewManager reviewManager, IAPIRevisionsManager apiRevisionManager, IConfiguration configuration)
+        public ReviewBackgroundHostedService(
+            IReviewManager reviewManager, IAPIRevisionsManager apiRevisionManager,
+            IConfiguration configuration, TelemetryClient telemetryClient)
         {
             _reviewManager = reviewManager;
             _apiRevisionManager = apiRevisionManager;
+            _telemetryClient = telemetryClient;
 
             // We can disable background task using app settings if required
             if (bool.TryParse(configuration["BackgroundTaskDisabled"], out bool taskDisabled))

--- a/src/dotnet/APIView/APIViewWeb/Hubs/SignalRHub.cs
+++ b/src/dotnet/APIView/APIViewWeb/Hubs/SignalRHub.cs
@@ -8,11 +8,6 @@ namespace APIViewWeb.Hubs
     [Authorize]
     public class SignalRHub : Hub
     {
-        private readonly ILogger<SignalRHub> _logger;
-        public SignalRHub(ILogger<SignalRHub> logger) {
-            _logger = logger;
-        }
-
         public override Task OnConnectedAsync()
         {
             string name = Context.User.GetGitHubLogin();

--- a/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
@@ -1,11 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
 using System.Diagnostics;
 using System.IO;
-using System.Text.Json;
 using System.Threading.Tasks;
 using ApiView;
-using APIViewWeb.Models;
 
 namespace APIViewWeb
 {

--- a/src/dotnet/APIView/APIViewWeb/Languages/LanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/LanguageService.cs
@@ -1,14 +1,10 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using ApiView;
 using APIView;
 using APIViewWeb.Models;
-using Microsoft.ApplicationInsights.Extensibility;
-using Microsoft.ApplicationInsights;
 using APIViewWeb.Helpers;
-using Microsoft.VisualStudio.Services.Common;
 using System.Linq;
 
 namespace APIViewWeb
@@ -35,8 +31,5 @@ namespace APIViewWeb
         public static string[] SupportedLanguages = LanguageServiceHelpers.SupportedLanguages;
 
         public virtual bool GeneratePipelineRunParams(APIRevisionGenerationPipelineParamModel param) => true;
-
-
-        public static TelemetryClient _telemetryClient = new(TelemetryConfiguration.CreateDefault());
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -7,24 +7,23 @@ using System.IO;
 using System.Threading.Tasks;
 using ApiView;
 using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
 
 namespace APIViewWeb
 {
     public class PythonLanguageService : LanguageProcessor
     {
+        private readonly string _pythonExecutablePath;
+        private readonly TelemetryClient _telemetryClient;
         public override string Name { get; } = "Python";
         public override string[] Extensions { get; } = { ".whl" };
         public override string VersionString { get; } = "0.3.10";
-
-        private readonly string _pythonExecutablePath;
         public override string ProcessName => _pythonExecutablePath;
 
-        public PythonLanguageService(IConfiguration configuration)
+        public PythonLanguageService(IConfiguration configuration, TelemetryClient telemetryClient)
         {
             _pythonExecutablePath = configuration["PYTHONEXECUTABLEPATH"] ?? "python";
+            _telemetryClient = telemetryClient;
 
             // Check if sandboxing is disabled for python
             bool.TryParse(configuration["ReviewGenByPipelineDisabledForPython"], out bool _isDisabledForPython);

--- a/src/dotnet/APIView/APIViewWeb/Languages/TypeSpecLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/TypeSpecLanguageService.cs
@@ -7,6 +7,7 @@ using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using ApiView;
 using APIViewWeb.Models;
+using Microsoft.ApplicationInsights;
 using Microsoft.Extensions.Configuration;
 using Newtonsoft.Json;
 
@@ -14,20 +15,19 @@ namespace APIViewWeb
 {
     public class TypeSpecLanguageService : LanguageProcessor
     {
-        public override string Name { get; } = "TypeSpec";
-
-        public override string [] Extensions { get; } = { ".tsp", ".cadl" };
-
-        public override string VersionString { get; } = "0";
-
-        public override string ProcessName => throw new NotImplementedException();
-
+        private readonly TelemetryClient _telemetryClient;
         private string _typeSpecSpecificPathPrefix;
 
-        public TypeSpecLanguageService(IConfiguration configuration)
+        public override string Name { get; } = "TypeSpec";
+        public override string [] Extensions { get; } = { ".tsp", ".cadl" };
+        public override string VersionString { get; } = "0";
+        public override string ProcessName => throw new NotImplementedException();
+
+        public TypeSpecLanguageService(IConfiguration configuration, TelemetryClient telemetryClient)
         {
             IsReviewGenByPipeline = true;
             _typeSpecSpecificPathPrefix = "/specification";
+            _telemetryClient = telemetryClient;
         }
         public override async Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis)
         {

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/AICommentsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/AICommentsController.cs
@@ -10,6 +10,8 @@ using APIViewWeb.LeanModels;
 using Microsoft.AspNetCore.Mvc.ModelBinding;
 using APIViewWeb.Helpers;
 using Microsoft.Azure.Cosmos.Serialization.HybridRow;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
 
 namespace APIViewWeb.LeanControllers
 {
@@ -17,12 +19,12 @@ namespace APIViewWeb.LeanControllers
     public class AICommentsController : BaseApiController
     {
         private readonly IAICommentsManager _aiCommentsManager;
-        private readonly ILogger _logger;
+        private readonly TelemetryClient _telemetryClient;
 
-        public AICommentsController(IAICommentsManager aiCommentsManager, ILogger<AICommentsController> logger)
+        public AICommentsController(IAICommentsManager aiCommentsManager, TelemetryClient telemetryClient)
         {
             _aiCommentsManager = aiCommentsManager;
-            _logger = logger;
+            _telemetryClient = telemetryClient;
         }
         /// <summary>
         /// Create AI Comment
@@ -35,12 +37,12 @@ namespace APIViewWeb.LeanControllers
             try
             {
                 var result = await _aiCommentsManager.CreateAICommentAsync(aiCommentDTOForCreate, User.GetGitHubLogin());
-                _logger.LogInformation("New comment added to database");
+                _telemetryClient.TrackTrace("New comment added to database", SeverityLevel.Information);
                 return new LeanJsonResult(result, StatusCodes.Status201Created);
             }
             catch (Exception err)
             {
-                _logger.LogInformation("Error: Failed to create AI Comment " + err.Message);
+                _telemetryClient.TrackTrace("Error: Failed to create AI Comment " + err.Message, SeverityLevel.Information);
                 return StatusCode(statusCode: StatusCodes.Status500InternalServerError);
             }
         }
@@ -61,7 +63,7 @@ namespace APIViewWeb.LeanControllers
             }
             catch (Exception err)
             {
-                _logger.LogInformation("Error: Failed to update AI comment. " + err.Message);
+                _telemetryClient.TrackTrace("Error: Failed to update AI comment. " + err.Message, SeverityLevel.Information);
                 return StatusCode(statusCode: StatusCodes.Status500InternalServerError);
             }
         }
@@ -81,7 +83,7 @@ namespace APIViewWeb.LeanControllers
             }
             catch (Exception err)
             {
-                _logger.LogInformation("Error:  Failed to update AI comment. " + err.Message);
+                _telemetryClient.TrackTrace("Error:  Failed to update AI comment. " + err.Message, SeverityLevel.Information);
                 return StatusCode(statusCode: StatusCodes.Status500InternalServerError);
             }
 
@@ -103,7 +105,7 @@ namespace APIViewWeb.LeanControllers
             }
             catch (Exception err)
             {
-                _logger.LogInformation("Error: Failed to delete AI comment " + err.Message);
+                _telemetryClient.TrackTrace("Error: Failed to delete AI comment " + err.Message, SeverityLevel.Information);
                 return StatusCode(statusCode: StatusCodes.Status500InternalServerError);
             }
         }
@@ -124,7 +126,7 @@ namespace APIViewWeb.LeanControllers
             }
             catch (Exception err)
             {
-                _logger.LogInformation("Error: Failed to retrieve AI comment" + err.Message);
+                _telemetryClient.TrackTrace("Error: Failed to retrieve AI comment" + err.Message, SeverityLevel.Information);
                 return StatusCode(statusCode: StatusCodes.Status500InternalServerError);
             }
         }

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -9,9 +9,7 @@ using APIViewWeb.Models;
 using APIViewWeb.Repositories;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authorization;
-using Microsoft.AspNetCore.Mvc.ViewEngines;
 using Microsoft.AspNetCore.SignalR;
 using System;
 using System.Collections.Generic;
@@ -36,9 +34,7 @@ namespace APIViewWeb.Managers
         private readonly IDevopsArtifactRepository _devopsArtifactRepository;
         private readonly IBlobOriginalsRepository _originalsRepository;
         private readonly INotificationManager _notificationManager;
-
-        static TelemetryClient _telemetryClient = new(TelemetryConfiguration.CreateDefault());
-
+        private readonly TelemetryClient _telemetryClient;
 
         public APIRevisionsManager(
             IAuthorizationService authorizationService,
@@ -50,7 +46,8 @@ namespace APIViewWeb.Managers
             ICodeFileManager codeFileManager,
             IBlobCodeFileRepository codeFileRepository,
             IBlobOriginalsRepository originalsRepository,
-            INotificationManager notificationManager)
+            INotificationManager notificationManager,
+            TelemetryClient telemetryClient)
         {
             _reviewsRepository = reviewsRepository;
             _apiRevisionsRepository = apiRevisionsRepository;
@@ -62,6 +59,7 @@ namespace APIViewWeb.Managers
             _devopsArtifactRepository = devopsArtifactRepository;
             _originalsRepository = originalsRepository;
             _notificationManager = notificationManager;
+            _telemetryClient = telemetryClient;
         }
 
         /// <summary>
@@ -628,9 +626,8 @@ namespace APIViewWeb.Managers
         /// </summary>
         /// <param name="revision"></param>
         /// <param name="languageService"></param>
-        /// <param name="telemetryClient"></param>
         /// <returns></returns>
-        public async Task UpdateAPIRevisionAsync(APIRevisionListItemModel revision, LanguageService languageService, TelemetryClient telemetryClient)
+        public async Task UpdateAPIRevisionAsync(APIRevisionListItemModel revision, LanguageService languageService)
         {
             foreach (var file in revision.Files)
             {
@@ -655,8 +652,8 @@ namespace APIViewWeb.Managers
                 }
                 catch (Exception ex)
                 {
-                    telemetryClient.TrackTrace("Failed to update revision " + revision.Id);
-                    telemetryClient.TrackException(ex);
+                    _telemetryClient.TrackTrace("Failed to update revision " + revision.Id);
+                    _telemetryClient.TrackException(ex);
                 }
             }
         }

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -35,7 +35,7 @@ namespace APIViewWeb.Managers.Interfaces
         public TreeNode<InlineDiffLine<CodeLine>> ComputeSectionDiff(TreeNode<CodeLine> before, TreeNode<CodeLine> after, RenderedCodeFile beforeFile, RenderedCodeFile afterFile);
         public Task<APIRevisionListItemModel> CreateAPIRevisionAsync(string userName, string reviewId, APIRevisionType apiRevisionType, string label,
             MemoryStream memoryStream, CodeFile codeFile, string originalName = null, int? prNumber = null);
-        public Task UpdateAPIRevisionAsync(APIRevisionListItemModel revision, LanguageService languageService, TelemetryClient telemetryClient);
+        public Task UpdateAPIRevisionAsync(APIRevisionListItemModel revision, LanguageService languageService);
         public Task UpdateAPIRevisionAsync(APIRevisionListItemModel revision);
         public Task AutoArchiveAPIRevisions(int archiveAfterMonths);
     }

--- a/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
@@ -12,7 +12,6 @@ using System.Security.Claims;
 using System.Text;
 using System.Threading.Tasks;
 using APIViewWeb.Repositories;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights;
 using System.Net.Http;
 using System.Text.Json;
@@ -26,24 +25,23 @@ namespace APIViewWeb.Managers
         private readonly string _apiviewEndpoint;
         private readonly ICosmosReviewRepository _reviewRepository;
         private readonly ICosmosUserProfileRepository _userProfileRepository;
-        private readonly IConfiguration _configuration;
         private readonly string _testEmailToAddress;
         private readonly string _emailSenderServiceUrl;
+        private readonly TelemetryClient _telemetryClient;
 
         private const string ENDPOINT_SETTING = "Endpoint";
 
-        static TelemetryClient _telemetryClient = new(TelemetryConfiguration.CreateDefault());
-
         public NotificationManager(IConfiguration configuration,
             ICosmosReviewRepository reviewRepository,
-            ICosmosUserProfileRepository userProfileRepository)
+            ICosmosUserProfileRepository userProfileRepository,
+            TelemetryClient telemetryClient)
         {
             _apiviewEndpoint = configuration.GetValue<string>(ENDPOINT_SETTING);
             _reviewRepository = reviewRepository;
             _userProfileRepository = userProfileRepository;
-            _configuration = configuration;
             _testEmailToAddress = configuration["apiview-email-test-address"] ?? "";
             _emailSenderServiceUrl = configuration["azure-sdk-emailer-url"] ?? "";
+            _telemetryClient = telemetryClient;
         }
 
         public async Task NotifySubscribersOnComment(ClaimsPrincipal user, CommentItemModel comment)

--- a/src/dotnet/APIView/APIViewWeb/Managers/OpenSourceRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/OpenSourceRequestManager.cs
@@ -10,30 +10,25 @@ using APIViewWeb.Models;
 using Azure.Core;
 using Azure.Identity;
 using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.Logging;
-using Microsoft.Identity.Client.Platforms.Features.DesktopOs.Kerberos;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
-using Octokit;
 
 namespace APIViewWeb.Managers
 {
     public class OpenSourceRequestManager : IOpenSourceRequestManager
     {
         static readonly string[] scopes = new string[] { "api://2789159d-8d8b-4d13-b90b-ca29c1707afd/.default" };
-        static TelemetryClient _telemetryClient = new(TelemetryConfiguration.CreateDefault());
-
         private readonly string _aadClientId;
         private readonly string _aadClientSecret;
         private readonly string _aadTenantId;
+        private readonly TelemetryClient _telemetryClient;
 
-        public OpenSourceRequestManager(IConfiguration configuration)
+        public OpenSourceRequestManager(IConfiguration configuration, TelemetryClient telemetryClient)
         {
             _aadClientId = configuration["opensource-aad-app-id"] ?? "";
             _aadClientSecret = configuration["opensource-aad-client-secret"] ?? "";
             _aadTenantId = configuration["opensource-aad-tenant-id"] ?? "";
+            _telemetryClient = telemetryClient;
         }
 
         public async Task<OpenSourceUserInfo> GetUserInfo(string githubUserId)

--- a/src/dotnet/APIView/APIViewWeb/Managers/PackageNameManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/PackageNameManager.cs
@@ -8,18 +8,23 @@ using APIViewWeb.Models;
 using CsvHelper;
 using CsvHelper.Configuration;
 using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 
 namespace APIViewWeb.Managers
 {
 
     public class PackageNameManager : IPackageNameManager
     {
+
+        private readonly TelemetryClient _telemetryClient;
+
         static readonly string PACKAGE_CSV_LOOKUP_URL = "https://raw.githubusercontent.com/Azure/azure-sdk/main/_data/releases/latest/<langauge>-packages.csv";
         static readonly HttpClient _httpClient = new();
-
         static Dictionary<string, PackageModel> _packageNameMap = new();
-        static TelemetryClient _telemetryClient = new(TelemetryConfiguration.CreateDefault());
+
+        public PackageNameManager(TelemetryClient telemetryClient) 
+        {
+            _telemetryClient = telemetryClient;
+        }
 
         public async Task<PackageModel> GetPackageDetails(string packageName)
         {

--- a/src/dotnet/APIView/APIViewWeb/Managers/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/PullRequestManager.cs
@@ -11,7 +11,6 @@ using APIViewWeb.Models;
 using APIViewWeb.Repositories;
 using Microsoft.ApplicationInsights;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Extensions.Configuration;
 using Octokit;
 
@@ -23,8 +22,8 @@ namespace APIViewWeb.Managers
         static readonly string PR_APIVIEW_BOT_COMMENT = "APIView has identified API level changes in this PR and created following API reviews.";
         static readonly string PR_APIVIEW_BOT_NO_CHANGE_COMMENT = "API changes are not detected in this pull request.";
         static readonly GitHubClient _githubClient = new GitHubClient(new ProductHeaderValue("apiview"));
-        readonly TelemetryClient _telemetryClient = new TelemetryClient(TelemetryConfiguration.CreateDefault());
-
+        
+        private readonly TelemetryClient _telemetryClient;
         private readonly ICosmosPullRequestsRepository _pullRequestsRepository;
         private readonly ICosmosAPIRevisionsRepository _apiRevisionsRepository;
         private readonly IAPIRevisionsManager _apiRevisionManager;
@@ -36,13 +35,16 @@ namespace APIViewWeb.Managers
             ICosmosPullRequestsRepository pullRequestsRepository,
             ICosmosAPIRevisionsRepository apiRevisionsRepository,
             IAPIRevisionsManager apiRevisionManager,
-            IConfiguration configuration
+            IConfiguration configuration,
+            TelemetryClient telemetryClient
             )
         {
             _pullRequestsRepository = pullRequestsRepository;
             _apiRevisionsRepository = apiRevisionsRepository;
             _apiRevisionManager = apiRevisionManager;
             _configuration = configuration;
+            _telemetryClient = telemetryClient;
+
             var ghToken = _configuration["github-access-token"];
             if (!string.IsNullOrEmpty(ghToken))
             {

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -11,7 +11,6 @@ using APIViewWeb.Hubs;
 using APIViewWeb.Models;
 using APIViewWeb.Repositories;
 using Microsoft.ApplicationInsights;
-using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 using System.Net.Http;
@@ -36,14 +35,14 @@ namespace APIViewWeb.Managers
         private readonly ICosmosCommentsRepository _commentsRepository;
         private readonly IHubContext<SignalRHub> _signalRHubContext;
         private readonly IEnumerable<LanguageService> _languageServices;
-
-        static TelemetryClient _telemetryClient = new(TelemetryConfiguration.CreateDefault());
+        private readonly TelemetryClient _telemetryClient;
 
         public ReviewManager (
             IAuthorizationService authorizationService, ICosmosReviewRepository reviewsRepository,
             IAPIRevisionsManager apiRevisionsManager, ICommentsManager commentManager,
             IBlobCodeFileRepository codeFileRepository, ICosmosCommentsRepository commentsRepository, 
-            IHubContext<SignalRHub> signalRHubContext, IEnumerable<LanguageService> languageServices)
+            IHubContext<SignalRHub> signalRHubContext, IEnumerable<LanguageService> languageServices,
+            TelemetryClient telemetryClient)
 
         {
             _authorizationService = authorizationService;
@@ -54,6 +53,7 @@ namespace APIViewWeb.Managers
             _commentsRepository = commentsRepository;
             _signalRHubContext = signalRHubContext;
             _languageServices = languageServices;
+            _telemetryClient = telemetryClient;
         }
 
         /// <summary>
@@ -400,7 +400,7 @@ namespace APIViewWeb.Managers
                                 try
                                 {
                                     await Task.Delay(500);
-                                    await _apiRevisionsManager.UpdateAPIRevisionAsync(revision, languageService, _telemetryClient);
+                                    await _apiRevisionsManager.UpdateAPIRevisionAsync(revision, languageService);
                                 }
                                 catch (Exception e)
                                 {

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml.cs
@@ -129,7 +129,7 @@ namespace APIViewWeb.Pages.Assemblies
                 NotificationMessage = ReviewContent.NotificationMessage;
             }
 
-            if (!ReviewContent.APIRevisionsGrouped.Any())
+            if (ReviewContent.APIRevisionsGrouped == null || !ReviewContent.APIRevisionsGrouped.Any())
             {
                 return RedirectToPage("LegacyReview", new { id = id });
             }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Error.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Error.cshtml
@@ -10,14 +10,14 @@
         <div class="col-sm-6 text-center">
             <h1 class="text-danger">Error.</h1>
             <h2 class="text-danger">An unexpected error occurred while processing your request.</h2>
-            @if (Model.ShowRequestId)
+            @if (Model.ShowTraceId)
             {
                 <p>
-                    <strong>Request ID:</strong> <code>@Model.RequestId</code>
+                    <strong>Trace ID:</strong> <code>@Model.TraceId</code>
                 </p>
             }
             <p>
-                Please <a href="mailto:azuresdkengsysteam@microsoft.com">email</a> site adminstrator for support.
+                Please reach out to <a href="https://teams.microsoft.com/l/channel/19%3A3adeba4aa1164f1c889e148b1b3e3ddd%40thread.skype/APIView?groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47">site adminstrator</a> for support.
             </p>
         </div>
         <div class="col-sm-3">

--- a/src/dotnet/APIView/APIViewWeb/Pages/Error.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Error.cshtml.cs
@@ -12,13 +12,13 @@ namespace APIViewWeb.Pages
     [ResponseCache(Duration = 0, Location = ResponseCacheLocation.None, NoStore = true)]
     public class ErrorModel : PageModel
     {
-        public string RequestId { get; set; }
+        public string TraceId { get; set; }
 
-        public bool ShowRequestId => !string.IsNullOrEmpty(RequestId);
+        public bool ShowTraceId => !string.IsNullOrEmpty(TraceId);
 
         public void OnGet()
         {
-            RequestId = Activity.Current?.Id ?? HttpContext.TraceIdentifier;
+            TraceId = Activity.Current?.TraceId.ToString() ?? HttpContext.TraceIdentifier;
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -25,17 +25,16 @@ namespace APIViewWeb.Repositories
     {
         private readonly HttpClient _devopsClient;
         private readonly IConfiguration _configuration;
-
         private readonly string _devopsAccessToken;
         private readonly string _hostUrl;
-
         private readonly TelemetryClient _telemetryClient;
-        public DevopsArtifactRepository(IConfiguration configuration)
+
+        public DevopsArtifactRepository(IConfiguration configuration, TelemetryClient telemetryClient)
         {
             _configuration = configuration;
             _devopsAccessToken = Convert.ToBase64String(System.Text.Encoding.ASCII.GetBytes(string.Format("{0}:{1}", "", _configuration["Azure-Devops-PAT"])));
             _hostUrl = _configuration["APIVIew-Host-Url"];
-            _telemetryClient = new TelemetryClient(TelemetryConfiguration.CreateDefault());
+            _telemetryClient = telemetryClient;
 
             _devopsClient = new HttpClient();
             _devopsClient.DefaultRequestHeaders.Accept.Clear();


### PR DESCRIPTION
- Update APIView Dependencies
- Consume TelemetryClient via Dependency Injection to avoid OutOfMemoryException
- Remove all Instances to ILogger. We should just stick to using TelemetryClient
- Fix Bug in AutoReviewController
- Fix bug in Review Page
- Update APIView Error Page.
- Add `Microsoft.ApplicationInsights.SnapshotCollector` to allow for live debugging.
Resolves https://github.com/Azure/azure-sdk-tools/issues/5714