### PR TITLE
[tsp-client] Create unique sparse spec directories

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release
 
-## Unreleased - 0.8.0
+## 2024-05-29 - 0.8.0
 
 - Create unique directories for sparse spec checkout.
 

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## Unreleased - 0.8.0
+
+- Create unique directories for sparse spec checkout.
+
 ## 2024-05-20 - 0.7.1
 
 - Added `--no-prompt` flag to skip the output directory confirmation prompt.

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.7.1",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@azure/core-rest-pipeline": "^1.12.0",
@@ -1151,20 +1151,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/get-caller-file": {
       "version": "2.0.5",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -3,12 +3,12 @@ import { createTempDirectory, removeDirectory, readTspLocation, getEmitterFromRe
 import { Logger, printBanner, enableDebug, printVersion } from "./log.js";
 import { TspLocation, compileTsp, discoverMainFile, resolveTspConfigUrl } from "./typespec.js";
 import { getOptions } from "./options.js";
-import { mkdir, writeFile, cp, readFile, access, stat, rename, unlink } from "node:fs/promises";
+import { mkdir, writeFile, cp, readFile, stat, rename, unlink, readdir } from "node:fs/promises";
 import { addSpecFiles, checkoutCommit, cloneRepo, getRepoRoot, sparseCheckout } from "./git.js";
 import { doesFileExist } from "./network.js";
 import { parse as parseYaml } from "yaml";
 import { joinPaths, normalizePath, resolvePath } from "@typespec/compiler";
-import { formatAdditionalDirectories, getAdditionalDirectoryName } from "./utils.js";
+import { formatAdditionalDirectories, getAdditionalDirectoryName, makeSparseSpecPath } from "./utils.js";
 import { resolve } from "node:path";
 import { config as dotenvConfig } from "dotenv";
 
@@ -33,8 +33,7 @@ async function sdkInit(
     // URL scenario
     const repoRoot = await getRepoRoot(outputDir);
     const resolvedConfigUrl = resolveTspConfigUrl(config);
-    const cloneDir = joinPaths(repoRoot, "..", "sparse-spec");
-    await mkdir(cloneDir, { recursive: true });
+    const cloneDir = await makeSparseSpecPath(repoRoot);
     Logger.debug(`Created temporary sparse-checkout directory ${cloneDir}`);
     Logger.debug(`Cloning repo to ${cloneDir}`);
     await cloneRepo(outputDir, cloneDir, `https://github.com/${resolvedConfigUrl.repo}.git`);
@@ -152,8 +151,7 @@ async function syncTspFiles(outputDir: string, localSpecRepo?: string) {
       await cp(joinPaths(localSpecRepoRoot, dir), joinPaths(tempRoot, getAdditionalDirectoryName(dir)), { recursive: true, filter: filter });
     }
   } else {
-    const cloneDir = joinPaths(repoRoot, "..", "sparse-spec");
-    await mkdir(cloneDir, { recursive: true });
+    const cloneDir = await makeSparseSpecPath(repoRoot);
     Logger.debug(`Created temporary sparse-checkout directory ${cloneDir}`);
     Logger.debug(`Cloning repo to ${cloneDir}`);
     await cloneRepo(tempRoot, cloneDir, `https://github.com/${tspLocation.repo}.git`);
@@ -295,10 +293,16 @@ async function main() {
   try {
     // FIXME: this is a workaround meanwhile we fix the issue with failing to delete the sparse-spec directory
     // Tracking issue: https://github.com/Azure/azure-sdk-tools/issues/7636
-    access(joinPaths(repoRoot, "..", "sparse-spec")).then(() => {
-      Logger.debug("Deleting existing sparse-spec directory");
-      removeDirectory(joinPaths(repoRoot, "..", "sparse-spec"));
-    }).catch(() => {});
+    const baseDir = joinPaths(repoRoot, "..");
+    const sparseSpecDirs = (await readdir(baseDir))
+    .filter((item) => stat(joinPaths(baseDir, item))
+    .then((stat) => stat.isDirectory()))
+    .filter((dir) => dir.startsWith("sparse-spec"));
+    Logger.info(`Found sparse-spec directories: ${sparseSpecDirs}`);
+    for (const dir of sparseSpecDirs) {
+      Logger.debug(`Deleting ${dir}`);
+      await removeDirectory(joinPaths(baseDir, dir));
+    }
   } catch (err) {
     Logger.debug(`Error occurred while attempting to remove sparse-spec directory: ${err}`);
   }

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -3,12 +3,12 @@ import { createTempDirectory, removeDirectory, readTspLocation, getEmitterFromRe
 import { Logger, printBanner, enableDebug, printVersion } from "./log.js";
 import { TspLocation, compileTsp, discoverMainFile, resolveTspConfigUrl } from "./typespec.js";
 import { getOptions } from "./options.js";
-import { mkdir, writeFile, cp, readFile, stat, rename, unlink, readdir } from "node:fs/promises";
+import { mkdir, writeFile, cp, readFile, stat, rename, unlink } from "node:fs/promises";
 import { addSpecFiles, checkoutCommit, cloneRepo, getRepoRoot, sparseCheckout } from "./git.js";
 import { doesFileExist } from "./network.js";
 import { parse as parseYaml } from "yaml";
 import { joinPaths, normalizePath, resolvePath } from "@typespec/compiler";
-import { formatAdditionalDirectories, getAdditionalDirectoryName, makeSparseSpecPath } from "./utils.js";
+import { formatAdditionalDirectories, getAdditionalDirectoryName, makeSparseSpecDir } from "./utils.js";
 import { resolve } from "node:path";
 import { config as dotenvConfig } from "dotenv";
 
@@ -33,7 +33,7 @@ async function sdkInit(
     // URL scenario
     const repoRoot = await getRepoRoot(outputDir);
     const resolvedConfigUrl = resolveTspConfigUrl(config);
-    const cloneDir = await makeSparseSpecPath(repoRoot);
+    const cloneDir = await makeSparseSpecDir(repoRoot);
     Logger.debug(`Created temporary sparse-checkout directory ${cloneDir}`);
     Logger.debug(`Cloning repo to ${cloneDir}`);
     await cloneRepo(outputDir, cloneDir, `https://github.com/${resolvedConfigUrl.repo}.git`);
@@ -151,7 +151,7 @@ async function syncTspFiles(outputDir: string, localSpecRepo?: string) {
       await cp(joinPaths(localSpecRepoRoot, dir), joinPaths(tempRoot, getAdditionalDirectoryName(dir)), { recursive: true, filter: filter });
     }
   } else {
-    const cloneDir = await makeSparseSpecPath(repoRoot);
+    const cloneDir = await makeSparseSpecDir(repoRoot);
     Logger.debug(`Created temporary sparse-checkout directory ${cloneDir}`);
     Logger.debug(`Cloning repo to ${cloneDir}`);
     await cloneRepo(tempRoot, cloneDir, `https://github.com/${tspLocation.repo}.git`);

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -290,22 +290,6 @@ async function main() {
   }
 
   const repoRoot = await getRepoRoot(rootUrl);
-  try {
-    // FIXME: this is a workaround meanwhile we fix the issue with failing to delete the sparse-spec directory
-    // Tracking issue: https://github.com/Azure/azure-sdk-tools/issues/7636
-    const baseDir = joinPaths(repoRoot, "..");
-    const sparseSpecDirs = (await readdir(baseDir))
-    .filter((item) => stat(joinPaths(baseDir, item))
-    .then((stat) => stat.isDirectory()))
-    .filter((dir) => dir.startsWith("sparse-spec"));
-    Logger.info(`Found sparse-spec directories: ${sparseSpecDirs}`);
-    for (const dir of sparseSpecDirs) {
-      Logger.debug(`Deleting ${dir}`);
-      await removeDirectory(joinPaths(baseDir, dir));
-    }
-  } catch (err) {
-    Logger.debug(`Error occurred while attempting to remove sparse-spec directory: ${err}`);
-  }
 
   if (options.generateLockFile) {
     await generateLockFile(rootUrl, repoRoot);

--- a/tools/tsp-client/src/utils.ts
+++ b/tools/tsp-client/src/utils.ts
@@ -1,4 +1,6 @@
-import { normalizeSlashes } from "@typespec/compiler";
+import { joinPaths, normalizeSlashes } from "@typespec/compiler";
+import { randomUUID } from "node:crypto";
+import { mkdir } from "node:fs/promises";
 
 export function formatAdditionalDirectories(additionalDirectories?: string[]): string {
     let additionalDirOutput = "";
@@ -18,4 +20,10 @@ export function getAdditionalDirectoryName(dir: string): string {
         throw new Error(`Could not find a final directory for the following value: ${normalizedDir}`);
     }
     return finalDirName;
+}
+
+export async function makeSparseSpecPath(repoRoot:string): Promise<string> {
+    const spareSpecPath = joinPaths(repoRoot, "..", `sparse-spec${randomUUID()}`);
+    await mkdir(spareSpecPath, { recursive: true });
+    return spareSpecPath;
 }

--- a/tools/tsp-client/src/utils.ts
+++ b/tools/tsp-client/src/utils.ts
@@ -22,7 +22,7 @@ export function getAdditionalDirectoryName(dir: string): string {
     return finalDirName;
 }
 
-export async function makeSparseSpecPath(repoRoot:string): Promise<string> {
+export async function makeSparseSpecDir(repoRoot: string): Promise<string> {
     const spareSpecPath = joinPaths(repoRoot, "..", `sparse-spec${randomUUID()}`);
     await mkdir(spareSpecPath, { recursive: true });
     return spareSpecPath;


### PR DESCRIPTION
In order to use tsp-client in parallel to generate multiple libraries, we cannot modify the shared sparse-spec/ directory. This PR changes the tool so that we create unique sparse spec directories per typespec project.

Fixes #8352 