### PR TITLE
Add support for missing build processing

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/AzurePipelines/AzurePipelinesProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/AzurePipelines/AzurePipelinesProcessor.cs
@@ -183,6 +183,30 @@ namespace Azure.Sdk.Tools.PipelineWitness.AzurePipelines
             await UploadBuildBlobAsync(account, build);
         }
 
+        public async Task<string[]> GetBuildBlobNamesAsync(string projectName, DateTimeOffset minTime, DateTimeOffset maxTime, CancellationToken cancellationToken)
+        {
+            DateTimeOffset minDay = minTime.ToUniversalTime().Date;
+            DateTimeOffset maxDay = maxTime.ToUniversalTime().Date;
+
+            DateTimeOffset[] days = Enumerable.Range(0, (int)(maxDay - minDay).TotalDays + 1)
+                .Select(offset => minDay.AddDays(offset))
+                .ToArray();
+
+            List<string> blobNames = [];
+
+            foreach (DateTimeOffset day in days)
+            {
+                string blobPrefix = $"{projectName}/{day:yyyy/MM/dd}/";
+
+                await foreach (BlobItem blob in this.buildsContainerClient.GetBlobsAsync(prefix: blobPrefix, cancellationToken: cancellationToken))
+                {
+                    blobNames.Add(blob.Name);
+                }
+            }
+
+            return [.. blobNames];
+        }
+
         public string GetBuildBlobName(Build build)
         {
             long changeTime = ((DateTimeOffset)build.LastChangedDate).ToUnixTimeSeconds();

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/AzurePipelines/MissingAzurePipelineRunsWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/AzurePipelines/MissingAzurePipelineRunsWorker.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Sdk.Tools.PipelineWitness.Configuration;
+using Azure.Sdk.Tools.PipelineWitness.Services;
+using Azure.Sdk.Tools.PipelineWitness.Services.WorkTokens;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Microsoft.TeamFoundation.Build.WebApi;
+using Microsoft.VisualStudio.Services.WebApi;
+
+namespace Azure.Sdk.Tools.PipelineWitness.AzurePipelines
+{
+    public class MissingAzurePipelineRunsWorker : PeriodicLockingBackgroundService
+    {
+        private readonly ILogger<MissingAzurePipelineRunsWorker> logger;
+        private readonly AzurePipelinesProcessor runProcessor;
+        private readonly BuildCompleteQueue buildCompleteQueue;
+        private readonly IOptions<PipelineWitnessSettings> options;
+        private readonly EnhancedBuildHttpClient buildClient;
+
+        public MissingAzurePipelineRunsWorker(
+            ILogger<MissingAzurePipelineRunsWorker> logger,
+            AzurePipelinesProcessor runProcessor,
+            IAsyncLockProvider asyncLockProvider,
+            VssConnection vssConnection,
+            BuildCompleteQueue buildCompleteQueue,
+            IOptions<PipelineWitnessSettings> options)
+            : base(
+                  logger,
+                  asyncLockProvider,
+                  options.Value.MissingPipelineRunsWorker)
+        {
+            this.logger = logger;
+            this.runProcessor = runProcessor;
+            this.buildCompleteQueue = buildCompleteQueue;
+            this.options = options;
+
+            ArgumentNullException.ThrowIfNull(vssConnection);
+
+            this.buildClient = vssConnection.GetClient<EnhancedBuildHttpClient>();
+        }
+
+        protected override async Task ProcessAsync(CancellationToken cancellationToken)
+        {
+            var settings = this.options.Value;
+
+            // search for builds that completed within this window
+            var buildMinTime = DateTimeOffset.UtcNow.Subtract(settings.MissingPipelineRunsWorker.LookbackPeriod);
+            var buildMaxTime = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1));
+
+            foreach (string project in settings.Projects)
+            {
+                var knownBlobs = await this.runProcessor.GetBuildBlobNamesAsync(project, buildMinTime, buildMaxTime, cancellationToken);
+
+                string continuationToken = null;
+                do
+                {
+                    var completedBuilds = await this.buildClient.GetBuildsAsync2(
+                        project,
+                        minFinishTime: buildMinTime.DateTime,
+                        maxFinishTime: buildMaxTime.DateTime,
+                        statusFilter: BuildStatus.Completed,
+                        continuationToken: continuationToken,
+                        cancellationToken: cancellationToken);
+
+                    var skipCount = 0;
+                    var enqueueCount = 0;
+                    foreach (var build in completedBuilds)
+                    {
+                        var blobName = this.runProcessor.GetBuildBlobName(build);
+
+                        if (knownBlobs.Contains(blobName, StringComparer.InvariantCultureIgnoreCase))
+                        {
+                            skipCount++;
+                            continue;
+                        }
+
+                        var queueMessage = new BuildCompleteQueueMessage
+                        {
+                            Account = settings.Account,
+                            ProjectId = build.Project.Id,
+                            BuildId = build.Id
+                        };
+
+                        this.logger.LogInformation("Enqueuing missing build {Project} {BuildId} for processing", build.Project.Name, build.Id);
+                        await this.buildCompleteQueue.EnqueueMessageAsync(queueMessage);
+                        enqueueCount++;
+                    }
+
+                    this.logger.LogInformation("Enqueued {EnqueueCount} missing builds, skipped {SkipCount} existing builds in project {Project}", enqueueCount, skipCount, project);
+
+                    continuationToken = completedBuilds.ContinuationToken;
+                } while(!string.IsNullOrEmpty(continuationToken));
+            }
+        }
+
+        protected override Task ProcessExceptionAsync(Exception ex)
+        {
+            this.logger.LogError(ex, "Error processing missing builds");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Configuration/PeriodicProcessSettings.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Configuration/PeriodicProcessSettings.cs
@@ -25,6 +25,11 @@ namespace Azure.Sdk.Tools.PipelineWitness.Configuration
         public TimeSpan CooldownPeriod { get; set; }
 
         /// <summary>
+        /// Gets or sets the amount of history to process in each iteration
+        /// </summary>
+        public TimeSpan LookbackPeriod { get; set; }
+
+        /// <summary>
         /// Gets or sets the name of the distributed lock
         /// </summary>
         public string LockName { get; set; }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Configuration/PipelineWitnessSettings.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Configuration/PipelineWitnessSettings.cs
@@ -86,6 +86,16 @@ namespace Azure.Sdk.Tools.PipelineWitness.Configuration
         public PeriodicProcessSettings BuildDefinitionWorker { get; set; }
 
         /// <summary>
+        /// Gets or sets the loops settins for the Missing Azure Pipline Runs worker
+        /// </summary>
+        public PeriodicProcessSettings MissingPipelineRunsWorker { get; set; }
+
+        /// <summary>
+        /// Gets or sets the loops settins for the Missing GitHub Actions worker
+        /// </summary>
+        public PeriodicProcessSettings MissingGitHubActionsWorker { get; set; }
+
+        /// <summary>
         /// Gets or sets the artifact name used by the pipeline owners extraction build
         /// </summary>
         public string PipelineOwnersArtifactName { get; set; }
@@ -109,5 +119,15 @@ namespace Azure.Sdk.Tools.PipelineWitness.Configuration
         /// Gets or sets the container to use for async locks
         /// </summary>
         public string CosmosAsyncLockContainer { get; set; }
+
+        /// <summary>
+        /// Gets or sets the list of monitored GitHub repositories (Overrides GitHubRepositoriesSource)
+        /// </summary>
+        public string[] GitHubRepositories { get; set; }
+
+        /// <summary>
+        /// Gets or sets the url for a list of monitored GitHub repositories
+        /// </summary>
+        public string GitHubRepositoriesSource { get; set; }
     }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Configuration/PostConfigureSettings.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Configuration/PostConfigureSettings.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Net.Http;
+using System.Net.Http.Json;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Azure.Sdk.Tools.PipelineWitness.Configuration;
+
+public class PostConfigureSettings : IPostConfigureOptions<PipelineWitnessSettings>
+{
+    private readonly ILogger logger;
+
+    public PostConfigureSettings(ILogger<PostConfigureSettings> logger)
+    {
+        this.logger = logger;
+    }
+
+    public void PostConfigure(string name, PipelineWitnessSettings options)
+    {
+        if (options.GitHubRepositories == null || options.GitHubRepositories.Length == 0)
+        {
+            options.GitHubRepositories = [];
+
+            if (string.IsNullOrEmpty(options.GitHubRepositoriesSource))
+            {
+                this.logger.LogWarning("No GitHubRepositories or GitHubRepositoriesSource configured");
+                return;
+            }
+
+            try
+            {
+                this.logger.LogInformation("Replacing settings property GitHubRepositories with values from {Source}", options.GitHubRepositoriesSource);
+                using var client = new HttpClient();
+
+                options.GitHubRepositories = client.GetFromJsonAsync<string[]>(options.GitHubRepositoriesSource)
+                    .ConfigureAwait(true)
+                    .GetAwaiter()
+                    .GetResult();
+            }
+            catch (Exception ex)
+            {
+                this.logger.LogError(ex, "Error loading repository list from source");
+                return;
+            }
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/GitHubActions/MissingGitHubActionsWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/GitHubActions/MissingGitHubActionsWorker.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Azure.Sdk.Tools.PipelineWitness.Configuration;
+using Azure.Sdk.Tools.PipelineWitness.Services;
+using Azure.Sdk.Tools.PipelineWitness.Services.WorkTokens;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Octokit;
+
+namespace Azure.Sdk.Tools.PipelineWitness.GitHubActions
+{
+    public class MissingGitHubActionsWorker : PeriodicLockingBackgroundService
+    {
+        private readonly ILogger<MissingGitHubActionsWorker> logger;
+        private readonly GitHubActionProcessor processor;
+        private readonly RunCompleteQueue queue;
+        private readonly IOptions<PipelineWitnessSettings> options;
+        private readonly GitHubClient client;
+
+        public MissingGitHubActionsWorker(
+            ILogger<MissingGitHubActionsWorker> logger,
+            GitHubActionProcessor processor,
+            IAsyncLockProvider asyncLockProvider,
+            ICredentialStore credentials,
+            RunCompleteQueue queue,
+            IOptions<PipelineWitnessSettings> options)
+            : base(
+                  logger,
+                  asyncLockProvider,
+                  options.Value.MissingGitHubActionsWorker)
+        {
+            this.logger = logger;
+            this.processor = processor;
+            this.queue = queue;
+            this.options = options;
+
+            if (credentials == null)
+            {
+                throw new ArgumentNullException(nameof(credentials));
+            }
+
+            this.client = new GitHubClient(new ProductHeaderValue("PipelineWitness", "1.0"), credentials);
+        }
+
+        protected override async Task ProcessAsync(CancellationToken cancellationToken)
+        {
+            PipelineWitnessSettings settings = this.options.Value;
+
+            var repositories = settings.GitHubRepositories;
+
+            // search for builds that completed within this window
+            DateTimeOffset runMinTime = DateTimeOffset.UtcNow.Subtract(settings.MissingGitHubActionsWorker.LookbackPeriod);
+            DateTimeOffset runMaxTime = DateTimeOffset.UtcNow.Subtract(TimeSpan.FromHours(1));
+
+            foreach (string ownerAndRepository in repositories)
+            {
+                string owner = ownerAndRepository.Split('/')[0];
+                string repository = ownerAndRepository.Split('/')[1];
+
+                string[] knownBlobs = await this.processor.GetRunBlobNamesAsync(ownerAndRepository, runMinTime, runMaxTime, cancellationToken);
+
+                WorkflowRunsResponse listRunsResponse = await this.client.Actions.Workflows.Runs.List(owner, repository, new WorkflowRunsRequest
+                {
+                    Created = $"{runMinTime:o}..{runMaxTime:o}",
+                    Status = CheckRunStatusFilter.Completed,
+                });
+
+                var skipCount = 0;
+                var enqueueCount = 0;
+
+                foreach (WorkflowRun run in listRunsResponse.WorkflowRuns)
+                {
+                    var blobName = this.processor.GetRunBlobName(run);
+
+                    if (knownBlobs.Contains(blobName, StringComparer.InvariantCultureIgnoreCase))
+                    {
+                        skipCount++;
+                        continue;
+                    }
+
+                    var queueMessage = new RunCompleteQueueMessage
+                    {
+                        Owner = owner,
+                        Repository = repository,
+                        RunId = run.Id
+                    };
+
+                    this.logger.LogInformation("Enqueuing missing run {Repository} {RunId} for processing", ownerAndRepository, run.Id);
+                    await this.queue.EnqueueMessageAsync(queueMessage);
+                    enqueueCount++;
+                }
+
+                this.logger.LogInformation("Enqueued {EnqueueCount} missing runs, skipped {SkipCount} existing runs in repository {Repository}", enqueueCount, skipCount, ownerAndRepository);
+            }
+        }
+
+        protected override Task ProcessExceptionAsync(Exception ex)
+        {
+            this.logger.LogError(ex, "Error processing missing builds");
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -37,6 +37,7 @@ public static class Startup
         builder.Services.Configure<PipelineWitnessSettings>(settingsSection);
         builder.Services.AddSingleton<ISecretClientProvider, SecretClientProvider>();
         builder.Services.AddSingleton<IPostConfigureOptions<PipelineWitnessSettings>, PostConfigureKeyVaultSettings<PipelineWitnessSettings>>();
+        builder.Services.AddSingleton<IPostConfigureOptions<PipelineWitnessSettings>, PostConfigureSettings>();
 
         builder.Services.AddApplicationInsightsTelemetry(builder.Configuration);
         builder.Services.AddApplicationInsightsTelemetryProcessor<BlobNotFoundTelemetryProcessor>();
@@ -66,6 +67,8 @@ public static class Startup
         builder.Services.AddHostedService<RunCompleteQueueWorker>(settings.GitHubActionRunsWorkerCount);
 
         builder.Services.AddHostedService<AzurePipelinesBuildDefinitionWorker>();
+        builder.Services.AddHostedService<MissingGitHubActionsWorker>();
+        builder.Services.AddHostedService<MissingAzurePipelineRunsWorker>();
     }
 
     private static void AddHostedService<T>(this IServiceCollection services, int instanceCount) where T : class, IHostedService

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.development.json
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.development.json
@@ -19,11 +19,30 @@
     "CosmosAccountUri": "https://pipelinewitnesstest.documents.azure.com",
     "GitHubWebhookSecret": "https://pipelinewitnesstest.vault.azure.net/secrets/github-webhook-validation-secret",
     "GitHubAccessToken": null,
-    "BuildDefinitionWorker": {
-      "LoopPeriod": "00:01:00",
-      "Enabled": true
-    },
+
+    "GitHubRepositoriesSource": "https://raw.githubusercontent.com/Azure/azure-sdk-tools/users/pahallis/missing-build/tools/pipeline-witness/monitored-repos.json",
+
     "BuildCompleteWorkerCount": 1,
-    "GitHubActionRunsWorkerCount": 1
+    "GitHubActionRunsWorkerCount": 1,
+
+    "BuildDefinitionWorker": {
+      "Enabled": false,
+      "LoopPeriod": "00:01:00",
+      "CooldownPeriod": "7.00:00:00"
+    },
+
+    "MissingPipelineRunsWorker": {
+      "Enabled": true,
+      "LoopPeriod": "00:01:00",
+      "CooldownPeriod": "00:10:00",
+      "LookbackPeriod": "12:00:00"
+    },
+
+    "MissingGitHubActionsWorker": {
+      "Enabled": true,
+      "LoopPeriod": "00:01:00",
+      "CooldownPeriod": "00:10:00",
+      "LookbackPeriod": "12:00:00"
+    }
   }
 }

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.json
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.json
@@ -29,11 +29,29 @@
       "LockName": "BuildDefinitionWorker"
     },
 
+    "MissingPipelineRunsWorker": {
+      "Enabled": true,
+      "LoopPeriod": "01:00:00",
+      "CooldownPeriod": "7.00:00:00",
+      "LookbackPeriod": "14.00:00:00",
+      "LockName": "MissingPipelineRunsWorker"
+    },
+
+    "MissingGitHubActionsWorker": {
+      "Enabled": true,
+      "LoopPeriod": "01:00:00",
+      "CooldownPeriod": "7.00:00:00",
+      "LookbackPeriod": "14.00:00:00",
+      "LockName": "MissingGitHubActionsWorker"
+    },
+
     "BuildCompleteQueueName": "azurepipelines-build-completed",
     "BuildCompleteWorkerCount": 10,
 
     "GitHubActionRunsQueueName": "github-actionrun-completed",
     "GitHubActionRunsWorkerCount": 10,
+
+    "GitHubRepositoriesSource": "https://raw.githubusercontent.com/Azure/azure-sdk-tools/main/tools/pipeline-witness/monitored-repos.json",
     "GitHubWebhookSecret": "https://pipelinewitnessprod.vault.azure.net/secrets/github-webhook-validation-secret",
     "GitHubAccessToken": "https://pipelinewitnessprod.vault.azure.net/secrets/azuresdk-github-pat",
     "MessageLeasePeriod": "00:03:00",

--- a/tools/pipeline-witness/monitored-repos.json
+++ b/tools/pipeline-witness/monitored-repos.json
@@ -2,11 +2,13 @@
     "Azure/autorest.csharp",
     "Azure/autorest.go",
     "Azure/autorest.java",
+    "Azure/autorest.rust",
     "Azure/azure-sdk",
     "Azure/azure-sdk-for-go",
     "Azure/azure-sdk-for-js",
     "Azure/azure-sdk-for-java",
     "Azure/azure-sdk-for-net",
     "Azure/azure-sdk-for-python",
+    "Azure/azure-sdk-for-rust",
     "Azure/azure-sdk-tools"    
 ]


### PR DESCRIPTION
This creates the `PeriodicLockingBackgroundService` class to encapsulate the logic of periodically running a process in a single worker instance only if the worker is able to establish a lock on a central cosmos document.  It continually renews the lock while the processing is handled by a  ProcessAsync implementation. 

This change also starts paving the way for GitHub Actions logging by moving the Azure Pipelines related classes into 
 their own namespace.