### PR TITLE
Add continueOnError to create emitter-package-lock

### DIFF
--- a/eng/pipelines/templates/stages/archetype-autorest-preview.yml
+++ b/eng/pipelines/templates/stages/archetype-autorest-preview.yml
@@ -282,7 +282,9 @@ stages:
         inputs:
           pwsh: true
           filePath: $(autorestRepositoryPath)/eng/scripts/Initialize-Repository.ps1
-          arguments: -BuildArtifactsPath '$(buildArtifactsPath)'
+          arguments: >
+            -BuildArtifactsPath '$(buildArtifactsPath)'
+            -UseTypeSpecNext:$${{ parameters.UseTypeSpecNext }}
           workingDirectory: $(autorestRepositoryPath)
 
       - task: PowerShell@2

--- a/eng/pipelines/templates/stages/archetype-autorest-preview.yml
+++ b/eng/pipelines/templates/stages/archetype-autorest-preview.yml
@@ -242,6 +242,7 @@ stages:
           arguments: >
             -EmitterPackageJsonPath "$(buildArtifactsPath)/emitter-package.json"
             -OutputDirectory "$(Build.ArtifactStagingDirectory)"
+        continueOnError: true
 
     - template: ../../../common/pipelines/templates/steps/publish-artifact.yml
       parameters:


### PR DESCRIPTION
We are seeing this error for a long time. https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3976469&view=logs&j=739bb7ec-7296-5b40-7dff-ee3297bfdaa4&t=164b9cb9-850d-5194-a052-63f5151be232

Now it cannot be handled at autorest.csharp side because we are now depending on @typespec/http-client-csharp which is in the TypeSpec repo. As a result we could see the error message 
![image](https://github.com/user-attachments/assets/1afb553c-b01a-4af9-b98f-7ae72f9e5499)

As suggested by @mikeharder , I think adding "continue on error" is the most appropriate/acceptable way to us now, since this error not impact code generation.