### PR TITLE
upgrade resource manager to 1.10.1 and include reference to System.ClientModel

### DIFF
--- a/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen/Azure.SDK.Management.ChangelogGen.csproj
+++ b/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen/Azure.SDK.Management.ChangelogGen.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.ResourceManager" Version="1.9.0" />
+    <PackageReference Include="Azure.ResourceManager" Version="1.10.1" />
     <PackageReference Include="LibGit2Sharp" Version="0.27.2" />
     <PackageReference Include="Markdig.Signed" Version="0.31.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.5.0" />

--- a/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen/Program.cs
+++ b/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen/Program.cs
@@ -1,14 +1,11 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections;
 using System.Reflection;
-using System.Text.RegularExpressions;
 using Azure.SDK.ChangelogGen.Compare;
 using Azure.SDK.ChangelogGen.Report;
 using Azure.SDK.ChangelogGen.Utilities;
 using LibGit2Sharp;
-using Markdig.Parsers;
 
 namespace Azure.SDK.ChangelogGen
 {
@@ -36,7 +33,8 @@ namespace Azure.SDK.ChangelogGen
                 }
 
                 Context context = new Context();
-                if (!context.Init(args)) {
+                if (!context.Init(args))
+                {
                     return;
                 }
 
@@ -156,7 +154,7 @@ namespace Azure.SDK.ChangelogGen
             else
             {
                 Logger.Log($"Spec Tag change detected: {baselineVersionTag} -> {curVersionTag}");
-                return new StringValueChange(curVersionTag, baselineVersionTag, 
+                return new StringValueChange(curVersionTag, baselineVersionTag,
                     $"Upgraded api-version tag from '{baselineVersionTag}' to '{curVersionTag}'. Tag detail available at {source}");
             }
         }
@@ -173,7 +171,8 @@ namespace Azure.SDK.ChangelogGen
             List<string> azureRefs = new List<string>()
             {
                 typeof(Azure.ResourceManager.ArmClient).Assembly.Location,
-                typeof(Azure.Core.AzureLocation).Assembly.Location
+                typeof(Azure.Core.AzureLocation).Assembly.Location,
+                typeof(System.ClientModel.Primitives.ModelReaderWriter).Assembly.Location,
             };
             List<string> allRefs = runtimeRefs.Concat(azureRefs).ToList();
             Assembly curApi = CompileHelper.Compile("curApi.dll", curApiFileContent, allRefs);


### PR DESCRIPTION
1. Upgrade Azure.ResourceManager to 1.10.1
2. Include System.ClientModel when compiling api file to avoid compile error