### PR TITLE
Fix issue in Verify-Link.ps1 after PS 7.4 update

### DIFF
--- a/eng/common/scripts/Verify-Links.ps1
+++ b/eng/common/scripts/Verify-Links.ps1
@@ -260,7 +260,7 @@ function CheckLink ([System.Uri]$linkUri, $allowRetry=$true)
         $innerExceptionPresent = $_.Exception.psobject.Properties.name -contains "InnerException"
         
         $errorCodePresent = $false
-        if ($innerExceptionPresent) {
+        if ($innerExceptionPresent -and $_.Exception.InnerException) {
           $errorCodePresent = $_.Exception.InnerException.psobject.Properties.name -contains "ErrorCode"
         }
 


### PR DESCRIPTION
https://learn.microsoft.com/en-us/powershell/scripting/whats-new/what-s-new-in-powershell-74?view=powershell-7.4
- Add AllowInsecureRedirect switch to Web cmdlets (#18546)

That new option cause a new exception type that exposed a bug where we assumed if InnerException property existed that it was not null. This fix verifies that the property is not null.


We only seem to hit this issue in the ios pipeline at https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3458379&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=bdeefc16-b669-5ebd-ad94-a2c19ade53b0. 