### PR TITLE
Write linux proxy logs to mount folder

### DIFF
--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -63,7 +63,7 @@ steps:
 
     # nohup does NOT continue beyond the current session if you use it within powershell
     - bash: |
-        nohup $(Build.BinariesDirectory)/test-proxy/test-proxy &>$(Build.SourcesDirectory)/test-proxy.log &
+        nohup $(Build.BinariesDirectory)/test-proxy/test-proxy &>${{ parameters.rootFolder }}/test-proxy.log &
 
         echo $! > $(Build.SourcesDirectory)/test-proxy.pid
         echo "##vso[task.setvariable variable=PROXY_PID]$(cat $(Build.SourcesDirectory)/test-proxy.pid)"

--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -63,8 +63,8 @@ steps:
 
     # nohup does NOT continue beyond the current session if you use it within powershell
     - bash: |
-        nohup $(Build.BinariesDirectory)/test-proxy/test-proxy &>$(Build.SourcesDirectory)/test-proxy.log &
-        
+        nohup $(Build.BinariesDirectory)/test-proxy/test-proxy &>${{ parameters.rootFolder }}/test-proxy.log &
+
         echo $! > $(Build.SourcesDirectory)/test-proxy.pid
         echo "##vso[task.setvariable variable=PROXY_PID]$(cat $(Build.SourcesDirectory)/test-proxy.pid)"
       displayName: "Run the testproxy - linux/mac"

--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -63,7 +63,7 @@ steps:
 
     # nohup does NOT continue beyond the current session if you use it within powershell
     - bash: |
-        nohup $(Build.BinariesDirectory)/test-proxy/test-proxy &>${{ parameters.rootFolder }}/test-proxy.log &
+        nohup $(Build.BinariesDirectory)/test-proxy/test-proxy &>$(Build.SourcesDirectory)/test-proxy.log &
 
         echo $! > $(Build.SourcesDirectory)/test-proxy.pid
         echo "##vso[task.setvariable variable=PROXY_PID]$(cat $(Build.SourcesDirectory)/test-proxy.pid)"


### PR DESCRIPTION
So we can avoid situations like [this](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3798805&view=logs&j=ba3dad2b-ce90-52d5-0c84-4172d8b9d063&t=23b3eb06-0e1d-52c0-ea78-4a25bce86ae9).