### PR TITLE
Pass pipeline vnet to live test arm templates

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -106,6 +106,15 @@ param (
 
 . $PSScriptRoot/SubConfig-Helpers.ps1
 
+$azsdkPipelineVnet = "/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourceGroups/azsdk-pools/providers/Microsoft.Network/virtualNetworks/azsdk-pipeline-vnet-wus"
+$azsdkPipelineSubnets = @(
+    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-1804-general"),
+    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-2004-general"),
+    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-ubuntu-2204-general"),
+    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2019-general"),
+    ($azsdkPipelineVnet + "/subnets/pipeline-subnet-win-2022-general")
+)
+
 if (!$ServicePrincipalAuth) {
     # Clear secrets if not using Service Principal auth. This prevents secrets
     # from being passed to pre- and post-scripts.
@@ -743,12 +752,14 @@ try {
     if ($ProvisionerApplicationOid) {
         $templateParameters["provisionerApplicationOid"] = "$ProvisionerApplicationOid"
     }
-
     if ($TenantId) {
         $templateParameters.Add('tenantId', $TenantId)
     }
     if ($TestApplicationSecret -and $ServicePrincipalAuth) {
         $templateParameters.Add('testApplicationSecret', $TestApplicationSecret)
+    }
+    if ($CI -and $Environment -eq 'AzureCloud') {
+        $templateParameters.Add('azsdkPipelineSubnetList', $azsdkPipelineSubnets)
     }
 
     $defaultCloudParameters = LoadCloudConfig $Environment


### PR DESCRIPTION
Some azure resources (sql) cannot be accessed by VMs in a vnet even if they have public access enabled. In these cases we have to set up the vnet rules in the arm template at deploy time (instead of via azure policy).

See for example: https://github.com/Azure/azure-sdk-for-java/pull/40639