### PR TITLE
Removed `cleanup` flag from code snippet

### DIFF
--- a/doc/common/TypeSpec-Project-Scripts.md
+++ b/doc/common/TypeSpec-Project-Scripts.md
@@ -110,7 +110,6 @@ additionalDirectories:
   - specification/cognitiveservices/OpenAI.Authoring
 commit: 14f11cab735354c3e253045f7fbd2f1b9f90f7ca
 repo: Azure/azure-rest-api-specs
-cleanup: false
 ```
 
 ## TypeSpec-Project-Process.ps1


### PR DESCRIPTION
Removing seemingly deprecated flag from code snippet example.

In order to achieve the same one must pass the `-SaveInputs` flag instead. This is mentioned later in the document, but it might be a good idea to draw more attention to it.

```pwsh
pwsh ..\..\..\eng\common\scripts\TypeSpec-Project-Generate.ps1 -SaveInputs .
```