### PR TITLE
Set oidc variables for use in pre/post scripts and elsewhere

### DIFF
--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -43,6 +43,18 @@ steps:
   - template: /eng/common/TestResources/setup-environments.yml
 
   - ${{ if eq('true', parameters.UseFederatedAuth) }}:
+    - task: AzureCLI@2
+      displayName: Set OIDC variables
+      inputs:
+        azureSubscription: ${{ parameters.ServiceConnection }}
+        scriptType: pscore
+        scriptLocation: inlineScript
+        addSpnToEnvironment: true
+        inlineScript: |
+          Write-Host "##vso[task.setvariable variable=ARM_CLIENT_ID;issecret=true]$($env:servicePrincipalId)"
+          Write-Host "##vso[task.setvariable variable=ARM_TENANT_ID;issecret=true]$($env:tenantId)"
+          Write-Host "##vso[task.setvariable variable=ARM_OIDC_TOKEN;issecret=true]$($env:idToken)"
+
     - task: AzurePowerShell@5
       displayName: Deploy test resources
       env:


### PR DESCRIPTION
Some pre/post test resources scripts require az login to run setup commands (e.g. for identity). It seems useful to propagate the oidc token variable across the pipeline context regardless.

We could unset the variables after the pre/post script runs as well if we think we don't want it available everywhere.
