### PR TITLE
A pshell update (7.4?) caused `git show` to stop working

### DIFF
--- a/eng/common/scripts/Helpers/git-helpers.ps1
+++ b/eng/common/scripts/Helpers/git-helpers.ps1
@@ -65,8 +65,9 @@ class ConflictedFile {
       # powershell ignores the newlines with and without --textconv, which results in a json file without original spacing.
       # by forcefully reading into the array line by line, the whitespace is preserved. we're relying on gits autoconverstion of clrf to lf
       # to ensure that the line endings are consistent.
-      Write-Host "git show $($this.LeftSource):$($this.Path)"
-      $tempContent = git show ("$($this.LeftSource):$($this.Path)")
+      $toShow = "$($this.LeftSource):$($this.Path)" -replace "\\", "/"
+      Write-Host "git show $toShow"
+      $tempContent = git show $toShow
       return $tempContent -split "`r?`n"
     }
     else {
@@ -76,8 +77,9 @@ class ConflictedFile {
 
   [array] Right(){
     if ($this.IsConflicted) {
-      Write-Host "git show $($this.RightSource):$($this.Path)"
-      $tempContent =  git show ("$($this.RightSource):$($this.Path)")
+      $toShow = "$($this.RightSource):$($this.Path)" -replace "\\", "/"
+      Write-Host "git show $toShow"
+      $tempContent = git show $toShow
       return $tempContent -split "`r?`n"
     }
     else {


### PR DESCRIPTION
- `git show head:sdk\storage\Azure.Storage.Blob\assets.json` no longer results in visible output.
  - The script grabs the tag from the **left** side of the merge, holds it constant, and merges the incoming branch tag _into_ the assets. If we aren't able to properly utilize `git show`, we can't generate the `left` or `right` side of the assets.json, and end up setting the `assets.json` to **empty**.
- `git show head:sdk/storage/Azure.Storage.Blob/assets.json` does still work, so amending the command



