### PR TITLE
Add static file secret-less sub-config support

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -52,7 +52,7 @@ param (
     [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
     [string] $ProvisionerApplicationOid,
 
-    [Parameter(ParameterSetName = 'Provisioner', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'Provisioner')]
     [string] $ProvisionerApplicationSecret,
 
     [Parameter()]

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -29,7 +29,7 @@ New-TestResources.ps1 [-BaseName <String>] [-ResourceGroupName <String>] [-Servi
  [-TestResourcesDirectory <String>] [-TestApplicationId <String>] [-TestApplicationSecret <String>]
  [-TestApplicationOid <String>] -TenantId <String> [-SubscriptionId <String>]
  -ProvisionerApplicationId <String> [-ProvisionerApplicationOid <String>]
- -ProvisionerApplicationSecret <String> [-DeleteAfterHours <Int32>] [-Location <String>]
+ [-ProvisionerApplicationSecret <String>] [-DeleteAfterHours <Int32>] [-Location <String>]
  [-Environment <String>] [-ResourceType <String>] [-ArmTemplateParameters <Hashtable>]
  [-AdditionalParameters <Hashtable>] [-EnvironmentVariables <Hashtable>] [-CI] [-Force] [-OutFile]
  [-SuppressVsoCommands] [-ServicePrincipalAuth] [-NewTestResourcesRemainingArguments <Object>]
@@ -426,7 +426,7 @@ Type: String
 Parameter Sets: Provisioner
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -712,7 +712,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/eng/common/TestResources/New-TestResources.ps1.md
+++ b/eng/common/TestResources/New-TestResources.ps1.md
@@ -712,7 +712,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -34,8 +34,8 @@ param (
     [ValidatePattern('^[0-9a-f]{8}(-[0-9a-f]{4}){3}-[0-9a-f]{12}$')]
     [string] $ProvisionerApplicationId,
 
-    [Parameter(ParameterSetName = 'Default+Provisioner', Mandatory = $true)]
-    [Parameter(ParameterSetName = 'ResourceGroup+Provisioner', Mandatory = $true)]
+    [Parameter(ParameterSetName = 'Default+Provisioner')]
+    [Parameter(ParameterSetName = 'ResourceGroup+Provisioner')]
     [string] $ProvisionerApplicationSecret,
 
     [Parameter(ParameterSetName = 'Default', Position = 0)]

--- a/eng/common/TestResources/Remove-TestResources.ps1.md
+++ b/eng/common/TestResources/Remove-TestResources.ps1.md
@@ -23,7 +23,7 @@ Remove-TestResources.ps1 [-BaseName <String>] [-SubscriptionId <String>] [[-Serv
 ### Default+Provisioner
 ```
 Remove-TestResources.ps1 -BaseName <String> -TenantId <String> [-SubscriptionId <String>]
- -ProvisionerApplicationId <String> -ProvisionerApplicationSecret <String> [[-ServiceDirectory] <String>]
+ -ProvisionerApplicationId <String> [-ProvisionerApplicationSecret <String>] [[-ServiceDirectory] <String>]
  [-Environment <String>] [-ResourceType <String>] [-ServicePrincipalAuth] [-Force]
  [-RemoveTestResourcesRemainingArguments <Object>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
@@ -32,7 +32,7 @@ Remove-TestResources.ps1 -BaseName <String> -TenantId <String> [-SubscriptionId 
 ### ResourceGroup+Provisioner
 ```
 Remove-TestResources.ps1 [-ResourceGroupName <String>] -TenantId <String> [-SubscriptionId <String>]
- -ProvisionerApplicationId <String> -ProvisionerApplicationSecret <String> [[-ServiceDirectory] <String>]
+ -ProvisionerApplicationId <String> [-ProvisionerApplicationSecret <String>] [[-ServiceDirectory] <String>]
  [-Environment <String>] [-CI] [-ResourceType <String>] [-ServicePrincipalAuth] [-Force]
  [-RemoveTestResourcesRemainingArguments <Object>] [-ProgressAction <ActionPreference>] [-WhatIf] [-Confirm]
  [<CommonParameters>]
@@ -184,7 +184,7 @@ Type: String
 Parameter Sets: Default+Provisioner, ResourceGroup+Provisioner
 Aliases:
 
-Required: True
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -347,7 +347,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/eng/common/TestResources/Remove-TestResources.ps1.md
+++ b/eng/common/TestResources/Remove-TestResources.ps1.md
@@ -347,7 +347,7 @@ Accept wildcard characters: False
 ```
 
 ### CommonParameters
-This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](https://go.microsoft.com/fwlink/?LinkID=113216).
 
 ## INPUTS
 

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -56,7 +56,6 @@ steps:
           eng/common/scripts/Import-AzModules.ps1
 
 
-
           if ('${{ parameters.SubscriptionConfigurationFilePath }}' -ne '') {
             $subscriptionConfiguration = `
               Get-Content '${{ parameters.SubscriptionConfigurationFilePath }}' `

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -7,6 +7,7 @@ parameters:
   ServiceConnection: not-specified
   ResourceType: test
   UseFederatedAuth: false
+  SubscriptionConfigurationFilePath: ''
 
 
 # SubscriptionConfiguration will be splatted into the parameters of the test
@@ -57,6 +58,12 @@ steps:
           $subscriptionConfiguration = @'
             ${{ parameters.SubscriptionConfiguration }}
           '@ | ConvertFrom-Json -AsHashtable;
+
+          if ('${{ parameters.SubscriptionConfigurationFilePath }}' -ne '') {
+            $subscriptionConfiguration = `
+              Get-Content '${{ parameters.SubscriptionConfigurationFilePath }}' `
+              | ConvertFrom-Json -AsHashtable;
+          }
 
           # The subscriptionConfiguration may have ArmTemplateParameters defined, so
           # pass those in via the ArmTemplateParameters flag, and handle any

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -55,7 +55,6 @@ steps:
         Inline: |
           eng/common/scripts/Import-AzModules.ps1
 
-
           if ('${{ parameters.SubscriptionConfigurationFilePath }}' -ne '') {
             $subscriptionConfiguration = `
               Get-Content '${{ parameters.SubscriptionConfigurationFilePath }}' `

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -55,14 +55,18 @@ steps:
         Inline: |
           eng/common/scripts/Import-AzModules.ps1
 
-          $subscriptionConfiguration = @'
-            ${{ parameters.SubscriptionConfiguration }}
-          '@ | ConvertFrom-Json -AsHashtable;
+
 
           if ('${{ parameters.SubscriptionConfigurationFilePath }}' -ne '') {
             $subscriptionConfiguration = `
               Get-Content '${{ parameters.SubscriptionConfigurationFilePath }}' `
               | ConvertFrom-Json -AsHashtable;
+          } else {
+            # Multiline string termination ('@) needs to be at the beginning
+            # of the line
+            $subscriptionConfiguration = @'
+              ${{ parameters.SubscriptionConfiguration }}
+          '@ | ConvertFrom-Json -AsHashtable;
           }
 
           # The subscriptionConfiguration may have ArmTemplateParameters defined, so

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -7,6 +7,7 @@ parameters:
   ServiceConnection: not-specified
   ResourceType: test
   UseFederatedAuth: false
+  SubscriptionConfigurationFilePath: ''
 
 # SubscriptionConfiguration will be splat into the parameters of the test
 # resources script. It should be JSON in the form:
@@ -39,6 +40,12 @@ steps:
           $subscriptionConfiguration = @"
             ${{ parameters.SubscriptionConfiguration }}
           "@ | ConvertFrom-Json -AsHashtable;
+
+          if ('${{ parameters.SubscriptionConfigurationFilePath }}' -ne '') {
+            $subscriptionConfiguration = `
+              Get-Content '${{ parameters.SubscriptionConfigurationFilePath }}' `
+              | ConvertFrom-Json -AsHashtable;
+          }
 
           eng/common/TestResources/Remove-TestResources.ps1 `
             @subscriptionConfiguration `

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -37,14 +37,18 @@ steps:
         Inline: |
           eng/common/scripts/Import-AzModules.ps1
 
-          $subscriptionConfiguration = @"
-            ${{ parameters.SubscriptionConfiguration }}
-          "@ | ConvertFrom-Json -AsHashtable;
 
           if ('${{ parameters.SubscriptionConfigurationFilePath }}' -ne '') {
             $subscriptionConfiguration = `
               Get-Content '${{ parameters.SubscriptionConfigurationFilePath }}' `
               | ConvertFrom-Json -AsHashtable;
+          } else {
+            # Multiline string termination ("@) needs to be at the beginning
+            # of the line
+            $subscriptionConfiguration = @"
+              ${{ parameters.SubscriptionConfiguration }}
+          "@ | ConvertFrom-Json -AsHashtable;
+
           }
 
           eng/common/TestResources/Remove-TestResources.ps1 `

--- a/eng/common/TestResources/sub-config/AzurePublicMsft.json
+++ b/eng/common/TestResources/sub-config/AzurePublicMsft.json
@@ -1,0 +1,11 @@
+{
+    "SubscriptionId": "2cd617ea-1866-46b1-90e3-fffb087ebf9b",
+    "TenantId": "72f988bf-86f1-41af-91ab-2d7cd011db47",
+    "TestApplicationId": "f850650c-1fcf-4489-b46f-71af2e30d360",
+    "TestApplicationOid": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
+    "ProvisionerApplicationId": "f850650c-1fcf-4489-b46f-71af2e30d360",
+    "ProvisionerApplicationOid": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
+    "Environment": "AzureCloud",
+    "AzureSubscription": "Azure SDK Test Resources",
+    "EnvironmentVariables": {}
+}

--- a/eng/common/TestResources/sub-config/AzurePublicMsft.json
+++ b/eng/common/TestResources/sub-config/AzurePublicMsft.json
@@ -6,6 +6,5 @@
     "ProvisionerApplicationId": "f850650c-1fcf-4489-b46f-71af2e30d360",
     "ProvisionerApplicationOid": "30511c9d-ba1a-4c7b-b422-5b543da11b3f",
     "Environment": "AzureCloud",
-    "AzureSubscription": "Azure SDK Test Resources",
-    "EnvironmentVariables": {}
+    "AzureSubscription": "Azure SDK Test Resources"
 }


### PR DESCRIPTION
Example successful pipeline run: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3825341&view=results

Example wiring up in `tests.yml` https://github.com/Azure/azure-sdk-for-net/compare/main...djurek%2Fworkload-identity-live-tests-sub-config-files?body=&expand=1#diff-a38d5bba40ecff60e025723b70c9a682e464bcadf5e87e6571a641ca8659dee3R9-R12

Testing .NET appconfig in its current state (no federated auth) to ensure no wider regression: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3811807&view=logs&j=d1b595c4-8536-5d61-1a0c-a149c6a83c63&t=20c529b1-7692-5b7f-3681-519a295cdefc