### PR TITLE
Remove providerhub from mirror pipeline

### DIFF
--- a/eng/pipelines/mirror-repos.yml
+++ b/eng/pipelines/mirror-repos.yml
@@ -55,12 +55,6 @@ jobs:
                 Merge: '@("specification/common-types")'
                 AcceptTheirsForFinalMerge: true
 
-          Azure/typespec-azure-pr:
-            Branch: main
-            TargetBranches:
-              providerhub:
-                Theirs: '@("common/config/rush/pnpm-lock.yaml")'
-
     - template: ./templates/steps/sync-repo-branch.yml
       parameters:
         GH_TOKEN: $(azuresdk-github-pat)


### PR DESCRIPTION
@markcowl the merge into the providerhub branch has started failing due to submodule conflicts. Given we aren't using this currently anyway I'm removing it from the mirroring. Once we figure out the merge update process we can add it back or setup independent automation. 