### PR TITLE
Plumb env vars through deploy test resources

### DIFF
--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -108,5 +108,4 @@ steps:
       displayName: Deploy test resources
       env:
         TEMP: $(Agent.TempDirectory)
-        ${{ each var in parameters.EnvVars }}:
-          ${{ var.key }}: ${{ var.value }}
+        ${{ insert }}: ${{ parameters.EnvVars }}

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -3,6 +3,7 @@ parameters:
   ArmTemplateParameters: '@{}'
   DeleteAfterHours: 8
   Location: ''
+  EnvVars: {}
   SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
   ServiceConnection: not-specified
   ResourceType: test
@@ -47,6 +48,8 @@ steps:
       displayName: Deploy test resources
       env:
         TEMP: $(Agent.TempDirectory)
+        ${{ each var in parameters.EnvVars }}:
+          ${{ var.key }}: ${{ var.value }}
       inputs:
         azureSubscription: ${{ parameters.ServiceConnection }}
         azurePowerShellVersion: LatestVersion
@@ -106,3 +109,5 @@ steps:
       displayName: Deploy test resources
       env:
         TEMP: $(Agent.TempDirectory)
+        ${{ each var in parameters.EnvVars }}:
+          ${{ var.key }}: ${{ var.value }}

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -48,8 +48,7 @@ steps:
       displayName: Deploy test resources
       env:
         TEMP: $(Agent.TempDirectory)
-        ${{ each var in parameters.EnvVars }}:
-          ${{ var.key }}: ${{ var.value }}
+        ${{ insert }}: ${{ parameters.EnvVars }}
       inputs:
         azureSubscription: ${{ parameters.ServiceConnection }}
         azurePowerShellVersion: LatestVersion

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -6,6 +6,7 @@ parameters:
   SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
   ServiceConnection: not-specified
   ResourceType: test
+  EnvVars: {}
   UseFederatedAuth: false
   SubscriptionConfigurationFilePath: ''
 
@@ -29,6 +30,7 @@ steps:
       displayName: Remove test resources
       condition: and(eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'), ne(variables['Skip.RemoveTestResources'], 'true'))
       continueOnError: true
+      env: ${{ parameters.EnvVars }}
       inputs:
         azureSubscription: ${{ parameters.ServiceConnection }}
         azurePowerShellVersion: LatestVersion
@@ -78,3 +80,4 @@ steps:
       displayName: Remove test resources
       condition: and(eq(variables['CI_HAS_DEPLOYED_RESOURCES'], 'true'), ne(variables['Skip.RemoveTestResources'], 'true'))
       continueOnError: true
+      env: ${{ parameters.EnvVars }}


### PR DESCRIPTION
This will allow us to pass OIDC token env and possibly other values through to deploy pre/post scripts.