### PR TITLE
Restrict live test storage account access to client IP

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -262,7 +262,7 @@ function MergeHashes([hashtable] $source, [psvariable] $dest)
 function BuildBicepFile([System.IO.FileSystemInfo] $file)
 {
     if (!(Get-Command bicep -ErrorAction Ignore)) {
-        Write-Error "A bicep file was found at '$($file.FullName)' but the Azure Bicep CLI is not installed. See https://aka.ms/install-bicep-pwsh"
+        Write-Error "A bicep file was found at '$($file.FullName)' but the Azure Bicep CLI is not installed. See aka.ms/bicep-install"
         throw
     }
 
@@ -758,6 +758,7 @@ try {
     if ($TestApplicationSecret -and $ServicePrincipalAuth) {
         $templateParameters.Add('testApplicationSecret', $TestApplicationSecret)
     }
+    # Only add subnets when running in an azure pipeline context
     if ($CI -and $Environment -eq 'AzureCloud') {
         $templateParameters.Add('azsdkPipelineSubnetList', $azsdkPipelineSubnets)
     }
@@ -838,6 +839,28 @@ try {
                                                                 -templateFile $templateFile `
                                                                 -environmentVariables $EnvironmentVariables
 
+        $storageAccounts = Retry { Get-AzResource -ResourceGroupName $ResourceGroupName -ResourceType "Microsoft.Storage/storageAccounts" }
+        # Add client IP to storage account when running as local user. Pipeline's have their own vnet with access
+        if ($storageAccounts) {
+            foreach ($account in $storageAccounts) {
+                $rules = Get-AzStorageAccountNetworkRuleSet -ResourceGroupName $ResourceGroupName -AccountName $account.Name
+                if ($rules -and $rules.DefaultAction -eq "Allow") {
+                    Write-Host "Restricting network rules in storage account '$($account.Name)' to deny access by default"
+                    Retry { Update-AzStorageAccountNetworkRuleSet -ResourceGroupName $ResourceGroupName -Name $account.Name -DefaultAction Deny }
+                    if ($CI) {
+                        Write-Host "Enabling access to '$($account.Name)' from pipeline subnets"
+                        foreach ($subnet in $azsdkPipelineSubnets) {
+                            Retry { Add-AzStorageAccountNetworkRule -ResourceGroupName $ResourceGroupName -Name $account.Name -VirtualNetworkResourceId $subnet }
+                        }
+                    } else {
+                        Write-Host "Enabling access to '$($account.Name)' from client IP"
+                        $clientIp ??= Retry { Invoke-RestMethod -Uri 'https://icanhazip.com/' }  # cloudflare owned ip site
+                        Retry { Add-AzStorageAccountNetworkRule -ResourceGroupName $ResourceGroupName -Name $account.Name -IPAddressOrRange $clientIp | Out-Null }
+                    }
+                }
+            }
+        }
+
         $postDeploymentScript = $templateFile.originalFilePath | Split-Path | Join-Path -ChildPath "$ResourceType-resources-post.ps1"
         if (Test-Path $postDeploymentScript) {
             Log "Invoking post-deployment script '$postDeploymentScript'"
@@ -852,7 +875,6 @@ try {
         Write-Host "Deleting ARM deployment as it may contain secrets. Deployed resources will not be affected."
         $null = $deployment | Remove-AzResourceGroupDeployment
     }
-
 } finally {
     $exitActions.Invoke()
 }

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -112,7 +112,11 @@ $azsdkPipelineSubnets = @(
     ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-2004-general"),
     ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-2204-general"),
     ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2019-general"),
-    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2022-general")
+    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2022-general"),
+    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-1804-storage"),
+    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-2004-storage"),
+    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2019-storage"),
+    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2022-storage")
 )
 
 if (!$ServicePrincipalAuth) {

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -106,18 +106,27 @@ param (
 
 . $PSScriptRoot/SubConfig-Helpers.ps1
 
-$azsdkPipelineVnet = "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azsdk-pools/providers/Microsoft.Network/virtualNetworks/azsdk-pipeline-vnet-wus"
-$azsdkPipelineSubnets = @(
-    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-1804-general"),
-    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-2004-general"),
-    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-2204-general"),
-    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2019-general"),
-    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2022-general"),
-    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-1804-storage"),
-    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-2004-storage"),
-    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2019-storage"),
-    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2022-storage")
-)
+$azsdkPipelineVnetWestUS = '/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azsdk-pools/providers/Microsoft.Network/virtualNetworks/azsdk-pipeline-vnet-wus'
+$azsdkPipelineVnetCanadaCentral = '/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azsdk-pools/providers/Microsoft.Network/virtualNetworks/azsdk-pipeline-vnet-cnc'
+$azsdkPipelineSubnetMap = @{
+    'azsdk-pool-mms-ubuntu-1804-general' = ($azsdkPipelineVnetWestUS + '/subnets/pipeline-subnet-ubuntu-1804-general')
+    'azsdk-pool-mms-ubuntu-2004-general' = ($azsdkPipelineVnetWestUS + '/subnets/pipeline-subnet-ubuntu-2004-general')
+    'azsdk-pool-mms-ubuntu-2204-general' = ($azsdkPipelineVnetWestUS + '/subnets/pipeline-subnet-ubuntu-2204-general')
+    'azsdk-pool-mms-win-2019-general' = ($azsdkPipelineVnetWestUS + '/subnets/pipeline-subnet-win-2019-general')
+    'azsdk-pool-mms-win-2022-general' = ($azsdkPipelineVnetWestUS + '/subnets/pipeline-subnet-win-2022-general')
+    'azsdk-pool-mms-ubuntu-1804-storage' = ($azsdkPipelineVnetCanadaCentral + '/subnets/pipeline-subnet-ubuntu-1804-storage')
+    'azsdk-pool-mms-ubuntu-2004-storage' = ($azsdkPipelineVnetCanadaCentral + '/subnets/pipeline-subnet-ubuntu-2004-storage')
+    'azsdk-pool-mms-win-2019-storage' = ($azsdkPipelineVnetCanadaCentral + '/subnets/pipeline-subnet-win-2019-storage')
+    'azsdk-pool-mms-win-2022-storage' = ($azsdkPipelineVnetCanadaCentral + '/subnets/pipeline-subnet-win-2022-storage')
+    'Azure Pipelines' = ''
+}
+
+$poolSubnet = ''
+if ($env:Pool) {
+  $poolSubnet = $azsdkPipelineSubnetMap[$env:Pool]
+} else {
+  Write-Warning "Pool environment variable is not defined! Subnet allowlisting will not work and live test resources may be non-compliant."
+}
 
 if (!$ServicePrincipalAuth) {
     # Clear secrets if not using Service Principal auth. This prevents secrets
@@ -763,8 +772,8 @@ try {
         $templateParameters.Add('testApplicationSecret', $TestApplicationSecret)
     }
     # Only add subnets when running in an azure pipeline context
-    if ($CI -and $Environment -eq 'AzureCloud') {
-        $templateParameters.Add('azsdkPipelineSubnetList', $azsdkPipelineSubnets)
+    if ($CI -and $Environment -eq 'AzureCloud' -and $poolSubnet) {
+        $templateParameters.Add('azsdkPipelineSubnetList', @($poolSubnet))
     }
 
     $defaultCloudParameters = LoadCloudConfig $Environment
@@ -851,12 +860,10 @@ try {
                 if ($rules -and $rules.DefaultAction -eq "Allow") {
                     Write-Host "Restricting network rules in storage account '$($account.Name)' to deny access by default"
                     Retry { Update-AzStorageAccountNetworkRuleSet -ResourceGroupName $ResourceGroupName -Name $account.Name -DefaultAction Deny }
-                    if ($CI) {
-                        Write-Host "Enabling access to '$($account.Name)' from pipeline subnets"
-                        foreach ($subnet in $azsdkPipelineSubnets) {
-                            Retry { Add-AzStorageAccountNetworkRule -ResourceGroupName $ResourceGroupName -Name $account.Name -VirtualNetworkResourceId $subnet }
-                        }
-                    } else {
+                    if ($CI -and $poolSubnet) {
+                        Write-Host "Enabling access to '$($account.Name)' from pipeline subnet $poolSubnet"
+                        Retry { Add-AzStorageAccountNetworkRule -ResourceGroupName $ResourceGroupName -Name $account.Name -VirtualNetworkResourceId $poolSubnet }
+                    } elseif (!$CI -or $env:Pool -eq 'Azure Pipelines') {
                         Write-Host "Enabling access to '$($account.Name)' from client IP"
                         $clientIp ??= Retry { Invoke-RestMethod -Uri 'https://icanhazip.com/' }  # cloudflare owned ip site
                         Retry { Add-AzStorageAccountNetworkRule -ResourceGroupName $ResourceGroupName -Name $account.Name -IPAddressOrRange $clientIp | Out-Null }

--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -14,6 +14,25 @@ parameters:
     default: null
 
 steps:
+  - task: AzurePowerShell@5
+    displayName: Set Pipeline Subnet Info
+    env: ${{ parameters.EnvVars }}
+    inputs:
+      azureSubscription: azure-sdk-tests
+      azurePowerShellVersion: LatestVersion
+      pwsh: true
+      ScriptType: InlineScript
+      Inline: |
+        Set-AzContext 'Azure SDK Engineering System'
+        if ($env:Pool -eq 'Azure Pipelines') {
+          Write-Host "Skipping pool subnet lookup when running on an Azure Pipelines hosted pool"
+          Write-Host "##vso[task.setvariable variable=PoolSubnet;]"
+          exit 0
+        }
+        $poolSubnet = (Get-AzResource -ResourceGroupName azsdk-pools -Name $env:Pool -ExpandProperties).Properties.networkProfile.subnetId
+        Write-Host "Setting pipeline subnet env variable PoolSubnet to '$poolSubnet'"
+        Write-Host "##vso[task.setvariable variable=PoolSubnet;]$poolSubnet"
+
   - pwsh: |
       . ./eng/common/TestResources/SubConfig-Helpers.ps1
 

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -46,6 +46,7 @@ steps:
       displayName: Deploy test resources
       env:
         TEMP: $(Agent.TempDirectory)
+        PoolSubnet: $(PoolSubnet)
         ${{ insert }}: ${{ parameters.EnvVars }}
       inputs:
         azureSubscription: ${{ parameters.ServiceConnection }}
@@ -98,4 +99,5 @@ steps:
       displayName: Deploy test resources
       env:
         TEMP: $(Agent.TempDirectory)
+        PoolSubnet: $(PoolSubnet)
         ${{ insert }}: ${{ parameters.EnvVars }}

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -68,6 +68,7 @@ steps:
             -DeleteAfterHours '${{ parameters.DeleteAfterHours }}' `
             @subscriptionConfiguration `
             -AdditionalParameters ${{ parameters.ArmTemplateParameters }} `
+            -AllowIpRanges ('$(azsdk-corp-net-ip-ranges)' -split ',') `
             -CI `
             -Force `
             -Verbose | Out-Null
@@ -89,6 +90,7 @@ steps:
           -DeleteAfterHours '${{ parameters.DeleteAfterHours }}' `
           @subscriptionConfiguration `
           -AdditionalParameters ${{ parameters.ArmTemplateParameters }} `
+          -AllowIpRanges ('$(azsdk-corp-net-ip-ranges)' -split ',') `
           -CI `
           -ServicePrincipalAuth `
           -Force `


### PR DESCRIPTION
Not quite sure about the ordering here, if we want to set networks rules before or after post-script/deployment removal or not.

This adds a step to our deployment script that sets any deployed storage accounts to a network deny state, but punches a hole through for the client's IP. A medium term solution until better ones come online (reach out for details).