### PR TITLE
Hide Line Numbers switch connected and working

### DIFF
--- a/src/dotnet/APIView/ClientSPA/angular.json
+++ b/src/dotnet/APIView/ClientSPA/angular.json
@@ -123,5 +123,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/dotnet/APIView/ClientSPA/angular.json
+++ b/src/dotnet/APIView/ClientSPA/angular.json
@@ -123,8 +123,5 @@
         }
       }
     }
-  },
-  "cli": {
-    "analytics": false
   }
 }

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.html
@@ -6,7 +6,7 @@
   <div *uiScroll="let item of codePanelRowSource; let index = index" class="code-line" [attr.data-node-id]="item.nodeIdHashed" [ngClass]="getClassObject(item.rowClasses)">
     <ng-container *ngIf="item.type === CodePanelRowDatatype.CodeLine || item.type === CodePanelRowDatatype.Documentation">
       <div class="line-actions">
-          <span *ngIf="!showLineNumbers" class="line-number first">{{item.lineNumber}}</span>
+          <span *ngIf="showLineNumbers" class="line-number first">{{item.lineNumber}}</span>
           <span *ngIf="isDiffView" class="line-number second">{{item.lineNumber}}</span>
           <span class="small toggle-user-comments-btn {{item.toggleCommentsClasses}}"></span>
           <span class="small toggle-documentation-btn {{item.toggleDocumentationClasses}}"></span>

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.html
@@ -6,7 +6,7 @@
   <div *uiScroll="let item of codePanelRowSource; let index = index" class="code-line" [attr.data-node-id]="item.nodeIdHashed" [ngClass]="getClassObject(item.rowClasses)">
     <ng-container *ngIf="item.type === CodePanelRowDatatype.CodeLine || item.type === CodePanelRowDatatype.Documentation">
       <div class="line-actions">
-          <span class="line-number first">{{item.lineNumber}}</span>
+          <span *ngIf="!showLineNumbers" class="line-number first">{{item.lineNumber}}</span>
           <span *ngIf="isDiffView" class="line-number second">{{item.lineNumber}}</span>
           <span class="small toggle-user-comments-btn {{item.toggleCommentsClasses}}"></span>
           <span class="small toggle-documentation-btn {{item.toggleDocumentationClasses}}"></span>

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
@@ -21,7 +21,7 @@ export class CodePanelComponent implements OnChanges{
   @Input() navTreeNodIdHashed: string | undefined;
   @Input() reviewId: string | undefined;
   @Input() activeApiRevisionId: string | undefined;
-  @Input() showLineNumbers: boolean = false;
+  @Input() showLineNumbers: boolean = true;
 
   lineNumberCount : number = 0;
   isLoading: boolean = true;

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/code-panel/code-panel.component.ts
@@ -21,6 +21,7 @@ export class CodePanelComponent implements OnChanges{
   @Input() navTreeNodIdHashed: string | undefined;
   @Input() reviewId: string | undefined;
   @Input() activeApiRevisionId: string | undefined;
+  @Input() showLineNumbers: boolean = false;
 
   lineNumberCount : number = 0;
   isLoading: boolean = true;

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.html
@@ -43,7 +43,8 @@
             <label class="ms-2">Documentation</label>
         </li>
         <li class="list-group-item">
-            <p-inputSwitch [(ngModel)]="showLineNumberSwitch" />
+            <p-inputSwitch [(ngModel)]="showLineNumbersSwitch" 
+            (onChange)="onShowLineNumbersSwitchChange($event)" />
             <label class="ms-2">Line Numbers</label>
         </li>
         <li class="list-group-item">

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
@@ -54,7 +54,9 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges{
     this.showCommentsSwitch = this.userProfile?.preferences.showComments ?? true;
     this.showSystemCommentsSwitch = this.userProfile?.preferences.showSystemComments ?? true;
     this.showDocumentationSwitch = this.userProfile?.preferences.showDocumentation ?? false;
-    this.showLineNumbersSwitch = !(this.userProfile?.preferences.showDocumentation ?? false);
+    if (this.userProfile?.preferences.hideLineNumbers){
+      this.showLineNumbersSwitch = false;
+   }
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -66,7 +68,9 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges{
       this.showCommentsSwitch = this.userProfile?.preferences.showComments ?? this.showCommentsSwitch;
       this.showSystemCommentsSwitch = this.userProfile?.preferences.showSystemComments ?? this.showSystemCommentsSwitch;
       this.showDocumentationSwitch = this.userProfile?.preferences.showDocumentation ?? this.showDocumentationSwitch;
-      this.showLineNumbersSwitch = !(this.userProfile?.preferences.hideLineNumbers ?? true);
+      if (this.userProfile?.preferences.hideLineNumbers){
+        this.showLineNumbersSwitch = false;
+     }
     }
     
     if (changes['activeAPIRevision'] && changes['activeAPIRevision'].currentValue != undefined) {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
@@ -56,6 +56,8 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges{
     this.showDocumentationSwitch = this.userProfile?.preferences.showDocumentation ?? false;
     if (this.userProfile?.preferences.hideLineNumbers){
       this.showLineNumbersSwitch = false;
+   } else {
+    this.showLineNumbersSwitch = true;
    }
   }
 
@@ -70,6 +72,8 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges{
       this.showDocumentationSwitch = this.userProfile?.preferences.showDocumentation ?? this.showDocumentationSwitch;
       if (this.userProfile?.preferences.hideLineNumbers){
         this.showLineNumbersSwitch = false;
+     } else {
+      this.showLineNumbersSwitch = true;
      }
     }
     

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
@@ -19,13 +19,14 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges{
   @Output() showSystemCommentsEmitter : EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() showDocumentationEmitter : EventEmitter<boolean> = new EventEmitter<boolean>();
   @Output() markAsViewedEmitter : EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output() showLineNumbersEmitter : EventEmitter<boolean> = new EventEmitter<boolean>();
   
   showCommentsSwitch : boolean = true;
   showSystemCommentsSwitch : boolean = true;
   showDocumentationSwitch : boolean = true;
-  showLineNumberSwitch : boolean = true;
   showLeftNavigationSwitch : boolean = true;
   markedAsViewSwitch : boolean = false;
+  showLineNumbersSwitch : boolean = true;
 
   activeAPIRevisionIsApprovedByCurrentUser: boolean = false;
   activeAPIRevisionApprovalMessage: string = '';
@@ -53,6 +54,7 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges{
     this.showCommentsSwitch = this.userProfile?.preferences.showComments ?? true;
     this.showSystemCommentsSwitch = this.userProfile?.preferences.showSystemComments ?? true;
     this.showDocumentationSwitch = this.userProfile?.preferences.showDocumentation ?? false;
+    this.showLineNumbersSwitch = !(this.userProfile?.preferences.showDocumentation ?? false);
   }
 
   ngOnChanges(changes: SimpleChanges) {
@@ -64,6 +66,7 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges{
       this.showCommentsSwitch = this.userProfile?.preferences.showComments ?? this.showCommentsSwitch;
       this.showSystemCommentsSwitch = this.userProfile?.preferences.showSystemComments ?? this.showSystemCommentsSwitch;
       this.showDocumentationSwitch = this.userProfile?.preferences.showDocumentation ?? this.showDocumentationSwitch;
+      this.showLineNumbersSwitch = !(this.userProfile?.preferences.hideLineNumbers ?? true);
     }
     
     if (changes['activeAPIRevision'] && changes['activeAPIRevision'].currentValue != undefined) {
@@ -111,6 +114,14 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges{
   */
   onMarkedAsViewedSwitchChange(event: InputSwitchOnChangeEvent) {
     this.markAsViewedEmitter.emit(event.checked);
+  }
+
+  /**
+   * Callback for showLineNumbersSwitch Change
+   * @param event the Filter event
+   */
+  onShowLineNumbersSwitchChange(event: InputSwitchOnChangeEvent) {
+    this.showLineNumbersEmitter.emit(event.checked);
   }
 
   setSelectedDiffStyle() {

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.html
@@ -26,7 +26,8 @@
                             [language]="language" [languageSafeName]="languageSafeName"
                             [reviewComments]="reviewComments" [isDiffView]="!!diffApiRevisionId"
                             [reviewId]="reviewId!" [activeApiRevisionId]="activeApiRevisionId!"
-                            [navTreeNodIdHashed]="navTreeNodeIdHashed"></app-code-panel>
+                            [navTreeNodIdHashed]="navTreeNodeIdHashed"
+                            [showLineNumbers]="showLineNumbers"></app-code-panel>
                     </div>
                 </ng-template>
                 <ng-template pTemplate>
@@ -40,7 +41,8 @@
                             (showDocumentationEmitter)="handleShowDocumentationEmitter($event)"
                             (showCommentsEmitter)="handleShowCommentsEmitter($event)"
                             (diffStyleEmitter)="handleDiffStyleEmitter($event)"
-                            (markAsViewedEmitter)="handleMarkAsViewedEmitter($event)"></app-review-page-options>
+                            (markAsViewedEmitter)="handleMarkAsViewedEmitter($event)"
+                            (showLineNumbersEmitter)="handleShowLineNumbersEmitter($event)"></app-review-page-options>
                     </div>
                 </ng-template>
             </p-splitter>

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
@@ -39,6 +39,7 @@ export class ReviewPageComponent implements OnInit {
   language: string | undefined;
   languageSafeName: string | undefined;
   navTreeNodeIdHashed : string | undefined;
+  showLineNumbers : boolean = true;
 
   codePanelData: CodePanelData | null = null;
   codePanelRowData: CodePanelRowData[] = [];
@@ -216,6 +217,14 @@ export class ReviewPageComponent implements OnInit {
       this.codePanelComponent?.removeRowTypeFromScroller(CodePanelRowDatatype.Documentation);
     }
   }
+
+  handleShowLineNumbersEmitter(state: boolean) {
+    let userPreferenceModel = this.userProfile?.preferences;
+    userPreferenceModel!.hideLineNumbers = state;
+    this.userProfileService.updateUserPrefernece(userPreferenceModel!).pipe(takeUntil(this.destroy$)).subscribe(() => {
+      this.showLineNumbers = !state;
+    });
+    }
 
   handleNavTreeNodeEmmitter(nodeIdHashed: string) {
     this.navTreeNodeIdHashed = nodeIdHashed;

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
@@ -224,9 +224,9 @@ export class ReviewPageComponent implements OnInit {
 
   handleShowLineNumbersEmitter(state: boolean) {
     let userPreferenceModel = this.userProfile?.preferences;
-    userPreferenceModel!.hideLineNumbers = state;
+    userPreferenceModel!.hideLineNumbers = !state;
     this.userProfileService.updateUserPrefernece(userPreferenceModel!).pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.showLineNumbers = state;
+      this.showLineNumbers = userPreferenceModel!.hideLineNumbers;
     });
     }
 

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
@@ -226,7 +226,7 @@ export class ReviewPageComponent implements OnInit {
     let userPreferenceModel = this.userProfile?.preferences;
     userPreferenceModel!.hideLineNumbers = !state;
     this.userProfileService.updateUserPrefernece(userPreferenceModel!).pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.showLineNumbers = userPreferenceModel!.hideLineNumbers;
+      this.showLineNumbers = !userPreferenceModel!.hideLineNumbers;
     });
     }
 

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
@@ -60,7 +60,6 @@ export class ReviewPageComponent implements OnInit {
     this.userProfileService.getUserProfile().subscribe(
       (userProfile : any) => {
         this.userProfile = userProfile;
-        console.log('userProfile', userProfile)
         if(this.userProfile?.preferences.hideLineNumbers) {
           this.showLineNumbers = false;
         }

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page/review-page.component.ts
@@ -60,6 +60,10 @@ export class ReviewPageComponent implements OnInit {
     this.userProfileService.getUserProfile().subscribe(
       (userProfile : any) => {
         this.userProfile = userProfile;
+        console.log('userProfile', userProfile)
+        if(this.userProfile?.preferences.hideLineNumbers) {
+          this.showLineNumbers = false;
+        }
       });
 
     this.route.queryParams.pipe(takeUntil(this.destroy$)).subscribe(params => {
@@ -222,7 +226,7 @@ export class ReviewPageComponent implements OnInit {
     let userPreferenceModel = this.userProfile?.preferences;
     userPreferenceModel!.hideLineNumbers = state;
     this.userProfileService.updateUserPrefernece(userPreferenceModel!).pipe(takeUntil(this.destroy$)).subscribe(() => {
-      this.showLineNumbers = !state;
+      this.showLineNumbers = state;
     });
     }
 


### PR DESCRIPTION
Added functionality to Line Numbers switch in right navigation panel to hide/show code line numbers in center panel.