### PR TITLE
[.NET Analyzers] Fix Template special case

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
@@ -33,6 +33,38 @@ namespace RandomNamespace
         }
 
         [Fact]
+        public async Task AZC0001ProducedForInvalidNamespaceWithValidRoot()
+        {
+            const string code = @"
+namespace Azure.StorageBadNamespace
+{
+    public class Program { }
+}";
+
+            var diagnostic = Verifier.Diagnostic("AZC0001")
+                .WithMessage(string.Format(this.message, "Azure.StorageBadNamespace"))
+                .WithSpan(2, 17, 2, 36);
+
+            await Verifier.VerifyAnalyzerAsync(code, diagnostic);
+        }
+
+        [Fact]
+        public async Task AZC0001ProducedForInvalidSubNamespaceWithValidRoot()
+        {
+            const string code = @"
+namespace Azure.StorageBadNamespace.Child
+{
+    public class Program { }
+}";
+
+            var diagnostic = Verifier.Diagnostic("AZC0001")
+                .WithMessage(string.Format(this.message, "Azure.StorageBadNamespace.Child"))
+                .WithSpan(2, 37, 2, 42);
+
+            await Verifier.VerifyAnalyzerAsync(code, diagnostic);
+        }
+
+        [Fact]
         public async Task AZC0001ProducedOneErrorPerNamespaceDefinition()
         {
             const string code = @"
@@ -63,6 +95,17 @@ namespace RandomNamespace
         public async Task AZC0001NotProducedForAllowedNamespaces()
         {
             const string code = @"
+namespace Azure.Storage
+{
+    public class Program { }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0001NotProducedForAllowedSubNamespaces()
+        {
+            const string code = @"
 namespace Azure.Storage.Hello
 {
     public class Program { }
@@ -72,6 +115,18 @@ namespace Azure.Storage.Hello
 
         [Fact]
         public async Task AZC0001NotProducedForAzureCoreExpressions()
+        {
+            const string code = @"
+namespace Azure.Core.Expressions
+{
+    public class Program { }
+}";
+
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0001NotProducedForAzureCoreExpressionsSubNamespace()
         {
             const string code = @"
 namespace Azure.Core.Expressions.Foobar

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
@@ -33,22 +33,6 @@ namespace RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0001ProducedForSubNamespacesOfAzureTemplate()
-        {
-            const string code = @"
-namespace Azure.Template.RandomNamespace
-{
-    public class Program { }
-}";
-
-            var diagnostic = Verifier.Diagnostic("AZC0001")
-                .WithMessage(string.Format(this.message, "Azure.Template.RandomNamespace"))
-                .WithSpan(2, 26, 2, 41);
-
-            await Verifier.VerifyAnalyzerAsync(code, diagnostic);
-        }
-
-        [Fact]
         public async Task AZC0001ProducedOneErrorPerNamespaceDefinition()
         {
             const string code = @"
@@ -91,6 +75,18 @@ namespace Azure.Storage.Hello
         {
             const string code = @"
 namespace Azure.Core.Expressions.Foobar
+{
+    public class Program { }
+}";
+
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0001NotProducedForSubNamespacesOfAzureTemplate()
+        {
+            const string code = @"
+namespace Azure.Template.RandomNamespace
 {
     public class Program { }
 }";

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0001Tests.cs
@@ -150,10 +150,22 @@ namespace Azure.Template.RandomNamespace
         }
 
         [Fact]
-        public async Task AZC0001NotProducedForAzureTemplate()
+        public async Task AZC0001NotProducedForAzureTemplateRoot()
         {
             const string code = @"
 namespace Azure.Template
+{
+    public class Program { }
+}";
+
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0001NotProducedForAzureTemplateSubNamespace()
+        {
+            const string code = @"
+namespace Azure.Template.Models
 {
     public class Program { }
 }";

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
@@ -78,7 +78,7 @@ namespace Azure.ClientSdk.Analyzers
                 // "Azure.Template" is not an approved namespace prefix, but we have a project template by that name
                 // to help customers get started. We do not want our template to include a suppression for this
                 // descriptor out of the box, so we need to treat it as a special case.
-                if (displayString == "Azure.Template")
+                if (displayString.StartsWith("Azure.Template"))
                 {
                     return;
                 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAssemblyNamespaceAnalyzer.cs
@@ -70,7 +70,8 @@ namespace Azure.ClientSdk.Analyzers
             var displayString = namespaceSymbol.ToDisplayString();
             foreach (var prefix in AllowedNamespacePrefix)
             {
-                if (displayString.StartsWith(prefix))
+                // Both the namespace itself or a sub-namespace are valid.
+                if (displayString == prefix || displayString.StartsWith(prefix + "."))
                 {
                     return;
                 }
@@ -78,7 +79,7 @@ namespace Azure.ClientSdk.Analyzers
                 // "Azure.Template" is not an approved namespace prefix, but we have a project template by that name
                 // to help customers get started. We do not want our template to include a suppression for this
                 // descriptor out of the box, so we need to treat it as a special case.
-                if (displayString.StartsWith("Azure.Template"))
+                if (displayString == "Azure.Template" || displayString.StartsWith("Azure.Template."))
                 {
                     return;
                 }


### PR DESCRIPTION
# Summary

The focus of these changes is to move the template special case logic from an equality check to a `StartsWith`, matching the behavior of the other checks.  By design, this allows subnamespaces of `Azure.Template` which are needed due to the structure of the Template project.