### PR TITLE
Adjust `Verify-Agent-OS` for the osname being passed in

### DIFF
--- a/eng/common/scripts/Verify-AgentOS.ps1
+++ b/eng/common/scripts/Verify-AgentOS.ps1
@@ -10,7 +10,7 @@ function Throw-InvalidOperatingSystem {
 
 if ($IsWindows -and $AgentImage -match "windows|win|MMS\d{4}") {
     $osName = "Windows"
-} elseif ($IsLinux -and $AgentImage -match "ubuntu") {
+} elseif ($IsLinux -and $AgentImage -match "ubuntu|linux") {
     $osName = "Linux"
 } elseif ($IsMacOs -and $AgentImage -match "macos") {
     $osName = "macOS"


### PR DESCRIPTION
- [Example Failure](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3556677&view=logs&j=34a74d89-87cb-562a-2d02-4b1440261725&t=c57de52d-5883-56a4-7b0a-3d2d2cae2886)
