### PR TITLE
Change the daily docs branch name

### DIFF
--- a/eng/common/pipelines/templates/steps/set-daily-docs-branch-name.yml
+++ b/eng/common/pipelines/templates/steps/set-daily-docs-branch-name.yml
@@ -6,8 +6,8 @@ parameters:
 steps:
   - pwsh: |
       $branchName = $env:DAILYDOCSBRANCHNAMEOVERRIDE
-      if (!$branchName) { 
-        $branchName = "daily/$(Get-Date -Format 'yyyy-MM-dd')"
+      if (!$branchName) {
+        $branchName = "daily/$(Get-Date -Format 'yyyy-MM-dd')-ignore-build"
       }
       Write-Host "Daily Branch Name: $branchName"
       Write-Host "##vso[task.setvariable variable=${{ parameters.DailyBranchVariableName }};]$branchName"


### PR DESCRIPTION
Still in draft because I'm still investigating the entirety of the changes required.

The problem being looked at is that committing to a docs branch will automatically kick off runs. Adding the -ignore-build suffix will prevent this. The doc-index runs for java, js, net and python, already run a content CI docs run which will, in turn, create the nightly docs branch and this already happens today.
 
Fixes #6569 