### PR TITLE
Node Publishing Update

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-publish-js.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-js.yml
@@ -8,6 +8,9 @@ parameters:
 - name: ArtifactName
   type: string
   default: ''
+- name: PackageJsonPath
+  type: string
+  default: ''
 
 
 extends:
@@ -45,6 +48,7 @@ extends:
                         filePath: '$(Build.SourcesDirectory)/eng/scripts/determine-js-release-tag.ps1'
                         failOnStderr: true
                         pwsh: true
+                        arguments: '-PackageJsonPath ${{ parameters.PackageJsonPath }}'
 
                     - pwsh: |
                         Write-Host "Will deploy with tag of $(Tag)"
@@ -55,20 +59,20 @@ extends:
                         Get-ChildItem "$(Build.ArtifactStagingDirectory)" -Recurse -Force | % { Write-Host $_.FullName }
                       displayName: Move artifact to $(Build.ArtifactStagingDirectory)
 
-                    - task: EsrpRelease@7
-                      inputs:
-                        displayName: 'Publish oav to ESRP'
-                        ConnectedServiceName: 'Azure SDK Engineering System'
-                        ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
-                        KeyVaultName: 'AzureSDKEngKeyVault'
-                        AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
-                        SignCertName: 'azure-sdk-esrp-release-sign-certificate'
-                        Intent: 'PackageDistribution'
-                        ContentType: 'npm'
-                        FolderLocation: $(Build.ArtifactStagingDirectory)
-                        Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
-                        Approvers: 'azuresdk@microsoft.com'
-                        ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
-                        MainPublisher: 'ESRPRELPACMANTEST'
-                        DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-                        productstate: $(Tag)
+                    # - task: EsrpRelease@7
+                    #   inputs:
+                    #     displayName: 'Publish oav to ESRP'
+                    #     ConnectedServiceName: 'Azure SDK Engineering System'
+                    #     ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+                    #     KeyVaultName: 'AzureSDKEngKeyVault'
+                    #     AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
+                    #     SignCertName: 'azure-sdk-esrp-release-sign-certificate'
+                    #     Intent: 'PackageDistribution'
+                    #     ContentType: 'npm'
+                    #     FolderLocation: $(Build.ArtifactStagingDirectory)
+                    #     Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+                    #     Approvers: 'azuresdk@microsoft.com'
+                    #     ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+                    #     MainPublisher: 'ESRPRELPACMANTEST'
+                    #     DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+                    #     productstate: $(Tag)

--- a/eng/pipelines/templates/stages/archetype-sdk-publish-js.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-publish-js.yml
@@ -59,20 +59,20 @@ extends:
                         Get-ChildItem "$(Build.ArtifactStagingDirectory)" -Recurse -Force | % { Write-Host $_.FullName }
                       displayName: Move artifact to $(Build.ArtifactStagingDirectory)
 
-                    # - task: EsrpRelease@7
-                    #   inputs:
-                    #     displayName: 'Publish oav to ESRP'
-                    #     ConnectedServiceName: 'Azure SDK Engineering System'
-                    #     ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
-                    #     KeyVaultName: 'AzureSDKEngKeyVault'
-                    #     AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
-                    #     SignCertName: 'azure-sdk-esrp-release-sign-certificate'
-                    #     Intent: 'PackageDistribution'
-                    #     ContentType: 'npm'
-                    #     FolderLocation: $(Build.ArtifactStagingDirectory)
-                    #     Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
-                    #     Approvers: 'azuresdk@microsoft.com'
-                    #     ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
-                    #     MainPublisher: 'ESRPRELPACMANTEST'
-                    #     DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
-                    #     productstate: $(Tag)
+                    - task: EsrpRelease@7
+                      inputs:
+                        displayName: 'Publish oav to ESRP'
+                        ConnectedServiceName: 'Azure SDK Engineering System'
+                        ClientId: '5f81938c-2544-4f1f-9251-dd9de5b8a81b'
+                        KeyVaultName: 'AzureSDKEngKeyVault'
+                        AuthCertName: 'azure-sdk-esrp-release-auth-certificate'
+                        SignCertName: 'azure-sdk-esrp-release-sign-certificate'
+                        Intent: 'PackageDistribution'
+                        ContentType: 'npm'
+                        FolderLocation: $(Build.ArtifactStagingDirectory)
+                        Owners: ${{ coalesce(variables['Build.RequestedForEmail'], 'azuresdk@microsoft.com') }}
+                        Approvers: 'azuresdk@microsoft.com'
+                        ServiceEndpointUrl: 'https://api.esrp.microsoft.com'
+                        MainPublisher: 'ESRPRELPACMANTEST'
+                        DomainTenantId: '72f988bf-86f1-41af-91ab-2d7cd011db47'
+                        productstate: $(Tag)

--- a/eng/scripts/determine-js-release-tag.ps1
+++ b/eng/scripts/determine-js-release-tag.ps1
@@ -1,6 +1,12 @@
-# Read the package.json file
-$packageJsonPath = "$PSScriptRoot/../../package.json"
-$packageJson = Get-Content $packageJsonPath -Raw | ConvertFrom-Json
+params(
+    [string]$PackageJsonPath
+)
+
+if (-not $PackageJsonPath.Endswith("package.json")) {
+    $PackageJsonPath = Join-Path $PackageJsonPath "package.json"
+}
+
+$packageJson = Get-Content $PackageJsonPath -Raw | ConvertFrom-Json
 
 # Function to check if a version is non-GA
 function Is-NonGA($version) {

--- a/eng/scripts/determine-js-release-tag.ps1
+++ b/eng/scripts/determine-js-release-tag.ps1
@@ -1,4 +1,4 @@
-params(
+param(
     [string]$PackageJsonPath
 )
 

--- a/tools/apiview/emitters/typespec-apiview/ci.yml
+++ b/tools/apiview/emitters/typespec-apiview/ci.yml
@@ -26,6 +26,7 @@ extends:
   parameters:
     BuildStageName: Build
     ArtifactName: apiview
+    PackageJsonPath: $(Build.SourcesDirectory)/tools/apiview/emitters/typespec-apiview
     BuildStages:
       - stage: 'Build'
         variables:

--- a/tools/js-sdk-release-tools/ci.yml
+++ b/tools/js-sdk-release-tools/ci.yml
@@ -30,6 +30,7 @@ extends:
   parameters:
     BuildStageName: InstallAndBuild
     ArtifactName: drop
+    PackageJsonPath: $(Build.SourcesDirectory)/tools/js-sdk-release-tools
     BuildStages:
       - stage: InstallAndBuild
         variables:

--- a/tools/mock-service-host/ci.yml
+++ b/tools/mock-service-host/ci.yml
@@ -40,6 +40,7 @@ extends:
   parameters:
     BuildStageName: InstallAndTest
     ArtifactName: drop
+    PackageJsonPath: $(Build.SourcesDirectory)/tools/mock-service-host
     BuildStages:
     - stage: InstallAndTest
       variables:

--- a/tools/oav-traffic-converter/ci.yml
+++ b/tools/oav-traffic-converter/ci.yml
@@ -30,6 +30,7 @@ extends:
   parameters:
     BuildStageName: Test
     ArtifactName: drop
+    PackageJsonPath: $(Build.SourcesDirectory)/tools/oav-traffic-converter
     BuildStages:
     - stage: InstallAndTest
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Azure.Sdk.Tools.TestProxy": {
       "commandName": "Project",
+      "commandLineArgs": "start --storage-location=C:/repo/azure-sdk-for-net",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "Logging__LogLevel__Microsoft": "Information"

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -2,7 +2,6 @@
   "profiles": {
     "Azure.Sdk.Tools.TestProxy": {
       "commandName": "Project",
-      "commandLineArgs": "start --storage-location=C:/repo/azure-sdk-for-net",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "Logging__LogLevel__Microsoft": "Information"

--- a/tools/tsp-client/ci.yml
+++ b/tools/tsp-client/ci.yml
@@ -25,6 +25,7 @@ extends:
   parameters:
     BuildStageName: InstallAndBuild
     ArtifactName: drop
+    PackageJsonPath: $(Build.SourcesDirectory)/tools/tsp-client
     BuildStages:
       - stage: InstallAndBuild
         variables:


### PR DESCRIPTION
Looks like when I tested an actual release, I tested the only case that would actually work when merging #8460 

@catalinaperalta  hit issues this past Friday with this as a result. I unblocked her, but wanted to make an adjustment to re-use the `SemVer` package before merging.

Unfortunately, it looks like if I use `SemVer`, it marks packages < 1.0.0 (even if if GA-marked) as `Prerelease`. While I agree with this for our production packages, our internal tooling conflicts with this bar.

Specifically, the typespec-emitter `latest` version is `0.4.8`. If we used `SemVer` and `IsPrerelease` property to determine whether to set `latest` or `beta` tag, we would erroneously mark the latest version of `typespec-emitter` with `beta`. At least until 1.0.0. For now I'm leaving the simple tag check in place.