### PR TITLE
Scheduled event processing update

### DIFF
--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
@@ -116,6 +116,25 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests
         }
 
         /// <summary>
+        /// The mock ProcessPendingScheduledUpdates just returns the number of updates
+        /// </summary>
+        /// <returns>integer,the number of pending updates that would be processed</returns>
+        public override Task<int> ProcessPendingScheduledUpdates()
+        {
+            int numUpdates = 0;
+            Console.WriteLine($"ProcessPendingScheduledUpdates::ProcessPendingUpdates, number of pending comments = {_gitHubComments.Count}");
+            numUpdates += _gitHubComments.Count;
+
+            Console.WriteLine($"ProcessPendingScheduledUpdates::ProcessPendingUpdates, number of pending IssueUpdates = {_gitHubIssuesToUpdate.Count}");
+            numUpdates += _gitHubIssuesToUpdate.Count;
+
+            Console.WriteLine($"ProcessPendingScheduledUpdates::ProcessPendingUpdates, number of issues to Lock = {_gitHubIssuesToLock.Count}");
+            numUpdates += _gitHubIssuesToLock.Count;
+
+            return Task.FromResult(numUpdates);
+        }
+
+        /// <summary>
         /// IsUserCollaborator override. Returns IsCollaboratorReturn value
         /// </summary>
         /// <param name="repositoryId">The Id of the repository</param>

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Static/ScheduledEventProcessingTests.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Static/ScheduledEventProcessingTests.cs
@@ -43,7 +43,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
             mockGitHubEventClient.CreateSearchIssuesResult(expectedUpdates, scheduledEventPayload.Repository, ItemState.Open);
             await ScheduledEventProcessing.CloseAddressedIssues(mockGitHubEventClient, scheduledEventPayload);
 
-            var totalUpdates = await mockGitHubEventClient.ProcessPendingUpdates(scheduledEventPayload.Repository.Id);
+            var totalUpdates = await mockGitHubEventClient.ProcessPendingScheduledUpdates();
             // Verify the RuleCheck 
             Assert.AreEqual(ruleState == RuleState.On, mockGitHubEventClient.RulesConfiguration.RuleEnabled(rule), $"Rule '{rule}' enabled should have been {ruleState == RuleState.On} but RuleEnabled returned {ruleState != RuleState.On}.'");
             if (RuleState.On == ruleState)
@@ -86,7 +86,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
             mockGitHubEventClient.CreateSearchIssuesResult(expectedUpdates, scheduledEventPayload.Repository, ItemState.Open);
             await ScheduledEventProcessing.CloseStaleIssues(mockGitHubEventClient, scheduledEventPayload);
 
-            var totalUpdates = await mockGitHubEventClient.ProcessPendingUpdates(scheduledEventPayload.Repository.Id);
+            var totalUpdates = await mockGitHubEventClient.ProcessPendingScheduledUpdates();
             // Verify the RuleCheck 
             Assert.AreEqual(ruleState == RuleState.On, mockGitHubEventClient.RulesConfiguration.RuleEnabled(rule), $"Rule '{rule}' enabled should have been {ruleState == RuleState.On} but RuleEnabled returned {ruleState != RuleState.On}.'");
             if (RuleState.On == ruleState)
@@ -128,7 +128,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
             mockGitHubEventClient.CreateSearchIssuesResult(expectedUpdates, scheduledEventPayload.Repository, ItemState.Open);
             await ScheduledEventProcessing.CloseStalePullRequests(mockGitHubEventClient, scheduledEventPayload);
 
-            var totalUpdates = await mockGitHubEventClient.ProcessPendingUpdates(scheduledEventPayload.Repository.Id);
+            var totalUpdates = await mockGitHubEventClient.ProcessPendingScheduledUpdates();
             // Verify the RuleCheck 
             Assert.AreEqual(ruleState == RuleState.On, mockGitHubEventClient.RulesConfiguration.RuleEnabled(rule), $"Rule '{rule}' enabled should have been {ruleState == RuleState.On} but RuleEnabled returned {ruleState != RuleState.On}.'");
             if (RuleState.On == ruleState)
@@ -173,7 +173,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
             mockGitHubEventClient.CreateSearchIssuesResult(expectedUpdates, scheduledEventPayload.Repository, ItemState.Open);
             await ScheduledEventProcessing.IdentifyStalePullRequests(mockGitHubEventClient, scheduledEventPayload);
 
-            var totalUpdates = await mockGitHubEventClient.ProcessPendingUpdates(scheduledEventPayload.Repository.Id);
+            var totalUpdates = await mockGitHubEventClient.ProcessPendingScheduledUpdates();
             // Verify the RuleCheck 
             Assert.AreEqual(ruleState == RuleState.On, mockGitHubEventClient.RulesConfiguration.RuleEnabled(rule), $"Rule '{rule}' enabled should have been {ruleState == RuleState.On} but RuleEnabled returned {ruleState != RuleState.On}.'");
             if (RuleState.On == ruleState)
@@ -218,7 +218,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
             mockGitHubEventClient.CreateSearchIssuesResult(expectedUpdates, scheduledEventPayload.Repository, ItemState.Open);
             await ScheduledEventProcessing.IdentifyStaleIssues(mockGitHubEventClient, scheduledEventPayload);
 
-            var totalUpdates = await mockGitHubEventClient.ProcessPendingUpdates(scheduledEventPayload.Repository.Id);
+            var totalUpdates = await mockGitHubEventClient.ProcessPendingScheduledUpdates();
             // Verify the RuleCheck 
             Assert.AreEqual(ruleState == RuleState.On, mockGitHubEventClient.RulesConfiguration.RuleEnabled(rule), $"Rule '{rule}' enabled should have been {ruleState == RuleState.On} but RuleEnabled returned {ruleState != RuleState.On}.'");
             if (RuleState.On == ruleState)
@@ -261,7 +261,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
             mockGitHubEventClient.CreateSearchIssuesResult(expectedUpdates, scheduledEventPayload.Repository, ItemState.Open);
             await ScheduledEventProcessing.LockClosedIssues(mockGitHubEventClient, scheduledEventPayload);
 
-            var totalUpdates = await mockGitHubEventClient.ProcessPendingUpdates(scheduledEventPayload.Repository.Id);
+            var totalUpdates = await mockGitHubEventClient.ProcessPendingScheduledUpdates();
             // Verify the RuleCheck 
             Assert.AreEqual(ruleState == RuleState.On, mockGitHubEventClient.RulesConfiguration.RuleEnabled(rule), $"Rule '{rule}' enabled should have been {ruleState == RuleState.On} but RuleEnabled returned {ruleState != RuleState.On}.'");
             if (RuleState.On == ruleState)
@@ -303,7 +303,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
             mockGitHubEventClient.CreateSearchIssuesResult(expectedUpdates, scheduledEventPayload.Repository, ItemState.Open);
             await ScheduledEventProcessing.EnforceMaxLifeOfIssues(mockGitHubEventClient, scheduledEventPayload);
 
-            var totalUpdates = await mockGitHubEventClient.ProcessPendingUpdates(scheduledEventPayload.Repository.Id);
+            var totalUpdates = await mockGitHubEventClient.ProcessPendingScheduledUpdates();
             // Verify the RuleCheck 
             Assert.AreEqual(ruleState == RuleState.On, mockGitHubEventClient.RulesConfiguration.RuleEnabled(rule), $"Rule '{rule}' enabled should have been {ruleState == RuleState.On} but RuleEnabled returned {ruleState != RuleState.On}.'");
             if (RuleState.On == ruleState)

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Constants/RateLimitConstants.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Constants/RateLimitConstants.cs
@@ -11,5 +11,12 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Constants
         // https://docs.github.com/en/rest/search?apiVersion=2022-11-28#about-search
         // The SearchIssues API has a rate limit of 1000 results which resets every 60 seconds
         public const int SearchIssuesRateLimit = 1000;
+        // https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#about-primary-rate-limits
+        // There's a 500/hour limit on content creation. In theory, Closing an issue, Locking an issue and
+        // creating a comment are all considered content creation.
+        public const int ContentCreationRateLimit = 300;
+        // The actual rate limit per minute for content creation is 80 but to ensure that scheduled tasks
+        // don't interfere with Actions processing or people doing things in the GitHub UI.
+        public const int ScheduledUpdatesPerMinuteRateLimit = 50;
     }
 }

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/ScheduledEventProcessing.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/ScheduledEventProcessing.cs
@@ -79,7 +79,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
             {
                 // The second argument is IssueOrPullRequestNumber which isn't applicable to scheduled events (cron tasks)
                 // since they're not going to be changing a single IssueUpdate like rules processing does.
-                await gitHubEventClient.ProcessPendingUpdates(scheduledEventPayload.Repository.Id);
+                await gitHubEventClient.ProcessPendingScheduledUpdates();
             }
         }
 
@@ -130,6 +130,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                         )
                     {
                         Issue issue = result.Items[iCounter++];
+                        // This rule only sets the state
                         IssueUpdate issueUpdate = gitHubEventClient.GetIssueUpdate(issue, false);
                         issueUpdate.State = ItemState.Closed;
                         issueUpdate.StateReason = ItemStateReason.Completed;
@@ -211,6 +212,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                         )
                     {
                         Issue issue = result.Items[iCounter++];
+                        // This rule only sets the state
                         IssueUpdate issueUpdate = gitHubEventClient.GetIssueUpdate(issue, false);
                         issueUpdate.State = ItemState.Closed;
                         issueUpdate.StateReason = ItemStateReason.NotPlanned;
@@ -285,6 +287,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                         )
                     {
                         Issue issue = result.Items[iCounter++];
+                        // This rule only sets the state
                         IssueUpdate issueUpdate = gitHubEventClient.GetIssueUpdate(issue, false);
                         issueUpdate.State = ItemState.Closed;
                         issueUpdate.StateReason = ItemStateReason.NotPlanned;
@@ -366,7 +369,8 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                         )
                     {
                         Issue issue = result.Items[iCounter++];
-                        IssueUpdate issueUpdate = gitHubEventClient.GetIssueUpdate(issue, false);
+                        // This rule needs to the full IssueUpdate as it's adding a label
+                        IssueUpdate issueUpdate = gitHubEventClient.GetIssueUpdate(issue, false, false);
                         issueUpdate.AddLabel(TriageLabelConstants.NoRecentActivity);
                         gitHubEventClient.AddToIssueUpdateList(scheduledEventPayload.Repository.Id,
                                                                issue.Number,
@@ -451,7 +455,8 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                         )
                     {
                         Issue issue = result.Items[iCounter++];
-                        IssueUpdate issueUpdate = gitHubEventClient.GetIssueUpdate(issue, false);
+                        // This rule needs to the full IssueUpdate as it's adding a label
+                        IssueUpdate issueUpdate = gitHubEventClient.GetIssueUpdate(issue, false, false);
                         issueUpdate.AddLabel(TriageLabelConstants.NoRecentActivity);
                         gitHubEventClient.AddToIssueUpdateList(scheduledEventPayload.Repository.Id,
                                                                issue.Number,
@@ -597,6 +602,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                         )
                     {
                         Issue issue = result.Items[iCounter++];
+                        // This rule only sets the state
                         IssueUpdate issueUpdate = gitHubEventClient.GetIssueUpdate(issue, false);
                         // Close the issue
                         issueUpdate.State = ItemState.Closed;


### PR DESCRIPTION
The new rule, EnforceMaxLifeOfIssues, creates a comment, closes and locks issues. As it turns out, when the rule first ran in azure-sdk-for-net, it was there were several hundred issues that matched the criteria. When the rule started processing this backlog, it hit a SecondaryRateLimitExceededException while creating comments due to the fact it tried to update more than 80 in a 60 second period. Theoretically, can happen with any API that "creates content" which includes creating comments, closing and locking. _Though we already know that locking 1000 issues never hits this._ The reason we've never previously seen this is that the existing Scheduled events is because those events are all caught up and just processing a small handful if they process anything at all.

While the per-minute limit is 80, hitting the SecondaryRateLimitExceededException can affect more than just Actions/Scheduled events, it can also affect people doing things in the UI. I've split the pending update processing to create a method specifically for processing pending scheduled updates. This method will sleep for 60 seconds after processing 50 items and, if any update call hits a SecondaryRateLimitExceededException, it'll sleep before retry and try up to 5x. I'm not expecting these to be hit, with the delay that happens after every 50 updates.

The other thing that had to change was the overall limit to the number of items we'd process in any given scheduled event. In theory, this number is 500/hour. For scheduled events I've lowered it from 1/10th of the hourly limit, with cap of 1000, to 300. This is the same reason as the 50/minute. While exiting scheduled events are processing scraps, any new events being added that have to play catch up, will process more. The 300 max limit of updates is just a safety buffer. The solution to processing less events per iteration would be to have a given scheduled event run more frequently which would catch it up faster.