### PR TITLE
[GitHub] Update common labels

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -1,5 +1,6 @@
 AAD,,e99695
 ACS,,e99695
+AI Model Inference,,e99695
 AKS,,e99695
 API Management,,e99695
 APIChange,This PR contains an addition or change to the API signature and must be reviewed by an architect.,d8f74c


### PR DESCRIPTION
# Summary

The focus of these changes is to add a common label for the "AI Model Inference" service.