### PR TITLE
Fix broken `push` scenario with only deleted files

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -378,19 +378,11 @@ namespace Azure.Sdk.Tools.TestProxy.Store
 
             if (!string.IsNullOrWhiteSpace(diffResult.StdOut))
             {
-                /* 
-                 * Normally, we'd use Environment.NewLine here but this doesn't work on Windows since its NewLine is \r\n and Git's NewLine is just \n
-                 * 
-                 * The output from git status porcelain will include two possible additional values
-                 * " ?? path/to/file" -> File that is new
-                 * " M path/to/file" -> File that is modified
-                 * " D path/to/file" -> File that is deleted
-                */
+                // Normally, we'd use Environment.NewLine here but this doesn't work on Windows since its NewLine is \r\n and
+                // Git's NewLine is just \n
                 var individualResults = diffResult.StdOut.Split("\n")
-                    // strim the leading space, the characters for ADDED or MODIFIED, and the space after them
-                    .Select(x => x.Trim().TrimStart('?', 'M').Trim())
-                    // exclude empty paths or paths that have been DELETED
-                    .Where(x => !string.IsNullOrWhiteSpace(x) && !x.StartsWith("D")).ToArray();
+                    .Select(x => x.Trim())
+                    .Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
                 return individualResults;
             }
 


### PR DESCRIPTION
We use `DetectPendingChanges` to generate the file list of files to scan. I had a bit of a brainfart and filtered out `Deleted` files because why would we credscan those? The problem is that made it so we don't detect that we need to **push** when it's only deleted files.

I even _had the protection to not attempt to open a file that doesn't exist for scanning_ but I still left the dumb filter logic.

This PR adds an integration test for only-delete scenario.