### PR TITLE
Create token file using file name given as param

### DIFF
--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/CSharpAPIParser.csproj
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/CSharpAPIParser.csproj
@@ -4,7 +4,7 @@
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>CSharpAPIParserForAPIView</ToolCommandName>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>CSharpAPIParser</RootNamespace>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
@@ -125,8 +125,7 @@ static async Task HandlePackageFileParsing(Stream stream, FileInfo packageFilePa
 
         await using FileStream gzipFileStream = new FileStream(gzipJsonTokenFilePath, FileMode.Create, FileAccess.Write);
         await using GZipStream gZipStream = new GZipStream(gzipFileStream, CompressionLevel.Optimal);
-        JsonSerializer.Serialize(new Utf8JsonWriter(gZipStream, new JsonWriterOptions { Indented = false }), treeTokenCodeFile, options);
-        await Task.Delay(1000);
+        await JsonSerializer.SerializeAsync(gZipStream, treeTokenCodeFile, options);
         Console.WriteLine($"TokenCodeFile File {gzipJsonTokenFilePath} Generated Successfully.");
         Console.WriteLine();
     }

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
@@ -126,7 +126,7 @@ static async Task HandlePackageFileParsing(Stream stream, FileInfo packageFilePa
         await using FileStream gzipFileStream = new FileStream(gzipJsonTokenFilePath, FileMode.Create, FileAccess.Write);
         await using GZipStream gZipStream = new GZipStream(gzipFileStream, CompressionLevel.Optimal);
         JsonSerializer.Serialize(new Utf8JsonWriter(gZipStream, new JsonWriterOptions { Indented = false }), treeTokenCodeFile, options);
-
+        await Task.Delay(1000);
         Console.WriteLine($"TokenCodeFile File {gzipJsonTokenFilePath} Generated Successfully.");
         Console.WriteLine();
     }

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
@@ -113,9 +113,9 @@ static async Task HandlePackageFileParsing(Stream stream, FileInfo packageFilePa
             return;
         }
 
-        var parsedFileName = string.IsNullOrEmpty(outputFileName) ? assemblySymbol.Name : outputFileName;
+        var parsedFileName = string.IsNullOrEmpty(outputFileName) ? $"{assemblySymbol.Name}.json.tgz" : Path.GetFileName(outputFileName);
         var treeTokenCodeFile = new CSharpAPIParser.TreeToken.CodeFileBuilder().Build(assemblySymbol, runAnalysis, dependencies);
-        var gzipJsonTokenFilePath = Path.Combine(OutputDirectory.FullName, $"{parsedFileName}.json.tgz");
+        var gzipJsonTokenFilePath = Path.Combine(OutputDirectory.FullName, parsedFileName);
 
 
         var options = new JsonSerializerOptions()

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
@@ -113,9 +113,9 @@ static async Task HandlePackageFileParsing(Stream stream, FileInfo packageFilePa
             return;
         }
 
-        var parsedFileName = string.IsNullOrEmpty(outputFileName) ? $"{assemblySymbol.Name}.json.tgz" : Path.GetFileName(outputFileName);
+        var parsedFileName = string.IsNullOrEmpty(outputFileName) ? assemblySymbol.Name : Path.GetFileName(outputFileName);
         var treeTokenCodeFile = new CSharpAPIParser.TreeToken.CodeFileBuilder().Build(assemblySymbol, runAnalysis, dependencies);
-        var gzipJsonTokenFilePath = Path.Combine(OutputDirectory.FullName, parsedFileName);
+        var gzipJsonTokenFilePath = Path.Combine(OutputDirectory.FullName, $"{parsedFileName}.json.tgz");
 
 
         var options = new JsonSerializerOptions()

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
@@ -113,7 +113,7 @@ static async Task HandlePackageFileParsing(Stream stream, FileInfo packageFilePa
             return;
         }
 
-        var parsedFileName = string.IsNullOrEmpty(outputFileName) ? assemblySymbol.Name : Path.GetFileName(outputFileName);
+        var parsedFileName = string.IsNullOrEmpty(outputFileName) ? assemblySymbol.Name : outputFileName;
         var treeTokenCodeFile = new CSharpAPIParser.TreeToken.CodeFileBuilder().Build(assemblySymbol, runAnalysis, dependencies);
         var gzipJsonTokenFilePath = Path.Combine(OutputDirectory.FullName, $"{parsedFileName}.json.tgz");
 
@@ -123,11 +123,9 @@ static async Task HandlePackageFileParsing(Stream stream, FileInfo packageFilePa
             DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
         };
 
-        {
-            using FileStream gzipFileStream = new FileStream(gzipJsonTokenFilePath, FileMode.Create, FileAccess.Write);
-            using GZipStream gZipStream = new GZipStream(gzipFileStream, CompressionLevel.Optimal);
-            JsonSerializer.Serialize(new Utf8JsonWriter(gZipStream, new JsonWriterOptions { Indented = false }), treeTokenCodeFile, options);
-        }
+        await using FileStream gzipFileStream = new FileStream(gzipJsonTokenFilePath, FileMode.Create, FileAccess.Write);
+        await using GZipStream gZipStream = new GZipStream(gzipFileStream, CompressionLevel.Optimal);
+        JsonSerializer.Serialize(new Utf8JsonWriter(gZipStream, new JsonWriterOptions { Indented = false }), treeTokenCodeFile, options);
 
         Console.WriteLine($"TokenCodeFile File {gzipJsonTokenFilePath} Generated Successfully.");
         Console.WriteLine();


### PR DESCRIPTION
Token file is created using incorrect file name even when a path is passed, and this leads to file not found error.