### PR TITLE
Update version of github-event-processor

### DIFF
--- a/.github/event-processor.config
+++ b/.github/event-processor.config
@@ -21,5 +21,6 @@
   "IdentifyStaleIssues": "Off",
   "IdentifyStalePullRequests": "On",
   "CloseAddressedIssues": "Off",
-  "LockClosedIssues": "Off"
+  "LockClosedIssues": "Off",
+  "EnforceMaxLifeOfIssues": "Off"
 }

--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -55,7 +55,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20240223.2
+          --version 1.0.0-dev.20240227.2
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -14,6 +14,8 @@ on:
     - cron: '30 4,10,16,22 * * *'
     # Lock closed issues, every 6 hours at 05:30 AM, 11:30 AM, 05:30 PM and 11:30 PM - LockClosedIssues
     - cron: '30 5,11,17,23 * * *'
+    # Enforce max life of issues, every Monday at 10:00 AM - EnforceMaxLifeOfIssues
+    - cron: '0 10 * * MON'
 # This removes all unnecessary permissions, the ones needed will be set below.
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 permissions: {}
@@ -34,7 +36,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20240223.2
+          --version 1.0.0-dev.20240227.2
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash
@@ -123,6 +125,15 @@ jobs:
           ${{ toJson(github.event) }}
           EOF
           github-event-processor ${{ github.event_name }} payload.json LockClosedIssues
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enforce Max Life of Issues Scheduled Event
+        if: github.event.schedule == '0 10 * * MON'
+        run: |
+          echo $GITHUB_PAYLOAD > payload.json
+          github-event-processor ${{ github.event_name }} payload.json EnforceMaxLifeOfIssues
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
1. The CodeownersUtils update to [change the way ServiceLabel parses with AzureSdkOwners](https://github.com/Azure/azure-sdk-tools/pull/7754)
2. github-event-processor has new scheduled to [event to enforce max life of issues](https://github.com/Azure/azure-sdk-tools/pull/7693) which needs to be added to the scheduled-event.yml.
3. Add the new rule, EnforceMaxLifeOfIssues, to azure-sdk-tools' config file. Default it to Off.

Note: The .github/workflows yml files will get pushed out to all of the repositories that have the github-event-processor enabled but the event-processor.config does not. These are repository specific and are not controlled from a central location.