### PR TITLE
Add stress test arm/bicep template prefix to New-TestResources ResourceType set

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -67,7 +67,7 @@ param (
     [string] $Environment = 'AzureCloud',
 
     [Parameter()]
-    [ValidateSet('test', 'perf')]
+    [ValidateSet('test', 'perf', 'stress-test')]
     [string] $ResourceType = 'test',
 
     [Parameter()]


### PR DESCRIPTION
For people doing local debugging of their bicep templates for stress tests, enable the deployment script to actually find those templates!