### PR TITLE
Remove SAS from comments and option help

### DIFF
--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Program.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/Program.cs
@@ -11,19 +11,19 @@ namespace GitHubTeamUserStore
         {
             var teamUserBlobStorageUriOption = new Option<string>
                 (name: "--teamUserBlobStorageURI", 
-                description: "The team/user blob storage URI including the SAS.");
+                description: "The team/user blob storage URI.");
             teamUserBlobStorageUriOption.AddAlias("-tUri");
             teamUserBlobStorageUriOption.IsRequired = true;
 
             var userOrgVisibilityBlobStorageUriOption = new Option<string>
                 (name: "--userOrgVisibilityBlobStorageURI",
-                description: "The user/org blob storage URI including the SAS.");
+                description: "The user/org blob storage URI.");
             userOrgVisibilityBlobStorageUriOption.AddAlias("-uUri");
             userOrgVisibilityBlobStorageUriOption.IsRequired = true;
 
             var repoLabelBlobStorageUriOption = new Option<string>
                 (name: "--repoLabelBlobStorageURI",
-                description: "The repo/label blob storage URI including the SAS.");
+                description: "The repo/label blob storage URI.");
             repoLabelBlobStorageUriOption.AddAlias("-rUri");
             repoLabelBlobStorageUriOption.IsRequired = true;
 

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/TeamUserGenerator.cs
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/TeamUserGenerator.cs
@@ -22,8 +22,8 @@ namespace GitHubTeamUserStore
         /// teams is less than 1/10th of that. The team/user data is serialized into json and stored in azure blob storage.
         /// </summary>
         /// <param name="gitHubEventClient">Authenticated GitHubEventClient</param>
-        /// <param name="teamUserBlobStorageUri">The URI, including SAS, of the team/user blob storage URI</param>
-        /// <param name="userOrgVisibilityBlobStorageUri">The URI, including SAS, of the user/org visibility blob</param>
+        /// <param name="teamUserBlobStorageUri">The URI of the team/user blob storage URI</param>
+        /// <param name="userOrgVisibilityBlobStorageUri">The URI of the user/org visibility blob</param>
         /// <returns>true if everything stored successfully, false otherwise</returns>
         public static async Task<bool> GenerateAndStoreTeamUserAndOrgData(GitHubEventClient gitHubEventClient,
                                                                           string teamUserBlobStorageUri,
@@ -160,7 +160,7 @@ namespace GitHubTeamUserStore
         /// to generate the org visibility data.
         /// </summary>
         /// <param name="gitHubEventClient">Authenticated GitHubEventClient</param>
-        /// <param name="userOrgVisibilityBlobStorageUri">The URI, including SAS, of the user/org visibility blob</param>
+        /// <param name="userOrgVisibilityBlobStorageUri">The URI of the user/org visibility blob</param>
         /// <returns></returns>
         public static async Task<bool> GenerateAndStoreUserOrgData(GitHubEventClient gitHubEventClient,
                                                                    string userOrgVisibilityBlobStorageUri,


### PR DESCRIPTION
The SAS token is no longer needed and was removed in a previous [PR](https://github.com/Azure/azure-sdk-tools/pull/8246) but it looks like I missed a couple of comments and the help for the arguments that used to require it.