### PR TITLE
[GitHub] Add Code Signing service label

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -35,6 +35,7 @@ Central-EngSys,This issue is owned by the Engineering System team.,ffeb77
 Client,This issue points to a problem in the data-plane of the library.,ffeb77
 Cloud Shell,,e99695
 CodeGen,Issues that relate to code generation,e99695
+Code Signing,,e99695
 Cognitive - Anomaly Detector,,e99695
 Cognitive - Bing,,e99695
 Cognitive - Computer Vision,,e99695


### PR DESCRIPTION
# Summary

The focus of these changes is to a new service label for `Code Signing` to the common label set in support of the client library under development.