### PR TITLE
Skip env processing on matrix import step

### DIFF
--- a/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
+++ b/eng/common-tests/matrix-generator/tests/job-matrix-functions.modification.tests.ps1
@@ -388,6 +388,23 @@ Describe "Platform Matrix Import" -Tag "import" {
         { GenerateMatrix $importConfig "sparse" } | Should -Throw
     }
 
+    It "Should process filters against env references in imported matrix in the correct order" {
+        $matrixJson = @'
+{
+    "matrix": {
+        "$IMPORT": "./matrix-generator/tests/test-import-matrix-env.json",
+        "BarEnv": "env:BAR"
+    }
+}
+'@
+
+        [System.Environment]::SetEnvironmentVariable("FOO", "Value1")
+        [System.Environment]::SetEnvironmentVariable("BAR", "Value2")
+        $importConfig = GetMatrixConfigFromJson $matrixJson
+        [array]$matrix = GenerateMatrix $importConfig "sparse" -filter @("FooEnv=.*FOO.*")
+
+        $matrix[0].name | Should -Be Value2_Value1
+    }
 }
 
 Describe "Platform Matrix Replace" -Tag "UnitTest", "replace" {

--- a/eng/common-tests/matrix-generator/tests/test-import-matrix-env.json
+++ b/eng/common-tests/matrix-generator/tests/test-import-matrix-env.json
@@ -1,0 +1,5 @@
+{
+  "matrix": {
+    "FooEnv": "env:FOO"
+  }
+}


### PR DESCRIPTION
Matrix filters are intended to work against the environment variable key, not the resolved value. There is a bug where resolve environment variables on an imported matrix, before processing any matrix filters passed in from the top level. This PR changes import behavior to skip env var lookup until after the imported matrix has been combined with the parent matrix.
