### PR TITLE
Update CodeownersLinter version to 1.0.0-dev.20240614.4

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -31,7 +31,7 @@ stages:
       vmImage: ubuntu-22.04
 
     variables:
-      CodeownersLinterVersion: '1.0.0-dev.20240514.2'
+      CodeownersLinterVersion: '1.0.0-dev.20240614.4'
       DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
       RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
       TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"


### PR DESCRIPTION
Update CodeownersLinter version.

The full description is in the fix [PR](https://github.com/Azure/azure-sdk-tools/pull/8450).