### PR TITLE
Add polly retry to get artifact URL from DevOps

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -56,11 +56,10 @@ namespace APIViewWeb.Repositories
 
         private async Task<string> getDownloadArtifactUrl(string buildId, string artifactName, string project)
         {
-            var maxRetryAttempts = 5;
             var pauseBetweenFailures = TimeSpan.FromSeconds(2);
             var retryPolicy = Policy
                 .Handle<HttpRequestException>()
-                .WaitAndRetryAsync(maxRetryAttempts, i => pauseBetweenFailures);
+                .WaitAndRetryAsync(5, i => pauseBetweenFailures);
 
             var connection = await CreateVssConnection();
             var buildClient = connection.GetClient<BuildHttpClient>();

--- a/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/DevopsArtifactRepository.cs
@@ -63,12 +63,18 @@ namespace APIViewWeb.Repositories
 
             var connection = await CreateVssConnection();
             var buildClient = connection.GetClient<BuildHttpClient>();
+            string url = null;
             await retryPolicy.ExecuteAsync(async () =>
             {
                 var artifact = await buildClient.GetArtifactAsync(project, int.Parse(buildId), artifactName);
-                return artifact?.Resource?.DownloadUrl;
+                url =  artifact?.Resource?.DownloadUrl;
             });
-            throw new Exception(string.Format("Failed to get download url for artifact {0} in build {1} in project {2}", artifactName, buildId, project));
+
+            if (string.IsNullOrEmpty(url))
+            {
+                throw new Exception(string.Format("Failed to get download url for artifact {0} in build {1} in project {2}", artifactName, buildId, project));
+            }
+            return url;
         }
 
         private async Task<VssConnection> CreateVssConnection()


### PR DESCRIPTION
Request to get artifact URL is still failing with 404 error. Adding polly retry to get URL.URL is working fine when attempted again.