### PR TITLE
Migrate image and dotnet tool publish to 1es pipelines

### DIFF
--- a/eng/containers/ci.yml
+++ b/eng/containers/ci.yml
@@ -3,39 +3,29 @@ parameters:
   type: object
   default:
   - name: mock_attestation
-    pool: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: ubuntu-22.04
     dockerRepo: 'keyvault-mock-attestation'
-    dockerFile: 'tools/keyvault-mock-attestation/Dockerfile'
+    configPath: 'tools/keyvault-mock-attestation'
     stableTags:
     - 'latest'
   - name: stress_watcher
-    pool: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: ubuntu-22.04
     dockerRepo: 'stress/watcher'
-    dockerFile: 'tools/stress-cluster/services/Stress.Watcher/Dockerfile'
+    configPath: 'tools/stress-cluster/services/Stress.Watcher'
     stableTags:
     - 'latest'
   - name: stress_deploy_test_resources
-    pool: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: ubuntu-22.04
     dockerRepo: 'stress/deploy-test-resources'
     prepareScript: tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/prepare.ps1
-    dockerFile: 'tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer/Dockerfile'
+    configPath: 'tools/stress-cluster/cluster/kubernetes/stress-test-addons/images/test-resource-deployer'
     stableTags:
     - 'latest'
   - name: http_fault_injector
-    pool: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: ubuntu-22.04
     dockerRepo: 'stress/httpfaultinjector'
-    dockerFile: 'tools/http-fault-injector/Dockerfile'
+    configPath: 'tools/http-fault-injector'
     stableTags:
     - 'latest'
   - name: otel_collector
-    pool: azsdk-pool-mms-ubuntu-2204-general
-    vmImage: ubuntu-22.04
     dockerRepo: 'stress/otelcollector'
-    dockerFile: 'tools/stress-cluster/services/otelcollector/Dockerfile'
+    configPath: 'tools/stress-cluster/services/otelcollector'
     stableTags:
     - '0.94.0'
 
@@ -70,7 +60,6 @@ variables:
     value: 'azsdkengsys'
   - name: imageTag
     value: $(build.buildid)
-  - template: ../pipelines/templates/variables/globals.yml
 
 extends:
   template: ../pipelines/publish-docker-image.yml

--- a/eng/pipelines/mirror-container-images.yml
+++ b/eng/pipelines/mirror-container-images.yml
@@ -17,32 +17,41 @@ parameters:
       - source: ubuntu/squid
         mirror: azsdkengsys.azurecr.io/mirror/ubuntu/squid
 
-jobs:
-  - job: MirrorImages
-    displayName: Mirror Container Images
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - stage:
+        displayName: Mirror Images
+        variables:
+          - template: /eng/pipelines/templates/variables/image.yml
+        jobs:
+          - job: MirrorImages
+            displayName: Mirror Container Images
 
-    pool:
-      name: azsdk-pool-mms-ubuntu-2004-general
-      vmImage: MMSUbuntu20.04
+            pool:
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
+              os: linux
 
-    steps:
-      - ${{ each image in parameters.Images }}:
-        - task: Docker@2
-          displayName: Login to ${{ split(image.mirror, '.')[0] }}
-          inputs:
-            command: login
-            containerRegistry: ${{ split(image.mirror, '.')[0] }}
-        - task: Powershell@2
-          displayName: Mirror ${{ image.source }} to ${{ image.mirror }}
-          inputs:
-            pwsh: true
-            filePath: $(Build.SourcesDirectory)/eng/scripts/mirror-container-image.ps1
-            ${{ if image.changes }}:
-              arguments: >
-                -Image ${{ image.source }}
-                -Mirror ${{ image.mirror }}
-                -changes '${{ image.changes }}'
-            ${{ else }}:
-              arguments: >
-                -Image ${{ image.source }}
-                -Mirror ${{ image.mirror }}
+            steps:
+              - ${{ each image in parameters.Images }}:
+                - task: Docker@2
+                  displayName: Login to ${{ split(image.mirror, '.')[0] }}
+                  inputs:
+                    command: login
+                    containerRegistry: ${{ split(image.mirror, '.')[0] }}
+                - task: Powershell@2
+                  displayName: Mirror ${{ image.source }} to ${{ image.mirror }}
+                  inputs:
+                    pwsh: true
+                    filePath: $(Build.SourcesDirectory)/eng/scripts/mirror-container-image.ps1
+                    ${{ if image.changes }}:
+                      arguments: >
+                        -Image ${{ image.source }}
+                        -Mirror ${{ image.mirror }}
+                        -changes '${{ image.changes }}'
+                    ${{ else }}:
+                      arguments: >
+                        -Image ${{ image.source }}
+                        -Mirror ${{ image.mirror }}

--- a/eng/pipelines/publish-docker-image-isolated.yml
+++ b/eng/pipelines/publish-docker-image-isolated.yml
@@ -1,0 +1,135 @@
+# Additional sample inputs can be found in `eng/containers/ci.yml`, but here is an example.
+# - name: test_proxy_linux
+#   dockerRepo: 'engsys/testproxy-lin'
+#   prepareScript: tools/test-proxy/docker/prepare.ps1
+#   excludeFromManifest: true/false
+#   configPath: 'tools/test-proxy/docker'
+#   stableTags:
+#   - 'latest'
+
+# A "ManifestDeployment" is a secondary deployment that can be used to map multiple docker tags to a single platform-sensitive one. It waits until
+# all previous tag deployments are created, then triggers a manifest upload that bundles all tags configured in DockerDeployments. To exclude an item from the
+# manifest upload, set deployment config property excludeFromManifest to true.
+# - name: test_proxy_manifest
+#   dockerRepo: 'engsys/testproxy'
+#   stableTags:
+#   - 'latest'
+parameters:
+  - name: DockerDeployments
+    type: object
+    default: []
+  - name: ManifestDeployment
+    type: object
+    default: []
+  - name: ImageTag
+    type: string
+  - name: ContainerRegistry
+    type: string
+    default: 'azsdkengsys'
+  - name: Publish
+    type: boolean
+    default: true
+
+stages:
+  - stage:
+    displayName: Build/Publish Containers
+    variables:
+      - template: /eng/pipelines/templates/variables/globals.yml
+      - template: /eng/pipelines/templates/variables/image.yml
+    jobs:
+      - ${{ each config in parameters.DockerDeployments }}:
+        - job: container_build_${{ config.name }}
+          displayName: Build ${{ config.name }} Image
+          pool:
+            name: $(LINUXPOOL)
+            image: $(LINUXVMIMAGE)
+            os: linux
+
+          ${{ if parameters.Publish }}:
+            templateContext:
+              outputs:
+                - output: containerImage
+                  displayName: Push ${{ config.name }}:${{ parameters.ImageTag }}
+                  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+                  image: ${{ parameters.ContainerRegistry }}.azurecr.io/${{ config.dockerRepo }}:${{ parameters.ImageTag }}
+                - ${{ if config.stableTags }}:
+                  - ${{ each stableTag in config.stableTags }}:
+                    - output: containerImage
+                      displayName: Push ${{ config.name }}:${{ stableTag }}
+                      condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+                      image: ${{ parameters.ContainerRegistry }}.azurecr.io/${{ config.dockerRepo }}:${{ stableTag }}
+
+          steps:
+            - ${{ if config.prepareScript }}:
+              - pwsh: |
+                  ./${{ config.prepareScript }}
+                displayName: "Run prep script"
+            - task: 1ES.BuildContainerImage@1
+              displayName: Build ${{ config.name }}:${{ parameters.ImageTag }}
+              inputs:
+                image: ${{ parameters.ContainerRegistry }}.azurecr.io/${{ config.dockerRepo }}:${{ parameters.ImageTag }}
+                path: ${{ config.configPath }}
+                enableNetwork: true
+                useBuildKit: true
+            - ${{ if config.stableTags }}:
+              - ${{ each stableTag in config.stableTags }}:
+                - task: 1ES.BuildContainerImage@1
+                  displayName: Build ${{ config.name }}:${{ stableTag }}
+                  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+                  inputs:
+                    image: ${{ parameters.ContainerRegistry }}.azurecr.io/${{ config.dockerRepo }}:${{ stableTag }}
+                    path: ${{ config.configPath }}
+                    enableNetwork: true
+                    useBuildKit: true
+
+      - ${{ if and(parameters.ManifestDeployment, parameters.Publish) }}:
+        - ${{ each deployment in parameters.ManifestDeployment }}:
+          - job: container_build_${{ deployment.name }}
+            displayName: Build ${{ deployment.name }} Manifest
+            ${{ if gt(length(parameters.DockerDeployments), 0) }}:
+              dependsOn:
+                - ${{ each config in parameters.DockerDeployments }}:
+                  - container_build_${{ config.name }}
+            pool:
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
+              os: linux
+
+            steps:
+              - pwsh: |
+                  $configurations = '${{ convertToJson(parameters.DockerDeployments) }}' -replace '\\', '/'
+                  $assembledDependentTags = $(Build.SourcesDirectory)/eng/pipelines/templates/scripts/get-docker-manifest-input.ps1 `
+                    -DockerDeploymentJson $configurations `
+                    -ContainerRegistry "${{ parameters.ContainerRegistry }}" `
+                    -ImageTag "${{ parameters.ImageTag }}" `
+
+                  Write-Host "##vso[task.setvariable variable=ManifestVariable]$assembledDependentTags"
+                displayName: Generate Manifest Variable
+
+              - pwsh: |
+                  docker manifest create ${{ parameters.ContainerRegistry }}.azurecr.io/${{ deployment.dockerRepo }}:${{ parameters.ImageTag }} $(ManifestVariable)
+                displayName: Generate Manifest
+
+              - pwsh: |
+                  docker manifest push ${{ parameters.ContainerRegistry }}.azurecr.io/${{ deployment.dockerRepo }}:${{ parameters.ImageTag }}
+                displayName: Upload Manifest
+
+              - ${{ if deployment.stableTags }}:
+                - ${{ each stableTag in deployment.stableTags }}:
+                  - pwsh: |
+                      $configurations = '${{ convertToJson(parameters.DockerDeployments) }}' -replace '\\', '/'
+                      $assembledDependentTags = $(Build.SourcesDirectory)/eng/pipelines/templates/scripts/get-docker-manifest-input.ps1 `
+                        -DockerDeploymentJson $configurations `
+                        -ContainerRegistry "${{ parameters.ContainerRegistry }}" `
+                        -ImageTag "${{ stableTag }}" `
+
+                      Write-Host "##vso[task.setvariable variable=ManifestVariable]$assembledDependentTags"
+                    displayName: Generate Manifest Variable
+
+                  - pwsh: |
+                      docker manifest create ${{ parameters.ContainerRegistry }}.azurecr.io/${{ deployment.dockerRepo }}:${{ stableTag }} $(ManifestVariable)
+                    displayName: Generate Manifest
+
+                  - pwsh: |
+                      docker manifest push ${{ parameters.ContainerRegistry }}.azurecr.io/${{ deployment.dockerRepo }}:${{ stableTag }}
+                    displayName: Upload Manifest

--- a/eng/pipelines/publish-docker-image.yml
+++ b/eng/pipelines/publish-docker-image.yml
@@ -1,12 +1,9 @@
 # Additional sample inputs can be found in `eng/containers/ci.yml`, but here is an example.
 # - name: test_proxy_linux
-#   pool: azsdk-pool-mms-ubuntu-2204-general
-#   vmImage: ubuntu-22.04
 #   dockerRepo: 'engsys/testproxy-lin'
-#   additionalDockerArgs: ''
 #   prepareScript: tools/test-proxy/docker/prepare.ps1
 #   excludeFromManifest: true/false
-#   dockerFile: 'tools/test-proxy/docker/dockerfile'
+#   configPath: 'tools/test-proxy/docker'
 #   stableTags:
 #   - 'latest'
 
@@ -33,109 +30,9 @@ parameters:
     type: boolean
     default: true
 
-jobs:
-  - ${{ each config in parameters.DockerDeployments }}:
-    - job: container_build_${{ config.name }}
-      displayName: Build ${{ config.name }} Image
-      pool:
-        name: ${{ config.pool }}
-        vmImage: ${{ config.vmImage }}
-      steps:
-        - ${{ if config.prepareScript }}:
-          - pwsh: |
-              ./${{ config.prepareScript }}
-            displayName: "Run prep script"
-        - task: Docker@2
-          displayName: Build ${{ config.name }}:${{ parameters.ImageTag }}
-          inputs:
-            command: build
-            Dockerfile: ${{ config.dockerFile }}
-            tags: ${{ parameters.ImageTag }}
-            arguments: '-t ${{ parameters.ContainerRegistry }}.azurecr.io/${{ config.dockerRepo }}:${{ parameters.ImageTag }} ${{ config.AdditionalDockerArgs }}'
-
-        - ${{ if parameters.Publish }}:
-          - task: Docker@2
-            displayName: Push ${{ config.name }}:${{ parameters.ImageTag }}
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-            inputs:
-              containerRegistry: ${{ parameters.ContainerRegistry }}
-              repository: ${{ config.dockerRepo }}
-              command: push
-              tags: ${{ parameters.ImageTag }}
-
-          - ${{ if config.stableTags }}:
-            - ${{ each stableTag in config.stableTags }}:
-              - task: Docker@2
-                displayName: Build ${{ config.name }}:${{ stableTag }}
-                condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-                inputs:
-                  command: build
-                  Dockerfile: ${{ config.dockerFile }}
-                  tags: ${{ stableTag }}
-                  arguments: '-t ${{ parameters.ContainerRegistry }}.azurecr.io/${{ config.dockerRepo }}:${{ stableTag }} ${{ config.exclude }}'
-
-              - task: Docker@2
-                displayName: Push ${{ config.name }}:${{ stableTag }}
-                condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-                inputs:
-                  containerRegistry: ${{ parameters.ContainerRegistry }}
-                  repository: ${{ config.dockerRepo }}
-                  command: push
-                  tags: ${{ stableTag }}
-
-  - ${{ if and(parameters.ManifestDeployment, parameters.Publish) }}:
-    - ${{ each deployment in parameters.ManifestDeployment }}:
-      - job: container_build_${{ deployment.name }}
-        displayName: Build ${{ deployment.name }} Manifest
-        ${{ if gt(length(parameters.DockerDeployments), 0) }}:
-          dependsOn:
-            - ${{ each config in parameters.DockerDeployments }}:
-              - container_build_${{ config.name }}
-        pool:
-          name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: ubuntu-22.04
-
-        steps:
-          - task: Docker@2
-            displayName: Login to ACR
-            inputs:
-              command: login
-              containerRegistry: ${{ parameters.ContainerRegistry }}
-
-          - pwsh: |
-              $configurations = '${{ convertToJson(parameters.DockerDeployments) }}' -replace '\\', '/'
-              $assembledDependentTags = $(Build.SourcesDirectory)/eng/pipelines/templates/scripts/get-docker-manifest-input.ps1 `
-                -DockerDeploymentJson $configurations `
-                -ContainerRegistry "${{ parameters.ContainerRegistry }}" `
-                -ImageTag "${{ parameters.ImageTag }}" `
-
-              Write-Host "##vso[task.setvariable variable=ManifestVariable]$assembledDependentTags"
-            displayName: Generate Manifest Variable
-
-          - pwsh: |
-              docker manifest create ${{ parameters.ContainerRegistry }}.azurecr.io/${{ deployment.dockerRepo }}:${{ parameters.ImageTag }} $(ManifestVariable)
-            displayName: Generate Manifest
-
-          - pwsh: |
-              docker manifest push ${{ parameters.ContainerRegistry }}.azurecr.io/${{ deployment.dockerRepo }}:${{ parameters.ImageTag }}
-            displayName: Upload Manifest
-
-          - ${{ if deployment.stableTags }}:
-            - ${{ each stableTag in deployment.stableTags }}:
-              - pwsh: |
-                  $configurations = '${{ convertToJson(parameters.DockerDeployments) }}' -replace '\\', '/'
-                  $assembledDependentTags = $(Build.SourcesDirectory)/eng/pipelines/templates/scripts/get-docker-manifest-input.ps1 `
-                    -DockerDeploymentJson $configurations `
-                    -ContainerRegistry "${{ parameters.ContainerRegistry }}" `
-                    -ImageTag "${{ stableTag }}" `
-
-                  Write-Host "##vso[task.setvariable variable=ManifestVariable]$assembledDependentTags"
-                displayName: Generate Manifest Variable
-
-              - pwsh: |
-                  docker manifest create ${{ parameters.ContainerRegistry }}.azurecr.io/${{ deployment.dockerRepo }}:${{ stableTag }} $(ManifestVariable)
-                displayName: Generate Manifest
-
-              - pwsh: |
-                  docker manifest push ${{ parameters.ContainerRegistry }}.azurecr.io/${{ deployment.dockerRepo }}:${{ stableTag }}
-                displayName: Upload Manifest
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - template: /eng/pipelines/publish-docker-image-isolated.yml
+        parameters: ${{ parameters }}

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -1,0 +1,50 @@
+resources:
+  repositories:
+    - repository: 1ESPipelineTemplates
+      type: git
+      name: 1ESPipelineTemplates/1ESPipelineTemplates
+      ref: refs/tags/release
+    - repository: azure-sdk-build-tools
+      type: git
+      name: internal/azure-sdk-build-tools
+      ref: refs/tags/1es-migration
+
+parameters:
+- name: stages
+  type: stageList
+  default: []
+- name: Use1ESOfficial
+  type: boolean
+  default: true
+
+extends:
+  ${{ if and(parameters.Use1ESOfficial, eq(variables['System.TeamProject'], 'internal')) }}:
+    template: v1/1ES.Official.PipelineTemplate.yml@1ESPipelineTemplates
+  ${{ else }}:
+    template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
+  parameters:
+    authenticatedContainerRegistries:
+      - serviceConnection: azsdkengsys
+    settings:
+      skipBuildTagsForGitHubPullRequests: true
+    sdl:
+      sourceAnalysisPool:
+        name: azsdk-pool-mms-win-2022-general
+        image: azsdk-pool-mms-win-2022-1espt
+        os: windows
+      sourceRepositoriesToScan:
+        exclude:
+          - repository: azure-sdk-build-tools
+      eslint:
+        enabled: false
+        justificationForDisabling: 'ESLint injected task has failures because it uses an old version of mkdirp. We should not fail for tools not controlled by the repo. See: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3499746'
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: CodeQL times our pipelines out by running for 2+ hours before being force canceled.
+      psscriptanalyzer:
+        compiled: true
+        break: true
+      policy: M365
+
+    stages: ${{ parameters.stages }}

--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -7,7 +7,7 @@ resources:
     - repository: azure-sdk-build-tools
       type: git
       name: internal/azure-sdk-build-tools
-      ref: refs/tags/1es-migration
+      ref: refs/tags/azure-sdk-build-tools_20240320.1
 
 parameters:
 - name: stages

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -1,10 +1,3 @@
-resources:
-  repositories:
-    - repository: azure-sdk-build-tools
-      type: git
-      name: internal/azure-sdk-build-tools
-      ref: refs/tags/azure-sdk-build-tools_20240320.1
-
 parameters:
   - name: ToolDirectory
     type: string
@@ -45,154 +38,179 @@ parameters:
   - name: RequireStrongNames
     type: boolean
     default: true
+  - name: Use1ESOfficial
+    type: boolean
+    default: false
+  - name: TestMatrix
+    type: object
+    default:
+      - name: Windows
+        Pool: $(WINDOWSPOOL)
+        Image: $(WINDOWSVMIMAGE)
+        Os: windows
+      - name: Linux
+        Pool: $(LINUXPOOL)
+        Image: $(LINUXVMIMAGE)
+        Os: linux
+      - name: Mac
+        Pool: $(MACPOOL)
+        Image: $(MACVMIMAGE)
+        Os: macOS
 
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    Use1ESOfficial: ${{ parameters.Use1ESOfficial }}
+    stages:
+      - stage: BuildTestAndPackage
 
-variables:
-  - template: ../variables/globals.yml
-  - name: Warn
-    ${{ if parameters.NoWarn }}:
-      value: ''
-    ${{ if not(parameters.NoWarn) }}:
-      value: -warnaserror
-  # A path to directory to contain the output of "dotnet pack" call,
-  # to be consumed as input by "publish" task.
-  - name: packagesToPublishDir
-    value: $(Build.ArtifactStagingDirectory)/packages
-
-stages:
-  - stage: BuildTestAndPackage
-
-    pool:
-      name: azsdk-pool-mms-ubuntu-2204-general
-      vmImage: ubuntu-22.04
-
-    jobs:
-      - job: BuildAndPackage
-        displayName: Build and Package
-
-        steps:
-          - template: /eng/pipelines/templates/steps/install-dotnet.yml
-
-          - script: 'dotnet pack /p:ArtifactsPackagesDir=$(packagesToPublishDir) $(Warn) -c Release'
-            displayName: 'Build and Package'
-            workingDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
-            env:
-              DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-              DOTNET_CLI_TELEMETRY_OPTOUT: 1
-              DOTNET_MULTILEVEL_LOOKUP: 0
-
-          # This step creates "$(packagesToPublishDir)" directory if it doesn't exist.
-          # This step is necessary since migration to net6.0. This is because since net6.0,
-          # in case the "Build and Package" above would not output any packages to this directory,
-          # the "Publish to packages artifact" step below would fail on missing directory.
-          - pwsh: |
-              if (!(Test-Path -PathType container "$(packagesToPublishDir)")) {
-                New-Item -ItemType Directory -Path "$(packagesToPublishDir)"
-                Write-Host "Created directory ""$(packagesToPublishDir)"""
-              } else {
-                Write-Host "Directory ""$(packagesToPublishDir)"" already exists. Nothing to do."
-                Write-Host "Directory ""$(packagesToPublishDir)"" contents:"
-                Get-ChildItem $(packagesToPublishDir) | ForEach-Object { Write-Host $_ }
-              }
-            displayName: Create dir for packages to publish or list its contents
-
-          - publish: $(packagesToPublishDir)
-            displayName: Publish to packages artifact
-            artifact: packages
-            condition: succeededOrFailed()
-
-      - ${{ if ne(length(parameters.StandaloneExeMatrix), 0) }}:
-        - job: Produce_Executables
-
-          strategy:
-            matrix:
-              linux:
-                imageName: 'ubuntu-22.04'
-                poolName: 'azsdk-pool-mms-ubuntu-2204-general'
-                artifactName: 'linux_windows'
-              mac:
-                imageName: 'macos-11'
-                poolName: 'Azure Pipelines'
-                artifactName: 'mac'
-
-          pool:
-            name: $(poolName)
-            vmImage: $(imageName)
-
-          steps:
-            - template: /eng/pipelines/templates/steps/install-dotnet.yml
-
-            - template: /eng/pipelines/templates/steps/produce-net-standalone-packs.yml
-              parameters:
-                StagingDirectory: $(Build.ArtifactStagingDirectory)
-                BuildMatrix: ${{ parameters.StandaloneExeMatrix }}
-                TargetDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
-
-      - job: Test
-
-        strategy:
-          matrix:
-            Windows:
-              Pool: azsdk-pool-mms-win-2022-general
-              Image: windows-2022
-            Linux:
-              Pool: azsdk-pool-mms-ubuntu-2204-general
-              Image: ubuntu-22.04
-            Mac:
-              Pool: Azure Pipelines
-              Image: macos-11
+        variables:
+          - template: /eng/pipelines/templates/variables/globals.yml
+          - template: /eng/pipelines/templates/variables/image.yml
+          - name: Warn
+            ${{ if parameters.NoWarn }}:
+              value: ''
+            ${{ if not(parameters.NoWarn) }}:
+              value: -warnaserror
+          # A path to directory to contain the output of "dotnet pack" call,
+          # to be consumed as input by "publish" task.
+          - name: packagesToPublishDir
+            value: $(Build.ArtifactStagingDirectory)/packages
 
         pool:
-          name: $(Pool)
-          vmImage: $(Image)
+          name: $(LINUXPOOL)
+          image: $(LINUXVMIMAGE)
+          os: linux
 
-        steps:
-          - template: /eng/pipelines/templates/steps/install-dotnet.yml
+        jobs:
+          - job: BuildAndPackage
+            displayName: Build and Package
 
-          - ${{ parameters.TestPreSteps }}
+            templateContext:
+              outputs:
+                - output: pipelineArtifact
+                  displayName: Publish to packages artifact
+                  condition: succeededOrFailed()
+                  artifactName: packages
+                  targetPath: $(packagesToPublishDir)
 
-          - script: 'dotnet test /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) $(Warn) --logger trx'
-            displayName: 'Test'
-            workingDirectory: '${{ coalesce(parameters.TestDirectory, parameters.ToolDirectory) }}'
-            env:
-              DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
-              DOTNET_CLI_TELEMETRY_OPTOUT: 1
-              DOTNET_MULTILEVEL_LOOKUP: 0
+            steps:
+              - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
-          - ${{ parameters.TestPostSteps }}
+              - script: 'dotnet pack /p:ArtifactsPackagesDir=$(packagesToPublishDir) $(Warn) -c Release'
+                displayName: 'Build and Package'
+                workingDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
+                env:
+                  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+                  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+                  DOTNET_MULTILEVEL_LOOKUP: 0
 
-          - task: PublishTestResults@2
-            condition: succeededOrFailed()
-            inputs:
-              testResultsFiles: '**/*.trx'
-              testRunTitle: $(System.JobDisplayName)
-              testResultsFormat: 'VSTest'
-              mergeTestResults: true
+              # This step creates "$(packagesToPublishDir)" directory if it doesn't exist.
+              # This step is necessary since migration to net6.0. This is because since net6.0,
+              # in case the "Build and Package" above would not output any packages to this directory,
+              # the "Publish to packages artifact" step below would fail on missing directory.
+              - pwsh: |
+                  if (!(Test-Path -PathType container "$(packagesToPublishDir)")) {
+                    New-Item -ItemType Directory -Path "$(packagesToPublishDir)"
+                    Write-Host "Created directory ""$(packagesToPublishDir)"""
+                  } else {
+                    Write-Host "Directory ""$(packagesToPublishDir)"" already exists. Nothing to do."
+                    Write-Host "Directory ""$(packagesToPublishDir)"" contents:"
+                    Get-ChildItem $(packagesToPublishDir) | ForEach-Object { Write-Host $_ }
+                  }
+                displayName: Create dir for packages to publish or list its contents
 
-      - ${{ if not(eq(length(parameters.DockerDeployments), 0)) }}:
-        - template: /eng/pipelines/publish-docker-image.yml
+          - ${{ if ne(length(parameters.StandaloneExeMatrix), 0) }}:
+            - job: Produce_Executables_linux
+
+              pool:
+                name: $(LINUXPOOL)
+                image: $(LINUXVMIMAGE)
+                os: linux
+
+              steps:
+                - template: /eng/pipelines/templates/steps/install-dotnet.yml
+
+                - template: /eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+                  parameters:
+                    StagingDirectory: $(Build.ArtifactStagingDirectory)
+                    BuildMatrix: ${{ parameters.StandaloneExeMatrix }}
+                    TargetDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
+
+            - job: Produce_Executables_mac
+
+              pool:
+                name: $(MACPOOL)
+                vmImage: $(MACVMIMAGE)
+                os: macOS
+
+              steps:
+                - template: /eng/pipelines/templates/steps/install-dotnet.yml
+
+                - template: /eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+                  parameters:
+                    StagingDirectory: $(Build.ArtifactStagingDirectory)
+                    BuildMatrix: ${{ parameters.StandaloneExeMatrix }}
+                    TargetDirectory: '${{ coalesce(parameters.PackageDirectory, parameters.ToolDirectory) }}'
+
+          - ${{ each test in parameters.TestMatrix }}:
+            - job: Test_${{ test.name }}
+
+              pool:
+                ${{ if eq(test.os, 'macOS') }}:
+                  vmImage: ${{ test.Image }}
+                ${{ else }}:
+                  image: ${{ test.Image }}
+                name: ${{ test.Pool }}
+                os: ${{ test.Os }}
+
+              steps:
+                - template: /eng/pipelines/templates/steps/install-dotnet.yml
+
+                - ${{ parameters.TestPreSteps }}
+
+                - script: 'dotnet test /p:ArtifactsPackagesDir=$(Build.ArtifactStagingDirectory) $(Warn) --logger trx'
+                  displayName: 'Test'
+                  workingDirectory: '${{ coalesce(parameters.TestDirectory, parameters.ToolDirectory) }}'
+                  env:
+                    DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+                    DOTNET_CLI_TELEMETRY_OPTOUT: 1
+                    DOTNET_MULTILEVEL_LOOKUP: 0
+
+                - ${{ parameters.TestPostSteps }}
+
+                - task: PublishTestResults@2
+                  condition: succeededOrFailed()
+                  inputs:
+                    testResultsFiles: '**/*.trx'
+                    testRunTitle: $(System.JobDisplayName)
+                    testResultsFormat: 'VSTest'
+                    mergeTestResults: true
+
+          - ${{ if not(eq(length(parameters.DockerDeployments), 0)) }}:
+            - template: /eng/pipelines/publish-docker-image-isolated.yml
+              parameters:
+                DockerDeployments: ${{ parameters.DockerDeployments }}
+                Publish: false
+                ImageTag: "${{ parameters.DockerTagPrefix }}$(Build.BuildNumber)"
+
+      - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+        - template: pipelines/stages/net-release-to-feed.yml@azure-sdk-build-tools
           parameters:
-            DockerDeployments: ${{ parameters.DockerDeployments }}
-            Publish: false
-            ImageTag: "${{ parameters.DockerTagPrefix }}$(Build.BuildNumber)"
+            # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
+            DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
+            ExeMatrix: ${{ parameters.StandaloneExeMatrix }}
+            ShouldPublishExecutables: ${{ parameters.ReleaseBinaries }}
+            ShouldPublishSymbols: ${{ parameters.ShouldPublishSymbols }}
+            RequireStrongNames: ${{ parameters.RequireStrongNames }}
 
-  - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - template: pipelines/stages/net-release-to-feed.yml@azure-sdk-build-tools
-      parameters:
-        # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
-        DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
-        ExeMatrix: ${{ parameters.StandaloneExeMatrix }}
-        ShouldPublishExecutables: ${{ parameters.ReleaseBinaries }}
-        ShouldPublishSymbols: ${{ parameters.ShouldPublishSymbols }}
-        RequireStrongNames: ${{ parameters.RequireStrongNames }}
-
-  - ${{if and(not(eq(length(parameters.DockerDeployments), 0)), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - stage: PublishDockerImages
-      displayName: Publish Docker Images
-      dependsOn: BuildTestAndPackage
-      jobs:
-        - template: /eng/pipelines/publish-docker-image.yml
-          parameters:
-            DockerDeployments: ${{ parameters.DockerDeployments }}
-            ManifestDeployment: ${{ parameters.ManifestDeployment }}
-            ImageTag: "${{ parameters.DockerTagPrefix }}$(Build.BuildNumber)"
+      - ${{if and(not(eq(length(parameters.DockerDeployments), 0)), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+        - stage: PublishDockerImages
+          displayName: Publish Docker Images
+          dependsOn: BuildTestAndPackage
+          jobs:
+            - template: /eng/pipelines/publish-docker-image-isolated.yml
+              parameters:
+                DockerDeployments: ${{ parameters.DockerDeployments }}
+                ManifestDeployment: ${{ parameters.ManifestDeployment }}
+                ImageTag: "${{ parameters.DockerTagPrefix }}$(Build.BuildNumber)"

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -1,0 +1,27 @@
+# Default pool image selection. Set as variable so we can override at pipeline level
+
+variables:
+  - name: LINUXPOOL
+    value: azsdk-pool-mms-ubuntu-2004-general
+  - name: WINDOWSPOOL
+    value: azsdk-pool-mms-win-2022-general
+  - name: MACPOOL
+    value: Azure Pipelines
+
+  - name: LINUXVMIMAGE
+    value: azsdk-pool-mms-ubuntu-2004-1espt
+  - name: LINUXNEXTVMIMAGE
+    value: azsdk-pool-mms-ubuntu-2204-1espt
+  - name: WINDOWSVMIMAGE
+    value: azsdk-pool-mms-win-2022-1espt
+  - name: MACVMIMAGE
+    value: macos-11
+
+  # Values required for pool.os field in 1es pipeline templates
+  - name: LINUXOS
+    value: linux
+  - name: WINDOWSOS
+    value: windows
+  - name: MACOS
+    value: macOS
+

--- a/tools/http-fault-injector/ci.yml
+++ b/tools/http-fault-injector/ci.yml
@@ -25,3 +25,4 @@ extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
     ToolDirectory: tools/http-fault-injector
+    Use1ESOfficial: true


### PR DESCRIPTION
Migrates the docker publish pipelines and the dotnet tool pipeline to 1es pipeline templates. Also includes base 1es-redirect.yml and image.yml files that will be foundational for further migrations. This PR depends on an update to azure-sdk-build-tools which I will merge and update the tag for before completing this PR.
