### PR TITLE
Set storage account test resources to disable blob public access. Disable network firewall.

### DIFF
--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -257,7 +257,7 @@ $verifyDeleteScript = {
 # Get any resources that can be purged after the resource group is deleted coerced into a collection even if empty.
 $purgeableResources = Get-PurgeableGroupResources $ResourceGroupName
 
-SetResourceNetworkAccessRules -ResourceGroupName $ResourceGroupName -AllowIpRanges $AllowIpRanges -Override -CI:$CI
+SetResourceNetworkAccessRules -ResourceGroupName $ResourceGroupName -AllowIpRanges $AllowIpRanges -SetFirewall -CI:$CI
 Remove-WormStorageAccounts -GroupPrefix $ResourceGroupName -CI:$CI
 
 Log "Deleting resource group '$ResourceGroupName'"

--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -16,7 +16,7 @@ parameters:
 steps:
   - task: AzurePowerShell@5
     displayName: Set Pipeline Subnet Info
-    condition: ne(variables['Pool'], '')
+    condition: and(succeeded(), ne(variables['Pool'], ''))
     env: ${{ parameters.EnvVars }}
     inputs:
       azureSubscription: azure-sdk-tests

--- a/eng/common/scripts/Helpers/Resource-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Resource-Helpers.ps1
@@ -319,7 +319,14 @@ function SetStorageNetworkAccessRules([string]$ResourceGroupName, [array]$AllowI
   if ($storageAccounts) {
     $appliedRule = $false
     foreach ($account in $storageAccounts) {
+      $properties = Get-AzStorageAccount -ResourceGroupName $ResourceGroupName -AccountName $account.Name
       $rules = Get-AzStorageAccountNetworkRuleSet -ResourceGroupName $ResourceGroupName -AccountName $account.Name
+
+      if ($properties.AllowBlobPublicAccess) {
+        Write-Host "Restricting public blob access in storage account '$($account.Name)'"
+        Set-AzStorageAccount -ResourceGroupName $ResourceGroupName -StorageAccountName $account.Name -AllowBlobPublicAccess $false
+      }
+
       if ($rules -and ($Override -or $rules.DefaultAction -eq "Allow")) {
         Write-Host "Restricting network rules in storage account '$($account.Name)' to deny access by default"
         Retry { Update-AzStorageAccountNetworkRuleSet -ResourceGroupName $ResourceGroupName -Name $account.Name -DefaultAction Deny }


### PR DESCRIPTION
This will disable this by default as an override.

There are several places where we have this marked as `true` in live test ARM templates, but I'm not convinced those are necessary. Will do testing against these changes before merging.

EDIT: Also removing the pieces that add the network firewall by default on resource creation. This is causing a whole host of issues that we aren't getting much value from, and aren't required to do in the near term.