### PR TITLE
Remove soft errors in validation step from Devops pipeline

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -149,7 +149,7 @@ function Submit-APIReview($packageInfo, $packagePath, $packageArtifactName)
     $reviewTokenFileName =  Get-APITokenFileName $packageArtifactName
     if ($reviewTokenFileName) {
         Write-Host "Uploading review token file $reviewTokenFileName to APIView."
-        return Upload-ReviewTokenFile $packageName $apiLabel $packageInfo.ReleaseStatus $reviewTokenFileName $packageInfo.Version $packagePath
+        return Upload-ReviewTokenFile $packageArtifactName $apiLabel $packageInfo.ReleaseStatus $reviewTokenFileName $packageInfo.Version $packagePath
     }
     else {
         Write-Host "Uploading $packagePath to APIView."


### PR DESCRIPTION
Validation step in pipeline ignores any failures in change log verification but DevOps still report it as error which confuses users to think that pipeline has failed. This change is to suppress error logs when a status object is passed.