### PR TITLE
[tsp-client] Delete sparse-spec dir if it exists

### DIFF
--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -3,7 +3,7 @@ import { createTempDirectory, removeDirectory, readTspLocation, getEmitterFromRe
 import { Logger, printBanner, enableDebug, printVersion } from "./log.js";
 import { TspLocation, compileTsp, discoverMainFile, resolveTspConfigUrl } from "./typespec.js";
 import { getOptions } from "./options.js";
-import { mkdir, writeFile, cp, readFile } from "node:fs/promises";
+import { mkdir, writeFile, cp, readFile, access } from "node:fs/promises";
 import { addSpecFiles, checkoutCommit, cloneRepo, getRepoRoot, sparseCheckout } from "./git.js";
 import { doesFileExist } from "./network.js";
 import { parse as parseYaml } from "yaml";
@@ -229,9 +229,17 @@ async function main() {
     rootUrl = resolvePath(options.outputDir);
   }
 
+  // FIXME: this is a workaround meanwhile we fix the issue with failing to delete the sparse-spec directory
+  // Tracking issue: https://github.com/Azure/azure-sdk-tools/issues/7636
+  const repoRoot = await getRepoRoot(rootUrl);
+  access(joinPaths(repoRoot, "..", "sparse-spec")).then(() => {
+    Logger.debug("Deleting existing sparse-spec directory");
+    removeDirectory(joinPaths(repoRoot, "..", "sparse-spec"));
+  }).catch(() => {});
+
   switch (options.command) {
       case "init":
-        const emitter = await getEmitterFromRepoConfig(joinPaths(await getRepoRoot(rootUrl), "eng", "emitter-package.json"));
+        const emitter = await getEmitterFromRepoConfig(joinPaths(repoRoot, "eng", "emitter-package.json"));
         if (!emitter) {
           throw new Error("Couldn't find emitter-package.json in the repo");
         }

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -229,14 +229,18 @@ async function main() {
     rootUrl = resolvePath(options.outputDir);
   }
 
-  // FIXME: this is a workaround meanwhile we fix the issue with failing to delete the sparse-spec directory
-  // Tracking issue: https://github.com/Azure/azure-sdk-tools/issues/7636
   const repoRoot = await getRepoRoot(rootUrl);
-  access(joinPaths(repoRoot, "..", "sparse-spec")).then(() => {
-    Logger.debug("Deleting existing sparse-spec directory");
-    removeDirectory(joinPaths(repoRoot, "..", "sparse-spec"));
-  }).catch(() => {});
-
+  try {
+    // FIXME: this is a workaround meanwhile we fix the issue with failing to delete the sparse-spec directory
+    // Tracking issue: https://github.com/Azure/azure-sdk-tools/issues/7636
+    access(joinPaths(repoRoot, "..", "sparse-spec")).then(() => {
+      Logger.debug("Deleting existing sparse-spec directory");
+      removeDirectory(joinPaths(repoRoot, "..", "sparse-spec"));
+    }).catch(() => {});
+  } catch (err) {
+    Logger.debug(`Error occurred while attempting to remove sparse-spec directory: ${err}`);
+  }
+  
   switch (options.command) {
       case "init":
         const emitter = await getEmitterFromRepoConfig(joinPaths(repoRoot, "eng", "emitter-package.json"));


### PR DESCRIPTION
Adding a temporary workaround to delete the sparse-spec/ directory to reduce issues for folks who ran into errors during program execution. Have a tracking issue to do this at the end of the program instead: https://github.com/Azure/azure-sdk-tools/issues/7636