### PR TITLE
Fix prepare-pipelines line wrapping

### DIFF
--- a/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
@@ -40,20 +40,20 @@ jobs:
           azureSubscription: 'opensource-api-connection'
           scriptType: pscore
           scriptLocation: inlineScript
-          inlineScript:
-            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-            --organization azure-sdk `
-            --project public `
-            --prefix ${{parameters.Prefix}} `
-            --devopspath "\${{parameters.Prefix}}" `
-            --path $(System.DefaultWorkingDirectory)/sdk `
-            --endpoint Azure `
-            --repository ${{parameters.Repository}} `
-            --convention ci `
-            --agentpool Hosted `
-            --branch refs/heads/$(DefaultBranch) `
-            --set-managed-variables `
-            --debug `
+          inlineScript: >
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+            --organization azure-sdk
+            --project public
+            --prefix ${{parameters.Prefix}}
+            --devopspath "\${{parameters.Prefix}}"
+            --path $(System.DefaultWorkingDirectory)/sdk
+            --endpoint Azure
+            --repository ${{parameters.Repository}}
+            --convention ci
+            --agentpool Hosted
+            --branch refs/heads/$(DefaultBranch)
+            --set-managed-variables
+            --debug
             ${{parameters.CIConventionOptions}}
         displayName: Create CI Pipelines for Public Repository
       - task: AzureCLI@2
@@ -61,20 +61,20 @@ jobs:
           azureSubscription: 'opensource-api-connection'
           scriptType: pscore
           scriptLocation: inlineScript
-          inlineScript:
-            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-            --organization azure-sdk `
-            --project internal `
-            --prefix ${{parameters.Prefix}} `
-            --devopspath "\${{parameters.Prefix}}" `
-            --path $(System.DefaultWorkingDirectory)/sdk `
-            --endpoint Azure `
-            --repository ${{parameters.Repository}} `
-            --convention up `
-            --agentpool Hosted `
-            --branch refs/heads/$(DefaultBranch) `
-            --set-managed-variables `
-            --debug `
+          inlineScript: >
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+            --organization azure-sdk
+            --project internal
+            --prefix ${{parameters.Prefix}}
+            --devopspath "\${{parameters.Prefix}}"
+            --path $(System.DefaultWorkingDirectory)/sdk
+            --endpoint Azure
+            --repository ${{parameters.Repository}}
+            --convention up
+            --agentpool Hosted
+            --branch refs/heads/$(DefaultBranch)
+            --set-managed-variables
+            --debug
             ${{parameters.UPConventionOptions}}
         displayName: Create UP Pipelines for Public Repository
       - task: AzureCLI@2
@@ -82,20 +82,20 @@ jobs:
           azureSubscription: 'opensource-api-connection'
           scriptType: pscore
           scriptLocation: inlineScript
-          inlineScript:
-            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-            --organization azure-sdk `
-            --project internal `
-            --prefix ${{parameters.Prefix}} `
-            --devopspath "\${{parameters.Prefix}}" `
-            --path $(System.DefaultWorkingDirectory)/sdk `
-            --endpoint Azure `
-            --repository ${{parameters.Repository}} `
-            --convention tests `
-            --agentpool Hosted `
-            --branch refs/heads/$(DefaultBranch) `
-            --set-managed-variables `
-            --debug `
+          inlineScript: >
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+            --organization azure-sdk
+            --project internal
+            --prefix ${{parameters.Prefix}}
+            --devopspath "\${{parameters.Prefix}}"
+            --path $(System.DefaultWorkingDirectory)/sdk
+            --endpoint Azure
+            --repository ${{parameters.Repository}}
+            --convention tests
+            --agentpool Hosted
+            --branch refs/heads/$(DefaultBranch)
+            --set-managed-variables
+            --debug
             ${{parameters.TestsConventionOptions}}
         displayName: Create Live Test Pipelines for Public Repository
         condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
@@ -104,20 +104,20 @@ jobs:
           azureSubscription: 'opensource-api-connection'
           scriptType: pscore
           scriptLocation: inlineScript
-          inlineScript:
-            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-            --organization azure-sdk `
-            --project internal `
-            --prefix ${{parameters.Prefix}} `
-            --devopspath "\${{parameters.Prefix}}" `
-            --path $(System.DefaultWorkingDirectory)/sdk `
-            --endpoint Azure `
-            --repository ${{parameters.Repository}} `
-            --convention testsweekly `
-            --agentpool Hosted `
-            --branch refs/heads/$(DefaultBranch) `
-            --set-managed-variables `
-            --debug `
+          inlineScript: >
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+            --organization azure-sdk
+            --project internal
+            --prefix ${{parameters.Prefix}}
+            --devopspath "\${{parameters.Prefix}}"
+            --path $(System.DefaultWorkingDirectory)/sdk
+            --endpoint Azure
+            --repository ${{parameters.Repository}}
+            --convention testsweekly
+            --agentpool Hosted
+            --branch refs/heads/$(DefaultBranch)
+            --set-managed-variables
+            --debug
             ${{parameters.TestsConventionOptions}}
         displayName: Create Weekly (Multi-Cloud) Live Test Pipelines for Public Repository
         condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))
@@ -126,20 +126,20 @@ jobs:
           azureSubscription: 'opensource-api-connection'
           scriptType: pscore
           scriptLocation: inlineScript
-          inlineScript:
-            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-            --organization azure-sdk `
-            --project internal `
-            --prefix ${{parameters.Prefix}} `
-            --devopspath "\${{parameters.Prefix}}" `
-            --path $(System.DefaultWorkingDirectory)/sdk `
-            --endpoint Azure `
-            --repository ${{parameters.Repository}} `
-            --convention upweekly `
-            --agentpool Hosted `
-            --branch refs/heads/$(DefaultBranch) `
-            --set-managed-variables `
-            --debug `
+          inlineScript: >
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+            --organization azure-sdk
+            --project internal
+            --prefix ${{parameters.Prefix}}
+            --devopspath "\${{parameters.Prefix}}"
+            --path $(System.DefaultWorkingDirectory)/sdk
+            --endpoint Azure
+            --repository ${{parameters.Repository}}
+            --convention upweekly
+            --agentpool Hosted
+            --branch refs/heads/$(DefaultBranch)
+            --set-managed-variables
+            --debug
             ${{parameters.UPConventionOptions}}
         displayName: Create Weekly (Multi-Cloud) Unified Test Pipelines for Public Repository
         condition: and(succeeded(), eq(${{parameters.GenerateUnifiedWeekly}},true))
@@ -151,21 +151,21 @@ jobs:
           azureSubscription: 'opensource-api-connection'
           scriptType: pscore
           scriptLocation: inlineScript
-          inlineScript:
-            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-            --organization azure-sdk `
-            --project internal `
-            --prefix ${{parameters.Prefix}}-pr `
-            --devopspath "\${{parameters.Prefix}}\pr" `
-            --path $(System.DefaultWorkingDirectory)/sdk `
-            --endpoint Azure `
-            --repository ${{parameters.Repository}} `
-            --convention ci `
-            --agentpool Hosted `
-            --branch refs/heads/$(DefaultBranch) `
-            --set-managed-variables `
-            --debug `
-            --no-schedule `
+          inlineScript: >
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+            --organization azure-sdk
+            --project internal
+            --prefix ${{parameters.Prefix}}-pr
+            --devopspath "\${{parameters.Prefix}}\pr"
+            --path $(System.DefaultWorkingDirectory)/sdk
+            --endpoint Azure
+            --repository ${{parameters.Repository}}
+            --convention ci
+            --agentpool Hosted
+            --branch refs/heads/$(DefaultBranch)
+            --set-managed-variables
+            --debug
+            --no-schedule
             ${{parameters.CIConventionOptions}}
         displayName: Create CI Pipelines for Private Repository
       - task: AzureCLI@2
@@ -173,21 +173,21 @@ jobs:
           azureSubscription: 'opensource-api-connection'
           scriptType: pscore
           scriptLocation: inlineScript
-          inlineScript:
-            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-            --organization azure-sdk `
-            --project internal `
-            --prefix ${{parameters.Prefix}}-pr `
-            --devopspath "\${{parameters.Prefix}}\pr" `
-            --path $(System.DefaultWorkingDirectory)/sdk `
-            --endpoint Azure `
-            --repository ${{parameters.Repository}} `
-            --convention up `
-            --agentpool Hosted `
-            --branch refs/heads/$(DefaultBranch) `
-            --set-managed-variables `
-            --debug `
-            --no-schedule `
+          inlineScript: >
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+            --organization azure-sdk
+            --project internal
+            --prefix ${{parameters.Prefix}}-pr
+            --devopspath "\${{parameters.Prefix}}\pr"
+            --path $(System.DefaultWorkingDirectory)/sdk
+            --endpoint Azure
+            --repository ${{parameters.Repository}}
+            --convention up
+            --agentpool Hosted
+            --branch refs/heads/$(DefaultBranch)
+            --set-managed-variables
+            --debug
+            --no-schedule
             ${{parameters.UPConventionOptions}}
         displayName: Create UP Pipelines for Private Repository
       - task: AzureCLI@2
@@ -195,21 +195,21 @@ jobs:
           azureSubscription: 'opensource-api-connection'
           scriptType: pscore
           scriptLocation: inlineScript
-          inlineScript:
-            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate `
-            --organization azure-sdk `
-            --project internal `
-            --prefix ${{parameters.Prefix}}-pr `
-            --devopspath "\${{parameters.Prefix}}\pr" `
-            --path $(System.DefaultWorkingDirectory)/sdk `
-            --endpoint Azure `
-            --repository ${{parameters.Repository}} `
-            --convention tests `
-            --agentpool Hosted `
-            --branch refs/heads/$(DefaultBranch) `
-            --set-managed-variables `
-            --debug `
-            --no-schedule `
+          inlineScript: >
+            $(Pipeline.Workspace)/pipeline-generator/pipeline-generator generate
+            --organization azure-sdk
+            --project internal
+            --prefix ${{parameters.Prefix}}-pr
+            --devopspath "\${{parameters.Prefix}}\pr"
+            --path $(System.DefaultWorkingDirectory)/sdk
+            --endpoint Azure
+            --repository ${{parameters.Repository}}
+            --convention tests
+            --agentpool Hosted
+            --branch refs/heads/$(DefaultBranch)
+            --set-managed-variables
+            --debug
+            --no-schedule
             ${{parameters.TestsConventionOptions}}
         displayName: Create Live Test Pipelines for Private Repository
         condition: and(succeeded(), ne('${{parameters.TestsConventionOptions}}',''))


### PR DESCRIPTION
Switch to older line wrapping because some cases fail if there is no extra parameters on the last line.

See example https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3866634&view=logs&j=7f42699e-eeb0-56c8-40c2-c88ae4093e4f&t=82d183d4-b652-5968-0d60-46aa50150c79&l=59 