### PR TITLE
[GitHub] Add common service label

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -111,6 +111,7 @@ Defender ESAM,,e99695
 Dev Spaces,,e99695
 Device Update,,e99695
 DevOps,,e99695
+DevOps - Infrastructure,,e99695
 Devtestlab,,e99695
 Digital Twins,,e99695
 Do Not Merge,,b60205


### PR DESCRIPTION
# Summary

The focus of these changes is to add a new service label for the "DevOps - Infrastructure" resource provider to the common set.