### PR TITLE
Revert "emit cross language definition Id"

### DIFF
--- a/eng/scripts/Create-Apiview-Token-Python.ps1
+++ b/eng/scripts/Create-Apiview-Token-Python.ps1
@@ -7,4 +7,4 @@ param (
 )
 
 Write-Host "Generating API review token file: $($SourcePath)"
-python -m apistub --pkg-path $SourcePath --emit-cross-language-definition-id --out-path $OutPath
+python -m apistub --pkg-path $SourcePath --out-path $OutPath


### PR DESCRIPTION
Reverts Azure/azure-sdk-tools#7961
argument is not yet available in published version of python