### PR TITLE
Pass flag to suppress errors correctly when verifying release change log

### DIFF
--- a/eng/common/scripts/Validate-Package.ps1
+++ b/eng/common/scripts/Validate-Package.ps1
@@ -60,7 +60,7 @@ function ValidateChangeLog($changeLogPath, $versionString, $validationStatus)
         Write-Host "Path to change log: [$changeLogFullPath]"        
         if (Test-Path $changeLogFullPath)
         {
-            Confirm-ChangeLogEntry -ChangeLogLocation $changeLogFullPath -VersionString $versionString -ForRelease $true -ChangeLogStatus $ChangeLogStatus
+            Confirm-ChangeLogEntry -ChangeLogLocation $changeLogFullPath -VersionString $versionString -ForRelease $true -ChangeLogStatus $ChangeLogStatus -SuppressErrors $true
             $validationStatus.Status = if ($ChangeLogStatus.IsValid) { "Success" } else { "Failed" }
             $validationStatus.Message = $ChangeLogStatus.Message 
         }


### PR DESCRIPTION
SuppressErrors flag was incorrectly set as true when verifying change log for releases.