### PR TITLE
Remove SAS token from GitHubIO blob storage docs publish

### DIFF
--- a/eng/common/pipelines/templates/steps/publish-blobs.yml
+++ b/eng/common/pipelines/templates/steps/publish-blobs.yml
@@ -1,6 +1,5 @@
 parameters:
   FolderForUpload: ''
-  BlobSASKey: ''
   TargetLanguage: ''
   BlobName: ''
   ScriptPath: ''
@@ -17,17 +16,20 @@ steps:
   workingDirectory: $(Build.BinariesDirectory)
   displayName: Download and Extract azcopy Zip
 
-- task: Powershell@2
+- task: AzurePowerShell@5
+  displayName: 'Copy Docs to Blob Storage'
+  continueOnError: false
   inputs:
-    filePath: ${{ parameters.ScriptPath }}
-    arguments: >
+    azureSubscription: 'Azure SDK Artifacts'
+    ScriptType: 'FilePath'
+    ScriptPath: ${{ parameters.ScriptPath }}
+    ScriptArguments: >
       -AzCopy $(Resolve-Path "$(Build.BinariesDirectory)/azcopy/azcopy_windows_amd64_*/azcopy.exe")[0]
       -DocLocation "${{ parameters.FolderForUpload }}"
-      -SASKey "${{ parameters.BlobSASKey }}"
       -BlobName "${{ parameters.BlobName }}"
       -PublicArtifactLocation "${{ parameters.ArtifactLocation }}"
       -RepoReplaceRegex "(https://github.com/${{ parameters.RepoId }}/(?:blob|tree)/)$(DefaultBranch)"
+    azurePowerShellVersion: latestVersion
     pwsh: true
-    workingDirectory: $(Pipeline.Workspace)
-  displayName: Copy Docs to Blob
-  continueOnError: false
+  env:
+    AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -4,7 +4,6 @@
 param (
   $AzCopy,
   $DocLocation,
-  $SASKey,
   $BlobName,
   $ExitOnError=1,
   $UploadLatest=1,
@@ -176,9 +175,9 @@ function Update-Existing-Versions
     $sortedVersionObj.LatestGAPackage | Out-File -File "$($DocLocation)/latest-ga" -Force -NoNewLine
     $sortedVersionObj.LatestPreviewPackage | Out-File -File "$($DocLocation)/latest-preview" -Force -NoNewLine
 
-    & $($AzCopy) cp "$($DocLocation)/versions" "$($DocDest)/$($PkgName)/versioning/versions$($SASKey)" --cache-control "max-age=300, must-revalidate"
-    & $($AzCopy) cp "$($DocLocation)/latest-preview" "$($DocDest)/$($PkgName)/versioning/latest-preview$($SASKey)" --cache-control "max-age=300, must-revalidate"
-    & $($AzCopy) cp "$($DocLocation)/latest-ga" "$($DocDest)/$($PkgName)/versioning/latest-ga$($SASKey)" --cache-control "max-age=300, must-revalidate"
+    & $($AzCopy) cp "$($DocLocation)/versions" "$($DocDest)/$($PkgName)/versioning/versions" --cache-control "max-age=300, must-revalidate"
+    & $($AzCopy) cp "$($DocLocation)/latest-preview" "$($DocDest)/$($PkgName)/versioning/latest-preview" --cache-control "max-age=300, must-revalidate"
+    & $($AzCopy) cp "$($DocLocation)/latest-ga" "$($DocDest)/$($PkgName)/versioning/latest-ga" --cache-control "max-age=300, must-revalidate"
     return $sortedVersionObj
 }
 
@@ -216,7 +215,7 @@ function Upload-Blobs
     }
 
     LogDebug "Uploading $($PkgName)/$($DocVersion) to $($DocDest)..."
-    & $($AzCopy) cp "$($DocDir)/**" "$($DocDest)/$($PkgName)/$($DocVersion)$($SASKey)" --recursive=true --cache-control "max-age=300, must-revalidate"
+    & $($AzCopy) cp "$($DocDir)/**" "$($DocDest)/$($PkgName)/$($DocVersion)" --recursive=true --cache-control "max-age=300, must-revalidate"
 
     LogDebug "Handling versioning files under $($DocDest)/$($PkgName)/versioning/"
     $versionsObj = (Update-Existing-Versions -PkgName $PkgName -PkgVersion $DocVersion -DocDest $DocDest)
@@ -229,7 +228,7 @@ function Upload-Blobs
     if ($UploadLatest -and ($latestVersion -eq $DocVersion))
     {
         LogDebug "Uploading $($PkgName) to latest folder in $($DocDest)..."
-        & $($AzCopy) cp "$($DocDir)/**" "$($DocDest)/$($PkgName)/latest$($SASKey)" --recursive=true --cache-control "max-age=300, must-revalidate"
+        & $($AzCopy) cp "$($DocDir)/**" "$($DocDest)/$($PkgName)/latest" --recursive=true --cache-control "max-age=300, must-revalidate"
     }
 }
 


### PR DESCRIPTION
GitHubIO versioned docs are published to blob storage which required the SAS key to write.

As part of this work, I did have to give Storage Blob Data Contributor access to azuresdkdocs to the service principal. This is in the same resource group as azure-sdk-artifacts. The replacement of the SAS usage in the eng/common code was pretty straightforward and the language repositories will continue to work without issue. Once this is in, I'll have to go through each language repository to remove usage of azure-sdk-docs-prod-sas and then I'll be able to remove this from the variable group and, ultimately, the keyvault.

The changes were tested via [temporary PR in Java](https://github.com/Azure/azure-sdk-for-java/pull/40214) and this is the [pipeline run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3796273&view=logs&j=19b87903-f8bc-5cbb-22d9-4f6eb3469d8e&t=83618b74-9683-5f47-3a05-e2f3e3ea330a&l=17) for template which published docs