### PR TITLE
APIView - Connect to cosmos and storage using managed identity

### DIFF
--- a/src/dotnet/APIView/APIViewIntegrationTests/APIViewIntegrationTests.csproj
+++ b/src/dotnet/APIView/APIViewIntegrationTests/APIViewIntegrationTests.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.40.0" />
     <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="8.0.0" />

--- a/src/dotnet/APIView/APIViewIntegrationTests/RepositoryTests/CosmosPullRequestRepositoryTests.cs
+++ b/src/dotnet/APIView/APIViewIntegrationTests/RepositoryTests/CosmosPullRequestRepositoryTests.cs
@@ -8,6 +8,7 @@ using APIViewWeb.Models;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Linq;
+using Azure.Identity;
 
 namespace APIViewIntegrationTests.RepositoryTests
 {
@@ -28,7 +29,7 @@ namespace APIViewIntegrationTests.RepositoryTests
             _cosmosDBname = "CosmosPullRequestRepositoryTestsDB";
             config["CosmosDBName"] = _cosmosDBname;
 
-            _cosmosClient = new CosmosClient(config["Cosmos:ConnectionString"]);
+            _cosmosClient = new CosmosClient(config["CosmosEndpoint"], new DefaultAzureCredential());
             var dataBaseResponse = _cosmosClient.CreateDatabaseIfNotExistsAsync(config["CosmosDBName"]).Result;
             dataBaseResponse.Database.CreateContainerIfNotExistsAsync("Reviews", "/id").Wait();
             dataBaseResponse.Database.CreateContainerIfNotExistsAsync("PullRequests", "/ReviewId").Wait();

--- a/src/dotnet/APIView/APIViewIntegrationTests/RepositoryTests/CosmosReviewRepositoryTests.cs
+++ b/src/dotnet/APIView/APIViewIntegrationTests/RepositoryTests/CosmosReviewRepositoryTests.cs
@@ -8,6 +8,7 @@ using APIViewWeb.Models;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using System.Linq;
+using Azure.Identity;
 
 namespace APIViewIntegrationTests.RepositoryTests
 {
@@ -27,7 +28,7 @@ namespace APIViewIntegrationTests.RepositoryTests
             _cosmosDBname = "CosmosReviewRepositoryTestsDB";
             config["CosmosDBName"] = _cosmosDBname;
 
-            _cosmosClient = new CosmosClient(config["Cosmos:ConnectionString"]);
+            _cosmosClient = new CosmosClient(config["CosmosEndpoint"], new DefaultAzureCredential());
             var dataBaseResponse = _cosmosClient.CreateDatabaseIfNotExistsAsync(config["CosmosDBName"]).Result;
             dataBaseResponse.Database.CreateContainerIfNotExistsAsync("Reviews", "/id").Wait();
 

--- a/src/dotnet/APIView/APIViewIntegrationTests/TestsBaseFixture.cs
+++ b/src/dotnet/APIView/APIViewIntegrationTests/TestsBaseFixture.cs
@@ -20,6 +20,7 @@ using APIViewWeb.Hubs;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Options;
 using Microsoft.ApplicationInsights;
+using Azure.Identity;
 
 namespace APIViewIntegrationTests
 {
@@ -74,7 +75,7 @@ namespace APIViewIntegrationTests
             PackageNameManager = serviceProvider.GetService<PackageNameManager>();
             User = TestUser.GetTestuser();
 
-            _cosmosClient = new CosmosClient(_config["Cosmos:ConnectionString"]);
+            _cosmosClient = new CosmosClient(_config["CosmosEndpoint"], new DefaultAzureCredential());
             var dataBaseResponse = _cosmosClient.CreateDatabaseIfNotExistsAsync(_config["CosmosDBName"]).Result;
             dataBaseResponse.Database.CreateContainerIfNotExistsAsync("Reviews", "/id").Wait();
             dataBaseResponse.Database.CreateContainerIfNotExistsAsync("APIRevisions", "/ReviewId").Wait();
@@ -86,8 +87,9 @@ namespace APIViewIntegrationTests
             CommentRepository = new CosmosCommentsRepository(_config, _cosmosClient);
             var cosmosUserProfileRepository = new CosmosUserProfileRepository(_config, _cosmosClient);
 
-            _blobCodeFileContainerClient = new BlobContainerClient(_config["Blob:ConnectionString"], "codefiles");
-            _blobOriginalContainerClient = new BlobContainerClient(_config["Blob:ConnectionString"], "originals");
+            var blobServiceClient = new BlobServiceClient(new Uri(_config["StorageAccountUrl"]), new DefaultAzureCredential());
+            _blobCodeFileContainerClient = blobServiceClient.GetBlobContainerClient("codefiles");
+            _blobOriginalContainerClient = blobServiceClient.GetBlobContainerClient("originals");
             _ = _blobCodeFileContainerClient.CreateIfNotExistsAsync(PublicAccessType.BlobContainer);
             _ = _blobOriginalContainerClient.CreateIfNotExistsAsync(PublicAccessType.BlobContainer);
 

--- a/src/dotnet/APIView/APIViewUnitTests/APIViewUnitTests.csproj
+++ b/src/dotnet/APIView/APIViewUnitTests/APIViewUnitTests.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.10.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.40.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="8.0.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.2.0" />

--- a/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
+++ b/src/dotnet/APIView/APIViewWeb/APIViewWeb.csproj
@@ -43,7 +43,7 @@
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.SnapshotCollector" Version="1.4.5" />
     <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.37.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.40.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="7.0.15" />
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.4" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />

--- a/src/dotnet/APIView/APIViewWeb/MiddleWare/UITestsMiddleWare.cs
+++ b/src/dotnet/APIView/APIViewWeb/MiddleWare/UITestsMiddleWare.cs
@@ -5,6 +5,8 @@ using Azure.Storage.Blobs.Models;
 using Azure.Storage.Blobs;
 using Microsoft.Azure.Cosmos;
 using Microsoft.Extensions.Configuration;
+using Azure.Identity;
+using System;
 
 namespace APIViewWeb.MiddleWare
 {
@@ -18,8 +20,8 @@ namespace APIViewWeb.MiddleWare
 
         public async Task InvokeAsync(HttpContext httpContext, IConfiguration config)
         {
-            var cosmosClient = new CosmosClient(config["Cosmos:ConnectionString"]);
-            var dataBaseResponse = await cosmosClient.CreateDatabaseIfNotExistsAsync("APIView");
+            var cosmosClient = new CosmosClient(config["CosmosEndpoint"], new DefaultAzureCredential());
+            var dataBaseResponse = await cosmosClient.CreateDatabaseIfNotExistsAsync(config["CosmosDBName"]);
             _ = await dataBaseResponse.Database.CreateContainerIfNotExistsAsync("Reviews", "/id");
             _ = await dataBaseResponse.Database.CreateContainerIfNotExistsAsync("Comments", "/ReviewId");
             _ = await dataBaseResponse.Database.CreateContainerIfNotExistsAsync("Profiles", "/id");
@@ -27,10 +29,11 @@ namespace APIViewWeb.MiddleWare
             _ = await dataBaseResponse.Database.CreateContainerIfNotExistsAsync("UsageSamples", "/ReviewId");
             _ = await dataBaseResponse.Database.CreateContainerIfNotExistsAsync("UserPreference", "/ReviewId");
 
-            var blobCodeFileContainerClient = new BlobContainerClient(config["Blob:ConnectionString"], "codefiles");
-            var blobOriginalContainerClient = new BlobContainerClient(config["Blob:ConnectionString"], "originals");
-            var blobUsageSampleRepository = new BlobContainerClient(config["Blob:ConnectionString"], "usagesamples");
-            var blobCommentsRepository = new BlobContainerClient(config["Blob:ConnectionString"], "comments");
+            var blobServiceClient = new BlobServiceClient(new Uri(config["StorageAccountUrl"]), new DefaultAzureCredential());
+            var blobCodeFileContainerClient = blobServiceClient.GetBlobContainerClient("codefiles");
+            var blobOriginalContainerClient = blobServiceClient.GetBlobContainerClient("originals");
+            var blobUsageSampleRepository = blobServiceClient.GetBlobContainerClient("usagesamples");
+            var blobCommentsRepository = blobServiceClient.GetBlobContainerClient("comments");
             _ = await blobCodeFileContainerClient.CreateIfNotExistsAsync(PublicAccessType.BlobContainer);
             _ = await blobOriginalContainerClient.CreateIfNotExistsAsync(PublicAccessType.BlobContainer);
             _ = await blobUsageSampleRepository.CreateIfNotExistsAsync(PublicAccessType.BlobContainer);

--- a/src/dotnet/APIView/APIViewWeb/Repositories/BlobCodeFileRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/BlobCodeFileRepository.cs
@@ -9,6 +9,7 @@ using ApiView;
 using APIViewWeb.LeanModels;
 using APIViewWeb.Models;
 using APIViewWeb.Repositories;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Configuration;
@@ -17,12 +18,12 @@ namespace APIViewWeb
 {
     public class BlobCodeFileRepository : IBlobCodeFileRepository
     {
-        private BlobContainerClient _container;
         private readonly IMemoryCache _cache;
+        private BlobServiceClient _serviceClient;
 
         public BlobCodeFileRepository(IConfiguration configuration, IMemoryCache cache)
         {
-            _container = new BlobContainerClient(configuration["Blob:ConnectionString"], "codefiles");
+            _serviceClient = new BlobServiceClient(new Uri(configuration["StorageAccountUrl"]), new DefaultAzureCredential());
             _cache = cache;
         }
 
@@ -84,7 +85,8 @@ namespace APIViewWeb
             {
                 key = revisionId + "/" + codeFileId;
             }
-            return _container.GetBlobClient(key);
+            var container = _serviceClient.GetBlobContainerClient("codefiles");
+            return container.GetBlobClient(key);
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Repositories/BlobOriginalsRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/BlobOriginalsRepository.cs
@@ -5,6 +5,7 @@ using System;
 using System.IO;
 using System.Threading.Tasks;
 using APIViewWeb.Repositories;
+using Azure.Identity;
 using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 
@@ -18,7 +19,8 @@ namespace APIViewWeb
 
         public BlobOriginalsRepository(IConfiguration configuration)
         {
-            _container = new BlobContainerClient(configuration["Blob:ConnectionString"], "originals");
+            var serviceClient = new BlobServiceClient(new Uri(configuration["StorageAccountUrl"]), new DefaultAzureCredential());
+            _container = serviceClient.GetBlobContainerClient("originals");
         }
 
         public async Task<Stream> GetOriginalAsync(string codeFileId)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/BlobUsageSampleRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/BlobUsageSampleRepository.cs
@@ -7,17 +7,17 @@ using Azure.Storage.Blobs;
 using Microsoft.Extensions.Configuration;
 using System.Text;
 using System;
+using Azure.Identity;
 
 namespace APIViewWeb.Repositories
 {
     public class BlobUsageSampleRepository : IBlobUsageSampleRepository
     {
-        private BlobContainerClient _container;
+        private BlobServiceClient _serviceClient;
 
         public BlobUsageSampleRepository(IConfiguration configuration)
         {
-            var connectionString = configuration["Blob:ConnectionString"];
-            _container = new BlobContainerClient(connectionString, "usagesamples"); 
+            _serviceClient = new BlobServiceClient(new Uri(configuration["StorageAccountUrl"]), new DefaultAzureCredential());
         }
 
         public async Task<Stream> GetUsageSampleAsync(string sampleFileId)
@@ -53,7 +53,8 @@ namespace APIViewWeb.Repositories
 
         private BlobClient GetBlobClient(string sampleFileId)
         {
-            return _container.GetBlobClient(sampleFileId);
+            var container = _serviceClient.GetBlobContainerClient("usagesamples");
+            return container.GetBlobClient(sampleFileId);
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -34,6 +34,7 @@ using Microsoft.OpenApi.Models;
 using System.IO;
 using Microsoft.Azure.Cosmos;
 using APIViewWeb.Managers.Interfaces;
+using Azure.Identity;
 
 namespace APIViewWeb
 {
@@ -235,7 +236,7 @@ namespace APIViewWeb
             services.AddSingleton<IAuthorizationHandler, SamplesRevisionOwnerRequirementHandler>();
             services.AddSingleton<CosmosClient>(x =>
             {
-                return new CosmosClient(Configuration["Cosmos:ConnectionString"]);
+                return new CosmosClient(Configuration["CosmosEndpoint"], new DefaultAzureCredential());
             });
 
             services.AddHostedService<ReviewBackgroundHostedService>();


### PR DESCRIPTION
Changes to connect to Cosmos and Storage using managed identity instead of using connection strings.