### PR TITLE
Add revision release date

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Client/css/pages/revisions.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/pages/revisions.scss
@@ -59,3 +59,19 @@
         display: inline-flex;
     }
 }
+
+.shipped-label {
+    display: inline-block;
+    padding: .2em .6em .3em;
+    font-size: small;
+    font-weight: bolder;
+    /*font-size: 75%;
+    font-weight: 700;*/
+    line-height: 1;
+    color: #fff;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+    border-radius: .25em;
+    background-color: green;
+}

--- a/src/dotnet/APIView/APIViewWeb/Client/css/pages/revisions.scss
+++ b/src/dotnet/APIView/APIViewWeb/Client/css/pages/revisions.scss
@@ -65,8 +65,6 @@
     padding: .2em .6em .3em;
     font-size: small;
     font-weight: bolder;
-    /*font-size: 75%;
-    font-weight: 700;*/
     line-height: 1;
     color: #fff;
     text-align: center;

--- a/src/dotnet/APIView/APIViewWeb/Pages/Shared/_APIRevisionsPartial.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Shared/_APIRevisionsPartial.cshtml
@@ -42,7 +42,7 @@
                             </div>
                         }
                         <p class="card-subtitle mb-1 text-body-secondary"><b>Created: </b><span date="@apiRevision.CreatedOn"></span> , <b>By: </b>@apiRevision.CreatedBy , <b>Updated: </b><span date="@apiRevision.LastUpdatedOn"></span></p>
-                        <p class="card-subtitle mb-1 text-body-secondary"><b>Type: </b>@apiRevision.APIRevisionType , <b>Version: </b>@apiRevision.Files[0].PackageVersion , @if (apiRevision.IsReleased) { <b>Released: </b><span date="@apiRevision.ReleasedOn"></span> } </p>
+                        <p class="card-subtitle mb-1 text-body-secondary"><b>Type: </b>@apiRevision.APIRevisionType , <b>Version: </b>@apiRevision.Files[0].PackageVersion @if (apiRevision.IsReleased) { <span class="shipped-label">Shipped</span> } </p>
                     </div>
                     <div class="revision-actions">
                         <div class="btn-group animate__animated animate__fadeIn" role="group" aria-label="apiRevision action buttons">


### PR DESCRIPTION
Replaced "Released: Date/Time" element in Revision Panel with a more visible label for Shipped Revisions