### PR TITLE
Support CrossLanguagePackageId

### DIFF
--- a/packages/python-packages/apistubgentest/apiview_mapping_python.json
+++ b/packages/python-packages/apistubgentest/apiview_mapping_python.json
@@ -1,4 +1,5 @@
 {
+    "CrossLanguagePackageId": "ApiStubGenTest",
     "CrossLanguageDefinitionId": {
         "apistubgentest.models.DocstringClass.docstring_with_default_formal": "Docstring_DocstringWithFormalDefault",
         "apistubgentest.models.DocstringClass": "Formal_Model_Id"

--- a/packages/python-packages/apiview-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/apiview-stub-generator/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release History
 
+## Version 0.3.12 (2024-02-27)
+Add support for Cross Language Package ID.
+
 ## Version 0.3.11 (2024-1-11)
 Remove ePylint dependency.
 

--- a/packages/python-packages/apiview-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_apiview.py
@@ -12,7 +12,7 @@ from ._version import VERSION
 from ._diagnostic import Diagnostic
 from ._metadata_map import MetadataMap
 
-JSON_FIELDS = ["Name", "Version", "VersionString", "Navigation", "Tokens", "Diagnostics", "PackageName", "Language", "PackageVersion"]
+JSON_FIELDS = ["Name", "Version", "VersionString", "Navigation", "Tokens", "Diagnostics", "PackageName", "Language", "PackageVersion", "CrossLanguagePackageId"]
 
 HEADER_TEXT = "# Package is parsed using apiview-stub-generator(version:{0}), Python version: {1}".format(VERSION, platform.python_version())
 TYPE_NAME_REGEX = re.compile(r"(~?[a-zA-Z\d._]+)")
@@ -54,6 +54,7 @@ class ApiView:
         self.package_name = pkg_name
         self.package_version = pkg_version
         self.metadata_map = metadata_map or MetadataMap("")
+        self.cross_language_package_id = self.metadata_map.cross_language_package_id
         self.add_token(Token("", TokenKind.SkipDiffRangeStart))
         self.add_literal(HEADER_TEXT)
         self.add_line_marker("GLOBAL")

--- a/packages/python-packages/apiview-stub-generator/apistub/_metadata_map.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_metadata_map.py
@@ -20,6 +20,7 @@ class MetadataMap:
         if not mapping_path:
             if pkg_path.endswith(".whl") or pkg_path.endswith(".zip"):
                 self.cross_language_map = {}
+                self.cross_language_package_id = ""
                 return
             mapping_path = os.path.join(pkg_path, MAPPING_FILE_NAME)
 
@@ -27,6 +28,8 @@ class MetadataMap:
             with open(mapping_path, "r") as json_file:
                 mapping = json.load(json_file)
                 self.cross_language_map = mapping.get("CrossLanguageDefinitionId", {})
+                self.cross_language_package_id = mapping.get("CrossLanguagePackageId", "")
         except OSError:
             self.cross_language_map = {}
+            self.cross_language_package_id = ""
             return

--- a/packages/python-packages/apiview-stub-generator/apistub/_version.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.3.11"
+VERSION = "0.3.12"

--- a/packages/python-packages/apiview-stub-generator/tests/apiview_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/apiview_test.py
@@ -93,3 +93,16 @@ class TestApiView:
         stub_gen = StubGenerator(pkg_path=pkg_path, temp_path=temp_path)
         apiview = stub_gen.generate_tokens()
         self._validate_definition_ids(apiview)
+
+    def test_mapping_file(self):
+        pkg_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "apistubgentest"))
+        mapping_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", "apistubgentest", "apiview_mapping_python.json"))
+        temp_path = tempfile.gettempdir()
+        stub_gen = StubGenerator(pkg_path=pkg_path, temp_path=temp_path, mapping_path=mapping_path)
+        apiview = stub_gen.generate_tokens()
+        self._validate_definition_ids(apiview)
+        cross_language_tokens = [token for token in apiview.tokens if token.cross_language_definition_id]
+        assert cross_language_tokens[0].cross_language_definition_id == "Formal_Model_Id"
+        assert cross_language_tokens[1].cross_language_definition_id == "Docstring_DocstringWithFormalDefault"
+        assert len(cross_language_tokens) == 2
+        assert apiview.cross_language_package_id == "ApiStubGenTest"


### PR DESCRIPTION
Support "CrossLanguagePackageId". Requires an entry in `apiview_mapping_python.json` file:

```json
{
  "CrossLanguagePackageId": "Foo",
  "CrossLanguageDefinitionId": {
     ... // same as before
  }
}
```