### PR TITLE
Missing a condition passthrough on `verify-links.yml`

### DIFF
--- a/eng/common/pipelines/templates/steps/set-default-branch.yml
+++ b/eng/common/pipelines/templates/steps/set-default-branch.yml
@@ -2,6 +2,7 @@ parameters:
   WorkingDirectory: '$(System.DefaultWorkingDirectory)'
   RemoteRepo: 'origin'
   DefaultBranchVariableName: DefaultBranch
+  Condition: 'succeeded()'
 steps:
 - pwsh: |
     $setDefaultBranch = (git remote show ${{ parameters.RemoteRepo }} | Out-String) -replace "(?ms).*HEAD branch: (\w+).*", '$1'
@@ -13,4 +14,5 @@ steps:
     Write-Host "##vso[task.setvariable variable=${{ parameters.DefaultBranchVariableName }}]$setDefaultBranch"
   displayName: "Setup Default Branch"
   workingDirectory: ${{ parameters.workingDirectory }}
+  condition: ${{ parameters.Condition }}
   ignoreLASTEXITCODE: true

--- a/eng/common/pipelines/templates/steps/verify-links.yml
+++ b/eng/common/pipelines/templates/steps/verify-links.yml
@@ -13,7 +13,7 @@ parameters:
 steps:
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
     parameters:
-      condition: ${{ parameters.Condition }}
+      Condition: ${{ parameters.Condition }}
   - task: PowerShell@2
     displayName: Link verification check
     condition: ${{ parameters.Condition }}

--- a/eng/common/pipelines/templates/steps/verify-links.yml
+++ b/eng/common/pipelines/templates/steps/verify-links.yml
@@ -12,6 +12,8 @@ parameters:
 
 steps:
   - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
+    parameters:
+      condition: ${{ parameters.Condition }}
   - task: PowerShell@2
     displayName: Link verification check
     condition: ${{ parameters.Condition }}


### PR DESCRIPTION
See title, [discovered in build failure](https://dev.azure.com/azure-sdk/public/_build/results?buildId=3967720&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=a880e989-7d1a-5c96-a41f-d540b383cc43).

The build failed correctly, but we should have invoked the SetDefaultBranch regardless of cspell failing.