### PR TITLE
Update language param name to avoid collision with common eng variable

### DIFF
--- a/eng/pipelines/devops-create-package-workitem.yml
+++ b/eng/pipelines/devops-create-package-workitem.yml
@@ -51,7 +51,7 @@ steps:
     pwsh: true
     filePath: $(Build.SourcesDirectory)/eng/scripts/Create-Package-WorkItem.ps1
     arguments: >
-      -Language "$(Language)"
+      -PackageLanguage "$(Language)"
       -ServiceName "$(ServiceName)"
       -PackageDisplayName "$(PackageDisplayName)"
       -PackageName "$(PackageName)"

--- a/eng/scripts/Create-Package-WorkItem.ps1
+++ b/eng/scripts/Create-Package-WorkItem.ps1
@@ -1,7 +1,7 @@
 [CmdletBinding()]
 param (
   [Parameter(Mandatory = $true)]
-  [string]$Language,
+  [string]$PackageLanguage,
   [Parameter(Mandatory = $true)]
   [string]$ServiceName,
   [Parameter(Mandatory = $true)]
@@ -38,10 +38,10 @@ function Get-Repo-Name($language)
 }
 
 
-$repoName = Get-Repo-Name $language
+$repoName = Get-Repo-Name $PackageLanguage
 if (!$repoName)
 {
-    Write-Error "GitHub repo name is not found for language [$language]. Failed to find package root path."
+    Write-Error "GitHub repo name is not found for language [$PackageLanguage]. Failed to find package root path."
     exit 1
 }
 
@@ -64,7 +64,7 @@ try
 
     # Create or update package work item  
     &$EngCommonScriptsDir/Update-DevOps-Release-WorkItem.ps1 `
-    -language $Language `
+    -language $PackageLanguage `
     -packageName $PackageName `
     -version $PackageVersion `
     -plannedDate $ReleaseDate `


### PR DESCRIPTION
Create package work item uses param `$Language` and this collides with `$Language` in eng/common.ps1. This works in most cases but .NET repo his this value set to `dotnet` instead of `.NET` so create package work item request fails with invalid language value error.