### PR TITLE
[tsp-client] Upgrade minimum node versions for import.meta.resolve()

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release
 
-## Unreleased - 0.9.5
+## Unreleased - 0.10.0
 
 - Increase minimum node version to "^18.19.0 || >=20.6.0", to ensure API import.meta.resolve() is available. (#8765)
 

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## Unreleased - 0.9.5
+
+- Increase minimum node version to "^18.19.0 || >=20.6.0", to ensure API import.meta.resolve() is available. (#8765)
+
 ## 2024-07-23 - 0.9.4
 
 - Fixed issue where one additional directory entry is treated as a string instead of an array. (#8551)

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "type": "module",
   "engines": {
-    "node": ">=18.0.0"
+    "node": "^18.19.0 || >=20.6.0"
   },
   "bin": {
     "tsp-client": "cmd/tsp-client.js"

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.9.4",
+  "version": "0.10.0",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",


### PR DESCRIPTION
The following PR added a call to `import.meta.resolve()`, which is only available starting with Node 18.19.0 and 20.6.0:

https://github.com/Azure/azure-sdk-tools/commit/f5d595557cdcba4c32612d8082505f88dba423e9#diff-6f62171ec5df7a0f474274b3d6aed40ffebe0ff3f78c0ef749dc8f315b777107R58

On older Node versions, tsp-client now fails with this error:

```
TypeError: (intermediate value).resolve is not a function
```

To address this, the minimum node versions should be incremented, so consumers get a better error message:

```
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: '@azure-tools/typespec-client-generator-cli@0.9.4',
npm WARN EBADENGINE   required: { node: '^18.19.0 || >=20.6.0' },
npm WARN EBADENGINE   current: { node: 'v18.18.2', npm: '9.8.1' }
npm WARN EBADENGINE }
```