### PR TITLE
Update AZSDK1001 to replace the value with a base64 one

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
@@ -75,7 +75,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                     "AZSDK1000"
                 ),
                 new RegisteredSanitizer(
-                    new GeneralRegexSanitizer(regex: "AccountKey=(?<key>[^;\\\"]+)", groupForReplace: "key"),
+                    new GeneralRegexSanitizer(regex: "AccountKey=(?<key>[^;\\\"]+)", value: BASE64ZERO, groupForReplace: "key"),
                     "AZSDK1001"
                 ),
                 new RegisteredSanitizer(


### PR DESCRIPTION
Given that the existing value is `Sanitized` and we apply the sanitizers to recordings when loaded for playback, I expect 0 downstream impact from this change.