### PR TITLE
Deprecate `tox-monorepo`

### DIFF
--- a/packages/python-packages/tox-monorepo/README.md
+++ b/packages/python-packages/tox-monorepo/README.md
@@ -2,6 +2,18 @@
 
 This plugin changes {toxinidir} to be the directory that executes the tox command, rather than where the tox.ini actually lives on disk. This allows a monorepo to easily share a single tox.ini file rather than have to keep copies up to date.
 
+Deprecation Notice
+------------------
+
+With the availability of `tox 4`, `tox-monorepo` no longer has a purpose. It's usage has been entirely supplanted by the `root` argument provided with `tox 4`. Users should only consume `tox-monorepo` if they are forced onto the earlier `tox 3`.
+
+To take advantage of `tox 4`'s new feature in your `tox.ini`...
+
+1. Call `tox` with the addition of `--root path/to/folder/with/tox.ini` (still from the root of your package)
+2. Replace all occurrences of `{toxinidir}` with `{tox_root}`.
+
+Feel free to reference [this PR](https://github.com/Azure/azure-sdk-for-python/pull/30159/files) from azure-sdk-for-python supplanting the usage of `tox-monorepo` while upgrading to `tox 4`.
+
 Features
 --------
 

--- a/packages/python-packages/tox-monorepo/setup.py
+++ b/packages/python-packages/tox-monorepo/setup.py
@@ -27,11 +27,11 @@ setup(
     author_email="azuresdkengsysadmins@microsoft.com",
     license="MIT License",
     packages=find_packages(),
-    install_requires=["tox >= 3.12.0"],
+    install_requires=["tox<4.0.0,>=3.12.0"],
     entry_points={"tox": ["monorepo=tox_monorepo:monorepo"]},
     classifiers=[
         "Framework :: tox",
-        "Development Status :: 3 - Alpha",
+        "Development Status :: 7 - Inactive",
         "Programming Language :: Python",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",

--- a/packages/python-packages/tox-monorepo/tox_monorepo/version.py
+++ b/packages/python-packages/tox-monorepo/tox_monorepo/version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.1.2"
+VERSION = "0.1.3"


### PR DESCRIPTION
And associated docs, per issue #4917 