### PR TITLE
[tsp-client] Fix compiler diagnostic reporting

### DIFF
--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -219,13 +219,16 @@ async function generate({
     args.push("--force");
   }
   await npmCommand(srcDir, args);
-  await compileTsp({ emitterPackage: emitter, outputPath: rootUrl, resolvedMainFilePath, saveInputs: noCleanup, additionalEmitterOptions });
+  const succeeded = await compileTsp({ emitterPackage: emitter, outputPath: rootUrl, resolvedMainFilePath, saveInputs: noCleanup, additionalEmitterOptions });
 
   if (noCleanup) {
     Logger.debug(`Skipping cleanup of temp directory: ${tempRoot}`);
   } else {
     Logger.debug("Cleaning up temp directory");
     await removeDirectory(tempRoot);
+  }
+  if (!succeeded) {
+    exit(1);
   }
 }
 

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -228,7 +228,7 @@ async function generate({
     await removeDirectory(tempRoot);
   }
   if (!succeeded) {
-    exit(1);
+    process.exit(1);
   }
 }
 

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -64,7 +64,7 @@ export async function compileTsp({
   resolvedMainFilePath: string;
   additionalEmitterOptions?: string;
   saveInputs?: boolean;
-}) {
+}): Promise<boolean> {
   const parsedEntrypoint = getDirectoryPath(resolvedMainFilePath);
   const { compile, NodeHost, resolveCompilerOptions } = await importTsp(parsedEntrypoint);
 
@@ -100,7 +100,8 @@ export async function compileTsp({
   Logger.debug(`Compiler options: ${JSON.stringify(options)}`);
   if (diagnostics.length > 0) {
     // This should not happen, but if it does, we should log it.
-    Logger.debug(`Compiler options diagnostic information: ${JSON.stringify(diagnostics)}`);
+    Logger.error(`Compiler options diagnostic information: ${JSON.stringify(diagnostics)}`);
+    return false;
   }
 
   const program = await compile(NodeHost, resolvedMainFilePath, options);
@@ -109,10 +110,11 @@ export async function compileTsp({
     for (const diagnostic of program.diagnostics) {
       Logger.error(formatDiagnostic(diagnostic));
     }
-    process.exit(1);
+    return false;
   } else {
     Logger.success("generation complete");
   }
+  return true;
 }
 
 export async function importTsp(baseDir: string): Promise<typeof import("@typespec/compiler")> {

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -100,16 +100,16 @@ export async function compileTsp({
   Logger.debug(`Compiler options: ${JSON.stringify(options)}`);
   if (diagnostics.length > 0) {
     // This should not happen, but if it does, we should log it.
-    Logger.error(`Compiler options diagnostic information: ${JSON.stringify(diagnostics)}`);
+    Logger.error("Diagnostics were reported while resolving compiler options...")
+    diagnostics.forEach((diagnostic) => { Logger.error(formatDiagnostic(diagnostic)); });
     return false;
   }
 
   const program = await compile(NodeHost, resolvedMainFilePath, options);
 
   if (program.diagnostics.length > 0) {
-    for (const diagnostic of program.diagnostics) {
-      Logger.error(formatDiagnostic(diagnostic));
-    }
+    Logger.error("Diagnostics were reported during compilation...");
+    program.diagnostics.forEach((diagnostic) => { Logger.error(formatDiagnostic(diagnostic)); });
     return false;
   } else {
     Logger.success("generation complete");


### PR DESCRIPTION
More fixes related to diagnostic reporting. Return boolean from compileTsp to exit after file clean up in case of diagnostics.