### PR TITLE
Use different service connection and az CLI for ACR auth

### DIFF
--- a/eng/common/pipelines/templates/steps/docker-pull-image.yml
+++ b/eng/common/pipelines/templates/steps/docker-pull-image.yml
@@ -6,7 +6,7 @@ parameters:
     type: string
 steps:
   - task: AzureCLI@2
-    displayName: Authenticate to Container Registry
+    displayName: Docker Auth and Pull
     inputs:
       azureSubscription: ${{ parameters.ServiceConnectionName }}
       scriptType: pscore

--- a/eng/common/pipelines/templates/steps/docker-pull-image.yml
+++ b/eng/common/pipelines/templates/steps/docker-pull-image.yml
@@ -1,15 +1,19 @@
 parameters: 
-  - name: ContainerRegistryClientId
+  - name: ServiceConnectionName
     type: string
-  - name: ContainerRegistryClientSecret
-    type: string
+    default: azuresdkimages_container-registry
   - name: ImageId
     type: string
 steps:
-- pwsh: |
-    $containerRegistry = ("${{parameters.ImageId}}" -split "\/")[0]
-    docker login $containerRegistry -u "${{ parameters.ContainerRegistryClientId }}" -p "${{ parameters.ContainerRegistryClientSecret }}"
-  displayName: Login container registry
-- pwsh: |
-    docker pull '${{ parameters.ImageId}}'
-  displayName: Pull docker image ${{ parameters.ImageId }}
+  - task: AzureCLI@2
+    displayName: Authenticate to Container Registry
+    inputs:
+      azureSubscription: ${{ parameters.ServiceConnectionName }}
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: |
+        # azuresdkimages.azurecr.io/pyrefautocr:latest -> azuresdkimages
+        $containerRegistryName = ("${{ parameters.ImageId }}" -split "\/")[0].Replace(".azurecr.io", "")
+
+        az acr login --name $containerRegistryName
+        docker pull '${{ parameters.ImageId }}'

--- a/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
+++ b/eng/common/pipelines/templates/steps/update-docsms-metadata.yml
@@ -87,8 +87,6 @@ steps:
     - ${{ if ne(parameters.DocValidationImageId, '') }}:
       - template: /eng/common/pipelines/templates/steps/docker-pull-image.yml
         parameters:
-          ContainerRegistryClientId: $(azuresdkimages-cr-clientid)
-          ContainerRegistryClientSecret: $(azuresdkimages-cr-clientsecret)
           ImageId: '${{ parameters.DocValidationImageId }}'
     - pwsh: |
         $packageInfoJson = '${{ convertToJson(parameters.PackageInfoLocations) }}'.Trim('"').Replace("\\", "/")


### PR DESCRIPTION
Updates docker pulls from internal ACR to use a different service connection and auth strategy.

Example release pipeline: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3662553&view=logs&j=19b87903-f8bc-5cbb-22d9-4f6eb3469d8e&t=789ec5f9-c426-56bf-c6a5-d85b141abeda 

Changes in Java and Python pipelines will require this change: 
* https://github.com/Azure/azure-sdk-for-java/pull/39535
* https://github.com/Azure/azure-sdk-for-python/pull/35048