### PR TITLE
Add api approval history

### DIFF
--- a/src/dotnet/APIView/APIView/Model/CodeDiagnosticLevel.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeDiagnosticLevel.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 namespace APIView
 {

--- a/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
@@ -65,3 +65,14 @@
     color: var(--success-color);
     font-size: medium;
 }
+
+
+/*#approval-list-group #approval-list-group-item {
+    list-style-type: none !important;
+    padding-left: 0;
+}*/
+
+
+.bi bi-plus-circle-fill created {
+    color: darkorange;
+}

--- a/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
@@ -66,8 +66,6 @@
     font-size: medium;
 }
 
-
-
 .approval-list-group {
     padding-left: 0;
 }
@@ -78,6 +76,8 @@
 
 .revision-info {
     display: inline-block;
+    font-size: 13px;
+    padding-left: 5px;
 }
 
 .created {
@@ -101,5 +101,5 @@
 }
 
 .status-icon {
-    font-size: 21px;
+    font-size: 18px;
 }

--- a/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
@@ -67,12 +67,39 @@
 }
 
 
-/*#approval-list-group #approval-list-group-item {
-    list-style-type: none !important;
+
+.approval-list-group {
     padding-left: 0;
-}*/
+}
 
+.approval-list-group-item {
+    list-style-type: none;
+}
 
-.bi bi-plus-circle-fill created {
+.revision-info {
+    display: inline-block;
+}
+
+.created {
     color: darkorange;
+}
+
+.approved {
+    color: forestgreen;
+}
+
+.approval-reverted {
+    color: red;
+}
+
+.deleted {
+    color: black;
+}
+
+.undeleted {
+    color: yellow;
+}
+
+.status-icon {
+    font-size: 21px;
 }

--- a/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
@@ -76,7 +76,6 @@
 
 .revision-info {
     display: inline-block;
-    /*font-size: 13px;*/
     padding-left: 5px;
 }
 
@@ -102,4 +101,7 @@
 
 .status-icon {
     font-size: 0.8em;
+}
+.revision-info:last-child {
+    margin-left: 17px;
 }

--- a/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
@@ -76,7 +76,7 @@
 
 .revision-info {
     display: inline-block;
-    font-size: 13px;
+    /*font-size: 13px;*/
     padding-left: 5px;
 }
 

--- a/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
@@ -66,12 +66,12 @@
     font-size: medium;
 }
 
-.approval-list-group {
-    padding-left: 0;
-}
-
 .approval-list-group-item {
     list-style-type: none;
+}
+
+.revision-title {
+    margin-bottom: 0;
 }
 
 .revision-info {
@@ -101,5 +101,5 @@
 }
 
 .status-icon {
-    font-size: 18px;
+    font-size: 0.8em;
 }

--- a/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/pages/review.scss
@@ -79,29 +79,30 @@
     padding-left: 5px;
 }
 
-.created {
-    color: darkorange;
-}
-
-.approved {
-    color: forestgreen;
-}
-
-.approval-reverted {
-    color: red;
-}
-
-.deleted {
-    color: black;
-}
-
-.undeleted {
-    color: yellow;
-}
-
 .status-icon {
     font-size: 0.8em;
+
+    &.deleted {
+        color: black;
+    }
+
+    &.approval-reverted {
+        color: red;
+    }
+
+    &.created {
+        color: darkorange;
+    }
+
+    &.approved {
+        color: forestgreen;
+    }
+
+    &.undeleted {
+        color: yellow;
+    }
 }
+
 .revision-info:last-child {
     margin-left: 17px;
 }

--- a/src/dotnet/APIView/APIViewWeb/Client/css/shared/bootstraps-overrides.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/shared/bootstraps-overrides.scss
@@ -272,12 +272,3 @@ select {
 pre {
     color: var(--base-text-color);
 }
-
-/*#approval-list-group #approval-list-group-item {
-    list-style-type: none !important;
-    padding-left: 0;
-}*/
-
-.bi bi-plus-circle-fill created {
-    color: darkorange;
-}

--- a/src/dotnet/APIView/APIViewWeb/Client/css/shared/bootstraps-overrides.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/shared/bootstraps-overrides.scss
@@ -273,15 +273,11 @@ pre {
     color: var(--base-text-color);
 }
 
+/*#approval-list-group #approval-list-group-item {
+    list-style-type: none !important;
+    padding-left: 0;
+}*/
 
-.approval-list-group {
-    list-style-type: none !important; /* Remove default bullet points */
-}
-
-.approval-list-group-item::before {
-    content: "\f00c"; /* Unicode for the check icon in Bootstrap Icons */
-    font-family: "Bootstrap Icons";
-    display: inline-block;
-    width: 1em; /* Space out the icon and the list item text */
-    margin-right: 0.5em; /* Align the icon with the list item text */
+.bi bi-plus-circle-fill created {
+    color: darkorange;
 }

--- a/src/dotnet/APIView/APIViewWeb/Client/css/shared/bootstraps-overrides.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/shared/bootstraps-overrides.scss
@@ -272,3 +272,16 @@ select {
 pre {
     color: var(--base-text-color);
 }
+
+
+.approval-list-group {
+    list-style-type: none !important; /* Remove default bullet points */
+}
+
+.approval-list-group-item::before {
+    content: "\f00c"; /* Unicode for the check icon in Bootstrap Icons */
+    font-family: "Bootstrap Icons";
+    display: inline-block;
+    width: 1em; /* Space out the icon and the list item text */
+    margin-right: 0.5em; /* Align the icon with the list item text */
+}

--- a/src/dotnet/APIView/APIViewWeb/LeanModels/ChangeHistory.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanModels/ChangeHistory.cs
@@ -47,7 +47,6 @@ namespace APIViewWeb.LeanModels
 
     public abstract class ChangeHistoryModel
     {   
-        public string ChangeAction { get; set; }
         public string ChangedBy { get; set; }
         public DateTime? ChangedOn { get; set; }
         public string Notes { get; set; }

--- a/src/dotnet/APIView/APIViewWeb/LeanModels/ChangeHistory.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanModels/ChangeHistory.cs
@@ -46,7 +46,8 @@ namespace APIViewWeb.LeanModels
     }
 
     public abstract class ChangeHistoryModel
-    {
+    {   
+        public string ChangeAction { get; set; }
         public string ChangedBy { get; set; }
         public DateTime? ChangedOn { get; set; }
         public string Notes { get; set; }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -574,12 +574,10 @@
                                             <p>Note: @change.Notes</p>
                                         </div>
                                     }
-                                    @*
                                     else
                                     {
                                         <p>Note:</p>
                                     }
-                                    *@
                                 </div>
                             </li>
                         }    

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -505,9 +505,26 @@
                     </form>
                 </div>
             </li>
+            <li class="list-group-item">
+            @if (Model.ReviewContent.ActiveAPIRevision.ChangeHistory.Any())
+            {
+                <ul class="approval-list-group">
+                    @foreach (var change in Model.ReviewContent.ActiveAPIRevision.ChangeHistory)
+                    {
+                        <li class="approval-list-group-item">@change.ChangeAction by @change.ChangedBy on @change.ChangedOn</li>
+                    }
+                </ul>
+            }    
+            </li>
         </ul>
     </div>
 </div>
+
+
+
+
+
+
 
 <div class="container-fluid mx-0 px-0 sub-header-content">
     <div class="row px-3 py-2 border-bottom" id="review-info-bar">

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -537,31 +537,11 @@
                                                 break;
                                         }
                                     }
-
-                            @* <div class="me-3">
-                                <i class="@iconClass"></i>
-                            </div>
-                                        @if (change.ChangeAction.ToString() == "Created")
-                                        {
-                                            <i class="bi bi-plus-circle-fill created status-icon"></i>
-                                        }
-                                        else if (change.ChangeAction.ToString() == "Approved")
-                                        {
-                                            <i class="bi bi-check-circle-fill approved status-icon"></i>
-                                        }
-                                        else if (change.ChangeAction.ToString() == "ApprovalReverted")
-                                        {
-                                            <i class="bi bi-arrow-left-circle-fill approval-reverted status-icon"></i>
-                                        }
-                                        else if (change.ChangeAction.ToString() == "Deleted")
-                                        {
-                                            <i class="bi bi-backspace-fill deleted status-icon"></i>
-                                        }
-                                        else if (change.ChangeAction.ToString() == "UnDeleted")
-                                        {
-                                            <i class="bi bi-plus-circle-fill undeleted status-icon"></i>
-                                        }
-                                    </div> *@                                   
+                                    @if (!string.IsNullOrEmpty(iconClass))
+                                    {
+                                        <i class="@iconClass"></i>
+                                    }
+                                    
                                     <div class="revision-events">
                                         @if (change.ChangeAction.ToString() == "Created")
                                         {

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -506,15 +506,71 @@
                 </div>
             </li>
             <li class="list-group-item">
-            @if (Model.ReviewContent.ActiveAPIRevision.ChangeHistory.Any())
-            {
-                <ul class="approval-list-group">
-                    @foreach (var change in Model.ReviewContent.ActiveAPIRevision.ChangeHistory)
-                    {
-                        <li class="approval-list-group-item">@change.ChangeAction by @change.ChangedBy on @change.ChangedOn</li>
-                    }
-                </ul>
-            }    
+                <div class="approval-list-group" id="approval-list-group"
+                    <h6>Revision History</h6><br />
+                        @if (Model.ReviewContent.ActiveAPIRevision.ChangeHistory.Any())
+                        {
+                            <ul class="approval-list-group" id="approval-list-group">
+                            @foreach (var change in Model.ReviewContent.ActiveAPIRevision.ChangeHistory)
+                            {
+                                <li class="approval-list-group-item">
+                                    <div class="d-flex align-items-start">
+                                        <div class="me-2">
+                                            @if (change.ChangeAction.ToString() == "Created")
+                                            {
+                                                <i class="bi bi-plus-circle-fill created"></i>
+                                            }
+                                            else if (change.ChangeAction.ToString() == "Approved")
+                                            {
+                                                <i class="bi bi-check-circle-fill approved"></i>
+                                            }
+                                            else if (change.ChangeAction.ToString() == "ApprovalReverted")
+                                            {
+                                                <i class="bi bi-arrow-left-circle-fill approvalreverted"></i>
+                                            }
+                                            else if (change.ChangeAction.ToString() == "Deleted")
+                                            {
+                                                <i class="bi bi-backspace-fill deleted"></i>
+                                            }
+                                            else if (change.ChangeAction.ToString() == "UnDeleted")
+                                            {
+                                                <i class="bi bi-plus-circle-fill undeleted"></i>
+                                            }
+                                        </div>
+                                        <div>
+                                            @if (change.ChangeAction.ToString() == "Created")
+                                            {
+                                                <span>Revision Created</span><br />                                           
+                                                <span>@change.ChangedOn</span>
+                                            }
+                                            else if (change.ChangeAction.ToString() == "Approved")
+                                            {
+                                                <span>Approved</span><br />                                                
+                                                <span>@change.ChangedOn</span><br />
+                                                <span>@change.ChangedBy</span>
+                                            }
+                                            else if (change.ChangeAction.ToString() == "ApprovalReverted")
+                                            {
+                                                <span>Reverted by: @change.ChangedBy</span><br />
+                                                <span>On: @change.ChangedOn</span>
+                                            }
+                                            else if (change.ChangeAction.ToString() == "Deleted")
+                                            {
+                                                <span>Deleted by: @change.ChangedBy</span><br />
+                                                <span>On: @change.ChangedOn</span>
+                                            }
+                                            else if (change.ChangeAction.ToString() == "UnDeleted")
+                                            {
+                                                <span>UnDeleted by: @change.ChangedBy</span><br />
+                                                <span>On: @change.ChangedOn</span>
+                                            }
+                                        </div>
+                                    </div>
+                                </li>
+                            }    
+                            </ul>
+                        } 
+                </div>
             </li>
         </ul>
     </div>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -3,6 +3,8 @@
 @using APIViewWeb.Helpers
 @using APIViewWeb.LeanModels;
 @using APIViewWeb.Models
+@using System
+@using System.Text.RegularExpressions
 @{
     Layout = "Shared/_Layout";
     ViewData["Title"] = Model.ReviewContent.Review.PackageName;
@@ -538,33 +540,26 @@
                                     <div class="revision-events">
                                         @if (change.ChangeAction.ToString() == "Created")
                                         {
-                                            <span class="revision-info">Created</span><br />                                           
-                                            <span class="revision-info">@change.ChangedOn</span>
+                                            <span class="revision-info">Created</span><br />
                                         }
                                         else if (change.ChangeAction.ToString() == "Approved")
                                         {
-                                            <span class="revision-info">Approved</span><br />                                                
-                                            <span class="revision-info">@change.ChangedBy</span><br />
-                                            <span class="revision-info">@change.ChangedOn</span>
+                                            <span class="revision-info">Approved</span><br />                                                                                           
                                         }
                                         else if (change.ChangeAction.ToString() == "ApprovalReverted")
                                         {
-                                            <span class="revision-info">Approval Reverted</span><br />
-                                            <span class="revision-info">@change.ChangedBy</span><br />
-                                            <span class="revision-info">@change.ChangedOn</span>
+                                            <span class="revision-info">Approval Reverted</span><br />                                            
                                         }
                                         else if (change.ChangeAction.ToString() == "Deleted")
                                         {
                                             <span class="revision-info">Deleted</span><br />
-                                            <span class="revision-info">@change.ChangedBy</span><br />
-                                            <span class="revision-info">change.ChangedOn</span>
                                         }
                                         else if (change.ChangeAction.ToString() == "UnDeleted")
                                         {
                                             <span class="revision-info">UnDeleted</span><br />
-                                            <span >@change.ChangedBy</span><br />
-                                            <span class="revision-info">@change.ChangedOn</span>
                                         }
+                                        <span class="revision-info">@change.ChangedBy</span><br />
+                                        <span data-bs-toggle="tooltip" title="@change.ChangedOn" date="@(change.ChangedOn.GetValueOrDefault())" class="revision-info"></span>
                                     </div>                                   
                                 </div>
                                 <div>
@@ -574,10 +569,12 @@
                                             <p>Note: @change.Notes</p>
                                         </div>
                                     }
+                                    @*
                                     else
                                     {
                                         <p>Note:</p>
                                     }
+                                    *@
                                 </div>
                             </li>
                         }    

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -506,70 +506,84 @@
                 </div>
             </li>
             <li class="list-group-item">
-                <div class="approval-list-group" id="approval-list-group"
-                    <h6>Revision History</h6><br />
-                        @if (Model.ReviewContent.ActiveAPIRevision.ChangeHistory.Any())
+                <div>
+                    <h6>Revision History</h6>
+                        <ul class="approval-list-group" id="approval-list-group">
+                        @foreach (var change in Model.ReviewContent.ActiveAPIRevision.ChangeHistory)
                         {
-                            <ul class="approval-list-group" id="approval-list-group">
-                            @foreach (var change in Model.ReviewContent.ActiveAPIRevision.ChangeHistory)
-                            {
-                                <li class="approval-list-group-item">
-                                    <div class="d-flex align-items-start">
-                                        <div class="me-2">
-                                            @if (change.ChangeAction.ToString() == "Created")
-                                            {
-                                                <i class="bi bi-plus-circle-fill created"></i>
-                                            }
-                                            else if (change.ChangeAction.ToString() == "Approved")
-                                            {
-                                                <i class="bi bi-check-circle-fill approved"></i>
-                                            }
-                                            else if (change.ChangeAction.ToString() == "ApprovalReverted")
-                                            {
-                                                <i class="bi bi-arrow-left-circle-fill approvalreverted"></i>
-                                            }
-                                            else if (change.ChangeAction.ToString() == "Deleted")
-                                            {
-                                                <i class="bi bi-backspace-fill deleted"></i>
-                                            }
-                                            else if (change.ChangeAction.ToString() == "UnDeleted")
-                                            {
-                                                <i class="bi bi-plus-circle-fill undeleted"></i>
-                                            }
-                                        </div>
+                            <li class="list-group-item approval-list-group-item">
+                                <div class="d-flex align-items-start">
+                                    <div class="me-3">
+                                        @if (change.ChangeAction.ToString() == "Created")
+                                        {
+                                            <i class="bi bi-plus-circle-fill created status-icon"></i>
+                                        }
+                                        else if (change.ChangeAction.ToString() == "Approved")
+                                        {
+                                            <i class="bi bi-check-circle-fill approved status-icon"></i>
+                                        }
+                                        else if (change.ChangeAction.ToString() == "ApprovalReverted")
+                                        {
+                                            <i class="bi bi-arrow-left-circle-fill approval-reverted status-icon"></i>
+                                        }
+                                        else if (change.ChangeAction.ToString() == "Deleted")
+                                        {
+                                            <i class="bi bi-backspace-fill deleted status-icon"></i>
+                                        }
+                                        else if (change.ChangeAction.ToString() == "UnDeleted")
+                                        {
+                                            <i class="bi bi-plus-circle-fill undeleted status-icon"></i>
+                                        }
+                                    </div>                                   
+                                    <div class="revision-events">
+                                        @if (change.ChangeAction.ToString() == "Created")
+                                        {
+                                            <span class="revision-info">Created</span><br />                                           
+                                            <span class="revision-info">@change.ChangedOn</span>
+                                        }
+                                        else if (change.ChangeAction.ToString() == "Approved")
+                                        {
+                                            <span class="revision-info">Approved</span><br />                                                
+                                            <span class="revision-info">@change.ChangedBy</span><br />
+                                            <span class="revision-info">@change.ChangedOn</span>
+                                        }
+                                        else if (change.ChangeAction.ToString() == "ApprovalReverted")
+                                        {
+                                            <span class="revision-info">Approval Reverted</span><br />
+                                            <span class="revision-info">@change.ChangedBy</span><br />
+                                            <span class="revision-info">@change.ChangedOn</span>
+                                        }
+                                        else if (change.ChangeAction.ToString() == "Deleted")
+                                        {
+                                            <span class="revision-info">Deleted</span><br />
+                                            <span class="revision-info">@change.ChangedBy</span><br />
+                                            <span class="revision-info">change.ChangedOn</span>
+                                        }
+                                        else if (change.ChangeAction.ToString() == "UnDeleted")
+                                        {
+                                            <span class="revision-info">UnDeleted</span><br />
+                                            <span >@change.ChangedBy</span><br />
+                                            <span class="revision-info">@change.ChangedOn</span>
+                                        }
+                                    </div>                                   
+                                </div>
+                                <div>
+                                    @if (!String.IsNullOrEmpty(change.Notes))
+                                    {
                                         <div>
-                                            @if (change.ChangeAction.ToString() == "Created")
-                                            {
-                                                <span>Revision Created</span><br />                                           
-                                                <span>@change.ChangedOn</span>
-                                            }
-                                            else if (change.ChangeAction.ToString() == "Approved")
-                                            {
-                                                <span>Approved</span><br />                                                
-                                                <span>@change.ChangedOn</span><br />
-                                                <span>@change.ChangedBy</span>
-                                            }
-                                            else if (change.ChangeAction.ToString() == "ApprovalReverted")
-                                            {
-                                                <span>Reverted by: @change.ChangedBy</span><br />
-                                                <span>On: @change.ChangedOn</span>
-                                            }
-                                            else if (change.ChangeAction.ToString() == "Deleted")
-                                            {
-                                                <span>Deleted by: @change.ChangedBy</span><br />
-                                                <span>On: @change.ChangedOn</span>
-                                            }
-                                            else if (change.ChangeAction.ToString() == "UnDeleted")
-                                            {
-                                                <span>UnDeleted by: @change.ChangedBy</span><br />
-                                                <span>On: @change.ChangedOn</span>
-                                            }
+                                            <p>Note: @change.Notes</p>
                                         </div>
-                                    </div>
-                                </li>
-                            }    
-                            </ul>
-                        } 
+                                    }
+                                    @*
+                                    else
+                                    {
+                                        <p>Note:</p>
+                                    }
+                                    *@
+                                </div>
+                            </li>
+                        }    
+                        </ul> 
                 </div>
             </li>
         </ul>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -509,7 +509,7 @@
             </li>
             <li class="list-group-item">
                 <div>
-                    <p class="revision-title">Revision History:</p>
+                    <p class="revision-title">Change History:</p>
                         @foreach (var change in Model.ReviewContent.ActiveAPIRevision.ChangeHistory)
                         {
                             <li class="list-group-item approval-list-group-item">
@@ -541,30 +541,80 @@
                                     {
                                         <i class="@iconClass"></i>
                                     }
-                                    
-                                    <div class="revision-events">
+
+                            @* <div class="me-3">
+                                <i class="@iconClass"></i>
+                            </div>
                                         @if (change.ChangeAction.ToString() == "Created")
                                         {
-                                            <span class="revision-info">Created:</span>
+                                            <i class="bi bi-plus-circle-fill created status-icon"></i>
                                         }
                                         else if (change.ChangeAction.ToString() == "Approved")
                                         {
-                                            <span class="revision-info">Approved:</span>                                                                                           
+                                            <i class="bi bi-check-circle-fill approved status-icon"></i>
                                         }
                                         else if (change.ChangeAction.ToString() == "ApprovalReverted")
                                         {
-                                            <span class="revision-info">Approval Reverted:</span>                                         
+                                            <i class="bi bi-arrow-left-circle-fill approval-reverted status-icon"></i>
                                         }
                                         else if (change.ChangeAction.ToString() == "Deleted")
                                         {
-                                            <span class="revision-info">Deleted:</span>
+                                            <i class="bi bi-backspace-fill deleted status-icon"></i>
                                         }
                                         else if (change.ChangeAction.ToString() == "UnDeleted")
                                         {
-                                            <span class="revision-info">UnDeleted:</span>
+                                            <i class="bi bi-plus-circle-fill undeleted status-icon"></i>
                                         }
-                                        <span class="revision-info">@change.ChangedBy</span><br />
-                                        <span data-bs-toggle="tooltip" title="@change.ChangedOn" date="@(change.ChangedOn.GetValueOrDefault())" class="revision-info"></span>
+                            @{
+                                string iconClass = "";
+                                switch (change.ChangeAction.ToString())
+                                {
+                                    case "Created":
+                                        iconClass = "bi bi-plus-circle-fill created status-icon";
+                                        break;
+                                    case "Approved":
+                                        iconClass = "bi bi-check-circle-fill approved status-icon";
+                                        break;
+                                    case "ApprovalReverted":
+                                        iconClass = "bi bi-arrow-left-circle-fill approval-reverted status-icon";
+                                        break;
+                                    case "Deleted":
+                                        iconClass = "bi bi-backspace-fill deleted status-icon";
+                                        break;
+                                    case "UnDeleted":
+                                        iconClass = "bi bi-plus-circle-fill undeleted status-icon";
+                                        break;
+                                }
+                            }
+
+                            @if (!string.IsNullOrEmpty(iconClass))
+                            {
+                                <i class="@iconClass"></i>
+                            }
+                                    </div> *@                                   
+                                    <div class="revision-events">                               
+                                        @if (change.ChangeAction.ToString() == "Created")
+                                        {
+                                            <span class="revision-info"><small>Created:</small></span>
+                                        }
+                                        else if (change.ChangeAction.ToString() == "Approved")
+                                        {
+                                            <span class="revision-info"><small>Approved:</small></span>                                                                                           
+                                        }
+                                        else if (change.ChangeAction.ToString() == "ApprovalReverted")
+                                        {
+                                            <span class="revision-info"><small>Approval Reverted:</small></span>                                         
+                                        }
+                                        else if (change.ChangeAction.ToString() == "Deleted")
+                                        {
+                                            <span class="revision-info"><small>Deleted:</small></span>
+                                        }
+                                        else if (change.ChangeAction.ToString() == "UnDeleted")
+                                        {
+                                            <span class="revision-info"><small>UnDeleted:</small></span>
+                                        }
+                                        <span class="revision-info"><small>@change.ChangedBy</small></span><br />
+                                        <span data-bs-toggle="tooltip" title="@change.ChangedOn" date="@(change.ChangedOn.GetValueOrDefault())" class="small revision-info"></span>
                                     </div>                                   
                                 </div>
                             </li>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -509,13 +509,38 @@
             </li>
             <li class="list-group-item">
                 <div>
-                    <h6>Revision History</h6>
-                        <ul class="approval-list-group" id="approval-list-group">
+                    <p class="revision-title">Revision History:</p>
                         @foreach (var change in Model.ReviewContent.ActiveAPIRevision.ChangeHistory)
                         {
                             <li class="list-group-item approval-list-group-item">
                                 <div class="d-flex align-items-start">
                                     <div class="me-3">
+                                    @{
+                                        var changeAction = change.ChangeAction.ToString();
+                                        string iconClass = "";
+                                        switch (changeAction)
+                                        {
+                                            case "Created":
+                                                iconClass = "bi bi-plus-circle-fill created status-icon";
+                                                break;
+                                            case "Approved":
+                                                iconClass = "bi bi-check-circle-fill approved status-icon";
+                                                break;
+                                            case "ApprovalReverted":
+                                                iconClass = "bi bi-arrow-left-circle-fill approval-reverted status-icon";
+                                                break;
+                                            case "Deleted":
+                                                iconClass = "bi bi-backspace-fill deleted status-icon";
+                                                break;
+                                            case "UnDeleted":
+                                                iconClass = "bi bi-plus-circle-fill undeleted status-icon";
+                                                break;
+                                        }
+                                    }
+
+                            @* <div class="me-3">
+                                <i class="@iconClass"></i>
+                            </div>
                                         @if (change.ChangeAction.ToString() == "Created")
                                         {
                                             <i class="bi bi-plus-circle-fill created status-icon"></i>
@@ -536,61 +561,39 @@
                                         {
                                             <i class="bi bi-plus-circle-fill undeleted status-icon"></i>
                                         }
-                                    </div>                                   
+                                    </div> *@                                   
                                     <div class="revision-events">
                                         @if (change.ChangeAction.ToString() == "Created")
                                         {
-                                            <span class="revision-info">Created</span><br />
+                                            <span class="revision-info">Created:</span>
                                         }
                                         else if (change.ChangeAction.ToString() == "Approved")
                                         {
-                                            <span class="revision-info">Approved</span><br />                                                                                           
+                                            <span class="revision-info">Approved:</span>                                                                                           
                                         }
                                         else if (change.ChangeAction.ToString() == "ApprovalReverted")
                                         {
-                                            <span class="revision-info">Approval Reverted</span><br />                                            
+                                            <span class="revision-info">Approval Reverted:</span>                                         
                                         }
                                         else if (change.ChangeAction.ToString() == "Deleted")
                                         {
-                                            <span class="revision-info">Deleted</span><br />
+                                            <span class="revision-info">Deleted:</span>
                                         }
                                         else if (change.ChangeAction.ToString() == "UnDeleted")
                                         {
-                                            <span class="revision-info">UnDeleted</span><br />
+                                            <span class="revision-info">UnDeleted:</span>
                                         }
                                         <span class="revision-info">@change.ChangedBy</span><br />
                                         <span data-bs-toggle="tooltip" title="@change.ChangedOn" date="@(change.ChangedOn.GetValueOrDefault())" class="revision-info"></span>
                                     </div>                                   
                                 </div>
-                                <div>
-                                    @if (!String.IsNullOrEmpty(change.Notes))
-                                    {
-                                        <div>
-                                            <p>Note: @change.Notes</p>
-                                        </div>
-                                    }
-                                    @*
-                                    else
-                                    {
-                                        <p>Note:</p>
-                                    }
-                                    *@
-                                </div>
                             </li>
                         }    
-                        </ul> 
                 </div>
             </li>
         </ul>
     </div>
 </div>
-
-
-
-
-
-
-
 <div class="container-fluid mx-0 px-0 sub-header-content">
     <div class="row px-3 py-2 border-bottom" id="review-info-bar">
         <partial name="Shared/_ReviewBadge" model="(Model.ReviewContent.Review, Model.ReviewContent.ActiveAPIRevision, Model.ReviewContent.DiffAPIRevision, Model.UserPreference)" />

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -509,7 +509,7 @@
             </li>
             <li class="list-group-item">
                 <div>
-                    <p class="revision-title">Change History:</p>
+                    <p class="small revision-title">Change History:</p>
                         @foreach (var change in Model.ReviewContent.ActiveAPIRevision.ChangeHistory)
                         {
                             <li class="list-group-item approval-list-group-item">
@@ -537,83 +537,33 @@
                                                 break;
                                         }
                                     }
-                                    @if (!string.IsNullOrEmpty(iconClass))
-                                    {
-                                        <i class="@iconClass"></i>
-                                    }
-
-                            @* <div class="me-3">
-                                <i class="@iconClass"></i>
-                            </div>
+                                                                     
+                                    <div class="revision-events">          
+                                        @if (!string.IsNullOrEmpty(iconClass))
+                                        {
+                                            <i class="@iconClass"></i>
+                                        } 
                                         @if (change.ChangeAction.ToString() == "Created")
                                         {
-                                            <i class="bi bi-plus-circle-fill created status-icon"></i>
+                                            <span class="small revision-info">Created:</span>
                                         }
                                         else if (change.ChangeAction.ToString() == "Approved")
                                         {
-                                            <i class="bi bi-check-circle-fill approved status-icon"></i>
+                                            <span class="small revision-info">Approved:</span>                                                                                           
                                         }
                                         else if (change.ChangeAction.ToString() == "ApprovalReverted")
                                         {
-                                            <i class="bi bi-arrow-left-circle-fill approval-reverted status-icon"></i>
+                                            <span class="small revision-info">Reverted:</span>                                         
                                         }
                                         else if (change.ChangeAction.ToString() == "Deleted")
                                         {
-                                            <i class="bi bi-backspace-fill deleted status-icon"></i>
+                                            <span class="small revision-info">Deleted:</span>
                                         }
                                         else if (change.ChangeAction.ToString() == "UnDeleted")
                                         {
-                                            <i class="bi bi-plus-circle-fill undeleted status-icon"></i>
+                                            <span class="small revision-info">UnDeleted:</span>
                                         }
-                            @{
-                                string iconClass = "";
-                                switch (change.ChangeAction.ToString())
-                                {
-                                    case "Created":
-                                        iconClass = "bi bi-plus-circle-fill created status-icon";
-                                        break;
-                                    case "Approved":
-                                        iconClass = "bi bi-check-circle-fill approved status-icon";
-                                        break;
-                                    case "ApprovalReverted":
-                                        iconClass = "bi bi-arrow-left-circle-fill approval-reverted status-icon";
-                                        break;
-                                    case "Deleted":
-                                        iconClass = "bi bi-backspace-fill deleted status-icon";
-                                        break;
-                                    case "UnDeleted":
-                                        iconClass = "bi bi-plus-circle-fill undeleted status-icon";
-                                        break;
-                                }
-                            }
-
-                            @if (!string.IsNullOrEmpty(iconClass))
-                            {
-                                <i class="@iconClass"></i>
-                            }
-                                    </div> *@                                   
-                                    <div class="revision-events">                               
-                                        @if (change.ChangeAction.ToString() == "Created")
-                                        {
-                                            <span class="revision-info"><small>Created:</small></span>
-                                        }
-                                        else if (change.ChangeAction.ToString() == "Approved")
-                                        {
-                                            <span class="revision-info"><small>Approved:</small></span>                                                                                           
-                                        }
-                                        else if (change.ChangeAction.ToString() == "ApprovalReverted")
-                                        {
-                                            <span class="revision-info"><small>Approval Reverted:</small></span>                                         
-                                        }
-                                        else if (change.ChangeAction.ToString() == "Deleted")
-                                        {
-                                            <span class="revision-info"><small>Deleted:</small></span>
-                                        }
-                                        else if (change.ChangeAction.ToString() == "UnDeleted")
-                                        {
-                                            <span class="revision-info"><small>UnDeleted:</small></span>
-                                        }
-                                        <span class="revision-info"><small>@change.ChangedBy</small></span><br />
+                                        <span class="small revision-info">@change.ChangedBy</span><br />
                                         <span data-bs-toggle="tooltip" title="@change.ChangedOn" date="@(change.ChangedOn.GetValueOrDefault())" class="small revision-info"></span>
                                     </div>                                   
                                 </div>

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -3,8 +3,6 @@
 @using APIViewWeb.Helpers
 @using APIViewWeb.LeanModels;
 @using APIViewWeb.Models
-@using System
-@using System.Text.RegularExpressions
 @{
     Layout = "Shared/_Layout";
     ViewData["Title"] = Model.ReviewContent.Review.PackageName;

--- a/src/dotnet/APIView/APIViewWeb/Program.cs
+++ b/src/dotnet/APIView/APIViewWeb/Program.cs
@@ -16,7 +16,7 @@ namespace APIViewWeb
             WebHost.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((hostingContext, config) =>
                 {
-                    config.AddEnvironmentVariables(prefix: "APIVIEW_");                    
+                    config.AddEnvironmentVariables(prefix: "APIVIEW_");                  
                     IConfiguration settings = config.Build();
                     string connectionString = settings.GetValue<string>("APPCONFIG");
                     // Load configuration from Azure App Configuration


### PR DESCRIPTION
Added display to APIView to show the approval status history for the currently active revision. Included corresponding icons, date/time and reviewers who changed approval status.