### PR TITLE
Pass condition to a few `analyze` eng/common checks

### DIFF
--- a/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
+++ b/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml
@@ -2,6 +2,7 @@
 # is used when this pipeline is going to be generating and publishing daily dev builds.
 parameters:
   ServiceDirectory: ''
+  Condition: succeeded()
 steps:
 - ${{if ne(parameters.ServiceDirectory, '')}}:
   - task: Powershell@2
@@ -13,7 +14,7 @@ steps:
       pwsh: true
       workingDirectory: $(Pipeline.Workspace)
     displayName: Dump Package properties
-    condition: succeeded()
+    condition: ${{ parameters.Condition }}
 - pwsh: |
     $setDailyDevBuild = "false"
     if (('$(Build.Reason)' -eq 'Schedule') -and ('$(System.TeamProject)' -eq 'internal')) {
@@ -21,4 +22,4 @@ steps:
     }
     echo "##vso[task.setvariable variable=SetDevVersion]$setDailyDevBuild"
   displayName: "Setup Versioning Properties"
-  condition: and(succeeded(), eq(variables['SetDevVersion'], ''))
+  condition: and(${{ parameters.Condition }}, eq(variables['SetDevVersion'], ''))

--- a/eng/common/pipelines/templates/steps/verify-changelog.yml
+++ b/eng/common/pipelines/templates/steps/verify-changelog.yml
@@ -11,6 +11,9 @@ parameters:
 - name: ForRelease
   type: boolean
   default: false
+- name: Condition
+  type: string
+  default: succeeded()
 
 steps:
   - task: Powershell@2
@@ -23,4 +26,5 @@ steps:
       pwsh: true
       workingDirectory: $(Pipeline.Workspace)
     displayName: Verify ChangeLogEntry for ${{ parameters.PackageName }}
+    condition: ${{ parameters.Condition }}
     continueOnError: false

--- a/eng/common/pipelines/templates/steps/verify-path-length.yml
+++ b/eng/common/pipelines/templates/steps/verify-path-length.yml
@@ -1,11 +1,13 @@
 # Template for all Python Scripts in this repository
-parameters: 
+parameters:
   SourceDirectory: ''
   BasePathLength: 49
+  Condition: succeeded()
 
 steps:
   - task: PythonScript@0
     displayName: Analyze Path Lengths
+    condition: ${{ parameters.Condition }}
     inputs:
       scriptSource: inline
       script: |

--- a/eng/common/pipelines/templates/steps/verify-readme.yml
+++ b/eng/common/pipelines/templates/steps/verify-readme.yml
@@ -15,10 +15,14 @@ parameters:
 - name: DocWardenVersion
   type: string
   default: ''
+- name: Condition
+  type: string
+  default: succeeded()
 
 steps:
 - task: PowerShell@2
   displayName: "Verify Readmes"
+  condition: ${{ parameters.Condition }}
   inputs:
     filePath: "eng/common/scripts/Verify-Readme.ps1"
     arguments: >


### PR DESCRIPTION
Python had a nightly `analyze` failure that had me really confused. The issue was that one of the eng/common steps which set the daily dev build variable skipped due to a default `succeeded()` condition when a step above it unexpectedly failed.

I walked the rest of the `analyze` steps in Python, and identified a few more where a custom condition can be provided to allow `succeededOrFailed()` to be passed. This way all the enforcement runs on a given analyze job.

Once this PR merges I'll take advantage of it on python side and ensure the issue that hit @kristapratico is avoided in the future.