### PR TITLE
Add branch ruleset files used for the specs repo

### DIFF
--- a/eng/branch-rulesets/require-one-pullrequest-approval.json
+++ b/eng/branch-rulesets/require-one-pullrequest-approval.json
@@ -1,0 +1,25 @@
+{
+  "name": "Require One PullRequest Approver",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": []
+    }
+  },
+  "rules": [
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/eng/branch-rulesets/required-pullrequest-checks-specs-full.json
+++ b/eng/branch-rulesets/required-pullrequest-checks-specs-full.json
@@ -1,0 +1,80 @@
+{
+  "name": "Required PullRequest Checks - Full",
+  "target": "branch",
+  "source_type": "Repository",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "required_status_checks": [
+          {
+            "context": "Automated merging requirements met"
+          },
+          {
+            "context": "Breaking Change(Cross-Version)"
+          },
+          {
+            "context": "license/cla"
+          },
+          {
+            "context": "Swagger BreakingChange"
+          },
+          {
+            "context": "Swagger Lint(RPaaS)"
+          },
+          {
+            "context": "Swagger LintDiff"
+          },
+          {
+            "context": "Swagger ModelValidation"
+          },
+          {
+            "context": "Swagger PrettierCheck"
+          },
+          {
+            "context": "Swagger SemanticValidation"
+          },
+          {
+            "context": "Swagger SpellCheck"
+          },
+          {
+            "context": "SDK azure-sdk-for-go"
+          },
+          {
+            "context": "TypeSpec Requirement (resource-manager)"
+          },
+          {
+            "context": "TypeSpec Validation"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": [
+    {
+      "actor_id": 3028359,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 10313102,
+      "actor_type": "Team",
+      "bypass_mode": "always"
+    },
+    {
+      "actor_id": 1,
+      "actor_type": "OrganizationAdmin",
+      "bypass_mode": "always"
+    }
+  ]
+}


### PR DESCRIPTION
FYI @konrad-jamrozik @mikeharder 

These are rulesets I applied to the public and private specs repos. We can maintain these and use them to import and share in both of the repos as needed.