### PR TITLE
Revert HTML Minification Changes

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -57,7 +57,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Octokit" Version="9.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
-    <PackageReference Include="WebMarkupMin.AspNetCore7" Version="2.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/_CodeLine.cshtml
@@ -98,7 +98,7 @@
                             </svg>";
         }
     }
-    cellContent += Model.CodeLine.DisplayString.Replace(' ', '\u00A0');
+    cellContent += Model.CodeLine.DisplayString;
 }
 
 <tr class="@rowClass" data-line-id="@(isRemoved ? string.Empty : Model.CodeLine.ElementId)" data-cross-lang-id="@(isRemoved ? string.Empty : Model.CodeLine.CrossLanguageDefinitionId)">

--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -34,7 +34,6 @@ using Microsoft.OpenApi.Models;
 using System.IO;
 using Microsoft.Azure.Cosmos;
 using APIViewWeb.Managers.Interfaces;
-using WebMarkupMin.AspNetCore7;
 
 namespace APIViewWeb
 {
@@ -243,11 +242,7 @@ namespace APIViewWeb
             services.AddHostedService<PullRequestBackgroundHostedService>();
             services.AddHostedService<LinesWithDiffBackgroundHostedService>();
             services.AddAutoMapper(Assembly.GetExecutingAssembly());
-            services.AddWebMarkupMin(options =>
-            {
-                options.AllowMinificationInDevelopmentEnvironment = true;
-                options.AllowCompressionInDevelopmentEnvironment = true;
-            }).AddHtmlMinification().AddHttpCompression();
+
             services.AddControllersWithViews()
                 .AddJsonOptions(options => options.JsonSerializerOptions.ReferenceHandler = ReferenceHandler.Preserve)
                 .PartManager.ApplicationParts.Add(new AssemblyPart(typeof(BaseApiController).Assembly));
@@ -329,7 +324,6 @@ namespace APIViewWeb
             app.UseMiddleware<SwaggerAuthMiddleware>();
             app.UseSwagger();
             app.UseSwaggerUI();
-            app.UseWebMarkupMin();
 
             app.UseEndpoints(endpoints => {
                 endpoints.MapRazorPages();


### PR DESCRIPTION
- Reverts some of the changes introduced in https://github.com/Azure/azure-sdk-tools/pull/7807
- HTML Minification improves performance but introduces some other issues in the codelines.
- Ultimately, we need to resolve performance issues by reducing DOM size via lazy loading