### PR TITLE
[tsp-client] Fix tsp compile diagnostics logging

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2024-07-02 - 0.9.1
 
 - Fix error logging after the `compile()` call and exit if diagnostics are encountered.
-- Use `formatDiagnostic()` from "@typespec/compiler" to report diagnostics after the compiling.
+- Use `formatDiagnostic()` from "@typespec/compiler" to report diagnostics after compiling.
 
 ## 2024-06-21 - 0.9.0
 

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2024-07-01 - 0.9.1
+
+- Fix error logging during the `compile` call and exit if diagnostics are encountered.
+
 ## 2024-06-21 - 0.9.0
 
 - Prefer the `service-dir` parameter in the emitter configurations in tspconfig.yaml if specified.

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2024-07-02 - 0.9.1
 
-- Fix error logging during the `compile` call and exit if diagnostics are encountered.
+- Fix error logging after the `compile()` call and exit if diagnostics are encountered.
+- Use `formatDiagnostic()` from "@typespec/compiler" to report diagnostics after the compiling.
 
 ## 2024-06-21 - 0.9.0
 

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release
 
-## 2024-07-01 - 0.9.1
+## 2024-07-02 - 0.9.1
 
 - Fix error logging during the `compile` call and exit if diagnostics are encountered.
 

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -26,7 +26,7 @@
         "@types/prompt-sync": "^4.2.1",
         "@typespec/compiler": "0.50.0",
         "chai": "^4.3.7",
-        "mocha": "^10.2.0",
+        "mocha": "^10.5.2",
         "prettier": "^3.0.1",
         "rimraf": "^5.0.1",
         "ts-node": "^10.9.1",
@@ -1580,14 +1580,14 @@
       }
     },
     "node_modules/mocha": {
-      "version": "10.3.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.3.0.tgz",
-      "integrity": "sha512-uF2XJs+7xSLsrmIvn37i/wnc91nw7XjOQB8ccyx5aEgdnohr7n+rEiZP23WkCYHjilR6+EboEnbq/ZQDz4LSbg==",
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.5.2.tgz",
+      "integrity": "sha512-9btlN3JKCefPf+vKd/kcKz2SXxi12z6JswkGfaAF0saQvnsqLJk504ZmbxhSoENge08E9dsymozKgFMTl5PQsA==",
       "dev": true,
       "dependencies": {
         "ansi-colors": "4.1.1",
         "browser-stdout": "1.3.1",
-        "chokidar": "3.5.3",
+        "chokidar": "^3.5.3",
         "debug": "4.3.4",
         "diff": "5.0.0",
         "escape-string-regexp": "4.0.0",

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@azure/core-rest-pipeline": "^1.12.0",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -17,7 +17,7 @@
     "clean": "rimraf ./dist ./types",
     "example": "npx ts-node src/index.ts update",
     "prepack": "npm run build",
-    "test": "mocha"
+    "test": "mocha --exclude **/examples/**"
   },
   "author": "Microsoft Corporation",
   "license": "MIT",
@@ -39,7 +39,7 @@
     "@types/prompt-sync": "^4.2.1",
     "@typespec/compiler": "0.50.0",
     "chai": "^4.3.7",
-    "mocha": "^10.2.0",
+    "mocha": "^10.5.2",
     "prettier": "^3.0.1",
     "rimraf": "^5.0.1",
     "ts-node": "^10.9.1",

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -3,6 +3,7 @@ import { ModuleResolutionResult, resolveModule, ResolveModuleHost } from "@types
 import { Logger } from "./log.js";
 import { readFile, readdir, realpath, stat } from "fs/promises";
 import { pathToFileURL } from "url";
+import { exit } from "process";
 
 
 export interface TspLocation {
@@ -109,10 +110,11 @@ export async function compileTsp({
     for (const diagnostic of program.diagnostics) {
       const location = getSourceLocation(diagnostic.target);
       const source = location ? location.file.path : "unknown";
-      console.error(
+      Logger.error(
         `${diagnostic.severity}: ${diagnostic.code} - ${diagnostic.message} @ ${source}`,
       );
     }
+    exit(1);
   } else {
     Logger.success("generation complete");
   }

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -1,4 +1,4 @@
-import { resolvePath, getDirectoryPath, ResolveCompilerOptionsOptions } from "@typespec/compiler";
+import { resolvePath, getDirectoryPath, ResolveCompilerOptionsOptions, formatDiagnostic } from "@typespec/compiler";
 import { ModuleResolutionResult, resolveModule, ResolveModuleHost } from "@typespec/compiler/module-resolver";
 import { Logger } from "./log.js";
 import { readFile, readdir, realpath, stat } from "fs/promises";
@@ -66,7 +66,7 @@ export async function compileTsp({
   saveInputs?: boolean;
 }) {
   const parsedEntrypoint = getDirectoryPath(resolvedMainFilePath);
-  const { compile, NodeHost, getSourceLocation, resolveCompilerOptions } = await importTsp(parsedEntrypoint);
+  const { compile, NodeHost, resolveCompilerOptions } = await importTsp(parsedEntrypoint);
 
   const outputDir = resolvePath(outputPath);
   const overrideOptions: Record<string, Record<string, string>> = {
@@ -107,11 +107,7 @@ export async function compileTsp({
 
   if (program.diagnostics.length > 0) {
     for (const diagnostic of program.diagnostics) {
-      const location = getSourceLocation(diagnostic.target);
-      const source = location ? location.file.path : "unknown";
-      Logger.error(
-        `${diagnostic.severity}: ${diagnostic.code} - ${diagnostic.message} @ ${source}`,
-      );
+      Logger.error(formatDiagnostic(diagnostic));
     }
     process.exit(1);
   } else {

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -3,7 +3,6 @@ import { ModuleResolutionResult, resolveModule, ResolveModuleHost } from "@types
 import { Logger } from "./log.js";
 import { readFile, readdir, realpath, stat } from "fs/promises";
 import { pathToFileURL } from "url";
-import { exit } from "process";
 
 
 export interface TspLocation {
@@ -114,7 +113,7 @@ export async function compileTsp({
         `${diagnostic.severity}: ${diagnostic.code} - ${diagnostic.message} @ ${source}`,
       );
     }
-    exit(1);
+    process.exit(1);
   } else {
     Logger.success("generation complete");
   }

--- a/tools/tsp-client/test/examples/specification/diagnostics/main.tsp
+++ b/tools/tsp-client/test/examples/specification/diagnostics/main.tsp
@@ -1,0 +1,70 @@
+// DONT specify @useDependency to get a diagnostic reported
+
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+using Azure.Core.Traits;
+
+@useAuth(
+  ApiKeyAuth<ApiKeyLocation.header, "api-key"> | OAuth2Auth<[
+    {
+      type: OAuth2FlowType.implicit,
+      authorizationUrl: "https://login.contoso.com/common/oauth2/v2.0/authorize",
+      scopes: ["https://widget.contoso.com/.default"],
+    }
+  ]>
+)
+@service({
+  title: "Contoso Widget Manager",
+})
+@server(
+  "{endpoint}/widget",
+  "Contoso Widget APIs",
+  {
+    /** 
+Supported Widget Services endpoints (protocol and hostname, for example:
+https://westus.api.widget.contoso.com).
+ */
+    endpoint: string,
+  }
+)
+@versioned(Contoso.WidgetManager.Versions)
+namespace Contoso.WidgetManager;
+
+/** The Contoso Widget Manager service version. */
+enum Versions {
+  /** Version 2022-08-31 */
+  // @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  `2022-08-30`,
+}
+
+/** A widget. */
+@resource("widgets")
+model Widget {
+  /** The widget name. */
+  @key("widgetName")
+  @visibility("read")
+  name: string;
+
+  /** The widget color. */
+  color: string;
+
+  /** The ID of the widget's manufacturer. */
+  manufacturerId: string;
+}
+
+alias ServiceTraits = SupportsRepeatableRequests &
+  SupportsConditionalRequests &
+  SupportsClientRequestId;
+
+alias Operations = Azure.Core.ResourceOperations<ServiceTraits>;
+
+interface Widgets {
+    getWidget is Operations.ResourceRead<Widget>;
+}

--- a/tools/tsp-client/test/examples/specification/diagnostics/tspconfig.yaml
+++ b/tools/tsp-client/test/examples/specification/diagnostics/tspconfig.yaml
@@ -1,0 +1,34 @@
+parameters:
+  "service-dir":
+    default: "sdk/contosowidgetmanager"
+emit:
+  - "@azure-tools/typespec-autorest"
+linter:
+  extends:
+    - "@azure-tools/typespec-azure-rulesets/data-plane"
+options:
+  "@azure-tools/typespec-autorest":
+    azure-resource-provider-folder: "data-plane"
+    emit-lro-options: "none"
+    emitter-output-dir: "{project-root}/.."
+    examples-directory: "examples"
+    output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/widgets.json"
+  "@azure-tools/typespec-python":
+    package-dir: "azure-contoso-widgetmanager"
+    package-name: "{package-dir}"
+    flavor: azure
+  "@azure-tools/typespec-csharp":
+    package-dir: "Azure.Template.Contoso"
+    clear-output-folder: true
+    model-namespace: false
+    namespace: "{package-dir}"
+    flavor: azure
+  "@azure-tools/typespec-ts":
+    package-dir: "contosowidgetmanager-rest"
+    packageDetails:
+      name: "@azure-rest/contoso-widgetmanager-rest"
+    flavor: azure
+  "@azure-tools/typespec-java":
+    package-dir: "azure-contoso-widgetmanager"
+    namespace: com.azure.contoso.widgetmanager
+    flavor: azure

--- a/tools/tsp-client/test/typespec.spec.ts
+++ b/tools/tsp-client/test/typespec.spec.ts
@@ -1,0 +1,23 @@
+import { assert } from "chai";
+import { compileTsp } from "../src/typespec.js";
+import { describe, it } from "node:test";
+import { joinPaths } from "@typespec/compiler";
+
+describe("Check diagnostic reporting", function () {
+  it("Check diagnostic format", async function () {
+        compileTsp({
+            emitterPackage: "@azure-tools/typespec-ts",
+            outputPath: joinPaths(process.cwd(), "examples"),
+            resolvedMainFilePath: joinPaths(process.cwd(), "examples", "specification", "diagnostics", "main.tsp"),
+            additionalEmitterOptions: "",
+            saveInputs: false
+        }).then(
+            () => {
+                assert.fail("Expected error but got none");
+            },
+            (e) => {
+                assert.ok(e.message.includes("test/examples/specification/diagnostics/main.tsp:38:19 - error @typespec/versioning/using-versioned-library: Namespace 'Contoso.WidgetManager' is referencing types from versioned namespace 'Azure.Core' but didn't specify which versions with @useDependency."));
+            }
+        );
+  });
+});


### PR DESCRIPTION
Use logger for diagnostics and exit if there are diagnostics reported during the tsp `compile` call

Fixes https://github.com/Azure/azure-sdk-tools/issues/8523