### PR TITLE
Pass Group in request to get package status

### DIFF
--- a/eng/common/scripts/Validate-Package.ps1
+++ b/eng/common/scripts/Validate-Package.ps1
@@ -212,7 +212,11 @@ $changeLogStatus = [PSCustomObject]@{
 ValidateChangeLog $changeLogPath $versionString $changeLogStatus
 
 # API review and package name validation
-$apireviewDetails = VerifyAPIReview $PackageName $pkgInfo.Version $Language
+$fulPackageName = $PackageName
+if ($pkgInfo.Group){
+    $fulPackageName = "$($pkgInfo.Group):$PackageName"
+}
+$apireviewDetails = VerifyAPIReview $fulPackageName $pkgInfo.Version $Language
 
 $pkgValidationDetails= [PSCustomObject]@{
     Name = $PackageName

--- a/eng/common/scripts/Validate-Package.ps1
+++ b/eng/common/scripts/Validate-Package.ps1
@@ -213,9 +213,14 @@ ValidateChangeLog $changeLogPath $versionString $changeLogStatus
 
 # API review and package name validation
 $fulPackageName = $pkgName
-if ($pkgInfo.Group){
-    $fulPackageName = "$($pkgInfo.Group):$pkgName"
+$groupId = $null
+if ($pkgInfo.PSObject.Members.Name -contains "Group") {
+    $groupId = $pkgInfo.Group
 }
+if ($groupId){
+    $fulPackageName = "${groupId}:${pkgName}"
+}
+Write-Host "Checking API review status for package $fulPackageName"
 $apireviewDetails = VerifyAPIReview $fulPackageName $pkgInfo.Version $Language
 
 $pkgValidationDetails= [PSCustomObject]@{


### PR DESCRIPTION
Java packages contains `group name:` as a prefix in APIView.  API status request should pass full package name including group name when it's present for a language to get correct status.