### PR TITLE
Adjustments enabling change-specific PackageInfo

### DIFF
--- a/eng/common/scripts/Generate-PR-Diff.ps1
+++ b/eng/common/scripts/Generate-PR-Diff.ps1
@@ -45,7 +45,7 @@ $changedServices = Get-ChangedServices -ChangedFiles $changedFiles
 $result = [PSCustomObject]@{
     "ChangedFiles" = $changedFiles
     "ChangedServices" = $changedServices
-    "PRNumber" = $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER
+    "PRNumber" = if ($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER) { $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER } else { "-1" }
 }
 
 $result | ConvertTo-Json | Out-File $ArtifactName

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -105,6 +105,20 @@ function Get-PkgProperties
     return $null
 }
 
+function Get-PrPkgProperties([string]$InputDiffJson) {
+    $pkgPropsResult = @()
+
+    Write-Host "In Get-PRPkgProperties function"
+
+    if ($GetPRPackageInfoFromRepoFn -and (Test-Path "Function:$GetPRPackageInfoFromRepoFn"))
+    {
+        Write-Host "Attempting to invoke the language one"
+        $pkgPropsResult = &$GetPRPackageInfoFromRepoFn -InputDiffJson $InputDiffJson
+    }
+
+    return $pkgPropsResult
+}
+
 # Takes ServiceName and Repo Root Directory
 # Returns important properties for each package in the specified service, or entire repo if the serviceName is not specified
 # Returns a Table of service key to array values of PS Object with properties @ { pkgName, pkgVersion, pkgDirectoryPath, pkgReadMePath, pkgChangeLogPath }

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -14,8 +14,8 @@ In cases of collisions where track 2 packages (IsNewSdk = true) have the same
 filename as track 1 packages (e.g. same artifact name or package name), the
 track 2 package properties will be written.
 
-.PARAMETER serviceDirectory
-Service directory in which to search for packages
+.PARAMETER serviceInput
+Service directory in which to search for packages, or file path ending in diff.json.
 
 .PARAMETER outDirectory
 Output location (generally a package artifact directory in DevOps) for JSON 
@@ -33,7 +33,7 @@ Verison property in that file.
 [CmdletBinding()]
 Param (
   [Parameter(Mandatory=$True)]
-  [string] $serviceDirectory,
+  [string] $serviceInput,
   [Parameter(Mandatory=$True)]
   [string] $outDirectory,
   [switch] $addDevVersion
@@ -92,7 +92,18 @@ function GetRelativePath($path) {
 }
 
 $exportedPaths = @{}
-$allPackageProperties = Get-AllPkgProperties $serviceDirectory
+
+$allPackageProperties = @()
+
+if ($serviceInput.endswith("diff.json")) {
+  $allPackageProperties = Get-PrPkgProperties $serviceInput
+}
+else {
+  $allPackageProperties = Get-AllPkgProperties $serviceInput
+}
+
+Write-Host $allPackageProperties
+
 if ($allPackageProperties)
 {
     if (-not (Test-Path -Path $outDirectory))
@@ -137,6 +148,6 @@ if ($allPackageProperties)
 }
 else
 {
-    Write-Error "Package properties are not available for service directory $($serviceDirectory)"
+    Write-Error "Package properties are not available for service directory $($serviceInput)"
     exit 1
 }

--- a/eng/common/scripts/common.ps1
+++ b/eng/common/scripts/common.ps1
@@ -63,6 +63,7 @@ $GetEmitterAdditionalOptionsFn = "Get-${Language}-EmitterAdditionalOptions"
 $GetEmitterNameFn = "Get-${Language}-EmitterName"
 $GetDirectoriesForGenerationFn = "Get-${Language}-DirectoriesForGeneration"
 $UpdateGeneratedSdksFn = "Update-${Language}-GeneratedSdks"
+$IsApiviewStatusCheckRequiredFn = "Get-${Language}-ApiviewStatusCheckRequirement" 
 
 # Expected to be set in eng/scripts/docs/Docs-Onboarding.ps1
 $SetDocsPackageOnboarding = "Set-${Language}-DocsPackageOnboarding"

--- a/eng/common/scripts/common.ps1
+++ b/eng/common/scripts/common.ps1
@@ -42,6 +42,7 @@ if (!(Get-Variable -Name "LanguageDisplayName" -ValueOnly -ErrorAction "Ignore")
 # Transformed Functions
 # Expected to be set in eng/scripts/Language-Settings.ps1
 $GetPackageInfoFromRepoFn = "Get-${Language}-PackageInfoFromRepo"
+$GetPRPackageInfoFromRepoFn = "Get-${Language}-PRPackageInfoFromRepo"
 $GetPackageInfoFromPackageFileFn = "Get-${Language}-PackageInfoFromPackageFile"
 $PublishGithubIODocsFn = "Publish-${Language}-GithubIODocs"
 $UpdateDocsMsPackagesFn = "Update-${Language}-DocsMsPackages"
@@ -62,7 +63,6 @@ $GetEmitterAdditionalOptionsFn = "Get-${Language}-EmitterAdditionalOptions"
 $GetEmitterNameFn = "Get-${Language}-EmitterName"
 $GetDirectoriesForGenerationFn = "Get-${Language}-DirectoriesForGeneration"
 $UpdateGeneratedSdksFn = "Update-${Language}-GeneratedSdks"
-$IsApiviewStatusCheckRequiredFn = "Get-${Language}-ApiviewStatusCheckRequirement" 
 
 # Expected to be set in eng/scripts/docs/Docs-Onboarding.ps1
 $SetDocsPackageOnboarding = "Set-${Language}-DocsPackageOnboarding"


### PR DESCRIPTION
Effectively, this allows `Save-Package-Properties` to honor the `diff` file.

[In practice it looks like this](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3950939&view=results)

todo:

- [ ] Do we want to keep `ServiceInput` or duplicate this thing into another script entirely?
- [ ] Remove debugging outputs

On my `build` phase, this is the yml gating access to the filter

```yml
- ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
    - pwsh: |
        mkdir -p $(Build.ArtifactStagingDirectory)/diff
      displayName: Create PR Diff Folder

    - task: PowerShell@2
      inputs:
        filePath: 'eng/common/scripts/Generate-PR-Diff.ps1'
        arguments: '-TargetPath "$(Build.SourcesDirectory)" -ArtifactPath $(Build.ArtifactStagingDirectory)/diff'
      displayName: 'Generate PR Diff'

    - pwsh: |
        Write-Host "We freshly generated the PR diff, and this is what it sees!"
        Get-ChildItem -R -Force $(Build.ArtifactStagingDirectory)/diff | % { $_.FullName }
        cat $(Build.ArtifactStagingDirectory)/diff/diff.json
      displayName: Dump PR Diff

    - task: Powershell@2
      inputs:
        filePath: $(Build.SourcesDirectory)/eng/common/scripts/Save-Package-Properties.ps1
        arguments: >
          -ServiceInput $(Build.ArtifactStagingDirectory)/diff/diff.json
          -OutDirectory $(Build.ArtifactStagingDirectory)/PackageInfo
        pwsh: true
        workingDirectory: $(Pipeline.Workspace)
      displayName: Save package properties filtered for PR
  - ${{ else }}:
    - task: Powershell@2
      inputs:
        filePath: $(Build.SourcesDirectory)/eng/common/scripts/Save-Package-Properties.ps1
        arguments: >
          -ServiceInput ${{parameters.ServiceDirectory}}
          -OutDirectory $(Build.ArtifactStagingDirectory)/PackageInfo
        pwsh: true
        workingDirectory: $(Pipeline.Workspace)
      displayName: Save package properties for service
```
Everywhere else that may need to do work against the changeset will get this `packages` artifact, then utilize it to determine targeted packages

```
  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
    # if we are in a PR, utilize the fact that the package properties folder will already be downloaded in the Packages folder
    # any json file that exists within the PackagePropertiesFolder will be added to the targeting string
    - pwsh: |
        $packageProperties = Get-ChildItem -Recurse -Force "${{ parameters.PackagePropertiesFolder }}" `
          | Where-Object { $_.Extension -eq '.json' } `
          | Foreach-Object { $_.Name } `
          | ForEach-Object { $_.Replace(".json", "") }

        $setting = $packageProperties -join ","

        Write-Host "Setting TargetingString to $setting"
        Write-Host "##vso[task.setvariable variable=TargetingString;]$setting"
      displayName: Check override of targeting string by variable for PR builds
```

What _this_ specifically willl vary per language. For Python it's just setting `TargetingString` variable to a comma separated list of package names.

