### PR TITLE
SAS token removal from team/user store

### DIFF
--- a/eng/pipelines/pipeline-owners-extraction.yml
+++ b/eng/pipelines/pipeline-owners-extraction.yml
@@ -35,7 +35,7 @@ stages:
           scriptLocation: inlineScript
           inlineScript: |
             dotnet run -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -rlFile "$(RepoListFile)"
-        workingDirectory: tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore
+          workingDirectory: tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore
         env:
           GITHUB_TOKEN: $(azuresdkartifacts-azure-sdk-write-teams-github-pat)
 

--- a/eng/pipelines/pipeline-owners-extraction.yml
+++ b/eng/pipelines/pipeline-owners-extraction.yml
@@ -21,12 +21,24 @@ stages:
       Project: internal
       DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
       OutputPath: '$(Agent.BuildDirectory)/pipelineOwners.json'
-      RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob?$(azuresdkartifacts-azure-sdk-write-teams-sas)"
-      TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob?$(azuresdkartifacts-azure-sdk-write-teams-sas)"
-      UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob?$(azuresdkartifacts-azure-sdk-write-teams-sas)"
+      RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
+      TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"
+      UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
       RepoListFile: "$(Build.SourcesDirectory)/tools/github/data/repositories.txt"
 
     steps:
+      - task: AzureCLI@2
+        displayName: 'Fetch and store team/user data'
+        inputs:
+          azureSubscription: 'Azure SDK Artifacts'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript: |
+            dotnet run -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -rlFile "$(RepoListFile)"
+        workingDirectory: tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore
+        env:
+          GITHUB_TOKEN: $(azuresdkartifacts-azure-sdk-write-teams-github-pat)
+
       - task: DotNetCoreCLI@2
         displayName: 'Install Pipeline Owners Extractor'
         inputs:
@@ -46,9 +58,3 @@ stages:
         artifact: pipelineOwners
         condition: succeededOrFailed()
 
-      - pwsh: |
-          dotnet run -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -rlFile "$(RepoListFile)"
-        displayName: 'Fetch and store team/user data'
-        workingDirectory: tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore
-        env:
-          GITHUB_TOKEN: $(azuresdkartifacts-azure-sdk-write-teams-github-pat)

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/GitHubEventClient.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/GitHubEventClient.cs
@@ -178,7 +178,7 @@ namespace GitHubTeamUserStore
         /// <returns></returns>
         public async Task UploadDataToBlobStorage(string rawJson, BlobUriBuilder blobUriBuilder)
         {
-            var cred = new DefaultAzureCredential();
+            var cred = new AzureCliCredential();
             BlobServiceClient blobServiceClient = new BlobServiceClient(blobUriBuilder.ToUri(), cred);
 
             BlobContainerClient blobContainerClient = blobServiceClient.GetBlobContainerClient(blobUriBuilder.BlobContainerName);

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/GitHubTeamUserStore.csproj
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/GitHubTeamUserStore.csproj
@@ -8,7 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
+    <PackageReference Include="Azure.Identity" Version="1.11.3" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.19.1" />
     <PackageReference Include="Octokit" Version="5.0.2" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Program.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Program.cs
@@ -71,22 +71,13 @@ namespace GitHubTeamUserStore
             bool success = false;
             // The team/user list needs to be generated before the user/org data. The reason being is that the User/Org
             // visibility data is generated for the azure-sdk-write team users.
-            // JRS-BEGIN - uncomment when done testing
-            //if (await TeamUserGenerator.GenerateAndStoreTeamUserAndOrgData(gitHubEventClient, teamUserBlobStorageUri, userOrgVisibilityBlobStorageUri))
-            //{
-            //    if (await RepositoryLabelGenerator.GenerateAndStoreRepositoryLabels(gitHubEventClient, repoLabelBlobStorageUri, repositoryListFile))
-            //    {
-            //        success = true;
-            //    }
-            //}
-            // JRS-END - uncomment when done testing
-
-            // JRS-BEGIN - remove when done testing
-            if (await RepositoryLabelGenerator.GenerateAndStoreRepositoryLabels(gitHubEventClient, repoLabelBlobStorageUri, repositoryListFile))
+            if (await TeamUserGenerator.GenerateAndStoreTeamUserAndOrgData(gitHubEventClient, teamUserBlobStorageUri, userOrgVisibilityBlobStorageUri))
             {
-                success = true;
+                if (await RepositoryLabelGenerator.GenerateAndStoreRepositoryLabels(gitHubEventClient, repoLabelBlobStorageUri, repositoryListFile))
+                {
+                    success = true;
+                }
             }
-            // JRS-END - remove when done testing
 
             await gitHubEventClient.WriteRateLimits("RateLimit at end of execution:");
 

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Program.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Program.cs
@@ -71,13 +71,22 @@ namespace GitHubTeamUserStore
             bool success = false;
             // The team/user list needs to be generated before the user/org data. The reason being is that the User/Org
             // visibility data is generated for the azure-sdk-write team users.
-            if (await TeamUserGenerator.GenerateAndStoreTeamUserAndOrgData(gitHubEventClient, teamUserBlobStorageUri, userOrgVisibilityBlobStorageUri))
+            // JRS-BEGIN - uncomment when done testing
+            //if (await TeamUserGenerator.GenerateAndStoreTeamUserAndOrgData(gitHubEventClient, teamUserBlobStorageUri, userOrgVisibilityBlobStorageUri))
+            //{
+            //    if (await RepositoryLabelGenerator.GenerateAndStoreRepositoryLabels(gitHubEventClient, repoLabelBlobStorageUri, repositoryListFile))
+            //    {
+            //        success = true;
+            //    }
+            //}
+            // JRS-END - uncomment when done testing
+
+            // JRS-BEGIN - remove when done testing
+            if (await RepositoryLabelGenerator.GenerateAndStoreRepositoryLabels(gitHubEventClient, repoLabelBlobStorageUri, repositoryListFile))
             {
-                if (await RepositoryLabelGenerator.GenerateAndStoreRepositoryLabels(gitHubEventClient, repoLabelBlobStorageUri, repositoryListFile))
-                {
-                    success = true;
-                }
+                success = true;
             }
+            // JRS-END - remove when done testing
 
             await gitHubEventClient.WriteRateLimits("RateLimit at end of execution:");
 


### PR DESCRIPTION
Use azure credentials instead of the SAS token for the team/user store.

In the pipeline use the AzureCLI task to authenticate to the Azure SDK Artifacts, which has already been setup. As mentioned in the comments, we can't use the DefaultAzureCredential. The reason for this is because, in CI pipelines, it picks up the ManagedIdentityCredential over the AzureCliCredential and the AzureCliCredential is what we need to be using.
