### PR TITLE
Remove SAS token usage from apiview-review-gen

### DIFF
--- a/eng/pipelines/templates/steps/apiview-review-gen.yml
+++ b/eng/pipelines/templates/steps/apiview-review-gen.yml
@@ -18,7 +18,6 @@ parameters:
 steps:
 - task: AzurePowerShell@5
   displayName: 'Generate APIView Token files'
-  continueOnError: false
   inputs:
     azureSubscription: 'Azure SDK Engineering System'
     ScriptType: 'FilePath'

--- a/eng/pipelines/templates/steps/apiview-review-gen.yml
+++ b/eng/pipelines/templates/steps/apiview-review-gen.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: Reviews
     type: string
-    default: ''  
+    default: ''
   - name: APIViewURL
     type: string
     default: ''
@@ -16,19 +16,24 @@ parameters:
     default: ''
 
 steps:
-- task: Powershell@2
+- task: AzurePowerShell@5
   displayName: 'Generate APIView Token files'
+  continueOnError: false
   inputs:
-    pwsh: true
-    filePath: $(Build.SourcesDirectory)/eng/scripts/Create-Apiview-Token-Files.ps1
-    arguments: >
+    azureSubscription: 'Azure SDK Engineering System'
+    ScriptType: 'FilePath'
+    ScriptPath: $(Build.SourcesDirectory)/eng/scripts/Create-Apiview-Token-Files.ps1
+    ScriptArguments: >
       -ReviewDetailsJson "${{ parameters.Reviews }}"
       -StagingPath "$(Build.ArtifactStagingDirectory)"
       -WorkingDir "$(Pipeline.Workspace)"
       -StorageBaseUrl "${{ parameters.StorageContainerUrl }}"
       -ApiviewGenScript "${{ parameters.ApiviewGenScript }}"
-      -ContainerSas "$(apiview-originals-sas)"
       -ParserPath "${{ parameters.ParserPath }}"
+    azurePowerShellVersion: latestVersion
+    pwsh: true
+  env:
+    AZCOPY_AUTO_LOGIN_TYPE: 'PSCRED'
 
 - task: PublishBuildArtifacts@1
   inputs:

--- a/eng/scripts/Create-Apiview-Token-Files.ps1
+++ b/eng/scripts/Create-Apiview-Token-Files.ps1
@@ -9,8 +9,6 @@ param (
   [Parameter(Mandatory = $true)]
   [string]$StorageBaseUrl,
   [Parameter(Mandatory = $true)]
-  [string]$ContainerSas,
-  [Parameter(Mandatory = $true)]
   [string]$ApiviewGenScript,
   [string]$ParserPath = ""
 )
@@ -28,7 +26,7 @@ if ($reviews -ne $null)
 
         $pkgWorkingDir = Join-Path -Path $WorkingDir $r.ReviewID | Join-Path -ChildPath $r.RevisionID
         $codeDir = New-Item -Path $pkgWorkingDir -ItemType Directory
-        $sourcePath = $StorageBaseUrl + "/" + $r.FileID + "?"+ $ContainerSas
+        $sourcePath = $StorageBaseUrl + "/" + $r.FileID
         Write-Host "Copying $($sourcePath)"
         azcopy cp "$sourcePath" $codeDir/$($r.FileName) --recursive=true
 


### PR DESCRIPTION
SAS token removal. 

The [APIView-Sandboxing](https://dev.azure.com/azure-sdk/internal/_apps/hub/ms.vss-distributed-task.hub-library?itemType=VariableGroups&view=VariableGroupView&variableGroupId=124&path=APIView-Sandboxing) variable group only has two SAS tokens in it, apiview-originals-sas and apiview-staging-originals-sas. The apiview-staging-originals-sas was setup, but ultimately never used, and the only use of apiview-originals-sas is being removed in this PR. In theory, the variable group can be removed once we know which pipelines it's linked to.

The above being said, APIView-Sandboxing isn't the only VG with apiview-originals-sas in it.