### PR TITLE
Feedback from `Java` Integration

### DIFF
--- a/eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
+++ b/eng/pipelines/templates/jobs/azuresdkpartnerdrops-to-nugetfeed.yml
@@ -45,14 +45,20 @@ jobs:
       - checkout: self
       - checkout: azure-sdk-build-tools
 
-      - pwsh: |
-          azcopy cp '${{ parameters.PartnerDropsBlobBase }}/${{ parameters.PartnerDropsBlobSourceSuffix }}/*' '${{ parameters.ArtifactsPath }}' --recursive=true
-        displayName: 'Copy from AzureSdkPartnerDrops'
-        env:
-          AZCOPY_AUTO_LOGIN_TYPE: SPN
-          AZCOPY_SPA_APPLICATION_ID: $(azuresdkpartnerdrops-application-id)
-          AZCOPY_SPA_CLIENT_SECRET: $(azuresdkpartnerdrops-service-principal-key)
+      - task: AzurePowerShell@5
+        displayName: 'Copy from azuresdkpartnerdrops'
         condition: and(succeeded(), ne(variables['SkipCopyFromPartnerDrops'], 'true'))
+        inputs:
+          azureSubscription: 'azuresdkpartnerdrops - Storage Partner Drops'
+          ScriptType: 'InlineScript'
+          azurePowerShellVersion: LatestVersion 
+          pwsh: true
+          Inline: |
+            azcopy copy '${{ parameters.PartnerDropsBlobBase }}/${{ parameters.PartnerDropsBlobSourceSuffix }}/*' '${{ parameters.ArtifactsPath }}' --recursive=true
+            echo "Copied files:"
+            dir '${{ parameters.ArtifactsPath }}' -r | % { $_.FullName }
+        env: 
+          AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'     
 
       - ${{ if eq(parameters.ShouldSign, true) }}:
         - template: pipelines/steps/net-signing.yml@azure-sdk-build-tools

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ModifiableRecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ModifiableRecordSession.cs
@@ -14,14 +14,20 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
         public ModifiableRecordSession(SanitizerDictionary sanitizerRegistry, string sessionId)
         {
-            this.AppliedSanitizers = sanitizerRegistry.SessionSanitizers.ToList();
+            lock(sanitizerRegistry.SessionSanitizerLock)
+            {
+                this.AppliedSanitizers = sanitizerRegistry.SessionSanitizers.ToList();
+            }
             this.SessionId = sessionId;
         }
 
         public ModifiableRecordSession(RecordSession session, SanitizerDictionary sanitizerRegistry, string sessionId)
         {
             Session = session;
-            this.AppliedSanitizers = sanitizerRegistry.SessionSanitizers.ToList();
+            lock (sanitizerRegistry.SessionSanitizerLock)
+            {
+                this.AppliedSanitizers = sanitizerRegistry.SessionSanitizers.ToList();
+            }
             this.SessionId = sessionId;
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
@@ -608,10 +608,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                     "AZSDK3480"
                 ),
                 new RegisteredSanitizer(
-                    new BodyKeySanitizer("$..connectionString"),
-                    "AZSDK3481"
-                ),
-                new RegisteredSanitizer(
                     new BodyKeySanitizer("$..password"),
                     "AZSDK3482"
                 ),

--- a/tools/test-proxy/tests.yml
+++ b/tools/test-proxy/tests.yml
@@ -8,7 +8,6 @@ stages:
     displayName: "Asset Sync Integration Tests"
     jobs:
     - job: Solution_Integration_Test
-      condition: false
 
       strategy:
         matrix:
@@ -81,7 +80,6 @@ stages:
 
   - stage: RepoUnitTests
     displayName: Repo-Specific Unit Tests
-    condition: false
     dependsOn: []
     jobs:
     - job: Test_JS_Utils


### PR DESCRIPTION
- [x] Eliminating any possibility that a set of session sanitizers is _always_ stable for a new playback/recording session
- [x] Handling JToken parsing errors in the BodyKeySanitizer with logging to repro the issue and fix the sanitizer itself later.
- [x] Fix failing [CLI integration test](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3790514&view=logs&s=843cf892-394e-5a95-58a2-f157705529be&j=8f9f4964-c72c-5d42-b048-5ad0840422bb)
- [x] Remove duplicate common sanitizer