### PR TITLE
Get api review approval status for a given package version

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -868,7 +868,7 @@ namespace APIViewWeb.Managers
 
                 // Check for revisions with matching
                 var versionGroups = packageVersion.Split('.');
-                var majorMinor = $"{versionGroups[0]}.{versionGroups[1]}";
+                var majorMinor = $"{versionGroups[0]}.{versionGroups[1]}.";
                 var majorMinorMatchRevisions = apiRevisions.Where(r => !string.IsNullOrEmpty(r.Files[0].PackageVersion) && r.Files[0].PackageVersion.StartsWith(majorMinor));
                 if (majorMinorMatchRevisions.Any())
                 {

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -77,10 +77,37 @@ namespace APIViewWeb.Managers
         /// Retrieve Revisions for a particular Review from the Revisions container in CosmosDb
         /// </summary>
         /// <param name="reviewId"></param> The Reviewid for which the revisions are to be retrieved
+        /// <param name="packageVersion"></param> Optional package version param to return a matching revision for the package version 
+        /// <param name="apiRevisionType"></param> optional API revision type filter
         /// <returns></returns>
-        public async Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAsync(string reviewId)
+        public async Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAsync(string reviewId, string packageVersion = "", APIRevisionType apiRevisionType = APIRevisionType.All)
         {
-            return await _apiRevisionsRepository.GetAPIRevisionsAsync(reviewId);
+            var apiRevisions = await _apiRevisionsRepository.GetAPIRevisionsAsync(reviewId);
+
+            if (apiRevisionType != APIRevisionType.All)
+                apiRevisions = apiRevisions.Where(r => r.APIRevisionType == apiRevisionType);
+
+            if (!string.IsNullOrEmpty(packageVersion))
+            {                
+                // Check for exact same package version
+                // If exact version is not found in revision then search for same major and minor version and return the latest.
+                var exactMatchRevisions = apiRevisions.Where(r => packageVersion.Equals(r.Files[0].PackageVersion));
+                if (exactMatchRevisions.Any())
+                {
+                    return exactMatchRevisions.OrderByDescending(r => r.CreatedOn);
+                }
+
+                // Check for revisions with matching
+                var versionGroups = packageVersion.Split('.');
+                var majorMinor = $"{versionGroups[0]}.{versionGroups[1]}.";
+                var majorMinorMatchRevisions = apiRevisions.Where(r => !string.IsNullOrEmpty(r.Files[0].PackageVersion) && r.Files[0].PackageVersion.StartsWith(majorMinor));
+                if (majorMinorMatchRevisions.Any())
+                {
+                    return majorMinorMatchRevisions.OrderByDescending(r => r.CreatedOn);
+                }                
+                return majorMinorMatchRevisions;
+            }
+            return apiRevisions;
         }
 
         /// <summary>
@@ -839,43 +866,6 @@ namespace APIViewWeb.Managers
                 await _apiRevisionsRepository.UpsertAPIRevisionAsync(revision);
             }
             return revision;
-        }
-
-
-        /// <summary>
-        /// Retrieve the latest APIRevison for a particular Review with a matching package version(atleast major and minor version match).
-        /// Filter by APIRevisionType if specified and Review contains specified type
-        /// If APIRevisionType is not specified, return the latest revision irrespective of the type
-        /// Return default if no revision is found
-        /// </summary>
-        /// <param name="reviewId"></param>
-        /// <param name="packageVersion"></param>
-        /// <param name="apiRevisionType"></param>
-        /// <returns>APIRevisionListItemModel</returns>
-        public async Task<APIRevisionListItemModel> GetRevisionForPackageVersionAsync(string reviewId, string packageVersion, APIRevisionType apiRevisionType = APIRevisionType.All)
-        {
-            var apiRevisions = await _apiRevisionsRepository.GetAPIRevisionsAsync(reviewId);
-            if (apiRevisionType != APIRevisionType.All && apiRevisions.Any(r => r.APIRevisionType == apiRevisionType))
-            {
-                apiRevisions = apiRevisions.Where(r => r.APIRevisionType == apiRevisionType);
-                // Check for exact same package version
-                // If exact version is not found in revision then search for same major and minor version and return the latest.
-                var exactMatchRevisions = apiRevisions.Where(r => packageVersion.Equals(r.Files[0].PackageVersion));
-                if (exactMatchRevisions.Any())
-                {
-                    return exactMatchRevisions.OrderByDescending(r => r.CreatedOn).First();
-                }
-
-                // Check for revisions with matching
-                var versionGroups = packageVersion.Split('.');
-                var majorMinor = $"{versionGroups[0]}.{versionGroups[1]}.";
-                var majorMinorMatchRevisions = apiRevisions.Where(r => !string.IsNullOrEmpty(r.Files[0].PackageVersion) && r.Files[0].PackageVersion.StartsWith(majorMinor));
-                if (majorMinorMatchRevisions.Any())
-                {
-                    return majorMinorMatchRevisions.OrderByDescending(r => r.CreatedOn).First();
-                }
-            }
-            return null;
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -41,5 +41,6 @@ namespace APIViewWeb.Managers.Interfaces
         public Task AssignReviewersToAPIRevisionAsync(ClaimsPrincipal User, string apiRevisionId, HashSet<string> reviewers);
         public Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAssignedToUser(string userName);
         public Task<APIRevisionListItemModel> UpdateRevisionMetadataAsync(APIRevisionListItemModel revision, string packageVersion, string label);
+        public Task<APIRevisionListItemModel> GetRevisionForPackageVersionAsync(string reviewId, string packageVersion, APIRevisionType apiRevisionType);
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -15,7 +15,7 @@ namespace APIViewWeb.Managers.Interfaces
     public interface IAPIRevisionsManager
     {
         public Task<PagedList<APIRevisionListItemModel>> GetAPIRevisionsAsync(PageParams pageParams, APIRevisionsFilterAndSortParams filterAndSortParams);
-        public Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAsync(string reviewId);
+        public Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAsync(string reviewId, string packageVersion = "", APIRevisionType apiRevisionType = APIRevisionType.All);
         public Task<APIRevisionListItemModel> GetLatestAPIRevisionsAsync(string reviewId = null, IEnumerable<APIRevisionListItemModel> apiRevisions = null, APIRevisionType apiRevisionType = APIRevisionType.All);
         public Task<APIRevisionListItemModel> GetAPIRevisionAsync(ClaimsPrincipal user, string apiRevisionId);
         public Task<APIRevisionListItemModel> GetAPIRevisionAsync(string apiRevisionId);
@@ -41,6 +41,5 @@ namespace APIViewWeb.Managers.Interfaces
         public Task AssignReviewersToAPIRevisionAsync(ClaimsPrincipal User, string apiRevisionId, HashSet<string> reviewers);
         public Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAssignedToUser(string userName);
         public Task<APIRevisionListItemModel> UpdateRevisionMetadataAsync(APIRevisionListItemModel revision, string packageVersion, string label);
-        public Task<APIRevisionListItemModel> GetRevisionForPackageVersionAsync(string reviewId, string packageVersion, APIRevisionType apiRevisionType);
     }
 }


### PR DESCRIPTION
Add new option param to get review status for a given package version. If exact match is not for input version, then check will look for latest matching revision with same major and minor version number. If there is still no match then it will return latest automatic API review revision status.