### PR TITLE
Add jsquire and ronniegeraghty as owners of github-event-processor

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -32,7 +32,7 @@
 ###########
 /tools/                                @azure/azure-sdk-eng
 /tools/codeowners-utils/               @JimSuplizio
-/tools/github-event-processor/         @JimSuplizio @benbp
+/tools/github-event-processor/         @JimSuplizio @benbp @jsquire @ronniegeraghty
 /tools/github-team-user-store/         @JimSuplizio @weshaggard
 /tools/js-sdk-release-tools/           @qiaozha @MaryGao
 /tools/mock-service-host/              @raych1 @tadelesh


### PR DESCRIPTION
Changes were made in azure-sdk-tools which now require PRs to be signed off by owners of the code defined in CODEOWNERS. I'm adding @jsquire and @ronniegeraghty as owners of github-event-processor since they're the major stakeholders and the primary sources driving rules changes (with me tending to be the developer).