### PR TITLE
Fix pom path and artifact name parser

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
@@ -79,6 +79,9 @@ public class Main {
         final ReviewProperties reviewProperties = new ReviewProperties();
         final String filename = inputFile.getName();
         int i = 0;
+
+        // This will not work for artifact names that contain digits like msal4j. So, we will use this as backup in case
+        // we don't find a pom.xml file in the jar. If pom.xml is found, we'll use the artifact name defined in pom.xml.
         while (i < filename.length() && !Character.isDigit(filename.charAt(i))) {
             i++;
         }
@@ -95,8 +98,13 @@ public class Main {
 
                 // use the pom.xml of this artifact only
                 // shaded jars can contain a pom.xml file each for every shaded dependencies
-                if (fullPath.startsWith("META-INF/maven") && fullPath.endsWith(artifactId + "/pom.xml")) {
-                    reviewProperties.setMavenPom(new Pom(jarFile.getInputStream(entry)));
+                if (fullPath.startsWith("META-INF/maven") && fullPath.endsWith("/pom.xml")) {
+                    Pom pom = new Pom(jarFile.getInputStream(entry));
+                    if (filename.startsWith(artifactId)) {
+                        artifactId = pom.getArtifactId();
+                        packageVersion = pom.getVersion();
+                        reviewProperties.setMavenPom(pom);
+                    }
                 }
             }
         } catch (IOException e) {

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
@@ -100,7 +100,7 @@ public class Main {
                 // shaded jars can contain a pom.xml file each for every shaded dependencies
                 if (fullPath.startsWith("META-INF/maven") && fullPath.endsWith("/pom.xml")) {
                     Pom pom = new Pom(jarFile.getInputStream(entry));
-                    if (filename.startsWith(artifactId)) {
+                    if (filename.startsWith(pom.getArtifactId())) {
                         artifactId = pom.getArtifactId();
                         packageVersion = pom.getVersion();
                         reviewProperties.setMavenPom(pom);

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/Flavor.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/model/Flavor.java
@@ -52,22 +52,24 @@ public enum Flavor {
         // to see if it brings in com.azure or io.clientcore libraries.
         int azureCount = 0;
         int genericCount = 0;
-        for (Dependency dependency : apiListing.getMavenPom().getDependencies()) {
-            if (dependency.getGroupId().equals(AZURE.getPackagePrefix())) {
-                // if we have azure-core, then we are an azure library and we bail
-                if (dependency.getArtifactId().equals("azure-core")) {
-                    return AZURE;
+
+        if (apiListing.getMavenPom().getDependencies() != null) {
+            for (Dependency dependency : apiListing.getMavenPom().getDependencies()) {
+                if (dependency.getGroupId().equals(AZURE.getPackagePrefix())) {
+                    // if we have azure-core, then we are an azure library and we bail
+                    if (dependency.getArtifactId().equals("azure-core")) {
+                        return AZURE;
+                    }
+                    azureCount++;
+                } else if (dependency.getGroupId().equals(GENERIC.getPackagePrefix())) {
+                    // if we have 'core', then we are a clientcore library and we bail
+                    if (dependency.getArtifactId().equals("core")) {
+                        return GENERIC;
+                    }
+                    genericCount++;
                 }
-                azureCount++;
-            } else if (dependency.getGroupId().equals(GENERIC.getPackagePrefix())) {
-                // if we have 'core', then we are a clientcore library and we bail
-                if (dependency.getArtifactId().equals("core")) {
-                    return GENERIC;
-                }
-                genericCount++;
             }
         }
-
         // see which count is greatest (and non-zero), and return that flavour. If equal, return unknown
         return azureCount > genericCount ? AZURE : genericCount > azureCount ? GENERIC : UNKNOWN;
     }


### PR DESCRIPTION
Fixes an issue where we look for `META-INF/maven/.../<artifactId>/pom.xml` to get the primary pom file. The artifact id is computed by parsing the jar filename until the first digit is found. This does not work for artifacts ids like msal4j that have digits in the name. So, the primary pom is never found because it looks for `META-INF/maven/.../msa/pom.xml` while the file is actually in `META-INF/maven/.../msal4j/pom.xml`.