### PR TITLE
Added variable to skip spec location check

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
+++ b/eng/common/pipelines/templates/steps/verify-restapi-spec-location.yml
@@ -22,3 +22,4 @@ steps:
     displayName: Verify REST API spec location for "${{ parameters.PackageName }}"
     env:
       GH_TOKEN: $(azuresdk-github-pat)
+    condition: and(succeededOrFailed(), ne(variables['Skip.Verify-RestApiSpecLocation'], 'true'))


### PR DESCRIPTION
Storage team is blocked for the GA release which depends on a legacy version spec in non-main branch. Service team needs more time to use the latest stable version specs from the main branch of Azure spec repo. As discussed with Scott, we decided to allow the check to be skipped by pipeline variable to unblock the release.

This is the [dotnet test pipeline run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3789610&view=logs&j=7bb69cc7-6f52-585e-8b13-5bae7c4a9fa4&t=7abbbe6b-d005-5c95-feb6-99ffe4e699e1) which skips this check after set the variable when triggered the run.
