### PR TITLE
Update package version on automatic API revision

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
@@ -46,9 +46,9 @@ namespace APIViewWeb.Controllers
                         runAnalysis: false, memoryStream: memoryStream);
 
                     var apiRevision = await CreateAutomaticRevisionAsync(codeFile: codeFile, label: label, originalName: file.FileName, memoryStream: memoryStream, compareAllRevisions);
-
                     if (apiRevision != null)
                     {
+                        apiRevision = await _apiRevisionsManager.UpdateRevisionPackageVersionAsync(apiRevision, codeFile.PackageVersion);
                         var reviewUrl = $"{this.Request.Scheme}://{this.Request.Host}/Assemblies/Review/{apiRevision.ReviewId}?revisionId={apiRevision.Id}";
                         return apiRevision.IsApproved ? Ok(reviewUrl) : StatusCode(statusCode: StatusCodes.Status201Created, reviewUrl);
                     }
@@ -115,6 +115,7 @@ namespace APIViewWeb.Controllers
             var apiRevision = await CreateAutomaticRevisionAsync(codeFile: codeFile, label: label, originalName: originalFilePath, memoryStream: memoryStream, compareAllRevisions);
             if (apiRevision != null)
             {
+                apiRevision = await _apiRevisionsManager.UpdateRevisionPackageVersionAsync(apiRevision, codeFile.PackageVersion);
                 var reviewUrl = $"{this.Request.Scheme}://{this.Request.Host}/Assemblies/Review/{apiRevision.ReviewId}?revisionId={apiRevision.Id}";
                 return apiRevision.IsApproved ? Ok(reviewUrl) : StatusCode(statusCode: StatusCodes.Status201Created, reviewUrl);
             }

--- a/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
@@ -35,7 +35,7 @@ namespace APIViewWeb.Controllers
         }
 
         [HttpPost]
-        public async Task<ActionResult> UploadAutoReview([FromForm] IFormFile file, string label, bool compareAllRevisions = false)
+        public async Task<ActionResult> UploadAutoReview([FromForm] IFormFile file, string label, bool compareAllRevisions = false, string packageVersion = null)
         {
             if (file != null)
             {
@@ -48,7 +48,7 @@ namespace APIViewWeb.Controllers
                     var apiRevision = await CreateAutomaticRevisionAsync(codeFile: codeFile, label: label, originalName: file.FileName, memoryStream: memoryStream, compareAllRevisions);
                     if (apiRevision != null)
                     {
-                        apiRevision = await _apiRevisionsManager.UpdateRevisionPackageVersionAsync(apiRevision, codeFile.PackageVersion);
+                        apiRevision = await _apiRevisionsManager.UpdateRevisionMetadataAsync(apiRevision, packageVersion ?? codeFile.PackageVersion, label);
                         var reviewUrl = $"{this.Request.Scheme}://{this.Request.Host}/Assemblies/Review/{apiRevision.ReviewId}?revisionId={apiRevision.Id}";
                         return apiRevision.IsApproved ? Ok(reviewUrl) : StatusCode(statusCode: StatusCodes.Status201Created, reviewUrl);
                     }
@@ -100,7 +100,8 @@ namespace APIViewWeb.Controllers
             string repoName,
             string packageName,
             bool compareAllRevisions,
-            string project
+            string project,
+            string packageVersion = null
             )
         {
             using var memoryStream = new MemoryStream();
@@ -115,7 +116,7 @@ namespace APIViewWeb.Controllers
             var apiRevision = await CreateAutomaticRevisionAsync(codeFile: codeFile, label: label, originalName: originalFilePath, memoryStream: memoryStream, compareAllRevisions);
             if (apiRevision != null)
             {
-                apiRevision = await _apiRevisionsManager.UpdateRevisionPackageVersionAsync(apiRevision, codeFile.PackageVersion);
+                apiRevision = await _apiRevisionsManager.UpdateRevisionMetadataAsync(apiRevision, packageVersion ?? codeFile.PackageVersion, label);
                 var reviewUrl = $"{this.Request.Scheme}://{this.Request.Host}/Assemblies/Review/{apiRevision.ReviewId}?revisionId={apiRevision.Id}";
                 return apiRevision.IsApproved ? Ok(reviewUrl) : StatusCode(statusCode: StatusCodes.Status201Created, reviewUrl);
             }
@@ -199,8 +200,8 @@ namespace APIViewWeb.Controllers
                         if (apiRev.IsApproved && await _apiRevisionsManager.AreAPIRevisionsTheSame(apiRev, renderedCodeFile))
                         {
                             await _apiRevisionsManager.ToggleAPIRevisionApprovalAsync(user: User, id: review.Id, apiRevision: apiRevision, notes: $"Approval Copied over from Revision with Id : {apiRev.Id}", approver: apiRev.Approvers.LastOrDefault());
-                        }
-                        break;
+                            break;
+                        }    
                     }
                 }
             }

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -829,11 +829,12 @@ namespace APIViewWeb.Managers
             return result;
         }
 
-        public async Task<APIRevisionListItemModel> UpdateRevisionPackageVersionAsync(APIRevisionListItemModel revision, string packageVersion)
+        public async Task<APIRevisionListItemModel> UpdateRevisionMetadataAsync(APIRevisionListItemModel revision, string packageVersion, string label)
         {
             if (packageVersion != null && !packageVersion.Equals(revision.Files[0].PackageVersion))
             {
                 revision.Files[0].PackageVersion = packageVersion;
+                revision.Label = label;
                 await _apiRevisionsRepository.UpsertAPIRevisionAsync(revision);
             }
             return revision;

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -828,5 +828,15 @@ namespace APIViewWeb.Managers
             }
             return result;
         }
+
+        public async Task<APIRevisionListItemModel> UpdateRevisionPackageVersionAsync(APIRevisionListItemModel revision, string packageVersion)
+        {
+            if (packageVersion != null && !packageVersion.Equals(revision.Files[0].PackageVersion))
+            {
+                revision.Files[0].PackageVersion = packageVersion;
+                await _apiRevisionsRepository.UpsertAPIRevisionAsync(revision);
+            }
+            return revision;
+        }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -40,5 +40,6 @@ namespace APIViewWeb.Managers.Interfaces
         public Task AutoArchiveAPIRevisions(int archiveAfterMonths);
         public Task AssignReviewersToAPIRevisionAsync(ClaimsPrincipal User, string apiRevisionId, HashSet<string> reviewers);
         public Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAssignedToUser(string userName);
+        public Task<APIRevisionListItemModel> UpdateRevisionPackageVersionAsync(APIRevisionListItemModel revision, string packageVersion);
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -40,6 +40,6 @@ namespace APIViewWeb.Managers.Interfaces
         public Task AutoArchiveAPIRevisions(int archiveAfterMonths);
         public Task AssignReviewersToAPIRevisionAsync(ClaimsPrincipal User, string apiRevisionId, HashSet<string> reviewers);
         public Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAssignedToUser(string userName);
-        public Task<APIRevisionListItemModel> UpdateRevisionPackageVersionAsync(APIRevisionListItemModel revision, string packageVersion);
+        public Task<APIRevisionListItemModel> UpdateRevisionMetadataAsync(APIRevisionListItemModel revision, string packageVersion, string label);
     }
 }


### PR DESCRIPTION
Update package version on API revision even if API surface matches to reflect correct package version info. This change along with tagging a revision after package release will ensure that package version is updated correctly(A separate change from updating package version). 