### PR TITLE
CODEOWNERS linter yml updates

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -46,7 +46,7 @@ stages:
           arguments: 'install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"'
           workingDirectory: '$(Build.SourcesDirectory)/eng/common'
 
-      - ${{if eq(variables['Build.Reason'], 'PullRequest') }}:
+      - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         - pwsh: |
             Write-Host "git checkout $ENV:SYSTEM_PULLREQUEST_TARGETBRANCH"
             git checkout $ENV:SYSTEM_PULLREQUEST_TARGETBRANCH

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -21,6 +21,7 @@ stages:
   variables:
     skipComponentGovernanceDetection: true
     nugetMultiFeedWarnLevel: 'none'
+    baseBranchBaseline: ''
 
   jobs:
   - job: Run
@@ -30,21 +31,13 @@ stages:
       vmImage: ubuntu-22.04
 
     variables:
-      CodeownersLinterVersion: '1.0.0-dev.20240227.2'
+      CodeownersLinterVersion: '1.0.0-dev.20240514.2'
       DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
       RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
       TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"
       UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
 
     steps:
-      # Skip sparse checkout for the `azure-sdk-for-<lang>-pr` private mirrored repositories
-      # as we require the github service connection to be loaded.
-      - ${{ if not(contains(variables['Build.DefinitionName'], '-pr - ')) }}:
-        - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-          parameters:
-            Paths:
-              - '/*'
-
       - task: DotNetCoreCLI@2
         displayName: 'Install CodeownersLinter'
         inputs:
@@ -52,7 +45,32 @@ stages:
           custom: 'tool'
           arguments: 'install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"'
           workingDirectory: '$(Build.SourcesDirectory)/eng/common'
+
+      - ${{if eq(variables['Build.Reason'], 'PullRequest') }}:
+        - pwsh: |
+            Write-Host "git checkout $ENV:SYSTEM_PULLREQUEST_TARGETBRANCH"
+            git checkout $ENV:SYSTEM_PULLREQUEST_TARGETBRANCH
+          displayName: Checkout the base branch
+
+        - pwsh: |
+            # Generate the base branch baseline file to the Build.BinariesDirectory. This will create
+            # a baseline error file against the CODEOWNERS in the base branch
+            $baseBranchBaselineFile = "$(Build.BinariesDirectory)/CODEOWNERS_BaseBranch_Baseline_errors.txt"
+            Write-Host "codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -gbl -rUri ""$(RepoLabelUri)"" -tUri ""$(TeamUserUri)"" -uUri ""$(UserOrgUri)"" -bbf ""$baseBranchBaselineFile"""
+            codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -gbl -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -bbf "$baseBranchBaselineFile"
+            echo "##vso[task.setvariable variable=baseBranchBaseline]$baseBranchBaselineFile"
+          displayName: 'Generate baseline file for base branch'
+          workingDirectory: '$(Build.SourcesDirectory)/eng/common'
+
+        - pwsh: |
+            Write-Host "git checkout refs/remotes/pull/$ENV:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/merge"
+            git checkout refs/remotes/pull/$ENV:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER/merge
+          displayName: Checkout the PR branch
+
       - pwsh: |
-          codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -fbl -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)"
+          # In the case of a PR, the baseBranchBaseline will be set which will be used to further filter results.
+          # For scheduled runs, the baseBranchBaseline won't be set and only the existing baseline file will be used to filter
+          Write-Host "codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -fbl -rUri ""$(RepoLabelUri)"" -tUri ""$(TeamUserUri)"" -uUri ""$(UserOrgUri)"" -bbf ""$(baseBranchBaseline)"""
+          codeowners-linter --repoRoot $(Build.SourcesDirectory) --repoName $(Build.Repository.Name) -fbl -rUri "$(RepoLabelUri)" -tUri "$(TeamUserUri)" -uUri "$(UserOrgUri)" -bbf "$(baseBranchBaseline)"
         displayName: 'Lint CODEOWNERS and filter using baseline'
         workingDirectory: '$(Build.SourcesDirectory)/eng/common'


### PR DESCRIPTION
These is the yml changes for the [linter update](https://github.com/Azure/azure-sdk-tools/pull/8264).

Testing was done by pushing test commits with errors in their CODEOWNERS files that were removed from the baseline errors as part of their PRs. This means that only by using the generated base branch baseline file would they have passed.

[PR](https://github.com/Azure/azure-sdk-for-java/pull/40153) with main as the base branch and its [codeowners-linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3787959&view=results)

[PR](https://github.com/Azure/azure-sdk-for-java/pull/40161) with a feature branch as the base branch and its [codeowners-linter run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3788427&view=results)

These cases were necessary to test the inline powershell scripts that swap the branch to the base branch to create the base branch baseline file and swap back to run the linter against the files in the PR, which only passed because of the base branch baseline file.