### PR TITLE
Merge `eng/` from `main` on assets push

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
@@ -438,10 +438,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Theory]
-        [InlineData("assets.json", false, "./ eng/")]
-        [InlineData("assets.json", true, "python/recordings eng/")]
-        [InlineData("sdk/storage/assets.json", false, "sdk/storage eng/")]
-        [InlineData("sdk/storage/assets.json", true, "python/recordings/sdk/storage eng/")]
+        [InlineData("assets.json", false, "./ eng/ .gitignore")]
+        [InlineData("assets.json", true, "python/recordings eng/ .gitignore")]
+        [InlineData("sdk/storage/assets.json", false, "sdk/storage eng/ .gitignore")]
+        [InlineData("sdk/storage/assets.json", true, "python/recordings/sdk/storage eng/ .gitignore")]
         public async Task ResolveCheckPathsResolvesProperly(string assetsJsonPath, bool includePrefix, string expectedResult)
         {
             var expectedPaths = new string[]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/GitStoreTests.cs
@@ -438,10 +438,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Theory]
-        [InlineData("assets.json", false, "./")]
-        [InlineData("assets.json", true, "python/recordings")]
-        [InlineData("sdk/storage/assets.json", false, "sdk/storage")]
-        [InlineData("sdk/storage/assets.json", true, "python/recordings/sdk/storage")]
+        [InlineData("assets.json", false, "./ eng/")]
+        [InlineData("assets.json", true, "python/recordings eng/")]
+        [InlineData("sdk/storage/assets.json", false, "sdk/storage eng/")]
+        [InlineData("sdk/storage/assets.json", true, "python/recordings/sdk/storage eng/")]
         public async Task ResolveCheckPathsResolvesProperly(string assetsJsonPath, bool includePrefix, string expectedResult)
         {
             var expectedPaths = new string[]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -2,7 +2,6 @@
   "profiles": {
     "Azure.Sdk.Tools.TestProxy": {
       "commandName": "Project",
-      "commandLineArgs": "start --storage-location=\"C:/repo/azure-sdk-for-python/\"",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "Logging__LogLevel__Microsoft": "Information"

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Azure.Sdk.Tools.TestProxy": {
       "commandName": "Project",
+      "commandLineArgs": "start --storage-location=\"C:/repo/azure-sdk-for-python/\"",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "Logging__LogLevel__Microsoft": "Information"

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -149,7 +149,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                         File.Delete(engPatchLocation);
                     }
 
-                    GitHandler.Run($"diff --output=changes.patch --no-color --binary --no-prefix HEAD main -- .gitignore", config);
+                    GitHandler.Run($"diff --output=changes.patch --no-color --binary HEAD main -- .gitignore", config);
                     if (GitHandler.TryRun($"apply --check changes.patch", config.AssetsRepoLocation.ToString(), out var applyResult))
                     {
                         GitHandler.Run($"apply changes.patch", config);
@@ -582,11 +582,11 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
             if (combinedPath.ToLower() == AssetsJsonFileName)
             {
-                return "./ eng/";
+                return "./ eng/ .gitignore";
             }
             else
             {
-                return combinedPath.Substring(0, combinedPath.Length - (AssetsJsonFileName.Length + 1)) + " eng/";
+                return combinedPath.Substring(0, combinedPath.Length - (AssetsJsonFileName.Length + 1)) + " eng/ .gitignore";
             }
         }
         #endregion

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -139,15 +139,24 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                      * push action will properly put their repo into the expected "ready to push" state that a failed
                      * merge would NOT.
                      */
+                    var engPatchLocation = Path.Combine(config.AssetsRepoLocation, "changes.patch");
                     GitHandler.Run($"diff --output=changes.patch --no-color --binary --no-prefix HEAD main -- eng/", config);
-                    if (GitHandler.TryRun($"apply --check --directory=eng/ changes.patch", config.AssetsRepoLocation.ToString(), out var applyResult))
+                    if (GitHandler.TryRun($"apply --check --directory=eng/ changes.patch", config.AssetsRepoLocation.ToString(), out var engPatchResult))
                     {
                         GitHandler.Run($"apply --directory=eng/ changes.patch", config);
                     }
-                    var pathLocation = Path.Combine(config.AssetsRepoLocation, "changes.patch");
+                    if (File.Exists(engPatchLocation)) {
+                        File.Delete(engPatchLocation);
+                    }
 
-                    if (File.Exists(pathLocation)) {
-                        File.Delete(pathLocation);
+                    GitHandler.Run($"diff --output=changes.patch --no-color --binary --no-prefix HEAD main -- .gitignore", config);
+                    if (GitHandler.TryRun($"apply --check changes.patch", config.AssetsRepoLocation.ToString(), out var applyResult))
+                    {
+                        GitHandler.Run($"apply changes.patch", config);
+                    }
+                    if (File.Exists(engPatchLocation))
+                    {
+                        File.Delete(engPatchLocation);
                     }
 
                     // add all the recording changes and commit them

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -129,7 +129,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
                     // fetch main and merge it
                     GitHandler.Run($"fetch origin main", config);
-                    GitHandler.Run($"fetch merge --no-edit origin/main", config);
+                    GitHandler.Run($"merge --no-edit origin/main", config);
 
                     // add all the recording changes and commit them
                     GitHandler.Run($"add -A .", config);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -126,9 +126,16 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     string gitUserEmail = GetGitOwnerEmail(config);
                     GitHandler.Run($"branch {branchGuid}", config);
                     GitHandler.Run($"checkout {branchGuid}", config);
+
+                    // fetch main and merge it
+                    GitHandler.Run($"fetch origin main", config);
+                    GitHandler.Run($"fetch merge --no-edit origin/main", config);
+
+                    // add all the recording changes and commit them
                     GitHandler.Run($"add -A .", config);
                     GitHandler.Run($"-c user.name=\"{gitUserName}\" -c user.email=\"{gitUserEmail}\" commit --no-gpg-sign -m \"Automatic asset update from test-proxy.\"", config);
-                    // Get the first 10 digits of the commit SHA. The generatedTagName will be the
+                    
+                    // Get the first 10 digits of the combined SHA. The generatedTagName will be the
                     // config.TagPrefix_<SHA>
                     if (GitHandler.TryRun("rev-parse --short=10 HEAD", config.AssetsRepoLocation.ToString(), out CommandResult SHAResult))
                     {
@@ -157,6 +164,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     HideOrigin(config);
 
                     // the only executions that have a real chance of failing are
+                    // - merge main
                     // - ls-remote origin
                     // - push
                     // if we have a failure on either of these, we need to unstage our changes for an easy re-attempt at pushing.
@@ -547,11 +555,11 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
             if (combinedPath.ToLower() == AssetsJsonFileName)
             {
-                return "./";
+                return "./ eng/";
             }
             else
             {
-                return combinedPath.Substring(0, combinedPath.Length - (AssetsJsonFileName.Length + 1));
+                return combinedPath.Substring(0, combinedPath.Length - (AssetsJsonFileName.Length + 1)) + " eng/";
             }
         }
         #endregion

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -127,10 +127,18 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     string assetMessage = "Automatic asset update from test-proxy.";
                     string configurationString = $"-c user.name=\"{gitUserName}\" -c user.email=\"{gitUserEmail}\"";
 
-
                     GitHandler.Run($"branch {branchGuid}", config);
                     GitHandler.Run($"checkout {branchGuid}", config);
 
+                    /*
+                     * This code works by generating a patch file for SPECIFICALLY the eng folder from main.
+                     * Given that these changes appear as "new" changes, they just look like normal file additions. 
+                     * This totally eliminates the possibility of weird historical merge if main has code that we don't expect. 
+                     * Under azure-sdk-assets, we should never see this, but we have already seen it with specific integration
+                     * test tags under azure-sdk-assets-integration. By keeping it as "patch", the soft RESET on unsuccessful 
+                     * push action will properly put their repo into the expected "ready to push" state that a failed
+                     * merge would NOT.
+                     */
                     GitHandler.Run($"diff --output=changes.patch --no-color --binary --no-prefix HEAD main -- eng/", config);
                     GitHandler.Run($"apply --directory=eng/ changes.patch", config);
                     var pathLocation = Path.Combine(config.AssetsRepoLocation, "changes.patch");

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -124,19 +124,22 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     string branchGuid = Guid.NewGuid().ToString().Substring(0, 8);
                     string gitUserName = GetGitOwnerName(config);
                     string gitUserEmail = GetGitOwnerEmail(config);
-                    string commitMessage = "Automatic asset update from test-proxy.";
+                    string assetMessage = "Automatic asset update from test-proxy.";
+                    string mergeMessage = "Automated merge from main for this asset.";
+                    string configurationString = $"-c user.name=\"{gitUserName}\" -c user.email=\"{gitUserEmail}\"";
+
 
                     GitHandler.Run($"branch {branchGuid}", config);
                     GitHandler.Run($"checkout {branchGuid}", config);
 
                     // add all the recording changes and commit them
                     GitHandler.Run($"add -A .", config);
-                    GitHandler.Run($"-c user.name=\"{gitUserName}\" -c user.email=\"{gitUserEmail}\" commit --no-gpg-sign -m \"{commitMessage}\"", config);
+                    GitHandler.Run($"commit {configurationString} --no-gpg-sign -m \"{assetMessage}\"", config);
 
                     // fetch main and merge it, we must invoke this after the commit for code is complete, otherwise
                     // we get an error about unmerged changes present when we attempt to merge
                     GitHandler.Run($"fetch origin main", config);
-                    GitHandler.Run($"merge origin/main -m \"{commitMessage}\"", config);
+                    GitHandler.Run($"merge origin/main {configurationString} -m \"{mergeMessage}\"", config);
 
                     // Get the first 10 digits of the combined SHA. The generatedTagName will be the
                     // config.TagPrefix_<SHA>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -124,17 +124,20 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     string branchGuid = Guid.NewGuid().ToString().Substring(0, 8);
                     string gitUserName = GetGitOwnerName(config);
                     string gitUserEmail = GetGitOwnerEmail(config);
+                    string commitMessage = "Automatic asset update from test-proxy.";
+
                     GitHandler.Run($"branch {branchGuid}", config);
                     GitHandler.Run($"checkout {branchGuid}", config);
 
-                    // fetch main and merge it
-                    GitHandler.Run($"fetch origin main", config);
-                    GitHandler.Run($"merge --no-edit origin/main", config);
-
                     // add all the recording changes and commit them
                     GitHandler.Run($"add -A .", config);
-                    GitHandler.Run($"-c user.name=\"{gitUserName}\" -c user.email=\"{gitUserEmail}\" commit --no-gpg-sign -m \"Automatic asset update from test-proxy.\"", config);
-                    
+                    GitHandler.Run($"-c user.name=\"{gitUserName}\" -c user.email=\"{gitUserEmail}\" commit --no-gpg-sign -m \"{commitMessage}\"", config);
+
+                    // fetch main and merge it, we must invoke this after the commit for code is complete, otherwise
+                    // we get an error about unmerged changes present when we attempt to merge
+                    GitHandler.Run($"fetch origin main", config);
+                    GitHandler.Run($"merge origin/main -m \"{commitMessage}\"", config);
+
                     // Get the first 10 digits of the combined SHA. The generatedTagName will be the
                     // config.TagPrefix_<SHA>
                     if (GitHandler.TryRun("rev-parse --short=10 HEAD", config.AssetsRepoLocation.ToString(), out CommandResult SHAResult))

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -180,7 +180,6 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                     HideOrigin(config);
 
                     // the only executions that have a real chance of failing are
-                    // - merge main
                     // - ls-remote origin
                     // - push
                     // if we have a failure on either of these, we need to unstage our changes for an easy re-attempt at pushing.

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -140,7 +140,10 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                      * merge would NOT.
                      */
                     GitHandler.Run($"diff --output=changes.patch --no-color --binary --no-prefix HEAD main -- eng/", config);
-                    GitHandler.Run($"apply --directory=eng/ changes.patch", config);
+                    if (GitHandler.TryRun($"apply --check --directory=eng/ changes.patch", config.AssetsRepoLocation.ToString(), out var applyResult))
+                    {
+                        GitHandler.Run($"apply --directory=eng/ changes.patch", config);
+                    }
                     var pathLocation = Path.Combine(config.AssetsRepoLocation, "changes.patch");
 
                     if (File.Exists(pathLocation)) {


### PR DESCRIPTION
@weshaggard  I'm extremely pleased with this little diff methodology. Let me know what you think.

- [x] Handle when the patch is empty (call out to git apply --check)
- [x] PR another change that fixes the tools build. 
- [x] Resolve integration issue on pure windows `git` discovered in integration tests. Why is a soft reset failing?
  - This was failing due to a case that should only really ever occur in our test cases, where we _force_ a failed auth by setting an invalid GIT_TOKEN. This meant that we failed to retrieve remote `main` for the patch. The weird error we were seeing on CLI integration for windows, is that a soft reset with _uncommitted changes_ resulted in a weird error state that git couldn't understand how to resolve automatically. (`unable to retrieve promisor remote`) By placing the soft reset behind the changes actually being committed, we totally sidestep the entire problem.