### PR TITLE
Add Azure/azure-rest-api-specs to the list of repositories to sync common labels

### DIFF
--- a/tools/github/data/repositories.txt
+++ b/tools/github/data/repositories.txt
@@ -30,3 +30,4 @@ Azure/autorest.go
 Azure/autorest.swift
 Azure/autorest.cpp
 Azure/perks
+Azure/azure-rest-api-specs


### PR DESCRIPTION
The GitHubTeamUserStore uses the repositories.txt, the file which holds the list of repositories that we sync common labels, as the list of repositories to get labels for. The label information is used by several tools, including the CODEOWNERS linter. We need to add Azure/azure-rest-api-specs here so we'll get the repo/label data. This will also cause the common labels to get added to the Azure/azure-rest-api-specs repository but considering that many of them are already there, this shouldn't be a problem.