### PR TITLE
Remove strict mode for create apiview

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -17,7 +17,6 @@ Param (
   [bool] $MarkPackageAsShipped = $false
 )
 
-Set-StrictMode -Version 3
 . (Join-Path $PSScriptRoot common.ps1)
 . (Join-Path $PSScriptRoot Helpers ApiView-Helpers.ps1)
 


### PR DESCRIPTION
strict mode is causing failures in language pipeline if any of the helper functions has unset properties. This is PR is a temporary work around to unblock java pipelines.