### PR TITLE
Correct the name of JS package folder

### DIFF
--- a/eng/common/scripts/Verify-RestApiSpecLocation.ps1
+++ b/eng/common/scripts/Verify-RestApiSpecLocation.ps1
@@ -222,7 +222,7 @@ function Verify-PackageVersion() {
 
 try {
   # Verify package version is not a prerelease version, only continue the validation if the package is GA version
-  # Verify-PackageVersion
+  Verify-PackageVersion
 
   $ServiceDir = Join-Path $RepoRoot 'sdk' $ServiceDirectory
   $PackageDirectory = Join-Path $ServiceDir $PackageName


### PR DESCRIPTION
There are two cases for the naming of JS package folder:
- RLC package case, removing the "azure-rest-" from package name then plus "-rest" to the end of the name.
- Non-RLC package case, removing the "azure-" from the package name.

The changes include:
- correct the name of package folder for JS case.
- correct the name prefix of JS ARM package.
- add exception catch handler
- style format fix

The [pipeline test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3430267&view=logs&j=7bb69cc7-6f52-585e-8b13-5bae7c4a9fa4&t=7abbbe6b-d005-5c95-feb6-99ffe4e699e1) of JS template package release with same script change looks good.