### PR TITLE
Handle the failures when package work item is unassigned

### DIFF
--- a/eng/common/scripts/Update-DevOps-Release-WorkItem.ps1
+++ b/eng/common/scripts/Update-DevOps-Release-WorkItem.ps1
@@ -93,7 +93,12 @@ Write-Host "Updated or created a release work item for a package release with th
 Write-Host "  Lanuage: $($workItem.fields['Custom.Language'])"
 Write-Host "  Version: $($workItem.fields['Custom.PackageVersionMajorMinor'])"
 Write-Host "  Package: $($workItem.fields['Custom.Package'])"
-Write-Host "  AssignedTo: $($workItem.fields['System.AssignedTo']["uniqueName"])"
+if ($workItem.fields['System.AssignedTo']) {
+  Write-Host "  AssignedTo: $($workItem.fields['System.AssignedTo']["uniqueName"])"
+}
+else {
+  Write-Host "  AssignedTo: unassigned"
+}
 Write-Host "  PackageDisplayName: $($workItem.fields['Custom.PackageDisplayName'])"
 Write-Host "  ServiceName: $($workItem.fields['Custom.ServiceName'])"
 Write-Host "  PackageType: $($workItem.fields['Custom.PackageType'])"


### PR DESCRIPTION
Step to update an existing work item fails with null index error if the package work item is unassigned. 
Error: Cannot index into a null array.



