### PR TITLE
Migrate more tools pipelines to 1es pipeline templates

### DIFF
--- a/eng/pipelines/templates/stages/1es-redirect.yml
+++ b/eng/pipelines/templates/stages/1es-redirect.yml
@@ -23,8 +23,9 @@ extends:
   ${{ else }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
-    authenticatedContainerRegistries:
-      - serviceConnection: azsdkengsys
+    ${{ if and(parameters.Use1ESOfficial, eq(variables['System.TeamProject'], 'internal')) }}:
+      authenticatedContainerRegistries:
+        - serviceConnection: azsdkengsys
     settings:
       skipBuildTagsForGitHubPullRequests: true
     sdl:

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -194,15 +194,15 @@ extends:
                 Publish: false
                 ImageTag: "${{ parameters.DockerTagPrefix }}$(Build.BuildNumber)"
 
-                  #- ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-                  #  - template: pipelines/stages/net-release-to-feed.yml@azure-sdk-build-tools
-                  #    parameters:
-                  #      # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
-                  #      DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
-                  #      ExeMatrix: ${{ parameters.StandaloneExeMatrix }}
-                  #      ShouldPublishExecutables: ${{ parameters.ReleaseBinaries }}
-                  #      ShouldPublishSymbols: ${{ parameters.ShouldPublishSymbols }}
-                  #      RequireStrongNames: ${{ parameters.RequireStrongNames }}
+      - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+        - template: pipelines/stages/net-release-to-feed.yml@azure-sdk-build-tools
+          parameters:
+            # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
+            DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
+            ExeMatrix: ${{ parameters.StandaloneExeMatrix }}
+            ShouldPublishExecutables: ${{ parameters.ReleaseBinaries }}
+            ShouldPublishSymbols: ${{ parameters.ShouldPublishSymbols }}
+            RequireStrongNames: ${{ parameters.RequireStrongNames }}
 
       - ${{if and(not(eq(length(parameters.DockerDeployments), 0)), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
         - stage: PublishDockerImages

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -194,15 +194,15 @@ extends:
                 Publish: false
                 ImageTag: "${{ parameters.DockerTagPrefix }}$(Build.BuildNumber)"
 
-      - ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
-        - template: pipelines/stages/net-release-to-feed.yml@azure-sdk-build-tools
-          parameters:
-            # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
-            DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
-            ExeMatrix: ${{ parameters.StandaloneExeMatrix }}
-            ShouldPublishExecutables: ${{ parameters.ReleaseBinaries }}
-            ShouldPublishSymbols: ${{ parameters.ShouldPublishSymbols }}
-            RequireStrongNames: ${{ parameters.RequireStrongNames }}
+                  #- ${{if and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+                  #  - template: pipelines/stages/net-release-to-feed.yml@azure-sdk-build-tools
+                  #    parameters:
+                  #      # Publish to https://dev.azure.com/azure-sdk/public/_packaging?_a=feed&feed=azure-sdk-for-net
+                  #      DevOpsFeedId: '29ec6040-b234-4e31-b139-33dc4287b756/fa8c16a3-dbe0-4de2-a297-03065ec1ba3f'
+                  #      ExeMatrix: ${{ parameters.StandaloneExeMatrix }}
+                  #      ShouldPublishExecutables: ${{ parameters.ReleaseBinaries }}
+                  #      ShouldPublishSymbols: ${{ parameters.ShouldPublishSymbols }}
+                  #      RequireStrongNames: ${{ parameters.RequireStrongNames }}
 
       - ${{if and(not(eq(length(parameters.DockerDeployments), 0)), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
         - stage: PublishDockerImages

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
@@ -18,88 +18,99 @@ parameters:
   type: object
   default: []
 
-variables:
-  - template: /eng/pipelines/templates/variables/globals.yml
 
-stages:
-  - stage: 'Build'
-    jobs:
-      - job: 'Build'
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - stage: 'Build'
+        variables:
+          - template: /eng/pipelines/templates/variables/globals.yml
+          - template: /eng/pipelines/templates/variables/image.yml
+        jobs:
+          - job: 'Build'
 
-        pool:
-          name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: ubuntu-22.04
+            pool:
+              name: $(LINUXNEXTPOOL)
+              image: $(LINUXNEXTVMIMAGE)
+              os: linux
 
-        steps:
-          - template: /eng/pipelines/templates/steps/use-python-version.yml
-            parameters:
-              versionSpec: '${{ parameters.PythonVersion }}'
+            steps:
+              - template: /eng/pipelines/templates/steps/use-python-version.yml
+                parameters:
+                  versionSpec: '${{ parameters.PythonVersion }}'
 
-          - script: |
-              python --version
-              python -m pip install virtualenv aiohttp chardet trio setuptools wheel packaging
-            displayName: 'Setup Python Environment'
+              - script: |
+                  python --version
+                  python -m pip install virtualenv aiohttp chardet trio setuptools wheel packaging
+                displayName: 'Setup Python Environment'
 
-          - pwsh: |
-              Write-Host "Bundling stable version of python apiview-stub-generator"
-              python setup.py bdist_wheel --universal --dist-dir $(Build.ArtifactStagingDirectory)
-            displayName: 'Build ${{ parameters.PackageName }}'
-            workingDirectory: $(Build.SourcesDirectory)/${{ parameters.PackagePath }}
+              - pwsh: |
+                  Write-Host "Bundling stable version of python apiview-stub-generator"
+                  python setup.py bdist_wheel --universal --dist-dir $(Build.ArtifactStagingDirectory)
+                displayName: 'Build ${{ parameters.PackageName }}'
+                workingDirectory: $(Build.SourcesDirectory)/${{ parameters.PackagePath }}
 
-          - task: PublishBuildArtifacts@1
-            inputs:
-              pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-              artifactName: ${{ parameters.ArtifactName }}
-              
-      - ${{ if not(eq(length(parameters.TestSteps), 0)) }}:
-        - job: 'Test'
+              - task: 1ES.PublishPipelineArtifact@1
+                inputs:
+                  targetPath: '$(Build.ArtifactStagingDirectory)'
+                  artifactName: ${{ parameters.ArtifactName }}
 
-          dependsOn:
-            - 'Build'
+          - ${{ if not(eq(length(parameters.TestSteps), 0)) }}:
+            - job: 'Test'
 
-          pool:
-            name: azsdk-pool-mms-ubuntu-2204-general
-            vmImage: ubuntu-22.04
+              dependsOn:
+                - 'Build'
 
-          steps:
-            - template: /eng/pipelines/templates/steps/use-python-version.yml
-              parameters:
-                versionSpec: '${{ parameters.PythonVersion }}'
+              pool:
+                name: $(LINUXNEXTPOOL)
+                image: $(LINUXNEXTVMIMAGE)
+                os: linux
 
-            - ${{ parameters.TestSteps }}
+              steps:
+                - template: /eng/pipelines/templates/steps/use-python-version.yml
+                  parameters:
+                    versionSpec: '${{ parameters.PythonVersion }}'
 
-  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - stage: 'Release'
-      dependsOn: Build
-      condition: Succeeded()
-      jobs:
-      - job: PublishPackage
-        displayName: 'Publish ${{ parameters.PackageName }} package to devops feed'
-        pool:
-          name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: ubuntu-22.04
-        steps:
-        - checkout: none
-        - download: current
-        - task: UsePythonVersion@0
+                - ${{ parameters.TestSteps }}
 
-        - script: |
-            set -e
-            python -m pip install twine
-          displayName: Install Twine
+      - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+        - stage: 'Release'
+          dependsOn: Build
+          condition: Succeeded()
+          variables:
+            - template: /eng/pipelines/templates/variables/globals.yml
+            - template: /eng/pipelines/templates/variables/image.yml
+          jobs:
+          - job: PublishPackage
+            displayName: 'Publish ${{ parameters.PackageName }} package to devops feed'
+            pool:
+              name: $(LINUXNEXTPOOL)
+              image: $(LINUXNEXTVMIMAGE)
+              os: linux
+            steps:
+            - checkout: none
+            - download: current
+            - task: UsePythonVersion@0
 
-        - task: TwineAuthenticate@0
-          displayName: 'Twine Authenticate to feed'
-          inputs:
-            artifactFeeds: ${{ parameters.FeedName }}
+            - script: |
+                set -e
+                python -m pip install twine
+              displayName: Install Twine
 
-        - task: PipAuthenticate@1
-          displayName: 'Pip Authenticate to feed'
-          inputs:
-            artifactFeeds: ${{ parameters.FeedName }}
-            onlyAddExtraIndex: false
+            - task: TwineAuthenticate@0
+              displayName: 'Twine Authenticate to feed'
+              inputs:
+                artifactFeeds: ${{ parameters.FeedName }}
 
-        - pwsh: |
-            twine upload --repository ${{ parameters.FeedName }} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{ parameters.ArtifactName }}/*.whl
-            echo "Uploaded whl to devops feed ${{ parameters.FeedName }}"
-          displayName: 'Publish ${{ parameters.PackageName }} to DevOps feed'
+            - task: PipAuthenticate@1
+              displayName: 'Pip Authenticate to feed'
+              inputs:
+                artifactFeeds: ${{ parameters.FeedName }}
+                onlyAddExtraIndex: false
+
+            - pwsh: |
+                # twine upload --repository ${{ parameters.FeedName }} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{ parameters.ArtifactName }}/*.whl
+                echo "Uploaded whl to devops feed ${{ parameters.FeedName }}"
+                echo "BEBRODER SKIPPED"
+              displayName: 'Publish ${{ parameters.PackageName }} to DevOps feed'

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
@@ -110,7 +110,6 @@ extends:
                 onlyAddExtraIndex: false
 
             - pwsh: |
-                # twine upload --repository ${{ parameters.FeedName }} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{ parameters.ArtifactName }}/*.whl
+                twine upload --repository ${{ parameters.FeedName }} --config-file $(PYPIRC_PATH) $(Pipeline.Workspace)/${{ parameters.ArtifactName }}/*.whl
                 echo "Uploaded whl to devops feed ${{ parameters.FeedName }}"
-                echo "BEBRODER SKIPPED"
               displayName: 'Publish ${{ parameters.PackageName }} to DevOps feed'

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -3,6 +3,8 @@
 variables:
   - name: LINUXPOOL
     value: azsdk-pool-mms-ubuntu-2004-general
+  - name: LINUXNEXTPOOL
+    value: azsdk-pool-mms-ubuntu-2204-general
   - name: WINDOWSPOOL
     value: azsdk-pool-mms-win-2022-general
   - name: MACPOOL

--- a/tools/apiview/emitters/typespec-apiview/ci.yml
+++ b/tools/apiview/emitters/typespec-apiview/ci.yml
@@ -21,74 +21,88 @@ pr:
     include:
       - tools/apiview/emitters/typespec-apiview
 
-variables:
-  NodeVersion: '16.x'
-  TypeSpecEmitterDirectory: 'tools/apiview/emitters/typespec-apiview'
-  ArtifactName: 'apiview'
-  FeedRegistry: 'https://registry.npmjs.org/'
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - stage: 'Build'
+        variables:
+          - template: /eng/pipelines/templates/variables/image.yml
+          - name: NodeVersion
+            value: '16.x'
+          - name: TypeSpecEmitterDirectory
+            value: 'tools/apiview/emitters/typespec-apiview'
+          - name: ArtifactName
+            value: 'apiview'
+        jobs:
+          - job: 'Build'
 
-stages:
-  - stage: 'Build'
-    jobs:
-      - job: 'Build'
+            pool:
+              name: $(LINUXNEXTPOOL)
+              image: $(LINUXNEXTVMIMAGE)
+              os: linux
 
-        pool:
-          name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: ubuntu-22.04
+            steps:
+              - task: NodeTool@0
+                inputs:
+                  versionSpec: '$(NodeVersion)'
+                displayName: 'Use NodeJS $(NodeVersion)'
 
-        steps:
-          - task: NodeTool@0
-            inputs:
-              versionSpec: '$(NodeVersion)'
-            displayName: 'Use NodeJS $(NodeVersion)'
+              - script: |
+                  npm install
+                workingDirectory: $(TypeSpecEmitterDirectory)
+                displayName: "Install npm packages for TypeSpec emiter"
 
-          - script: |
-              npm install
-            workingDirectory: $(TypeSpecEmitterDirectory)
-            displayName: "Install npm packages for TypeSpec emiter"
+              - script: |
+                  npm run-script build
+                workingDirectory: $(TypeSpecEmitterDirectory)
+                displayName: "Build TypeSpec emitter"
 
-          - script: |
-              npm run-script build
-            workingDirectory: $(TypeSpecEmitterDirectory)
-            displayName: "Build TypeSpec emitter"
+              - script: |
+                  npm run-script test
+                workingDirectory: $(TypeSpecEmitterDirectory)
+                displayName: "Test TypeSpec emitter"
 
-          - script: |
-              npm run-script test
-            workingDirectory: $(TypeSpecEmitterDirectory)
-            displayName: "Test TypeSpec emitter"
+              - pwsh: |
+                  npm pack $(TypeSpecEmitterDirectory)
+                  Copy-Item ./*.tgz $(Build.ArtifactStagingDirectory)
+                displayName: "Pack TypeSpec Emitter"
 
-          - pwsh: |
-              npm pack $(TypeSpecEmitterDirectory)
-              Copy-Item ./*.tgz $(Build.ArtifactStagingDirectory)
-            displayName: "Pack TypeSpec Emitter"
+              - task: 1ES.PublishPipelineArtifact@1
+                inputs:
+                  targetPath: '$(Build.ArtifactStagingDirectory)'
+                  artifactName: $(ArtifactName)
 
-          - task: PublishBuildArtifacts@1
-            inputs:
-              pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-              artifactName: $(ArtifactName)
+      - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'), ne(variables['Skip.PublishPackage'], 'true'))}}:
+        - stage: 'Release'
+          dependsOn: Build
+          condition: Succeeded()
+          variables:
+            - template: /eng/pipelines/templates/variables/image.yml
+            - name: FeedRegistry
+              value: 'https://registry.npmjs.org/'
+            - name: ArtifactName
+              value: 'apiview'
+          jobs:
+          - job: PublishPackage
+            displayName: 'Publish typespec-apiview package to devops feed'
+            pool:
+              name: $(LINUXNEXTPOOL)
+              image: $(LINUXNEXTVMIMAGE)
+              os: linux
+            steps:
+            - checkout: none
+            - download: current
 
-  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'), ne(variables['Skip.PublishPackage'], 'true'))}}:
-    - stage: 'Release'
-      dependsOn: Build
-      condition: Succeeded()
-      jobs:
-      - job: PublishPackage
-        displayName: 'Publish typespec-apiview package to devops feed'
-        pool:
-          name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: ubuntu-22.04
-        steps:
-        - checkout: none
-        - download: current
-
-        - pwsh: |
-            $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/$(ArtifactName)/*.tgz
-            Write-Host "Detected package name: $detectedPackageName"
-            $registry="$(FeedRegistry)"
-            $regAuth=$registry.replace("https:","")
-            $env:NPM_TOKEN="$(azure-sdk-npm-token)"
-            npm config set $regAuth`:_authToken=`$`{NPM_TOKEN`}
-            Write-Host "Publishing to $($regAuth)"
-            Write-Host "npm publish $detectedPackageName --registry=$registry --always-auth=true --access='public'"
-            npm publish $detectedPackageName --registry=$registry --always-auth=true --access="public"
-          displayName: Publish package
+            - pwsh: |
+                $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/$(ArtifactName)/*.tgz
+                Write-Host "Detected package name: $detectedPackageName"
+                $registry="$(FeedRegistry)"
+                $regAuth=$registry.replace("https:","")
+                $env:NPM_TOKEN="$(azure-sdk-npm-token)"
+                npm config set $regAuth`:_authToken=`$`{NPM_TOKEN`}
+                Write-Host "Publishing to $($regAuth)"
+                Write-Host "npm publish $detectedPackageName --registry=$registry --always-auth=true --access='public'"
+                # npm publish $detectedPackageName --registry=$registry --always-auth=true --access="public"
+                Write-Host "BEBRODER SKIPPING"
+              displayName: Publish package

--- a/tools/apiview/emitters/typespec-apiview/ci.yml
+++ b/tools/apiview/emitters/typespec-apiview/ci.yml
@@ -103,6 +103,5 @@ extends:
                 npm config set $regAuth`:_authToken=`$`{NPM_TOKEN`}
                 Write-Host "Publishing to $($regAuth)"
                 Write-Host "npm publish $detectedPackageName --registry=$registry --always-auth=true --access='public'"
-                # npm publish $detectedPackageName --registry=$registry --always-auth=true --access="public"
-                Write-Host "BEBRODER SKIPPING"
+                npm publish $detectedPackageName --registry=$registry --always-auth=true --access="public"
               displayName: Publish package

--- a/tools/apiview/emitters/typespec-apiview/ci.yml
+++ b/tools/apiview/emitters/typespec-apiview/ci.yml
@@ -80,7 +80,7 @@ stages:
         steps:
         - checkout: none
         - download: current
-        
+
         - pwsh: |
             $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/$(ArtifactName)/*.tgz
             Write-Host "Detected package name: $detectedPackageName"

--- a/tools/apiview/parsers/js-api-parser/ci.yml
+++ b/tools/apiview/parsers/js-api-parser/ci.yml
@@ -8,7 +8,7 @@ trigger:
       - hotfix/*
   paths:
     include:
-      - tools/apiview/parsers/js-api-parser          
+      - tools/apiview/parsers/js-api-parser
 
 pr:
   branches:
@@ -19,82 +19,95 @@ pr:
       - hotfix/*
   paths:
     include:
-      - tools/apiview/parsers/js-api-parser          
+      - tools/apiview/parsers/js-api-parser
 
-variables:
-  NodeVersion: '18.x'
-  TypeScriptGeneratorDirectory: 'tools/apiview/parsers/js-api-parser'
-  ArtifactName: 'apiview'
-  FeedRegistry: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - stage: 'Build'
+        variables:
+          - template: /eng/pipelines/templates/variables/image.yml
+          - name: NodeVersion
+            value: '18.x'
+          - name: ArtifactName
+            value: 'apiview'
+          - name: TypeScriptGeneratorDirectory
+            value: 'tools/apiview/parsers/js-api-parser'
+        jobs:
+          - job: 'Build'
 
-stages:
-  - stage: 'Build'
-    jobs:
-      - job: 'Build'
+            pool:
+              name: $(LINUXNEXTPOOL)
+              image: $(LINUXNEXTVMIMAGE)
+              os: linux
 
-        pool:
-          name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: ubuntu-22.04
+            steps:
+              - task: NodeTool@0
+                inputs:
+                  versionSpec: '$(NodeVersion)'
+                displayName: 'Use NodeJS $(NodeVersion)'
 
-        steps:
-          - task: NodeTool@0
-            inputs:
-              versionSpec: '$(NodeVersion)'
-            displayName: 'Use NodeJS $(NodeVersion)'
+              - script: |
+                  npm install -g npm@8.16.0
+                displayName: "Install npm 8.16.0"
 
-          - script: |
-              npm install -g npm@8.16.0
-            displayName: "Install npm 8.16.0"
-          
-          - script: |
-              npm install
-            workingDirectory: $(TypeScriptGeneratorDirectory)
-            displayName: "Install npm packages typescript generator"
+              - script: |
+                  npm install
+                workingDirectory: $(TypeScriptGeneratorDirectory)
+                displayName: "Install npm packages typescript generator"
 
-          - script: |
-              npm run-script build
-            workingDirectory: $(TypeScriptGeneratorDirectory)
-            displayName: "Build typescript generator"
+              - script: |
+                  npm run-script build
+                workingDirectory: $(TypeScriptGeneratorDirectory)
+                displayName: "Build typescript generator"
 
-          - pwsh: |
-              npm pack $(TypeScriptGeneratorDirectory)
-              Copy-Item ./*.tgz $(Build.ArtifactStagingDirectory)
-            displayName: "Pack typescript generator"
+              - pwsh: |
+                  npm pack $(TypeScriptGeneratorDirectory)
+                  Copy-Item ./*.tgz $(Build.ArtifactStagingDirectory)
+                displayName: "Pack typescript generator"
 
-          - task: PublishBuildArtifacts@1
-            inputs:
-              pathtoPublish: '$(Build.ArtifactStagingDirectory)'
-              artifactName: $(ArtifactName)
+              - task: 1ES.PublishPipelineArtifact@1
+                inputs:
+                  targetPath: '$(Build.ArtifactStagingDirectory)'
+                  artifactName: $(ArtifactName)
 
-  - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
-    - stage: 'Release'
-      dependsOn: Build
-      condition: Succeeded()
-      jobs:
-      - job: PublishPackage
-        displayName: 'Publish ts-genapi package to devops feed'
-        pool:
-          name: azsdk-pool-mms-ubuntu-2204-general
-          vmImage: ubuntu-22.04
-        steps:
-        - checkout: none
-        - download: current
-        
-        - pwsh: |
-            $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/$(ArtifactName)/*.tgz
-            Write-Host "Detected package name: $detectedPackageName"
-            $registry="$(FeedRegistry)"
-            $regAuth=$registry.replace("https:","")
-            $npmReg = $regAuth.replace("registry/","");
-            $env:NPM_TOKEN="$(azure-sdk-devops-npm-token)"
-            Write-Host "Publishing to $($regAuth)"
-            npm config set $regAuth`:username=azure-sdk
-            npm config set $regAuth`:_password=`$`{NPM_TOKEN`}
-            npm config set $regAuth`:email=not_set
-            npm config set $npmReg`:username=azure-sdk
-            npm config set $npmReg`:_password=`$`{NPM_TOKEN`}
-            npm config set $npmReg`:email=not_set
-            Write-Host "Publishing package"
-            Write-Host "npm publish $detectedPackageName --registry=$registry --always-auth=true"
-            npm publish $detectedPackageName --registry=$registry --always-auth=true
-          displayName: Publish package
+      - ${{if and(eq(variables['Build.Reason'], 'Manual'), eq(variables['System.TeamProject'], 'internal'))}}:
+        - stage: 'Release'
+          dependsOn: Build
+          condition: Succeeded()
+          variables:
+            - template: /eng/pipelines/templates/variables/image.yml
+            - name: ArtifactName
+              value: 'apiview'
+            - name: FeedRegistry
+              value: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/'
+          jobs:
+          - job: PublishPackage
+            displayName: 'Publish ts-genapi package to devops feed'
+            pool:
+              name: $(LINUXNEXTPOOL)
+              image: $(LINUXNEXTVMIMAGE)
+              os: linux
+            steps:
+            - checkout: none
+            - download: current
+
+            - pwsh: |
+                $detectedPackageName=Get-ChildItem $(Pipeline.Workspace)/$(ArtifactName)/*.tgz
+                Write-Host "Detected package name: $detectedPackageName"
+                $registry="$(FeedRegistry)"
+                $regAuth=$registry.replace("https:","")
+                $npmReg = $regAuth.replace("registry/","");
+                $env:NPM_TOKEN="$(azure-sdk-devops-npm-token)"
+                Write-Host "Publishing to $($regAuth)"
+                npm config set $regAuth`:username=azure-sdk
+                npm config set $regAuth`:_password=`$`{NPM_TOKEN`}
+                npm config set $regAuth`:email=not_set
+                npm config set $npmReg`:username=azure-sdk
+                npm config set $npmReg`:_password=`$`{NPM_TOKEN`}
+                npm config set $npmReg`:email=not_set
+                Write-Host "Publishing package"
+                Write-Host "npm publish $detectedPackageName --registry=$registry --always-auth=true"
+                npm publish $detectedPackageName --registry=$registry --always-auth=true
+              displayName: Publish package

--- a/tools/tsp-client/build-tsp-client.yml
+++ b/tools/tsp-client/build-tsp-client.yml
@@ -1,0 +1,33 @@
+parameters:
+  - name: Publish
+    type: boolean
+    default: false
+
+steps:
+  - task: NodeTool@0
+    inputs:
+      versionSpec: '$(NodeVersion)'
+    displayName: 'Install Node.js'
+
+  - bash: |
+      npm ci
+    displayName: 'npm ci'
+    workingDirectory: $(System.DefaultWorkingDirectory)/tools/tsp-client
+
+  - bash: |
+      npm pack
+    displayName: 'npm pack'
+    workingDirectory: $(System.DefaultWorkingDirectory)/tools/tsp-client
+    condition: ${{ parameters.Publish }}
+
+  - bash: 'cp azure-tools-typespec-client-generator-cli-*.tgz $(VAR_BUILD_ARTIFACT_STAGING_DIRECTORY)'
+    displayName: 'copy to staging dir'
+    workingDirectory: $(System.DefaultWorkingDirectory)/tools/tsp-client
+    condition: ${{ parameters.Publish }}
+
+  - task: 1ES.PublishPipelineArtifact@1
+    inputs:
+      targetPath: '$(VAR_BUILD_ARTIFACT_STAGING_DIRECTORY)'
+      artifactName: '$(VAR_ARTIFACT_NAME)'
+    condition: ${{ parameters.Publish }}
+

--- a/tools/tsp-client/ci.yml
+++ b/tools/tsp-client/ci.yml
@@ -1,8 +1,3 @@
-# Node.js
-# Build a general Node.js project with npm.
-# Add steps that analyze code, save build artifacts, deploy, and more:
-# https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
-
 trigger:
   branches:
     include:
@@ -25,96 +20,90 @@ pr:
     include:
       - tools/tsp-client
 
-variables:
-  - template: ../../eng/pipelines/templates/variables/globals.yml
-  - name: NodeVersion
-    value: '18.x'
-  - name: VAR_ARTIFACT_NAME
-    value: 'drop'
-  - name: VAR_BUILD_ARTIFACT_STAGING_DIRECTORY
-    value: $(Build.ArtifactStagingDirectory)
+extends:
+  template: /eng/pipelines/templates/stages/1es-redirect.yml
+  parameters:
+    stages:
+      - stage: InstallAndBuild
+        variables:
+          - template: /eng/pipelines/templates/variables/globals.yml
+          - template: /eng/pipelines/templates/variables/image.yml
+          - name: NodeVersion
+            value: '18.x'
+          - name: VAR_ARTIFACT_NAME
+            value: 'drop'
+          - name: VAR_BUILD_ARTIFACT_STAGING_DIRECTORY
+            value: $(Build.ArtifactStagingDirectory)
+        jobs:
+          - job:
+            pool:
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
+              os: linux
+            steps:
+              - template: /tools/tsp-client/build-tsp-client.yml
+                parameters:
+                  Publish: true
+          - job:
+            pool:
+              name: $(WINDOWSPOOL)
+              image: $(WINDOWSVMIMAGE)
+              os: windows
+            steps:
+              - template: /tools/tsp-client/build-tsp-client.yml
+          - job:
+            pool:
+              name: $(MACPOOL)
+              vmImage: $(MACVMIMAGE)
+              os: macOS
+            steps:
+              - template: /tools/tsp-client/build-tsp-client.yml
 
-stages:
-  - stage: InstallAndBuild
-    jobs:
-      - job: Build
-        strategy:
-          matrix:
-            linux:
-              OSVmImage: 'MMSUbuntu20.04'
-              Pool: 'azsdk-pool-mms-ubuntu-2004-general'
-            mac:
-              OSVmImage: 'macos-12'
-              Pool: 'Azure Pipelines'
-            windows:
-              OSVmImage: 'MMS2022'
-              Pool: 'azsdk-pool-mms-win-2022-general'
-        pool:
-          name: $(Pool)
-          vmImage: $(OSVmImage)
-        steps:
-        - task: NodeTool@0
-          inputs:
-            versionSpec: '$(NodeVersion)'
-          displayName: 'Install Node.js'
-
-        - bash: |
-            npm ci
-          displayName: 'npm ci'
-          workingDirectory: $(System.DefaultWorkingDirectory)/tools/tsp-client
-
-        - bash: |
-            npm pack
-          displayName: 'npm pack'
-          workingDirectory: $(System.DefaultWorkingDirectory)/tools/tsp-client
-          condition: contains(variables['OSVmImage'], 'ubuntu')
-
-        - bash: 'cp azure-tools-typespec-client-generator-cli-*.tgz $(VAR_BUILD_ARTIFACT_STAGING_DIRECTORY)'
-          displayName: 'copy to staging dir'
-          workingDirectory: $(System.DefaultWorkingDirectory)/tools/tsp-client
-          condition: contains(variables['OSVmImage'], 'ubuntu')
-
-        - task: PublishBuildArtifacts@1
-          inputs:
-            PathtoPublish: '$(VAR_BUILD_ARTIFACT_STAGING_DIRECTORY)'
-            ArtifactName: '$(VAR_ARTIFACT_NAME)'
-            publishLocation: 'Container'
-          condition: contains(variables['OSVmImage'], 'ubuntu')
-
-  - ${{if ne(variables['Build.Reason'], 'PullRequest')}}:
-    - stage: Release
-      dependsOn: InstallAndBuild
-      condition: succeeded()
-      jobs:
-      - job: approve
-        pool: server
-        steps:
-        - task: ManualValidation@0
-          inputs:
-            notifyUsers: 'Click to approve if it''s an expected public release.'
-      - job: release
-        dependsOn: approve
-        condition: and(succeeded(), ne(variables['USER_SKIP_PUBLIC_RELEASE'], 'true'))
-        steps:
-        - task: NodeTool@0
-          inputs:
-            versionSpec: '$(NodeVersion)'
-          displayName: 'Install Node.js'
-        - task: DownloadBuildArtifacts@0
-          inputs:
-            buildType: 'current'
-            downloadType: 'single'
-            artifactName: '$(VAR_ARTIFACT_NAME)'
-            downloadPath: '$(VAR_BUILD_ARTIFACT_STAGING_DIRECTORY)'
-        - bash: |
-            echo -e "\e[32m[$(date -u)] LOG: publish the package"
-            echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" >> ~/.npmrc
-            for file in $(VAR_BUILD_ARTIFACT_STAGING_DIRECTORY)/$(VAR_ARTIFACT_NAME)/*.tgz
-            do
-              echo -e "\e[32m[$(date -u)] LOG: File: $file"
-              npm publish $file --access public || { echo 'publish $file failed' ; exit 1; }
-            done
-            rm ~/.npmrc || { echo 'rm ~/.npmrc failed' ; exit 1; }
-          displayName: Publish
-          workingDirectory: $(System.DefaultWorkingDirectory)/tools/tsp-client
+      - ${{if ne(variables['Build.Reason'], 'PullRequest')}}:
+        - stage: Release
+          dependsOn: InstallAndBuild
+          condition: succeeded()
+          variables:
+            - template: /eng/pipelines/templates/variables/globals.yml
+            - template: /eng/pipelines/templates/variables/image.yml
+            - name: NodeVersion
+              value: '18.x'
+            - name: VAR_ARTIFACT_NAME
+              value: 'drop'
+            - name: VAR_BUILD_ARTIFACT_STAGING_DIRECTORY
+              value: $(Build.ArtifactStagingDirectory)
+          jobs:
+          - job: approve
+            pool: server
+            steps:
+            - task: ManualValidation@0
+              inputs:
+                notifyUsers: 'Click to approve if it''s an expected public release.'
+          - job: release
+            dependsOn: approve
+            condition: and(succeeded(), ne(variables['USER_SKIP_PUBLIC_RELEASE'], 'true'))
+            pool:
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
+              os: linux
+            steps:
+            - task: NodeTool@0
+              inputs:
+                versionSpec: '$(NodeVersion)'
+              displayName: 'Install Node.js'
+            - task: DownloadPipelineArtifact@2
+              inputs:
+                artifactName: '$(VAR_ARTIFACT_NAME)'
+                targetPath: '$(VAR_BUILD_ARTIFACT_STAGING_DIRECTORY)'
+            - bash: |
+                echo -e "\e[32m[$(date -u)] LOG: publish the package"
+                echo "//registry.npmjs.org/:_authToken=$(azure-sdk-npm-token)" >> ~/.npmrc
+                for file in $(VAR_BUILD_ARTIFACT_STAGING_DIRECTORY)/$(VAR_ARTIFACT_NAME)/*.tgz
+                do
+                  echo -e "\e[32m[$(date -u)] LOG: File: $file"
+                  npm publish $file --access public || { echo 'publish $file failed' ; exit 1; }
+                done
+                rm ~/.npmrc || { echo 'rm ~/.npmrc failed' ; exit 1; }
+              displayName: Publish
+              workingDirectory: $(System.DefaultWorkingDirectory)/tools/tsp-client
 


### PR DESCRIPTION
Additional update: only auth to ACR on internal builds (not sure if this is necessary but just in case)

Pipelines:
tools - apiview-stub-generator
tools - apiview-typespec-emitter
tools - azure-pylint-guidelines-checker
tools - js - apiview-parser
tools - swaggerapiparser
tools - tsp-client
