### PR TITLE
Add Content-Type to the GH PR api call

### DIFF
--- a/eng/scripts/Verify-And-Merge-PRs.ps1
+++ b/eng/scripts/Verify-And-Merge-PRs.ps1
@@ -8,7 +8,7 @@ param(
 
 $ReadyForMerge = $true
 $mergablePRs = @()
-$headers = @{ }
+$headers = @{ "Content-Type" = "text/json" }
 $RetryCount = 5
 
 if ($null -eq $ShouldMerge) {
@@ -16,7 +16,7 @@ if ($null -eq $ShouldMerge) {
 }
 
 if ($AuthToken) {
-  $headers = @{
+  $headers += @{
     Authorization = "bearer $AuthToken"
   }
 }


### PR DESCRIPTION
We were hitting an error caused by some recent GH changes. Based on https://github.com/orgs/community/discussions/110246 you now need to explicitly set Content-Type in the headers to avoid the error:

The given key 'Content-Type' was not present in the dictionary.

Fixes https://github.com/Azure/azure-sdk-tools/issues/8269