### PR TITLE
Add dotnet-api product slug to sample metadata script

### DIFF
--- a/eng/common/scripts/Test-SampleMetadata.ps1
+++ b/eng/common/scripts/Test-SampleMetadata.ps1
@@ -330,6 +330,7 @@ begin {
         "blazor-webassembly",
         "common-data-service",
         "customer-voice",
+        "dotnet-api",
         "dotnet-core",
         "dotnet-standard",
         "document-intelligence",


### PR DESCRIPTION
Based on offline discussion, we believe `dotnet-api` is the best product slug for System.ClientModel samples added in https://github.com/Azure/azure-sdk-for-net/pull/42369.

This is because the [BinaryData](https://learn.microsoft.com/en-us/dotnet/api/system.binarydata?view=dotnet-plat-ext-8.0) type, also in the `System.` namespace uses the `ms.service=dotnet-api` and `ms.subservice=system`.  These were identified as well in the [msprod docs metadata-taxonomies](https://review.learn.microsoft.com/en-us/help/platform/metadata-taxonomies?branch=main#msprod).

