### PR TITLE
use azure-sdk-eng for codeowner for everything under eng folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -19,9 +19,6 @@
 # Eng Sys
 ###########
 /eng/                                  @azure/azure-sdk-eng
-/eng/common/                           @konrad-jamrozik @weshaggard @benbp
-/eng/common/TestResources/             @benbp @weshaggard @heaths
-/eng/common/README.md                  @weshaggard
 
 ###########
 # CODEOWNERS Linter pipeline


### PR DESCRIPTION
Given we are moving to requiring codeowners to approve PRs I'm expanding the eng folder to the entire eng team. 

@benbp we are going to need to do that at least for eng/common in all the sync repos as well otherwise no one but you and I can merge approve a sync PR for merge.