### PR TITLE
Use repositories file by default for GH scripts

### DIFF
--- a/tools/github/README.md
+++ b/tools/github/README.md
@@ -1,6 +1,6 @@
 # Overview
 
-This area is focused on the management of the Azure SDK GitHub repositories, containing tools and data used for that purpose.  
+This area is focused on the management of the Azure SDK GitHub repositories, containing tools and data used for that purpose.
 
 ## Prerequisites
 
@@ -10,83 +10,86 @@ This area is focused on the management of the Azure SDK GitHub repositories, con
 
 ## Structure
 
-* **root**  
+- **root**
   _The root contains the scripts used for repository management and their associated data._
 
-* **scripts**  
+- **scripts**
   _The core scripts for repository management, such as managing milestones and labels._
 
-* **data**  
+- **data**
   _The data associated with the scripts.  This includes items such as the set of centrally managed Azure SDK repositories and the labels common to all repositories._
 
-* **data/repository-snapshots**  
+- **data/repository-snapshots**
   _The container for a snapshot of the labels that exist in each managed repository; primarily used to help detect and report on new labels that have been added outside the common set._
 
- ## Scripts
- 
- ### `Add-AzsdkMilestones.ps1`
- 
- _Creates a set of milestones in one or more repositories.  The milestones follow Azure SDK conventions for naming and due dates.  With the default parameter set, milestones will be created for the next 6 months in repositories in the 'repositories.txt' file in the script directory._
-   
- ```powershell
- # Create the default set of milestone and repository data.
- ./Add-AzsdkMilestones.ps1
-   
- # Create milestones in the .NET and Java repositories for a specific date range.
- ./Add-AzsdkMilestones.ps1 -Languages 'net', 'java' -StartDate 2023-01-01 -EndDate 2023-07-31
-   
- # View the help for the full set of parameters.
- get-help ./Add-AzsdkMilestones.ps1 -full
- ```
- 
- ### `Add-AzsdkProjectIssues.ps1`
- _Adds a set of Azure SDK repository issues tagged with a given set of labels to a GitHub project.  With the default parameter set, the issues with the specified labels will be queried from a set of core language repositories._
-   
- ```powershell
- # Adds issues with the "Client" and "KeyVault" labels to project #150, querying a set 
- # of core language  repositories.
- ./Add-AzsdkProjectIssues.ps1 -ProjectNumber 150 -Labels Client, KeyVault
-   
- # Adds issues with the "KeyVault" label in the .NET repository to project #150, setting
- # the "Status" custom field to "Todo".
- ./Add-AzsdkProjectIssues.ps1 -Languages 'net' -ProjectNumber 150 -Labels KeyVault -Fields @{Status="Todo"}
-   
- # View the help for the full set of parameters.
- get-help ./Add-AzsdkProjectIssues.ps1 -full
- ```
- 
- ### `Sync-AzsdkLabels.ps1`
-   _Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration._
-   
-   ```powershell
-   # Uses the files from the `data` directory to synchronize the common labels to all centrally managed 
-   # repositories using the default delay between each repository to guard against GitHub throttling.
-   ./Sync-AzsdkLabels.ps1 
+## Scripts
 
-   # Synchronize the common labels to the Azure SDK for .NET repository.
-   ./Sync-AzsdkLabels.ps1 -LabelsFilePath "../data/common-labels.csv" -Languages 'net' 
-   
-   # View the help for the full set of parameters.
-   get-help ./Sync-AzsdkLabels.ps1 -full
-   ```
+### `Add-AzsdkMilestones.ps1`
 
-  ### `Snapshot-AzsdkLabels.ps1`
-   _Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration._
-   
-   ```powershell
-   # Uses the files from the "data" directory to generate snapshots of non-common labels for each 
-   # of the centrally managed repositories in the "data/repository-snapshots" directory while 
-   # writing any new non-common labels created for the repository to the host.
-   ./Snapshot-AzsdkLabels.ps1 -Diff
+_Creates a set of milestones in one or more repositories.  The milestones follow Azure SDK conventions for naming and due dates.  With the default parameter set, milestones will be created for the next 6 months in repositories in the 'repositories.txt' file in the script directory._
 
-   # Create a snapshot for the Azure SDK for .NET repository, treating the labels defined in 
-   # "../data/common-labels.csv" as the expected common set.  The resulting snapshot is written to the ""./snapshots" directory.
-   ./Snapshot-AzsdkLabels.ps1 -LabelsFilePath "../data/common-labels.csv" -Languages 'net' -RepositoryFilePath "snapshots"
-   
-   # View the help for the full set of parameters.
-   get-help ./Snapshot-AzsdkLabels.ps1 -full
-   ```
-   
+```powershell
+# Create the default set of milestone and repository data.
+./Add-AzsdkMilestones.ps1
+
+# Create milestones in the .NET and Java repositories for a specific date range.
+./Add-AzsdkMilestones.ps1 -Languages 'net', 'java' -StartDate 2023-01-01 -EndDate 2023-07-31
+
+# View the help for the full set of parameters.
+get-help ./Add-AzsdkMilestones.ps1 -full
+```
+
+### `Add-AzsdkProjectIssues.ps1`
+
+_Adds a set of Azure SDK repository issues tagged with a given set of labels to a GitHub project.  With the default parameter set, the issues with the specified labels will be queried from a set of core language repositories._
+
+```powershell
+# Adds issues with the "Client" and "KeyVault" labels to project #150, querying a set
+# of core language  repositories.
+./Add-AzsdkProjectIssues.ps1 -ProjectNumber 150 -Labels Client, KeyVault
+
+# Adds issues with the "KeyVault" label in the .NET repository to project #150, setting
+# the "Status" custom field to "Todo".
+./Add-AzsdkProjectIssues.ps1 -Languages 'net' -ProjectNumber 150 -Labels KeyVault -Fields @{Status="Todo"}
+
+# View the help for the full set of parameters.
+get-help ./Add-AzsdkProjectIssues.ps1 -full
+```
+
+### `Sync-AzsdkLabels.ps1`
+
+_Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration._
+
+```powershell
+# Uses the files from the `data` directory to synchronize the common labels to all centrally managed
+# repositories using the default delay between each repository to guard against GitHub throttling.
+./Sync-AzsdkLabels.ps1
+
+# Synchronize the common labels to the Azure SDK for .NET repository.
+./Sync-AzsdkLabels.ps1 -LabelsFilePath "../data/common-labels.csv" -Languages 'net'
+
+# View the help for the full set of parameters.
+get-help ./Sync-AzsdkLabels.ps1 -full
+```
+
+### `Snapshot-AzsdkLabels.ps1`
+
+_Creates or updates the set of labels expected to be common across the Azure SDK repositories, ensuring that names, descriptions, and colors share the common configuration._
+
+```powershell
+# Uses the files from the "data" directory to generate snapshots of non-common labels for each
+# of the centrally managed repositories in the "data/repository-snapshots" directory while
+# writing any new non-common labels created for the repository to the host.
+./Snapshot-AzsdkLabels.ps1 -Diff
+
+# Create a snapshot for the Azure SDK for .NET repository, treating the labels defined in
+# "../data/common-labels.csv" as the expected common set.  The resulting snapshot is written to the ""./snapshots" directory.
+./Snapshot-AzsdkLabels.ps1 -LabelsFilePath "../data/common-labels.csv" -Languages 'net' -RepositoryFilePath "snapshots"
+
+# View the help for the full set of parameters.
+get-help ./Snapshot-AzsdkLabels.ps1 -full
+```
+
 ## References and Resources
-  
+
 - [GitHub CLI Docs](https://docs.github.com/en/github-cli)

--- a/tools/github/README.md
+++ b/tools/github/README.md
@@ -11,15 +11,19 @@ This area is focused on the management of the Azure SDK GitHub repositories, con
 ## Structure
 
 - **root**
+
   _The root contains the scripts used for repository management and their associated data._
 
 - **scripts**
+
   _The core scripts for repository management, such as managing milestones and labels._
 
 - **data**
+
   _The data associated with the scripts.  This includes items such as the set of centrally managed Azure SDK repositories and the labels common to all repositories._
 
 - **data/repository-snapshots**
+
   _The container for a snapshot of the labels that exist in each managed repository; primarily used to help detect and report on new labels that have been added outside the common set._
 
 ## Scripts

--- a/tools/github/scripts/Add-AzsdkMilestones.ps1
+++ b/tools/github/scripts/Add-AzsdkMilestones.ps1
@@ -4,22 +4,11 @@ param (
     [ValidateScript({Test-Path $_ -PathType 'Leaf'})]
     [string]$RepositoryFilePath = "$PSScriptRoot/../data/repositories.txt",
 
-    [Parameter(ParameterSetName = 'Repositories')]
-    [ValidateNotNullOrEmpty()]
-    [string[]] $Repositories = @(
-        'Azure/azure-sdk-for-cpp'
-        'Azure/azure-sdk-for-go'
-        'Azure/azure-sdk-for-java'
-        'Azure/azure-sdk-for-js'
-        'Azure/azure-sdk-for-net'
-        'Azure/azure-sdk-for-python'
-        'Azure/azure-sdk-for-rust'
-        'Azure/azure-sdk-tools'
-    ),
+    [Parameter(ParameterSetName = 'Repositories', Mandatory = $true)]
+    [string[]] $Repositories,
 
-    [Parameter(ParameterSetName = 'Languages')]
-    [ValidateNotNullOrEmpty()]
-    [string[]] $Languages = @('cpp', 'go', 'java', 'js', 'net', 'python', 'rust', 'c', 'ios', 'android'),
+    [Parameter(ParameterSetName = 'Languages', Mandatory = $true)]
+    [string[]] $Languages,
 
     [Parameter()]
     [DateTimeOffset] $StartDate = [DateTimeOffset]::Now,

--- a/tools/github/scripts/Add-AzsdkProjectIssues.ps1
+++ b/tools/github/scripts/Add-AzsdkProjectIssues.ps1
@@ -1,4 +1,4 @@
-[CmdletBinding(DefaultParameterSetName = 'Repositories', SupportsShouldProcess = $true)]
+[CmdletBinding(DefaultParameterSetName = 'RepositoryFile', SupportsShouldProcess = $true)]
 param (
     [Parameter(Mandatory = $true, Position = 0)]
     [int] $ProjectNumber,
@@ -6,23 +6,11 @@ param (
     [Parameter(Mandatory = $true, Position = 1)]
     [string[]] $Labels,
 
-    [Parameter(ParameterSetName = 'Repositories')]
-    [Alias("repos")]
-    [ValidateNotNullOrEmpty()]
-    [string[]] $Repositories = @(
-        'Azure/azure-sdk-for-cpp'
-        'Azure/azure-sdk-for-go'
-        'Azure/azure-sdk-for-java'
-        'Azure/azure-sdk-for-js'
-        'Azure/azure-sdk-for-net'
-        'Azure/azure-sdk-for-python'
-        'Azure/azure-sdk-for-rust'
-        'Azure/azure-sdk-tools'
-    ),
+    [Parameter(ParameterSetName = 'Repositories', Mandatory = $true)]
+    [string[]] $Repositories,
 
-    [Parameter(ParameterSetName = 'Languages')]
-    [ValidateNotNullOrEmpty()]
-    [string[]] $Languages = @('cpp', 'go', 'java', 'js', 'net', 'python', 'rust', 'c', 'ios', 'android'),
+    [Parameter(ParameterSetName = 'Languages', Mandatory = $true)]
+    [string[]] $Languages,
 
     [Parameter(ParameterSetName = 'RepositoryFile')]
     [ValidateScript({Test-Path $_ -PathType 'Leaf'})]

--- a/tools/github/scripts/Snapshot-AzsdkLabels.ps1
+++ b/tools/github/scripts/Snapshot-AzsdkLabels.ps1
@@ -12,22 +12,11 @@ param (
     [ValidateScript({Test-Path $_ -PathType 'Leaf'})]
     [string] $RepositoryFilePath = "$PSScriptRoot/../data/repositories.txt",
 
-    [Parameter(ParameterSetName = 'Repositories')]
-    [ValidateNotNullOrEmpty()]
-    [string[]] $Repositories = @(
-        'Azure/azure-sdk-for-cpp'
-        'Azure/azure-sdk-for-go'
-        'Azure/azure-sdk-for-java'
-        'Azure/azure-sdk-for-js'
-        'Azure/azure-sdk-for-net'
-        'Azure/azure-sdk-for-python'
-        'Azure/azure-sdk-for-rust'
-        'Azure/azure-sdk-tools'
-    ),
+    [Parameter(ParameterSetName = 'Repositories', Mandatory = $true)]
+    [string[]] $Repositories,
 
-    [Parameter(ParameterSetName = 'Languages')]
-    [ValidateNotNullOrEmpty()]
-    [string[]] $Languages = @('cpp', 'go', 'java', 'js', 'net', 'python', 'rust', 'c', 'ios', 'android'),
+    [Parameter(ParameterSetName = 'Languages', Mandatory = $true)]
+    [string[]] $Languages,
 
     [Parameter()]
     [ValidateRange(0,100)]
@@ -76,13 +65,13 @@ foreach ($repo in $Repositories) {
         }
 
         $filePath = (Join-Path $SnapshotDirectory "$($repo.Substring(($repo.IndexOf('/') + 1))).txt")
-        $snapshot = ((ConvertFrom-Json $repositoryLabels)| where { -not $commonLabels.Contains($_.Name) }).Name
+        $snapshot = ((ConvertFrom-Json $repositoryLabels)| Where-Object { -not $commonLabels.Contains($_.Name) }).Name
 
         if ($Diff) {
             $previousSnapshot = [Collections.Generic.HashSet[string]]::new()
 
             if (Test-Path $filePath) {
-                (Get-Content $filePath) | select { $previousSnapshot.Add($_) } | Out-Null
+                (Get-Content $filePath) | Select-Object { $previousSnapshot.Add($_) } | Out-Null
             }
 
             Write-Host "==================================================== " -ForegroundColor Green
@@ -90,13 +79,13 @@ foreach ($repo in $Repositories) {
             Write-Host "==================================================== " -ForegroundColor Green
             Write-Host "New labels added since the last snapshot:"
 
-            $newLabels = $snapshot | where { -not $previousSnapshot.Contains($_) }
+            $newLabels = $snapshot | Where-Object { -not $previousSnapshot.Contains($_) }
 
             if ($newLabels.Count -eq 0) {
                 Write-Host "`t None"
             }
             else {
-                $newLabels | foreach { Write-Host "`t$_" }
+                $newLabels | ForEach-Object { Write-Host "`t$_" }
             }
 
             Write-Host ""

--- a/tools/github/scripts/Sync-AzsdkLabels.ps1
+++ b/tools/github/scripts/Sync-AzsdkLabels.ps1
@@ -8,22 +8,11 @@ param (
     [ValidateScript({Test-Path $_ -PathType 'Leaf'})]
     [string] $RepositoryFilePath = "$PSScriptRoot/../data/repositories.txt",
 
-    [Parameter(ParameterSetName = 'Repositories')]
-    [ValidateNotNullOrEmpty()]
-    [string[]] $Repositories = @(
-        'Azure/azure-sdk-for-cpp'
-        'Azure/azure-sdk-for-go'
-        'Azure/azure-sdk-for-java'
-        'Azure/azure-sdk-for-js'
-        'Azure/azure-sdk-for-net'
-        'Azure/azure-sdk-for-python'
-        'Azure/azure-sdk-for-rust'
-        'Azure/azure-sdk-tools'
-    ),
+    [Parameter(ParameterSetName = 'Repositories', Mandatory = $true)]
+    [string[]] $Repositories,
 
-    [Parameter(ParameterSetName = 'Languages')]
-    [ValidateNotNullOrEmpty()]
-    [string[]] $Languages = @('cpp', 'go', 'java', 'js', 'net', 'python', 'rust', 'c', 'ios', 'android'),
+    [Parameter(ParameterSetName = 'Languages', Mandatory = $true)]
+    [string[]] $Languages,
 
     [Parameter()]
     [ValidateRange(0,100)]

--- a/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
+++ b/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
@@ -14,13 +14,7 @@ $hasPermissions = $false
 # Verify that the user exists and has the correct public
 # organization memberships.
 $orgResponse = (gh api "https://api.github.com/users/$UserName/orgs")
-$orgs = $orgResponse | ConvertFrom-Json
-
-if (!$org) {
-    $orgs = $orgs | Select-Object -Expand login -ErrorAction Ignore
-} else {
-    $orgs = @()
-}
+$orgs = $orgResponse | ConvertFrom-Json | Select-Object -Expand login -ErrorAction Ignore
 
 # Validate that the user has the required public organization memberships.
 $requiredOrgs = [System.Collections.Generic.HashSet[String]]::new([StringComparer]::InvariantCultureIgnoreCase)

--- a/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
+++ b/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
@@ -16,8 +16,8 @@ $hasPermissions = $false
 $orgResponse = (gh api "https://api.github.com/users/$UserName/orgs")
 $orgs = $orgResponse | ConvertFrom-Json
 
-if ($orgs -ne $null) {
-    $orgs = $orgs | select -Expand login
+if (!$org) {
+    $orgs = $orgs | Select-Object -Expand login
 } else {
     $orgs = @()
 }
@@ -28,7 +28,7 @@ $requiredOrgs.Add("Microsoft") | Out-Null
 $requiredOrgs.Add("Azure") | Out-Null
 
 # Capture non-required organizations for verbose output.
-$otherOrgs = $orgs | where { -not $requiredOrgs.Contains($_) }
+$otherOrgs = $orgs | Where-Object { -not $requiredOrgs.Contains($_) }
 
 Write-Host ""
 Write-Host "Required Orginizations:" -ForegroundColor DarkGray

--- a/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
+++ b/tools/github/scripts/Validate-AzsdkCodeOwner.ps1
@@ -17,7 +17,7 @@ $orgResponse = (gh api "https://api.github.com/users/$UserName/orgs")
 $orgs = $orgResponse | ConvertFrom-Json
 
 if (!$org) {
-    $orgs = $orgs | Select-Object -Expand login
+    $orgs = $orgs | Select-Object -Expand login -ErrorAction Ignore
 } else {
     $orgs = @()
 }


### PR DESCRIPTION
The default UX shouldn't change: to override any default values for disambiguating parameters, you had to pass values. If we change the default parameter set (or, for a couple scripts, leave it) to use the file we can remove the duplicate repo and language information from the `-Repositories` and `-Languages` parameters because to override those - even if they were the default parameter - you had to specify a different value. The end result should be no change.

Also cleans up warnings in the README and a couple other scripts using their respective linters I have enabled in VSCode.
