### PR TITLE
Universal Output wasn't actually universal

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/OptionsGenerator.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/OptionsGenerator.cs
@@ -50,7 +50,7 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
             dumpOption.AddAlias("-d");
 
             var universalOption = new Option<bool>(
-                name: "--universalOutput",
+                name: "--universal",
                 description: "Flag; Redirect all logs to stdout, including what would normally be showing up on stderr.",
                 getDefaultValue: () => false);
             universalOption.AddAlias("-u");
@@ -83,6 +83,7 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
             var startCommand = new Command("start", "Start the TestProxy.");
             startCommand.AddOption(insecureOption);
             startCommand.AddOption(dumpOption);
+            startCommand.AddOption(universalOption);
             startCommand.AddArgument(collectedArgs);
 
             startCommand.SetHandler(async (startOpts) => await callback(startOpts),

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -147,12 +147,9 @@ namespace Azure.Sdk.Tools.TestProxy
                     {
                         loggingBuilder.ClearProviders();
                         loggingBuilder.AddConfiguration(hostBuilder.Configuration.GetSection("Logging"));
-                        loggingBuilder.AddConsole(options =>
+                        loggingBuilder.AddSimpleConsole(formatterOptions =>
                         {
-                            options.LogToStandardErrorThreshold = startOptions.UniversalOutput ? LogLevel.None : LogLevel.Error;
-                        }).AddSimpleConsole(options =>
-                        {
-                            options.TimestampFormat = "[HH:mm:ss] ";
+                            formatterOptions.TimestampFormat = "[HH:mm:ss] ";
                         });
                         loggingBuilder.AddDebug();
                         loggingBuilder.AddEventSourceLogger();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -147,9 +147,16 @@ namespace Azure.Sdk.Tools.TestProxy
                     {
                         loggingBuilder.ClearProviders();
                         loggingBuilder.AddConfiguration(hostBuilder.Configuration.GetSection("Logging"));
-                        loggingBuilder.AddSimpleConsole(formatterOptions =>
+                        if (!startOptions.UniversalOutput)
                         {
-                            formatterOptions.TimestampFormat = "[HH:mm:ss] ";
+                            loggingBuilder.AddConsole(options =>
+                            {
+                                options.LogToStandardErrorThreshold = LogLevel.Error;
+                            });
+                        }
+                        loggingBuilder.AddSimpleConsole(options =>
+                        {
+                            options.TimestampFormat = "[HH:mm:ss] ";
                         });
                         loggingBuilder.AddDebug();
                         loggingBuilder.AddEventSourceLogger();


### PR DESCRIPTION
1. Universal option wasn't being properly enabled, so we couldn't run the .NET tests properly
2. After fixing bug from 1), even w/ LogLevel set to 0, having the standard console would output _something_ to stderr, breaking the .NET tests
3. Fix the problem by only including the additional console if universal is set to true


