### PR TITLE
Stress: adding in a wrapper image for the otel collector so we can use it with our stress cluster

### DIFF
--- a/tools/stress-cluster/services/otelcollector/Dockerfile
+++ b/tools/stress-cluster/services/otelcollector/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/oss/otel/opentelemetry-collector-contrib:0.94.0 as otel
+
+FROM busybox:latest as busybox
+COPY --from=otel / /
+ADD ./otel-collector-config.yml /otel-collector-config.yml
+ADD ./startup.sh /startup.sh
+
+EXPOSE 4317
+EXPOSE 55678
+EXPOSE 55679
+
+ENTRYPOINT [ "/bin/sh", "-c", "/startup.sh" ]

--- a/tools/stress-cluster/services/otelcollector/otel-collector-config.yml
+++ b/tools/stress-cluster/services/otelcollector/otel-collector-config.yml
@@ -2,7 +2,6 @@ receivers:
   otlp:
     protocols:
       http:
-      grpc:
  
 processors:
   batch:
@@ -16,18 +15,14 @@ service:
     metrics:
       receivers: [otlp]
       processors: [batch]
-      exporters: [prometheus, azuremonitor]
+      exporters: [azuremonitor]
     logs:
       receivers: [otlp]
       processors: [batch]
       exporters: [azuremonitor]
 
 exporters:
-  prometheus:
-    endpoint: "0.0.0.0:8889"
-    resource_to_telemetry_conversion: 
-      enabled: true
   logging:
-    verbosity: detailed
+    verbosity: normal
   azuremonitor:
 #    connection_string: "%APPLICATIONINSIGHTS_CONNECTION_STRING%"

--- a/tools/stress-cluster/services/otelcollector/otel-collector-config.yml
+++ b/tools/stress-cluster/services/otelcollector/otel-collector-config.yml
@@ -1,0 +1,33 @@
+receivers:
+  otlp:
+    protocols:
+      http:
+      grpc:
+ 
+processors:
+  batch:
+ 
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging, azuremonitor]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [prometheus, azuremonitor]
+    logs:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [azuremonitor]
+
+exporters:
+  prometheus:
+    endpoint: "0.0.0.0:8889"
+    resource_to_telemetry_conversion: 
+      enabled: true
+  logging:
+    verbosity: detailed
+  azuremonitor:
+#    connection_string: "%APPLICATIONINSIGHTS_CONNECTION_STRING%"

--- a/tools/stress-cluster/services/otelcollector/startup.sh
+++ b/tools/stress-cluster/services/otelcollector/startup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+set -ex
+
+source $ENV_FILE
+echo "    connection_string: \"$APPLICATIONINSIGHTS_CONNECTION_STRING\"" >> /otel-collector-config.yml
+
+cat /otel-collector-config.yml
+
+/otelcol-contrib --config otel-collector-config.yml $@

--- a/tools/stress-cluster/services/otelcollector/startup.sh
+++ b/tools/stress-cluster/services/otelcollector/startup.sh
@@ -4,7 +4,4 @@ set -ex
 
 source $ENV_FILE
 echo "    connection_string: \"$APPLICATIONINSIGHTS_CONNECTION_STRING\"" >> /otel-collector-config.yml
-
-cat /otel-collector-config.yml
-
 /otelcol-contrib --config otel-collector-config.yml $@


### PR DESCRIPTION
This creates a Docker image that wraps the actual otel collector in a container which can pull the proper env variable and write out a config file.

Note, this is dependent on a fix that injects the .env file into all containers in a pod, not just one, but can be built and pushed independent of that work.

CC: @LarryOsterman 