### PR TITLE
Fix case-sensitive spelling in scripts that get deployed to C++ repo

### DIFF
--- a/eng/common/spelling/Invoke-Cspell.ps1
+++ b/eng/common/spelling/Invoke-Cspell.ps1
@@ -87,7 +87,7 @@ function Test-VersionReportMatches() {
   $expectedPackageVersion = '6.12.0'
 
   # Act
-  $actual = &"$PSSCriptRoot/Invoke-Cspell.ps1" `
+  $actual = &"$PSScriptRoot/Invoke-Cspell.ps1" `
     -JobType '--version'
 
   # Assert

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -1,5 +1,3 @@
-#cspell: ignore azblob
-
 param(
     [string] $StorageAccountKey
 )

--- a/eng/scripts/Set-VcpkgWriteModeCache.ps1
+++ b/eng/scripts/Set-VcpkgWriteModeCache.ps1
@@ -1,3 +1,5 @@
+#cspell: ignore azblob
+
 param(
     [string] $StorageAccountKey
 )


### PR DESCRIPTION
For C++-only fixes, see https://github.com/Azure/azure-sdk-for-cpp/pull/5346