### PR TITLE
examples automation, pin eslint to 0.8.57

### DIFF
--- a/tools/azure-rest-api-specs-examples-automation/js/lint.py
+++ b/tools/azure-rest-api-specs-examples-automation/js/lint.py
@@ -64,7 +64,7 @@ class JsLint:
                 cmd = [npm_cmd, 'install', self.module, '--save', '--save-exact']
                 check_call(cmd, tmp_dir_name)
 
-                cmd = [npm_cmd, 'install', 'eslint', '--save-dev']
+                cmd = [npm_cmd, 'install', 'eslint@8.57.0', '--save-dev']
                 check_call(cmd, tmp_dir_name)
 
                 with open(path.join(tmp_dir_name, 'package.json'), encoding='utf-8') as f:


### PR DESCRIPTION
The new eslint 9.0.0 appears to have breaking changes/behaviors.

Also our major libs is still using 0.8.57
https://github.com/microsoft/typespec/blob/main/package.json#L46

Loop Mary from typescript/javascript for advice as well.