### PR TITLE
Add azure-sdk to eng/common sync

### DIFF
--- a/eng/pipelines/eng-common-sync.yml
+++ b/eng/pipelines/eng-common-sync.yml
@@ -9,6 +9,7 @@ parameters:
 - name: Repos
   type: object
   default:
+    - azure-sdk
     - azure-sdk-for-android
     - azure-sdk-for-c
     - azure-sdk-for-cpp


### PR DESCRIPTION
After https://github.com/Azure/azure-sdk/pull/7201 azure-sdk will be dependent on changes from eng/common. It only depends on a few items but I decided it is better to add to eng/common instead of manually syncing or doing a reference. 