### PR TITLE
Fix fault injector default ports

### DIFF
--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/appsettings.json
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/appsettings.json
@@ -7,5 +7,14 @@
       "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information"
     }
   },
-  "Urls": "http://+:7777/;https://+:7778/"
+  "Kestrel": {
+    "Endpoints": {
+      "http": {
+        "Url": "http://+:7777"
+      },
+      "https": {
+        "Url": "https://+:7778"
+      }
+    }
+  }
 }


### PR DESCRIPTION
"Urls" in appsettings,json does not work, which broke storage live tests in java. Fixing to define kestrel endpoints there, tested locally