### PR TITLE
Ensure subConfigFiles is not an empty string

### DIFF
--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -47,10 +47,14 @@ steps:
 
       if ($subConfigFilesRaw) {
         $subConfigFiles = $subConfigFilesRaw | ConvertFrom-Json -AsHashtable
-        foreach ($file in $subConfigFiles) {
-          Write-Host "Merging sub config from file: $file"
-          $subConfig = Get-Content $file | ConvertFrom-Json -AsHashtable
-          $finalConfig = UpdateSubscriptionConfiguration $finalConfig $subConfig
+        # Handle cases where $subConfigFilesRaw converts to an empty string
+        # instead of an array of strings
+        if ($subConfigFiles) {
+          foreach ($file in $subConfigFiles) {
+            Write-Host "Merging sub config from file: $file"
+            $subConfig = Get-Content $file | ConvertFrom-Json -AsHashtable
+            $finalConfig = UpdateSubscriptionConfiguration $finalConfig $subConfig
+          }
         }
       }
 

--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -47,14 +47,16 @@ steps:
 
       if ($subConfigFilesRaw) {
         $subConfigFiles = $subConfigFilesRaw | ConvertFrom-Json -AsHashtable
-        # Handle cases where $subConfigFilesRaw converts to an empty string
-        # instead of an array of strings
-        if ($subConfigFiles) {
-          foreach ($file in $subConfigFiles) {
-            Write-Host "Merging sub config from file: $file"
-            $subConfig = Get-Content $file | ConvertFrom-Json -AsHashtable
-            $finalConfig = UpdateSubscriptionConfiguration $finalConfig $subConfig
+        foreach ($file in $subConfigFiles) {
+          # In some cases, $file could be an empty string. Get-Content will fail
+          # if $file is an empty string, so skip those cases.
+          if (!$file) {
+            continue
           }
+
+          Write-Host "Merging sub config from file: $file"
+          $subConfig = Get-Content $file | ConvertFrom-Json -AsHashtable
+          $finalConfig = UpdateSubscriptionConfiguration $finalConfig $subConfig
         }
       }
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-tools/issues/8507

Tests: 

* No changes: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3932581&view=logs&j=43701d7e-216c-59bf-08d1-1efd0c7ac90a&t=b6d99d7a-c889-583c-28b5-43c35affcd50&l=234
* CloudConfig with SubscriptionConfigurationFilePaths set -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3932609&view=logs&j=43701d7e-216c-59bf-08d1-1efd0c7ac90a&t=b6d99d7a-c889-583c-28b5-43c35affcd50&l=234
* CloudConfig with NO SubscriptionConfigurationFilePaths set (used to produce errors) -- https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3932621&view=logs&j=efd63400-1b36-5c22-495f-5e04b5698008&t=04da24dd-1265-5b7d-577b-fed9b6b497d0&l=231