### PR TITLE
[tsp-client] Log diagnostics with --debug flag

### DIFF
--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -100,16 +100,16 @@ export async function compileTsp({
   Logger.debug(`Compiler options: ${JSON.stringify(options)}`);
   if (diagnostics.length > 0) {
     // This should not happen, but if it does, we should log it.
-    Logger.error("Diagnostics were reported while resolving compiler options...")
-    diagnostics.forEach((diagnostic) => { Logger.error(formatDiagnostic(diagnostic)); });
+    Logger.error("Diagnostics were reported while resolving compiler options. Use the `--debug` flag to see the diagnostic output.")
+    diagnostics.forEach((diagnostic) => { Logger.debug(formatDiagnostic(diagnostic)); });
     return false;
   }
 
   const program = await compile(NodeHost, resolvedMainFilePath, options);
 
   if (program.diagnostics.length > 0) {
-    Logger.error("Diagnostics were reported during compilation...");
-    program.diagnostics.forEach((diagnostic) => { Logger.error(formatDiagnostic(diagnostic)); });
+    Logger.error("Diagnostics were reported during compilation. Use the `--debug` flag to see the diagnostic output.");
+    program.diagnostics.forEach((diagnostic) => { Logger.debug(formatDiagnostic(diagnostic)); });
     return false;
   } else {
     Logger.success("generation complete");


### PR DESCRIPTION
Instead of always logging the diagnostics, only log if the user passes the --debug flag.