### PR TITLE
Exclude any API reviews no longer affected by PR

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -171,7 +171,7 @@ namespace APIViewWeb.Controllers
                 //Generate combined single comment to update on PR or add a comment stating no API changes.            
                 if (commentOnPR)
                 {
-                    await _pullRequestManager.CreateOrUpdateCommentsOnPR(pullRequests, repoInfo[0], repoInfo[1], prNumber, hostName);
+                    await _pullRequestManager.CreateOrUpdateCommentsOnPR(pullRequests, repoInfo[0], repoInfo[1], prNumber, hostName, commitSha);
                 }
             }
             finally

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IPullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IPullRequestManager.cs
@@ -10,7 +10,7 @@ namespace APIViewWeb.Managers
         public Task<IEnumerable<PullRequestModel>> GetPullRequestsModelAsync(string reviewId, string apiRevisionId = null);
         public Task<IEnumerable<PullRequestModel>> GetPullRequestsModelAsync(int pullRequestNumber, string repoName);
         public Task<PullRequestModel> GetPullRequestModelAsync(int prNumber, string repoName, string packageName, string originalFile, string language);
-        public Task CreateOrUpdateCommentsOnPR(List<PullRequestModel> pullRequests, string repoOwner, string repoName, int prNumber, string hostName);
+        public Task CreateOrUpdateCommentsOnPR(List<PullRequestModel> pullRequests, string repoOwner, string repoName, int prNumber, string hostName, string commitSha);
         public Task CleanupPullRequestData();
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/PullRequestManager.cs
@@ -89,7 +89,7 @@ namespace APIViewWeb.Managers
             return pullRequestModel;
         }
 
-        public async Task CreateOrUpdateCommentsOnPR(List<PullRequestModel> pullRequests, string repoOwner, string repoName, int prNumber, string hostName)
+        public async Task CreateOrUpdateCommentsOnPR(List<PullRequestModel> pullRequests, string repoOwner, string repoName, int prNumber, string hostName, string commitSha)
         {
             var existingComment = await GetExistingCommentForPackage(repoOwner, repoName, prNumber);
             var bldr = new StringBuilder(PR_APIVIEW_BOT_COMMENT_IDENTIFIER);
@@ -97,7 +97,9 @@ namespace APIViewWeb.Managers
             if (pullRequests.Count > 0)
             {
                 bldr.Append(PR_APIVIEW_BOT_COMMENT).Append(Environment.NewLine).Append(Environment.NewLine);
-                foreach (var p in pullRequests)
+                // Include API review revisions generated with same exact Commit Sha as latest commit SHA to exclude any stale reviews that are not modified in latest commit.
+                // This will ensure comment shows only the reviews modified byu latest commit.
+                foreach (var p in pullRequests.Where(p => p.Commits.LastOrDefault() == commitSha))
                 {
                     var revisionLink = ManagerHelpers.ResolveReviewUrl(pullRequest: p, hostName: hostName);
                     bldr.Append('[').Append(p.PackageName).Append("](").Append(revisionLink).Append(')');


### PR DESCRIPTION
Include API reviews affected by current commit only in the comment on GitHub whenever APIView process the request to detect API changes. This will eliminate showing links of any stale reviews that were created by previous commit.