### PR TITLE
Pass valid original artifact file name in request to APIView

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -125,10 +125,10 @@ function Upload-ReviewTokenFile($packageName, $apiLabel, $releaseStatus, $review
     return $StatusCode
 }
 
-function Get-APITokenFileName($packageName)
+function Get-APITokenFileName($artifactName)
 {
-    $reviewTokenFileName = "${packageName}_${LanguageShort}.json"
-    $tokenFilePath = Join-Path $ArtifactPath $packageName $reviewTokenFileName
+    $reviewTokenFileName = "${artifactName}_${LanguageShort}.json"
+    $tokenFilePath = Join-Path $ArtifactPath $artifactName $reviewTokenFileName
     if (Test-Path $tokenFilePath) {
         Write-Host "Review token file is present at $tokenFilePath"
         return $reviewTokenFileName
@@ -139,14 +139,14 @@ function Get-APITokenFileName($packageName)
     }
 }
 
-function Submit-APIReview($packageInfo, $packagePath)
+function Submit-APIReview($packageInfo, $packagePath, $artifactName)
 {
     $packageName = $packageInfo.Name    
     $apiLabel = "Source Branch:${SourceBranch}"
 
     # Get generated review token file if present
     # APIView processes request using different API if token file is already generated
-    $reviewTokenFileName =  Get-APITokenFileName $packageName
+    $reviewTokenFileName =  Get-APITokenFileName $artifactName
     if ($reviewTokenFileName) {
         Write-Host "Uploading review token file $reviewTokenFileName to APIView."
         return Upload-ReviewTokenFile $packageName $apiLabel $packageInfo.ReleaseStatus $reviewTokenFileName $packageInfo.Version $packagePath
@@ -209,7 +209,7 @@ function ProcessPackage($packageName)
             if ( ($SourceBranch -eq $DefaultBranch) -or (-not $version.IsPrerelease) -or $MarkPackageAsShipped)
             {
                 Write-Host "Submitting API Review request for package $($pkg), File path: $($pkgPath)"
-                $respCode = Submit-APIReview $pkgInfo $pkgPath
+                $respCode = Submit-APIReview $pkgInfo $pkgPath $packageName
                 Write-Host "HTTP Response code: $($respCode)"
 
                 # no need to check API review status when marking a package as shipped

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -125,10 +125,10 @@ function Upload-ReviewTokenFile($packageName, $apiLabel, $releaseStatus, $review
     return $StatusCode
 }
 
-function Get-APITokenFileName($artifactName)
+function Get-APITokenFileName($packageArtifactName)
 {
-    $reviewTokenFileName = "${artifactName}_${LanguageShort}.json"
-    $tokenFilePath = Join-Path $ArtifactPath $artifactName $reviewTokenFileName
+    $reviewTokenFileName = "${packageArtifactName}_${LanguageShort}.json"
+    $tokenFilePath = Join-Path $ArtifactPath $packageArtifactName $reviewTokenFileName
     if (Test-Path $tokenFilePath) {
         Write-Host "Review token file is present at $tokenFilePath"
         return $reviewTokenFileName
@@ -139,14 +139,14 @@ function Get-APITokenFileName($artifactName)
     }
 }
 
-function Submit-APIReview($packageInfo, $packagePath, $artifactName)
+function Submit-APIReview($packageInfo, $packagePath, $packageArtifactName)
 {
     $packageName = $packageInfo.Name    
     $apiLabel = "Source Branch:${SourceBranch}"
 
     # Get generated review token file if present
     # APIView processes request using different API if token file is already generated
-    $reviewTokenFileName =  Get-APITokenFileName $artifactName
+    $reviewTokenFileName =  Get-APITokenFileName $packageArtifactName
     if ($reviewTokenFileName) {
         Write-Host "Uploading review token file $reviewTokenFileName to APIView."
         return Upload-ReviewTokenFile $packageName $apiLabel $packageInfo.ReleaseStatus $reviewTokenFileName $packageInfo.Version $packagePath

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -125,10 +125,10 @@ function Upload-ReviewTokenFile($packageName, $apiLabel, $releaseStatus, $review
     return $StatusCode
 }
 
-function Get-APITokenFileName($packageArtifactName)
+function Get-APITokenFileName($packageName)
 {
-    $reviewTokenFileName = "${packageArtifactName}_${LanguageShort}.json"
-    $tokenFilePath = Join-Path $ArtifactPath $packageArtifactName $reviewTokenFileName
+    $reviewTokenFileName = "${packageName}_${LanguageShort}.json"
+    $tokenFilePath = Join-Path $ArtifactPath $packageName $reviewTokenFileName
     if (Test-Path $tokenFilePath) {
         Write-Host "Review token file is present at $tokenFilePath"
         return $reviewTokenFileName

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -89,9 +89,13 @@ function Upload-SourceArtifact($filePath, $apiLabel, $releaseStatus, $packageVer
     return $StatusCode
 }
 
-function Upload-ReviewTokenFile($packageName, $apiLabel, $releaseStatus, $reviewFileName, $packageVersion)
+function Upload-ReviewTokenFile($packageName, $apiLabel, $releaseStatus, $reviewFileName, $packageVersion, $filePath)
 {
-    $params = "buildId=${BuildId}&artifactName=${ArtifactName}&originalFilePath=${packageName}&reviewFilePath=${reviewFileName}"    
+    Write-Host "Original File path: $filePath"
+    $fileName = Split-Path -Leaf $filePath
+    Write-Host "OriginalFile name: $fileName"
+
+    $params = "buildId=${BuildId}&artifactName=${ArtifactName}&originalFilePath=${fileName}&reviewFilePath=${reviewFileName}"    
     $params += "&label=${apiLabel}&repoName=${RepoName}&packageName=${packageName}&project=internal&packageVersion=${packageVersion}"
     if($MarkPackageAsShipped) {
         $params += "&setReleaseTag=true"
@@ -145,7 +149,7 @@ function Submit-APIReview($packageInfo, $packagePath)
     $reviewTokenFileName =  Get-APITokenFileName $packageName
     if ($reviewTokenFileName) {
         Write-Host "Uploading review token file $reviewTokenFileName to APIView."
-        return Upload-ReviewTokenFile $packageName $apiLabel $packageInfo.ReleaseStatus $reviewTokenFileName $packageInfo.Version
+        return Upload-ReviewTokenFile $packageName $apiLabel $packageInfo.ReleaseStatus $reviewTokenFileName $packageInfo.Version $packagePath
     }
     else {
         Write-Host "Uploading $packagePath to APIView."


### PR DESCRIPTION
Original file path is incorrect in request to APIView when token file is already generated. This will become an issue when attempting to rebuild existing reviews after the parser is upgraded to a newer version. Common script also uses incorrect path to find the token file if artifact name and package name are different. For e.g. JS package name is @azure/core-http and artifact name is azure-core-http. Currently we are looking for file within in the path @azure/core-http instead of azure-core-http.