### PR TITLE
Remove github-issues from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,6 @@
 ###########
 /tools/                                @azure/azure-sdk-eng
 /tools/codeowners-utils/               @JimSuplizio
-/tools/github-issues/                  @praveenkuttappan @weshaggard
 /tools/github-event-processor/         @JimSuplizio @benbp
 /tools/github-team-user-store/         @JimSuplizio @weshaggard
 /tools/js-sdk-release-tools/           @qiaozha @MaryGao


### PR DESCRIPTION
@jsquire removed this directory with https://github.com/Azure/azure-sdk-tools/pull/7777 so making codeowners update as well given the linting pipeline failed for it last night https://dev.azure.com/azure-sdk/public/_build/results?buildId=3542559&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=259e4be2-1fd3-5c65-f373-9da11bbaf3b4&l=23