### PR TITLE
Updates to tools for CodeownerUtils updates

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -30,7 +30,7 @@ stages:
       vmImage: ubuntu-22.04
 
     variables:
-      CodeownersLinterVersion: '1.0.0-dev.20240216.3'
+      CodeownersLinterVersion: '1.0.0-dev.20240227.2'
       DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
       RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
       TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
   OfficialBuildId: $(Build.BuildNumber)
   skipComponentGovernanceDetection: true
-  NotificationsCreatorVersion: '1.0.0-dev.20240216.1'
-  PipelineOwnersExtractorVersion: '1.0.0-dev.20240216.1'
+  NotificationsCreatorVersion: '1.0.0-dev.20240227.1'
+  PipelineOwnersExtractorVersion: '1.0.0-dev.20240227.1'


### PR DESCRIPTION
Updates to the CodeownersLinter, NotificationConfiguration and PipelineOwnersExtractor tool versions for the CodeownersUtils update to [change the way ServiceLabel parses with AzureSdkOwners](https://github.com/Azure/azure-sdk-tools/pull/7754)