### PR TITLE
Minimize exceptions thrown from `BodyKeySanitizer`

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/BodyKeySanitizer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/BodyKeySanitizer.cs
@@ -2,8 +2,6 @@ using Azure.Sdk.Tools.TestProxy.Common;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
-using System.Net;
-using System.Runtime.Serialization;
 
 namespace Azure.Sdk.Tools.TestProxy.Sanitizers
 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/BodyKeySanitizer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Sanitizers/BodyKeySanitizer.cs
@@ -3,6 +3,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
 using System.Net;
+using System.Runtime.Serialization;
 
 namespace Azure.Sdk.Tools.TestProxy.Sanitizers
 {
@@ -44,24 +45,27 @@ namespace Azure.Sdk.Tools.TestProxy.Sanitizers
         public override string SanitizeTextBody(string contentType, string body)
         {
             bool sanitized = false;
-            JToken jsonO;
+            JToken jsonO = null;
 
-            try
+            if (contentType.ToLower().Contains("json"))
             {
-                // Prevent default behavior where JSON.NET will convert DateTimeOffset
-                // into a DateTime.
-                if (!LegacyConvertJsonDateTokens)
+                try
                 {
-                    jsonO = JsonConvert.DeserializeObject<JToken>(body, SerializerSettings);
+                    // Prevent default behavior where JSON.NET will convert DateTimeOffset
+                    // into a DateTime.
+                    if (!LegacyConvertJsonDateTokens)
+                    {
+                        jsonO = JsonConvert.DeserializeObject<JToken>(body, SerializerSettings);
+                    }
+                    else
+                    {
+                        jsonO = JToken.Parse(body);
+                    }
                 }
-                else
+                catch (JsonReaderException)
                 {
-                    jsonO = JToken.Parse(body);
+                    return body;
                 }
-            }
-            catch(JsonReaderException)
-            {
-                return body;
             }
 
             if (jsonO != null)


### PR DESCRIPTION
So many exceptions is quite costly. No reason to be throwing them when we can very simply check for json in the Content-Type before attempting to parse prior to applying the bodykeysanitizer.