### PR TITLE
PAT Removal from pipeline generation yml

### DIFF
--- a/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
@@ -35,166 +35,181 @@ jobs:
     - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     # This covers our public repos.
     - ${{ if not(endsWith(parameters.Repository, '-pr'))}}:
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-          --organization azure-sdk
-          --project public
-          --prefix ${{parameters.Prefix}}
-          --devopspath "\${{parameters.Prefix}}"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention ci
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --set-managed-variables
-          --debug
-          ${{parameters.CIConventionOptions}}
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: 'opensource-api-connection'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript:
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+            --organization azure-sdk `
+            --project public `
+            --prefix ${{parameters.Prefix}} `
+            --devopspath "\${{parameters.Prefix}}" `
+            --path $(System.DefaultWorkingDirectory)/sdk `
+            --endpoint Azure `
+            --repository ${{parameters.Repository}} `
+            --convention ci `
+            --agentpool Hosted `
+            --branch refs/heads/$(DefaultBranch) `
+            --set-managed-variables `
+            --debug `
+            ${{parameters.CIConventionOptions}}
         displayName: Create CI Pipelines for Public Repository
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-          --organization azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}
-          --devopspath "\${{parameters.Prefix}}"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention up
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --set-managed-variables
-          --debug
-          ${{parameters.UPConventionOptions}}
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: 'opensource-api-connection'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript:
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+            --organization azure-sdk `
+            --project internal `
+            --prefix ${{parameters.Prefix}} `
+            --devopspath "\${{parameters.Prefix}}" `
+            --path $(System.DefaultWorkingDirectory)/sdk `
+            --endpoint Azure `
+            --repository ${{parameters.Repository}} `
+            --convention up `
+            --agentpool Hosted `
+            --branch refs/heads/$(DefaultBranch) `
+            --set-managed-variables `
+            --debug `
+            ${{parameters.UPConventionOptions}}
         displayName: Create UP Pipelines for Public Repository
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-          --organization azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}
-          --devopspath "\${{parameters.Prefix}}"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention tests
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --set-managed-variables
-          --debug
-          ${{parameters.TestsConventionOptions}}
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: 'opensource-api-connection'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript:
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+            --organization azure-sdk `
+            --project internal `
+            --prefix ${{parameters.Prefix}} `
+            --devopspath "\${{parameters.Prefix}}" `
+            --path $(System.DefaultWorkingDirectory)/sdk `
+            --endpoint Azure `
+            --repository ${{parameters.Repository}} `
+            --convention tests `
+            --agentpool Hosted `
+            --branch refs/heads/$(DefaultBranch) `
+            --set-managed-variables `
+            --debug `
+            ${{parameters.TestsConventionOptions}}
         displayName: Create Live Test Pipelines for Public Repository
         condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-          --organization azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}
-          --devopspath "\${{parameters.Prefix}}"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention testsweekly
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --set-managed-variables
-          --debug
-          ${{parameters.TestsConventionOptions}}
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: 'opensource-api-connection'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript:
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+            --organization azure-sdk `
+            --project internal `
+            --prefix ${{parameters.Prefix}} `
+            --devopspath "\${{parameters.Prefix}}" `
+            --path $(System.DefaultWorkingDirectory)/sdk `
+            --endpoint Azure `
+            --repository ${{parameters.Repository}} `
+            --convention testsweekly `
+            --agentpool Hosted `
+            --branch refs/heads/$(DefaultBranch) `
+            --set-managed-variables `
+            --debug `
+            ${{parameters.TestsConventionOptions}}
         displayName: Create Weekly (Multi-Cloud) Live Test Pipelines for Public Repository
         condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-          --organization azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}
-          --devopspath "\${{parameters.Prefix}}"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention upweekly
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --set-managed-variables
-          --debug
-          ${{parameters.UPConventionOptions}}
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: 'opensource-api-connection'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript:
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+            --organization azure-sdk `
+            --project internal `
+            --prefix ${{parameters.Prefix}} `
+            --devopspath "\${{parameters.Prefix}}" `
+            --path $(System.DefaultWorkingDirectory)/sdk `
+            --endpoint Azure `
+            --repository ${{parameters.Repository}} `
+            --convention upweekly `
+            --agentpool Hosted `
+            --branch refs/heads/$(DefaultBranch) `
+            --set-managed-variables `
+            --debug `
+            ${{parameters.UPConventionOptions}}
         displayName: Create Weekly (Multi-Cloud) Unified Test Pipelines for Public Repository
         condition: and(succeeded(), eq(${{parameters.GenerateUnifiedWeekly}},true))
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-
 
     # This covers our -pr repositories.
     - ${{ if endsWith(parameters.Repository, '-pr')}}:
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-          --organization azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}-pr
-          --devopspath "\${{parameters.Prefix}}\pr"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention ci
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --set-managed-variables
-          --debug
-          --no-schedule
-          ${{parameters.CIConventionOptions}}
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: 'opensource-api-connection'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript:
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+            --organization azure-sdk `
+            --project internal `
+            --prefix ${{parameters.Prefix}}-pr `
+            --devopspath "\${{parameters.Prefix}}\pr" `
+            --path $(System.DefaultWorkingDirectory)/sdk `
+            --endpoint Azure `
+            --repository ${{parameters.Repository}} `
+            --convention ci `
+            --agentpool Hosted `
+            --branch refs/heads/$(DefaultBranch) `
+            --set-managed-variables `
+            --debug `
+            --no-schedule `
+            ${{parameters.CIConventionOptions}}
         displayName: Create CI Pipelines for Private Repository
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-          --organization azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}-pr
-          --devopspath "\${{parameters.Prefix}}\pr"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention up
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --set-managed-variables
-          --debug
-          --no-schedule
-          ${{parameters.UPConventionOptions}}
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: 'opensource-api-connection'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript:
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+            --organization azure-sdk `
+            --project internal `
+            --prefix ${{parameters.Prefix}}-pr `
+            --devopspath "\${{parameters.Prefix}}\pr" `
+            --path $(System.DefaultWorkingDirectory)/sdk `
+            --endpoint Azure `
+            --repository ${{parameters.Repository}} `
+            --convention up `
+            --agentpool Hosted `
+            --branch refs/heads/$(DefaultBranch) `
+            --set-managed-variables `
+            --debug `
+            --no-schedule `
+            ${{parameters.UPConventionOptions}}
         displayName: Create UP Pipelines for Private Repository
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-      - script: >
-          $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-          --organization azure-sdk
-          --project internal
-          --prefix ${{parameters.Prefix}}-pr
-          --devopspath "\${{parameters.Prefix}}\pr"
-          --path $(System.DefaultWorkingDirectory)/sdk
-          --endpoint Azure
-          --repository ${{parameters.Repository}}
-          --convention tests
-          --agentpool Hosted
-          --branch refs/heads/$(DefaultBranch)
-          --patvar PATVAR
-          --set-managed-variables
-          --debug
-          --no-schedule
-          ${{parameters.TestsConventionOptions}}
+      - task: AzureCLI@2
+        inputs:
+          azureSubscription: 'opensource-api-connection'
+          scriptType: pscore
+          scriptLocation: inlineScript
+          inlineScript:
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+            --organization azure-sdk `
+            --project internal `
+            --prefix ${{parameters.Prefix}}-pr `
+            --devopspath "\${{parameters.Prefix}}\pr" `
+            --path $(System.DefaultWorkingDirectory)/sdk `
+            --endpoint Azure `
+            --repository ${{parameters.Repository}} `
+            --convention tests `
+            --agentpool Hosted `
+            --branch refs/heads/$(DefaultBranch) `
+            --set-managed-variables `
+            --debug `
+            --no-schedule `
+            ${{parameters.TestsConventionOptions}}
         displayName: Create Live Test Pipelines for Private Repository
         condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
-        env:
-          PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)

--- a/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
+++ b/eng/common/pipelines/templates/steps/install-pipeline-generation.yml
@@ -9,7 +9,7 @@ steps:
   - script: >
       dotnet tool install
       Azure.Sdk.Tools.PipelineGenerator
-      --version 1.1.0-dev.20221220.1
+      --version 1.1.0-dev.20240604.1
       --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
       --tool-path ${{parameters.ToolPath}}
     workingDirectory: $(Pipeline.Workspace)/pipeline-generator

--- a/eng/pipelines/pipeline-generation-single.yml
+++ b/eng/pipelines/pipeline-generation-single.yml
@@ -29,22 +29,23 @@ jobs:
   - script: |
       git clone --filter=blob:none --branch $(Branch) https://$(azuresdk-github-pat)@github.com/azure/$(RepositoryName) $(Pipeline.Workspace)/$(RepositoryName)
     displayName: 'Clone repository: $(RepositoryName)'
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization $(DevOpsOrg)
-      --project $(DevOpsProject)
-      --prefix $(Prefix)
-      --devopspath "$(DevOpsPath)"
-      --path $(PathFilter)
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention $(PipelineConvention)
-      --agentpool Hosted
-      --branch refs/heads/$(Branch)
-      --patvar PATVAR
-      --debug
-      $(AdditionalOptions)
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: 'opensource-api-connection'
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript:
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+        --organization $(DevOpsOrg) `
+        --project $(DevOpsProject) `
+        --prefix $(Prefix) `
+        --devopspath "$(DevOpsPath)" `
+        --path $(PathFilter) `
+        --endpoint Azure `
+        --repository Azure/$(RepositoryName) `
+        --convention $(PipelineConvention) `
+        --agentpool Hosted `
+        --branch refs/heads/$(Branch) `
+        --debug `
+        $(AdditionalOptions)
     displayName: 'Generate pipeline'
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -134,7 +134,7 @@ jobs:
         --agentpool Hosted `
         --branch refs/heads/$(DefaultBranch) `
         --set-managed-variables `
-        --debug `
+        --debug
     displayName: 'Generate public pipelines for: $(RepositoryName)'
 
   - task: AzureCLI@2
@@ -224,23 +224,3 @@ jobs:
     displayName: 'Generate weekly unified test pipelines (multi-cloud) for: $(RepositoryName)'
     condition: and(succeeded(), ne(variables['GenerateUnifiedWeekly'],''))
 
-  # - task: AzureCLI@2
-  #   inputs:
-  #     azureSubscription: 'opensource-api-connection'
-  #     scriptType: pscore
-  #     scriptLocation: inlineScript
-  #     inlineScript:
-  #       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-  #       --organization azure-sdk `
-  #       --project internal `
-  #       --prefix $(Prefix)-pr `
-  #       --devopspath "\$(Prefix)\pr" `
-  #       --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
-  #       --endpoint Azure `
-  #       --repository Azure/$(RepositoryName)-pr `
-  #       --convention ci `
-  #       --agentpool Hosted `
-  #       --branch refs/heads/ $(DefaultBranch) `
-  #       --set-managed-variables `
-  #       --debug
-  #   displayName: 'Generate internal pipelines for: $(RepositoryName)-pr'

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -116,114 +116,131 @@ jobs:
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     parameters:
       WorkingDirectory: $(Pipeline.Workspace)/$(RepositoryName)
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization azure-sdk
-      --project public
-      --prefix $(Prefix)
-      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention ci
-      --agentpool Hosted
-      --branch refs/heads/$(DefaultBranch)
-      --set-managed-variables
-      --patvar PATVAR
-      --debug
+
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: 'opensource-api-connection'
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript:
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+        --organization azure-sdk `
+        --project public `
+        --prefix $(Prefix) `
+        --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+        --endpoint Azure `
+        --repository Azure/$(RepositoryName) `
+        --convention ci `
+        --agentpool Hosted `
+        --branch refs/heads/$(DefaultBranch) `
+        --set-managed-variables `
+        --debug `
     displayName: 'Generate public pipelines for: $(RepositoryName)'
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization azure-sdk
-      --project internal
-      --prefix $(Prefix)
-      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention up
-      --agentpool Hosted
-      --branch refs/heads/$(DefaultBranch)
-      --set-managed-variables
-      --patvar PATVAR
-      --debug
-      --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
+
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: 'opensource-api-connection'
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript:
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+        --organization azure-sdk `
+        --project internal `
+        --prefix $(Prefix) `
+        --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+        --endpoint Azure `
+        --repository Azure/$(RepositoryName) `
+        --convention up `
+        --agentpool Hosted `
+        --branch refs/heads/$(DefaultBranch) `
+        --set-managed-variables `
+        --debug `
+        --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
     displayName: 'Generate internal pipelines for: $(RepositoryName)'
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization azure-sdk
-      --project internal
-      --prefix $(Prefix)
-      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention tests
-      --agentpool Hosted
-      --branch refs/heads/$(DefaultBranch)
-      --set-managed-variables
-      --patvar PATVAR
-      --debug
-      --variablegroups $(TestVariableGroups)
+
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: 'opensource-api-connection'
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript:
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+        --organization azure-sdk `
+        --project internal `
+        --prefix $(Prefix) `
+        --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+        --endpoint Azure `
+        --repository Azure/$(RepositoryName) `
+        --convention tests `
+        --agentpool Hosted `
+        --branch refs/heads/$(DefaultBranch) `
+        --set-managed-variables `
+        --debug `
+        --variablegroups $(TestVariableGroups)
     displayName: 'Generate test pipelines for: $(RepositoryName)'
     condition: and(succeeded(), ne(variables['TestVariableGroups'],''))
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization azure-sdk
-      --project internal
-      --prefix $(Prefix)
-      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention testsweekly
-      --agentpool Hosted
-      --branch refs/heads/$(DefaultBranch)
-      --set-managed-variables
-      --patvar PATVAR
-      --debug
-      --variablegroups $(TestVariableGroups)
+
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: 'opensource-api-connection'
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript:
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+        --organization azure-sdk `
+        --project internal `
+        --prefix $(Prefix) `
+        --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+        --endpoint Azure `
+        --repository Azure/$(RepositoryName) `
+        --convention testsweekly `
+        --agentpool Hosted `
+        --branch refs/heads/$(DefaultBranch) `
+        --set-managed-variables `
+        --debug `
+        --variablegroups $(TestVariableGroups)
     displayName: 'Generate weekly test pipelines (multi-cloud) for: $(RepositoryName)'
     condition: and(succeeded(), ne(variables['TestVariableGroups'],''))
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
-  - script: >
-      $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-      --organization azure-sdk
-      --project internal
-      --prefix $(Prefix)
-      --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-      --endpoint Azure
-      --repository Azure/$(RepositoryName)
-      --convention upweekly
-      --agentpool Hosted
-      --branch refs/heads/$(DefaultBranch)
-      --set-managed-variables
-      --patvar PATVAR
-      --debug
-      --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
+
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: 'opensource-api-connection'
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript:
+        $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+        --organization azure-sdk `
+        --project internal `
+        --prefix $(Prefix) `
+        --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+        --endpoint Azure `
+        --repository Azure/$(RepositoryName) `
+        --convention upweekly `
+        --agentpool Hosted `
+        --branch refs/heads/$(DefaultBranch) `
+        --set-managed-variables `
+        --debug `
+        --variablegroups $(InternalVariableGroups) $(TestVariableGroups)
     displayName: 'Generate weekly unified test pipelines (multi-cloud) for: $(RepositoryName)'
     condition: and(succeeded(), ne(variables['GenerateUnifiedWeekly'],''))
-    env:
-      PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)
 
-  # - script: >
-  #     $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
-  #     --organization azure-sdk
-  #     --project internal
-  #     --prefix $(Prefix)-pr
-  #     --devopspath "\$(Prefix)\pr"
-  #     --path $(Pipeline.Workspace)/$(RepositoryName)/sdk
-  #     --endpoint Azure
-  #     --repository Azure/$(RepositoryName)-pr
-  #     --convention ci
-  #     --agentpool Hosted
-  #     --branch refs/heads/ $(DefaultBranch)
-  #     --set-managed-variables
-  #     --patvar PATVAR
-  #     --debug
+  # - task: AzureCLI@2
+  #   inputs:
+  #     azureSubscription: 'opensource-api-connection'
+  #     scriptType: pscore
+  #     scriptLocation: inlineScript
+  #     inlineScript:
+  #       $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
+  #       --organization azure-sdk `
+  #       --project internal `
+  #       --prefix $(Prefix)-pr `
+  #       --devopspath "\$(Prefix)\pr" `
+  #       --path $(Pipeline.Workspace)/$(RepositoryName)/sdk `
+  #       --endpoint Azure `
+  #       --repository Azure/$(RepositoryName)-pr `
+  #       --convention ci `
+  #       --agentpool Hosted `
+  #       --branch refs/heads/ $(DefaultBranch) `
+  #       --set-managed-variables `
+  #       --debug
   #   displayName: 'Generate internal pipelines for: $(RepositoryName)-pr'
-  #   env:
-  #     PATVAR: $(azuresdk-azure-sdk-devops-pipeline-generation-pat)


### PR DESCRIPTION
This is the second PR, the one that removes the usage of azuresdk-azure-sdk-devops-pipeline-generation-pat. 

Note: As of right now, this PR is incomplete. This PR relies on another [PR](https://github.com/Azure/azure-sdk-tools/pull/8369) being merged, publishing a new version of the pipeline-generator and the version of [install-pipeline-generation.yml](https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/pipelines/templates/steps/install-pipeline-generation.yml) being updated to the published version. That needs to be part of this PR and will be updated once the other one is removed.