### PR TITLE
Remove SAS token usage from apiview-sync-staging

### DIFF
--- a/src/dotnet/APIView/apiview-sync-staging.yml
+++ b/src/dotnet/APIView/apiview-sync-staging.yml
@@ -26,11 +26,11 @@ stages:
         - ${{ each c in parameters.containers }}:
           - task: AzurePowerShell@5
             displayName: Copy Blobs in ${{c}}
-            workingDirectory: $(Build.BinariesDirectory)
             inputs:
               azureSubscription: 'Azure SDK Engineering System'
               ScriptType: 'InlineScript'
               azurePowerShellVersion: LatestVersion
+              workingDirectory: $(Build.BinariesDirectory)
               pwsh: true
               Inline: |
                 $azcopy = $(Resolve-Path "$(Build.BinariesDirectory)/azcopy/azcopy_windows_amd64_*/azcopy.exe")[0]

--- a/src/dotnet/APIView/apiview-sync-staging.yml
+++ b/src/dotnet/APIView/apiview-sync-staging.yml
@@ -34,8 +34,8 @@ stages:
               pwsh: true
               Inline: |
                 $azcopy = $(Resolve-Path "$(Build.BinariesDirectory)/azcopy/azcopy_windows_amd64_*/azcopy.exe")[0]
-                $sourceUrl = "https://$(apiview-prod-storageaccount).blob.core.windows.net/${{c}}$(apiview-production-storage-sas)"
-                $destUrl = "https://$(apiview-staging-storageaccount).blob.core.windows.net/${{c}}$(apiview-staging-storage-sas)"
+                $sourceUrl = "https://$(apiview-prod-storageaccount).blob.core.windows.net/${{c}}"
+                $destUrl = "https://$(apiview-staging-storageaccount).blob.core.windows.net/${{c}}"
                 &($azcopy) sc $sourceUrl $destUrl --recursive=true
             env:
               AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'

--- a/src/dotnet/APIView/apiview-sync-staging.yml
+++ b/src/dotnet/APIView/apiview-sync-staging.yml
@@ -24,13 +24,21 @@ stages:
           displayName: Download and Extract azcopy Zip
 
         - ${{ each c in parameters.containers }}:
-          - pwsh: |
-              $azcopy = $(Resolve-Path "$(Build.BinariesDirectory)/azcopy/azcopy_windows_amd64_*/azcopy.exe")[0]
-              $sourceUrl = "https://$(apiview-prod-storageaccount).blob.core.windows.net/${{c}}$(apiview-production-storage-sas)"
-              $destUrl = "https://$(apiview-staging-storageaccount).blob.core.windows.net/${{c}}$(apiview-staging-storage-sas)"
-              &($azcopy) sc $sourceUrl $destUrl --recursive=true
-            workingDirectory: $(Build.BinariesDirectory)
+          - task: AzurePowerShell@5
             displayName: Copy Blobs in ${{c}}
+            workingDirectory: $(Build.BinariesDirectory)
+            inputs:
+              azureSubscription: 'Azure SDK Engineering System'
+              ScriptType: 'InlineScript'
+              azurePowerShellVersion: LatestVersion
+              pwsh: true
+              Inline: |
+                $azcopy = $(Resolve-Path "$(Build.BinariesDirectory)/azcopy/azcopy_windows_amd64_*/azcopy.exe")[0]
+                $sourceUrl = "https://$(apiview-prod-storageaccount).blob.core.windows.net/${{c}}$(apiview-production-storage-sas)"
+                $destUrl = "https://$(apiview-staging-storageaccount).blob.core.windows.net/${{c}}$(apiview-staging-storage-sas)"
+                &($azcopy) sc $sourceUrl $destUrl --recursive=true
+            env:
+              AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
 
         - task: UsePythonVersion@0
           displayName: 'Use Python 3.6'


### PR DESCRIPTION
Replace the SAS token usage.

Because this pipeline is a standalone pipeline once these changes are tested and merged the SAS tokens (apiview-production-storage-sas and apiview-staging-storage-sas) can be removed from the [APIView daily Prod to staging sync](https://dev.azure.com/azure-sdk/internal/_apps/hub/ms.vss-distributed-task.hub-library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=86&path=APIView%20sync%20Staging%20variable) and from the keyvault. 

Also, both storage accounts will need to have their access by SAS turned off.