### PR TITLE
Add exception for Utf8JsonReader/Writer to AZC0014

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0014Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0014Tests.cs
@@ -39,6 +39,8 @@ namespace RandomNamespace
 
 
         [Theory]
+        [InlineData("public void JsonModelWriteCore(Utf8JsonWriter writer) {}")]
+        [InlineData("public void JsonModelCreateCore(ref Utf8JsonReader reader) {}")]
         [InlineData("internal class Class: System.IProgress<JsonElement> { public void Report (JsonElement value) {} }")]
         [InlineData("public void Report(string value) {}")]
         public async Task AZC0014NotProducedForNonPublicApisOrAllowedTypes(string usage)

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
@@ -38,7 +38,10 @@ namespace Azure.ClientSdk.Analyzers
                 {
                     if (BannedAssemblies.Contains(type.ContainingAssembly.Name))
                     {
-                        context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0014, symbol.Locations.First(), BannedAssembliesMessageArgs), symbol);
+                        if (type.Name != "Utf8JsonReader" && type.Name != "Utf8JsonWriter")
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0014, symbol.Locations.First(), BannedAssembliesMessageArgs), symbol);
+                        } 
                     }
 
                     if (namedTypeSymbol.IsGenericType)

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
@@ -95,9 +95,9 @@ namespace Azure.ClientSdk.Analyzers
             return (type.Name == "Utf8JsonReader" || type.Name == "Utf8JsonWriter") && GetFullNamespace(type.ContainingNamespace) == "System.Text.Json";
         }
 
-        private static string GetFullNamespace(INamespaceSymbol type)
+        private static string GetFullNamespace(INamespaceSymbol namespaceSymbol)
         {
-            return type.ContainingNamespace.Name == "" ? type.Name : $"{GetFullNamespace(type.ContainingNamespace)}.{type.Name}";
+            return namespaceSymbol.ContainingNamespace.Name == "" ? namespaceSymbol.Name : $"{GetFullNamespace(namespaceSymbol.ContainingNamespace)}.{namespaceSymbol.Name}";
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/BannedAssembliesAnalyzer.cs
@@ -38,7 +38,7 @@ namespace Azure.ClientSdk.Analyzers
                 {
                     if (BannedAssemblies.Contains(type.ContainingAssembly.Name))
                     {
-                        if (type.Name != "Utf8JsonReader" && type.Name != "Utf8JsonWriter")
+                        if (!IsUtf8JsonReaderWriter(type))
                         {
                             context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0014, symbol.Locations.First(), BannedAssembliesMessageArgs), symbol);
                         } 
@@ -88,6 +88,16 @@ namespace Azure.ClientSdk.Analyzers
                     }
                     break;
             }
+        }
+
+        private static bool IsUtf8JsonReaderWriter(ITypeSymbol type)
+        {
+            return (type.Name == "Utf8JsonReader" || type.Name == "Utf8JsonWriter") && GetFullNamespace(type.ContainingNamespace) == "System.Text.Json";
+        }
+
+        private static string GetFullNamespace(INamespaceSymbol type)
+        {
+            return type.ContainingNamespace.Name == "" ? type.Name : $"{GetFullNamespace(type.ContainingNamespace)}.{type.Name}";
         }
     }
 }


### PR DESCRIPTION
We have now enabled [JsonModelWriteCore](https://github.com/microsoft/typespec/blob/745b4f97229e128f61e35b725d4ae3adb436424a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/ProjectedNameModelRequest.Serialization.cs#L39) and [JsonModelCreateCore](https://github.com/microsoft/typespec/blob/745b4f97229e128f61e35b725d4ae3adb436424a/packages/http-client-csharp/generator/TestProjects/Local/Unbranded-TypeSpec/src/Generated/Models/ProjectedNameModelRequest.Serialization.cs#L69) in MGC. Now we are adding this WriteCore/CreateCore feature to autorest.csharp, because some customers are asking this. However, these two methods are violating “AZC0014: Types from System.Text.Json, Newtonsoft.Json, System.Collections.Immutable assemblies should not be exposed as part of public API surface. “
 
Confirmed with @KrzysztofCwalina that Utf8JsonReader/Writer should be an exception to AZC0014. You could refer to that decision in the email titled "Suppress AZC0014 on WriteCore and CreateCore".