### PR TITLE
Remove deleted notification variable group from pipeline-generation

### DIFF
--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -16,8 +16,6 @@ parameters:
     default: 98
   - name: NPM_Registry_Authentication
     default: 24
-  - name: Secrets_for_DevOps_Notification_Configuration_and_User_Resolution
-    default: 56
   - name: Release_Secrets_for_GitHub
     default: 58
   - name: Secrets_for_Resource_Provisioner
@@ -44,7 +42,6 @@ jobs:
           ${{ parameters.AzureSDK_Maven_Release_Pipeline_Secrets }}
           ${{ parameters.Release_Secrets_for_GitHub }}
           ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           ${{ parameters.APIReview_AutoCreate_Configurations }}
         TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
       Android:
@@ -54,7 +51,6 @@ jobs:
           ${{ parameters.AzureSDK_Maven_Release_Pipeline_Secrets }}
           ${{ parameters.Release_Secrets_for_GitHub }}
           ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           ${{ parameters.APIReview_AutoCreate_Configurations }}
       JavaScript:
         RepositoryName: azure-sdk-for-js
@@ -63,7 +59,6 @@ jobs:
           ${{ parameters.NPM_Registry_Authentication }}
           ${{ parameters.Release_Secrets_for_GitHub }}
           ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           ${{ parameters.APIReview_AutoCreate_Configurations }}
         TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
       Python:
@@ -72,7 +67,6 @@ jobs:
         InternalVariableGroups: >-
           ${{ parameters.Release_Secrets_for_GitHub }}
           ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           ${{ parameters.APIReview_AutoCreate_Configurations }}
         TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
       Net:
@@ -82,7 +76,6 @@ jobs:
           ${{ parameters.AzureSDK_Nuget_Release_Pipeline_Secrets }}
           ${{ parameters.Release_Secrets_for_GitHub }}
           ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           ${{ parameters.APIReview_AutoCreate_Configurations }}
         TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
       Cpp:
@@ -92,7 +85,6 @@ jobs:
         InternalVariableGroups: >-
           ${{ parameters.Release_Secrets_for_GitHub }}
           ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           ${{ parameters.APIReview_AutoCreate_Configurations }}
           ${{ parameters.Secrets_for_Resource_Provisioner }}
           ${{ parameters.Cache_Secrets_for_CPP }}
@@ -103,7 +95,6 @@ jobs:
         InternalVariableGroups: >-
           ${{ parameters.Release_Secrets_for_GitHub }}
           ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           ${{ parameters.APIReview_AutoCreate_Configurations }}
           ${{ parameters.Secrets_for_Resource_Provisioner }}
           ${{ parameters.AzureSDK_CocoaPods_Release_Pipeline_Secrets}}
@@ -114,7 +105,6 @@ jobs:
         InternalVariableGroups: >-
           ${{ parameters.Release_Secrets_for_GitHub }}
           ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.Secrets_for_DevOps_Notification_Configuration_and_User_Resolution }}
           ${{ parameters.APIReview_AutoCreate_Configurations }}
           ${{ parameters.Secrets_for_Resource_Provisioner }}
         GenerateUnifiedWeekly: true


### PR DESCRIPTION
As part of secret clean-up we need to remove variable group 56 from the pipelines we generate so we can delete it.