### PR TITLE
Support templated strings in APIView

### DIFF
--- a/tools/apiview/emitters/typespec-apiview/CHANGELOG.md
+++ b/tools/apiview/emitters/typespec-apiview/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release History
 
+## Version 0.4.7 (03-22-2024)
+Support TypeSpec string templates.
+Fix display issue with templated aliases.
+Ensure alias statements end with semicolon.
+
 ## Version 0.4.6 (03-08-2024)
 Support CrossLanguagePackageId.
 

--- a/tools/apiview/emitters/typespec-apiview/package-lock.json
+++ b/tools/apiview/emitters/typespec-apiview/package-lock.json
@@ -62,25 +62,6 @@
         "@typespec/rest": "~0.53.0"
       }
     },
-    "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.39.1.tgz",
-      "integrity": "sha512-EV3N6IN1i/hXGqYKNfXx6+2QAyZnG4IpC9RUk6fqwSQDWX7HtMcfdXqlOaK3Rz2H6BUAc9OnH+Trq/uJCl/RgA==",
-      "dev": true,
-      "dependencies": {
-        "change-case": "~5.3.0",
-        "pluralize": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@typespec/compiler": "~0.53.1",
-        "@typespec/http": "~0.53.0",
-        "@typespec/rest": "~0.53.0",
-        "@typespec/versioning": "~0.53.0"
-      }
-    },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
@@ -1841,7 +1822,8 @@
     "node_modules/change-case": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.3.0.tgz",
-      "integrity": "sha512-Eykca0fGS/xYlx2fG5NqnGSnsWauhSGiSXYhB1kO6E909GUfo8S54u4UZNS7lMJmgZumZ2SUpWaoLgAcfQRICg=="
+      "integrity": "sha512-Eykca0fGS/xYlx2fG5NqnGSnsWauhSGiSXYhB1kO6E909GUfo8S54u4UZNS7lMJmgZumZ2SUpWaoLgAcfQRICg==",
+      "peer": true
     },
     "node_modules/charenc": {
       "version": "0.0.2",

--- a/tools/apiview/emitters/typespec-apiview/package.json
+++ b/tools/apiview/emitters/typespec-apiview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-apiview",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "author": "Microsoft Corporation",
   "description": "Library for emitting APIView token files from TypeSpec",
   "homepage": "https://github.com/Azure/azure-sdk-tools",

--- a/tools/apiview/emitters/typespec-apiview/src/version.ts
+++ b/tools/apiview/emitters/typespec-apiview/src/version.ts
@@ -1,1 +1,1 @@
-export const LIB_VERSION = "0.4.6";
+export const LIB_VERSION = "0.4.7";

--- a/tools/apiview/emitters/typespec-apiview/test/apiview.test.ts
+++ b/tools/apiview/emitters/typespec-apiview/test/apiview.test.ts
@@ -243,7 +243,7 @@ describe("apiview: tests", () => {
           species: string;
         }
   
-        alias Creature = Animal
+        alias Creature = Animal;
       }
       `;
       const apiview = await apiViewFor(input, {});
@@ -251,7 +251,33 @@ describe("apiview: tests", () => {
       compare(expect, actual, 9);
       validateDefinitionIds(apiview);
     });  
-  });
+
+    it("templated alias", async () => {
+        const input = `
+        @TypeSpec.service( { title: "Test", version: "1" } )
+        namespace Azure.Test {
+          model Animal {
+            species: string;
+          }
+
+          alias Template<T extends valueof string> = "Foo \${T} bar";
+        }
+        `;
+        const expect = `
+        namespace Azure.Test {
+          model Animal {
+            species: string;
+          }
+    
+          alias Template<T extends valueof string> = "Foo \${T} bar";
+        }
+        `;
+        const apiview = await apiViewFor(input, {});
+        const actual = apiViewText(apiview);
+        compare(expect, actual, 9);
+        validateDefinitionIds(apiview);
+      });  
+    });
 
   describe("augment decorators", () => {
     it("simple augment", async () => {
@@ -704,8 +730,8 @@ describe("apiview: tests", () => {
           simple: "Simple \${123} end";
           multiline: """
             Multi
-               \${123}
-               \${true}
+              \${123}
+              \${true}
             line
           """;
           ref: "Ref this alias \${myconst} end";
@@ -719,10 +745,10 @@ describe("apiview: tests", () => {
         model Person {
           simple: "Simple \${123} end";
           multiline: """
-            Multi
-               \${123}
-               \${true}
-            line
+              Multi
+                \${123}
+                \${true}
+              line
           """;
           ref: "Ref this alias \${myconst} end";
           template: Template<"custom">;

--- a/tools/apiview/emitters/typespec-apiview/test/apiview.test.ts
+++ b/tools/apiview/emitters/typespec-apiview/test/apiview.test.ts
@@ -693,4 +693,50 @@ describe("apiview: tests", () => {
       validateDefinitionIds(apiview);
     });  
   });
+
+  describe("string templates", () => {
+    it("templates", async () => {
+      const input = `
+      @TypeSpec.service( { title: "Test", version: "1" } )
+      namespace Azure.Test {  
+        alias myconst = "foobar";
+        model Person {
+          simple: "Simple \${123} end";
+          multiline: """
+            Multi
+               \${123}
+               \${true}
+            line
+          """;
+          ref: "Ref this alias \${myconst} end";
+          template: Template<"custom">;          
+        }
+        alias Template<T extends valueof string> = "Foo \${T} bar";
+      }`;
+
+      const expect = `
+      namespace Azure.Test {
+        model Person {
+          simple: "Simple \${123} end";
+          multiline: """
+            Multi
+               \${123}
+               \${true}
+            line
+          """;
+          ref: "Ref this alias \${myconst} end";
+          template: Template<"custom">;
+        }
+
+        alias myconst = "foobar";
+
+        alias Template<T extends valueof string> = "Foo \${T} bar";
+      }
+      `;
+      const apiview = await apiViewFor(input, {});
+      const lines = apiViewText(apiview);
+      compare(expect, lines, 9);
+      validateDefinitionIds(apiview);
+    });
+  });
 });


### PR DESCRIPTION
Fixes: https://github.com/Azure/azure-sdk-tools/issues/7930

Also, ensures that future failures will say the name of the case, rather than the number. 