### PR TITLE
Move sparse checkout to downloadable script

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -22,84 +22,20 @@ steps:
     ${{ else }}:
       displayName: 'Sparse checkout repositories'
     inputs:
+      # Use inline instead of file because of the chicken/egg problem with loading a script
+      # when nothing has been checked out yet. Download script to save size on the generated
+      # template to stay below the devops max.
       targetType: inline
-      # Define this inline, because of the chicken/egg problem with loading a script when nothing
-      # has been checked out yet.
       script: |
-        # Setting $PSNativeCommandArgumentPassing to 'Legacy' to use PowerShell
-        # 7.2 behavior for command argument passing. Newer behaviors will result
-        # in errors from git.exe.
-        $PSNativeCommandArgumentPassing = 'Legacy'
-        
-        function SparseCheckout([Array]$paths, [Hashtable]$repository)
-        {
-            $dir = $repository.WorkingDirectory
-            if (!$dir) {
-              $dir = "./$($repository.Name)"
-            }
-            New-Item $dir -ItemType Directory -Force | Out-Null
-            Push-Location $dir
-
-            if (Test-Path .git/info/sparse-checkout) {
-              $hasInitialized = $true
-              Write-Host "Repository $($repository.Name) has already been initialized. Skipping this step."
-            } else {
-              Write-Host "Repository $($repository.Name) is being initialized."
-
-              if ($repository.Commitish -match '^refs/pull/\d+/merge$') {
-                Write-Host "git clone --no-checkout --filter=tree:0 -c remote.origin.fetch='+$($repository.Commitish):refs/remotes/origin/$($repository.Commitish)' https://github.com/$($repository.Name) ."
-                git clone --no-checkout --filter=tree:0 -c remote.origin.fetch=''+$($repository.Commitish):refs/remotes/origin/$($repository.Commitish)'' https://github.com/$($repository.Name) .
-              } else {
-                Write-Host "git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) ."
-                git clone --no-checkout --filter=tree:0 https://github.com/$($repository.Name) .
-              }
-
-              # Turn off git GC for sparse checkout. Note: The devops checkout task does this by default
-              Write-Host "git config gc.auto 0"
-              git config gc.auto 0
-
-              Write-Host "git sparse-checkout init"
-              git sparse-checkout init
-
-              # Set non-cone mode otherwise path filters will not work in git >= 2.37.0
-              # See https://github.blog/2022-06-27-highlights-from-git-2-37/#tidbits
-              Write-Host "git sparse-checkout set --no-cone '/*' '!/*/' '/eng'"
-              git sparse-checkout set --no-cone '/*' '!/*/' '/eng'
-            }
-
-            # Prevent wildcard expansion in Invoke-Expression (e.g. for checkout path '/*')
-            $quotedPaths = $paths | ForEach-Object { "'$_'" }
-            $gitsparsecmd = "git sparse-checkout add $quotedPaths"
-            Write-Host $gitsparsecmd
-            Invoke-Expression -Command $gitsparsecmd
-
-            Write-Host "Set sparse checkout paths to:"
-            Get-Content .git/info/sparse-checkout
-
-            # sparse-checkout commands after initial checkout will auto-checkout again
-            if (!$hasInitialized) {
-              # Remove refs/heads/ prefix from branch names
-              $commitish = $repository.Commitish -replace '^refs/heads/', ''
-
-              # use -- to prevent git from interpreting the commitish as a path
-              Write-Host "git -c advice.detachedHead=false checkout $commitish --"
-
-              # This will use the default branch if repo.Commitish is empty
-              git -c advice.detachedHead=false checkout $commitish --
-            } else {
-              Write-Host "Skipping checkout as repo has already been initialized"
-            }
-
-            Pop-Location
-        }
-
+        $req = Invoke-WebRequest "https://raw.githubusercontent.com/$(Build.Repository.Name)/main/eng/common/scripts/sparse-checkout.ps1"
+        $req.RawContent | Out-File $(Agent.TempDirectory)/sparse-checkout.ps1
         # Paths may be sourced as a yaml object literal OR a dynamically generated variable json string.
         # If the latter, convertToJson will wrap the 'string' in quotes, so remove them.
         $paths = '${{ convertToJson(parameters.Paths) }}'.Trim('"') | ConvertFrom-Json
         # Replace windows backslash paths, as Azure Pipelines default directories are sometimes formatted like 'D:\a\1\s'
         $repositories = '${{ convertToJson(parameters.Repositories) }}' -replace '\\', '/' | ConvertFrom-Json -AsHashtable
         foreach ($repo in $Repositories) {
-          SparseCheckout $paths $repo
+          $(Agent.TempDirectory)/sparse-checkout.ps1 -Paths $paths -Repository $repo
         }
       pwsh: true
       workingDirectory: $(System.DefaultWorkingDirectory)

--- a/eng/common/scripts/sparse-checkout.ps1
+++ b/eng/common/scripts/sparse-checkout.ps1
@@ -1,0 +1,77 @@
+param(
+  # Sparse checkout paths (glob optional via no-cone mode)
+  [Parameter()]
+  [Array]$Paths = @(),
+  # Expect like
+  # @{
+  #     Name = '<org>/<repo>'
+  #     Commitish = '<commit sha or branch/tag>'
+  #     WorkingDirectory = '<path to clone to>'
+  # }
+  [Parameter(Mandatory = $true)]
+  [Hashtable]$Repository
+)
+
+# Setting $PSNativeCommandArgumentPassing to 'Legacy' to use PowerShell
+# 7.2 behavior for command argument passing. Newer behaviors will result
+# in errors from git.exe.
+$PSNativeCommandArgumentPassing = 'Legacy'
+
+$dir = $Repository.WorkingDirectory
+if (!$dir) {
+  $dir = "./$($Repository.Name)"
+}
+New-Item $dir -ItemType Directory -Force | Out-Null
+Push-Location $dir
+
+if (Test-Path .git/info/sparse-checkout) {
+  $hasInitialized = $true
+  Write-Host "Repository $($Repository.Name) has already been initialized. Skipping this step."
+} else {
+  Write-Host "Repository $($Repository.Name) is being initialized."
+
+  if ($Repository.Commitish -match '^refs/pull/\d+/merge$') {
+    Write-Host "git clone --no-checkout --filter=tree:0 -c remote.origin.fetch='+$($Repository.Commitish):refs/remotes/origin/$($Repository.Commitish)' https://github.com/$($Repository.Name) ."
+    git clone --no-checkout --filter=tree:0 -c remote.origin.fetch=''+$($Repository.Commitish):refs/remotes/origin/$($Repository.Commitish)'' https://github.com/$($Repository.Name) .
+  } else {
+    Write-Host "git clone --no-checkout --filter=tree:0 https://github.com/$($Repository.Name) ."
+    git clone --no-checkout --filter=tree:0 https://github.com/$($Repository.Name) .
+  }
+
+  # Turn off git GC for sparse checkout. Note: The devops checkout task does this by default
+  Write-Host "git config gc.auto 0"
+  git config gc.auto 0
+
+  Write-Host "git sparse-checkout init"
+  git sparse-checkout init
+
+  # Set non-cone mode otherwise path filters will not work in git >= 2.37.0
+  # See https://github.blog/2022-06-27-highlights-from-git-2-37/#tidbits
+  Write-Host "git sparse-checkout set --no-cone '/*' '!/*/' '/eng'"
+  git sparse-checkout set --no-cone '/*' '!/*/' '/eng'
+}
+
+# Prevent wildcard expansion in Invoke-Expression (e.g. for checkout path '/*')
+$quotedPaths = $Paths | ForEach-Object { "'$_'" }
+$gitsparsecmd = "git sparse-checkout add $quotedPaths"
+Write-Host $gitsparsecmd
+Invoke-Expression -Command $gitsparsecmd
+
+Write-Host "Set sparse checkout paths to:"
+Get-Content .git/info/sparse-checkout
+
+# sparse-checkout commands after initial checkout will auto-checkout again
+if (!$hasInitialized) {
+  # Remove refs/heads/ prefix from branch names
+  $commitish = $Repository.Commitish -replace '^refs/heads/', ''
+
+  # use -- to prevent git from interpreting the commitish as a path
+  Write-Host "git -c advice.detachedHead=false checkout $commitish --"
+
+  # This will use the default branch if repo.Commitish is empty
+  git -c advice.detachedHead=false checkout $commitish --
+} else {
+  Write-Host "Skipping checkout as repo has already been initialized"
+}
+
+Pop-Location


### PR DESCRIPTION
With the move to 1es pipeline templates, some of our pipelines are again exceeding the azure pipelines max template size (4mb??). I found that about 3k lines of our 9k lines in core (pre 1es pt) is due to sparse checkout inlining duplication. We still have a chicken/egg problem so the script can't be referenced via file, but we CAN download the script from github raw content to save a bit of space. Another benefit is our checkout logic is finally in a script that other people can call if they so desire.
