### PR TITLE
Fix case where changelog wasn't marked as invalid

### DIFF
--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -297,8 +297,8 @@ function Remove-EmptySections {
   {
     $parsedSections = $ChangeLogEntry.Sections
     $sanitizedReleaseContent = New-Object System.Collections.ArrayList(,$releaseContent)
-  
-    foreach ($key in @($parsedSections.Keys)) 
+
+    foreach ($key in @($parsedSections.Keys))
     {
       if ([System.String]::IsNullOrWhiteSpace($parsedSections[$key]))
       {
@@ -442,6 +442,7 @@ function Confirm-ChangeLogForRelease {
   if (!$foundRecommendedSection)
   {
     $ChangeLogStatus.Message = "The changelog entry did not contain any of the recommended sections ($($RecommendedSectionHeaders -join ', ')), please add at least one. See https://aka.ms/azsdk/guideline/changelogs for more info."
+    $ChangeLogStatus.IsValid = $false
     if (!$SuppressErrors) {
       LogError "$($ChangeLogStatus.Message)"
     }


### PR DESCRIPTION
Fixing case were we didn't correctly fail the build see example https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3875412&view=logs&j=f8db92a5-5aa2-5af0-abb0-b907727011d6&t=69c0dc6a-7dc9-5030-86c4-e7a70f356a18

```
[debug]Verifying as a release build because ForRelease parameter is set to true
##[error]The changelog entry did not contain any of the recommended sections (Features Added, Breaking Changes, Bugs Fixed, Other Changes), please add at least one. See https://aka.ms/azsdk/guideline/changelogs for more info.

Finishing: Verify ChangeLogEntry for azure-ai-translation-document
```