### PR TITLE
Use WIF to connect storage container

### DIFF
--- a/eng/common/pipelines/templates/steps/policheck.yml
+++ b/eng/common/pipelines/templates/steps/policheck.yml
@@ -2,14 +2,20 @@ parameters:
   ExclusionDataBaseFileName: ''
   TargetDirectory: ''
   PublishAnalysisLogs: false
-  PoliCheckBlobSAS: "$(azuresdk-policheck-blob-SAS)"
   ExclusionFilePath: "$(Build.SourcesDirectory)/eng/guardian-tools/policheck/PolicheckExclusions.xml"
 
 steps:
-  - pwsh: |
-      azcopy copy "https://azuresdkartifacts.blob.core.windows.net/policheck/${{ parameters.ExclusionDataBaseFileName }}.mdb?${{ parameters.PoliCheckBlobSAS }}" `
-      "$(Build.BinariesDirectory)"
-    displayName: 'Download PoliCheck Exclusion Database'
+ - task: AzurePowerShell@5
+    displayName: 'Download Policheck Exclusion Database'
+    inputs:
+      azureSubscription: 'Azure SDK Artifacts'
+      ScriptType: 'InlineScript'
+      azurePowerShellVersion: LatestVersion 
+      pwsh: true
+      Inline: |
+        azcopy copy "https://azuresdkartifacts.blob.core.windows.net/policheck/${{ parameters.ExclusionDataBaseFileName }}.mdb" "$(Build.BinariesDirectory)"
+    env: 
+      AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
 
   - task: securedevelopmentteam.vss-secure-development-tools.build-task-policheck.PoliCheck@2
     displayName: 'Run PoliCheck'


### PR DESCRIPTION
Moving away from SAS tokens for connecting to storage so switching to using a Workload Identity Federation connection to the container to download the needed files.

Test this in the JS repo in PR https://github.com/Azure/azure-sdk-for-js/pull/29284

Tried a few options and the AzurePS option seemed to be the most efficient until AzCopy directly supports this auth mode, tracked by https://github.com/Azure/azure-storage-azcopy/issues/2545