### PR TITLE
Fix pypi mirror job

### DIFF
--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -39,6 +39,7 @@ jobs:
 
       - pwsh: |
           $configurations = '${{ convertToJson(parameters.PackageSpecifiers) }}' -replace '\\', '/' -replace '"', '`"'
+          Write-Host $configurations
           python $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages.py $configurations --dest-dir='$(Build.ArtifactStagingDirectory)'
         displayName: 'Download Targeted Packages'
 
@@ -57,7 +58,7 @@ jobs:
           $results = Get-ChildItem -Force -Path $(Build.ArtifactStagingDirectory)
           foreach ($file in $results) {
             Write-Host "Uploading $file"
-            
+
             twine upload --repository "${{ parameters.DevFeed }}" --config-file $(PYPIRC_PATH) $($file.FullName)
           }
         displayName: 'Publish Packages to Dev Feed'

--- a/eng/pipelines/mirror-pypi-to-dev-feed.yml
+++ b/eng/pipelines/mirror-pypi-to-dev-feed.yml
@@ -38,9 +38,7 @@ jobs:
         displayName: Install Requirements
 
       - pwsh: |
-          $configurations = '${{ convertToJson(parameters.PackageSpecifiers) }}' -replace '\\', '/' -replace '"', '`"'
-          Write-Host $configurations
-          python $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages.py $configurations --dest-dir='$(Build.ArtifactStagingDirectory)'
+          python $(Build.SourcesDirectory)/eng/scripts/download_targeted_packages.py ${{ parameters.PackageSpecifiers }} --dest-dir='$(Build.ArtifactStagingDirectory)'
         displayName: 'Download Targeted Packages'
 
       - task: TwineAuthenticate@0

--- a/eng/scripts/download_targeted_packages.py
+++ b/eng/scripts/download_targeted_packages.py
@@ -140,9 +140,8 @@ if __name__ == "__main__":
     )
 
     args = parser.parse_args()
-    
-    # powershell does some weird escaping. Leaving behind just the '`' in what would normally look like '`"`.
-    pkg_list = read_package_list(args.target_packages.replace("`", "\""))
+
+    pkg_list = args.target_packages.split(",")
 
     assembled_package_list = set()
 


### PR DESCRIPTION
Old change, but needed to get this in so I don't forget it for later. Before changes build was [on the floor.](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=3942428&view=results)