### PR TITLE
Initial Issue Triage was adding needs-team-triage incorrectly

### DIFF
--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/IssueProcessing.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/IssueProcessing.cs
@@ -213,8 +213,6 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                             {
                                 gitHubEventClient.AddLabel(TriageLabelConstants.NeedsTeamAttention);
                             }
-                            gitHubEventClient.AddLabel(TriageLabelConstants.NeedsTeamTriage);
-
                         }
                         // If there are no labels predicted add NeedsTriage to the issue
                         else


### PR DESCRIPTION
This [Issue in azure-sdk-for-java](https://github.com/Azure/azure-sdk-for-java/issues/39154) was processed using the new InitialIssueTriage rule and incorrectly had needs-team-triage added to it.

needs-team-triage should only be added in the case of no AzureSdkOwners and no ServiceOwners and is correctly done in that case but there looks to be a stray call to `gitHubEventClient.AddLabel(TriageLabelConstants.NeedsTeamTriage);` which was after the check to see if needs-team-attention was being added. 