### PR TITLE
Remove PATVAR from PipelineGenerator

### DIFF
--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -136,7 +136,7 @@ jobs:
         --branch refs/heads/$(DefaultBranch) `
         --set-managed-variables `
         --debug
-    workingDirectory: tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
+      workingDirectory: tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
     displayName: 'Generate public pipelines for: $(RepositoryName)'
 
   # - task: AzureCLI@2

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -44,189 +44,186 @@ jobs:
           ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
           ${{ parameters.APIReview_AutoCreate_Configurations }}
         TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
-      # Android:
-      #   RepositoryName: azure-sdk-for-android
-      #   Prefix: android
-      #   InternalVariableGroups: >-
-      #     ${{ parameters.AzureSDK_Maven_Release_Pipeline_Secrets }}
-      #     ${{ parameters.Release_Secrets_for_GitHub }}
-      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
-      # JavaScript:
-      #   RepositoryName: azure-sdk-for-js
-      #   Prefix: js
-      #   InternalVariableGroups: >-
-      #     ${{ parameters.NPM_Registry_Authentication }}
-      #     ${{ parameters.Release_Secrets_for_GitHub }}
-      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
-      #   TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
-      # Python:
-      #   RepositoryName: azure-sdk-for-python
-      #   Prefix: python
-      #   InternalVariableGroups: >-
-      #     ${{ parameters.Release_Secrets_for_GitHub }}
-      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
-      #   TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
-      # Net:
-      #   RepositoryName: azure-sdk-for-net
-      #   Prefix: net
-      #   InternalVariableGroups: >-
-      #     ${{ parameters.AzureSDK_Nuget_Release_Pipeline_Secrets }}
-      #     ${{ parameters.Release_Secrets_for_GitHub }}
-      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
-      #   TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
-      # Cpp:
-      #   RepositoryName: azure-sdk-for-cpp
-      #   Prefix: cpp
-      #   # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because C++ includes live tests in the unified pipelines
-      #   InternalVariableGroups: >-
-      #     ${{ parameters.Release_Secrets_for_GitHub }}
-      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
-      #     ${{ parameters.Secrets_for_Resource_Provisioner }}
-      #     ${{ parameters.Cache_Secrets_for_CPP }}
-      # iOS:
-      #   RepositoryName: azure-sdk-for-ios
-      #   Prefix: ios
-      #   # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because iOS includes live tests in the unified pipelines
-      #   InternalVariableGroups: >-
-      #     ${{ parameters.Release_Secrets_for_GitHub }}
-      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
-      #     ${{ parameters.Secrets_for_Resource_Provisioner }}
-      #     ${{ parameters.AzureSDK_CocoaPods_Release_Pipeline_Secrets}}
-      # Go:
-      #   RepositoryName: azure-sdk-for-go
-      #   Prefix: go
-      #   # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because Go includes live tests in the unified pipelines
-      #   InternalVariableGroups: >-
-      #     ${{ parameters.Release_Secrets_for_GitHub }}
-      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
-      #     ${{ parameters.Secrets_for_Resource_Provisioner }}
-      #   GenerateUnifiedWeekly: true
+      Android:
+        RepositoryName: azure-sdk-for-android
+        Prefix: android
+        InternalVariableGroups: >-
+          ${{ parameters.AzureSDK_Maven_Release_Pipeline_Secrets }}
+          ${{ parameters.Release_Secrets_for_GitHub }}
+          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          ${{ parameters.APIReview_AutoCreate_Configurations }}
+      JavaScript:
+        RepositoryName: azure-sdk-for-js
+        Prefix: js
+        InternalVariableGroups: >-
+          ${{ parameters.NPM_Registry_Authentication }}
+          ${{ parameters.Release_Secrets_for_GitHub }}
+          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          ${{ parameters.APIReview_AutoCreate_Configurations }}
+        TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
+      Python:
+        RepositoryName: azure-sdk-for-python
+        Prefix: python
+        InternalVariableGroups: >-
+          ${{ parameters.Release_Secrets_for_GitHub }}
+          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          ${{ parameters.APIReview_AutoCreate_Configurations }}
+        TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
+      Net:
+        RepositoryName: azure-sdk-for-net
+        Prefix: net
+        InternalVariableGroups: >-
+          ${{ parameters.AzureSDK_Nuget_Release_Pipeline_Secrets }}
+          ${{ parameters.Release_Secrets_for_GitHub }}
+          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          ${{ parameters.APIReview_AutoCreate_Configurations }}
+        TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
+      Cpp:
+        RepositoryName: azure-sdk-for-cpp
+        Prefix: cpp
+        # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because C++ includes live tests in the unified pipelines
+        InternalVariableGroups: >-
+          ${{ parameters.Release_Secrets_for_GitHub }}
+          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          ${{ parameters.APIReview_AutoCreate_Configurations }}
+          ${{ parameters.Secrets_for_Resource_Provisioner }}
+          ${{ parameters.Cache_Secrets_for_CPP }}
+      iOS:
+        RepositoryName: azure-sdk-for-ios
+        Prefix: ios
+        # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because iOS includes live tests in the unified pipelines
+        InternalVariableGroups: >-
+          ${{ parameters.Release_Secrets_for_GitHub }}
+          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          ${{ parameters.APIReview_AutoCreate_Configurations }}
+          ${{ parameters.Secrets_for_Resource_Provisioner }}
+          ${{ parameters.AzureSDK_CocoaPods_Release_Pipeline_Secrets}}
+      Go:
+        RepositoryName: azure-sdk-for-go
+        Prefix: go
+        # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because Go includes live tests in the unified pipelines
+        InternalVariableGroups: >-
+          ${{ parameters.Release_Secrets_for_GitHub }}
+          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+          ${{ parameters.APIReview_AutoCreate_Configurations }}
+          ${{ parameters.Secrets_for_Resource_Provisioner }}
+        GenerateUnifiedWeekly: true
   steps:
-#  - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
-
-  - script: |
-      dotnet pack
-      dotnet tool install --global --prerelease --add-source ../../../artifacts/packages/Debug Azure.Sdk.Tools.PipelineGenerator
-    displayName: 'Build and install pipeline-generator from sources'
-    workingDirectory: tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
-
+  - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
   - script: |
       git clone https://github.com/azure/$(RepositoryName) $(Pipeline.Workspace)/$(RepositoryName)
     displayName: 'Clone repository: $(RepositoryName)'
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     parameters:
       WorkingDirectory: $(Pipeline.Workspace)/$(RepositoryName)
-
-  - task: AzureCLI@2
-    inputs:
-      azureSubscription: 'opensource-api-connection'
-      scriptType: pscore
-      scriptLocation: inlineScript
-      inlineScript:
-        pipeline-generator generate generate `
-        --organization azure-sdk `
-        --project public `
-        --prefix $(Prefix) `
-        --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
-        --endpoint Azure `
-        --repository Azure/$(RepositoryName) `
-        --convention ci `
-        --agentpool Hosted `
-        --branch refs/heads/$(DefaultBranch) `
-        --set-managed-variables `
-        --debug
+  - script: >
+      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+      --organization azure-sdk
+      --project public
+      --prefix $(Prefix)
+      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
+      --endpoint Azure
+      --repository Azure/$(RepositoryName)
+      --convention ci
+      --agentpool Hosted
+      --branch refs/heads/$(DefaultBranch)
+      --set-managed-variables
+      --patvar PATVAR
+      --debug
     displayName: 'Generate public pipelines for: $(RepositoryName)'
+    env:
+      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+  - script: >
+      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+      --organization azure-sdk
+      --project internal
+      --prefix $(Prefix)
+      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
+      --endpoint Azure
+      --repository Azure/$(RepositoryName)
+      --convention up
+      --agentpool Hosted
+      --branch refs/heads/$(DefaultBranch)
+      --set-managed-variables
+      --patvar PATVAR
+      --debug
+      --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
+    displayName: 'Generate internal pipelines for: $(RepositoryName)'
+    env:
+      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+  - script: >
+      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+      --organization azure-sdk
+      --project internal
+      --prefix $(Prefix)
+      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
+      --endpoint Azure
+      --repository Azure/$(RepositoryName)
+      --convention tests
+      --agentpool Hosted
+      --branch refs/heads/$(DefaultBranch)
+      --set-managed-variables
+      --patvar PATVAR
+      --debug
+      --variablegroups $(TestVariableGroups)
+    displayName: 'Generate test pipelines for: $(RepositoryName)'
+    condition: and(succeeded(), ne(variables['TestVariableGroups'],''))
+    env:
+      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+  - script: >
+      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+      --organization azure-sdk
+      --project internal
+      --prefix $(Prefix)
+      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
+      --endpoint Azure
+      --repository Azure/$(RepositoryName)
+      --convention testsweekly
+      --agentpool Hosted
+      --branch refs/heads/$(DefaultBranch)
+      --set-managed-variables
+      --patvar PATVAR
+      --debug
+      --variablegroups $(TestVariableGroups)
+    displayName: 'Generate weekly test pipelines (multi-cloud) for: $(RepositoryName)'
+    condition: and(succeeded(), ne(variables['TestVariableGroups'],''))
+    env:
+      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+  - script: >
+      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+      --organization azure-sdk
+      --project internal
+      --prefix $(Prefix)
+      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
+      --endpoint Azure
+      --repository Azure/$(RepositoryName)
+      --convention upweekly
+      --agentpool Hosted
+      --branch refs/heads/$(DefaultBranch)
+      --set-managed-variables
+      --patvar PATVAR
+      --debug
+      --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
+    displayName: 'Generate weekly unified test pipelines (multi-cloud) for: $(RepositoryName)'
+    condition: and(succeeded(), ne(variables['GenerateUnifiedWeekly'],''))
+    env:
+      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 
-  # - task: AzureCLI@2
-  #   inputs:
-  #     azureSubscription: 'opensource-api-connection'
-  #     scriptType: pscore
-  #     scriptLocation: inlineScript
-  #     inlineScript:
-  #       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-  #       --organization azure-sdk `
-  #       --project internal `
-  #       --prefix $(Prefix) `
-  #       --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
-  #       --endpoint Azure `
-  #       --repository Azure/$(RepositoryName) `
-  #       --convention up `
-  #       --agentpool Hosted `
-  #       --branch refs/heads/$(DefaultBranch) `
-  #       --set-managed-variables `
-  #       --debug `
-  #       --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
-  #   displayName: 'Generate internal pipelines for: $(RepositoryName)'
-
-  # - task: AzureCLI@2
-  #   inputs:
-  #     azureSubscription: 'opensource-api-connection'
-  #     scriptType: pscore
-  #     scriptLocation: inlineScript
-  #     inlineScript:
-  #       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-  #       --organization azure-sdk `
-  #       --project internal `
-  #       --prefix $(Prefix) `
-  #       --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
-  #       --endpoint Azure `
-  #       --repository Azure/$(RepositoryName) `
-  #       --convention tests `
-  #       --agentpool Hosted `
-  #       --branch refs/heads/$(DefaultBranch) `
-  #       --set-managed-variables `
-  #       --debug `
-  #       --variablegroups $(TestVariableGroups)
-  #   displayName: 'Generate test pipelines for: $(RepositoryName)'
-  #   condition: and(succeeded(), ne(variables['TestVariableGroups'],''))
-
-  # - task: AzureCLI@2
-  #   inputs:
-  #     azureSubscription: 'opensource-api-connection'
-  #     scriptType: pscore
-  #     scriptLocation: inlineScript
-  #     inlineScript:
-  #       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-  #       --organization azure-sdk `
-  #       --project internal `
-  #       --prefix $(Prefix) `
-  #       --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
-  #       --endpoint Azure `
-  #       --repository Azure/$(RepositoryName) `
-  #       --convention testsweekly `
-  #       --agentpool Hosted `
-  #       --branch refs/heads/$(DefaultBranch) `
-  #       --set-managed-variables `
-  #       --debug `
-  #       --variablegroups $(TestVariableGroups)
-  #   displayName: 'Generate weekly test pipelines (multi-cloud) for: $(RepositoryName)'
-  #   condition: and(succeeded(), ne(variables['TestVariableGroups'],''))
-
-  # - task: AzureCLI@2
-  #   inputs:
-  #     azureSubscription: 'opensource-api-connection'
-  #     scriptType: pscore
-  #     scriptLocation: inlineScript
-  #     inlineScript:
-  #       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-  #       --organization azure-sdk `
-  #       --project internal `
-  #       --prefix $(Prefix) `
-  #       --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
-  #       --endpoint Azure `
-  #       --repository Azure/$(RepositoryName) `
-  #       --convention upweekly `
-  #       --agentpool Hosted `
-  #       --branch refs/heads/$(DefaultBranch) `
-  #       --set-managed-variables `
-  #       --debug `
-  #       --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
-  #   displayName: 'Generate weekly unified test pipelines (multi-cloud) for: $(RepositoryName)'
-  #   condition: and(succeeded(), ne(variables['GenerateUnifiedWeekly'],''))
+  # - script: >
+  #     $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+  #     --organization azure-sdk
+  #     --project internal
+  #     --prefix $(Prefix)-pr
+  #     --devopspath "\$(Prefix)\pr"
+  #     --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
+  #     --endpoint Azure
+  #     --repository Azure/$(RepositoryName)-pr
+  #     --convention ci
+  #     --agentpool Hosted
+  #     --branch refs/heads/ $(DefaultBranch)
+  #     --set-managed-variables
+  #     --patvar PATVAR
+  #     --debug
+  #   displayName: 'Generate internal pipelines for: $(RepositoryName)-pr'
+  #   env:
+  #     PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -136,7 +136,7 @@ jobs:
         --branch refs/heads/$(DefaultBranch) `
         --set-managed-variables `
         --debug
-      workingDirectory: tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
+      workingDirectory: /tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
     displayName: 'Generate public pipelines for: $(RepositoryName)'
 
   # - task: AzureCLI@2

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -136,7 +136,7 @@ jobs:
         --branch refs/heads/$(DefaultBranch) `
         --set-managed-variables `
         --debug
-      workingDirectory: tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
+      workingDirectory: $(Pipeline.Workspace)/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
     displayName: 'Generate public pipelines for: $(RepositoryName)'
 
   # - task: AzureCLI@2

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -136,7 +136,7 @@ jobs:
         --branch refs/heads/$(DefaultBranch) `
         --set-managed-variables `
         --debug
-      workingDirectory: /tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
+      workingDirectory: tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
     displayName: 'Generate public pipelines for: $(RepositoryName)'
 
   # - task: AzureCLI@2

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -44,186 +44,184 @@ jobs:
           ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
           ${{ parameters.APIReview_AutoCreate_Configurations }}
         TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
-      Android:
-        RepositoryName: azure-sdk-for-android
-        Prefix: android
-        InternalVariableGroups: >-
-          ${{ parameters.AzureSDK_Maven_Release_Pipeline_Secrets }}
-          ${{ parameters.Release_Secrets_for_GitHub }}
-          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.APIReview_AutoCreate_Configurations }}
-      JavaScript:
-        RepositoryName: azure-sdk-for-js
-        Prefix: js
-        InternalVariableGroups: >-
-          ${{ parameters.NPM_Registry_Authentication }}
-          ${{ parameters.Release_Secrets_for_GitHub }}
-          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.APIReview_AutoCreate_Configurations }}
-        TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
-      Python:
-        RepositoryName: azure-sdk-for-python
-        Prefix: python
-        InternalVariableGroups: >-
-          ${{ parameters.Release_Secrets_for_GitHub }}
-          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.APIReview_AutoCreate_Configurations }}
-        TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
-      Net:
-        RepositoryName: azure-sdk-for-net
-        Prefix: net
-        InternalVariableGroups: >-
-          ${{ parameters.AzureSDK_Nuget_Release_Pipeline_Secrets }}
-          ${{ parameters.Release_Secrets_for_GitHub }}
-          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.APIReview_AutoCreate_Configurations }}
-        TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
-      Cpp:
-        RepositoryName: azure-sdk-for-cpp
-        Prefix: cpp
-        # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because C++ includes live tests in the unified pipelines
-        InternalVariableGroups: >-
-          ${{ parameters.Release_Secrets_for_GitHub }}
-          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.APIReview_AutoCreate_Configurations }}
-          ${{ parameters.Secrets_for_Resource_Provisioner }}
-          ${{ parameters.Cache_Secrets_for_CPP }}
-      iOS:
-        RepositoryName: azure-sdk-for-ios
-        Prefix: ios
-        # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because iOS includes live tests in the unified pipelines
-        InternalVariableGroups: >-
-          ${{ parameters.Release_Secrets_for_GitHub }}
-          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.APIReview_AutoCreate_Configurations }}
-          ${{ parameters.Secrets_for_Resource_Provisioner }}
-          ${{ parameters.AzureSDK_CocoaPods_Release_Pipeline_Secrets}}
-      Go:
-        RepositoryName: azure-sdk-for-go
-        Prefix: go
-        # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because Go includes live tests in the unified pipelines
-        InternalVariableGroups: >-
-          ${{ parameters.Release_Secrets_for_GitHub }}
-          ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
-          ${{ parameters.APIReview_AutoCreate_Configurations }}
-          ${{ parameters.Secrets_for_Resource_Provisioner }}
-        GenerateUnifiedWeekly: true
+      # Android:
+      #   RepositoryName: azure-sdk-for-android
+      #   Prefix: android
+      #   InternalVariableGroups: >-
+      #     ${{ parameters.AzureSDK_Maven_Release_Pipeline_Secrets }}
+      #     ${{ parameters.Release_Secrets_for_GitHub }}
+      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
+      # JavaScript:
+      #   RepositoryName: azure-sdk-for-js
+      #   Prefix: js
+      #   InternalVariableGroups: >-
+      #     ${{ parameters.NPM_Registry_Authentication }}
+      #     ${{ parameters.Release_Secrets_for_GitHub }}
+      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
+      #   TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
+      # Python:
+      #   RepositoryName: azure-sdk-for-python
+      #   Prefix: python
+      #   InternalVariableGroups: >-
+      #     ${{ parameters.Release_Secrets_for_GitHub }}
+      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
+      #   TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
+      # Net:
+      #   RepositoryName: azure-sdk-for-net
+      #   Prefix: net
+      #   InternalVariableGroups: >-
+      #     ${{ parameters.AzureSDK_Nuget_Release_Pipeline_Secrets }}
+      #     ${{ parameters.Release_Secrets_for_GitHub }}
+      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
+      #   TestVariableGroups: '${{ parameters.Secrets_for_Resource_Provisioner }}'
+      # Cpp:
+      #   RepositoryName: azure-sdk-for-cpp
+      #   Prefix: cpp
+      #   # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because C++ includes live tests in the unified pipelines
+      #   InternalVariableGroups: >-
+      #     ${{ parameters.Release_Secrets_for_GitHub }}
+      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
+      #     ${{ parameters.Secrets_for_Resource_Provisioner }}
+      #     ${{ parameters.Cache_Secrets_for_CPP }}
+      # iOS:
+      #   RepositoryName: azure-sdk-for-ios
+      #   Prefix: ios
+      #   # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because iOS includes live tests in the unified pipelines
+      #   InternalVariableGroups: >-
+      #     ${{ parameters.Release_Secrets_for_GitHub }}
+      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
+      #     ${{ parameters.Secrets_for_Resource_Provisioner }}
+      #     ${{ parameters.AzureSDK_CocoaPods_Release_Pipeline_Secrets}}
+      # Go:
+      #   RepositoryName: azure-sdk-for-go
+      #   Prefix: go
+      #   # Resource Provisioner is in InternalVariableGroups and not TestVariableGroups because Go includes live tests in the unified pipelines
+      #   InternalVariableGroups: >-
+      #     ${{ parameters.Release_Secrets_for_GitHub }}
+      #     ${{ parameters.Release_Secrets_for_GitHubIO_Publishing }}
+      #     ${{ parameters.APIReview_AutoCreate_Configurations }}
+      #     ${{ parameters.Secrets_for_Resource_Provisioner }}
+      #   GenerateUnifiedWeekly: true
   steps:
-  - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
+#  - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
+
   - script: |
       git clone https://github.com/azure/$(RepositoryName) $(Pipeline.Workspace)/$(RepositoryName)
     displayName: 'Clone repository: $(RepositoryName)'
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     parameters:
       WorkingDirectory: $(Pipeline.Workspace)/$(RepositoryName)
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization azure-sdk
-      --project public
-      --prefix $(Prefix)
-      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention ci
-      --agentpool Hosted
-      --branch refs/heads/$(DefaultBranch)
-      --set-managed-variables
-      --patvar PATVAR
-      --debug
-    displayName: 'Generate public pipelines for: $(RepositoryName)'
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization azure-sdk
-      --project internal
-      --prefix $(Prefix)
-      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention up
-      --agentpool Hosted
-      --branch refs/heads/$(DefaultBranch)
-      --set-managed-variables
-      --patvar PATVAR
-      --debug
-      --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
-    displayName: 'Generate internal pipelines for: $(RepositoryName)'
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization azure-sdk
-      --project internal
-      --prefix $(Prefix)
-      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention tests
-      --agentpool Hosted
-      --branch refs/heads/$(DefaultBranch)
-      --set-managed-variables
-      --patvar PATVAR
-      --debug
-      --variablegroups $(TestVariableGroups)
-    displayName: 'Generate test pipelines for: $(RepositoryName)'
-    condition: and(succeeded(), ne(variables['TestVariableGroups'],''))
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization azure-sdk
-      --project internal
-      --prefix $(Prefix)
-      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention testsweekly
-      --agentpool Hosted
-      --branch refs/heads/$(DefaultBranch)
-      --set-managed-variables
-      --patvar PATVAR
-      --debug
-      --variablegroups $(TestVariableGroups)
-    displayName: 'Generate weekly test pipelines (multi-cloud) for: $(RepositoryName)'
-    condition: and(succeeded(), ne(variables['TestVariableGroups'],''))
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization azure-sdk
-      --project internal
-      --prefix $(Prefix)
-      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention upweekly
-      --agentpool Hosted
-      --branch refs/heads/$(DefaultBranch)
-      --set-managed-variables
-      --patvar PATVAR
-      --debug
-      --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
-    displayName: 'Generate weekly unified test pipelines (multi-cloud) for: $(RepositoryName)'
-    condition: and(succeeded(), ne(variables['GenerateUnifiedWeekly'],''))
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 
-  # - script: >
-  #     $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-  #     --organization azure-sdk
-  #     --project internal
-  #     --prefix $(Prefix)-pr
-  #     --devopspath "\$(Prefix)\pr"
-  #     --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-  #     --endpoint Azure
-  #     --repository Azure/$(RepositoryName)-pr
-  #     --convention ci
-  #     --agentpool Hosted
-  #     --branch refs/heads/ $(DefaultBranch)
-  #     --set-managed-variables
-  #     --patvar PATVAR
-  #     --debug
-  #   displayName: 'Generate internal pipelines for: $(RepositoryName)-pr'
-  #   env:
-  #     PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: 'opensource-api-connection'
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript:
+        dotnet run generate `
+        --organization azure-sdk `
+        --project public `
+        --prefix $(Prefix) `
+        --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+        --endpoint Azure `
+        --repository Azure/$(RepositoryName) `
+        --convention ci `
+        --agentpool Hosted `
+        --branch refs/heads/$(DefaultBranch) `
+        --set-managed-variables `
+        --debug
+    workingDirectory: tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
+    displayName: 'Generate public pipelines for: $(RepositoryName)'
+
+  # - task: AzureCLI@2
+  #   inputs:
+  #     azureSubscription: 'opensource-api-connection'
+  #     scriptType: pscore
+  #     scriptLocation: inlineScript
+  #     inlineScript:
+  #       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+  #       --organization azure-sdk `
+  #       --project internal `
+  #       --prefix $(Prefix) `
+  #       --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+  #       --endpoint Azure `
+  #       --repository Azure/$(RepositoryName) `
+  #       --convention up `
+  #       --agentpool Hosted `
+  #       --branch refs/heads/$(DefaultBranch) `
+  #       --set-managed-variables `
+  #       --debug `
+  #       --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
+  #   displayName: 'Generate internal pipelines for: $(RepositoryName)'
+
+  # - task: AzureCLI@2
+  #   inputs:
+  #     azureSubscription: 'opensource-api-connection'
+  #     scriptType: pscore
+  #     scriptLocation: inlineScript
+  #     inlineScript:
+  #       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+  #       --organization azure-sdk `
+  #       --project internal `
+  #       --prefix $(Prefix) `
+  #       --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+  #       --endpoint Azure `
+  #       --repository Azure/$(RepositoryName) `
+  #       --convention tests `
+  #       --agentpool Hosted `
+  #       --branch refs/heads/$(DefaultBranch) `
+  #       --set-managed-variables `
+  #       --debug `
+  #       --variablegroups $(TestVariableGroups)
+  #   displayName: 'Generate test pipelines for: $(RepositoryName)'
+  #   condition: and(succeeded(), ne(variables['TestVariableGroups'],''))
+
+  # - task: AzureCLI@2
+  #   inputs:
+  #     azureSubscription: 'opensource-api-connection'
+  #     scriptType: pscore
+  #     scriptLocation: inlineScript
+  #     inlineScript:
+  #       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+  #       --organization azure-sdk `
+  #       --project internal `
+  #       --prefix $(Prefix) `
+  #       --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+  #       --endpoint Azure `
+  #       --repository Azure/$(RepositoryName) `
+  #       --convention testsweekly `
+  #       --agentpool Hosted `
+  #       --branch refs/heads/$(DefaultBranch) `
+  #       --set-managed-variables `
+  #       --debug `
+  #       --variablegroups $(TestVariableGroups)
+  #   displayName: 'Generate weekly test pipelines (multi-cloud) for: $(RepositoryName)'
+  #   condition: and(succeeded(), ne(variables['TestVariableGroups'],''))
+
+  # - task: AzureCLI@2
+  #   inputs:
+  #     azureSubscription: 'opensource-api-connection'
+  #     scriptType: pscore
+  #     scriptLocation: inlineScript
+  #     inlineScript:
+  #       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+  #       --organization azure-sdk `
+  #       --project internal `
+  #       --prefix $(Prefix) `
+  #       --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+  #       --endpoint Azure `
+  #       --repository Azure/$(RepositoryName) `
+  #       --convention upweekly `
+  #       --agentpool Hosted `
+  #       --branch refs/heads/$(DefaultBranch) `
+  #       --set-managed-variables `
+  #       --debug `
+  #       --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
+  #   displayName: 'Generate weekly unified test pipelines (multi-cloud) for: $(RepositoryName)'
+  #   condition: and(succeeded(), ne(variables['GenerateUnifiedWeekly'],''))

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -115,7 +115,7 @@ jobs:
       dotnet pack
       dotnet tool install --global --prerelease --add-source ../../../artifacts/packages/Debug Azure.Sdk.Tools.PipelineGenerator
     displayName: 'Build and install pipeline-generator from sources'
-    workingDirectory: $(Pipeline.Workspace)/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
+    workingDirectory: tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
 
   - script: |
       git clone https://github.com/azure/$(RepositoryName) $(Pipeline.Workspace)/$(RepositoryName)

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -111,11 +111,10 @@ jobs:
   steps:
 #  - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
 
-  - name: Build and install pipeline-generator from sources
-    run: |
+  - script: |
       dotnet pack
       dotnet tool install --global --prerelease --add-source ../../../artifacts/packages/Debug Azure.Sdk.Tools.PipelineGenerator
-    shell: bash
+    displayName: 'Build and install pipeline-generator from sources'
     workingDirectory: $(Pipeline.Workspace)/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
 
   - script: |

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -111,6 +111,13 @@ jobs:
   steps:
 #  - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
 
+  - name: Build and install pipeline-generator from sources
+    run: |
+      dotnet pack
+      dotnet tool install --global --prerelease --add-source ../../../artifacts/packages/Debug Azure.Sdk.Tools.PipelineGenerator
+    shell: bash
+    workingDirectory: $(Pipeline.Workspace)/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
+
   - script: |
       git clone https://github.com/azure/$(RepositoryName) $(Pipeline.Workspace)/$(RepositoryName)
     displayName: 'Clone repository: $(RepositoryName)'
@@ -124,7 +131,7 @@ jobs:
       scriptType: pscore
       scriptLocation: inlineScript
       inlineScript:
-        dotnet run generate `
+        pipeline-generator generate generate `
         --organization azure-sdk `
         --project public `
         --prefix $(Prefix) `
@@ -136,7 +143,6 @@ jobs:
         --branch refs/heads/$(DefaultBranch) `
         --set-managed-variables `
         --debug
-      workingDirectory: $(Pipeline.Workspace)/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator
     displayName: 'Generate public pipelines for: $(RepositoryName)'
 
   # - task: AzureCLI@2

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
@@ -14,13 +14,14 @@
 
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Azure.Identity" Version="1.11.3" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
 
-    <PackageReference Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="16.170.0" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.170.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="16.170.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi" Version="16.170.0" />
+    <PackageReference Include="Microsoft.TeamFoundation.DistributedTask.WebApi" Version="19.232.0-preview" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.232.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.232.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.ServiceEndpoints.WebApi" Version="19.232.0-preview" />
   </ItemGroup>
 </Project>

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/CommandParserOptions/DefaultOptions.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/CommandParserOptions/DefaultOptions.cs
@@ -25,9 +25,6 @@ namespace PipelineGenerator.CommandParserOptions
         [Option('p', "project", Required = false, Default = "internal", HelpText = "Azure DevOps project name. Default: internal")]
         public string Project { get; set; }
 
-        [Option('t', "patvar", Required = false, HelpText = "Environment variable name containing a Personal Access Token.")]
-        public string Patvar { get; set; }
-
         [Option("whatif", Required = false, HelpText = "Dry Run changes")]
         public bool WhatIf { get; set; }
     }

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
@@ -80,6 +80,7 @@ namespace PipelineGenerator
                 );
                 var devopsCredential = new VssAzureIdentityCredential(azureCredential);
                 cachedConnection = new VssConnection(new Uri(organization), devopsCredential);
+                await cachedConnection.ConnectAsync();
             }
 
             return cachedConnection;

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
@@ -73,11 +73,15 @@ namespace PipelineGenerator
         {
             if (cachedConnection == null)
             {
+                // JRS-REMOVE NEXT LINE
+                Console.WriteLine("*****Start Authentication*****");
                 VssCredentials credentials;
                 var azureTokenProvider = new AzureServiceTokenProvider();
                 var authenticationResult = await azureTokenProvider.GetAuthenticationResultAsync("499b84ac-1321-427f-aa17-267ca6975798");
                 credentials = new VssAadCredential(new VssAadToken(authenticationResult.TokenType, authenticationResult.AccessToken));
                 cachedConnection = new VssConnection(new Uri(organization), credentials);
+                // JRS-REMOVE NEXT LINE
+                Console.WriteLine("*****Finish Authentication*****");
             }
 
             return cachedConnection;

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Azure.Services.AppAuthentication;
+using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Microsoft.TeamFoundation.Core.WebApi;
@@ -20,7 +20,6 @@ namespace PipelineGenerator
     {
         private string organization;
         private string project;
-        private string patvar;
         private string endpoint;
         private string agentPool;
         private int[] variableGroups;
@@ -30,7 +29,6 @@ namespace PipelineGenerator
             ILogger logger,
             string organization,
             string project,
-            string patvar,
             string endpoint,
             string repository,
             string branch,
@@ -46,7 +44,6 @@ namespace PipelineGenerator
             this.logger = logger;
             this.organization = organization;
             this.project = project;
-            this.patvar = patvar;
             this.endpoint = endpoint;
             this.Repository = repository;
             this.Branch = branch;
@@ -77,18 +74,9 @@ namespace PipelineGenerator
             if (cachedConnection == null)
             {
                 VssCredentials credentials;
-                if (string.IsNullOrWhiteSpace(patvar))
-                {
-                    var azureTokenProvider = new AzureServiceTokenProvider();
-                    var authenticationResult = await azureTokenProvider.GetAuthenticationResultAsync("499b84ac-1321-427f-aa17-267ca6975798");
-                    credentials = new VssAadCredential(new VssAadToken(authenticationResult.TokenType, authenticationResult.AccessToken));
-                }
-                else
-                {
-                    var pat = Environment.GetEnvironmentVariable(patvar);
-                    credentials = new VssBasicCredential("nobody", pat);
-                }
-
+                var azureTokenProvider = new AzureServiceTokenProvider();
+                var authenticationResult = await azureTokenProvider.GetAuthenticationResultAsync("499b84ac-1321-427f-aa17-267ca6975798");
+                credentials = new VssAadCredential(new VssAadToken(authenticationResult.TokenType, authenticationResult.AccessToken));
                 cachedConnection = new VssConnection(new Uri(organization), credentials);
             }
 

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/PipelineGenerationContext.cs
@@ -1,3 +1,4 @@
+using Azure.Identity;
 using Microsoft.Azure.Services.AppAuthentication;
 using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Build.WebApi;
@@ -73,15 +74,12 @@ namespace PipelineGenerator
         {
             if (cachedConnection == null)
             {
-                // JRS-REMOVE NEXT LINE
-                Console.WriteLine("*****Start Authentication*****");
-                VssCredentials credentials;
-                var azureTokenProvider = new AzureServiceTokenProvider();
-                var authenticationResult = await azureTokenProvider.GetAuthenticationResultAsync("499b84ac-1321-427f-aa17-267ca6975798");
-                credentials = new VssAadCredential(new VssAadToken(authenticationResult.TokenType, authenticationResult.AccessToken));
-                cachedConnection = new VssConnection(new Uri(organization), credentials);
-                // JRS-REMOVE NEXT LINE
-                Console.WriteLine("*****Finish Authentication*****");
+                var azureCredential = new ChainedTokenCredential(
+                    new AzureCliCredential(),
+                    new AzurePowerShellCredential()
+                );
+                var devopsCredential = new VssAzureIdentityCredential(azureCredential);
+                cachedConnection = new VssConnection(new Uri(organization), devopsCredential);
             }
 
             return cachedConnection;

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -43,7 +43,6 @@ namespace PipelineGenerator
                         g.Project,
                         g.Prefix,
                         g.Path,
-                        g.Patvar,
                         g.Endpoint,
                         g.Repository,
                         g.Branch,
@@ -127,7 +126,6 @@ namespace PipelineGenerator
             string project,
             string prefix,
             string path,
-            string patvar,
             string endpoint,
             string repository,
             string branch,
@@ -154,7 +152,6 @@ namespace PipelineGenerator
                     this.logger,
                     organization,
                     project,
-                    patvar,
                     endpoint,
                     repository,
                     branch,


### PR DESCRIPTION
This is part of the PAT removal effort. The PAT being removed is azuresdk-azure-sdk-devops-pipeline-generation-pat. This PR is the first of two, the second PR will update the yml files remove the usage of azuresdk-azure-sdk-devops-pipeline-generation-pat. The second PR requires this to be published first so the version of pipeline-generator in install-pipeline-generator.yml can be updated.

There was a hacked up version of pipeline-generation.yml that was used to test these changes, this was the [successful run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3845151&view=results) after updates. The hacked up yml file has been removed from this PR.

The second PR will use an `AzureCLI@2` task to authenticate and call pipeline-generation within the task's inlinescript.
