### PR TITLE
Prepare-Release.ps1: Make dateTime.ToString("MM/dd/yyyy") to work on exotic setups

### DIFF
--- a/eng/common/scripts/Prepare-Release.ps1
+++ b/eng/common/scripts/Prepare-Release.ps1
@@ -112,7 +112,7 @@ else
 # On some machines, where people modified date format via Windows Registry,
 # "$ParsedReleaseDate.ToString("MM/dd/yyyy")" produces the date as "MM-dd-yyyy", which is probably a bug somewhere,
 # yet if we concatenate the parts individually, everything works as expected.
-$releaseDateString = $ParsedReleaseDate.ToString("MM") + "/" + $ParsedReleaseDate.ToString("dd") + "/" + $ParsedReleaseDate.ToString("yyyy")
+$releaseDateString = $ParsedReleaseDate.ToSTring("MM/dd/yyyy", [CultureInfo]::InvariantCulture)
 $month = $ParsedReleaseDate.ToString("MMMM")
 
 Write-Host "Assuming release is in $month with release date $releaseDateString" -ForegroundColor Green

--- a/eng/common/scripts/Prepare-Release.ps1
+++ b/eng/common/scripts/Prepare-Release.ps1
@@ -110,7 +110,7 @@ else
 }
 
 # Use InvariantCulture so that the date format is consistent on all machines
-$releaseDateString = $ParsedReleaseDate.ToSTring("MM/dd/yyyy", [CultureInfo]::InvariantCulture)
+$releaseDateString = $ParsedReleaseDate.ToString("MM/dd/yyyy", [CultureInfo]::InvariantCulture)
 $month = $ParsedReleaseDate.ToString("MMMM")
 
 Write-Host "Assuming release is in $month with release date $releaseDateString" -ForegroundColor Green

--- a/eng/common/scripts/Prepare-Release.ps1
+++ b/eng/common/scripts/Prepare-Release.ps1
@@ -109,9 +109,7 @@ else
   $ParsedReleaseDate = [datetime]$ReleaseDate
 }
 
-# On some machines, where people modified date format via Windows Registry,
-# "$ParsedReleaseDate.ToString("MM/dd/yyyy")" produces the date as "MM-dd-yyyy", which is probably a bug somewhere,
-# yet if we concatenate the parts individually, everything works as expected.
+# Use InvariantCulture so that the date format is consistent on all machines
 $releaseDateString = $ParsedReleaseDate.ToSTring("MM/dd/yyyy", [CultureInfo]::InvariantCulture)
 $month = $ParsedReleaseDate.ToString("MMMM")
 

--- a/eng/common/scripts/Prepare-Release.ps1
+++ b/eng/common/scripts/Prepare-Release.ps1
@@ -109,7 +109,10 @@ else
   $ParsedReleaseDate = [datetime]$ReleaseDate
 }
 
-$releaseDateString = $ParsedReleaseDate.ToString("MM/dd/yyyy")
+# On some machines, where people modified date format via Windows Registry,
+# "$ParsedReleaseDate.ToString("MM/dd/yyyy")" produces the date as "MM-dd-yyyy", which is probably a bug somewhere,
+# yet if we concatenate the parts individually, everything works as expected.
+$releaseDateString = $ParsedReleaseDate.ToString("MM") + "/" + $ParsedReleaseDate.ToString("dd") + "/" + $ParsedReleaseDate.ToString("yyyy")
 $month = $ParsedReleaseDate.ToString("MMMM")
 
 Write-Host "Assuming release is in $month with release date $releaseDateString" -ForegroundColor Green


### PR DESCRIPTION
On my machine, I experimented with the registry, and the worst part is that I don't remember/know how to reset it back.

The work items that script produces, do have datetimes for the upcoming releases in the `MM-dd-yyyy` format, and then I have to correct them by hand.

`dateTime.ToString("MM/dd/yyyy")` does produce the date in the format of `MM-dd-yyyy` on my machine. This also happens if I write a corresponding .NET app.

The fix that I am proposing makes it work on my specific setup and hopefully breaks no one else. I understand if you are hesitant to take it. Let me know, I'll see how I can restore my setting.

But on the other hand, I don't think it makes anything worse, it only makes things more robust, so maybe take it?