### PR TITLE
[GitHub] Add ESAM label

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -106,6 +106,7 @@ Data Migration,,e99695
 Data Share,,e99695
 DataBox,,e99695
 DataBox Edge,,e99695
+Defender ESAM,,e99695
 Dev Spaces,,e99695
 Device Update,,e99695
 DevOps,,e99695


### PR DESCRIPTION
# Summary

The focus of these changes is to add a new label for the "Defender EASM" service.