### PR TITLE
Refactor apiviewgo type definition hoisting

### DIFF
--- a/src/go/cmd/api_view.go
+++ b/src/go/cmd/api_view.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"slices"
+	"strings"
 )
 
 // CreateAPIView generates the output file that the API view tool uses.
@@ -30,4 +32,21 @@ func createReview(pkgDir string) (PackageReview, error) {
 		return PackageReview{}, err
 	}
 	return r.Review()
+}
+
+func recursiveSortNavigation(n Navigation) {
+	for _, nn := range n.ChildItems {
+		recursiveSortNavigation(nn)
+	}
+	slices.SortFunc(n.ChildItems, func(a Navigation, b Navigation) int {
+		aa, err := json.Marshal(a)
+		if err != nil {
+			panic(err)
+		}
+		bb, err := json.Marshal(b)
+		if err != nil {
+			panic(err)
+		}
+		return strings.Compare(string(aa), string(bb))
+	})
 }

--- a/src/go/cmd/api_view.go
+++ b/src/go/cmd/api_view.go
@@ -7,9 +7,6 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	"slices"
-	"sort"
-	"strings"
 )
 
 // CreateAPIView generates the output file that the API view tool uses.
@@ -28,93 +25,9 @@ func CreateAPIView(pkgDir, outputDir string) error {
 }
 
 func createReview(pkgDir string) (PackageReview, error) {
-	m, err := NewModule(pkgDir)
+	r, err := NewReview(pkgDir)
 	if err != nil {
 		return PackageReview{}, err
 	}
-	m.Index()
-	tokenList := &[]Token{}
-	nav := []Navigation{}
-	diagnostics := []Diagnostic{}
-	packageNames := []string{}
-	for name, p := range m.Packages {
-		// we use a prefixed path separator so that we can handle the "internal" module.
-		//  internal/dig
-		//  internal/errorinfo
-		//  etc.
-		// for other modules, we skip /internal subdirectories
-		//  azcore/internal/...
-		if strings.Contains(p.relName, "/internal") || p.c.isEmpty() {
-			continue
-		}
-		packageNames = append(packageNames, name)
-	}
-	sort.Strings(packageNames)
-	for _, name := range packageNames {
-		p := m.Packages[name]
-		n := p.relName
-		makeToken(nil, nil, "package", TokenTypeMemberName, tokenList)
-		makeToken(nil, nil, " ", TokenTypeWhitespace, tokenList)
-		makeToken(&n, nil, n, TokenTypeTypeName, tokenList)
-		makeToken(nil, nil, "", TokenTypeNewline, tokenList)
-		makeToken(nil, nil, "", TokenTypeNewline, tokenList)
-		// TODO: reordering these calls reorders APIView output and can omit content
-		p.c.parseInterface(tokenList)
-		p.c.parseStruct(tokenList)
-		p.c.parseSimpleType(tokenList)
-		p.c.parseVar(tokenList)
-		p.c.parseConst(tokenList)
-		p.c.parseFunc(tokenList)
-		navItems := p.c.generateNavChildItems()
-		nav = append(nav, Navigation{
-			Text:         n,
-			NavigationId: n,
-			ChildItems:   navItems,
-			Tags: &map[string]string{
-				"TypeKind": "namespace",
-			},
-		})
-		diagnostics = append(diagnostics, p.diagnostics...)
-	}
-
-	slices.SortFunc(diagnostics, func(a Diagnostic, b Diagnostic) int {
-		targetCmp := strings.Compare(a.TargetID, b.TargetID)
-		if targetCmp != 0 {
-			return targetCmp
-		}
-		// if the target IDs are the same then fall back to the text.
-		// this accounts for cases where there are multiple diagnostics
-		// for the same target ID.
-		return strings.Compare(a.Text, b.Text)
-	})
-
-	for _, n := range nav {
-		recursiveSortNavigation(n)
-	}
-
-	return PackageReview{
-		Diagnostics: diagnostics,
-		Language:    "Go",
-		Name:        m.Name,
-		Navigation:  nav,
-		Tokens:      *tokenList,
-		PackageName: m.PackageName,
-	}, nil
-}
-
-func recursiveSortNavigation(n Navigation) {
-	for _, nn := range n.ChildItems {
-		recursiveSortNavigation(nn)
-	}
-	slices.SortFunc(n.ChildItems, func(a Navigation, b Navigation) int {
-		aa, err := json.Marshal(a)
-		if err != nil {
-			panic(err)
-		}
-		bb, err := json.Marshal(b)
-		if err != nil {
-			panic(err)
-		}
-		return strings.Compare(string(aa), string(bb))
-	})
+	return r.Review()
 }

--- a/src/go/cmd/api_view.go
+++ b/src/go/cmd/api_view.go
@@ -32,11 +32,12 @@ func createReview(pkgDir string) (PackageReview, error) {
 	if err != nil {
 		return PackageReview{}, err
 	}
+	m.Index()
 	tokenList := &[]Token{}
 	nav := []Navigation{}
 	diagnostics := []Diagnostic{}
 	packageNames := []string{}
-	for name, p := range m.packages {
+	for name, p := range m.Packages {
 		// we use a prefixed path separator so that we can handle the "internal" module.
 		//  internal/dig
 		//  internal/errorinfo
@@ -50,7 +51,7 @@ func createReview(pkgDir string) (PackageReview, error) {
 	}
 	sort.Strings(packageNames)
 	for _, name := range packageNames {
-		p := m.packages[name]
+		p := m.Packages[name]
 		n := p.relName
 		makeToken(nil, nil, "package", TokenTypeMemberName, tokenList)
 		makeToken(nil, nil, " ", TokenTypeWhitespace, tokenList)

--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -163,10 +163,6 @@ func TestDiagnostics(t *testing.T) {
 }
 
 func TestAliasDefinitions(t *testing.T) {
-	priorValue := sdkDirName
-	sdkDirName = "testdata"
-	defer func() { sdkDirName = priorValue }()
-
 	for _, test := range []struct {
 		name, path, sourceName string
 		diagLevel              DiagnosticLevel
@@ -175,7 +171,7 @@ func TestAliasDefinitions(t *testing.T) {
 			diagLevel:  DiagnosticLevelWarning,
 			name:       "service_group",
 			path:       "testdata/test_service_group/group/test_alias_export",
-			sourceName: "github.com/Azure/azure-sdk-for-go/sdk/test_service_group/group/internal.Foo",
+			sourceName: "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_service_group/group/internal.Foo",
 		},
 		{
 			diagLevel:  DiagnosticLevelInfo,
@@ -187,11 +183,13 @@ func TestAliasDefinitions(t *testing.T) {
 			diagLevel:  DiagnosticLevelWarning,
 			name:       "external_package",
 			path:       "testdata/test_external_alias_exporter",
-			sourceName: "github.com/Azure/azure-sdk-for-go/sdk/test_external_alias_source.Foo",
+			sourceName: "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_source.Foo",
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			review, err := createReview(filepath.Clean(test.path))
+			p, err := filepath.Abs(test.path)
+			require.NoError(t, err)
+			review, err := createReview(p)
 			require.NoError(t, err)
 			require.Equal(t, "Go", review.Language)
 			require.Equal(t, 1, len(review.Diagnostics))
@@ -210,10 +208,6 @@ func TestAliasDefinitions(t *testing.T) {
 }
 
 func TestRecursiveAliasDefinitions(t *testing.T) {
-	priorValue := sdkDirName
-	sdkDirName = "testdata"
-	defer func() { sdkDirName = priorValue }()
-
 	for _, test := range []struct {
 		name, path, sourceName string
 		diagLevel              DiagnosticLevel

--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -286,12 +286,12 @@ func TestVars(t *testing.T) {
 	require.True(t, hasHTTPClient)
 }
 
-func Test_getPackageNameFromModPath(t *testing.T) {
-	require.EqualValues(t, "foo", getPackageNameFromModPath("foo"))
-	require.EqualValues(t, "foo", getPackageNameFromModPath("foo/v2"))
-	require.EqualValues(t, "sdk/foo", getPackageNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo"))
-	require.EqualValues(t, "sdk/foo/bar", getPackageNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo/bar"))
-	require.EqualValues(t, "sdk/foo/bar", getPackageNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo/bar/v5"))
+func TestGetReviewNameFromModPath(t *testing.T) {
+	require.EqualValues(t, "foo", getReviewNameFromModPath("foo"))
+	require.EqualValues(t, "foo", getReviewNameFromModPath("foo/v2"))
+	require.EqualValues(t, "sdk/foo", getReviewNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo"))
+	require.EqualValues(t, "sdk/foo/bar", getReviewNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo/bar"))
+	require.EqualValues(t, "sdk/foo/bar", getReviewNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo/bar/v5"))
 }
 
 func TestDeterministicOutput(t *testing.T) {

--- a/src/go/cmd/api_view_test.go
+++ b/src/go/cmd/api_view_test.go
@@ -286,12 +286,12 @@ func TestVars(t *testing.T) {
 	require.True(t, hasHTTPClient)
 }
 
-func TestGetReviewNameFromModPath(t *testing.T) {
-	require.EqualValues(t, "foo", getReviewNameFromModPath("foo"))
-	require.EqualValues(t, "foo", getReviewNameFromModPath("foo/v2"))
-	require.EqualValues(t, "sdk/foo", getReviewNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo"))
-	require.EqualValues(t, "sdk/foo/bar", getReviewNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo/bar"))
-	require.EqualValues(t, "sdk/foo/bar", getReviewNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo/bar/v5"))
+func Test_getPackageNameFromModPath(t *testing.T) {
+	require.EqualValues(t, "foo", getPackageNameFromModPath("foo"))
+	require.EqualValues(t, "foo", getPackageNameFromModPath("foo/v2"))
+	require.EqualValues(t, "sdk/foo", getPackageNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo"))
+	require.EqualValues(t, "sdk/foo/bar", getPackageNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo/bar"))
+	require.EqualValues(t, "sdk/foo/bar", getPackageNameFromModPath("github.com/Azure/azure-sdk-for-go/sdk/foo/bar/v5"))
 }
 
 func TestDeterministicOutput(t *testing.T) {

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -200,8 +200,9 @@ func recursiveFindTypeDef(typeName string, source *Pkg, packages map[string]*Pkg
 		if a.Name == typeName {
 			// a.QualifiedName == github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container.DeleteOptions
 			dot := strings.LastIndex(a.QualifiedName, ".")
-			if dot < 0 {
-				break
+			if len(a.QualifiedName)-2 < dot || dot < 1 {
+				// there must be at least one rune before and after the dot
+				panic(fmt.Sprintf("alias %q refers to an invalid qualified name %q", a.Name, a.QualifiedName))
 			}
 			pkgPath := a.QualifiedName[:dot]      // github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container
 			sourceName := a.QualifiedName[dot+1:] // DeleteOptions

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"golang.org/x/mod/modfile"
+	"golang.org/x/mod/module"
 )
 
 // indexTestdata allows tests to index this module's testdata
@@ -110,11 +111,11 @@ func NewModule(dir string) (*Module, error) {
 			// ExternalAliases so the caller can find the definition later.
 			for _, req := range m.ModFile.Require {
 				if strings.HasPrefix(alias.QualifiedName, req.Mod.Path) {
-					alias.SourceModPath = req.Mod.Path
+					alias.SourceMod = req.Mod
 					break
 				}
 			}
-			if alias.SourceModPath == "" {
+			if alias.SourceMod == (module.Version{}) {
 				// The exporting module doesn't require the source module, so this must be a standard library type.
 				// We want this to appear in the API like "type AzureTime time.Time" and don't want to hoist the
 				// definition into the review. Resolving with a zero typeDef adds a SimpleType to the review.

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -21,11 +21,6 @@ import (
 // (we never want to do that for real reviews)
 var indexTestdata bool
 
-// sdkDirName allows tests to set the name of the assumed common
-// directory of all Azure SDK modules, which enables tests to
-// pass without the code below having to compute this directory
-var sdkDirName = "sdk"
-
 // versionReg is the regex for version part in import
 var versionReg = regexp.MustCompile(`/v\d+$|/v\d+/`)
 

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -32,6 +32,9 @@ type Module struct {
 	Name string
 	// Packages maps import paths to the module's Packages
 	Packages map[string]*Pkg
+
+	// indexed is true after Index() succeeds
+	indexed bool
 }
 
 // NewModule constructs a Module, locating its constituent packages but not parsing any source.
@@ -85,6 +88,9 @@ func NewModule(dir string) (*Module, error) {
 // cross-package type aliases. It adds cross-module aliases to [Module.ExternalAliases]
 // so callers can later resolve these after indexing referenced external modules.
 func (m *Module) Index() {
+	if m.indexed {
+		return
+	}
 	for _, p := range m.Packages {
 		p.Index()
 	}
@@ -107,6 +113,7 @@ func (m *Module) Index() {
 			m.ExternalAliases = append(m.ExternalAliases, alias)
 		}
 	}
+	m.indexed = true
 }
 
 func parseModFile(dir string) (*modfile.File, error) {

--- a/src/go/cmd/pkg.go
+++ b/src/go/cmd/pkg.go
@@ -328,8 +328,10 @@ func (a *TypeAlias) Resolve(def typeDef) error {
 	}
 	level := DiagnosticLevelInfo
 	originalName := a.QualifiedName
+	// if the definition is in the same module as the alias, strip the module path from the diagnostic message
 	if _, after, found := strings.Cut(a.QualifiedName, a.Package.modulePath); found {
-		originalName = strings.TrimPrefix(after, "/")
+		// after is e.g. "/internal/log.Event" or ".StatusType"
+		originalName = after[1:]
 	} else {
 		level = DiagnosticLevelWarning
 	}

--- a/src/go/cmd/pkg.go
+++ b/src/go/cmd/pkg.go
@@ -298,6 +298,13 @@ func (pkg Pkg) addTypeNavigator(oriVal string, imports map[string]string) string
 	}
 }
 
+func hoistMethodsForType(source *Pkg, typeName string, p *Pkg) {
+	methods := source.c.findMethods(typeName)
+	for sig, fn := range methods {
+		p.c.Funcs[sig] = fn.ForAlias(p.Name())
+	}
+}
+
 // TypeAlias represents a type exported from one package but defined in another. In code
 // this looks like "type Event = log.Event".
 type TypeAlias struct {
@@ -386,4 +393,43 @@ type typeDef struct {
 	n *ast.TypeSpec
 	// p is the package defining the type
 	p *Pkg
+}
+
+// returns the type name for the specified struct field.
+// if the field can be ignored, an empty string is returned.
+func unwrapStructFieldTypeName(field *ast.Field) string {
+	if field.Names != nil && !field.Names[0].IsExported() {
+		// field isn't exported so skip it
+		return ""
+	}
+
+	// start with the field expression
+	exp := field.Type
+
+	// if it's an array, get the element expression.
+	// current codegen doesn't support *[]Type so no need to handle it.
+	if at, ok := exp.(*ast.ArrayType); ok {
+		// FieldName []FieldType
+		// FieldName []*FieldType
+		exp = at.Elt
+	}
+
+	// from here we either have a pointer-to-type or type
+	var ident *ast.Ident
+	if se, ok := exp.(*ast.StarExpr); ok {
+		// FieldName *FieldType
+		ident, _ = se.X.(*ast.Ident)
+	} else {
+		// FieldName FieldType
+		ident, _ = exp.(*ast.Ident)
+	}
+
+	// !IsExported() is a hacky way to ignore primitive types
+	// FieldName bool
+	if ident == nil || !ident.IsExported() {
+		return ""
+	}
+
+	// returns FieldType
+	return ident.Name
 }

--- a/src/go/cmd/pkg.go
+++ b/src/go/cmd/pkg.go
@@ -16,6 +16,7 @@ import (
 	"unicode"
 
 	"golang.org/x/exp/slices"
+	"golang.org/x/mod/module"
 )
 
 // diagnostic messages
@@ -307,8 +308,8 @@ type TypeAlias struct {
 	Package *Pkg
 	// QualifiedName of the source type e.g. "github.com/Azure/azure-sdk-for-go/sdk/internal/log.Event"
 	QualifiedName string
-	// SourceModPath is the path of the module defining the type e.g. "github.com/Azure/azure-sdk-for-go/sdk/internal"
-	SourceModPath string
+	// SourceMod is the module defining the type
+	SourceMod module.Version
 
 	// resolved indicates whether the alias has been resolved
 	resolved bool

--- a/src/go/cmd/review.go
+++ b/src/go/cmd/review.go
@@ -1,0 +1,275 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"sort"
+	"strings"
+)
+
+var errExternalModule = errors.New("reviewed module exports a type defined in a different repository")
+
+// Review represents an apiview review of an Azure SDK for Go module
+type Review struct {
+	// modules maps module paths to Modules implicated in this API review. It
+	// contains only the reviewed module in most cases, however it contains
+	// more when the reviewed module exports types defined in another module.
+	modules map[string]*Module
+	// name of the APIView review e.g. "sdk/azcore"
+	name string
+	// path on disk to the reviewed module
+	path string
+	// reviewed is the module being reviewed
+	reviewed *Module
+}
+
+// NewReview creates a Review for the module at path p
+func NewReview(p string) (*Review, error) {
+	m, err := NewModule(p)
+	if err != nil {
+		return nil, err
+	}
+	r := &Review{
+		modules: map[string]*Module{},
+		name:    getReviewNameFromModPath(m.ModFile.Module.Mod.Path),
+		path:    p,
+	}
+	fmt.Println("Reviewing", r.name)
+	err = r.AddModule(m)
+	return r, err
+}
+
+// AddModule adds a module to the review. Call this to add a module that exports
+// a type the reviewed module exports by alias.
+func (r *Review) AddModule(m *Module) error {
+	if _, ok := r.modules[m.ModFile.Module.Mod.Path]; ok {
+		return fmt.Errorf("module %s already exists in index", m.ModFile.Module.Mod.Path)
+	}
+	m.Index()
+	if len(r.modules) == 0 {
+		r.reviewed = m
+	}
+	r.modules[m.ModFile.Module.Mod.Path] = m
+	return nil
+}
+
+func (r *Review) Review() (PackageReview, error) {
+	r.index()
+
+	tokenList := &[]Token{}
+	nav := []Navigation{}
+	diagnostics := []Diagnostic{}
+	packageNames := []string{}
+	for name, p := range r.reviewed.Packages {
+		// we use a prefixed path separator so that we can handle the "internal" module.
+		//  internal/dig
+		//  internal/errorinfo
+		//  etc.
+		// for other modules, we skip /internal subdirectories
+		//  azcore/internal/...
+		if strings.Contains(p.relName, "/internal") || p.c.isEmpty() {
+			continue
+		}
+		packageNames = append(packageNames, name)
+	}
+	sort.Strings(packageNames)
+	for _, name := range packageNames {
+		p := r.reviewed.Packages[name]
+		n := p.relName
+		makeToken(nil, nil, "package", TokenTypeMemberName, tokenList)
+		makeToken(nil, nil, " ", TokenTypeWhitespace, tokenList)
+		makeToken(&n, nil, n, TokenTypeTypeName, tokenList)
+		makeToken(nil, nil, "", TokenTypeNewline, tokenList)
+		makeToken(nil, nil, "", TokenTypeNewline, tokenList)
+		// TODO: reordering these calls reorders APIView output and can omit content
+		p.c.parseInterface(tokenList)
+		p.c.parseStruct(tokenList)
+		p.c.parseSimpleType(tokenList)
+		p.c.parseVar(tokenList)
+		p.c.parseConst(tokenList)
+		p.c.parseFunc(tokenList)
+		navItems := p.c.generateNavChildItems()
+		nav = append(nav, Navigation{
+			Text:         n,
+			NavigationId: n,
+			ChildItems:   navItems,
+			Tags: &map[string]string{
+				"TypeKind": "namespace",
+			},
+		})
+		diagnostics = append(diagnostics, p.diagnostics...)
+		slices.SortFunc(diagnostics, func(a Diagnostic, b Diagnostic) int {
+			targetCmp := strings.Compare(a.TargetID, b.TargetID)
+			if targetCmp != 0 {
+				return targetCmp
+			}
+			// if the target IDs are the same then fall back to the text.
+			// this accounts for cases where there are multiple diagnostics
+			// for the same target ID.
+			return strings.Compare(a.Text, b.Text)
+		})
+		for _, n := range nav {
+			recursiveSortNavigation(n)
+		}
+	}
+	return PackageReview{
+		Diagnostics: diagnostics,
+		Language:    "Go",
+		Name:        r.reviewed.Name,
+		Navigation:  nav,
+		Tokens:      *tokenList,
+		PackageName: r.name,
+	}, nil
+}
+
+func (r *Review) index() {
+	for _, m := range r.modules {
+		m.Index()
+	}
+	r.resolveAliases()
+}
+
+// findLocalModule tries to find the source module defining a type in the same repository as
+// the reviewed module. Returns errExternalModule if the source module is in a different repository.
+func (r *Review) findLocalModule(ta TypeAlias) (*Module, error) {
+	// localModulePath could be inlined but is instead separate for easier testing
+	if dir := localModulePath(ta.SourceModPath, r.path); dir != "" {
+		return NewModule(dir)
+	}
+	return nil, errExternalModule
+}
+
+// localModulePath tries to find a file path for the given modPath assuming the module
+// is in the same repository as dir. If it is, the two paths must have a common segment
+// implying a disk location for modPath. For example:
+//
+//   - modPath "github.com/Azure/azure-sdk-for-go/sdk/internal"
+//   - dir "/home/me/azsdk/sdk/azcore"
+//   - return "/home/me/azsdk/sdk/internal"
+//
+// It returns an empty string when its arguments don't share a common segment.
+func localModulePath(modPath, dir string) string {
+	mp := strings.Split(modPath, "/")
+	// find the rightmost common segment of modPath and filePath
+	i, j := -1, -1
+	for m := len(mp) - 1; m > 0; m-- {
+		if n := strings.LastIndex(dir, mp[m]); n > i {
+			i = n
+			j = m
+		}
+	}
+	if i == -1 || j == -1 {
+		return ""
+	}
+	root := dir[:i]
+	modDir := filepath.Join(mp[j:]...)
+	return filepath.Join(root, modDir)
+}
+
+// resolveAliases resolves type aliases in the reviewed module that refer to types in other modules
+func (r *Review) resolveAliases() error {
+	for _, ref := range r.reviewed.ExternalAliases {
+		var (
+			err error
+			m   *Module
+			ok  bool
+		)
+		if m, ok = r.modules[ref.SourceModPath]; !ok {
+			m, err = r.findLocalModule(*ref)
+			if err == nil {
+				err = r.AddModule(m)
+			}
+			// TODO: handle errExternalModule by acquiring the module code from the external repository.
+			// For now, include the aliased type in the review without its definition and add a diagnostic.
+			if err != nil && !errors.Is(err, errExternalModule) {
+				return err
+			}
+		}
+		def := typeDef{}
+		if m != nil {
+			impPath := ref.QualifiedName[:strings.LastIndex(ref.QualifiedName, ".")]
+			p, ok := m.Packages[impPath]
+			if !ok {
+				return fmt.Errorf("couldn't find definition for " + ref.Name)
+			}
+			if d, ok := recursiveFindTypeDef(ref.Name, p, m.Packages); ok {
+				def = d
+			}
+		}
+		err = ref.Resolve(def)
+		if err != nil {
+			return (err)
+		}
+	}
+	return nil
+}
+
+// getReviewNameFromModPath gets the API review name for the module at modPath
+func getReviewNameFromModPath(modPath string) string {
+	// for official SDKs, use a subset of the full module path
+	// e.g. github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/appcomplianceautomation/armappcomplianceautomation
+	// becomes sdk/resourcemanager/appcomplianceautomation/armappcomplianceautomation
+	if suffix, ok := strings.CutPrefix(modPath, "github.com/Azure/azure-sdk-for-go/"); ok {
+		modPath = suffix
+	}
+	// now strip off any major version suffix
+	if loc := regexp.MustCompile(`/v\d+$`).FindStringIndex(modPath); loc != nil {
+		modPath = modPath[:loc[0]]
+	}
+	return modPath
+}
+
+// recursiveFindTypeDef finds a type definition in a collection of packages.
+//
+//   - typeName is the unqualified name of the type e.g. "RetryOptions"
+//   - source is the package containing the type alias
+//   - packages is the collection of Pkgs to search. Its keys are import paths e.g.
+//     "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+func recursiveFindTypeDef(typeName string, source *Pkg, packages map[string]*Pkg) (typeDef, bool) {
+	def, ok := source.types[typeName]
+	if ok {
+		return def, true
+	}
+	// source doesn't define typeName; it must export typeName via an alias.
+	// Recurse into the package from which source imports typeName.
+	for _, a := range source.TypeAliases {
+		if a.Name == typeName {
+			// a.QualifiedName == github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container.DeleteOptions
+			dot := strings.LastIndex(a.QualifiedName, ".")
+			if dot < 0 {
+				break
+			}
+			pkgPath := a.QualifiedName[:dot]      // github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container
+			sourceName := a.QualifiedName[dot+1:] // DeleteOptions
+			if p, ok := packages[pkgPath]; ok {
+				return recursiveFindTypeDef(sourceName, p, packages)
+			}
+			break
+		}
+	}
+	return typeDef{}, false
+}
+
+func recursiveSortNavigation(n Navigation) {
+	for _, nn := range n.ChildItems {
+		recursiveSortNavigation(nn)
+	}
+	slices.SortFunc(n.ChildItems, func(a Navigation, b Navigation) int {
+		aa, err := json.Marshal(a)
+		if err != nil {
+			panic(err)
+		}
+		bb, err := json.Marshal(b)
+		if err != nil {
+			panic(err)
+		}
+		return strings.Compare(string(aa), string(bb))
+	})
+}

--- a/src/go/cmd/review.go
+++ b/src/go/cmd/review.go
@@ -151,9 +151,10 @@ func (r *Review) findLocalModule(ta TypeAlias) (*Module, error) {
 // version, using only the module path.
 func localModulePath(mod module.Version, dir string) string {
 	mp := strings.Split(mod.Path, "/")
-	// find the rightmost common segment of modPath and filePath
+	// find the rightmost common segment of mod.Path and dir, ignoring the final
+	// segment of mod.Path because it's a package name that may be used in both modules
 	i, j := -1, -1
-	for m := len(mp) - 1; m > 0; m-- {
+	for m := len(mp) - 2; m > 0; m-- {
 		if n := strings.LastIndex(dir, mp[m]); n > i {
 			i = n
 			j = m

--- a/src/go/cmd/review.go
+++ b/src/go/cmd/review.go
@@ -39,7 +39,6 @@ func NewReview(p string) (*Review, error) {
 		name:    getPackageNameFromModPath(m.ModFile.Module.Mod.Path),
 		path:    p,
 	}
-	fmt.Println("Reviewing", r.name)
 	err = r.AddModule(m)
 	return r, err
 }
@@ -50,7 +49,6 @@ func (r *Review) AddModule(m *Module) error {
 	if _, ok := r.modules[m.ModFile.Module.Mod.Path]; ok {
 		return fmt.Errorf("module %s already exists in index", m.ModFile.Module.Mod.Path)
 	}
-	m.Index()
 	if len(r.modules) == 0 {
 		r.reviewed = m
 	}
@@ -59,7 +57,7 @@ func (r *Review) AddModule(m *Module) error {
 }
 
 func (r *Review) Review() (PackageReview, error) {
-	r.index()
+	r.resolveAliases()
 
 	tokenList := &[]Token{}
 	nav := []Navigation{}
@@ -125,13 +123,6 @@ func (r *Review) Review() (PackageReview, error) {
 		Tokens:      *tokenList,
 		PackageName: r.name,
 	}, nil
-}
-
-func (r *Review) index() {
-	for _, m := range r.modules {
-		m.Index()
-	}
-	r.resolveAliases()
 }
 
 // findLocalModule tries to find the source module defining a type in the same repository as

--- a/src/go/cmd/review.go
+++ b/src/go/cmd/review.go
@@ -59,7 +59,9 @@ func (r *Review) AddModule(m *Module) error {
 }
 
 func (r *Review) Review() (PackageReview, error) {
-	r.resolveAliases()
+	if err := r.resolveAliases(); err != nil {
+		return PackageReview{}, err
+	}
 
 	tokenList := &[]Token{}
 	nav := []Navigation{}

--- a/src/go/cmd/review.go
+++ b/src/go/cmd/review.go
@@ -169,14 +169,14 @@ func localModulePath(mod module.Version, dir string) string {
 
 // resolveAliases resolves type aliases in the reviewed module that refer to types in other modules
 func (r *Review) resolveAliases() error {
-	for _, ref := range r.reviewed.ExternalAliases {
+	for _, ta := range r.reviewed.ExternalAliases {
 		var (
 			err error
 			m   *Module
 			ok  bool
 		)
-		if m, ok = r.modules[ref.SourceMod.Path]; !ok {
-			m, err = r.findLocalModule(*ref)
+		if m, ok = r.modules[ta.SourceMod.Path]; !ok {
+			m, err = r.findLocalModule(*ta)
 			if err == nil {
 				err = r.AddModule(m)
 			}
@@ -188,16 +188,16 @@ func (r *Review) resolveAliases() error {
 		}
 		def := typeDef{}
 		if m != nil {
-			impPath := ref.QualifiedName[:strings.LastIndex(ref.QualifiedName, ".")]
+			impPath := ta.QualifiedName[:strings.LastIndex(ta.QualifiedName, ".")]
 			p, ok := m.Packages[impPath]
 			if !ok {
-				return fmt.Errorf("couldn't find definition for " + ref.Name)
+				return fmt.Errorf("couldn't find definition for " + ta.Name)
 			}
-			if d, ok := recursiveFindTypeDef(ref.Name, p, m.Packages); ok {
+			if d, ok := recursiveFindTypeDef(ta.Name, p, m.Packages); ok {
 				def = d
 			}
 		}
-		err = ref.Resolve(def)
+		err = ta.Resolve(def)
 		if err != nil {
 			return (err)
 		}

--- a/src/go/cmd/review_test.go
+++ b/src/go/cmd/review_test.go
@@ -1,3 +1,6 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 package cmd
 
 import (

--- a/src/go/cmd/review_test.go
+++ b/src/go/cmd/review_test.go
@@ -6,73 +6,75 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"golang.org/x/mod/module"
 )
 
 func TestLocalModulePath(t *testing.T) {
 	for _, tc := range []struct {
-		expect, filePath, modPath string
+		expect, filePath string
+		mod              module.Version
 	}{
 		// realistic cases
 		{
 			expect:   "/home/me/azure-sdk-for-go/sdk/azcore",
 			filePath: "/home/me/azure-sdk-for-go/sdk/storage/azblob",
-			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/azcore"},
 		},
 		{
 			expect:   "/home/me/sdk/foo/sdk/bar/sdk/internal",
 			filePath: "/home/me/sdk/foo/sdk/bar/sdk/azcore",
-			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/internal",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/internal"},
 		},
 		{
 			expect:   "c:/Users/me/work/sdk/storage/azblob",
 			filePath: "c:/Users/me/work/sdk/azcore",
-			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"},
 		},
 		{
 			expect:   "/home/me/az/sdk/security/keyvault/internal",
 			filePath: "/home/me/az/sdk/security/keyvault/azkeys",
-			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal"},
 		},
 		{
 			expect:   "c:/azure-sdk-for-go/sdk/azidentity",
 			filePath: "c:/azure-sdk-for-go/sdk/azidentity/cache",
-			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/azidentity"},
 		},
 		{
 			expect:   "d:/azure-sdk-for-go/sdk/azidentity/cache",
 			filePath: "d:/azure-sdk-for-go/sdk/azidentity",
-			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"},
 		},
 
 		// unrealistic edge cases just to exercise the algorithm
 		{
 			expect:   "/home/me/azure-sdk-for-go/sdk/azcore",
 			filePath: "/home/me/azure-sdk-for-go/sdk/azcore",
-			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/azcore"},
 		},
 		{
 			expect:   "",
 			filePath: "/foo",
-			modPath:  "",
+			mod:      module.Version{Path: ""},
 		},
 		{
 			expect:   "",
 			filePath: "",
-			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/azcore"},
 		},
 		{
 			expect:   "",
 			filePath: "/home/me/azure-sdk-for-go/sdk/storage/azblob",
-			modPath:  "net/http",
+			mod:      module.Version{Path: "net/http"},
 		},
 		{
 			expect:   "",
 			filePath: "/home/me/azure-sdk-for-go/sdk/storage/azblob",
-			modPath:  "github.com/Foo/bar",
+			mod:      module.Version{Path: "github.com/Foo/bar"},
 		},
 	} {
 		expect := strings.ReplaceAll(tc.expect, "/", string(filepath.Separator))
-		actual := localModulePath(tc.modPath, tc.filePath)
+		actual := localModulePath(tc.mod, tc.filePath)
 		require.Equal(t, expect, actual)
 	}
 }

--- a/src/go/cmd/review_test.go
+++ b/src/go/cmd/review_test.go
@@ -45,12 +45,27 @@ func TestLocalModulePath(t *testing.T) {
 			filePath: "d:/azure-sdk-for-go/sdk/azidentity",
 			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache"},
 		},
+		{
+			expect:   "/home/me/azure-sdk-for-go/sdk/internal",
+			filePath: "/home/me/azure-sdk-for-go/sdk/resourcemanager/internal",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/internal"},
+		},
+		{
+			expect:   "/home/me/azure-sdk-for-go/sdk/internal",
+			filePath: "/home/me/azure-sdk-for-go/sdk/security/keyvault/internal",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/internal"},
+		},
 
 		// unrealistic edge cases just to exercise the algorithm
 		{
 			expect:   "/home/me/azure-sdk-for-go/sdk/azcore",
 			filePath: "/home/me/azure-sdk-for-go/sdk/azcore",
 			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/azcore"},
+		},
+		{
+			expect:   "/home/me/azure-sdk-for-go/sdk/security/keyvault/internal",
+			filePath: "/home/me/azure-sdk-for-go/sdk/internal",
+			mod:      module.Version{Path: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal"},
 		},
 		{
 			expect:   "",

--- a/src/go/cmd/review_test.go
+++ b/src/go/cmd/review_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalModulePath(t *testing.T) {
+	for _, tc := range []struct {
+		expect, filePath, modPath string
+	}{
+		// realistic cases
+		{
+			expect:   "/home/me/azure-sdk-for-go/sdk/azcore",
+			filePath: "/home/me/azure-sdk-for-go/sdk/storage/azblob",
+			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+		},
+		{
+			expect:   "/home/me/sdk/foo/sdk/bar/sdk/internal",
+			filePath: "/home/me/sdk/foo/sdk/bar/sdk/azcore",
+			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/internal",
+		},
+		{
+			expect:   "c:/Users/me/work/sdk/storage/azblob",
+			filePath: "c:/Users/me/work/sdk/azcore",
+			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/storage/azblob",
+		},
+		{
+			expect:   "/home/me/az/sdk/security/keyvault/internal",
+			filePath: "/home/me/az/sdk/security/keyvault/azkeys",
+			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/internal",
+		},
+		{
+			expect:   "c:/azure-sdk-for-go/sdk/azidentity",
+			filePath: "c:/azure-sdk-for-go/sdk/azidentity/cache",
+			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/azidentity",
+		},
+		{
+			expect:   "d:/azure-sdk-for-go/sdk/azidentity/cache",
+			filePath: "d:/azure-sdk-for-go/sdk/azidentity",
+			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/azidentity/cache",
+		},
+
+		// unrealistic edge cases just to exercise the algorithm
+		{
+			expect:   "/home/me/azure-sdk-for-go/sdk/azcore",
+			filePath: "/home/me/azure-sdk-for-go/sdk/azcore",
+			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+		},
+		{
+			expect:   "",
+			filePath: "/foo",
+			modPath:  "",
+		},
+		{
+			expect:   "",
+			filePath: "",
+			modPath:  "github.com/Azure/azure-sdk-for-go/sdk/azcore",
+		},
+		{
+			expect:   "",
+			filePath: "/home/me/azure-sdk-for-go/sdk/storage/azblob",
+			modPath:  "net/http",
+		},
+		{
+			expect:   "",
+			filePath: "/home/me/azure-sdk-for-go/sdk/storage/azblob",
+			modPath:  "github.com/Foo/bar",
+		},
+	} {
+		expect := strings.ReplaceAll(tc.expect, "/", string(filepath.Separator))
+		actual := localModulePath(tc.modPath, tc.filePath)
+		require.Equal(t, expect, actual)
+	}
+}

--- a/src/go/cmd/testdata/test_alias_export/go.mod
+++ b/src/go/cmd/testdata/test_alias_export/go.mod
@@ -1,3 +1,3 @@
-module github.com/Azure/azure-sdk-for-go/sdk/test_alias_export
+module github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_alias_export
 
 go 1.18

--- a/src/go/cmd/testdata/test_alias_export/test.go
+++ b/src/go/cmd/testdata/test_alias_export/test.go
@@ -1,5 +1,5 @@
 package test_alias_export
 
-import "github.com/Azure/azure-sdk-for-go/sdk/test_alias_export/internal/exported"
+import "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_alias_export/internal/exported"
 
 type Foo = exported.Foo

--- a/src/go/cmd/testdata/test_external_alias_exporter/go.mod
+++ b/src/go/cmd/testdata/test_external_alias_exporter/go.mod
@@ -1,3 +1,5 @@
-module github.com/Azure/azure-sdk-for-go/sdk/test_external_alias_exporter
+module github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_exporter
 
 go 1.18
+
+require github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_source v1.0.0

--- a/src/go/cmd/testdata/test_external_alias_exporter/test.go
+++ b/src/go/cmd/testdata/test_external_alias_exporter/test.go
@@ -1,5 +1,5 @@
 package test_external_alias_exporter
 
-import "github.com/Azure/azure-sdk-for-go/sdk/test_external_alias_source"
+import "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_source"
 
 type Foo = test_external_alias_source.Foo

--- a/src/go/cmd/testdata/test_external_alias_source/go.mod
+++ b/src/go/cmd/testdata/test_external_alias_source/go.mod
@@ -1,3 +1,3 @@
-module github.com/Azure/azure-sdk-for-go/sdk/test_external_alias_source
+module github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_external_alias_source
 
 go 1.18

--- a/src/go/cmd/testdata/test_service_group/group/internal/go.mod
+++ b/src/go/cmd/testdata/test_service_group/group/internal/go.mod
@@ -1,3 +1,3 @@
-module github.com/Azure/azure-sdk-for-go/sdk/test_service_group/group/internal
+module github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_service_group/group/internal
 
 go 1.18

--- a/src/go/cmd/testdata/test_service_group/group/test_alias_export/go.mod
+++ b/src/go/cmd/testdata/test_service_group/group/test_alias_export/go.mod
@@ -1,3 +1,5 @@
-module github.com/Azure/azure-sdk-for-go/sdk/test_service_group/group/test_alias_export
+module github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_service_group/group/test_alias_export
 
 go 1.18
+
+require github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_service_group/group/internal v0.0.0

--- a/src/go/cmd/testdata/test_service_group/group/test_alias_export/test.go
+++ b/src/go/cmd/testdata/test_service_group/group/test_alias_export/test.go
@@ -1,5 +1,5 @@
 package test_alias_export
 
-import "github.com/Azure/azure-sdk-for-go/sdk/test_service_group/group/internal"
+import "github.com/Azure/azure-sdk-tools/src/go/cmd/testdata/test_service_group/group/internal"
 
 type Foo = internal.Foo


### PR DESCRIPTION
Part of #7866. Main goal here is to create a spot (the TODO in `Review.resolveAliases`) to handle type aliases (`type Event = log.Event`) referring to non-SDK modules.

- new `TypeAlias` type carries data about aliases, hoists the definition to the aliasing package when given a `typeDef`
- new `Review` type collects modules implicated in the review, resolves cross-module references, computes output
- `Module` now surfaces its cross-module type aliases for `Review` to resolve instead of resolving them itself
- removed assumption that all modules implicated in a review are in the same repo

Along the way I appear to have incidentally fixed a bug that omitted type aliases referring to underlying types. For example, [ExpiryTypeAbsolute](https://pkg.go.dev/github.com/Azure/azure-sdk-for-go/sdk/storage/azblob@v1.4.0/appendblob#ExpiryTypeAbsolute) doesn't appear in the latest [azblob review](https://apiview.dev/Assemblies/Review/e3f09c889fc54009a2ef911d083f8435). With this PR, it will appear without a hoisted definition; #8667 tracks improving that.