### PR TITLE
Stop downloading resource cleanup secrets that are commented out

### DIFF
--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -36,11 +36,11 @@ parameters:
       # see https://github.com/Azure/azure-sdk-for-python/pull/33483 were the tests were disabled.
       # - DisplayName: Dogfood Translation - Resource Cleanup
       #   SubscriptionConfigurations:
-      #     - $(sub-config-translation-int-test-resources)
+      #     - $ (sub-config-translation-int-test-resources)
       # TODO: re-enable dogfood cleanup after resource deletion issues are solved, to avoid pipeline timeouts
       # - DisplayName: Dogfood ACS - Resource Cleanup
       #   SubscriptionConfigurations:
-      #     - $(sub-config-communication-int-test-resources-common)
+      #     - $ (sub-config-communication-int-test-resources-common)
       - DisplayName: AzureCloud ACS - Resource Cleanup
         SubscriptionConfigurations:
           - $(sub-config-azure-cloud-test-resources)


### PR DESCRIPTION
Seems like even if the `$(<var group>)` reference is commented out, we still attempt to download it.
