### PR TITLE
Pin azure/login action step to v1.5.1

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: 'Az CLI login'
         if: ${{ github.event_name == 'issues' && github.event.action == 'opened' }}
-        uses: azure/login@v1
+        uses: azure/login@v1.5.1
         with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
The azure/login@v1.6.0 task added pre/post Azure Login steps and the pre-step is seriously impacting the time it takes to run an Action because it takes 30 seconds to run. This is further exacerbated by the fact that we only need the azure/login step for the issues opened event and the pre/post Azure Login steps are being added to each and Action.