### PR TITLE
Use `publish-1es-artifact` instead of `publish-artifact` in `archetype-tool-dotnet`

### DIFF
--- a/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
+++ b/eng/pipelines/templates/steps/produce-net-standalone-packs.yml
@@ -41,7 +41,7 @@ steps:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
 
-      - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+      - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
         parameters:
           ArtifactName: "standalone-${{ target.rid }}"
           ArtifactPath: "$(Build.ArtifactStagingDirectory)/${{ target.rid }}"
@@ -66,7 +66,7 @@ steps:
           DOTNET_CLI_TELEMETRY_OPTOUT: 1
           DOTNET_MULTILEVEL_LOOKUP: 0
       
-      - template: /eng/common/pipelines/templates/steps/publish-artifact.yml
+      - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
         parameters:
           ArtifactName: "standalone-${{ target.rid }}"
           ArtifactPath: "$(Build.ArtifactStagingDirectory)/${{ target.rid }}"


### PR DESCRIPTION
This has the knock on effect of fixing the proxy build.

- `produce-net-standalone-packs` only used in archetype-tool-dotnet.yml
- `archetype-tool-dotnet` is an `extends` on top of 1es-redirect.
- Because it's only ever used in 1es context we're safe to swap the artifact publishing.