### PR TITLE
Update to azure/login@v2

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -38,7 +38,6 @@ jobs:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}
             subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-            enable-AzPSSession: true
 
       - name: 'Run Azure CLI commands'
         run: |

--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -33,11 +33,12 @@ jobs:
     if: ${{ github.event_name == 'issues' && github.event.action == 'opened' }}
     steps:
       - name: 'Az CLI login'
-        uses: azure/login@v1
+        uses: azure/login@v2
         with:
             client-id: ${{ secrets.AZURE_CLIENT_ID }}
             tenant-id: ${{ secrets.AZURE_TENANT_ID }}
             subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+            enable-AzPSSession: true
 
       - name: 'Run Azure CLI commands'
         run: |


### PR DESCRIPTION
There was a [recent announcement](https://github.com/Azure/login/issues/424) that the default runtime of azure/login is being updated from Node 16 to Note 20 due to the deprecation of Node 16. This is a breaking change and does require an extra variable being added to the step. `enable-AzPSSession: true`.

I've already t[ested this change in github-event-processor-test](https://github.com/azure-sdk/github-event-processor-test/blob/main/.github/workflows/event-processor.yml#L36) repository and things look fine.