### PR TITLE
Make create apireview runnable from non default working directory

### DIFF
--- a/eng/common/pipelines/templates/steps/create-apireview.yml
+++ b/eng/common/pipelines/templates/steps/create-apireview.yml
@@ -7,7 +7,6 @@ parameters:
   ArtifactName: 'packages'
   PackageName: ''
   SourceRootPath: $(Build.SourcesDirectory)
-  WorkingDirectory: $(Pipeline.Workspace)
 
 steps:
   # ideally this should be done as initial step of a job in caller template
@@ -21,7 +20,7 @@ steps:
   - ${{ if or(ne(parameters.GenerateApiReviewForManualOnly, true), eq(variables['Build.Reason'], 'Manual')) }}:
     - task: Powershell@2
       inputs:
-        filePath: ${{parameters.SourceRootPath}}/eng/common/scripts/Create-APIReview.ps1
+        filePath: ./eng/common/scripts/Create-APIReview.ps1
         arguments: >
           -ArtifactList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json | Select-Object Name)
           -ArtifactPath ${{parameters.ArtifactPath}}
@@ -35,7 +34,7 @@ steps:
           -RepoName '$(Build.Repository.Name)'    
           -MarkPackageAsShipped $${{parameters.MarkPackageAsShipped}}
         pwsh: true
-        workingDirectory: ${{parameters.WorkingDirectory}}
+        workingDirectory: ${{parameters.SourceRootPath}}
       displayName: Create API Review
       condition: >-
         and(

--- a/eng/common/pipelines/templates/steps/create-apireview.yml
+++ b/eng/common/pipelines/templates/steps/create-apireview.yml
@@ -13,7 +13,7 @@ steps:
   # We can remove this step later once it is added in caller
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     parameters:
-      WorkingDirectory: ${{parameters.SourceRootPath}}
+      WorkingDirectory: ${{ parameters.SourceRootPath }}
 
   # Automatic API review is generated for a package when pipeline runs irrespective of how pipeline gets triggered.
   # Below condition ensures that API review is generated only for manual pipeline runs when flag GenerateApiReviewForManualOnly is set to true. 
@@ -34,7 +34,7 @@ steps:
           -RepoName '$(Build.Repository.Name)'    
           -MarkPackageAsShipped $${{parameters.MarkPackageAsShipped}}
         pwsh: true
-        workingDirectory: ${{parameters.SourceRootPath}}
+        workingDirectory: ${{ parameters.SourceRootPath }}
       displayName: Create API Review
       condition: >-
         and(

--- a/eng/common/pipelines/templates/steps/create-apireview.yml
+++ b/eng/common/pipelines/templates/steps/create-apireview.yml
@@ -6,18 +6,22 @@ parameters:
   GenerateApiReviewForManualOnly: false
   ArtifactName: 'packages'
   PackageName: ''
+  SourceRootPath: $(Build.SourcesDirectory)
+  WorkingDirectory: $(Pipeline.Workspace)
 
 steps:
   # ideally this should be done as initial step of a job in caller template
   # We can remove this step later once it is added in caller
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+    parameters:
+      WorkingDirectory: ${{parameters.SourceRootPath}}
 
   # Automatic API review is generated for a package when pipeline runs irrespective of how pipeline gets triggered.
   # Below condition ensures that API review is generated only for manual pipeline runs when flag GenerateApiReviewForManualOnly is set to true. 
   - ${{ if or(ne(parameters.GenerateApiReviewForManualOnly, true), eq(variables['Build.Reason'], 'Manual')) }}:
     - task: Powershell@2
       inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/scripts/Create-APIReview.ps1
+        filePath: ${{parameters.SourceRootPath}}/eng/common/scripts/Create-APIReview.ps1
         arguments: >
           -ArtifactList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json | Select-Object Name)
           -ArtifactPath ${{parameters.ArtifactPath}}
@@ -31,7 +35,7 @@ steps:
           -RepoName '$(Build.Repository.Name)'    
           -MarkPackageAsShipped $${{parameters.MarkPackageAsShipped}}
         pwsh: true
-        workingDirectory: $(Pipeline.Workspace)
+        workingDirectory: ${{parameters.WorkingDirectory}}
       displayName: Create API Review
       condition: >-
         and(


### PR DESCRIPTION
Release job for Java packages does not have azure-sdk-for-java in default source repo path.  This change is required so release job can use this common template to mark a package as shipped by overriding source repo path.