### PR TITLE
Fix issue with universal output short form clobbering the dump option

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/OptionsGenerator.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/OptionsGenerator.cs
@@ -53,7 +53,7 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
                 name: "--universalOutput",
                 description: "Flag; Redirect all logs to stdout, including what would normally be showing up on stderr.",
                 getDefaultValue: () => false);
-            dumpOption.AddAlias("-u");
+            universalOption.AddAlias("-u");
 
 
             var collectedArgs = new Argument<string[]>("args")


### PR DESCRIPTION
I noticed using `-U` alias of `--universalOutput` would erroneously activate the config dump, not universal output.