### PR TITLE
Improvement: stop depending on NPM changelog

### DIFF
--- a/tools/js-sdk-release-tools/src/common/utils.ts
+++ b/tools/js-sdk-release-tools/src/common/utils.ts
@@ -70,7 +70,7 @@ export function tryReadNpmPackageChangelog(packageFolderPath: string): string {
         const originalChangeLogContent = fs.readFileSync(changelogPath, { encoding: 'utf-8' });
         return originalChangeLogContent;
     } catch (err) {
-        logger.logError(`Failed to read NPM package's changelog "${changelogPath}": ${(err as Error)?.stack ?? err}`);
+        logger.logWarn(`Failed to read NPM package's changelog "${changelogPath}": ${(err as Error)?.stack ?? err}`);
         return '';
     }
 }

--- a/tools/js-sdk-release-tools/src/common/utils.ts
+++ b/tools/js-sdk-release-tools/src/common/utils.ts
@@ -59,3 +59,18 @@ export function fixChangelogFormat(content: string) {
     content  = replaceAll(content, '**Other Changes**', '### Other Changes')!;
     return content;
 }
+
+export function tryReadNpmPackageChangelog(packageFolderPath: string): string {
+    const changelogPath = path.join(packageFolderPath, 'changelog-temp', 'package', 'CHANGELOG.md');
+    try {
+        if (!fs.existsSync(changelogPath)) {
+            logger.logWarn(`NPM package's changelog "${changelogPath}" does not exists`);
+            return "";
+        }
+        const originalChangeLogContent = fs.readFileSync(changelogPath, { encoding: 'utf-8' });
+        return originalChangeLogContent;
+    } catch (err) {
+        logger.logError(`Failed to read NPM package's changelog "${changelogPath}": ${(err as Error)?.stack ?? err}`);
+        return '';
+    }
+}

--- a/tools/js-sdk-release-tools/src/hlc/utils/automaticGenerateChangeLogAndBumpVersion.ts
+++ b/tools/js-sdk-release-tools/src/hlc/utils/automaticGenerateChangeLogAndBumpVersion.ts
@@ -22,7 +22,7 @@ import { execSync } from "child_process";
 import { getversionDate } from "../../utils/version";
 import { ApiVersionType } from "../../common/types"
 import { getApiVersionType } from '../../xlc/apiVersion/apiVersionTypeExtractor'
-import { fixChangelogFormat, getApiReviewPath, getNpmPackageName, getSDKType } from '../../common/utils';
+import { fixChangelogFormat, getApiReviewPath, getNpmPackageName, getSDKType, tryReadNpmPackageChangelog } from '../../common/utils';
 
 export async function generateChangelogAndBumpVersion(packageFolderPath: string) {
     const jsSdkRepoPath = String(shell.pwd());
@@ -66,7 +66,7 @@ export async function generateChangelogAndBumpVersion(packageFolderPath: string)
                 const oldSDKType = getSDKType(npmPackageRoot);
                 const newSDKType = getSDKType(packageFolderPath);
                 const changelog: Changelog = await extractExportAndGenerateChangelog(apiMdFileNPM, apiMdFileLocal, oldSDKType, newSDKType);
-                let originalChangeLogContent = fs.readFileSync(path.join(packageFolderPath, 'changelog-temp', 'package', 'CHANGELOG.md'), { encoding: 'utf-8' });
+                let originalChangeLogContent = tryReadNpmPackageChangelog(packageFolderPath);
                 if(nextVersion){
                     shell.cd(path.join(packageFolderPath, 'changelog-temp'));
                     shell.mkdir(path.join(packageFolderPath, 'changelog-temp', 'next'));
@@ -80,7 +80,7 @@ export async function generateChangelogAndBumpVersion(packageFolderPath: string)
                     const latestDate = getversionDate(npmViewResult, stableVersion);
                     const nextDate = getversionDate(npmViewResult,nextVersion);
                     if (latestDate && nextDate && latestDate <= nextDate){
-                        originalChangeLogContent = fs.readFileSync(path.join(packageFolderPath,'changelog-temp', 'next', 'package', 'CHANGELOG.md'), {encoding: 'utf-8'});
+                        originalChangeLogContent = tryReadNpmPackageChangelog(packageFolderPath);
                         logger.log('Need to keep previous preview changelog');
                         
                     }

--- a/tools/js-sdk-release-tools/src/llc/utils/generateChangelog.ts
+++ b/tools/js-sdk-release-tools/src/llc/utils/generateChangelog.ts
@@ -4,7 +4,7 @@ import { NPMScope } from "@ts-common/azure-js-dev-tools";
 import { logger } from "../../utils/logger";
 import { getLatestStableVersion } from "../../utils/version";
 import { extractExportAndGenerateChangelog } from "../../changelog/extractMetaData";
-import { fixChangelogFormat, getApiReviewPath, getSDKType } from "../../common/utils";
+import { fixChangelogFormat, getApiReviewPath, getSDKType, tryReadNpmPackageChangelog } from "../../common/utils";
 
 const shell = require('shelljs');
 const todayDate = new Date();
@@ -22,7 +22,7 @@ function generateChangelogForFirstRelease(packagePath, version) {
 }
 
 function appendChangelog(packagePath, version, changelog) {
-    let originalChangeLogContent: string = fs.readFileSync(path.join(packagePath, 'changelog-temp', 'package', 'CHANGELOG.md'), { encoding: 'utf-8' });
+    let originalChangeLogContent: string = tryReadNpmPackageChangelog(packagePath);
     originalChangeLogContent = fixChangelogFormat(originalChangeLogContent);
 
     const modifiedChangelogContent = `## ${version} (${date})

--- a/tools/js-sdk-release-tools/src/test/changelog/changelogGenerator.test.ts
+++ b/tools/js-sdk-release-tools/src/test/changelog/changelogGenerator.test.ts
@@ -1,129 +1,158 @@
 import { expect, test } from "vitest";
 import { extractExportAndGenerateChangelog } from "../../changelog/extractMetaData";
-import path from "path";
+import path, { join } from "path";
 import { SDKType } from "../../common/types";
+import { describe } from "node:test";
+import { mkdirSync } from "node:fs";
+import { tryReadNpmPackageChangelog } from "../../common/utils";
+import { rmdirSync, writeFileSync } from "fs";
 
-test("HLC -> Modular: Rename", async () => {
-    const oldViewPath = path.join(
-        __dirname,
-        "testCases/operationGroups.1.old.hlc.api.md"
-    );
-    const newViewPath = path.join(
-        __dirname,
-        "testCases/operationGroups.1.new.modular.api.md"
-    );
-    const changelog = await extractExportAndGenerateChangelog(
-        oldViewPath,
-        newViewPath,
-        SDKType.HighLevelClient,
-        SDKType.ModularClient
-    );
+function getRandomInt(max) {
+    return Math.floor(Math.random() * max);
+}
 
-    expect(changelog.addedOperationGroup.length).toBe(0);
-    expect(changelog.removedOperationGroup.length).toBe(0);
+describe("Breaking change detection", () => {
+    test("HLC -> Modular: Rename", async () => {
+        const oldViewPath = path.join(
+            __dirname,
+            "testCases/operationGroups.1.old.hlc.api.md"
+        );
+        const newViewPath = path.join(
+            __dirname,
+            "testCases/operationGroups.1.new.modular.api.md"
+        );
+        const changelog = await extractExportAndGenerateChangelog(
+            oldViewPath,
+            newViewPath,
+            SDKType.HighLevelClient,
+            SDKType.ModularClient
+        );
 
-    expect(changelog.addedOperation.length).toBe(1);
-    expect(changelog.removedOperation.length).toBe(1);
+        expect(changelog.addedOperationGroup.length).toBe(0);
+        expect(changelog.removedOperationGroup.length).toBe(0);
 
-    expect(changelog.addedOperation[0]).toBe(
-        "Added operation DataProductsCatalogsOperations.listByResourceGroup_NEW"
-    );
-    expect(changelog.removedOperation[0]).toBe(
-        "Removed operation DataProductsCatalogs.listByResourceGroup"
-    );
+        expect(changelog.addedOperation.length).toBe(1);
+        expect(changelog.removedOperation.length).toBe(1);
+
+        expect(changelog.addedOperation[0]).toBe(
+            "Added operation DataProductsCatalogsOperations.listByResourceGroup_NEW"
+        );
+        expect(changelog.removedOperation[0]).toBe(
+            "Removed operation DataProductsCatalogs.listByResourceGroup"
+        );
+    });
+
+    test("HLC -> HLC: Change Op", async () => {
+        const oldViewPath = path.join(
+            __dirname,
+            "testCases/operationGroups.2.old.hlc.api.md"
+        );
+        const newViewPath = path.join(
+            __dirname,
+            "testCases/operationGroups.2.new.hlc.api.md"
+        );
+        const changelog = await extractExportAndGenerateChangelog(
+            oldViewPath,
+            newViewPath,
+            SDKType.HighLevelClient,
+            SDKType.HighLevelClient
+        );
+
+        expect(changelog.addedOperationGroup.length).toBe(0);
+        expect(changelog.removedOperationGroup.length).toBe(0);
+
+        expect(changelog.addedOperation.length).toBe(1);
+        expect(changelog.removedOperation.length).toBe(1);
+
+        expect(changelog.addedOperation[0]).toBe(
+            "Added operation DataProductsCatalogs.get_NEW"
+        );
+        expect(changelog.removedOperation[0]).toBe(
+            "Removed operation DataProductsCatalogs.get"
+        );
+    });
+
+    test("Modular -> Modular: Change Op", async () => {
+        const oldViewPath = path.join(
+            __dirname,
+            "testCases/operationGroups.3.old.modular.api.md"
+        );
+        const newViewPath = path.join(
+            __dirname,
+            "testCases/operationGroups.3.new.modular.api.md"
+        );
+        const changelog = await extractExportAndGenerateChangelog(
+            oldViewPath,
+            newViewPath,
+            SDKType.ModularClient,
+            SDKType.ModularClient
+        );
+
+        expect(changelog.addedOperationGroup.length).toBe(0);
+        expect(changelog.removedOperationGroup.length).toBe(0);
+
+        expect(changelog.addedOperation.length).toBe(1);
+        expect(changelog.removedOperation.length).toBe(1);
+
+        expect(changelog.addedOperation[0]).toBe(
+            "Added operation DataProductsCatalogsOperations.listByResourceGroup_NEW"
+        );
+        expect(changelog.removedOperation[0]).toBe(
+            "Removed operation DataProductsCatalogsOperations.listByResourceGroup"
+        );
+    });
+
+    test("HLC -> HLC: Operation Group Add/Remove/ChangeSig", async () => {
+        const oldViewPath = path.join(
+            __dirname,
+            "testCases/operationGroups.4.old.hlc.api.md"
+        );
+        const newViewPath = path.join(
+            __dirname,
+            "testCases/operationGroups.4.new.hlc.api.md"
+        );
+        const changelog = await extractExportAndGenerateChangelog(
+            oldViewPath,
+            newViewPath,
+            SDKType.HighLevelClient,
+            SDKType.HighLevelClient
+        );
+
+        expect(changelog.addedOperationGroup.length).toBe(1);
+        expect(changelog.removedOperationGroup.length).toBe(1);
+
+        expect(changelog.addedOperation.length).toBe(0);
+        expect(changelog.removedOperation.length).toBe(0);
+
+        expect(changelog.operationSignatureChange.length).toBe(1);
+
+        expect(changelog.addedOperationGroup[0]).toBe(
+            "Added operation group DataProductsCatalogs_add"
+        );
+        expect(changelog.removedOperationGroup[0]).toBe(
+            "Removed operation group DataProductsCatalogs_remove"
+        );
+        expect(changelog.operationSignatureChange[0]).toBe(
+            "Operation DataProductsCatalogs_sig_change.get has a new signature"
+        );
+    });
 });
 
-test("HLC -> HLC: Change Op", async () => {
-    const oldViewPath = path.join(
-        __dirname,
-        "testCases/operationGroups.2.old.hlc.api.md"
-    );
-    const newViewPath = path.join(
-        __dirname,
-        "testCases/operationGroups.2.new.hlc.api.md"
-    );
-    const changelog = await extractExportAndGenerateChangelog(
-        oldViewPath,
-        newViewPath,
-        SDKType.HighLevelClient,
-        SDKType.HighLevelClient
-    );
-
-    expect(changelog.addedOperationGroup.length).toBe(0);
-    expect(changelog.removedOperationGroup.length).toBe(0);
-
-    expect(changelog.addedOperation.length).toBe(1);
-    expect(changelog.removedOperation.length).toBe(1);
-
-    expect(changelog.addedOperation[0]).toBe(
-        "Added operation DataProductsCatalogs.get_NEW"
-    );
-    expect(changelog.removedOperation[0]).toBe(
-        "Removed operation DataProductsCatalogs.get"
-    );
-});
-
-test("Modular -> Modular: Change Op", async () => {
-    const oldViewPath = path.join(
-        __dirname,
-        "testCases/operationGroups.3.old.modular.api.md"
-    );
-    const newViewPath = path.join(
-        __dirname,
-        "testCases/operationGroups.3.new.modular.api.md"
-    );
-    const changelog = await extractExportAndGenerateChangelog(
-        oldViewPath,
-        newViewPath,
-        SDKType.ModularClient,
-        SDKType.ModularClient
-    );
-
-    expect(changelog.addedOperationGroup.length).toBe(0);
-    expect(changelog.removedOperationGroup.length).toBe(0);
-
-    expect(changelog.addedOperation.length).toBe(1);
-    expect(changelog.removedOperation.length).toBe(1);
-
-    expect(changelog.addedOperation[0]).toBe(
-        "Added operation DataProductsCatalogsOperations.listByResourceGroup_NEW"
-    );
-    expect(changelog.removedOperation[0]).toBe(
-        "Removed operation DataProductsCatalogsOperations.listByResourceGroup"
-    );
-});
-
-test("HLC -> HLC: Operation Group Add/Remove/ChangeSig", async () => {
-    const oldViewPath = path.join(
-        __dirname,
-        "testCases/operationGroups.4.old.hlc.api.md"
-    );
-    const newViewPath = path.join(
-        __dirname,
-        "testCases/operationGroups.4.new.hlc.api.md"
-    );
-    const changelog = await extractExportAndGenerateChangelog(
-        oldViewPath,
-        newViewPath,
-        SDKType.HighLevelClient,
-        SDKType.HighLevelClient
-    );
-
-    expect(changelog.addedOperationGroup.length).toBe(1);
-    expect(changelog.removedOperationGroup.length).toBe(1);
-
-    expect(changelog.addedOperation.length).toBe(0);
-    expect(changelog.removedOperation.length).toBe(0);
-
-    expect(changelog.operationSignatureChange.length).toBe(1);
-
-    expect(changelog.addedOperationGroup[0]).toBe(
-        "Added operation group DataProductsCatalogs_add"
-    );
-    expect(changelog.removedOperationGroup[0]).toBe(
-        "Removed operation group DataProductsCatalogs_remove"
-    );
-    expect(changelog.operationSignatureChange[0]).toBe(
-        "Operation DataProductsCatalogs_sig_change.get has a new signature"
-    );
+describe("Changelog reading", () => {
+    const tempPackageFolder = `./tmp/package-${getRandomInt(10000)}`;
+    try {
+        test("Read changelog that doesn't exist", () => {
+            const content = tryReadNpmPackageChangelog(tempPackageFolder);
+            expect(content).toBe("");
+        });
+        const changelogPath = join(tempPackageFolder, 'CHANGELOG.md')
+        writeFileSync(changelogPath, 'aaa', 'utf-8');
+    
+        test("Read changelog that exists", () => { 
+            const content = tryReadNpmPackageChangelog(tempPackageFolder);
+            expect(content).toBe("aaa");
+        })
+    } finally {
+        rmdirSync(tempPackageFolder);
+    }
 });


### PR DESCRIPTION
# Problem
Some published package doesn't contain changelog.md, it breaks the current changelog tool by throwing error when it try to append new content to changelog.

# Fix
Stop throwing error, but output warning log instead. Output "" by default.

 