### PR TITLE
Change scope used for OSS portal client

### DIFF
--- a/tools/identity-resolution/Helpers/GitHubToAADConverter.cs
+++ b/tools/identity-resolution/Helpers/GitHubToAADConverter.cs
@@ -77,7 +77,7 @@ namespace Azure.Sdk.Tools.NotificationConfiguration.Helpers
             try
             {
                 // This is aad scope of opensource rest API.
-                string[] scopes = new [] { "api://66b6ea26-954d-4b68-8f48-71e3faec7ad1/.default" };
+                string[] scopes = new [] { "66b6ea26-954d-4b68-8f48-71e3faec7ad1/.default" };
                 opsAuthToken = await credential.GetTokenAsync(new TokenRequestContext(scopes), CancellationToken.None);
             }
             catch (Exception ex)


### PR DESCRIPTION
`api://66b6ea26-954d-4b68-8f48-71e3faec7ad1` isn't a supported audience
`66b6ea26-954d-4b68-8f48-71e3faec7ad1` is supported