### PR TITLE
[tsp-client] Revert exit after compile

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release
 
-## 2024-07-03 - 0.9.2
+## 2024-07-04 - 0.9.2
 
 - Revert `exit(1)` on tsp compile diagnostics.
 

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2024-07-03 - 0.9.2
+
+- Revert `exit(1)` on tsp compile diagnostics.
+
 ## 2024-07-02 - 0.9.1
 
 - Fix error logging after the `compile()` call and exit if diagnostics are encountered.

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@azure/core-rest-pipeline": "^1.12.0",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -219,16 +219,13 @@ async function generate({
     args.push("--force");
   }
   await npmCommand(srcDir, args);
-  const succeeded = await compileTsp({ emitterPackage: emitter, outputPath: rootUrl, resolvedMainFilePath, saveInputs: noCleanup, additionalEmitterOptions });
+  await compileTsp({ emitterPackage: emitter, outputPath: rootUrl, resolvedMainFilePath, saveInputs: noCleanup, additionalEmitterOptions });
 
   if (noCleanup) {
     Logger.debug(`Skipping cleanup of temp directory: ${tempRoot}`);
   } else {
     Logger.debug("Cleaning up temp directory");
     await removeDirectory(tempRoot);
-  }
-  if (!succeeded) {
-    process.exit(1);
   }
 }
 


### PR DESCRIPTION
Exiting with `exit(1)` after a tsp compile returns diagnostics is not always correct since some diagnostics are at the warning vs error level. 

Tracking issue to fix this logic: #8555

Reverting now to unblock automation pipelines. Fixes #8553