### PR TITLE
Add CrossLanguagePackageId Property

### DIFF
--- a/src/dotnet/APIView/APIView/Model/CodeFile.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFile.cs
@@ -48,6 +48,8 @@ namespace ApiView
 
         public string PackageVersion { get; set; }
 
+        public string CrossLanguagePackageId { get; set; }
+
         public CodeFileToken[] Tokens { get; set; } = Array.Empty<CodeFileToken>();
 
         public List<CodeFileToken[]> LeafSections { get; set; }

--- a/src/dotnet/APIView/APIViewWeb/Managers/CodeFileManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/CodeFileManager.cs
@@ -227,6 +227,7 @@ namespace APIViewWeb.Managers
             file.Name = codeFile.Name;
             file.PackageName = codeFile.PackageName;
             file.PackageVersion = codeFile.PackageVersion;
+            file.CrossLanguagePackageId = codeFile.CrossLanguagePackageId;
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Models/APICodeFileModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/APICodeFileModel.cs
@@ -37,5 +37,6 @@ namespace APIViewWeb
         // This field stores original file name uploaded to create review
         public string FileName { get; set; }
         public string PackageVersion { get; set; }
+        public string CrossLanguagePackageId { get; set; }
     }
 }


### PR DESCRIPTION
Allows for identifying packages across different languages.