### PR TITLE
All semaphor all the time

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -41,7 +41,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(requestBody);
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
-            testRecordingHandler.SanitizerRegistry.ResetSessionSanitizers();
+            await testRecordingHandler.SanitizerRegistry.ResetSessionSanitizers();
 
             var controller = new Admin(testRecordingHandler, _nullLogger)
             {
@@ -64,7 +64,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
 
-            var defaultSessionSanitizers = testRecordingHandler.SanitizerRegistry.GetSanitizers();
+            var defaultSessionSanitizers = await testRecordingHandler.SanitizerRegistry.GetSanitizers();
 
             string requestBody = @"[
     {
@@ -88,7 +88,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(requestBody);
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
-            testRecordingHandler.SanitizerRegistry.ResetSessionSanitizers();
+            await testRecordingHandler.SanitizerRegistry.ResetSessionSanitizers();
             httpContext.Response.Body = new MemoryStream();
 
             var controller = new Admin(testRecordingHandler, _nullLogger)
@@ -100,7 +100,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             await controller.AddSanitizers();
 
-            var amendedSessionSanitizers = testRecordingHandler.SanitizerRegistry.GetSanitizers();
+            var amendedSessionSanitizers = await testRecordingHandler.SanitizerRegistry.GetSanitizers();
 
             Assert.Equal(defaultSessionSanitizers.Count + 2, amendedSessionSanitizers.Count);
             Assert.True(amendedSessionSanitizers[defaultSessionSanitizers.Count] is GeneralRegexSanitizer);
@@ -144,7 +144,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(requestBody);
             httpContext.Request.ContentLength = httpContext.Request.Body.Length;
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
 
             var controller = new Admin(testRecordingHandler, _nullLogger)
             {
@@ -174,7 +174,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                     HttpContext = httpContext
                 }
             };
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
 
             var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.AddSanitizer()
@@ -195,7 +195,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                     HttpContext = httpContext
                 }
             };
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
 
             var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.AddSanitizer()
@@ -302,7 +302,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                     HttpContext = httpContext
                 }
             };
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             await controller.SetMatcher();
 
             var result = testRecordingHandler.Matcher;
@@ -433,7 +433,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                     HttpContext = httpContext
                 }
             };
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             await controller.AddSanitizer();
 
             httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
@@ -442,7 +442,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             Assert.Equal((int)HttpStatusCode.OK, httpContext.Response.StatusCode);
             Assert.True(!string.IsNullOrWhiteSpace(response.RootElement.GetProperty("Sanitizer").GetString()));
 
-            var result = testRecordingHandler.SanitizerRegistry.GetSanitizers().First();
+            var result = (await testRecordingHandler.SanitizerRegistry.GetSanitizers()).First();
             Assert.True(result is HeaderRegexSanitizer);
         }
 
@@ -464,10 +464,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                     HttpContext = httpContext
                 }
             };
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             await controller.AddSanitizer();
 
-            var result = testRecordingHandler.SanitizerRegistry.GetSanitizers().First();
+            var result = (await testRecordingHandler.SanitizerRegistry.GetSanitizers()).First();
             Assert.True(result is BodyKeySanitizer);
         }
 
@@ -487,7 +487,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                     HttpContext = httpContext
                 }
             };
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             
             var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.AddSanitizer()
@@ -511,10 +511,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                     HttpContext = httpContext
                 }
             };
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             await controller.AddSanitizer();
 
-            var result = testRecordingHandler.SanitizerRegistry.GetSanitizers().First();
+            var result = (await testRecordingHandler.SanitizerRegistry.GetSanitizers()).First();
             Assert.True(result is HeaderRegexSanitizer);
         }
 
@@ -541,7 +541,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             await controller.AddSanitizer();
 
-            var result = testRecordingHandler.SanitizerRegistry.GetSanitizers(testRecordingHandler.PlaybackSessions[recordingId]).Last();
+            var result = (await testRecordingHandler.SanitizerRegistry.GetSanitizers(testRecordingHandler.PlaybackSessions[recordingId])).Last();
             
             Assert.True(result is HeaderRegexSanitizer);
         }
@@ -588,7 +588,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             
             var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.AddSanitizer()
@@ -615,7 +615,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
 
             var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.AddSanitizer()
@@ -778,12 +778,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.AddSanitizer()
             );
             Assert.Equal(HttpStatusCode.BadRequest, assertion.StatusCode);
-            Assert.Empty(testRecordingHandler.SanitizerRegistry.GetSanitizers());
+            Assert.Empty(await testRecordingHandler.SanitizerRegistry.GetSanitizers());
             Assert.Contains(errorText, assertion.Message);
         }
 
@@ -807,10 +807,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             await controller.AddSanitizer();
 
-            var appliedSanitizers = testRecordingHandler.SanitizerRegistry.GetSanitizers();
+            var appliedSanitizers = await testRecordingHandler.SanitizerRegistry.GetSanitizers();
 
             Assert.Single(appliedSanitizers);
             Assert.True(appliedSanitizers.First() is GeneralRegexSanitizer);
@@ -896,7 +896,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
 
             var assertion = await Assert.ThrowsAsync<HttpException>(
                async () => await controller.AddSanitizer()
@@ -926,10 +926,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             await controller.AddSanitizer();
 
-            var addedSanitizer = testRecordingHandler.SanitizerRegistry.GetSanitizers().First();
+            var addedSanitizer = (await testRecordingHandler.SanitizerRegistry.GetSanitizers()).First();
             Assert.True(addedSanitizer is HeaderStringSanitizer);
 
             var actualTargetString = (string)typeof(HeaderStringSanitizer).GetField("_targetValue", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(addedSanitizer);
@@ -1025,7 +1025,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            var expectedSanitizerCount = testRecordingHandler.SanitizerRegistry.GetSanitizers().Count;
+            var expectedSanitizerCount = (await testRecordingHandler.SanitizerRegistry.GetSanitizers()).Count;
             await controller.RemoveSanitizers(new RemoveSanitizerList() { Sanitizers = new List<string>() { "AZSDK0000" } });
 
             httpContext.Response.Body.Seek(0, SeekOrigin.Begin);
@@ -1038,14 +1038,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             Assert.Single(returnedSanitizerIds);
             Assert.Equal("AZSDK0000", returnedSanitizerIds.First());
 
-            Assert.Equal(expectedSanitizerCount - 1, testRecordingHandler.SanitizerRegistry.GetSanitizers().Count);
+            Assert.Equal(expectedSanitizerCount - 1, (await testRecordingHandler.SanitizerRegistry.GetSanitizers()).Count);
         }
 
         [Fact]
         public async Task RemoveSanitizerSucceedsForAddedRecordingSanitizer()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             var httpContext = new DefaultHttpContext();
             await testRecordingHandler.StartPlaybackAsync("Test.RecordEntries/oauth_request_with_variables.json", httpContext.Response);
             var recordingId = httpContext.Response.Headers["x-recording-id"];
@@ -1062,11 +1062,11 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             var session = testRecordingHandler.GetActiveSession(recordingId);
 
-            var forRemoval = testRecordingHandler.RegisterSanitizer(new HeaderRegexSanitizer("Content-Type"), recordingId);
-            testRecordingHandler.RegisterSanitizer(new HeaderRegexSanitizer("Connection"), recordingId);
+            var forRemoval = await testRecordingHandler.RegisterSanitizer(new HeaderRegexSanitizer("Content-Type"), recordingId);
+            await testRecordingHandler.RegisterSanitizer(new HeaderRegexSanitizer("Connection"), recordingId);
             await controller.RemoveSanitizers(new RemoveSanitizerList() { Sanitizers = new List<string>() { forRemoval } });
 
-            var activeRecordingSanitizers = testRecordingHandler.SanitizerRegistry.GetSanitizers(session);
+            var activeRecordingSanitizers = await testRecordingHandler.SanitizerRegistry.GetSanitizers(session);
 
             Assert.Single(activeRecordingSanitizers);
             var privateSetting = (string)typeof(HeaderRegexSanitizer).GetField("_targetKey", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(activeRecordingSanitizers.First());
@@ -1077,7 +1077,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         public async void GetSanitizersReturnsSessionSanitizers()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            testRecordingHandler.RegisterSanitizer(new HeaderRegexSanitizer("Connection"));
+            await testRecordingHandler.RegisterSanitizer(new HeaderRegexSanitizer("Connection"));
 
             var httpContext = new DefaultHttpContext();
             httpContext.Response.Body = new MemoryStream();
@@ -1112,7 +1112,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             await testRecordingHandler.StartPlaybackAsync("Test.RecordEntries/oauth_request_with_variables.json", httpContext.Response);
             var recordingId = httpContext.Response.Headers["x-recording-id"];
             httpContext.Request.Headers["x-recording-id"] = recordingId;
@@ -1125,7 +1125,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 }
             };
 
-            testRecordingHandler.RegisterSanitizer(new HeaderRegexSanitizer("Connection"), recordingId);
+            await testRecordingHandler.RegisterSanitizer(new HeaderRegexSanitizer("Connection"), recordingId);
             await controller.GetSanitizers();
 
             httpContext.Response.Body.Seek(0, SeekOrigin.Begin);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/LoggingTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/LoggingTests.cs
@@ -88,7 +88,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
 
             await testRecordingHandler.HandleRecordRequestAsync(recordingId, request, httpContext.Response);
-            testRecordingHandler.StopRecording(recordingId);
+            await testRecordingHandler.StopRecording(recordingId);
 
             try
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/LoggingTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/LoggingTests.cs
@@ -52,7 +52,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 HttpResponse response = new DefaultHttpContext().Response;
                 await testRecordingHandler.HandlePlaybackRequest(recordingId, request, response);
 
-                AssertLogs(logger, 5, 9, 12);
+                AssertLogs(logger, 4, 8, 12);
             }
             finally
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -63,7 +63,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await recordController.Start();
             var inMemId = recordContext.Response.Headers["x-recording-id"].ToString();
             recordContext.Request.Headers["x-recording-id"] = new string[] { inMemId };
-            recordController.Stop();
+            await recordController.Stop();
 
             // apply same recordingId when starting in-memory session
             var playbackContext = new DefaultHttpContext();
@@ -175,7 +175,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await recordController.Start();
             var inMemId = recordContext.Response.Headers["x-recording-id"].ToString();
             recordContext.Request.Headers["x-recording-id"] = new string[] { inMemId };
-            recordController.Stop();
+            await recordController.Stop();
 
             var playbackContext = new DefaultHttpContext();
             playbackContext.Request.Headers["x-recording-id"] = inMemId;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
@@ -163,7 +163,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var recordingId = ctx.Response.Headers["x-recording-id"].ToString();
             var session = handler.RecordingSessions[recordingId];
             session.Session.Entries.Add(testEntry);
-            handler.StopRecording(recordingId);
+            await handler.StopRecording(recordingId);
 
             // now load it, did we avoid mangling it?
             var sessionFromDisk = TestHelpers.LoadRecordSession(Path.Combine(testFolder, testName));
@@ -629,14 +629,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void RecordingSessionSanitizeSanitizesVariables()
+        public async Task RecordingSessionSanitizeSanitizesVariables()
         {
             var sanitizer = new TestSanitizer();
             var session = new RecordSession();
             session.Variables["A"] = "secret";
             session.Variables["B"] = "Totally not a secret";
 
-            session.Sanitize(sanitizer);
+            await session.Sanitize(sanitizer);
 
             Assert.Equal("SANITIZED", session.Variables["A"]);
             Assert.Equal("Totally not a SANITIZED", session.Variables["B"]);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
@@ -402,7 +402,6 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             TestRecordingMismatchException exception = Assert.Throws<TestRecordingMismatchException>(() => matcher.FindMatch(requestEntry, entries));
             Assert.Equal(
                 "Unable to find a record for the request HEAD http://localhost/" + Environment.NewLine +
-                "Remaining entry: http://remote-host" + Environment.NewLine +
                 "Method doesn't match, request <HEAD> record <PUT>" + Environment.NewLine +
                 "Uri doesn't match:" + Environment.NewLine +
                 "    request <http://localhost/>" + Environment.NewLine +

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
@@ -402,6 +402,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             TestRecordingMismatchException exception = Assert.Throws<TestRecordingMismatchException>(() => matcher.FindMatch(requestEntry, entries));
             Assert.Equal(
                 "Unable to find a record for the request HEAD http://localhost/" + Environment.NewLine +
+                "Remaining entry: http://remote-host" + Environment.NewLine +
                 "Method doesn't match, request <HEAD> record <PUT>" + Environment.NewLine +
                 "Uri doesn't match:" + Environment.NewLine +
                 "    request <http://localhost/>" + Environment.NewLine +

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -89,7 +89,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 httpContext.Request.Headers["x-recording-skip"] = additionalEntryModeHeader;
             }
 
-            controller.Stop();
+            await controller.Stop();
 
             if (string.IsNullOrEmpty(additionalEntryModeHeader))
             {
@@ -162,7 +162,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 recordContext.Request.Headers["x-recording-skip"] = additionalEntryModeHeader;
             }
 
-            recordController.Stop();
+            await recordController.Stop();
 
             if (string.IsNullOrEmpty(additionalEntryModeHeader))
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -129,8 +129,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Headers["x-recording-skip"] = additionalEntryModeHeader;
 
 
-            var resultingException = Assert.Throws<HttpException>(
-               () => controller.Stop()
+            var resultingException = await Assert.ThrowsAsync<HttpException>(
+               async () => await controller.Stop()
             );
 
             Assert.Equal("When stopping a recording and providing a \"x-recording-skip\" value, only value \"request-response\" is accepted.", resultingException.Message);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -81,7 +81,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             Default = IncludeTransforms | IncludeSanitizers | IncludeMatcher
         }
 
-        private void _checkDefaultExtensions(RecordingHandler handlerForTest, CheckSkips skipsToCheck = CheckSkips.Default)
+        private async Task _checkDefaultExtensions(RecordingHandler handlerForTest, CheckSkips skipsToCheck = CheckSkips.Default)
         {
             if (skipsToCheck.HasFlag(CheckSkips.IncludeTransforms))
             {
@@ -100,7 +100,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             if (skipsToCheck.HasFlag(CheckSkips.IncludeSanitizers))
             {
                 
-                var sanitizers = handlerForTest.SanitizerRegistry.GetSanitizers();
+                var sanitizers = await handlerForTest.SanitizerRegistry.GetSanitizers();
 
                 Assert.Equal(DefaultExtensionCount, sanitizers.Count);
                 Assert.IsType<RecordedTestSanitizer>(sanitizers[0]);
@@ -167,35 +167,35 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void TestResetAfterAddition()
+        public async Task TestResetAfterAddition()
         {
             // arrange
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
 
             // act
-            testRecordingHandler.SanitizerRegistry.Register(new BodyRegexSanitizer("sanitized", ".*"));
+            await testRecordingHandler.SanitizerRegistry.Register(new BodyRegexSanitizer("sanitized", ".*"));
             testRecordingHandler.Matcher = new BodilessMatcher();
             testRecordingHandler.Transforms.Add(new ApiVersionTransform());
-            testRecordingHandler.SetDefaultExtensions();
+            await testRecordingHandler.SetDefaultExtensions();
 
             //assert
-            _checkDefaultExtensions(testRecordingHandler);
+            await _checkDefaultExtensions(testRecordingHandler);
         }
 
         [Fact]
-        public void TestResetAfterRemoval()
+        public async Task TestResetAfterRemoval()
         {
             // arrange
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
 
             // act
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             testRecordingHandler.Matcher = null;
             testRecordingHandler.Transforms.Clear();
-            testRecordingHandler.SetDefaultExtensions();
+            await testRecordingHandler.SetDefaultExtensions();
 
             //assert
-            _checkDefaultExtensions(testRecordingHandler);
+            await _checkDefaultExtensions(testRecordingHandler);
         }
 
         [Fact]
@@ -206,18 +206,18 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await testRecordingHandler.StartRecordingAsync("recordingings/cool.json", httpContext.Response);
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
 
-            testRecordingHandler.SanitizerRegistry.Clear();
-            testRecordingHandler.SanitizerRegistry.Register(new BodyRegexSanitizer("sanitized", ".*"));
-            testRecordingHandler.RegisterSanitizer(new GeneralRegexSanitizer("sanitized", ".*"), recordingId);
-            testRecordingHandler.SetDefaultExtensions(recordingId);
+            await testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Register(new BodyRegexSanitizer("sanitized", ".*"));
+            await testRecordingHandler.RegisterSanitizer(new GeneralRegexSanitizer("sanitized", ".*"), recordingId);
+            await testRecordingHandler.SetDefaultExtensions(recordingId);
             var session = testRecordingHandler.RecordingSessions.First().Value;
             var recordingSanitizers = testRecordingHandler.SanitizerRegistry.GetSanitizers(session);
-            var sessionSanitizers = testRecordingHandler.SanitizerRegistry.GetSanitizers();
+            var sessionSanitizers = await testRecordingHandler.SanitizerRegistry.GetSanitizers();
 
             // session sanitizer is still set to a single one
             Assert.Single(sessionSanitizers);
             Assert.IsType<BodyRegexSanitizer>(sessionSanitizers[0]);
-            _checkDefaultExtensions(testRecordingHandler, CheckSkips.IncludeMatcher | CheckSkips.IncludeTransforms);
+            await _checkDefaultExtensions(testRecordingHandler, CheckSkips.IncludeMatcher | CheckSkips.IncludeTransforms);
             Assert.Equal(session.AppliedSanitizers, testRecordingHandler.SanitizerRegistry.SessionSanitizers);
             Assert.Empty(session.AdditionalTransforms);
             Assert.Null(session.CustomMatcher);
@@ -231,22 +231,22 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await testRecordingHandler.StartRecordingAsync("recordingings/cool.json", httpContext.Response);
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
 
-            testRecordingHandler.SanitizerRegistry.Clear();
-            testRecordingHandler.SanitizerRegistry.Register(new BodyRegexSanitizer("sanitized", ".*"));
+            await testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Register(new BodyRegexSanitizer("sanitized", ".*"));
             testRecordingHandler.Transforms.Clear();
-            testRecordingHandler.RegisterSanitizer(new GeneralRegexSanitizer("sanitized", ".*"), recordingId);
-            testRecordingHandler.SetDefaultExtensions(recordingId);
+            await testRecordingHandler.RegisterSanitizer(new GeneralRegexSanitizer("sanitized", ".*"), recordingId);
+            await testRecordingHandler.SetDefaultExtensions(recordingId);
             var session = testRecordingHandler.RecordingSessions.First().Value;
 
             // check that the individual session had reset sanitizers
             Assert.Equal(testRecordingHandler.SanitizerRegistry.GetSanitizers(), testRecordingHandler.SanitizerRegistry.GetSanitizers(session));
 
             // stop the recording to clear out the session cache
-            testRecordingHandler.StopRecording(recordingId);
+            await testRecordingHandler.StopRecording(recordingId);
 
             // then verify that the session level is NOT reset.
-            Assert.Single(testRecordingHandler.SanitizerRegistry.GetSanitizers());
-            Assert.IsType<BodyRegexSanitizer>(testRecordingHandler.SanitizerRegistry.GetSanitizers().First());
+            Assert.Single(await testRecordingHandler.SanitizerRegistry.GetSanitizers());
+            Assert.IsType<BodyRegexSanitizer>((await testRecordingHandler.SanitizerRegistry.GetSanitizers()).First());
         }
 
         [Fact]
@@ -257,8 +257,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await testRecordingHandler.StartRecordingAsync("recordingings/cool.json", httpContext.Response);
             var recordingId = httpContext.Response.Headers["x-recording-id"].ToString();
 
-            var assertion = Assert.Throws<HttpException>(
-                () => testRecordingHandler.SetDefaultExtensions()
+            var assertion = await Assert.ThrowsAsync<HttpException>(
+                async () => await testRecordingHandler.SetDefaultExtensions()
             );
 
             Assert.StartsWith("There are a total of 1 active sessions. Remove these sessions before hitting Admin/Reset.", assertion.Message);
@@ -337,7 +337,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
-            recordingHandler.StopRecording(sessionId);
+            await recordingHandler.StopRecording(sessionId);
 
             try
             {
@@ -360,7 +360,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
-            recordingHandler.StopRecording(sessionId);
+            await recordingHandler.StopRecording(sessionId);
 
 
             try
@@ -393,7 +393,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             CreateRecordModeRequest(httpContext, "request-body");
 
             await recordingHandler.HandleRecordRequestAsync(sessionId, httpContext.Request, httpContext.Response);
-            recordingHandler.StopRecording(sessionId);
+            await recordingHandler.StopRecording(sessionId);
 
             try
             {
@@ -441,7 +441,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody("{ \"key\": \"value\" }");
             await recordingHandler.HandleRecordRequestAsync(sessionId, httpContext.Request, httpContext.Response);
 
-            recordingHandler.StopRecording(sessionId);
+            await recordingHandler.StopRecording(sessionId);
 
             try
             {
@@ -545,7 +545,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await recordingHandler.StartRecordingAsync(pathToRecording, startHttpContext.Response);
             var sessionId = startHttpContext.Response.Headers["x-recording-id"].ToString();
 
-            recordingHandler.StopRecording(sessionId, variables: new SortedDictionary<string, string>(dict));
+            await recordingHandler.StopRecording(sessionId, variables: new SortedDictionary<string, string>(dict));
             var storedVariables = TestHelpers.LoadRecordSession(Path.Combine(tmpPath, pathToRecording)).Session.Variables;
 
             Assert.Equal(dict.Count, storedVariables.Count);
@@ -566,7 +566,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
-            recordingHandler.StopRecording(sessionId, variables: new SortedDictionary<string, string>());
+            await recordingHandler.StopRecording(sessionId, variables: new SortedDictionary<string, string>());
 
             var storedVariables = TestHelpers.LoadRecordSession(Path.Combine(tmpPath, pathToRecording)).Session.Variables;
 
@@ -583,7 +583,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             await recordingHandler.StartRecordingAsync(pathToRecording, httpContext.Response);
             var sessionId = httpContext.Response.Headers["x-recording-id"].ToString();
-            recordingHandler.StopRecording(sessionId, variables: null);
+            await recordingHandler.StopRecording(sessionId, variables: null);
 
             var storedVariables = TestHelpers.LoadRecordSession(Path.Combine(tmpPath, pathToRecording)).Session.Variables;
 
@@ -734,7 +734,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             httpContext.Request.Body = new MemoryStream(CompressionUtilities.CompressBody(bodyBytes, httpContext.Request.Headers));
 
             await recordingHandler.HandleRecordRequestAsync(recordingId, httpContext.Request, httpContext.Response);
-            recordingHandler.StopRecording(recordingId);
+            await recordingHandler.StopRecording(recordingId);
 
             try
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -239,7 +239,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var session = testRecordingHandler.RecordingSessions.First().Value;
 
             // check that the individual session had reset sanitizers
-            Assert.Equal(testRecordingHandler.SanitizerRegistry.GetSanitizers(), testRecordingHandler.SanitizerRegistry.GetSanitizers(session));
+            Assert.Equal(await testRecordingHandler.SanitizerRegistry.GetSanitizers(), await testRecordingHandler.SanitizerRegistry.GetSanitizers(session));
 
             // stop the recording to clear out the session cache
             await testRecordingHandler.StopRecording(recordingId);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/SanitizerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/SanitizerTests.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -27,61 +28,61 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         public string scopeClean = @"scope\=(?<scope>[^&]*)";
 
         [Fact]
-        public void OauthResponseSanitizerCleansV2AuthRequest()
+        public async void OauthResponseSanitizerCleansV2AuthRequest()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/oauth_request.json");
-            
-            session.Session.Sanitize(OAuthResponseSanitizer);
+
+            await session.Session.Sanitize(OAuthResponseSanitizer);
 
             Assert.Empty(session.Session.Entries);
         }
 
         [Fact]
-        public void SanitizerDecodesUnicodeAmpersandSanitizesClientIdAndSecret()
+        public async void SanitizerDecodesUnicodeAmpersandSanitizesClientIdAndSecret()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/request_with_encoding.json");
 
             var clientSan = new BodyRegexSanitizer(regex: "(client_id=)(?<cid>[^&\\\"]+)", groupForReplace: "cid");
             var secretSan = new BodyRegexSanitizer(regex: "client_secret=(?<secret>[^&\\\"]+)", groupForReplace: "secret");
 
-            session.Session.Sanitize(clientSan);
-            session.Session.Sanitize(secretSan);
+            await session.Session.Sanitize(clientSan);
+            await session.Session.Sanitize(secretSan);
 
             Assert.Equal("client_id=Sanitized&grant_type=client_credentials&client_info=1&client_secret=Sanitized&claims=%7B%22access_token=blahblah", Encoding.UTF8.GetString(session.Session.Entries[0].Request.Body));
         }
 
         [Fact]
-        public void EnsureSASCleanupDoesntOverrunInXML()
+        public async void EnsureSASCleanupDoesntOverrunInXML()
         {
             var sanitizerDictionary = new SanitizerDictionary();
             var sessionwithXmlBody = TestHelpers.LoadRecordSession("Test.RecordEntries/xml_body_with_sas_present.json");
 
             Assert.True(sanitizerDictionary.Sanitizers.TryGetValue("AZSDK1007", out RegisteredSanitizer SASURISanitizer));
 
-            sessionwithXmlBody.Session.Sanitize(SASURISanitizer.Sanitizer);
+            await sessionwithXmlBody.Session.Sanitize(SASURISanitizer.Sanitizer);
 
             Assert.Contains("<CopyProgress>1024/1024</CopyProgress>", Encoding.UTF8.GetString(sessionwithXmlBody.Session.Entries[0].Response.Body));
         }
 
         [Fact]
-        public void OauthResponseSanitizerCleansNonV2AuthRequest()
+        public async void OauthResponseSanitizerCleansNonV2AuthRequest()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/oauth_request.json");
             session.Session.Entries[0].RequestUri = "https://login.microsoftonline.com/12345678-1234-1234-1234-123456789012/oauth2/token";
 
-            session.Session.Sanitize(OAuthResponseSanitizer);
+            await session.Session.Sanitize(OAuthResponseSanitizer);
 
             Assert.Empty(session.Session.Entries);
         }
 
         [Fact]
-        public void OauthResponseSanitizerNotAggressive()
+        public async void OauthResponseSanitizerNotAggressive()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
 
             var expectedCount = session.Session.Entries.Count;
 
-            session.Session.Sanitize(OAuthResponseSanitizer);
+            await session.Session.Sanitize(OAuthResponseSanitizer);
 
             Assert.Equal(expectedCount, session.Session.Entries.Count);
         }
@@ -90,13 +91,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [InlineData("uri", "\"/oauth2(?:/v2.0)?/token\"")]
         [InlineData("body", "\"/oauth2(?:/v2.0)?/token\"")]
         [InlineData("header", "\"/oauth2(?:/v2.0)?/token\"")]
-        public void RegexEntrySanitizerNoOpsOnNonMatch(string target, string regex)
+        public async void RegexEntrySanitizerNoOpsOnNonMatch(string target, string regex)
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var sanitizer = new RegexEntrySanitizer(target, regex);
             var expectedCount = session.Session.Entries.Count;
 
-            session.Session.Sanitize(sanitizer);
+            await session.Session.Sanitize(sanitizer);
 
             Assert.Equal(expectedCount, session.Session.Entries.Count);
         }
@@ -106,25 +107,25 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [InlineData("uri", "fakeazsdktestaccount", 0)]
         [InlineData("body", "listtable09bf2a3d", 10)]
         [InlineData("header", "a50f2f9c-b830-11eb-b8c8-10e7c6392c5a", 10)]
-        public void RegexEntrySanitizerCorrectlySanitizes(string target, string regex, int endCount)
+        public async void RegexEntrySanitizerCorrectlySanitizes(string target, string regex, int endCount)
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var sanitizer = new RegexEntrySanitizer(target, regex);
             var expectedCount = session.Session.Entries.Count;
 
-            session.Session.Sanitize(sanitizer);
+            await session.Session.Sanitize(sanitizer);
 
             Assert.Equal(endCount, session.Session.Entries.Count);
         }
 
         [Fact]
-        public void RegexEntrySanitizerCorrectlySanitizesSpecific()
+        public async void RegexEntrySanitizerCorrectlySanitizesSpecific()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/response_with_xml_body.json");
             var sanitizer = new RegexEntrySanitizer("header", "b24f75a9-b830-11eb-b949-10e7c6392c5a");
             var expectedCount = session.Session.Entries.Count;
 
-            session.Session.Sanitize(sanitizer);
+            await session.Session.Sanitize(sanitizer);
 
             Assert.Equal(2, session.Session.Entries.Count);
             Assert.Equal("b25bf92a-b830-11eb-947a-10e7c6392c5a", session.Session.Entries[0].Request.Headers["x-ms-client-request-id"][0].ToString());
@@ -152,7 +153,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         {
 
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            testRecordingHandler.SanitizerRegistry.Clear();
+            await testRecordingHandler.SanitizerRegistry.Clear();
             var httpContext = new DefaultHttpContext();
             httpContext.Request.Headers["x-abstraction-identifier"] = "RegexEntrySanitizer";
             httpContext.Request.Body = TestHelpers.GenerateStreamRequestBody(body);
@@ -169,7 +170,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
 
             await controller.AddSanitizer();
-            var sanitizer = testRecordingHandler.SanitizerRegistry.GetSanitizers()[0];
+            var sanitizer = (await testRecordingHandler.SanitizerRegistry.GetSanitizers())[0];
             Assert.True(sanitizer is RegexEntrySanitizer);
 
 
@@ -179,13 +180,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
 
         [Fact]
-        public void UriRegexSanitizerReplacesTableName()
+        public async void UriRegexSanitizerReplacesTableName()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var originalValue = session.Session.Entries[0].RequestUri;
 
             var uriSanitizer = new UriRegexSanitizer(value: "fakeaccount", regex: lookaheadReplaceRegex);
-            session.Session.Sanitize(uriSanitizer);
+            await session.Session.Sanitize(uriSanitizer);
 
             var testValue = session.Session.Entries[0].RequestUri;
 
@@ -194,13 +195,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void UriRegexSanitizerAggressivenessCheck()
+        public async void UriRegexSanitizerAggressivenessCheck()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/oauth_request.json");
             var originalValue = session.Session.Entries[0].RequestUri;
 
             var uriSanitizer = new UriRegexSanitizer(value: "fakeaccount", regex: lookaheadReplaceRegex);
-            session.Session.Sanitize(uriSanitizer);
+            await session.Session.Sanitize(uriSanitizer);
 
             var testValue = session.Session.Entries[0].RequestUri;
 
@@ -209,7 +210,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
 
         [Fact]
-        public void GeneralRegexSanitizerAppliesToAllSets()
+        public async void GeneralRegexSanitizerAppliesToAllSets()
         {
             // arrange
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
@@ -229,8 +230,8 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var accountNameSanitizer = new GeneralRegexSanitizer(value: genericAValue, regex: realAValue);
 
             // act
-            session.Session.Sanitize(tableNameSanitizer);
-            session.Session.Sanitize(accountNameSanitizer);
+            await session.Session.Sanitize(tableNameSanitizer);
+            await session.Session.Sanitize(accountNameSanitizer);
             var locationHeaderValue = targetEntry.Response.Headers["Location"].First();
 
             // assert that we successfully changed a header, the body, and the uri
@@ -255,14 +256,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void ReplaceRequestSubscriptionId()
+        public async void voidReplaceRequestSubscriptionId()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/request_with_subscriptionid.json");
             var targetEntry = session.Session.Entries.First();
             var originalUri = targetEntry.RequestUri.ToString();
             var subscriptionIdReplaceSanitizer = new UriSubscriptionIdSanitizer();
 
-            session.Session.Sanitize(subscriptionIdReplaceSanitizer);
+            await session.Session.Sanitize(subscriptionIdReplaceSanitizer);
             var sanitizedUri = targetEntry.RequestUri;
 
             Assert.NotEqual(originalUri, sanitizedUri);
@@ -272,14 +273,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void ReplaceRequestSubscriptionIdNoAction()
+        public async void ReplaceRequestSubscriptionIdNoAction()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/oauth_request.json");
             var targetEntry = session.Session.Entries.First();
             var originalUri = targetEntry.RequestUri.ToString();
             var subscriptionIdReplaceSanitizer = new UriSubscriptionIdSanitizer();
 
-            session.Session.Sanitize(subscriptionIdReplaceSanitizer);
+            await session.Session.Sanitize(subscriptionIdReplaceSanitizer);
             var sanitizedUri = targetEntry.RequestUri;
 
             // no action should have taken place here.
@@ -287,7 +288,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void HeaderRegexSanitizerSimpleReplace()
+        public async void HeaderRegexSanitizerSimpleReplace()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetEntry = session.Session.Entries[0];
@@ -296,7 +297,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             // where we have a key, a regex, and no groupname.
             var headerRegexSanitizer = new HeaderRegexSanitizer(targetKey, value: "fakeaccount", regex: lookaheadReplaceRegex);
-            session.Session.Sanitize(headerRegexSanitizer);
+            await session.Session.Sanitize(headerRegexSanitizer);
 
             var testValue = targetEntry.Response.Headers[targetKey].First();
 
@@ -306,35 +307,35 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
 
         [Fact]
-        public void HeaderRegexSanitizerMultipartReplace()
+        public async void HeaderRegexSanitizerMultipartReplace()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/multipart_header.json");
             var targetEntry = session.Session.Entries[0];
             var targetKey = "Cookie";
 
             var headerRegexSanitizer = new HeaderRegexSanitizer(targetKey, value: "REDACTED", regex: "SuperDifferent");
-            session.Session.Sanitize(headerRegexSanitizer);
+            await session.Session.Sanitize(headerRegexSanitizer);
 
             Assert.Equal("REDACTEDCookie", targetEntry.Request.Headers[targetKey][0]);
             Assert.Equal("KindaDifferentCookie", targetEntry.Request.Headers[targetKey][1]);
         }
 
         [Fact]
-        public void HeaderRegexSanitizerMultipartReplaceLatterOnly()
+        public async void HeaderRegexSanitizerMultipartReplaceLatterOnly()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/multipart_header.json");
             var targetEntry = session.Session.Entries[0];
             var targetKey = "Cookie";
 
             var headerRegexSanitizer = new HeaderRegexSanitizer(targetKey, value: "REDACTED", regex: "KindaDifferent");
-            session.Session.Sanitize(headerRegexSanitizer);
+            await session.Session.Sanitize(headerRegexSanitizer);
 
             Assert.Equal("SuperDifferentCookie", targetEntry.Request.Headers[targetKey][0]);
             Assert.Equal("REDACTEDCookie", targetEntry.Request.Headers[targetKey][1]);
         }
 
         [Fact]
-        public void HeaderRegexSanitizerGroupedRegexReplace()
+        public async void HeaderRegexSanitizerGroupedRegexReplace()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetKey = "Location";
@@ -343,7 +344,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             // where we have a key, a regex, and a groupname to replace with value Y
             var headerRegexSanitizer = new HeaderRegexSanitizer(targetKey, value: "fakeaccount", regex: capturingGroupReplaceRegex, groupForReplace: "account");
-            session.Session.Sanitize(headerRegexSanitizer);
+            await session.Session.Sanitize(headerRegexSanitizer);
 
             var testValue = targetEntry.Response.Headers[targetKey].First();
 
@@ -352,7 +353,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void HeaderRegexSanitizerAggressivenessCheck()
+        public async void HeaderRegexSanitizerAggressivenessCheck()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetEntry = session.Session.Entries[0];
@@ -361,7 +362,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             // where we find a key, but there is nothing to be done by the sanitizer
             var headerRegexSanitizer = new HeaderRegexSanitizer(targetKey, value: "fakeaccount", regex: capturingGroupReplaceRegex, groupForReplace: "account");
-            session.Session.Sanitize(headerRegexSanitizer);
+            await session.Session.Sanitize(headerRegexSanitizer);
 
             var newResult = targetEntry.Response.Headers[targetKey].First();
 
@@ -369,7 +370,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void BodyRegexSanitizerCleansJSON()
+        public async void BodyRegexSanitizerCleansJSON()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetEntry = session.Session.Entries[0];
@@ -377,19 +378,19 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var replaceTableNameRegex = "TableName\"\\s*:\\s*\"(?<tablename>[a-z0-9]+)\"";
 
             var bodyRegexSanitizer = new BodyRegexSanitizer(value: "afaketable", regex: replaceTableNameRegex, groupForReplace: "tablename");
-            session.Session.Sanitize(bodyRegexSanitizer);
+            await session.Session.Sanitize(bodyRegexSanitizer);
 
             Assert.Contains("\"TableName\":\"afaketable\"", Encoding.UTF8.GetString(targetEntry.Response.Body));
         }
 
         [Fact]
-        public void BodyRegexSanitizerCleansText()
+        public async void BodyRegexSanitizerCleansText()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/oauth_request.json");
             var targetEntry = session.Session.Entries[0];
 
             var bodyRegexSanitizer = new BodyRegexSanitizer(value: "sanitized.scope", regex: scopeClean, groupForReplace: "scope");
-            session.Session.Sanitize(bodyRegexSanitizer);
+            await session.Session.Sanitize(bodyRegexSanitizer);
 
             var expectedBodyStartsWith = "scope=sanitized.scope&client_id";
 
@@ -397,66 +398,66 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void BodyRegexSanitizerIgnoresNonTextualBodies()
+        public async void BodyRegexSanitizerIgnoresNonTextualBodies()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/request_with_binary_content.json");
             var targetEntry = session.Session.Entries[0];
             var content = Encoding.UTF8.GetString(targetEntry.Request.Body);
 
             var bodyRegexSanitizer = new BodyRegexSanitizer(regex: ".*");
-            session.Session.Sanitize(bodyRegexSanitizer);
+            await session.Session.Sanitize(bodyRegexSanitizer);
 
             Assert.Equal(content, Encoding.UTF8.GetString(targetEntry.Request.Body));
         }
 
         [Fact]
-        public void BodyRegexSanitizerQuietlyExits()
+        public async void BodyRegexSanitizerQuietlyExits()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetEntry = session.Session.Entries[0];
 
             var beforeUpdate = targetEntry.Request.Body;
             var bodyRegexSanitizer = new BodyRegexSanitizer(value: "fakeaccount", regex: capturingGroupReplaceRegex, groupForReplace: "account");
-            session.Session.Sanitize(bodyRegexSanitizer);
+            await session.Session.Sanitize(bodyRegexSanitizer);
 
             Assert.Equal(beforeUpdate, targetEntry.Request.Body);
         }
 
         [Fact]
-        public void RemoveHeaderSanitizerQuietlyExits()
+        public async void RemoveHeaderSanitizerQuietlyExits()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetEntry = session.Session.Entries[0];
             var requestHeaderCountBefore = targetEntry.Request.Headers.Count;
 
             var removeHeaderSanitizer = new RemoveHeaderSanitizer(headersForRemoval: "fakeaccount");
-            session.Session.Sanitize(removeHeaderSanitizer);
+            await session.Session.Sanitize(removeHeaderSanitizer);
 
             Assert.Equal(requestHeaderCountBefore, targetEntry.Request.Headers.Count);
         }
 
         [Fact]
-        public void RemoveHeaderSanitizerRemovesSingleHeader()
+        public async void RemoveHeaderSanitizerRemovesSingleHeader()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetEntry = session.Session.Entries[0];
             var headerForRemoval = "DataServiceVersion";
 
             var removeHeaderSanitizer = new RemoveHeaderSanitizer(headersForRemoval: headerForRemoval);
-            session.Session.Sanitize(removeHeaderSanitizer);
+            await session.Session.Sanitize(removeHeaderSanitizer);
 
             Assert.False(targetEntry.Request.Headers.ContainsKey(headerForRemoval));
         }
 
         [Fact]
-        public void RemoveHeaderSanitizerRemovesMultipleHeaders()
+        public async void RemoveHeaderSanitizerRemovesMultipleHeaders()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetEntry = session.Session.Entries[0];
             var headerForRemoval = "DataServiceVersion, Date,User-Agent"; // please note the wonky spacing is intentional
 
             var removeHeaderSanitizer = new RemoveHeaderSanitizer(headersForRemoval: headerForRemoval);
-            session.Session.Sanitize(removeHeaderSanitizer);
+            await session.Session.Sanitize(removeHeaderSanitizer);
 
             foreach(var header in headerForRemoval.Split(",").Select(x => x.Trim()))
             {
@@ -465,14 +466,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void BodyKeySanitizerKeyReplace()
+        public async void BodyKeySanitizerKeyReplace()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetEntry = session.Session.Entries[0];
             var replacementValue = "sanitized.tablename";
 
             var bodyKeySanitizer = new BodyKeySanitizer(jsonPath: "$.TableName", value: replacementValue);
-            session.Session.Sanitize(bodyKeySanitizer);
+            await session.Session.Sanitize(bodyKeySanitizer);
 
             var newBody = Encoding.UTF8.GetString(targetEntry.Request.Body);
             Assert.Contains(replacementValue, newBody);
@@ -480,46 +481,46 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void BodyKeySanitizerIgnoresNulls()
+        public async void BodyKeySanitizerIgnoresNulls()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/response_with_null_secrets.json");
             var targetEntry = session.Session.Entries[0];
             var replacementValue = "sanitized.tablename";
             var originalBody = Encoding.UTF8.GetString(targetEntry.Request.Body);
             var bodyKeySanitizer = new BodyKeySanitizer(jsonPath: "$.connectionString", value: replacementValue);
-            session.Session.Sanitize(bodyKeySanitizer);
+            await session.Session.Sanitize(bodyKeySanitizer);
 
             var newBody = Encoding.UTF8.GetString(targetEntry.Request.Body);
             Assert.Equal(originalBody, newBody);
         }
 
         [Fact]
-        public void BodyKeySanitizerHandlesNonJSON()
+        public async void BodyKeySanitizerHandlesNonJSON()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/oauth_request.json");
             var targetEntry = session.Session.Entries[0];
             var replacementValue = "sanitized.tablename";
 
             var bodyKeySanitizer = new BodyKeySanitizer(jsonPath: "$.TableName", value: replacementValue);
-            session.Session.Sanitize(bodyKeySanitizer);
+            await session.Session.Sanitize(bodyKeySanitizer);
 
             Assert.DoesNotContain(replacementValue, Encoding.UTF8.GetString(targetEntry.Request.Body));
         }
 
         [Fact]
-        public void BodyKeySanitizerRegexReplace()
+        public async void BodyKeySanitizerRegexReplace()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetEntry = session.Session.Entries[0];
 
             var bodyKeySanitizer = new BodyKeySanitizer(jsonPath: "$.TableName", value: "TABLE_ID_IS_SANITIZED", regex: @"(?<=listtable)(?<tableid>[a-z0-9]+)", groupForReplace: "tableid");
-            session.Session.Sanitize(bodyKeySanitizer);
+            await session.Session.Sanitize(bodyKeySanitizer);
 
             Assert.Contains("listtableTABLE_ID_IS_SANITIZED", Encoding.UTF8.GetString(targetEntry.Response.Body));
         }
 
         [Fact]
-        public void BodyKeySanitizerQuietlyExits()
+        public async void BodyKeySanitizerQuietlyExits()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetEntry = session.Session.Entries[0];
@@ -527,7 +528,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             var bodyKeySanitizer = new BodyKeySanitizer(jsonPath: "$.Location", value: replacementValue);
             var originalValue = Encoding.UTF8.GetString(targetEntry.Request.Body);
-            session.Session.Sanitize(bodyKeySanitizer);
+            await session.Session.Sanitize(bodyKeySanitizer);
             var newValue = Encoding.UTF8.GetString(targetEntry.Request.Body);
 
             Assert.DoesNotContain(replacementValue, newValue);
@@ -536,14 +537,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
 
         [Fact]
-        public void ContinuationSanitizerSingleReplace()
+        public async void ContinuationSanitizerSingleReplace()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/requests_with_continuation.json");
             var continueSanitizer = new ContinuationSanitizer("correlationId", "guid", resetAfterFirst: "false");
             var targetKey = "correlationId";
             var originalRequestGuid = session.Session.Entries[0].Response.Headers[targetKey].First();
 
-            session.Session.Sanitize(continueSanitizer);
+            await session.Session.Sanitize(continueSanitizer);
 
             var firstRequest = session.Session.Entries[0].Response.Headers[targetKey].First();
             var firstResponse = session.Session.Entries[1].Request.Headers[targetKey].First();
@@ -557,14 +558,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void ContinuationSanitizerMultipleReplace()
+        public async void ContinuationSanitizerMultipleReplace()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/requests_with_continuation.json");
             var continueSanitizer = new ContinuationSanitizer("correlationId", "guid", resetAfterFirst: "true");
             var targetKey = "correlationId";
             var originalSendGuid = session.Session.Entries[0].Response.Headers[targetKey].First();
 
-            session.Session.Sanitize(continueSanitizer);
+            await session.Session.Sanitize(continueSanitizer);
 
             var firstRequest = session.Session.Entries[0].Response.Headers[targetKey].First();
             var firstResponse = session.Session.Entries[1].Request.Headers[targetKey].First();
@@ -578,14 +579,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void ContinuationSanitizerNonExistentKey()
+        public async void ContinuationSanitizerNonExistentKey()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/requests_with_continuation.json");
             var continueSanitizer = new ContinuationSanitizer("non-existent-key", "guid", resetAfterFirst: "true");
             var targetKey = "correlationId";
             var originalSendGuid = session.Session.Entries[0].Response.Headers[targetKey].First();
 
-            session.Session.Sanitize(continueSanitizer);
+            await session.Session.Sanitize(continueSanitizer);
 
             var firstRequest = session.Session.Entries[0].Response.Headers[targetKey].First();
             var firstResponse = session.Session.Entries[1].Request.Headers[targetKey].First();
@@ -599,13 +600,13 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void ConditionalSanitizeUriRegexAppliesForRegex()
+        public async void ConditionalSanitizeUriRegexAppliesForRegex()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/response_with_xml_body.json");
             var targetHeader = "x-ms-version";
 
             var removeHeadersSanitizer = new RemoveHeaderSanitizer(targetHeader, condition: new ApplyCondition() { UriRegex = @".+/Tables.*" });
-            session.Session.Sanitize(removeHeadersSanitizer);
+            await session.Session.Sanitize(removeHeadersSanitizer);
             var firstEntry = session.Session.Entries[0];
             // this entry should be untouched by sanitization, it's request URI should not match the regex above
             var secondEntry = session.Session.Entries[1];
@@ -617,18 +618,18 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void ConditionalSanitizeUriRegexProperlySkips()
+        public async void ConditionalSanitizeUriRegexProperlySkips()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/response_with_xml_body.json");
             var targetHeader = "x-ms-version";
 
             var removeHeadersSanitizer = new RemoveHeaderSanitizer(targetHeader, condition: new ApplyCondition() { UriRegex = @".+/token" });
-            session.Session.Sanitize(removeHeadersSanitizer);
+            await session.Session.Sanitize(removeHeadersSanitizer);
             Assert.DoesNotContain<bool>(false, session.Session.Entries.Select(x => x.Request.Headers.ContainsKey(targetHeader)));
         }
 
         [Fact]
-        public void GenStringSanitizerAppliesForMultipleComponents()
+        public async void GenStringSanitizerAppliesForMultipleComponents()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var targetString = "listtable09bf2a3d";
@@ -640,7 +641,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var originalLocation = targetEntry.Response.Headers["Location"].First().ToString();
 
             var sanitizer = new GeneralStringSanitizer(targetString, replacementString);
-            session.Session.Sanitize(sanitizer);
+            await session.Session.Sanitize(sanitizer);
 
             var resultRequestBody = Encoding.UTF8.GetString(targetEntry.Request.Body);
             var resultResponseBody = Encoding.UTF8.GetString(targetEntry.Response.Body);
@@ -651,12 +652,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             Assert.NotEqual(originalRequestBody, resultRequestBody);
             Assert.DoesNotContain(targetString, resultRequestBody);
             Assert.Contains(replacementString, resultRequestBody);
-            
+
             // result body
             Assert.NotEqual(originalResponseBody, resultResponseBody);
             Assert.DoesNotContain(targetString, resultResponseBody);
             Assert.Contains(replacementString, resultResponseBody);
-            
+
             // uri
             Assert.NotEqual(originalLocation, resultLocation);
             Assert.DoesNotContain(targetString, resultLocation);
@@ -664,7 +665,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void GenStringSanitizerQuietExitForAllHttpComponents()
+        public async void GenStringSanitizerQuietExitForAllHttpComponents()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
             var untouchedSession = TestHelpers.LoadRecordSession("Test.RecordEntries/post_delete_get_content.json");
@@ -676,7 +677,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var matcher = new RecordMatcher();
 
             var sanitizer = new GeneralStringSanitizer(targetString, replacementString);
-            session.Session.Sanitize(sanitizer);
+            await session.Session.Sanitize(sanitizer);
 
             var resultRequestBody = Encoding.UTF8.GetString(targetEntry.Request.Body);
             var resultResponseBody = Encoding.UTF8.GetString(targetEntry.Response.Body);
@@ -697,15 +698,15 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [InlineData("Accept-Encoding", ",", "<comma>", "Test.RecordEntries/post_delete_get_content.json")]
         [InlineData("Accept", "*/*", "<starslashstar>", "Test.RecordEntries/oauth_request_with_variables.json")]
         [InlineData("User-Agent", ".19041-SP0", "<useragent>", "Test.RecordEntries/post_delete_get_content.json")]
-        public void HeaderStringSanitizerApplies(string targetKey, string targetValue, string replacementValue, string recordingFile)
+        public async void HeaderStringSanitizerApplies(string targetKey, string targetValue, string replacementValue, string recordingFile)
         {
             var session = TestHelpers.LoadRecordSession(recordingFile);
             var targetEntry = session.Session.Entries[0];
             var originalHeaderValue = targetEntry.Request.Headers[targetKey].First().ToString();
-            
+
             var sanitizer = new HeaderStringSanitizer(targetKey, targetValue, value: replacementValue);
-            session.Session.Sanitize(sanitizer);
-            
+            await session.Session.Sanitize(sanitizer);
+
             var resultHeaderValue = targetEntry.Request.Headers[targetKey].First().ToString();
 
             Assert.NotEqual(resultHeaderValue, originalHeaderValue);
@@ -715,7 +716,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
         [Theory]
         [InlineData("DataServiceVersion", "application/json", "<replacedString>", "Test.RecordEntries/post_delete_get_content.json")]
-        public void HeaderStringSanitizerQuietlyExits(string targetKey, string targetValue, string replacementValue, string recordingFile)
+        public async void HeaderStringSanitizerQuietlyExits(string targetKey, string targetValue, string replacementValue, string recordingFile)
         {
             var session = TestHelpers.LoadRecordSession(recordingFile);
             var untouchedSession = TestHelpers.LoadRecordSession(recordingFile);
@@ -724,7 +725,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var matcher = new RecordMatcher();
 
             var sanitizer = new HeaderStringSanitizer(targetKey, targetValue, value: replacementValue);
-            session.Session.Sanitize(sanitizer);
+            await session.Session.Sanitize(sanitizer);
 
             Assert.Equal(0, matcher.CompareHeaderDictionaries(targetUntouchedEntry.Request.Headers, targetEntry.Request.Headers, new HashSet<string>(), new HashSet<string>()));
             Assert.Equal(0, matcher.CompareHeaderDictionaries(targetUntouchedEntry.Response.Headers, targetEntry.Response.Headers, new HashSet<string>(), new HashSet<string>()));
@@ -735,14 +736,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [InlineData("%20profile%20offline", "<profilereplaced>", "Test.RecordEntries/oauth_request.json")]
         [InlineData("|,&x-client-last-telemetry=2|0|", "<client>", "Test.RecordEntries/oauth_request.json")]
         [InlineData("}", "<bracket>", "Test.RecordEntries/response_with_null_secrets.json")]
-        public void BodyStringSanitizerApplies(string targetValue, string replacementValue, string recordingFile)
+        public async void BodyStringSanitizerApplies(string targetValue, string replacementValue, string recordingFile)
         {
             var session = TestHelpers.LoadRecordSession(recordingFile);
             var targetEntry = session.Session.Entries[0];
             var originalBodyValue = Encoding.UTF8.GetString(targetEntry.Request.Body);
 
             var sanitizer = new BodyStringSanitizer(targetValue, value: replacementValue);
-            session.Session.Sanitize(sanitizer);
+            await session.Session.Sanitize(sanitizer);
 
             var resultBodyValue = Encoding.UTF8.GetString(targetEntry.Request.Body);
 
@@ -755,7 +756,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [InlineData("TableNames", "<tablename>", "Test.RecordEntries/response_with_null_secrets.json")]
         [InlineData("d2270777-c002-0072-313d-4ce19f000000", "<targetId>", "Test.RecordEntries/response_with_null_secrets.json")]
         [InlineData(".19041-SP0", "<useragent>", "Test.RecordEntries/response_with_null_secrets.json")]
-        public void BodyStringSanitizerQuietlyExits(string targetValue, string replacementValue, string recordingFile)
+        public async void BodyStringSanitizerQuietlyExits(string targetValue, string replacementValue, string recordingFile)
         {
             var session = TestHelpers.LoadRecordSession(recordingFile);
             var untouchedSession = TestHelpers.LoadRecordSession(recordingFile);
@@ -765,7 +766,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var matcher = new RecordMatcher();
 
             var sanitizer = new BodyStringSanitizer(targetValue, value: replacementValue);
-            session.Session.Sanitize(sanitizer);
+            await session.Session.Sanitize(sanitizer);
 
             var resultBodyValue = Encoding.UTF8.GetString(targetEntry.Request.Body);
             Assert.Equal(0, matcher.CompareBodies(targetUntouchedEntry.Request.Body, targetEntry.Request.Body));
@@ -773,14 +774,14 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public void BodyStringSanitizerIgnoresNonTextualBodies()
+        public async void BodyStringSanitizerIgnoresNonTextualBodies()
         {
             var session = TestHelpers.LoadRecordSession("Test.RecordEntries/request_with_binary_content.json");
             var targetEntry = session.Session.Entries[0];
             var content = Encoding.UTF8.GetString(targetEntry.Request.Body);
 
             var bodyStringSanitizer = new BodyStringSanitizer("content");
-            session.Session.Sanitize(bodyStringSanitizer);
+            await session.Session.Sanitize(bodyStringSanitizer);
 
             Assert.Equal(content, Encoding.UTF8.GetString(targetEntry.Request.Body));
         }
@@ -789,7 +790,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         [InlineData("/v2.0/", "<oath-v2>", "Test.RecordEntries/oauth_request.json")]
         [InlineData("https://management.azure.com/subscriptions/12345678-1234-1234-5678-123456789010", "<partofpath>", "Test.RecordEntries/request_with_subscriptionid.json")]
         [InlineData("?api-version=2019-05-01", "<api-version>", "Test.RecordEntries/request_with_subscriptionid.json")]
-        public void UriStringSanitizerApplies(string targetValue, string replacementValue, string recordingFile)
+        public async void UriStringSanitizerApplies(string targetValue, string replacementValue, string recordingFile)
         {
             var session = TestHelpers.LoadRecordSession(recordingFile);
             var untouchedSession = TestHelpers.LoadRecordSession(recordingFile);
@@ -799,7 +800,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var matcher = new RecordMatcher();
 
             var sanitizer = new UriStringSanitizer(targetValue, replacementValue);
-            session.Session.Sanitize(sanitizer);
+            await session.Session.Sanitize(sanitizer);
 
             var originalUriValue = targetUntouchedEntry.RequestUri.ToString();
             var resultUriValue = targetEntry.RequestUri.ToString();
@@ -811,7 +812,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
         [Theory]
         [InlineData("fakeazsdktestaccount2", "<replacementValue!", "Test.RecordEntries/post_delete_get_content.json")]
-        public void UriStringSanitizerQuietlyExits(string targetValue, string replacementValue, string targetFile)
+        public async void UriStringSanitizerQuietlyExits(string targetValue, string replacementValue, string targetFile)
         {
             var session = TestHelpers.LoadRecordSession(targetFile);
             var untouchedSession = TestHelpers.LoadRecordSession(targetFile);
@@ -821,7 +822,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var matcher = new RecordMatcher();
 
             var sanitizer = new UriStringSanitizer(targetValue, replacementValue);
-            session.Session.Sanitize(sanitizer);
+            await session.Session.Sanitize(sanitizer);
 
             Assert.Equal(targetUntouchedEntry.RequestUri, targetEntry.RequestUri);
         }
@@ -834,7 +835,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         //public void GeneralRegexSanitizerAffectsMultipartRequest(string regex, string replacementValue, string targetFile)
         //{
         //    var session = TestHelpers.LoadRecordSession(targetFile);
-            
+
         //    var targetEntry = session.Session.Entries[0];
         //    var matcher = new RecordMatcher();
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -80,7 +80,7 @@ namespace Azure.Sdk.Tools.TestProxy
             foreach(var sanitizerId in sanitizerList.Sanitizers) {
                 try
                 {
-                    var removedId = _recordingHandler.UnregisterSanitizer(sanitizerId, recordingId);
+                    var removedId = await _recordingHandler.UnregisterSanitizer(sanitizerId, recordingId);
                     removedSanitizers.Add(sanitizerId);
                 }
                 catch (HttpException ex) {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -29,12 +29,12 @@ namespace Azure.Sdk.Tools.TestProxy
         }
 
         [HttpPost]
-        public void Reset()
+        public async Task Reset()
         {
             DebugLogger.LogAdminRequestDetails(_logger, Request);
             var recordingId = RecordingHandler.GetHeader(Request, "x-recording-id", allowNulls: true);
 
-            _recordingHandler.SetDefaultExtensions(recordingId);
+            await _recordingHandler.SetDefaultExtensions(recordingId);
         }
 
         [HttpGet]
@@ -116,11 +116,11 @@ namespace Azure.Sdk.Tools.TestProxy
             if (!string.IsNullOrEmpty(recordingId))
             {
                 var session = _recordingHandler.GetActiveSession(recordingId);
-                sanitizers = _recordingHandler.SanitizerRegistry.GetRegisteredSanitizers(session);
+                sanitizers = await _recordingHandler.SanitizerRegistry.GetRegisteredSanitizers(session);
             }
             else
             {
-                sanitizers = _recordingHandler.SanitizerRegistry.GetRegisteredSanitizers();
+                sanitizers = await _recordingHandler.SanitizerRegistry.GetRegisteredSanitizers();
             }
 
             var json = JsonSerializer.Serialize(new { Sanitizers = sanitizers });
@@ -143,11 +143,11 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (recordingId != null)
             {
-                registeredSanitizerId = _recordingHandler.RegisterSanitizer(s, recordingId);
+                registeredSanitizerId = await _recordingHandler.RegisterSanitizer(s, recordingId);
             }
             else
             {
-                registeredSanitizerId = _recordingHandler.RegisterSanitizer(s);
+                registeredSanitizerId = await _recordingHandler.RegisterSanitizer(s);
             }
 
             var json = JsonSerializer.Serialize(new { Sanitizer = registeredSanitizerId });
@@ -178,12 +178,12 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 if (recordingId != null)
                 {
-                    var registeredId = _recordingHandler.RegisterSanitizer(sanitizer, recordingId);
+                    var registeredId = await _recordingHandler.RegisterSanitizer(sanitizer, recordingId);
                     registeredSanitizers.Add(registeredId);
                 }
                 else
                 {
-                    var registeredId = _recordingHandler.RegisterSanitizer(sanitizer);
+                    var registeredId = await _recordingHandler.RegisterSanitizer(sanitizer);
                     registeredSanitizers.Add(registeredId);
                 }
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Azure.Core;
@@ -127,7 +127,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 }
             }
 
-            throw new TestRecordingMismatchException(GenerateException(request, bestScoreEntry));
+            throw new TestRecordingMismatchException(GenerateException(request, bestScoreEntry, entries));
         }
 
         public virtual int CompareBodies(byte[] requestBody, byte[] recordBody, StringBuilder descriptionBuilder = null)
@@ -213,10 +213,18 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             return req.ToUri().ToString();
         }
 
-        private string GenerateException(RecordEntry request, RecordEntry bestScoreEntry)
+        private string GenerateException(RecordEntry request, RecordEntry bestScoreEntry, IList<RecordEntry> entries = null)
         {
             StringBuilder builder = new StringBuilder();
             builder.AppendLine($"Unable to find a record for the request {request.RequestMethod} {request.RequestUri}");
+
+            if (entries != null)
+            {
+                foreach (var entry in entries)
+                {
+                    builder.AppendLine($"Remaining entry: {entry.RequestUri}");
+                }
+            }
 
             if (bestScoreEntry == null)
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -1,4 +1,4 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Azure.Core;
@@ -127,7 +127,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 }
             }
 
-            throw new TestRecordingMismatchException(GenerateException(request, bestScoreEntry, entries));
+            throw new TestRecordingMismatchException(GenerateException(request, bestScoreEntry));
         }
 
         public virtual int CompareBodies(byte[] requestBody, byte[] recordBody, StringBuilder descriptionBuilder = null)
@@ -213,18 +213,10 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             return req.ToUri().ToString();
         }
 
-        private string GenerateException(RecordEntry request, RecordEntry bestScoreEntry, IList<RecordEntry> entries = null)
+        private string GenerateException(RecordEntry request, RecordEntry bestScoreEntry)
         {
             StringBuilder builder = new StringBuilder();
             builder.AppendLine($"Unable to find a record for the request {request.RequestMethod} {request.RequestUri}");
-
-            if (entries != null)
-            {
-                foreach (var entry in entries)
-                {
-                    builder.AppendLine($"Remaining entry: {entry.RequestUri}");
-                }
-            }
 
             if (bestScoreEntry == null)
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
@@ -98,7 +98,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             }
         }
 
-        public RecordEntry Lookup(RecordEntry requestEntry, RecordMatcher matcher, IEnumerable<RecordedTestSanitizer> sanitizers, bool remove = true, bool shouldLock = false)
+        public RecordEntry Lookup(RecordEntry requestEntry, RecordMatcher matcher, IEnumerable<RecordedTestSanitizer> sanitizers, bool remove = true, string sessionId = null)
         {
             foreach (RecordedTestSanitizer sanitizer in sanitizers)
             {
@@ -112,6 +112,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             if (remove)
             {
                 Entries.Remove(entry);
+                DebugLogger.LogDebug($"We successfully matched and popped request URI {entry.RequestUri} for recordingId {sessionId??"Unknown"}");
             }
 
             return entry;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
@@ -78,9 +78,12 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             return session;
         }
 
-        public async Task Record(RecordEntry entry)
+        public async Task Record(RecordEntry entry, bool shouldLock = true)
         {
-            await EntryLock.WaitAsync();
+            if (shouldLock)
+            {
+                await EntryLock.WaitAsync();
+            }
 
             try
             {
@@ -88,11 +91,14 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             }
             finally
             {
-                EntryLock.Release();
+                if (shouldLock)
+                {
+                    EntryLock.Release();
+                }
             }
         }
 
-        public RecordEntry Lookup(RecordEntry requestEntry, RecordMatcher matcher, IEnumerable<RecordedTestSanitizer> sanitizers, bool remove = true)
+        public RecordEntry Lookup(RecordEntry requestEntry, RecordMatcher matcher, IEnumerable<RecordedTestSanitizer> sanitizers, bool remove = true, bool shouldLock = false)
         {
             foreach (RecordedTestSanitizer sanitizer in sanitizers)
             {
@@ -111,23 +117,32 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             return entry;
         }
 
-        public async Task Remove(RecordEntry entry)
+        public async Task Remove(RecordEntry entry, bool shouldLock = true)
         {
-            await EntryLock.WaitAsync();
-
+            if (shouldLock)
+            {
+                await EntryLock.WaitAsync();
+            }
+            
             try
             {
                 Entries.Remove(entry);
             }
             finally
             {
-                EntryLock.Release();
+                if (shouldLock)
+                {
+                    EntryLock.Release();
+                }
             }
         }
 
-        public async Task Sanitize(RecordedTestSanitizer sanitizer)
+        public async Task Sanitize(RecordedTestSanitizer sanitizer, bool shouldLock = true)
         {
-            await EntryLock.WaitAsync();
+            if (shouldLock)
+            {
+                await EntryLock.WaitAsync();
+            }
 
             try
             {
@@ -135,13 +150,19 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             }
             finally
             {
-                EntryLock.Release();
+                if (shouldLock)
+                {
+                    EntryLock.Release();
+                }
             }
         }
 
-        public async Task Sanitize(IEnumerable<RecordedTestSanitizer> sanitizers)
+        public async Task Sanitize(IEnumerable<RecordedTestSanitizer> sanitizers, bool shouldLock = true)
         {
-            await EntryLock.WaitAsync();
+            if (shouldLock)
+            {
+                await EntryLock.WaitAsync();
+            }
 
             try
             {
@@ -152,7 +173,10 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             }
             finally
             {
-                EntryLock.Release();
+                if (shouldLock)
+                {
+                    EntryLock.Release();
+                }
             }
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordTransport.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordTransport.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Azure.Core;
@@ -35,27 +35,27 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         public override void Process(HttpMessage message)
         {
             _innerTransport.Process(message);
-            Record(message);
+            Record(message).Wait();
         }
 
         public override async ValueTask ProcessAsync(HttpMessage message)
         {
             await _innerTransport.ProcessAsync(message);
-            Record(message);
+            await Record(message);
         }
 
-        private void Record(HttpMessage message)
+        private async Task Record(HttpMessage message)
         {
             RecordEntry recordEntry = CreateEntry(message.Request, message.Response);
 
             switch (_filter(recordEntry))
             {
                 case EntryRecordMode.Record:
-                    _session.Record(recordEntry);
+                    await _session.Record(recordEntry);
                     break;
                 case EntryRecordMode.RecordWithoutRequestBody:
                     recordEntry.Request.Body = null;
-                    _session.Record(recordEntry);
+                    await _session.Record(recordEntry);
                     break;
                 default:
                     break;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using System.Threading;
+using System.Threading.Tasks;
 using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
 using Azure.Sdk.Tools.TestProxy.Sanitizers;
 
@@ -42,11 +43,10 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         // so that when we start a new recording we can properly
         // apply only the sanitizers that have been registered at the global level
         public List<string> SessionSanitizers = new List<string>();
-
-        public readonly object SessionSanitizerLock = new object();
+        public SemaphoreSlim SessionSanitizerLock { get; set; } = new SemaphoreSlim(1);
 
         public SanitizerDictionary() {
-            ResetSessionSanitizers();
+            ResetSessionSanitizers().Wait();
         }
 
         /*
@@ -697,9 +697,10 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// <summary>
         /// Used to update the session sanitizers to their default configuration.
         /// </summary>
-        public void ResetSessionSanitizers()
+        public async Task ResetSessionSanitizers()
         {
-            lock (SessionSanitizerLock)
+            await SessionSanitizerLock.WaitAsync();
+            try
             {
                 var expectedSanitizers = DefaultSanitizerList;
 
@@ -716,6 +717,10 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
                 SessionSanitizers = DefaultSanitizerList.Select(x => x.Id).ToList();
             }
+            finally
+            {
+                SessionSanitizerLock.Release();
+            }
         }
 
         /// <summary>
@@ -723,18 +728,18 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// </summary>
         /// <param name="session"></param>
         /// <returns></returns>
-        public List<RecordedTestSanitizer> GetSanitizers(ModifiableRecordSession session)
+        public async Task<List<RecordedTestSanitizer>> GetSanitizers(ModifiableRecordSession session)
         {
-            return GetRegisteredSanitizers(session).Select(x => x.Sanitizer).ToList();
+            return (await GetRegisteredSanitizers(session)).Select(x => x.Sanitizer).ToList();
         }
 
         /// <summary>
         /// Gets a list of sanitizers that should be applied for the session level.
         /// </summary>
         /// <returns></returns>
-        public List<RecordedTestSanitizer> GetSanitizers()
+        public async Task<List<RecordedTestSanitizer>> GetSanitizers()
         {
-            return GetRegisteredSanitizers().Select(x => x.Sanitizer).ToList();
+            return (await GetRegisteredSanitizers()).Select(x => x.Sanitizer).ToList();
         }
 
         /// <summary>
@@ -742,9 +747,10 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// </summary>
         /// <param name="session"></param>
         /// <returns></returns>
-        public List<RegisteredSanitizer> GetRegisteredSanitizers(ModifiableRecordSession session)
+        public async Task<List<RegisteredSanitizer>> GetRegisteredSanitizers(ModifiableRecordSession session)
         {
-            lock (session.SanitizerLock)
+            await session.SanitizerLock.WaitAsync();
+            try
             {
                 var sanitizers = new List<RegisteredSanitizer>();
 
@@ -762,18 +768,22 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
                 return sanitizers;
             }
+            finally
+            {
+                session.SanitizerLock.Release();
+            }
         }
 
         /// <summary>
         /// Gets the set of registered sanitizers for the session level.
         /// </summary>
         /// <returns></returns>
-        public List<RegisteredSanitizer> GetRegisteredSanitizers()
+        public async Task<List<RegisteredSanitizer>> GetRegisteredSanitizers()
         {
-            lock (SessionSanitizerLock)
+            var sanitizers = new List<RegisteredSanitizer>();
+            await SessionSanitizerLock.WaitAsync();
+            try
             {
-                var sanitizers = new List<RegisteredSanitizer>();
-
                 foreach (var id in SessionSanitizers)
                 {
                     if (Sanitizers.TryGetValue(id, out RegisteredSanitizer sanitizer))
@@ -781,9 +791,13 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                         sanitizers.Add(sanitizer);
                     }
                 }
-
-                return sanitizers;
             }
+            finally
+            {
+                SessionSanitizerLock.Release();
+            }
+
+            return sanitizers;
         }
 
         private bool _register(RecordedTestSanitizer sanitizer, string id)
@@ -805,17 +819,22 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// <param name="sanitizer"></param>
         /// <returns>The Id of the newly registered sanitizer.</returns>
         /// <exception cref="HttpException"></exception>
-        public string Register(RecordedTestSanitizer sanitizer)
+        public async Task<string> Register(RecordedTestSanitizer sanitizer)
         {
             var strCurrent = IdFactory.GetNextId().ToString();
 
-            lock (SessionSanitizerLock)
+            await SessionSanitizerLock.WaitAsync();
+            try
             {
                 if (_register(sanitizer, strCurrent))
                 {
                     SessionSanitizers.Add(strCurrent);
                     return strCurrent;
                 }
+            }
+            finally
+            {
+                SessionSanitizerLock.Release();
             }
             throw new HttpException(System.Net.HttpStatusCode.InternalServerError, $"Unable to register global sanitizer id \"{strCurrent}\" with value '{JsonSerializer.Serialize(sanitizer)}'");
         }
@@ -827,11 +846,12 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// <param name="sanitizer"></param>
         /// <returns>The Id of the newly registered sanitizer.</returns>
         /// <exception cref="HttpException"></exception>
-        public string Register(ModifiableRecordSession session, RecordedTestSanitizer sanitizer)
+        public async Task<string> Register(ModifiableRecordSession session, RecordedTestSanitizer sanitizer)
         {
             var strCurrent = IdFactory.GetNextId().ToString();
 
-            lock (session.SanitizerLock)
+            await SessionSanitizerLock.WaitAsync();
+            try
             {
 
                 if (_register(sanitizer, strCurrent))
@@ -841,6 +861,10 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
                     return strCurrent;
                 }
+            }
+            finally
+            {
+                SessionSanitizerLock.Release();
             }
 
             return string.Empty;
@@ -852,15 +876,20 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// <param name="sanitizerId"></param>
         /// <returns></returns>
         /// <exception cref="HttpException"></exception>
-        public string Unregister(string sanitizerId)
+        public async Task<string> Unregister(string sanitizerId)
         {
-            lock (SessionSanitizerLock)
+            await SessionSanitizerLock.WaitAsync();
+            try
             {
                 if (SessionSanitizers.Contains(sanitizerId))
                 {
                     SessionSanitizers.Remove(sanitizerId);
                     return sanitizerId;
                 }
+            }
+            finally
+            {
+                SessionSanitizerLock.Release();
             }
 
             throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"The requested sanitizer for removal \"{sanitizerId}\" is not active at the session level.");
@@ -873,15 +902,20 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// <param name="session"></param>
         /// <returns></returns>
         /// <exception cref="HttpException"></exception>
-        public string Unregister(string sanitizerId, ModifiableRecordSession session)
+        public async Task<string> Unregister(string sanitizerId, ModifiableRecordSession session)
         {
-            lock (session.SanitizerLock)
+            await session.SanitizerLock.WaitAsync();
+            try
             {
                 if (session.AppliedSanitizers.Contains(sanitizerId))
                 {
                     session.AppliedSanitizers.Remove(sanitizerId);
                     return sanitizerId;
                 }
+            }
+            finally
+            {
+                session.SanitizerLock.Release();
             }
 
             throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"The requested sanitizer for removal \"{sanitizerId}\" is not active on recording/playback with id \"{session.SessionId}\".");
@@ -902,11 +936,16 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// <summary>
         /// Not publically available via an API Route, but used to remove all of the active default session sanitizers.
         /// </summary>
-        public void Clear()
+        public async Task Clear()
         {
-            lock (SessionSanitizerLock)
+            await SessionSanitizerLock.WaitAsync();
+            try
             {
                 SessionSanitizers.Clear();
+            }
+            finally
+            {
+                SessionSanitizerLock.Release();
             }
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Record.cs
@@ -69,7 +69,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
         [HttpPost]
         [AllowEmptyBody]
-        public void Stop([FromBody()] IDictionary<string, string> variables = null)
+        public async Task Stop([FromBody()] IDictionary<string, string> variables = null)
         {
             string id = RecordingHandler.GetHeader(Request, "x-recording-id");
             bool save = true;
@@ -87,7 +87,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             DebugLogger.LogAdminRequestDetails(_logger, Request);
 
-            _recordingHandler.StopRecording(id, variables: variables, saveRecording: save);
+            await _recordingHandler.StopRecording(id, variables: variables, saveRecording: save);
         }
 
         public async Task HandleRequest()

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -484,7 +484,7 @@ namespace Azure.Sdk.Tools.TestProxy
             try
             {
                 // Session may be removed later, but only after response has been fully written
-                var match = session.Session.Lookup(entry, session.CustomMatcher ?? Matcher, sanitizers, remove: false);
+                var match = session.Session.Lookup(entry, session.CustomMatcher ?? Matcher, sanitizers, remove: false, sessionId: recordingId);
 
                 foreach (ResponseTransform transform in Transforms.Concat(session.AdditionalTransforms))
                 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -466,7 +466,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 {
                     if (!session.IsSanitized)
                     {
-                        await session.Session.Sanitize(sanitizers);
+                        await session.Session.Sanitize(sanitizers, false);
                         session.IsSanitized = true;
                     }
                 }
@@ -526,7 +526,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
                 if (remove)
                 {
-                    await session.Session.Remove(match);
+                    await session.Session.Remove(match, shouldLock: false);
                 }
             }
             finally

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -461,7 +461,6 @@ namespace Azure.Sdk.Tools.TestProxy
             if (!session.IsSanitized)
             {
                 // we don't need to re-sanitize with recording-applicable sanitizers every time. just the very first one
-                await session.Session.EntryLock.WaitAsync();
                 await session.SanitizerLock.WaitAsync();
                 try
                 {
@@ -474,7 +473,6 @@ namespace Azure.Sdk.Tools.TestProxy
                 finally
                 {
                     session.SanitizerLock.Release();
-                    session.Session.EntryLock.Release();
                 }
             }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -207,11 +207,6 @@ namespace Azure.Sdk.Tools.TestProxy
                     });
             });
 
-            services.Configure<KestrelServerOptions>(options =>
-            {
-                options.AllowSynchronousIO = true;
-            });
-
             services.AddControllers(options =>
             {
                 options.InputFormatters.Add(new EmptyBodyFormatter());


### PR DESCRIPTION
This cuts out all `lock` usage for `await SemaphorSlim.WaitAsync()` to synchronize resource access.

Originally, we had 3 possible locks

- object SessionSanitizerLock
- Session.Entries
- object Session.SanitizerLock

This moves to using a semaphore for these. Unfortunately this has the impact of forcing `async` in a lot of places that _didn't_ use it before, so I've got some test pain to resolve as a result.

@mikeharder I'm very pleased with this one!

![image](https://github.com/user-attachments/assets/569bbcaf-ac50-4103-be70-11cc1014c4c6)
![image](https://github.com/user-attachments/assets/ce689567-1f77-452c-9d14-6da9a4d8177d)

