### PR TITLE
Update github-event-processor version

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -58,7 +58,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20240229.2
+          --version 1.0.0-dev.20240308.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash
@@ -114,7 +114,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20240229.2
+          --version 1.0.0-dev.20240308.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -2,6 +2,7 @@ name: GitHub Scheduled Event Processor
 
 on:
   schedule:
+    # These are generated/confirmed using https://crontab.cronhub.io/
     # Close stale issues, runs every day at 1am - CloseStaleIssues
     - cron: '0 1 * * *'
     # Identify stale pull requests, every Friday at 5am - IdentifyStalePullRequests
@@ -14,9 +15,10 @@ on:
     - cron: '30 4,10,16,22 * * *'
     # Lock closed issues, every 6 hours at 05:30 AM, 11:30 AM, 05:30 PM and 11:30 PM - LockClosedIssues
     - cron: '30 5,11,17,23 * * *'
-    # Enforce max life of issues, every Monday at 10:00 AM - EnforceMaxLifeOfIssues
+    # Enforce max life of issues, every M,W,F at 10:00 AM PST - EnforceMaxLifeOfIssues
     # Note: GitHub uses UTC, to run at 10am PST, the cron task needs to be 6pm (1800 hours) UTC
-    - cron: '0 18 * * MON'
+    #       When scheduling for multiple days the numeric days 0-6 (0=Sunday) must be used.
+    - cron: '0 18 * * 1,3,5'
 # This removes all unnecessary permissions, the ones needed will be set below.
 # https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
 permissions: {}
@@ -37,7 +39,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20240229.2
+          --version 1.0.0-dev.20240308.3
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash
@@ -131,7 +133,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Enforce Max Life of Issues Scheduled Event
-        if: github.event.schedule == '0 18 * * MON'
+        if: github.event.schedule == '0 18 * * 1,3,5'
         run: |
           cat > payload.json << 'EOF'
           ${{ toJson(github.event) }}


### PR DESCRIPTION
This change will NOT be merged or pushed out to the repositories until Monday, 03/11/2024.

The first update is to update the github-event-processor version which includes the new InitialIssueTriage rule that uses the AzureSdkOwners.

The second update is to the cron for EnforceMaxLifeOfIssues. Instead of running on just Mondays at 10am PST, it'll run on Monday, Wednesday and Friday. The reason for this for this is explained in the [PR](https://github.com/Azure/azure-sdk-tools/pull/7839) with the changes.