### PR TITLE
Add 1es changes for job/matrix generation and publish

### DIFF
--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -46,13 +46,14 @@ parameters:
 - name: Pools
   type: object
   default:
-    - name: LinuxPool
+    - name: Linux
+      filter: .*Linux.*Pool$
       os: linux
-    - name: LinuxNextPool
-      os: linux
-    - name: WindowsPool
+    - name: Windows
+      filter: .*Windows.*Pool$
       os: windows
-    - name: MacPool
+    - name: Mac
+      filter: .*MacPool$
       os: macOS
 
 jobs:
@@ -94,7 +95,7 @@ jobs:
                 -ConfigPath ${{ config.Path }}
                 -Selection ${{ config.Selection }}
                 -DisplayNameFilter '$(displayNameFilter)'
-                -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=.*${{ pool.name }}$'
+                -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}'
                 -Replace '${{ join(''',''', parameters.MatrixReplace) }}'
                 -NonSparseParameters '${{ join(''',''', config.NonSparseParameters) }}'
             displayName: Create ${{ pool.name }} Matrix ${{ config.Name }}
@@ -109,7 +110,7 @@ jobs:
                 -ConfigPath ${{ config.Path }}
                 -Selection ${{ config.Selection }}
                 -DisplayNameFilter '$(displayNameFilter)'
-                -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=.*${{ pool.name }}$'
+                -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}'
                 -NonSparseParameters '${{ join(''',''', config.NonSparseParameters) }}'
             displayName: Create ${{ pool.name }} Container Matrix ${{ config.Name }}
             name: container_job_matrix_${{ config.Name }}_${{ pool.name }}

--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -1,0 +1,139 @@
+parameters:
+- name: AdditionalParameters
+  type: object
+- name: DependsOn
+  type: object
+  default: null
+- name: CloudConfig
+  type: object
+  default: {}
+- name: MatrixConfigs
+  type: object
+  default: []
+- name: MatrixFilters
+  type: object
+  default: []
+- name: MatrixReplace
+  type: object
+  default: {}
+- name: JobTemplatePath
+  type: string
+# Set this to false to do a full checkout for private repositories with the azure pipelines service connection
+- name: SparseCheckout
+  type: boolean
+  default: true
+- name: SparseCheckoutPaths
+  type: object
+  default: []
+- name: Pool
+  type: string
+  default: azsdk-pool-mms-ubuntu-2204-general
+- name: OsVmImage
+  type: string
+  default: ubuntu-22.04
+- name: Os
+  type: string
+  default: linux
+# This parameter is only necessary if there are multiple invocations of this template within the SAME STAGE.
+# When that occurs, provide a name other than the default value.
+- name: GenerateJobName
+  type: string
+  default: 'generate_job_matrix'
+- name: PreGenerationSteps
+  type: stepList
+  default: []
+# Mappings to OS name required at template compile time by 1es pipeline templates
+- name: Pools
+  type: object
+  default:
+    - name: LinuxPool
+      os: linux
+    - name: LinuxNextPool
+      os: linux
+    - name: WindowsPool
+      os: windows
+    - name: MacPool
+      os: macOS
+
+jobs:
+- job: ${{ parameters.GenerateJobName }}
+  variables:
+    - template: /eng/pipelines/templates/variables/image.yml
+    - name: skipComponentGovernanceDetection
+      value: true
+    - name: displayNameFilter
+      value: $[ coalesce(variables.jobMatrixFilter, '.*') ]
+  pool:
+    name: ${{ parameters.Pool }}
+    vmImage: ${{ parameters.OsVmImage }}
+    os: ${{ parameters.Os }}
+  ${{ if parameters.DependsOn }}:
+    dependsOn: ${{ parameters.DependsOn }}
+  steps:
+    # Skip sparse checkout for the `azure-sdk-for-<lang>-pr` private mirrored repositories
+    # as we require the github service connection to be loaded.
+    - ${{ if and(parameters.SparseCheckout, not(contains(variables['Build.DefinitionName'], '-pr - '))) }}:
+      - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+        parameters:
+          ${{ if ne(length(parameters.SparseCheckoutPaths), 0) }}:
+            Paths: ${{ parameters.SparseCheckoutPaths }}
+          ${{ if and(eq(length(parameters.SparseCheckoutPaths), 0), ne(parameters.AdditionalParameters.ServiceDirectory, '')) }}:
+            Paths:
+              - "sdk/${{ parameters.AdditionalParameters.ServiceDirectory }}"
+
+    - ${{ parameters.PreGenerationSteps }}
+
+    - ${{ each config in parameters.MatrixConfigs }}:
+      - ${{ each pool in parameters.Pools }}:
+        - ${{ if eq(config.GenerateVMJobs, 'true') }}:
+          - task: Powershell@2
+            inputs:
+              pwsh: true
+              filePath: eng/common/scripts/job-matrix/Create-JobMatrix.ps1
+              arguments: >
+                -ConfigPath ${{ config.Path }}
+                -Selection ${{ config.Selection }}
+                -DisplayNameFilter '$(displayNameFilter)'
+                -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=.*${{ pool.name }}$'
+                -Replace '${{ join(''',''', parameters.MatrixReplace) }}'
+                -NonSparseParameters '${{ join(''',''', config.NonSparseParameters) }}'
+            displayName: Create ${{ pool.name }} Matrix ${{ config.Name }}
+            name: vm_job_matrix_${{ config.Name }}_${{ pool.name }}
+
+        - ${{ if eq(config.GenerateContainerJobs, 'true') }}:
+          - task: Powershell@2
+            inputs:
+              pwsh: true
+              filePath: eng/common/scripts/job-matrix/Create-JobMatrix.ps1
+              arguments: >
+                -ConfigPath ${{ config.Path }}
+                -Selection ${{ config.Selection }}
+                -DisplayNameFilter '$(displayNameFilter)'
+                -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=.*${{ pool.name }}$'
+                -NonSparseParameters '${{ join(''',''', config.NonSparseParameters) }}'
+            displayName: Create ${{ pool.name }} Container Matrix ${{ config.Name }}
+            name: container_job_matrix_${{ config.Name }}_${{ pool.name }}
+
+- ${{ each config in parameters.MatrixConfigs }}:
+  - ${{ each pool in parameters.Pools }}:
+    - ${{ if eq(config.GenerateVMJobs, 'true') }}:
+      - template: ${{ parameters.JobTemplatePath }}
+        parameters:
+          UsePlatformContainer: false
+          OSName: ${{ pool.os }}
+          Matrix: dependencies.${{ parameters.GenerateJobName }}.outputs['vm_job_matrix_${{ config.Name }}_${{ pool.name }}.matrix']
+          DependsOn: ${{ parameters.GenerateJobName }}
+          CloudConfig: ${{ parameters.CloudConfig }}
+          ${{ each param in parameters.AdditionalParameters }}:
+            ${{ param.key }}: ${{ param.value }}
+
+    - ${{ if eq(config.GenerateContainerJobs, 'true') }}:
+      - template: ${{ parameters.JobTemplatePath }}
+        parameters:
+          UsePlatformContainer: true
+          OSName: ${{ pool.os }}
+          Matrix: dependencies.${{ parameters.GenerateJobName }}.outputs['vm_job_matrix_${{ config.Name }}_${{ pool.name }}.matrix']
+          DependsOn: ${{ parameters.GenerateJobName }}
+          CloudConfig: ${{ parameters.CloudConfig }}
+          ${{ each param in parameters.AdditionalParameters }}:
+            ${{ param.key }}: ${{ param.value }}

--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -27,10 +27,10 @@ parameters:
   default: []
 - name: Pool
   type: string
-  default: azsdk-pool-mms-ubuntu-2204-general
+  default: $(LINUXPOOL)
 - name: OsVmImage
   type: string
-  default: ubuntu-22.04
+  default: $(LINUXVMIMAGE)
 - name: Os
   type: string
   default: linux

--- a/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -10,19 +10,21 @@ parameters:
   ArtifactName: ''
   ArtifactPath: ''
   CustomCondition: true
-  DisplayName: 'Publish Artifacts'
 
 steps:
-  - task: 1ES.PublishPipelineArtifact@1
+  - pwsh: |
+      Write-Host "##vso[task.setvariable variable=PublishArtifactName;]${{ parameters.ArtifactName }}"
     condition: and(succeeded(), ${{ parameters.CustomCondition }})
-    displayName: '${{ parameters.DisplayName }} - ${{ parameters.ArtifactName }}'
-    inputs:
-      artifact: '${{ parameters.ArtifactName }}'
-      path: '${{ parameters.ArtifactPath }}'
+    displayName: Set Artifact Name
+
+  - pwsh: |
+      Write-Host "##vso[task.setvariable variable=PublishArtifactName;]${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)"
+    condition: and(failed(), ${{ parameters.CustomCondition }})
+    displayName: Set Failed Artifact Name
 
   - task: 1ES.PublishPipelineArtifact@1
-    condition: and(failed(), ${{ parameters.CustomCondition }})
-    displayName: 'Failed - ${{ parameters.DisplayName }} - ${{ parameters.ArtifactName }}'
+    condition: and(succeeded(), ${{ parameters.CustomCondition }})
+    displayName: 'Publish ${{ parameters.ArtifactName }} Artifacts'
     inputs:
-      artifact: '${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)'
+      artifact: '$(PublishArtifactName)'
       path: '${{ parameters.ArtifactPath }}'

--- a/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -10,25 +10,19 @@ parameters:
   ArtifactName: ''
   ArtifactPath: ''
   CustomCondition: true
-  DisplayName: ''
+  DisplayName: 'Publish Artifacts'
 
 steps:
   - task: 1ES.PublishPipelineArtifact@1
     condition: and(succeeded(), ${{ parameters.CustomCondition }})
-    ${{ if parameters.DisplayName }}:
-      displayName: ${{ parameters.DisplayName }}
-    ${{ else }}:
-      displayName: 'Publish ${{ parameters.ArtifactName }} Artifacts'
+    displayName: '${{ parameters.DisplayName }} - ${{ parameters.ArtifactName }}'
     inputs:
       artifact: '${{ parameters.ArtifactName }}'
       path: '${{ parameters.ArtifactPath }}'
 
   - task: 1ES.PublishPipelineArtifact@1
     condition: and(failed(), ${{ parameters.CustomCondition }})
-    ${{ if parameters.DisplayName }}:
-      displayName: Failed - ${{ parameters.DisplayName }}
-    ${{ else }}:
-      displayName: 'Publish failed ${{ parameters.ArtifactName }} Artifacts'
+    displayName: 'Failed - ${{ parameters.DisplayName }} - ${{ parameters.ArtifactName }}'
     inputs:
       artifact: '${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)'
       path: '${{ parameters.ArtifactPath }}'

--- a/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -1,0 +1,34 @@
+# This step is used to prevent duplication of artifact publishes when there is an issue that would prevent the overall success of the job.
+# Ensuring that we only publish when successful (and two a differently named artifact otherwise) will allow easy retry on a build pipeline
+# without running into the "cannot override artifact" failure when we finally do get a passing run.
+
+# ArtifactName - The name of the artifact in the "successful" case.
+# ArtifactPath - The path we will be publishing.
+# CustomCondition - Used if there is additional logic necessary to prevent attempt of publish.
+
+parameters:
+  ArtifactName: ''
+  ArtifactPath: ''
+  CustomCondition: true
+  DisplayName: ''
+
+steps:
+  - task: 1ES.PublishPipelineArtifact@1
+    condition: and(succeeded(), ${{ parameters.CustomCondition }})
+    ${{ if parameters.DisplayName }}:
+      displayName: ${{ parameters.DisplayName }}
+    ${{ else }}:
+      displayName: 'Publish ${{ parameters.ArtifactName }} Artifacts'
+    inputs:
+      artifact: '${{ parameters.ArtifactName }}'
+      path: '${{ parameters.ArtifactPath }}'
+
+  - task: 1ES.PublishPipelineArtifact@1
+    condition: and(failed(), ${{ parameters.CustomCondition }})
+    ${{ if parameters.DisplayName }}:
+      displayName: Failed - ${{ parameters.DisplayName }}
+    ${{ else }}:
+      displayName: 'Publish failed ${{ parameters.ArtifactName }} Artifacts'
+    inputs:
+      artifact: '${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)'
+      path: '${{ parameters.ArtifactPath }}'

--- a/eng/common/pipelines/templates/steps/publish-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-artifact.yml
@@ -10,19 +10,18 @@ parameters:
   ArtifactName: ''
   ArtifactPath: ''
   CustomCondition: true
-  DisplayName: 'Publish Artifacts'
 
 steps:
-  - task: 1ES.PublishPipelineArtifact@1
+  - task: PublishPipelineArtifact@1
     condition: and(succeeded(), ${{ parameters.CustomCondition }})
-    displayName: '${{ parameters.DisplayName }} - ${{ parameters.ArtifactName }}'
+    displayName: 'Publish ${{ parameters.ArtifactName }} Artifacts'
     inputs:
-      artifact: '${{ parameters.ArtifactName }}'
+      artifactName: '${{ parameters.ArtifactName }}'
       path: '${{ parameters.ArtifactPath }}'
 
-  - task: 1ES.PublishPipelineArtifact@1
+  - task: PublishPipelineArtifact@1
     condition: and(failed(), ${{ parameters.CustomCondition }})
-    displayName: 'Failed - ${{ parameters.DisplayName }} - ${{ parameters.ArtifactName }}'
+    displayName: 'Publish failed ${{ parameters.ArtifactName }} Artifacts'
     inputs:
-      artifact: '${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)'
+      artifactName: '${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)'
       path: '${{ parameters.ArtifactPath }}'

--- a/eng/common/pipelines/templates/steps/publish-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-artifact.yml
@@ -10,18 +10,19 @@ parameters:
   ArtifactName: ''
   ArtifactPath: ''
   CustomCondition: true
+  DisplayName: 'Publish Artifacts'
 
 steps:
-  - task: PublishPipelineArtifact@1
+  - task: 1ES.PublishPipelineArtifact@1
     condition: and(succeeded(), ${{ parameters.CustomCondition }})
-    displayName: 'Publish ${{ parameters.ArtifactName }} Artifacts'
+    displayName: '${{ parameters.DisplayName }} - ${{ parameters.ArtifactName }}'
     inputs:
-      artifactName: '${{ parameters.ArtifactName }}'
+      artifact: '${{ parameters.ArtifactName }}'
       path: '${{ parameters.ArtifactPath }}'
 
-  - task: PublishPipelineArtifact@1
+  - task: 1ES.PublishPipelineArtifact@1
     condition: and(failed(), ${{ parameters.CustomCondition }})
-    displayName: 'Publish failed ${{ parameters.ArtifactName }} Artifacts'
+    displayName: 'Failed - ${{ parameters.DisplayName }} - ${{ parameters.ArtifactName }}'
     inputs:
-      artifactName: '${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)'
+      artifact: '${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)'
       path: '${{ parameters.ArtifactPath }}'


### PR DESCRIPTION
Adding these files as separate copies of their originals so we can do a rollout more easily.

1. Update `archetype-sdk-tests-generate.yml` to `generate-job-matrix.yml`. Changes to this file include generating a matrix with corresponding env vars for OS pools/agents, and passing in the now required `OSName` parameter which cannot be set as a variable for the 1es templates.
2. Moving `publish-artifact.yml` to `publish-1es-artifact.yml` to use the 1es publishing wrapper task. I don't think this task is available in a backwards compatible way without the repo reference and/or onboarding we're having to do, see https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3503459&view=logs&j=96791242-dbf3-587e-3a06-ae5af5c1a705&t=8e5c4a57-b21e-59c3-59e8-95279bb1be65&l=16 for example.