### PR TITLE
Support creating test resources based on logged in user

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -92,6 +92,9 @@ param (
     [Parameter()]
     [switch] $SuppressVsoCommands = ($null -eq $env:SYSTEM_TEAMPROJECTID),
 
+    [Parameter()]
+    [switch] $UseUserCredentials,
+
     # Captures any arguments not declared here (no parameter errors)
     # This enables backwards compatibility with old script versions in
     # hotfix branches if and when the dynamic subscription configuration
@@ -611,8 +614,14 @@ try {
         }
     }
 
+
+    if ($UseUserCredentials) {
+        $TestApplicationOid = (Get-AzADUser -UserPrincipalName (Get-AzContext).Account).Id
+        $TestApplicationId = $testApplicationOid
+        Log "User-based app id '$TestApplicationId' will be used."
+    }
     # If no test application ID was specified during an interactive session, create a new service principal.
-    if (!$CI -and !$TestApplicationId) {
+    elseif (!$CI -and !$TestApplicationId) {
         # Cache the created service principal in this session for frequent reuse.
         $servicePrincipal = if ($AzureTestPrincipal -and (Get-AzADServicePrincipal -ApplicationId $AzureTestPrincipal.AppId) -and $AzureTestSubscription -eq $SubscriptionId) {
             Log "TestApplicationId was not specified; loading cached service principal '$($AzureTestPrincipal.AppId)'"
@@ -996,6 +1005,14 @@ Save test environment settings into a .env file next to test resources template.
 The contents of the file are protected via the .NET Data Protection API (DPAPI).
 This is supported only on Windows. The environment file is scoped to the current
 service directory.
+
+The environment file will be named for the test resources template that it was
+generated for. For ARM templates, it will be test-resources.json.env. For
+Bicep templates, test-resources.bicep.env.
+
+.PARAMETER UseUserCredentials
+Create the resource group and deploy the template using the signed in user's credentials.
+No service principal will be created or used.
 
 The environment file will be named for the test resources template that it was
 generated for. For ARM templates, it will be test-resources.json.env. For

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -614,8 +614,11 @@ try {
         }
     }
 
-
     if ($UseUserCredentials) {
+        if ($TestApplicationId){
+            Write-Warning "The specified TestApplicationId '$TestApplicationId' will be ignored when UseUserCredentials is set."
+        }
+
         $TestApplicationOid = (Get-AzADUser -UserPrincipalName (Get-AzContext).Account).Id
         $TestApplicationId = $testApplicationOid
         Log "User-based app id '$TestApplicationId' will be used."

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -615,7 +615,7 @@ try {
     }
 
     if ($UseUserCredentials) {
-        if ($TestApplicationId){
+        if ($TestApplicationId) {
             Write-Warning "The specified TestApplicationId '$TestApplicationId' will be ignored when UseUserCredentials is set."
         }
 

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -93,7 +93,7 @@ param (
     [switch] $SuppressVsoCommands = ($null -eq $env:SYSTEM_TEAMPROJECTID),
 
     [Parameter()]
-    [switch] $UseUserCredentials,
+    [switch] $UserAuth,
 
     # Captures any arguments not declared here (no parameter errors)
     # This enables backwards compatibility with old script versions in
@@ -614,9 +614,9 @@ try {
         }
     }
 
-    if ($UseUserCredentials) {
+    if ($UserAuth) {
         if ($TestApplicationId) {
-            Write-Warning "The specified TestApplicationId '$TestApplicationId' will be ignored when UseUserCredentials is set."
+            Write-Warning "The specified TestApplicationId '$TestApplicationId' will be ignored when UserAuth is set."
         }
 
         $TestApplicationOid = (Get-AzADUser -UserPrincipalName (Get-AzContext).Account).Id
@@ -1013,7 +1013,7 @@ The environment file will be named for the test resources template that it was
 generated for. For ARM templates, it will be test-resources.json.env. For
 Bicep templates, test-resources.bicep.env.
 
-.PARAMETER UseUserCredentials
+.PARAMETER UserAuth
 Create the resource group and deploy the template using the signed in user's credentials.
 No service principal will be created or used.
 

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -19,7 +19,7 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
  [-TestApplicationOid <String>] [-SubscriptionId <String>] [-DeleteAfterHours <Int32>] [-Location <String>]
  [-Environment <String>] [-ResourceType <String>] [-ArmTemplateParameters <Hashtable>]
  [-AdditionalParameters <Hashtable>] [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile]
- [-SuppressVsoCommands] [-UseUserCredentials] [-NewTestResourcesRemainingArguments <Object>]
+ [-SuppressVsoCommands] [-UserAuth] [-NewTestResourcesRemainingArguments <Object>]
  [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -32,7 +32,7 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
  -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>] [-Location <String>]
  [-Environment <String>] [-ResourceType <String>] [-ArmTemplateParameters <Hashtable>]
  [-AdditionalParameters <Hashtable>] [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile]
- [-SuppressVsoCommands] [-UseUserCredentials] [-NewTestResourcesRemainingArguments <Object>]
+ [-SuppressVsoCommands] [-UserAuth] [-NewTestResourcesRemainingArguments <Object>]
  [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
@@ -629,7 +629,7 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
-### -UseUserCredentials
+### -UserAuth
 Create the resource group and deploy the template using the signed in user's credentials.
 No service principal will be created or used.
 

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -15,21 +15,25 @@ Deploys live test resources defined for a service directory to Azure.
 ### Default (Default)
 ```
 New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-ServiceDirectory] <String>
- [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
- [-SubscriptionId <String>] [-DeleteAfterHours <Int32>] [-Location <String>] [-Environment <String>]
- [-ArmTemplateParameters <Hashtable>] [-AdditionalParameters <Hashtable>] [-EnvironmentVariables <Hashtable>]
- [-CI] [-Force] [-OutFile] [-SuppressVsoCommands] [-WhatIf] [-Confirm] [<CommonParameters>]
+ [-TestResourcesDirectory <String>] [-TestApplicationId <String>] [-TestApplicationSecret <String>]
+ [-TestApplicationOid <String>] [-SubscriptionId <String>] [-DeleteAfterHours <Int32>] [-Location <String>]
+ [-Environment <String>] [-ResourceType <String>] [-ArmTemplateParameters <Hashtable>]
+ [-AdditionalParameters <Hashtable>] [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile]
+ [-SuppressVsoCommands] [-UseUserCredentials] [-NewTestResourcesRemainingArguments <Object>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ### Provisioner
 ```
 New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-ServiceDirectory] <String>
- [-TestApplicationId <String>] [-TestApplicationSecret <String>] [-TestApplicationOid <String>]
- -TenantId <String> [-SubscriptionId <String>] -ProvisionerApplicationId <String>
+ [-TestResourcesDirectory <String>] [-TestApplicationId <String>] [-TestApplicationSecret <String>]
+ [-TestApplicationOid <String>] -TenantId <String> [-SubscriptionId <String>]
+ -ProvisionerApplicationId <String> [-ProvisionerApplicationOid <String>]
  -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>] [-Location <String>]
- [-Environment <String>] [-ArmTemplateParameters <Hashtable>] [-AdditionalParameters <Hashtable>]
- [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile] [-SuppressVsoCommands] [-WhatIf] [-Confirm]
- [<CommonParameters>]
+ [-Environment <String>] [-ResourceType <String>] [-ArmTemplateParameters <Hashtable>]
+ [-AdditionalParameters <Hashtable>] [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile]
+ [-SuppressVsoCommands] [-UseUserCredentials] [-NewTestResourcesRemainingArguments <Object>]
+ [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -206,8 +210,10 @@ Accept wildcard characters: False
 A directory under 'sdk' in the repository root - optionally with subdirectories
 specified - in which to discover ARM templates named 'test-resources.json' and
 Bicep templates named 'test-resources.bicep'.
-This can also be an absolute path
+This can be an absolute path
 or specify parent directories.
+ServiceDirectory is also used for resource and
+environment variable naming.
 
 ```yaml
 Type: String
@@ -216,6 +222,24 @@ Aliases:
 
 Required: True
 Position: 1
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -TestResourcesDirectory
+An override directory in which to discover ARM templates named 'test-resources.json' and
+Bicep templates named 'test-resources.bicep'.
+This can be an absolute path
+or specify parent directories.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
@@ -376,6 +400,21 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ProvisionerApplicationOid
+{{ Fill ProvisionerApplicationOid Description }}
+
+```yaml
+Type: String
+Parameter Sets: Provisioner
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ProvisionerApplicationSecret
 A service principal secret (password) used to provision test resources when a
 provisioner is specified.
@@ -452,6 +491,21 @@ Aliases:
 Required: False
 Position: Named
 Default value: AzureCloud
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ResourceType
+{{ Fill ResourceType Description }}
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Test
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -560,7 +614,7 @@ Accept wildcard characters: False
 ### -SuppressVsoCommands
 By default, the -CI parameter will print out secrets to logs with Azure Pipelines log
 commands that cause them to be redacted.
-For CI environments that don't support this (like 
+For CI environments that don't support this (like
 stress test clusters), this flag can be set to $false to avoid printing out these secrets to the logs.
 
 ```yaml
@@ -571,6 +625,46 @@ Aliases:
 Required: False
 Position: Named
 Default value: ($null -eq $env:SYSTEM_TEAMPROJECTID)
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseUserCredentials
+Create the resource group and deploy the template using the signed in user's credentials.
+No service principal will be created or used.
+
+The environment file will be named for the test resources template that it was
+generated for.
+For ARM templates, it will be test-resources.json.env.
+For
+Bicep templates, test-resources.bicep.env.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: False
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -NewTestResourcesRemainingArguments
+Captures any arguments not declared here (no parameter errors)
+This enables backwards compatibility with old script versions in
+hotfix branches if and when the dynamic subscription configuration
+secrets get updated to add new parameters.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
 Accept pipeline input: False
 Accept wildcard characters: False
 ```
@@ -606,8 +700,23 @@ Accept pipeline input: False
 Accept wildcard characters: False
 ```
 
+### -ProgressAction
+{{ Fill ProgressAction Description }}
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -716,7 +716,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 


### PR DESCRIPTION
The way that this can be integrated into language test frameworks is by assuming that if no client secret is populated, a user credential should be created instead of a client secret credential.

Also, downstream test-resources templates should remove testApplicationSecret from the parameter list to avoid being prompted for it (assuming it is not actually necessary).