### PR TITLE
[ci] Add support for sdktype "utility" from the JS repo

### DIFF
--- a/eng/common/scripts/Validate-Package.ps1
+++ b/eng/common/scripts/Validate-Package.ps1
@@ -163,6 +163,11 @@ function CreateUpdatePackageWorkItem($pkgInfo)
         $setReleaseState = $false
         $plannedDate = "unknown"
     }
+    $sdkType = $pkgInfo.SDKType;
+    # JS uses "utility" instead of "tool" in package.json
+    if ($sdkType -eq "utility") {
+        $sdkType = "tool"
+    }
         
     # Create or update package work item  
     &$EngCommonScriptsDir/Update-DevOps-Release-WorkItem.ps1 `
@@ -171,7 +176,7 @@ function CreateUpdatePackageWorkItem($pkgInfo)
         -version $versionString `
         -plannedDate $plannedDate `
         -packageRepoPath $pkgInfo.serviceDirectory `
-        -packageType $pkgInfo.SDKType `
+        -packageType $sdkType `
         -packageNewLibrary $pkgInfo.IsNewSDK `
         -serviceName "unknown" `
         -packageDisplayName "unknown" `


### PR DESCRIPTION
In JS we use sdk-type: "utility" in our package manifests for things in the `@azure-tools` namespace, but this isn't one of the supported values in ADO work items for releases.

This can cause problems in CI like shown here:

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3751191&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=00913ed3-6224-599f-5780-70386e2dd22d

![example of the build issue](https://github.com/Azure/azure-sdk-tools/assets/639216/bef3b1fc-baaf-43a0-b9cb-fe69292e5a75)


This PR works around the problem by substituting the invalid string "utility" for the permitted work item value of "tool"