### PR TITLE
Compress Test Proxy logs before publishing

### DIFF
--- a/eng/common/testproxy/publish-proxy-logs.yml
+++ b/eng/common/testproxy/publish-proxy-logs.yml
@@ -3,16 +3,16 @@ parameters:
 
 steps:
   - pwsh: |
-      Copy-Item -Path "${{ parameters.rootFolder }}/test-proxy.log" -Destination "${{ parameters.rootFolder }}/proxy.log"
-    displayName: Copy Log File
+      Compress-Archive -Path "${{ parameters.rootFolder }}/test-proxy.log" -Destination "${{ parameters.rootFolder }}/proxy.zip"
+    displayName: Compress and Copy Log File
     condition: succeededOrFailed()
 
   - template: ../pipelines/templates/steps/publish-artifact.yml
     parameters:
       ArtifactName: "$(System.StageName)-$(System.JobName)-$(System.JobAttempt)-proxy-logs"
-      ArtifactPath: "${{ parameters.rootFolder }}/proxy.log"
+      ArtifactPath: "${{ parameters.rootFolder }}/proxy.zip"
 
   - pwsh: |
-      Remove-Item -Force ${{ parameters.rootFolder }}/proxy.log
+      Remove-Item -Force ${{ parameters.rootFolder }}/proxy.zip
     displayName: Cleanup Copied Log File
     condition: succeededOrFailed()

--- a/eng/common/testproxy/publish-proxy-logs.yml
+++ b/eng/common/testproxy/publish-proxy-logs.yml
@@ -3,8 +3,9 @@ parameters:
 
 steps:
   - pwsh: |
-      Compress-Archive -Path "${{ parameters.rootFolder }}/test-proxy.log" -Destination "${{ parameters.rootFolder }}/proxy.zip"
-    displayName: Compress and Copy Log File
+      Copy-Item -Path "${{ parameters.rootFolder }}/test-proxy.log" -Destination "${{ parameters.rootFolder }}/proxy.log"
+      Compress-Archive -Path "${{ parameters.rootFolder }}/proxy.log" -Destination "${{ parameters.rootFolder }}/proxy.zip"
+    displayName: Copy and Compress Log File
     condition: succeededOrFailed()
 
   - template: ../pipelines/templates/steps/publish-artifact.yml
@@ -13,6 +14,7 @@ steps:
       ArtifactPath: "${{ parameters.rootFolder }}/proxy.zip"
 
   - pwsh: |
+      Remove-Item -Force ${{ parameters.rootFolder }}/proxy.log
       Remove-Item -Force ${{ parameters.rootFolder }}/proxy.zip
     displayName: Cleanup Copied Log File
     condition: succeededOrFailed()


### PR DESCRIPTION
Adds compression of Test Proxy's `proxy.log` file before publishing it to reduce the size of the artifact and to make it faster to download large log files. For example, in Java Storage this generates roughly a 90-100MB log file uncompressed, compressed it's closer to 5-10MB.

Further work could be done in this area to only publish if the build has failed or DevOps pipeline debugging is enabled.