### PR TITLE
Only make one call to GetPackageInfoJson

### DIFF
--- a/eng/common/scripts/Update-DocsMsMetadata.ps1
+++ b/eng/common/scripts/Update-DocsMsMetadata.ps1
@@ -214,7 +214,7 @@ foreach ($packageInfoLocation in $PackageInfoJsonLocations) {
   }
 
   Write-Host "Updating metadata for package: $packageInfoLocation"
-  $packageMetadataName = Split-Path $packageInfoJsonLocation -Leaf
+  $packageMetadataName = Split-Path $packageInfoLocation -Leaf
   # Convert package metadata json file to metadata json property.
   UpdateDocsMsMetadataForPackage $packageInfo $packageMetadataName
 }


### PR DESCRIPTION
Update-DocsMsMetadata.ps1 is the entry point for MS Docs updates in our pipelines. 

Hoist the `$packageInfo = GetPackageInfoJson $packageInfoLocation` out of the `if ($ValidateDocsMsPackagesFn...` if check and pass the packageInfo into the UpdateDocsMsMetadataForPackage call. The reason for this is that UpdateDocsMsMetadataForPackage also calls GetPackageInfo and if the $GetDocsMsDevLanguageSpecificPackageInfoFn function pointer is defined, like it is for Java, JavaScript and Python, it ends up making calls across the network to get pieces to add to the packageInfo Json. In the cases of Java and Python, it's pulling the javadoc or .whl to crack open to get the namespaces. For JavaScript, it's invoking a rest method. Hoisting the call out of the if statement and passing in the structure to UpdateDocsMsMetadataForPackage prevents a second set of network calls to get information that we literally just got.
