### PR TITLE
Updates to `HandlePlaybackRequest` to force synchronous handling

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/LoggingTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/LoggingTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 HttpResponse response = new DefaultHttpContext().Response;
                 await testRecordingHandler.HandlePlaybackRequest(recordingId, request, response);
 
-                AssertLogs(logger, 4, 8, 12);
+                AssertLogs(logger, 5, 9, 12);
             }
             finally
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
@@ -402,6 +402,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             TestRecordingMismatchException exception = Assert.Throws<TestRecordingMismatchException>(() => matcher.FindMatch(requestEntry, entries));
             Assert.Equal(
                 "Unable to find a record for the request HEAD http://localhost/" + Environment.NewLine +
+                "Remaining entry: http://remote-host" + Environment.NewLine +
                 "Method doesn't match, request <HEAD> record <PUT>" + Environment.NewLine +
                 "Uri doesn't match:" + Environment.NewLine +
                 "    request <http://localhost/>" + Environment.NewLine +

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Azure.Core;
@@ -127,7 +127,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 }
             }
 
-            throw new TestRecordingMismatchException(GenerateException(request, bestScoreEntry));
+            throw new TestRecordingMismatchException(GenerateException(request, bestScoreEntry, entries));
         }
 
         public virtual int CompareBodies(byte[] requestBody, byte[] recordBody, StringBuilder descriptionBuilder = null)
@@ -213,10 +213,18 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             return req.ToUri().ToString();
         }
 
-        private string GenerateException(RecordEntry request, RecordEntry bestScoreEntry)
+        private string GenerateException(RecordEntry request, RecordEntry bestScoreEntry, IList<RecordEntry> entries = null)
         {
             StringBuilder builder = new StringBuilder();
             builder.AppendLine($"Unable to find a record for the request {request.RequestMethod} {request.RequestUri}");
+
+            if (entries != null)
+            {
+                foreach (var entry in entries)
+                {
+                    builder.AppendLine($"Remaining entry: {entry.RequestUri}");
+                }
+            }
 
             if (bestScoreEntry == null)
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
@@ -82,7 +82,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             }
         }
 
-        public RecordEntry Lookup(RecordEntry requestEntry, RecordMatcher matcher, IEnumerable<RecordedTestSanitizer> sanitizers, bool remove = true)
+        public RecordEntry Lookup(RecordEntry requestEntry, RecordMatcher matcher, IEnumerable<RecordedTestSanitizer> sanitizers, bool remove = true, string sessionId = null)
         {
             foreach (RecordedTestSanitizer sanitizer in sanitizers)
             {
@@ -97,6 +97,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 if (remove)
                 {
                     Entries.Remove(entry);
+                    DebugLogger.LogDebug($"We successfully matched and popped request URI {entry.RequestUri} for recordingId {sessionId}");
                 }
 
                 return entry;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
@@ -97,7 +97,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 if (remove)
                 {
                     Entries.Remove(entry);
-                    DebugLogger.LogDebug($"We successfully matched and popped request URI {entry.RequestUri} for recordingId {sessionId}");
+                    DebugLogger.LogInformation($"We successfully matched and popped request URI {entry.RequestUri} for recordingId {sessionId}");
                 }
 
                 return entry;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
@@ -82,6 +82,20 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             }
         }
 
+        public RecordEntry NonLockingLookup(RecordEntry requestEntry, RecordMatcher matcher, IEnumerable<RecordedTestSanitizer> sanitizers, string sessionId = null)
+        {
+            foreach (RecordedTestSanitizer sanitizer in sanitizers)
+            {
+                sanitizer.Sanitize(requestEntry);
+            }
+            // normalize request body with STJ using relaxed escaping to match behavior when Deserializing from session files
+            RecordEntry.NormalizeJsonBody(requestEntry.Request);
+
+            RecordEntry entry = matcher.FindMatch(requestEntry, Entries);
+
+            return entry;
+        }
+
         public RecordEntry Lookup(RecordEntry requestEntry, RecordMatcher matcher, IEnumerable<RecordedTestSanitizer> sanitizers, bool remove = true, string sessionId = null)
         {
             foreach (RecordedTestSanitizer sanitizer in sanitizers)
@@ -102,6 +116,11 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
                 return entry;
             }
+        }
+
+        public void NonLockingRemove(RecordEntry entry)
+        {
+            Entries.Remove(entry);
         }
 
         public void Remove(RecordEntry entry)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -475,7 +475,7 @@ namespace Azure.Sdk.Tools.TestProxy
             lock (session.Session.Entries)
             {
                 // Session may be removed later, but only after response has been fully written
-                var match = session.Session.NonLockingLookup(entry, session.CustomMatcher ?? Matcher, sanitizers, sessionId: recordingId);
+                var match = session.Session.Lookup(entry, session.CustomMatcher ?? Matcher, sanitizers, remove: false, sessionId: recordingId);
 
                 foreach (ResponseTransform transform in Transforms.Concat(session.AdditionalTransforms))
                 {
@@ -517,7 +517,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
                 if (remove)
                 {
-                    session.Session.NonLockingRemove(match);
+                    session.Session.Remove(match);
                 }
             }
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -471,7 +471,7 @@ namespace Azure.Sdk.Tools.TestProxy
             var entry = (await CreateEntryAsync(incomingRequest).ConfigureAwait(false)).Item1;
 
             // Session may be removed later, but only after response has been fully written
-            var match = session.Session.Lookup(entry, session.CustomMatcher ?? Matcher, sanitizers, remove: false);
+            var match = session.Session.Lookup(entry, session.CustomMatcher ?? Matcher, sanitizers, remove: false, sessionId: recordingId);
 
             foreach (ResponseTransform transform in Transforms.Concat(session.AdditionalTransforms))
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -394,6 +394,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 {
                     Path = path
                 };
+                DebugLogger.LogInformation($"Recording file {assetsPath} is associated with recording id {id}");
             }
 
             if (!PlaybackSessions.TryAdd(id, session))
@@ -409,6 +410,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             // Write to the response
             await outgoingResponse.WriteAsync(json);
+
 
             DebugLogger.LogTrace($"PLAYBACK START END {id}.");
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -230,13 +230,6 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
-            int maxWorkerThreads, maxCompletionPortThreads;
-            ThreadPool.GetMaxThreads(out maxWorkerThreads, out maxCompletionPortThreads);
-            System.Console.WriteLine($"Default max worker threads: {maxWorkerThreads}");
-            System.Console.WriteLine($"Default max completion port threads: {maxCompletionPortThreads}");
-
-
-
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -225,6 +225,11 @@ namespace Azure.Sdk.Tools.TestProxy
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
+            int maxWorkerThreads, maxCompletionPortThreads;
+            ThreadPool.GetMaxThreads(out maxWorkerThreads, out maxCompletionPortThreads);
+            System.Console.WriteLine($"Default max worker threads: {maxWorkerThreads}");
+            System.Console.WriteLine($"Default max completion port threads: {maxCompletionPortThreads}");
+
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -207,6 +207,11 @@ namespace Azure.Sdk.Tools.TestProxy
                     });
             });
 
+            services.Configure<KestrelServerOptions>(options =>
+            {
+                options.AllowSynchronousIO = true;
+            });
+
             services.AddControllers(options =>
             {
                 options.InputFormatters.Add(new EmptyBodyFormatter());
@@ -229,6 +234,8 @@ namespace Azure.Sdk.Tools.TestProxy
             ThreadPool.GetMaxThreads(out maxWorkerThreads, out maxCompletionPortThreads);
             System.Console.WriteLine($"Default max worker threads: {maxWorkerThreads}");
             System.Console.WriteLine($"Default max completion port threads: {maxCompletionPortThreads}");
+
+
 
             if (env.IsDevelopment())
             {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/d0b90cb5-56e8-427a-9195-3d4a56b1c6bf)

We pay next to nothing for stability. The failing test is the one that I think is actually going wrong on Java side.

Relevant to #8729 