### PR TITLE
ensure that sourceversion doesn't appear in the informationalversion

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
@@ -9,6 +9,7 @@
     <LangVersion>preview</LangVersion>
     <InformationalVersion>$(OfficialBuildId)</InformationalVersion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
+    <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
   <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">


### PR DESCRIPTION
Issue, `test-proxy --version` started returning `20240730.2+7b8a6a1ce5de8012452620aa1969dc549ed0b190` ...aka the version with source revision attached.

This is due to a new sourcelink version: https://stackoverflow.com/questions/77050814/fileversioninfo-productversion-suddenly-contains-git-commit-hash (cheers @weshaggard for the link)

We want this to be a nice clean: `1.0.0-dev.20240731.1` which is the better user experience and will unblock broken go tests.

