### PR TITLE
Add `sv` to `SAS` URL default sanitizer

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
@@ -101,7 +101,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                     "ACS Identity leverages these strings to store identity information."
                 ),
                 new RegisteredSanitizer(
-                    new GeneralRegexSanitizer(regex: "(?:[?&](sig)=)(?<secret>[^&\\\"\\s\\n,\\\\]+)", groupForReplace: "secret"),
+                    new GeneralRegexSanitizer(regex: "(?:[?&](sig|sv)=)(?<secret>[^&\\\"\\s\\n,\\\\]+)", groupForReplace: "secret"),
                     "AZSDK1007",
                     "Common SAS URL Sanitizer. Applies to all headers, URIs, and text bodies."
                 ),


### PR DESCRIPTION
See title

@mccoyp I dunno if this is a good plan, but I can't disagree that this will help folks a lot. Not a secret, and traditionally I wouldn't want to sanitize it by default....but it's part of a SAS url. It shouldn't break anything.