### PR TITLE
Add common branch rulesets we use

### DIFF
--- a/eng/branch-rulesets/require-codeowner-approval.json
+++ b/eng/branch-rulesets/require-codeowner-approval.json
@@ -1,0 +1,38 @@
+{
+  "name": "Require CodeOwner approval",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": true,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 2978638,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    }
+  ]
+}

--- a/eng/branch-rulesets/required-pullrequest-checks.json
+++ b/eng/branch-rulesets/required-pullrequest-checks.json
@@ -1,0 +1,58 @@
+{
+  "name": "Required Pull Request Checks",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "non_fast_forward"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": true
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          {
+            "context": "https://aka.ms/azsdk/checkenforcer"
+          },
+          {
+            "context": "license/cla"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 3028359,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
These are the exported branch rulesets that we can use when configuring other repos to have a consistent set of required checks across the azure-sdk-for-<lang> repos.