### PR TITLE
Skip API review package name approval for management plane packages

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -155,7 +155,6 @@ function Submit-APIReview($packageInfo, $packagePath)
 
 function IsApiviewStatusCheckRequired($packageInfo)
 {
-    # This function can be modified to control this check by individual language function
     if (($packageInfo.SdkType -eq "client" -or $packageInfo.SdkType -eq "spring") -and $packageInfo.IsNewSdk) {
         return $true
     }

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -241,7 +241,7 @@ function ProcessPackage($packageName)
                     # Check if package name is approved. Preview version cannot be released without package name approval
                     if (!$pkgNameStatus.IsApproved) 
                     {
-                        if (IsApiviewStatusCheckRequired($pkgInfo))
+                        if (IsApiviewStatusCheckRequired $pkgInfo)
                         {
                             Write-Error $($pkgNameStatus.Details)
                             return 1

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -258,7 +258,7 @@ function ProcessPackage($packageName)
                     # Return error code if status code is 201 for new data plane package
                     # Temporarily enable API review for spring SDK types. Ideally this should be done be using 'IsReviewRequired' method in language side
                     # to override default check of SDK type client
-                    if (IsApiviewStatusCheckRequired($pkgInfo))
+                    if (IsApiviewStatusCheckRequired $pkgInfo)
                     {
                         if (!$apiStatus.IsApproved)
                         {


### PR DESCRIPTION
Package name approval check is enforced for management plane package also due to a recent bug that got introduced as part of recent script restructure to consolidate language specific script into common script.

This PR has changes to skip package name check for management plane libraries.