### PR TITLE
Fix package type in pipeline

### DIFF
--- a/eng/pipelines/devops-create-package-workitem.yml
+++ b/eng/pipelines/devops-create-package-workitem.yml
@@ -24,9 +24,9 @@ parameters:
   default: ''
 - name: PackageType
   type: string
-  default: 'Client'
+  default: 'client'
   values:
-  - Client
+  - client
   - mgmt
 - name: PackageName
   displayName: Package Name (e.g. Azure.Core)
@@ -50,7 +50,6 @@ parameters:
 
 steps:
 - checkout: self
-
 
 - task: PowerShell@2
   displayName: Create Package Work Item


### PR DESCRIPTION
This will fix one of the issues which was the wrong case of the package type. 

We should however not reenable this pipeline until we can get a correct repo path as well.