### PR TITLE
Update file name when updating revision from PR

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -242,7 +242,7 @@ namespace APIViewWeb.Controllers
             // If a revision already exists for PR then just update the code file for that revision.
             if (revisionAlreadyExistsForPR(prModel, false))
             {
-                if (await UpdateExistingAPIRevisionCodeFile(apiRevisions, prModel.APIRevisionId, memoryStream, codeFile))
+                if (await UpdateExistingAPIRevisionCodeFile(apiRevisions, prModel.APIRevisionId, memoryStream, codeFile, originalFileName))
                     return;
             }
 
@@ -270,12 +270,12 @@ namespace APIViewWeb.Controllers
             bool createNewModifiedRevision = true;
             if (revisionAlreadyExistsForPR(prModel, true))
             {
-                if (await UpdateExistingAPIRevisionCodeFile(apiRevisions, prModel.APIRevisionId, baselineMemoryStream, baselineCodeFile))
+                if (await UpdateExistingAPIRevisionCodeFile(apiRevisions, prModel.APIRevisionId, baselineMemoryStream, baselineCodeFile, originalFileName))
                     createNewBaselineRevision = false;
             }
             if (revisionAlreadyExistsForPR(prModel, false))
             {
-                if (await UpdateExistingAPIRevisionCodeFile(apiRevisions, prModel.APIRevisionId, memoryStream, codeFile))
+                if (await UpdateExistingAPIRevisionCodeFile(apiRevisions, prModel.APIRevisionId, memoryStream, codeFile, originalFileName))
                     createNewModifiedRevision = false;
             }
 
@@ -320,8 +320,9 @@ namespace APIViewWeb.Controllers
         /// <param name="revisionId"></param>
         /// <param name="memoryStream"></param>
         /// <param name="codeFile"></param>
+        /// <param name="originalFileName"></param>
         /// <returns>true if update happened otherwise false</returns>
-        private async Task<bool> UpdateExistingAPIRevisionCodeFile(IEnumerable<APIRevisionListItemModel> apiRevisions, string revisionId, MemoryStream memoryStream, CodeFile codeFile)
+        private async Task<bool> UpdateExistingAPIRevisionCodeFile(IEnumerable<APIRevisionListItemModel> apiRevisions, string revisionId, MemoryStream memoryStream, CodeFile codeFile, string originalFileName)
         {
             var apiRevision = apiRevisions.FirstOrDefault(v => v.Id == revisionId);
             if (apiRevision != default(APIRevisionListItemModel))
@@ -329,7 +330,7 @@ namespace APIViewWeb.Controllers
                 //Update the code file if revision already exists
                 var codeModel = await _codeFileManager.CreateReviewCodeFileModel(
                        apiRevisionId: revisionId, memoryStream: memoryStream, codeFile: codeFile);
-
+                codeModel.FileName = originalFileName;
                 apiRevision.Files[0] = codeModel;
                 await _apiRevisionsManager.UpdateAPIRevisionAsync(apiRevision);
                 return true;


### PR DESCRIPTION
File name is not updated in cosmos DB when updating API revision if a new commit has more API changes. This causes issue when upgrading a revision due to parser version changes. Filename is required to upgrade revisions.