### PR TITLE
Add warning state to rotation

### DIFF
--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Configuration/PlanConfiguration.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Configuration/PlanConfiguration.cs
@@ -24,6 +24,8 @@ public class PlanConfiguration
 
     public TimeSpan? RotationThreshold { get; set; }
 
+    public TimeSpan? WarningThreshold { get; set; }
+
     public TimeSpan? RotationPeriod { get; set; }
 
     public TimeSpan? RevokeAfterPeriod { get; set; }

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Configuration/RotationConfiguration.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Configuration/RotationConfiguration.cs
@@ -122,6 +122,7 @@ public class RotationConfiguration
             primary!,
             secondaries,
             planConfiguration.RotationThreshold!.Value,
+            planConfiguration.WarningThreshold,
             planConfiguration.RotationPeriod!.Value,
             planConfiguration.RevokeAfterPeriod);
 

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationPlan.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationPlan.cs
@@ -16,6 +16,7 @@ public class RotationPlan
         SecretStore primaryStore,
         IList<SecretStore> secondaryStores,
         TimeSpan rotationThreshold,
+        TimeSpan? warningThreshold,
         TimeSpan rotationPeriod,
         TimeSpan? revokeAfterPeriod)
     {
@@ -25,6 +26,7 @@ public class RotationPlan
         OriginStore = originStore;
         PrimaryStore = primaryStore;
         RotationThreshold = rotationThreshold;
+        WarningThreshold = warningThreshold;
         RotationPeriod = rotationPeriod;
         RevokeAfterPeriod = revokeAfterPeriod;
         SecondaryStores = new ReadOnlyCollection<SecretStore>(secondaryStores);
@@ -39,6 +41,8 @@ public class RotationPlan
     public IReadOnlyCollection<SecretStore> SecondaryStores { get; }
 
     public TimeSpan RotationThreshold { get; }
+
+    public TimeSpan? WarningThreshold { get; }
 
     public TimeSpan RotationPeriod { get; }
 
@@ -102,21 +106,31 @@ public class RotationPlan
 
             SecretState[] allStates = secondaryStoreStates.Prepend(primaryStoreState).ToArray();
 
-            DateTimeOffset thresholdDate = this.timeProvider.GetCurrentDateTimeOffset().Add(RotationThreshold);
+            DateTimeOffset rotationThresholdDate = this.timeProvider.GetCurrentDateTimeOffset().Add(RotationThreshold);
 
-            DateTimeOffset? minExpirationDate = allStates.Where(x => x.ExpirationDate.HasValue).Min(x => x.ExpirationDate);
+            DateTimeOffset? warningThresholdDate = WarningThreshold.HasValue
+                ? this.timeProvider.GetCurrentDateTimeOffset().Add(WarningThreshold.Value)
+                : default;
 
-            bool anyExpired = minExpirationDate == null || minExpirationDate <= invocationTime;
+            DateTimeOffset? minExpirationDate = allStates
+                .Where(x => x.ExpirationDate.HasValue)
+                .Min(x => x.ExpirationDate);
 
-            bool anyThresholdExpired = minExpirationDate <= thresholdDate;
+            var state = RotationState.UpToDate;
+
+            if (minExpirationDate == null || minExpirationDate <= invocationTime)
+                state = RotationState.Expired;
+            else if (warningThresholdDate.HasValue && minExpirationDate <= warningThresholdDate)
+                state = RotationState.Warning;
+            else if (minExpirationDate <= rotationThresholdDate)
+                state = RotationState.Rotate;
 
             bool anyRequireRevocation = rotationArtifacts.Any(state => state.RevokeAfterDate <= invocationTime);
 
             var status = new RotationPlanStatus
             {
                 ExpirationDate = minExpirationDate,
-                Expired = anyExpired,
-                ThresholdExpired = anyThresholdExpired,
+                State = state,
                 RequiresRevocation = anyRequireRevocation,
                 PrimaryStoreState = primaryStoreState,
                 SecondaryStoreStates = secondaryStoreStates.ToArray()
@@ -128,6 +142,7 @@ public class RotationPlan
         {
             var status = new RotationPlanStatus
             {
+                State = RotationState.Error,
                 Exception = ex
             };
 

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationPlan.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationPlan.cs
@@ -26,7 +26,7 @@ public class RotationPlan
         OriginStore = originStore;
         PrimaryStore = primaryStore;
         RotationThreshold = rotationThreshold;
-        WarningThreshold = warningThreshold;
+        WarningThreshold = warningThreshold ?? rotationThreshold / 2;
         RotationPeriod = rotationPeriod;
         RevokeAfterPeriod = revokeAfterPeriod;
         SecondaryStores = new ReadOnlyCollection<SecretStore>(secondaryStores);
@@ -42,7 +42,7 @@ public class RotationPlan
 
     public TimeSpan RotationThreshold { get; }
 
-    public TimeSpan? WarningThreshold { get; }
+    public TimeSpan WarningThreshold { get; }
 
     public TimeSpan RotationPeriod { get; }
 
@@ -108,7 +108,7 @@ public class RotationPlan
 
             DateTimeOffset rotationThresholdDate = this.timeProvider.GetCurrentDateTimeOffset().Add(RotationThreshold);
 
-            DateTimeOffset warningThresholdDate = this.timeProvider.GetCurrentDateTimeOffset().Add(WarningThreshold ?? RotationThreshold / 2);
+            DateTimeOffset warningThresholdDate = this.timeProvider.GetCurrentDateTimeOffset().Add(WarningThreshold);
 
             DateTimeOffset? minExpirationDate = allStates
                 .Where(x => x.ExpirationDate.HasValue)

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationPlan.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationPlan.cs
@@ -108,9 +108,7 @@ public class RotationPlan
 
             DateTimeOffset rotationThresholdDate = this.timeProvider.GetCurrentDateTimeOffset().Add(RotationThreshold);
 
-            DateTimeOffset? warningThresholdDate = WarningThreshold.HasValue
-                ? this.timeProvider.GetCurrentDateTimeOffset().Add(WarningThreshold.Value)
-                : default;
+            DateTimeOffset warningThresholdDate = this.timeProvider.GetCurrentDateTimeOffset().Add(WarningThreshold ?? RotationThreshold / 2);
 
             DateTimeOffset? minExpirationDate = allStates
                 .Where(x => x.ExpirationDate.HasValue)
@@ -120,7 +118,7 @@ public class RotationPlan
 
             if (minExpirationDate == null || minExpirationDate <= invocationTime)
                 state = RotationState.Expired;
-            else if (warningThresholdDate.HasValue && minExpirationDate <= warningThresholdDate)
+            else if (minExpirationDate <= warningThresholdDate)
                 state = RotationState.Warning;
             else if (minExpirationDate <= rotationThresholdDate)
                 state = RotationState.Rotate;

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationPlanStatus.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationPlanStatus.cs
@@ -4,9 +4,7 @@ namespace Azure.Sdk.Tools.SecretRotation.Core;
 
 public class RotationPlanStatus
 {
-    public bool Expired { get; set; }
-
-    public bool ThresholdExpired { get; set; }
+    public RotationState State { get; set; }
 
     public bool RequiresRevocation { get; set; }
 

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationState.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationState.cs
@@ -1,0 +1,10 @@
+namespace Azure.Sdk.Tools.SecretRotation.Core;
+
+public enum RotationState
+{
+    Error,
+    UpToDate,
+    Rotate,
+    Warning,
+    Expired,
+}

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationPlanTests.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationPlanTests.cs
@@ -33,17 +33,18 @@ public class RotationPlanTests
     [TestCase(24, 22, 10, 30, RotationState.Warning)] // primary past warning
     [TestCase(24, 22, 30, 22, RotationState.Warning)] // secondary at warning
     [TestCase(24, 22, 30, 10, RotationState.Warning)] // secondary past warning
+    [TestCase(24, null, 30, 10, RotationState.Warning)] // implicit 12h warning window
     [TestCase(24, 22, 25, 25, RotationState.UpToDate)]
     public async Task GetStatusAsync_ExpectExpirationState(
         int rotateThresholdHours,
-        int warningThresholdHours,
+        int? warningThresholdHours,
         int hoursUntilPrimaryExpires,
         int hoursUntilSecondaryExpires,
         RotationState expectedState)
     {
         DateTimeOffset staticTestTime = DateTimeOffset.Parse("2020-06-01T12:00:00Z");
         TimeSpan rotateThreshold = TimeSpan.FromHours(rotateThresholdHours);
-        TimeSpan warningThreshold = TimeSpan.FromHours(warningThresholdHours);
+        TimeSpan? warningThreshold = warningThresholdHours.HasValue ? TimeSpan.FromHours(warningThresholdHours.Value) : null;
 
         var primaryState = new SecretState
         {

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/Valid/random-string.json
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/TestConfigurations/Valid/random-string.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/azure/azure-sdk-tools/main/tools/secret-management/schema/1.0.0/plan.json",
   "rotationThreshold": "9.00:00:00",
+  "warningThreshold": "6.00:00:00",
   "rotationPeriod": "12.00:00:00",
   "tags": [ "random" ],
   "stores": [

--- a/tools/secret-management/schema/1.0.0/plan.json
+++ b/tools/secret-management/schema/1.0.0/plan.json
@@ -14,7 +14,11 @@
             "type": "string"
         },
         "rotationThreshold": {
-            "description": "Time span indicating when the secret should be rotated before it expires",
+            "description": "Time span before expiration indicating when the secret should be rotated",
+            "type": "string"
+        },
+        "warningThreshold": {
+            "description": "Time span before expiration indicating when warnings should be issued",
             "type": "string"
         },
         "revokeAfterPeriod": {


### PR DESCRIPTION
This change allows for a secret to be in a warning state (should have been rotated previously and is close to expiration) and replaces the state booleans `Expired`, `ThresholdExpired`, and now `WarningExpired` with a single state enum:
```
    Error,
    UpToDate,
    Rotate,
    Warning,
    Expired,
```

If any secret enters the WarningThreshold, the cli will categorize it as Expiring and the status command will return a non-zero exit code.

The WarningThreshold for plans should be configured so there is reasonable time past the RotationThreshold to allow for rotation and prevent unnecessary warnings.