### PR TITLE
Update Prepare-Release.ps1 to handle only one previous release

### DIFF
--- a/eng/common/scripts/Prepare-Release.ps1
+++ b/eng/common/scripts/Prepare-Release.ps1
@@ -116,7 +116,7 @@ $month = $ParsedReleaseDate.ToString("MMMM")
 Write-Host "Assuming release is in $month with release date $releaseDateString" -ForegroundColor Green
 if (Test-Path "Function:GetExistingPackageVersions")
 {
-    $releasedVersions = GetExistingPackageVersions -PackageName $packageProperties.Name -GroupId $packageProperties.Group
+    $releasedVersions = @(GetExistingPackageVersions -PackageName $packageProperties.Name -GroupId $packageProperties.Group)
     if ($null -ne $releasedVersions -and $releasedVersions.Count -gt 0)
     {
       $latestReleasedVersion = $releasedVersions[$releasedVersions.Count - 1]


### PR DESCRIPTION
In the case there is exactly one previous release PS will return the single object and thus the Count property will not exist. Instead this change ensures that we always have a list.