### PR TITLE
Use DOTNET_ROLL_FORWARD: 'Major' for test-proxy

### DIFF
--- a/eng/common/testproxy/test-proxy-tool.yml
+++ b/eng/common/testproxy/test-proxy-tool.yml
@@ -60,6 +60,8 @@ steps:
         Write-Host "##vso[task.setvariable variable=PROXY_PID]$($Process.Id)"
       displayName: 'Run the testproxy - windows'
       condition: and(succeeded(), eq(variables['Agent.OS'],'Windows_NT'), ${{ parameters.condition }})
+      env:
+        DOTNET_ROLL_FORWARD: 'Major'
 
     # nohup does NOT continue beyond the current session if you use it within powershell
     - bash: |
@@ -70,6 +72,8 @@ steps:
       displayName: "Run the testproxy - linux/mac"
       condition: and(succeeded(), ne(variables['Agent.OS'],'Windows_NT'), ${{ parameters.condition }})
       workingDirectory: "${{ parameters.rootFolder }}"
+      env:
+        DOTNET_ROLL_FORWARD: 'Major'
 
     - pwsh: |
         for ($i = 0; $i -lt 10; $i++) {


### PR DESCRIPTION
The macos-14 agent does not currently include .NET 6.x: https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md

> .NET Core SDK: 7.0.102, 7.0.202, 7.0.306, 7.0.409, 8.0.101, 8.0.204, 8.0.300

Setting this variable ensures that test-proxy will run in environments which have later major versions of .NET Core. 