### PR TITLE
Case Insensitive Moniker Parsing

### DIFF
--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter.Tests/Utils/MonikerUtilsTests.cs
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter.Tests/Utils/MonikerUtilsTests.cs
@@ -42,6 +42,28 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Tests.Utils
 
         [Category("Utils")]
         [Category("Moniker")]
+        // Case Insensitive Tests
+        [TestCase(MonikerConstants.AzureSdkOwners, $"# AzureSDKOwners:          @fakeOwner1 @fakeOwner2")]
+        [TestCase(MonikerConstants.AzureSdkOwners, $"# azureSdkowners:          @fakeOwner1 @fakeOwner2")]
+        [TestCase(MonikerConstants.PRLabel, $"# prlabel: %Fake Label")]
+        [TestCase(MonikerConstants.PRLabel, $"# PrLabel: %Fake Label")]
+        [TestCase(MonikerConstants.ServiceLabel, $"# serviceLabel: %Fake Label")]
+        [TestCase(MonikerConstants.ServiceLabel, $"# SERVICELABEL: %Fake Label")]
+        [TestCase(MonikerConstants.ServiceOwners, $"# seRvICEowners:")]
+        [TestCase(MonikerConstants.ServiceOwners, $"# serviceOwners:")]
+        public void TestMonikerParsingForMonikerLinesCaseInsensitive(string moniker, string line)
+        {
+            // The MonikerUtils has 2 methods to test for Moniker parsing
+            // 1. ParseMonikerFromLine - returns the moniker if one is found on the line
+            // 2. IsMonikerLine - returns true if the line is a moniker line
+            bool isMonikerLine = MonikerUtils.IsMonikerLine(line);
+            Assert.IsTrue(isMonikerLine, $"IsMonikerLine for '{line}' contains '{moniker}' and should have returned true.");
+            string parsedMoniker = MonikerUtils.ParseMonikerFromLine(line);
+            Assert.That(parsedMoniker, Is.EqualTo(moniker), $"ParseMonikerFromLine for '{line}' should have returned '{moniker}' but returned '{parsedMoniker}'");
+        }
+
+        [Category("Utils")]
+        [Category("Moniker")]
         [TestCase("# just a comment line")]
         // Whitespace line with spaces and tabs
         [TestCase("  \t")]

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Utils/MonikerUtils.cs
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Utils/MonikerUtils.cs
@@ -34,7 +34,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Utils
                 {
                     // Line starts with "<Moniker>:", unfortunately /<NotInRepo>/ has no colon and needs
                     // to be checked separately
-                    if (strippedLine.StartsWith($"{tempMoniker}{SeparatorConstants.Colon}"))
+                    if (strippedLine.StartsWith($"{tempMoniker}{SeparatorConstants.Colon}", StringComparison.OrdinalIgnoreCase))
                     {
                         return tempMoniker;
                     }
@@ -69,7 +69,7 @@ namespace Azure.Sdk.Tools.CodeownersUtils.Utils
                 {
                     // Line starts with "<Moniker>:", unfortunately /<NotInRepo>/ has no colon and needs
                     // to be checked separately
-                    if (strippedLine.StartsWith($"{tempMoniker}{SeparatorConstants.Colon}"))
+                    if (strippedLine.StartsWith($"{tempMoniker}{SeparatorConstants.Colon}", StringComparison.OrdinalIgnoreCase))
                     {
                         return true;
                     }

--- a/tools/codeowners-utils/METADATA.md
+++ b/tools/codeowners-utils/METADATA.md
@@ -32,9 +32,11 @@ This list of examples is exhaustive. If an example isn't in here then it won't w
 ```text
 
 # AzureSdkOwners: @fakeUser3 @fakeUser4
+# ServiceLabel: %fakeLabel12
 /sdk/SomePath/  @fakeUser1 @fakeUser2 @Azure/fakeTeam1
 OR
 # AzureSdkOwners:
+# ServiceLabel: %fakeLabel12
 /sdk/SomePath/  @fakeUser1 @fakeUser2 @Azure/fakeTeam1
 OR
 # AzureSdkOwners: @fakeUser3 @fakeUser4


### PR DESCRIPTION
The CodeownersUtils was parsing Monikers case sensitive. The problem here is that any line that starts with # and doesn't match a moniker is treated as just a comment and ignored. CODEOWNERS files have blocks that are Moniker/Comment/MonikerOrSourceLine.

The main reason to make the moniker parsing case insensitive is that it would be more painful to try and plumb a casing error through the utils for just the linter. Parsing in any other context (github-event-processor or pipeline-owners-extractor) doesn't error, it throws out CODEOWNERS entries that are in error or, if the case of a mis cased moniker, would omit that piece of data from the entry. For example, if instead of PRLabel, the moniker in the file was prLabel it would treat that as a comment and ignore it but would still have the source path/owner in the CODEOWNERS entry with no PRLabel associated with it.

Moved the update to METADATA.md to this PR instead of the event processor PR.
The change adds a moniker to two example blocks that should have been there.