### PR TITLE
remove autorest.python from label syncing

### DIFF
--- a/tools/github/data/repositories.txt
+++ b/tools/github/data/repositories.txt
@@ -24,7 +24,6 @@ Azure/azure-sdk-actions
 Azure/autorest
 Azure/autorest.csharp
 Azure/autorest.java
-Azure/autorest.python
 Azure/autorest.typescript
 Azure/autorest.go
 Azure/autorest.swift


### PR DESCRIPTION
We want to remove `autorest.python` from the label syncing because we have labels that are very different from the rest of our sdk repos. We would like to keep only our small list of labels for greater labeling clarity in the `autorest.python` repo, and not have a bunch of labels synced into our repo that pollute the label namespace and are of no use to us