### PR TITLE
Remove package retrieval when verify pkg version

### DIFF
--- a/eng/common/scripts/Verify-RestApiSpecLocation.ps1
+++ b/eng/common/scripts/Verify-RestApiSpecLocation.ps1
@@ -9,7 +9,7 @@
   The directory path of the service.
 
 .PARAMETER PackageName
-  The name of the package.
+  The name of the package, which is the artifact name in pipeline.
 
 .PARAMETER ArtifactLocation
   The location of the generated artifact for the package.


### PR DESCRIPTION
The script fails to find the package for the `Go` language because the Go language doesn't generate a package for release; instead, it simply pushes the code to the GitHub repository. 

However, since the `Verify-PackageVersion` function doesn't actually use the package found by the `APIView` related function, I removed that part of the code. Now, the script works for these five languages by retrieving package information from the `{packagename}.json` file.

In addition, I added the validation for `Go` data plane scenario.

Test run result: 
[Go](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3438606&view=logs&j=6a8552c2-2ada-5ee5-a4d2-6fcf45f87c55&t=63abb2ae-8b99-518c-37b5-ceb4c0582ab3)
[JS](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3438579&view=logs&j=fad5caa0-24eb-51d7-9ee8-d55d6e9ffe5a&t=4b903053-dc5b-56d4-4838-edf64acaab7d)