### PR TITLE
Fault-injector: yet another port fix, also make bodyless requests work again

### DIFF
--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <VersionPrefix>0.2.0</VersionPrefix>

--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/FaultInjectingMiddleware.cs
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/FaultInjectingMiddleware.cs
@@ -67,10 +67,13 @@ namespace Azure.Sdk.Tools.HttpFaultInjector
 
             using (var upstreamRequest = new HttpRequestMessage(new HttpMethod(request.Method), upstreamUri))
             {
-                upstreamRequest.Content = new StreamContent(request.Body);
-                foreach (var header in request.Headers.Where(h => Utils.ContentRequestHeaders.Contains(h.Key)))
-                {
-                    upstreamRequest.Content.Headers.Add(header.Key, values: header.Value);
+                if (Utils.HasBody(request))
+                { 
+                    upstreamRequest.Content = new StreamContent(request.Body);
+                    foreach (var header in request.Headers.Where(h => Utils.ContentRequestHeaders.Contains(h.Key)))
+                    {
+                        upstreamRequest.Content.Headers.Add(header.Key, values: header.Value);
+                    }
                 }
 
                 foreach (var header in request.Headers.Where(h => !Utils.ExcludedRequestHeaders.Contains(h.Key) && !Utils.ContentRequestHeaders.Contains(h.Key)))

--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Program.cs
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Program.cs
@@ -7,7 +7,9 @@ using Microsoft.Extensions.Logging;
 using OpenTelemetry.Logs;
 using OpenTelemetry.Resources;
 using System;
+using System.IO;
 using System.Net.Http;
+using System.Reflection;
 
 namespace Azure.Sdk.Tools.HttpFaultInjector
 {
@@ -28,6 +30,7 @@ namespace Azure.Sdk.Tools.HttpFaultInjector
             {
                 settings.CaseSensitive = false;
                 settings.HelpWriter = Console.Error;
+                settings.IgnoreUnknownArguments = true;
             });
 
             parser.ParseArguments<Options>(args).WithParsed(options => Run(options, args));
@@ -36,7 +39,12 @@ namespace Azure.Sdk.Tools.HttpFaultInjector
         private static void Run(Options options, string[] args)
         {
             TimeSpan keepAlive = TimeSpan.FromSeconds(options.KeepAliveTimeout);
-            var builder = WebApplication.CreateBuilder(args);
+            var builder = WebApplication.CreateBuilder(new WebApplicationOptions()
+            {
+                Args = args,
+                ContentRootPath = Directory.GetParent(Assembly.GetExecutingAssembly().Location)?.FullName
+            });
+
             builder.WebHost.ConfigureKestrel(kestrelOptions =>
             {
                 kestrelOptions.Limits.KeepAliveTimeout = keepAlive;

--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Utils.cs
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Utils.cs
@@ -1,5 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata;
+using Microsoft.AspNetCore.Http;
+using OpenTelemetry.Trace;
 
 namespace Azure.Sdk.Tools.HttpFaultInjector
 {
@@ -34,14 +38,28 @@ namespace Azure.Sdk.Tools.HttpFaultInjector
             ResponseSelectionHeader
         };
 
-        // Headers which must be set on HttpContent instead of HttpRequestMessage
+        // Headers which must be set on HttpContent instead of HttpRequestMessage, values from HttpContentHeaders
         public static readonly string[] ContentRequestHeaders = new string[] {
+            "Allow",
+            "Content-Disposition",
+            "Content-Encoding",
+            "Content-Language",
             "Content-Length",
+            "Content-Location",
+            "Content-MD5",
+            "Content-Range",
             "Content-Type",
+            "Expires",
+            "Last-Modified"
         };
 
         public const string ResponseSelectionHeader = "x-ms-faultinjector-response-option";
         public const string UpstreamBaseUriHeader = "X-Upstream-Base-Uri";
+
+        public static bool HasBody(HttpRequest request)
+        {
+            return request.ContentLength > 0 || request.Headers.TransferEncoding.Contains("chunked");
+        }
 
         public static string ReadSelectionFromConsole()
         {

--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/appsettings.json
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/appsettings.json
@@ -7,14 +7,5 @@
       "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information"
     }
   },
-  "Kestrel": {
-    "Endpoints": {
-      "http": {
-        "Url": "http://+:7777"
-      },
-      "https": {
-        "Url": "https://+:7778"
-      }
-    }
-  }
+  "urls": "http://+:7777;https://+:7778"
 }


### PR DESCRIPTION
Fixes some issues:
1. Allows to pass `urls` in cmd line to ASP.NET Core (`settings.IgnoreUnknownArguments = true;`)
2. Allows to use appsettings.json when fault-injector runs as global CLI (`ContentRootPath = Directory.GetParent(Assembly.GetExecutingAssembly().Location)?.FullName`), stolen from https://github.com/dotnet/sdk/issues/9730#issuecomment-1279845747
3. Fixes exception when request without body is being proxied (`if (Utils.HasBody(request))`)