### PR TITLE
Update Octokit.Net version for github-event-processor

### DIFF
--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Azure.Sdk.Tools.GitHubEventProcessor.csproj
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Azure.Sdk.Tools.GitHubEventProcessor.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="5.0.2" />
+    <PackageReference Include="Octokit" Version="10.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
GitHub broke existing versions of Octokit.Net because GitHub is now creating Issues with long IDs (not to be confused with Issue Number) and Octokit.Net's Issue class had this as an int32 which caused deserialization of the payload to fail. 

To be clear: We don't use the Issue's Id when doing updates, everything updating an Issue for a repository uses the Number. Aside from updating the version of Octokit.Net, no other changes were necessary.