### PR TITLE
[APIView] Enable subpath exports in JS APIView

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaScriptLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaScriptLanguageService.cs
@@ -2,24 +2,57 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics;
 using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Threading.Tasks;
+using ApiView;
 
 namespace APIViewWeb
 {
     public class JavaScriptLanguageService : LanguageProcessor
     {
         public override string Name { get; } = "JavaScript";
-        public override string[] Extensions { get; } = { ".api.json" };
+        public override string[] Extensions { get; } = { ".api.json", ".zip" };
         public override string ProcessName { get; } = "node";
         public override string VersionString { get; } = "1.0.8";
+
+        public override async Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis)
+        {
+            var (tempDirectory, originalFilePath, jsonFilePath) = await PrepareTemporaryDirectory(originalName, stream);
+            if (originalName.EndsWith(".zip"))
+            {
+                ZipFile.ExtractToDirectory(originalFilePath, tempDirectory);
+            }
+
+            try
+            {
+                return await ExecuteProcessorAsync(originalName, tempDirectory, jsonFilePath);
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
 
         public override string GetProcessorArguments(string originalName, string tempDirectory, string jsonFilePath)
         {
             var jsPath = Path.Combine(
-                    Path.GetDirectoryName(typeof(JavaScriptLanguageService).Assembly.Location),
-                    "export.js");
+      Path.GetDirectoryName(typeof(JavaScriptLanguageService).Assembly.Location),
+      "export.js");
 
-            return $"{jsPath} \"{originalName}\" \"{jsonFilePath}\"";
+            var apiJsonFiles = Directory.EnumerateFiles(tempDirectory, "*.api.json");
+            if (originalName.EndsWith(".zip"))
+            {
+                return $"{jsPath} \"{tempDirectory}\" \"{jsonFilePath}\"";
+            }
+            else
+            {
+                return $"{jsPath} \"{originalName}\" \"{jsonFilePath}\"";
+            }
+
+
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
@@ -1,12 +1,15 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text.Json;
 using System.Threading.Tasks;
 using ApiView;
+using APIViewWeb.Models;
 
 namespace APIViewWeb
 {
-    public abstract class LanguageProcessor: LanguageService
+    public abstract class LanguageProcessor : LanguageService
     {
         public abstract string ProcessName { get; }
         public abstract string VersionString { get; }
@@ -19,52 +22,63 @@ namespace APIViewWeb
 
         public override async Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis)
         {
+            var (tempDirectory, _, jsonFilePath) = await PrepareTemporaryDirectory(originalName, stream);            
+            try
+            {
+                return await ExecuteProcessorAsync(originalName, tempDirectory, jsonFilePath);
+            }
+            finally
+            {
+                Directory.Delete(tempDirectory, true);
+            }
+        }
+
+        protected async Task<Tuple<string, string, string>> PrepareTemporaryDirectory(string originalName, Stream stream)
+        {
             var tempPath = Path.GetTempPath();
             var randomSegment = Guid.NewGuid().ToString("N");
             var tempDirectory = Path.Combine(tempPath, "ApiView", randomSegment);
             Directory.CreateDirectory(tempDirectory);
             var originalFilePath = Path.Combine(tempDirectory, originalName);
 
-            var jsonFilePath = Path.ChangeExtension(originalFilePath, ".json");
-
             using (var file = File.Create(originalFilePath))
             {
                 await stream.CopyToAsync(file);
             }
 
-            try
+            var jsonFilePath = Path.ChangeExtension(originalFilePath, ".json");
+
+            return Tuple.Create(tempDirectory, originalFilePath, jsonFilePath);
+        }
+
+        protected async Task<CodeFile> ExecuteProcessorAsync(string originalName, string tempDirectory, string jsonFilePath)
+        {
+            var arguments = GetProcessorArguments(originalName, tempDirectory, jsonFilePath);
+            var processStartInfo = new ProcessStartInfo(ProcessName, arguments);
+            processStartInfo.WorkingDirectory = tempDirectory;
+            processStartInfo.RedirectStandardError = true;
+            processStartInfo.RedirectStandardOutput = true;
+
+            using (var process = Process.Start(processStartInfo))
             {
-                var arguments = GetProcessorArguments(originalName, tempDirectory, jsonFilePath);
-                var processStartInfo = new ProcessStartInfo(ProcessName, arguments);
-                processStartInfo.WorkingDirectory = tempDirectory;
-                processStartInfo.RedirectStandardError = true;
-                processStartInfo.RedirectStandardOutput = true;
-
-                using (var process = Process.Start(processStartInfo))
+                process.WaitForExit();
+                if (process.ExitCode != 0)
                 {
-                    process.WaitForExit();
-                    if (process.ExitCode != 0)
-                    {
-                        throw new InvalidOperationException(
-                            "Processor failed: " + Environment.NewLine +
-                            "stdout: " + Environment.NewLine +
-                            process.StandardOutput.ReadToEnd() + Environment.NewLine +
-                            "stderr: " + Environment.NewLine +
-                            process.StandardError.ReadToEnd() + Environment.NewLine);
-                    }
-                }
-
-                using (var codeFileStream = File.OpenRead(jsonFilePath))
-                {
-                    var codeFile = await CodeFile.DeserializeAsync(codeFileStream);
-                    codeFile.VersionString = VersionString;
-                    codeFile.Language = Name;
-                    return codeFile;
+                    throw new InvalidOperationException(
+                        "Processor failed: " + Environment.NewLine +
+                        "stdout: " + Environment.NewLine +
+                        process.StandardOutput.ReadToEnd() + Environment.NewLine +
+                        "stderr: " + Environment.NewLine +
+                        process.StandardError.ReadToEnd() + Environment.NewLine);
                 }
             }
-            finally
+
+            using (var codeFileStream = File.OpenRead(jsonFilePath))
             {
-                Directory.Delete(tempDirectory, true);
+                var codeFile = await CodeFile.DeserializeAsync(codeFileStream);
+                codeFile.VersionString = VersionString;
+                codeFile.Language = Name;
+                return codeFile;
             }
         }
     }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewUploadHelp.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_ReviewUploadHelp.cshtml
@@ -53,10 +53,10 @@
             <p class="card-text">
                 <ol>
                     <li>
-                        Use <code>api-extractor</code> to generate a <a href="https://api-extractor.com/pages/setup/generating_docs/">docModel file</a>
+                        Use <code>api-extractor</code> to generate a <a href="https://api-extractor.com/pages/setup/generating_docs/">docModel file or a zip archive with multiple related files.</a>
                     </li>
                     <li>
-                        Upload generated api.json file
+                        Upload generated file
                     </li>
                 </ol>
             </p>

--- a/tools/apiview/parsers/js-api-parser/export.ts
+++ b/tools/apiview/parsers/js-api-parser/export.ts
@@ -4,39 +4,94 @@ import {
     ApiItemKind,
     ApiDeclaredItem,
     ExcerptTokenKind,
-    ReleaseTag
-  } from '@microsoft/api-extractor-model';
+    ReleaseTag,
+} from "@microsoft/api-extractor-model";
 
-import { writeFile } from 'fs';
+import { stat, readdir, writeFile } from "fs/promises";
 
-import { IApiViewFile, IApiViewNavItem } from './models';
-import { TokensBuilder } from './tokensBuilder';
+import { IApiViewFile, IApiViewNavItem } from "./models";
+import { TokensBuilder } from "./tokensBuilder";
+import path = require("path");
 
-function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], item: ApiItem)
-{
-    builder.lineId(item.canonicalReference.toString());
+const added = new Set<string>();
+
+function buildTableOfContents(files: string[], inputPath: string) {
+    const navItem: IApiViewNavItem = {
+        Text: "navigation",
+        NavigationId: "navigation",
+        Tags: {},
+        ChildItems: [],
+    };
+    const builder = new TokensBuilder();
+    // append children of each subpath export to enable api comparison
+    for (const file of files) {
+        if (!file.endsWith(".api.json")) {
+            continue;
+        }
+        const apiModel = new ApiModel();
+        apiModel.loadPackage(path.join(inputPath, file));
+        for (const modelPackage of apiModel.packages) {
+            for (const entryPoint of modelPackage.entryPoints) {
+                for (const member of entryPoint.members) {
+                    appendMembers(builder, navItem.ChildItems, member);
+                }
+            }
+        }
+    }
+    return navItem;
+}
+
+function appendMembers(
+    builder: TokensBuilder,
+    navigation: IApiViewNavItem[],
+    item: ApiItem
+) {
+    const itemCanonicalRef = item.canonicalReference.toString();
+    switch (item.kind) {
+        case ApiItemKind.Interface:
+        case ApiItemKind.Class:
+        case ApiItemKind.Namespace:
+        case ApiItemKind.Enum:
+        case ApiItemKind.Function:
+        case ApiItemKind.TypeAlias:
+            if (added.has(itemCanonicalRef)) {
+                return;
+            }
+    }
+
+    added.add(itemCanonicalRef);
+
+    builder.lineId(itemCanonicalRef);
     builder.indent();
     const releaseTag = getReleaseTag(item);
     const parentReleaseTag = getReleaseTag(item.parent);
-    if(releaseTag && releaseTag !== parentReleaseTag) {
-        if(item.parent.kind === ApiItemKind.EntryPoint) {
+    if (releaseTag && releaseTag !== parentReleaseTag) {
+        if (item.parent.kind === ApiItemKind.EntryPoint) {
             builder.newline();
         }
         builder.annotate(releaseTag);
     }
 
     if (item instanceof ApiDeclaredItem) {
-        if ( item.kind === ApiItemKind.Namespace) {
-            builder.splitAppend(`declare namespace ${item.displayName} `, item.canonicalReference.toString(), item.displayName);
+        if (item.kind === ApiItemKind.Namespace) {
+            builder.splitAppend(
+                `declare namespace ${item.displayName} `,
+                itemCanonicalRef,
+                item.displayName
+            );
         }
         for (const token of item.excerptTokens) {
-            if (token.kind === ExcerptTokenKind.Reference)
-            {
-                builder.typeReference(token.canonicalReference.toString(), token.text);
-            }
-            else
-            {
-                builder.splitAppend(token.text, item.canonicalReference.toString(), item.displayName);
+            if (token.kind === ExcerptTokenKind.Reference) {
+                builder.typeReference(
+                    token.canonicalReference.toString(),
+                    token.text
+                );
+            } else {
+                builder.splitAppend(
+                    token.text,
+                    itemCanonicalRef,
+                    item.displayName
+                );
             }
         }
     }
@@ -44,71 +99,59 @@ function appendMembers(builder: TokensBuilder, navigation: IApiViewNavItem[], it
     var navigationItem: IApiViewNavItem;
     var typeKind: string;
 
-    switch (item.kind)
-    {
+    switch (item.kind) {
         case ApiItemKind.Interface:
         case ApiItemKind.Class:
         case ApiItemKind.Namespace:
         case ApiItemKind.Enum:
             typeKind = item.kind.toLowerCase();
-            break
+            break;
+        case ApiItemKind.Function:
+            typeKind = "method";
+            break;
         case ApiItemKind.TypeAlias:
             typeKind = "struct";
-            break
+            break;
     }
 
-    if (typeKind)
-    {
+    if (typeKind) {
         navigationItem = {
             Text: item.displayName,
             NavigationId: item.canonicalReference.toString(),
             Tags: {
-                "TypeKind": typeKind
+                TypeKind: typeKind,
             },
-            ChildItems: []
+            ChildItems: [],
         };
         navigation.push(navigationItem);
     }
 
-    if (item.kind === ApiItemKind.Interface ||
+    if (
+        item.kind === ApiItemKind.Interface ||
         item.kind === ApiItemKind.Class ||
         item.kind === ApiItemKind.Namespace ||
-        item.kind === ApiItemKind.Enum)
-    {
-        if (item.members.length > 0)
-        {
-            builder
-                .punct("{")
-                .newline()
-                .incIndent()
+        item.kind === ApiItemKind.Enum
+    ) {
+        if (item.members.length > 0) {
+            builder.punct("{").newline().incIndent();
 
             for (const member of item.members) {
-                appendMembers(builder,navigationItem.ChildItems, member);
+                appendMembers(builder, navigationItem.ChildItems, member);
             }
 
-            builder
-                .decIndent()
-                .indent()
-                .punct("}")
-                .newline();
+            builder.decIndent().indent().punct("}").newline();
+        } else {
+            builder.punct("{").space().punct("}").newline();
         }
-        else
-        {
-            builder
-                .punct("{")
-                .space()
-                .punct("}")
-                .newline();
-        }
-    }
-    else
-    {
+    } else {
         builder.newline();
     }
 }
 
-function getReleaseTag(item: ApiItem & {releaseTag?: ReleaseTag}): "alpha" | "beta" | undefined {
-    switch(item.releaseTag) {
+function getReleaseTag(
+    item: ApiItem & { releaseTag?: ReleaseTag }
+): "alpha" | "beta" | undefined {
+    switch (item.releaseTag) {
         case ReleaseTag.Beta:
             return "beta";
         case ReleaseTag.Alpha:
@@ -118,44 +161,144 @@ function getReleaseTag(item: ApiItem & {releaseTag?: ReleaseTag}): "alpha" | "be
     }
 }
 
-const apiModel = new ApiModel();
-const fileName = process.argv[2];
-var PackageversionString = "";
-if (fileName.includes("_"))
-{
-    PackageversionString = fileName.split("_").pop().replace(".api.json", "");
-}
-apiModel.loadPackage(fileName);
+function noOp() {}
+const logger = process.env.DEBUG?.startsWith("export")
+    ? {
+          log: console.log,
+          error: console.error,
+          warn: console.warn,
+          info: console.info,
+      }
+    : {
+          log: noOp,
+          error: noOp,
+          warn: noOp,
+          info: noOp,
+      };
 
-var navigation: IApiViewNavItem[] = [];
-var builder = new TokensBuilder();
-
-for (const modelPackage of apiModel.packages) {
-    for (const entryPoint of modelPackage.entryPoints) {
-        for (const member of entryPoint.members) {
-            appendMembers(builder, navigation, member);
-        }
+function kindToKeyword(kind: ApiItemKind): string {
+    switch (kind) {
+        case ApiItemKind.TypeAlias:
+            return "type";
+        default:
+            return kind.toLowerCase();
     }
 }
 
-var name = apiModel.packages[0].name;
-if (PackageversionString != "")
-{
-    name += "(" +PackageversionString + ")";
-}
-var apiViewFile: IApiViewFile = {
-    Name: name,
-    Navigation: navigation,
-    Tokens: builder.tokens,
-    PackageName: apiModel.packages[0].name,
-    VersionString: "1.0.8",
-    Language: "JavaScript",
-    PackageVersion: PackageversionString
+async function main() {
+    const inputPath = process.argv[2];
+
+    var navigation: IApiViewNavItem[] = [];
+    var builder = new TokensBuilder();
+
+    const stats = await stat(inputPath);
+    if (stats.isDirectory()) {
+        logger.info(`Processing directory ${inputPath}`);
+        let name: string;
+        let packageName: string;
+        const files = await readdir(inputPath);
+        const pattern = /.*-(?<suffix>.*)\.api.json/;
+        for (const file of files) {
+            if (!file.endsWith(".api.json")) {
+                continue;
+            }
+            const matches = file.match(pattern);
+            let suffix = "<default>";
+            if (matches) {
+                suffix = matches.groups["suffix"];
+            }
+            const navItem: IApiViewNavItem = {
+                Text: suffix,
+                NavigationId: file,
+                Tags: {
+                    TypeKind: "namespace",
+                },
+                ChildItems: [],
+            };
+            navigation.push(navItem);
+
+            logger.info(`Processing ${file}`);
+            const apiModel = new ApiModel();
+            apiModel.loadPackage(path.join(inputPath, file));
+
+            for (const modelPackage of apiModel.packages) {
+                for (const entryPoint of modelPackage.entryPoints) {
+                    for (const member of entryPoint.members) {
+                        appendMembers(builder, navItem.ChildItems, member);
+                    }
+                }
+            }
+
+            if (!name) {
+                name = apiModel.packages[0].name;
+                packageName = apiModel.packages[0].name;
+            }
+        }
+
+        // Clear the `added` set to allow duplicates in the navigation pane
+        added.clear();
+        const navItem = buildTableOfContents(files, inputPath);
+        navigation.unshift(navItem);
+
+        const apiViewFile: IApiViewFile = {
+            Name: name,
+            Navigation: navigation,
+            Tokens: builder.tokens,
+            PackageName: packageName,
+            VersionString: "1.0.8",
+            Language: "JavaScript",
+            PackageVersion: "",
+        };
+        await writeFile(process.argv[3], JSON.stringify(apiViewFile));
+    } else {
+        const apiModel = new ApiModel();
+        const fileName = process.argv[2];
+        var PackageversionString = "";
+        if (fileName.includes("_")) {
+            PackageversionString = fileName
+                .split("_")
+                .pop()
+                .replace(".api.json", "");
+        }
+        apiModel.loadPackage(fileName);
+
+        for (const modelPackage of apiModel.packages) {
+            for (const entryPoint of modelPackage.entryPoints) {
+                for (const member of entryPoint.members) {
+                    appendMembers(builder, navigation, member);
+                }
+            }
+        }
+
+        var name = apiModel.packages[0].name;
+        if (PackageversionString != "") {
+            name += "(" + PackageversionString + ")";
+        }
+        var apiViewFile: IApiViewFile = {
+            Name: name,
+            Navigation: navigation,
+            Tokens: builder.tokens,
+            PackageName: apiModel.packages[0].name,
+            VersionString: "1.0.8",
+            Language: "JavaScript",
+            PackageVersion: PackageversionString,
+        };
+
+        await writeFile(
+            process.argv[3],
+            JSON.stringify(apiViewFile)
+            // err => {
+            //     if (err) {
+            //         console.error(err);
+            //         return;
+            //     };
+            // }
+        );
+    }
 }
 
-writeFile(process.argv[3], JSON.stringify(apiViewFile), err => {
-    if (err) {
-        console.error(err);
-        return;
-    };
-})
+main()
+    .then(() => {
+        console.log("Completed");
+    })
+    .catch(console.error);


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-tools/assets/753570/da364a6e-3c68-4069-8828-260c2c1bf900

- Top level navigation of all symbols (which I am now considering renaming to "Symbols"
- Each subpath export under a namespace

90% of this was done by our very own @jeremymeng - I am just filling in and trying to get it over the finish line 😄 

Other ideas:
- [ ] Rename "navigation" to symbols
- [ ] Sort symbols alphabetically (right now it's alphabetical per file)