### PR TITLE
[tsp-client] Add no-prompt flag

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2024-05-20 - 0.7.1
+
+- Added `--no-prompt` flag to skip the output directory confirmation prompt.
+
 ## 2024-04-18 - 0.7.0
 
 - Remove `resources.json` after converting resource manager specifications.

--- a/tools/tsp-client/README.md
+++ b/tools/tsp-client/README.md
@@ -56,6 +56,7 @@ Convert an existing swagger specification to a TypeSpec project. This command sh
                             an existing emitter-package.json                    [boolean]
   -h, --help                Show help                                           [boolean]
   --local-spec-repo         Path to local repository with the TypeSpec project  [string]
+  --no-prompt               Skip prompting for output directory confirmation    [boolean]
   --save-inputs             Don't clean up the temp directory after generation  [boolean]
   --skip-sync-and-generate  Skip sync and generate during project init          [boolean]
   --swagger-readme          Path or url to swagger readme file                  [string]

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "@azure/core-rest-pipeline": "^1.12.0",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/log.ts
+++ b/tools/tsp-client/src/log.ts
@@ -79,6 +79,7 @@ Options:
                             an existing emitter-package.json                    [boolean]
   -h, --help                Show help                                           [boolean]
   --local-spec-repo         Path to local repository with the TypeSpec project  [string]
+  --no-prompt               Skip prompting for output directory confirmation    [boolean]
   --save-inputs             Don't clean up the temp directory after generation  [boolean]
   --skip-sync-and-generate  Skip sync and generate during project init          [boolean]
   --swagger-readme          Path or url to swagger readme file                  [string]

--- a/tools/tsp-client/src/options.ts
+++ b/tools/tsp-client/src/options.ts
@@ -61,6 +61,9 @@ export async function getOptions(): Promise<Options> {
       ["local-spec-repo"]: {
         type: "string",
       },
+      ["no-prompt"]: {
+        type: "boolean",
+      },
       ["save-inputs"]: {
         type: "boolean",
       },
@@ -72,7 +75,7 @@ export async function getOptions(): Promise<Options> {
       },
       arm: {
         type: "boolean",
-      }
+      },
     },
   });
   if (values.help) {
@@ -142,8 +145,12 @@ export async function getOptions(): Promise<Options> {
   }
   outputDir = resolvePath(process.cwd(), outputDir);
 
+  let noPrompt = false;
+  if (values["no-prompt"]) {
+    noPrompt = true;
+  }
   let useOutputDir;
-  if (process.stdin.isTTY) {
+  if (process.stdin.isTTY && !noPrompt) {
     // Ask user is this is the correct output directory
     const prompt = PromptSync();
     useOutputDir = prompt("Use output directory '" + outputDir + "'? (y/n) ", "y");


### PR DESCRIPTION
Support `--no-prompt` flag to skip the output directory confirmation prompt. 