### PR TITLE
Update github-event-processor's Octokit version to 12.0.0

### DIFF
--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Azure.Sdk.Tools.GitHubEventProcessor.csproj
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Azure.Sdk.Tools.GitHubEventProcessor.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Octokit" Version="10.0.0" />
+    <PackageReference Include="Octokit" Version="12.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In the afternoon on 06/04/2024 the issue_comment ID was changed from an int to a long and issue_comment processing has been broken since then. Version 12.0.0 of Octokit.net was released this morning, 06/10/2024, and fixes this issue. I've verified using a payload that had an ID > int max and all of the automated tests for the github-event-processor have passed.