### PR TITLE
Exclude cspell.json from auto-sync

### DIFF
--- a/eng/pipelines/mirror-repos.yml
+++ b/eng/pipelines/mirror-repos.yml
@@ -36,22 +36,22 @@ jobs:
             TargetBranches:
               RPSaaSMaster:
                 Theirs: '@("**")'
-                Ours: '@("specification", "custom-words.txt")'
+                Ours: '@("specification", "custom-words.txt", "cSpell.json")'
                 Merge: '@("specification/common-types")'
                 AcceptTheirsForFinalMerge: true
               RPSaaSDev:
                 Theirs: '@("**")'
-                Ours: '@("specification", "custom-words.txt")'
+                Ours: '@("specification", "custom-words.txt", "cSpell.json")'
                 Merge: '@("specification/common-types")'
                 AcceptTheirsForFinalMerge: true
               ARMCoreRPDev:
                 Theirs: '@("**")'
-                Ours: '@("specification", "custom-words.txt")'
+                Ours: '@("specification", "custom-words.txt", "cSpell.json")'
                 Merge: '@("specification/common-types")'
                 AcceptTheirsForFinalMerge: true
               InternalARMContracts:
                 Theirs: '@("**")'
-                Ours: '@("specification", "custom-words.txt")'
+                Ours: '@("specification", "custom-words.txt", "cSpell.json")'
                 Merge: '@("specification/common-types")'
                 AcceptTheirsForFinalMerge: true
 


### PR DESCRIPTION
cspell.json file gets edited often enough on both public and private and causes conflicts which we currently have just been overwriting with the changes on the public side. This has cause a few issues so instead I'm going to stop auto-syncing this file and so folks might need to make similar changes on both  sides similar to spec changes.