### PR TITLE
Removal of the devops release PAT

### DIFF
--- a/eng/common/pipelines/templates/steps/validate-all-packages.yml
+++ b/eng/common/pipelines/templates/steps/validate-all-packages.yml
@@ -10,20 +10,23 @@ steps:
       displayName: "Set as release build"
       condition: and(succeeded(), eq(variables['SetAsReleaseBuild'], ''))
 
-    - task: Powershell@2
+    - task: AzureCLI@2
       inputs:
-        filePath: $(Build.SourcesDirectory)/eng/common/scripts/Validate-All-Packages.ps1
-        arguments: >
-          -ArtifactList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json | Select-Object Name)
-          -ArtifactPath ${{ parameters.ArtifactPath }}
-          -RepoRoot $(Build.SourcesDirectory)
-          -APIKey $(azuresdk-apiview-apikey)
-          -ConfigFileDir '${{ parameters.ConfigFileDir }}'
-          -BuildDefinition $(System.CollectionUri)$(System.TeamProject)/_build?definitionId=$(System.DefinitionId)
-          -PipelineUrl $(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId)
-          -Devops_pat '$(azuresdk-azure-sdk-devops-release-work-item-pat)'
-          -IsReleaseBuild $$(SetAsReleaseBuild)
-        pwsh: true
+        azureSubscription: opensource-api-connection
+        scriptType: pscore
+        scriptLocation: inlineScript
+        inlineScript: |
+          $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
+          $(Build.SourcesDirectory)/eng/common/scripts/Validate-All-Packages.ps1 `
+            -ArtifactList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json | Select-Object Name) `
+            -ArtifactPath ${{ parameters.ArtifactPath }} `
+            -RepoRoot $(Build.SourcesDirectory) `
+            -APIKey $(azuresdk-apiview-apikey) `
+            -ConfigFileDir '${{ parameters.ConfigFileDir }}' `
+            -BuildDefinition $(System.CollectionUri)$(System.TeamProject)/_build?definitionId=$(System.DefinitionId) `
+            -PipelineUrl $(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId) `
+            -AccessToken $accessToken `
+            -IsReleaseBuild $$(SetAsReleaseBuild)
         workingDirectory: $(Pipeline.Workspace)
       displayName: Validate packages and update work items
       continueOnError: true

--- a/eng/common/pipelines/templates/steps/validate-all-packages.yml
+++ b/eng/common/pipelines/templates/steps/validate-all-packages.yml
@@ -16,7 +16,6 @@ steps:
         scriptType: pscore
         scriptLocation: inlineScript
         inlineScript: |
-          $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
           $(Build.SourcesDirectory)/eng/common/scripts/Validate-All-Packages.ps1 `
             -ArtifactList ('${{ convertToJson(parameters.Artifacts) }}' | ConvertFrom-Json | Select-Object Name) `
             -ArtifactPath ${{ parameters.ArtifactPath }} `
@@ -25,7 +24,6 @@ steps:
             -ConfigFileDir '${{ parameters.ConfigFileDir }}' `
             -BuildDefinition $(System.CollectionUri)$(System.TeamProject)/_build?definitionId=$(System.DefinitionId) `
             -PipelineUrl $(System.CollectionUri)$(System.TeamProject)/_build/results?buildId=$(Build.BuildId) `
-            -AccessToken $accessToken `
             -IsReleaseBuild $$(SetAsReleaseBuild)
         workingDirectory: $(Pipeline.Workspace)
       displayName: Validate packages and update work items

--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -9,7 +9,7 @@ function Get-DevOpsRestHeaders()
   $headerAccessToken = (az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv)
 
   if ([System.String]::IsNullOrEmpty($headerAccessToken)) {
-    throw "Unable to create the DevOpsRestHeader due to access token being null or empy. The calling script needs to be pass an the accessToken value OR the calling script needs to be run in an azure authenticated environment."
+    throw "Unable to create the DevOpsRestHeader due to access token being null or empty. The caller needs to be logged in with az login to an account with enough permissions to edit work items in the azure-sdk Release team project."
   }
 
   $headers = @{ Authorization = "Bearer $headerAccessToken" }

--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -5,17 +5,8 @@ $ReleaseDevOpsCommonParametersWithProject = $ReleaseDevOpsCommonParameters + @("
 
 function Get-DevOpsRestHeaders()
 {
-  $headers = $null
-  $headerAccessToken = $null
-  if (Get-Variable -Name "accessToken" -ValueOnly -ErrorAction "Ignore")
-  {
-    $headerAccessToken = $accessToken
-  }
-  else
-  {
-    # Get a temp access token from the logged in az cli user for azure devops resource
-    $headerAccessToken = (az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv)
-  }
+  # Get a temp access token from the logged in az cli user for azure devops resource
+  $headerAccessToken = (az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv)
 
   if ([System.String]::IsNullOrEmpty($headerAccessToken)) {
     throw "Unable to create the DevOpsRestHeader due to access token being null or empy. The calling script needs to be pass an the accessToken value OR the calling script needs to be run in an azure authenticated environment."

--- a/eng/common/scripts/Update-DevOps-Release-WorkItem.ps1
+++ b/eng/common/scripts/Update-DevOps-Release-WorkItem.ps1
@@ -15,7 +15,7 @@ param(
   [string]$packageNewLibrary = "true",
   [string]$relatedWorkItemId = $null,
   [string]$tag = $null,
-  [string]$devops_pat = $env:DEVOPS_PAT,
+  [string]$accessToken = $null,
   [bool]$inRelease = $true
 )
 #Requires -Version 6.0
@@ -29,16 +29,12 @@ if (!(Get-Command az -ErrorAction SilentlyContinue)) {
 . (Join-Path $PSScriptRoot SemVer.ps1)
 . (Join-Path $PSScriptRoot Helpers DevOps-WorkItem-Helpers.ps1)
 
-if (!$devops_pat) {
+if (!$accessToken) {
   az account show *> $null
   if (!$?) {
     Write-Host 'Running az login...'
     az login *> $null
   }
-}
-else {
-  # Login using PAT
-  LoginToAzureDevops $devops_pat
 }
 
 az extension show -n azure-devops *> $null

--- a/eng/common/scripts/Update-DevOps-Release-WorkItem.ps1
+++ b/eng/common/scripts/Update-DevOps-Release-WorkItem.ps1
@@ -15,7 +15,6 @@ param(
   [string]$packageNewLibrary = "true",
   [string]$relatedWorkItemId = $null,
   [string]$tag = $null,
-  [string]$accessToken = $null,
   [bool]$inRelease = $true
 )
 #Requires -Version 6.0
@@ -29,12 +28,10 @@ if (!(Get-Command az -ErrorAction SilentlyContinue)) {
 . (Join-Path $PSScriptRoot SemVer.ps1)
 . (Join-Path $PSScriptRoot Helpers DevOps-WorkItem-Helpers.ps1)
 
-if (!$accessToken) {
-  az account show *> $null
-  if (!$?) {
-    Write-Host 'Running az login...'
-    az login *> $null
-  }
+az account show *> $null
+if (!$?) {
+  Write-Host 'Running az login...'
+  az login *> $null
 }
 
 az extension show -n azure-devops *> $null

--- a/eng/common/scripts/Validate-All-Packages.ps1
+++ b/eng/common/scripts/Validate-All-Packages.ps1
@@ -12,7 +12,7 @@ Param (
   [string]$BuildDefinition,
   [string]$PipelineUrl,
   [string]$APIViewUri  = "https://apiview.dev/AutoReview/GetReviewStatus",
-  [string]$Devops_pat = $env:DEVOPS_PAT,
+  [string]$AccessToken = $null,
   [bool] $IsReleaseBuild = $false
 )
 
@@ -34,7 +34,7 @@ function ProcessPackage($PackageName, $ConfigFileDir)
         -BuildDefinition $BuildDefinition `
         -PipelineUrl $PipelineUrl `
         -ConfigFileDir $ConfigFileDir `
-        -Devops_pat $Devops_pat
+        -AccessToken $AccessToken
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to validate package $PackageName"
         exit 1

--- a/eng/common/scripts/Validate-All-Packages.ps1
+++ b/eng/common/scripts/Validate-All-Packages.ps1
@@ -12,7 +12,6 @@ Param (
   [string]$BuildDefinition,
   [string]$PipelineUrl,
   [string]$APIViewUri  = "https://apiview.dev/AutoReview/GetReviewStatus",
-  [string]$AccessToken = $null,
   [bool] $IsReleaseBuild = $false
 )
 
@@ -33,8 +32,7 @@ function ProcessPackage($PackageName, $ConfigFileDir)
         -APIKey $APIKey `
         -BuildDefinition $BuildDefinition `
         -PipelineUrl $PipelineUrl `
-        -ConfigFileDir $ConfigFileDir `
-        -AccessToken $AccessToken
+        -ConfigFileDir $ConfigFileDir
     if ($LASTEXITCODE -ne 0) {
         Write-Error "Failed to validate package $PackageName"
         exit 1

--- a/eng/common/scripts/Validate-Package.ps1
+++ b/eng/common/scripts/Validate-Package.ps1
@@ -15,7 +15,6 @@ param (
   [string] $BuildDefinition,
   [string] $PipelineUrl,
   [string] $APIViewUri,
-  [string] $AccessToken = $null,
   [bool] $IsReleaseBuild = $false
 )
 Set-StrictMode -Version 3
@@ -24,12 +23,10 @@ Set-StrictMode -Version 3
 . ${PSScriptRoot}\Helpers\ApiView-Helpers.ps1
 . ${PSScriptRoot}\Helpers\DevOps-WorkItem-Helpers.ps1
 
-if (!$AccessToken) {
-  az account show *> $null
-  if (!$?) {
-    Write-Host 'Running az login...'
-    az login *> $null
-  }
+az account show *> $null
+if (!$?) {
+Write-Host 'Running az login...'
+az login *> $null
 }
 
 az extension show -n azure-devops *> $null
@@ -171,8 +168,7 @@ function CreateUpdatePackageWorkItem($pkgInfo)
         -packageNewLibrary $pkgInfo.IsNewSDK `
         -serviceName "unknown" `
         -packageDisplayName "unknown" `
-        -inRelease $IsReleaseBuild `
-        -accessToken $AccessToken
+        -inRelease $IsReleaseBuild
 
     if ($LASTEXITCODE -ne 0)
     {

--- a/eng/common/scripts/Validate-Package.ps1
+++ b/eng/common/scripts/Validate-Package.ps1
@@ -25,8 +25,8 @@ Set-StrictMode -Version 3
 
 az account show *> $null
 if (!$?) {
-Write-Host 'Running az login...'
-az login *> $null
+  Write-Host 'Running az login...'
+  az login *> $null
 }
 
 az extension show -n azure-devops *> $null

--- a/eng/common/scripts/Validate-Package.ps1
+++ b/eng/common/scripts/Validate-Package.ps1
@@ -2,20 +2,20 @@
 
 [CmdletBinding()]
 param (
-  [Parameter(Mandatory = $true)]  
+  [Parameter(Mandatory = $true)]
   [string] $PackageName,
-  [Parameter(Mandatory = $true)] 
+  [Parameter(Mandatory = $true)]
   [string] $ArtifactPath,
   [Parameter(Mandatory=$True)]
   [string] $RepoRoot,
   [Parameter(Mandatory=$True)]
-  [string] $APIKey,  
+  [string] $APIKey,
   [Parameter(Mandatory=$True)]
   [string] $ConfigFileDir,
   [string] $BuildDefinition,
   [string] $PipelineUrl,
   [string] $APIViewUri,
-  [string] $Devops_pat = $env:DEVOPS_PAT,
+  [string] $AccessToken = $null,
   [bool] $IsReleaseBuild = $false
 )
 Set-StrictMode -Version 3
@@ -24,16 +24,12 @@ Set-StrictMode -Version 3
 . ${PSScriptRoot}\Helpers\ApiView-Helpers.ps1
 . ${PSScriptRoot}\Helpers\DevOps-WorkItem-Helpers.ps1
 
-if (!$Devops_pat) {
+if (!$AccessToken) {
   az account show *> $null
   if (!$?) {
     Write-Host 'Running az login...'
     az login *> $null
   }
-}
-else {
-  # Login using PAT
-  LoginToAzureDevops $Devops_pat
 }
 
 az extension show -n azure-devops *> $null
@@ -57,12 +53,12 @@ function ValidateChangeLog($changeLogPath, $versionString, $validationStatus)
             Message = ""
         }
         $changeLogFullPath = Join-Path $RepoRoot $changeLogPath
-        Write-Host "Path to change log: [$changeLogFullPath]"        
+        Write-Host "Path to change log: [$changeLogFullPath]"
         if (Test-Path $changeLogFullPath)
         {
             Confirm-ChangeLogEntry -ChangeLogLocation $changeLogFullPath -VersionString $versionString -ForRelease $true -ChangeLogStatus $ChangeLogStatus -SuppressErrors $true
             $validationStatus.Status = if ($ChangeLogStatus.IsValid) { "Success" } else { "Failed" }
-            $validationStatus.Message = $ChangeLogStatus.Message 
+            $validationStatus.Message = $ChangeLogStatus.Message
         }
         else {
             $validationStatus.Status = "Failed"
@@ -83,7 +79,7 @@ function VerifyAPIReview($packageName, $packageVersion, $language)
     $APIReviewValidation = [PSCustomObject]@{
         Name = "API Review Approval"
         Status = "Pending"
-        Message = ""    
+        Message = ""
     }
     $PackageNameValidation = [PSCustomObject]@{
         Name = "Package Name Approval"
@@ -101,7 +97,7 @@ function VerifyAPIReview($packageName, $packageVersion, $language)
             IsApproved = $false
             Details = ""
         }
-        Write-Host "Checking API review status for package $packageName with version $packageVersion. language [$language]." 
+        Write-Host "Checking API review status for package $packageName with version $packageVersion. language [$language]."
         Check-ApiReviewStatus $packageName $packageVersion $language $APIViewUri $APIKey $apiStatus $packageNameStatus
 
         Write-Host "API review approval details: $($apiStatus.Details)"
@@ -132,14 +128,14 @@ function VerifyAPIReview($packageName, $packageVersion, $language)
 
 function IsVersionShipped($packageName, $packageVersion)
 {
-    # This function will decide if a package version is already shipped or not  
+    # This function will decide if a package version is already shipped or not
     Write-Host "Checking if a version is already shipped for package $packageName with version $packageVersion."
     $parsedNewVersion = [AzureEngSemanticVersion]::new($packageVersion)
     $versionMajorMinor = "" + $parsedNewVersion.Major + "." + $parsedNewVersion.Minor
     $workItem = FindPackageWorkItem -lang $LanguageDisplayName -packageName $packageName -version $versionMajorMinor -includeClosed $true -outputCommand $false
     if ($workItem)
     {
-        # Check if the package version is already shipped    
+        # Check if the package version is already shipped
         $shippedVersionSet = ParseVersionSetFromMDField $workItem.fields["Custom.ShippedPackages"]
         if ($shippedVersionSet.ContainsKey($packageVersion)) {
             return $true
@@ -163,8 +159,8 @@ function CreateUpdatePackageWorkItem($pkgInfo)
         $setReleaseState = $false
         $plannedDate = "unknown"
     }
-        
-    # Create or update package work item  
+
+    # Create or update package work item
     &$EngCommonScriptsDir/Update-DevOps-Release-WorkItem.ps1 `
         -language $LanguageDisplayName `
         -packageName $packageName `
@@ -176,8 +172,8 @@ function CreateUpdatePackageWorkItem($pkgInfo)
         -serviceName "unknown" `
         -packageDisplayName "unknown" `
         -inRelease $IsReleaseBuild `
-        -devops_pat $Devops_pat
-    
+        -accessToken $AccessToken
+
     if ($LASTEXITCODE -ne 0)
     {
         Write-Host "Update of the Devops Release WorkItem failed."
@@ -244,7 +240,7 @@ $updatedWi = CreateUpdatePackageWorkItem $pkgInfo
 # Update validation status in package work item
 if ($updatedWi) {
     Write-Host "Updating validation status in package work item."
-    $updatedWi = UpdateValidationStatus $pkgValidationDetails $BuildDefinition $PipelineUrl    
+    $updatedWi = UpdateValidationStatus $pkgValidationDetails $BuildDefinition $PipelineUrl
 }
 
 # Fail the build if any validation is not successful for a release build
@@ -254,7 +250,7 @@ Write-Host "Package Name status:" $apireviewDetails.PackageNameApproval.Status
 
 if ($IsReleaseBuild)
 {
-    if (!$updatedWi -or $changelogStatus.Status -ne "Success" -or $apireviewDetails.ApiviewApproval.Status -ne "Approved" -or $apireviewDetails.PackageNameApproval.Status -ne "Approved") {        
+    if (!$updatedWi -or $changelogStatus.Status -ne "Success" -or $apireviewDetails.ApiviewApproval.Status -ne "Approved" -or $apireviewDetails.PackageNameApproval.Status -ne "Approved") {
         Write-Error "At least one of the Validations above failed for package $pkgName with version $versionString."
         exit 1
     }

--- a/eng/pipelines/devops-create-package-workitem.yml
+++ b/eng/pipelines/devops-create-package-workitem.yml
@@ -45,19 +45,22 @@ parameters:
 steps:
 - checkout: self
 
-- task: PowerShell@2
+- task: AzureCLI@2
   displayName: Create Package Work Item
   inputs:
-    pwsh: true
-    filePath: $(Build.SourcesDirectory)/eng/scripts/Create-Package-WorkItem.ps1
-    arguments: >
-      -PackageLanguage "$(Language)"
-      -ServiceName "$(ServiceName)"
-      -PackageDisplayName "$(PackageDisplayName)"
-      -PackageName "$(PackageName)"
-      -PackageVersion "$(PackageVersion)"
-      -ReleaseDate "$(ReleaseDate)"
-      -RelatedWorkItemId "$(RelatedWorkItemId)"
-      -Tag "$(Tag)"
-      -WorkingDir "$(Pipeline.Workspace)"
-      -Devops_pat "$(azuresdk-azure-sdk-devops-release-work-item-pat)"
+    azureSubscription: opensource-api-connection
+    scriptType: pscore
+    scriptLocation: inlineScript
+    inlineScript: |
+      $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
+      $(Build.SourcesDirectory)/eng/scripts/Create-Package-WorkItem.ps1 `
+        -PackageLanguage "$(Language)" `
+        -ServiceName "$(ServiceName)" `
+        -PackageDisplayName "$(PackageDisplayName)" `
+        -PackageName "$(PackageName)" `
+        -PackageVersion "$(PackageVersion)" `
+        -ReleaseDate "$(ReleaseDate)" `
+        -RelatedWorkItemId "$(RelatedWorkItemId)" `
+        -Tag "$(Tag)" `
+        -WorkingDir "$(Pipeline.Workspace)" `
+        -AccessToken $accessToken

--- a/eng/pipelines/devops-create-package-workitem.yml
+++ b/eng/pipelines/devops-create-package-workitem.yml
@@ -52,7 +52,6 @@ steps:
     scriptType: pscore
     scriptLocation: inlineScript
     inlineScript: |
-      $accessToken = az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv
       $(Build.SourcesDirectory)/eng/scripts/Create-Package-WorkItem.ps1 `
         -PackageLanguage "$(Language)" `
         -ServiceName "$(ServiceName)" `
@@ -62,5 +61,4 @@ steps:
         -ReleaseDate "$(ReleaseDate)" `
         -RelatedWorkItemId "$(RelatedWorkItemId)" `
         -Tag "$(Tag)" `
-        -WorkingDir "$(Pipeline.Workspace)" `
-        -AccessToken $accessToken
+        -WorkingDir "$(Pipeline.Workspace)"

--- a/eng/scripts/Create-Package-WorkItem.ps1
+++ b/eng/scripts/Create-Package-WorkItem.ps1
@@ -16,7 +16,7 @@ param (
   [string]$Tag = "",
   [string]$WorkingDir = ".",
   [string]$PackageRootPath = "",
-  [string]$Devops_pat = $env:DEVOPS_PAT
+  [string]$AccessToken = $null
 )
 
 Set-StrictMode -Version 3
@@ -62,7 +62,7 @@ try
         exit 1
     }
 
-    # Create or update package work item  
+    # Create or update package work item
     &$EngCommonScriptsDir/Update-DevOps-Release-WorkItem.ps1 `
     -language $PackageLanguage `
     -packageName $PackageName `
@@ -75,7 +75,7 @@ try
     -packageDisplayName $PackageDisplayName `
     -relatedWorkItemId $RelatedWorkItemId `
     -tag $Tag `
-    -devops_pat $Devops_pat
+    -accessToken $AccessToken
 }
 finally {
     Pop-Location

--- a/eng/scripts/Create-Package-WorkItem.ps1
+++ b/eng/scripts/Create-Package-WorkItem.ps1
@@ -15,8 +15,7 @@ param (
   [string]$RelatedWorkItemId,
   [string]$Tag = "",
   [string]$WorkingDir = ".",
-  [string]$PackageRootPath = "",
-  [string]$AccessToken = $null
+  [string]$PackageRootPath = ""
 )
 
 Set-StrictMode -Version 3
@@ -74,8 +73,7 @@ try
     -serviceName $ServiceName `
     -packageDisplayName $PackageDisplayName `
     -relatedWorkItemId $RelatedWorkItemId `
-    -tag $Tag `
-    -accessToken $AccessToken
+    -tag $Tag
 }
 finally {
     Pop-Location


### PR DESCRIPTION
**This PR won't be merged until Thursday 6/13 as to not interfere with releases.**

These are the code changes to remove the devops release PAT. Use the AzureCLI task and get the token from azure. The other AZ commands that the scripts use should be fine with the azureSubscription. 

The LoginToAzureDevops function in DevOps-WorkItem-Helpers.ps1 is no longer necessary. The scenario for using this is that we passed the PAT to the pipeline and the variable was being used to log into azure. Being that this now needs to be run in an environment that's already logged into azure this function is completely moot.

The validate packages and update work items steps are part of the Build for Java, JS and NET. For Python these steps are in Analyze.

- [Java passes](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3856246&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=526cb169-4442-5378-373a-5a950554349c)
- [JS passes](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3856249&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=526cb169-4442-5378-373a-5a950554349c)
- [Net passes](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3856253&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=526cb169-4442-5378-373a-5a950554349c)
- [Python passes](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3856272&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=5265ed7f-6ddb-5fec-377e-87fe2884bb3c)