### PR TITLE
Handle DevOps PAT creation error

### DIFF
--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps/ServiceAccountPersonalAccessTokenStore.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Stores.AzureDevOps/ServiceAccountPersonalAccessTokenStore.cs
@@ -131,6 +131,10 @@ public class ServiceAccountPersonalAccessTokenStore : SecretStore
 
         PatTokenResult result = await client.CreatePatAsync(new PatTokenCreateRequest { AllOrgs = false, DisplayName = this.patDisplayName, Scope = this.scopes, ValidTo = expirationDate.UtcDateTime });
 
+        if (result.PatTokenError != SessionTokenError.None) {
+            throw new RotationException($"Unable to create PAT: {result.PatTokenError}");
+        }
+
         string authorizationId = result.PatToken.AuthorizationId.ToString();
 
         this.logger.LogInformation("Azure DevOps responded with authorization id '{AuthorizationId}'", authorizationId);


### PR DESCRIPTION
I was hitting a null reference exception while rotating a PAT and after debugging realized we aren't handling this case so I added handling to make the error message easier to understand. 