### PR TITLE
Fix default value for env vars in build-test-resource-config template

### DIFF
--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -8,7 +8,7 @@ parameters:
   # EnvVars is used to help diagnose variable conflict issues early
   - name: EnvVars
     type: object
-    default: null
+    default: {}
   - name: SubscriptionConfigurationFilePaths
     type: object
     default: null

--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -16,6 +16,7 @@ parameters:
 steps:
   - task: AzurePowerShell@5
     displayName: Set Pipeline Subnet Info
+    condition: ne(variables['Pool'], '')
     env: ${{ parameters.EnvVars }}
     inputs:
       azureSubscription: azure-sdk-tests

--- a/eng/scripts/live-test-resource-cleanup.ps1
+++ b/eng/scripts/live-test-resource-cleanup.ps1
@@ -441,7 +441,8 @@ function DeleteAndPurgeGroups([array]$toDelete) {
         }
       }
     } catch {
-      Write-Error $_
+      Write-Warning "Failure deleting/purging group $($rg.ResourceGroupName):"
+      Write-Warning $_
       $hasError = $true
     }
   }


### PR DESCRIPTION
The null default breaks any pipelines that don't specify env vars