### PR TITLE
Fix sparse-checkout git command line behavior

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -26,6 +26,11 @@ steps:
       # Define this inline, because of the chicken/egg problem with loading a script when nothing
       # has been checked out yet.
       script: |
+        # Setting $PSNativeCommandArgumentPassing to 'Legacy' to use PowerShell
+        # 7.2 behavior for command argument passing. Newer behaviors will result
+        # in errors from git.exe.
+        $PSNativeCommandArgumentPassing = 'Legacy'
+        
         function SparseCheckout([Array]$paths, [Hashtable]$repository)
         {
             $dir = $repository.WorkingDirectory
@@ -80,7 +85,7 @@ steps:
               Write-Host "git -c advice.detachedHead=false checkout $commitish --"
 
               # This will use the default branch if repo.Commitish is empty
-              Invoke-Expression -Command "git -c advice.detachedHead=false checkout $commitish --"
+              git -c advice.detachedHead=false checkout $commitish --
             } else {
               Write-Host "Skipping checkout as repo has already been initialized"
             }

--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -80,7 +80,7 @@ steps:
               Write-Host "git -c advice.detachedHead=false checkout $commitish --"
 
               # This will use the default branch if repo.Commitish is empty
-              git -c advice.detachedHead=false checkout $commitish --
+              Invoke-Expression -Command "git -c advice.detachedHead=false checkout $commitish --"
             } else {
               Write-Host "Skipping checkout as repo has already been initialized"
             }


### PR DESCRIPTION
This is found in pipelines which were using the Azure Pipelines pool (not 1ES) and invoked `sparse-checkout.yml` in this way: 

https://github.com/Azure/azure-sdk-for-java/blob/main/eng/pipelines/docindex.yml#L19-L29

```yml 
      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
        parameters:
          SkipCheckoutNone: true
          Paths:
            - package.json
            - metadata/
            - docs-ref-mapping/reference-unified.yml
            - docs-ref-services/
          Repositories:
            - Name: $(DocRepoOwner)/$(DocRepoName)
              WorkingDirectory: $(DocRepoLocation)
```

The final command in the sparse checkout fails: 

```pwsh 
git -c advice.detachedHead=false checkout $commitish --
```

When checking on parameter binding a subtle difference occurs: 
```
$PSNativeCommandArgumentPassing = 'Windows' 
Trace-Command -PSHost -Expression { git -c advice.detachedHead=false checkout $commitish -- } -Name ParameterBinding
DEBUG: 2024-02-05 09:36:16.2451 ParameterBinding Information: 0 : BIND NAMED native application line args [C:\Program Files\Git\cmd\git.exe]
DEBUG: 2024-02-05 09:36:16.2454 ParameterBinding Information: 0 :     BIND cmd line arg [-c] to position [0]
DEBUG: 2024-02-05 09:36:16.2456 ParameterBinding Information: 0 :     BIND cmd line arg [advice.detachedHead=false] to position [1]
DEBUG: 2024-02-05 09:36:16.2458 ParameterBinding Information: 0 :     BIND cmd line arg [checkout] to position [2]
DEBUG: 2024-02-05 09:36:16.2460 ParameterBinding Information: 0 :     BIND cmd line arg [] to position [3]
DEBUG: 2024-02-05 09:36:16.2462 ParameterBinding Information: 0 :     BIND cmd line arg [--] to position [4]
DEBUG: 2024-02-05 09:36:16.2499 ParameterBinding Information: 0 : CALLING BeginProcessing

$PSNativeCommandArgumentPassing = 'Windows'  
Trace-Command -PSHost -Expression { & git "-c advice.detachedHead=false checkout $commitish --" } -Name ParameterBinding
DEBUG: 2024-02-05 09:14:00.4704 ParameterBinding Information: 0 : BIND NAMED native application line args [C:\Program Files\Git\cmd\git.exe]
DEBUG: 2024-02-05 09:14:00.4707 ParameterBinding Information: 0 :     BIND cmd line arg [-c advice.detachedHead=false checkout  --] to position [0]
DEBUG: 2024-02-05 09:14:00.4743 ParameterBinding Information: 0 : CALLING BeginProcessing

$PSNativeCommandArgumentPassing = 'Legacy' 
Trace-Command -PSHost -Expression {  git -c advice.detachedHead=false checkout $commitish -- } -Name ParameterBinding
DEBUG: 2024-02-05 09:12:55.4343 ParameterBinding Information: 0 : BIND NAMED native application line args [C:\Program Files\Git\cmd\git.exe]
DEBUG: 2024-02-05 09:12:55.4347 ParameterBinding Information: 0 :     BIND argument [-c advice.detachedHead=false checkout  --]
DEBUG: 2024-02-05 09:12:55.4386 ParameterBinding Information: 0 : CALLING BeginProcessing
```

Note the `BIND cmd line arg` in the `Windows` configuration versus `BIND argument` in the `Legacy` configuration. 