### PR TITLE
Add webapi controller for devops POST webhook

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Controllers/DevopsEventsController.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Controllers/DevopsEventsController.cs
@@ -1,0 +1,53 @@
+using System.Text.Json;
+using System.Threading.Tasks;
+using Azure.Sdk.Tools.PipelineWitness.Configuration;
+using Azure.Storage.Queues;
+using Azure.Storage.Queues.Models;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+// For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
+
+namespace Azure.Sdk.Tools.PipelineWitness.Controllers
+{
+    [Route("api/devopsevents")]
+    [ApiController]
+    public class DevopsEventsController : ControllerBase
+    {
+        private readonly QueueClient queueClient;
+        private readonly ILogger<DevopsEventsController> logger;
+
+        public DevopsEventsController(ILogger<DevopsEventsController> logger, QueueServiceClient queueServiceClient, IOptions<PipelineWitnessSettings> options)
+        {
+            this.queueClient = queueServiceClient.GetQueueClient(options.Value.BuildCompleteQueueName);
+            this.logger = logger;
+        }
+
+        // POST api/devopsevents
+        [HttpPost]
+        public async Task PostAsync([FromBody] JsonDocument value)
+        {
+            if (value == null) {
+                throw new BadHttpRequestException("Missing payload", 400);
+            }
+
+            this.logger.LogInformation("Message received in DevopsEventsController.PostAsync");
+            string message = value.RootElement.GetRawText();
+
+            if (value.RootElement.TryGetProperty("resource", out var resource)
+                && resource.TryGetProperty("url", out var url)
+                && url.GetString().StartsWith("https://dev.azure.com/azure-sdk/"))
+            {
+                SendReceipt response = await this.queueClient.SendMessageAsync(message);
+                this.logger.LogInformation("Message added to queue with id {MessageId}", response.MessageId);
+            }
+            else
+            {
+                this.logger.LogError("Message content invalid: {Content}", message);
+                throw new BadHttpRequestException("Invalid payload", 400);
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Program.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Program.cs
@@ -19,6 +19,7 @@ namespace Azure.Sdk.Tools.PipelineWitness
             // Add services to the container.
             builder.Services.AddControllers();
             builder.Services.AddHealthChecks();
+            builder.Services.AddHttpLogging(options => { });
 
             // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
             builder.Services.AddEndpointsApiExplorer();
@@ -42,6 +43,8 @@ namespace Azure.Sdk.Tools.PipelineWitness
             app.MapControllers();
 
             app.UseHealthChecks("/");
+
+            app.UseHttpLogging();
 
             await app.RunAsync();
         }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.json
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.json
@@ -3,7 +3,6 @@
     "LogLevel": {
       "Default": "Warning",
       "Microsoft.Hosting": "Information",
-      "Microsoft.AspNetCore.HttpLogging.HttpLoggingMiddleware": "Information",
       "Azure.Sdk.Tools.PipelineWitness": "Debug",
       "Azure.Core": "Error"
     },

--- a/tools/pipeline-witness/infrastructure/Assign-StoragePermissions.ps1
+++ b/tools/pipeline-witness/infrastructure/Assign-StoragePermissions.ps1
@@ -18,6 +18,7 @@ try {
   $subscriptionName = $target -eq 'test' ? 'Azure SDK Developer Playground' : 'Azure SDK Engineering System'
   Write-Host "Setting subscription to '$subscriptionName'"
   Invoke "az account set --subscription '$subscriptionName' --output none"
+  $subscriptionId = az account show --query id -o tsv
 
   $parametersFile = "./bicep/parameters.$target.json"
   Write-Host "Reading parameters from $parametersFile"
@@ -30,7 +31,7 @@ try {
 
   Write-Host "Adding Azure SDK Engineering System Team RBAC access to storage resources:`n" + `
     "  Blob: $logsResourceGroupName/$logsStorageAccountName`n" + `
-    "  Queue: `n" + `
+    "  Queue: $appResourceGroupName/$appStorageAccountName`n" + `
     "  Cosmos: $appResourceGroupName/$cosmosAccountName`n"
 
   Write-Host "Getting group id for Azure SDK Engineering System Team"


### PR DESCRIPTION
Because the StorageQueue hook in Azure DevOps depends on a storage key, we need to migrate to a hook type that doesn't use a storage account.

This PR adds an HTTP POST endpoint to the app that receives a message from devops and pushes it to the storage queue, acting as an enqueue proxy. 