### PR TITLE
Fix AZC0006 and AZC0007 to accept endpoint as an exception

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0006Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0006Tests.cs
@@ -44,6 +44,41 @@ namespace RandomNamespace
         }
 
         [Fact]
+        public async Task AZC0006NotProducedForEquivalentOneWithoutEndpoint()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        public SomeClient() {}
+        public SomeClient(System.Uri endpoint, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0006NotProducedForEquivalentOneWithParameterAndWithoutEndpoint()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(string someAuth) {}
+        public SomeClient(System.Uri endpoint, string someAuth, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
         public async Task AZC0006NotProducedForClientsWithoutOptionsCtorWithArguments()
         {
             const string code = @"

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0007Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0007Tests.cs
@@ -73,5 +73,40 @@ namespace RandomNamespace
 }";
             await Verifier.VerifyAnalyzerAsync(code);
         }
+
+        [Fact]
+        public async Task AZC0007NotProducedForEquivalentOneWithEndpoint()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        public SomeClient() {}
+        public SomeClient(System.Uri endpoint, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+        [Fact]
+        public async Task AZC0007NotProducedForEquivalentOneWithParameterAndEndpoint()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class SomeClientOptions : Azure.Core.ClientOptions { }
+
+    public class SomeClient
+    {
+        protected SomeClient() {}
+        public SomeClient(string someAuth) {}
+        public SomeClient(System.Uri endpoint, string someAuth, SomeClientOptions options) {}
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAnalyzerBase.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientAnalyzerBase.cs
@@ -104,6 +104,26 @@ namespace Azure.ClientSdk.Analyzers
             });
         }
 
+        protected static IMethodSymbol FindMethod(IEnumerable<IMethodSymbol> methodSymbols, ImmutableArray<ITypeParameterSymbol> genericParameters, ImmutableArray<IParameterSymbol> parameters, Func<IParameterSymbol, bool> lastParameter, Func<IParameterSymbol, bool> firstParameter)
+        {
+            return methodSymbols.SingleOrDefault(symbol =>
+            {
+                if (symbol.Parameters.Length < 2 || !firstParameter(symbol.Parameters.First()) || !lastParameter(symbol.Parameters.Last()))
+                {
+                    return false;
+                }
+
+                if (!genericParameters.SequenceEqual(symbol.TypeParameters, ParameterEquivalenceComparer.Default))
+                {
+                    return false;
+                }
+
+                var allButLastAndFirst = symbol.Parameters.RemoveAt(symbol.Parameters.Length - 1).RemoveAt(0);
+
+                return allButLastAndFirst.SequenceEqual(parameters, ParameterEquivalenceComparer.Default);
+            });
+        }
+
         public abstract void AnalyzeCore(ISymbolAnalysisContext context);
     }
 }


### PR DESCRIPTION
The correct appearance of constructor is https://github.com/Azure/autorest.csharp/issues/3706#issuecomment-1752374728. We should put all the optional parameters into ClientOptions instead of being constructor parameters. However, endpoint is an exception. Even it is an optional parameter, it should still be in the constructor parameter list, not in the ClientOptions.

Currently our analyzer will report false alert for that endpoint exception like below, which is actually correct.
```
public AClient(string required): this(new Uri("http://localhost:3000/"), required, new AClientOptions()){}
public AClient(Uri endpoint, string required, AClientOptions options){}
```

This PR is to fix that false alert.