### PR TITLE
Pin pester version to 5.5.0

### DIFF
--- a/eng/common/pipelines/templates/steps/run-pester-tests.yml
+++ b/eng/common/pipelines/templates/steps/run-pester-tests.yml
@@ -12,8 +12,11 @@ parameters:
     default: ''
 
 steps:
+
+  # Lock Pester to 5.5.0. The reason being is that the signing of 5.6.0 is different and Windows complains.
+  # The tracking issue: https://github.com/Azure/azure-sdk-tools/issues/8395
   - pwsh: |
-       Install-Module -Name Pester -Force
+       Install-Module -Name Pester -RequiredVersion 5.5.0 -Force
     displayName: Install Pester
 
    # default test steps


### PR DESCRIPTION
The explanation of the problem is in the [issue tracking the unpinning once the version on Windows is 5.6.0 or higher](https://github.com/Azure/azure-sdk-tools/issues/8395).