### PR TITLE
[Validate-AzsdkCodeOwner] Missing permission display

### DIFF
--- a/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
+++ b/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
@@ -71,8 +71,14 @@ if ($permission -eq "admin" -or $permission -eq "write") {
     Write-Host "`t$([char]0x2713) $($permission) " -ForegroundColor Green
     $hasPermissions = $true
 } else {
-    Write-Host "`tx $($permission)" -ForegroundColor Red
+    Write-Host "`tx write" -ForegroundColor Red
 }
+
+# Write the other permissions organizations for the user, if
+# verbose output is enabled.
+Write-Verbose ""
+Write-Verbose "Other Permissions:"
+Write-Verbose "`t$($permission) (not required)"
 
 # Validate the user and write the results.
 $isValid = ($hasOrgs -and $hasPermissions)

--- a/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
+++ b/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
@@ -74,7 +74,7 @@ if ($permission -eq "admin" -or $permission -eq "write") {
     Write-Host "`tx write" -ForegroundColor Red
 }
 
-# Write the other permissions organizations for the user, if
+# Write the other permissions for the user, if
 # verbose output is enabled.
 Write-Verbose ""
 Write-Verbose "Other Permissions:"


### PR DESCRIPTION
# Summary

The focus of these changes is to fix a mistake when displaying required permissions that are missing.   The current implementation displays the permission held by the user rather than the required permission that is missing, causing it to be unclear what permission is needed.