### PR TITLE
Add proxy audit log and other assorted fixes

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -965,7 +965,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public async Task RemoveSanitizerErrorsForInvalidId()
+        public async Task RemoveSanitizersSilentlyAcceptsInvalidSanitizer()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
             var httpContext = new DefaultHttpContext();
@@ -980,11 +980,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             var testSet = new RemoveSanitizerList() { Sanitizers = new List<string>() { "AZSDK00-1" } };
 
-            var assertion = await Assert.ThrowsAsync<HttpException>(
-                async () => await controller.RemoveSanitizers(testSet)
-            );
+            await controller.RemoveSanitizers(testSet);
 
-            Assert.Equal("Unable to remove 1 sanitizer. Detailed list follows: \nThe requested sanitizer for removal \"AZSDK00-1\" is not active at the session level.", assertion.Message);
+            Assert.Equal(200, httpContext.Response.StatusCode);
         }
 
         [Fact]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/AdminTests.cs
@@ -939,32 +939,6 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
         }
 
         [Fact]
-        public async Task RemoveSanitizerErrorsForInvalidIdOnRecording()
-        {
-            RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());
-            var httpContext = new DefaultHttpContext();
-            await testRecordingHandler.StartPlaybackAsync("Test.RecordEntries/oauth_request_with_variables.json", httpContext.Response);
-            var recordingId = httpContext.Response.Headers["x-recording-id"];
-            httpContext.Request.Headers["x-recording-id"] = recordingId;
-            httpContext.Response.Body = new MemoryStream();
-            var controller = new Admin(testRecordingHandler, _nullLogger)
-            {
-                ControllerContext = new ControllerContext()
-                {
-                    HttpContext = httpContext
-                }
-            };
-
-            var testSet = new RemoveSanitizerList() { Sanitizers = new List<string>() { "0" } };
-
-            var assertion = await Assert.ThrowsAsync<HttpException>(
-                async () => await controller.RemoveSanitizers(testSet)
-            );
-           
-            Assert.Contains("Unable to remove 1 sanitizer. Detailed list follows: \nThe requested sanitizer for removal \"0\" is not active on recording/playback with id", assertion.Message);
-        }
-
-        [Fact]
         public async Task RemoveSanitizersSilentlyAcceptsInvalidSanitizer()
         {
             RecordingHandler testRecordingHandler = new RecordingHandler(Directory.GetCurrentDirectory());

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -153,7 +153,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             var targetRecordingId = httpContext.Response.Headers["x-recording-id"].ToString();
             
             httpContext.Request.Headers["x-recording-id"] = new string[] { targetRecordingId };
-            controller.Stop();
+            await controller.Stop();
 
             Assert.False(testRecordingHandler.PlaybackSessions.ContainsKey(targetRecordingId));
         }
@@ -189,7 +189,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await playbackController.Start();
             var targetRecordingId = playbackContext.Response.Headers["x-recording-id"].ToString();
             playbackContext.Request.Headers["x-recording-id"] = new string[] { targetRecordingId };
-            playbackController.Stop();
+            await playbackController.Stop();
 
             testRecordingHandler.InMemorySessions.ContainsKey(targetRecordingId);
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/PlaybackTests.cs
@@ -151,10 +151,16 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             await controller.Start();
             var targetRecordingId = httpContext.Response.Headers["x-recording-id"].ToString();
-            
+
             httpContext.Request.Headers["x-recording-id"] = new string[] { targetRecordingId };
             await controller.Stop();
 
+            var auditSession = testRecordingHandler.AuditSessions[targetRecordingId];
+
+            Assert.NotNull(auditSession);
+            var auditResults = TestHelpers.ExhaustQueue<AuditLogItem>(auditSession);
+
+            Assert.Equal(2, auditResults.Count);
             Assert.False(testRecordingHandler.PlaybackSessions.ContainsKey(targetRecordingId));
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
@@ -165,6 +165,12 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             session.Session.Entries.Add(testEntry);
             await handler.StopRecording(recordingId);
 
+            // ensure that we audited properly
+            var auditSession = handler.AuditSessions[recordingId];
+            var auditItems = TestHelpers.ExhaustQueue<AuditLogItem>(auditSession);
+
+            Assert.Equal(2, auditItems.Count);
+
             // now load it, did we avoid mangling it?
             var sessionFromDisk = TestHelpers.LoadRecordSession(Path.Combine(testFolder, testName));
             var targetEntry = sessionFromDisk.Session.Entries[0];

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordingHandlerTests.cs
@@ -273,7 +273,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             await recordingHandler.StartPlaybackAsync(key, httpContext.Response, Common.RecordingType.InMemory);
             var playbackSession = httpContext.Response.Headers["x-recording-id"];
-            recordingHandler.StopPlayback(playbackSession, true);
+            await recordingHandler.StopPlayback(playbackSession, true);
 
             Assert.True(0 == recordingHandler.InMemorySessions.Count);
         }
@@ -287,7 +287,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             await recordingHandler.StartPlaybackAsync(key, httpContext.Response, Common.RecordingType.InMemory);
             var playbackSession = httpContext.Response.Headers["x-recording-id"];
-            recordingHandler.StopPlayback(playbackSession, false);
+            await recordingHandler.StopPlayback(playbackSession, false);
 
             Assert.True(1 == recordingHandler.InMemorySessions.Count);
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/TestHelpers.cs
@@ -12,6 +12,7 @@ using System.Linq;
 using Xunit;
 using System.Threading.Tasks;
 using System.Security.Cryptography;
+using System.Collections.Concurrent;
 
 namespace Azure.Sdk.Tools.TestProxy.Tests
 {
@@ -34,6 +35,18 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
     public static class TestHelpers
     {
         public static readonly string DisableBranchCleanupEnvVar = "DISABLE_INTEGRATION_BRANCH_CLEANUP";
+
+        public static List<T> ExhaustQueue<T>(ConcurrentQueue<T> queue)
+        {
+            List<T> results = new List<T>();
+
+            while (queue.TryDequeue(out var item))
+            {
+                results.Add(item);
+            }
+
+            return results;
+        }
 
         public static string GetValueFromCertificateFile(string certName)
         {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -158,22 +158,11 @@ namespace Azure.Sdk.Tools.TestProxy
                 throw new HttpException(HttpStatusCode.BadRequest, "When bulk adding sanitizers, ensure there is at least one sanitizer added in each batch. Received 0 work items.");
             }
 
-            var registeredSanitizers = new List<string>();
+            // we need check if a recording id is present BEFORE the loop, as we want to encapsulate the entire
+            // sanitizer add operation in a single lock, rather than gathering and releasing a sanitizer lock
+            // for the session/recording on _each_ sanitizer addition.
 
-            // register them all
-            foreach(var sanitizer in workload)
-            {
-                if (recordingId != null)
-                {
-                    var registeredId = await _recordingHandler.RegisterSanitizer(sanitizer, recordingId);
-                    registeredSanitizers.Add(registeredId);
-                }
-                else
-                {
-                    var registeredId = await _recordingHandler.RegisterSanitizer(sanitizer);
-                    registeredSanitizers.Add(registeredId);
-                }
-            }
+            var registeredSanitizers = await _recordingHandler.RegisterSanitizers(workload, recordingId);
 
             if (recordingId != null)
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Audit.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Audit.cs
@@ -1,0 +1,94 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Azure.Sdk.Tools.TestProxy.Common;
+using Azure.Sdk.Tools.TestProxy.Common.Exceptions;
+using Azure.Sdk.Tools.TestProxy.Store;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System;
+using System.Collections.Generic;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.TestProxy
+{
+    [ApiController]
+    [Route("[controller]/[action]")]
+    public sealed class Audit : ControllerBase
+    {
+        private readonly ILogger _logger;
+        private readonly RecordingHandler _recordingHandler;
+
+        public Audit(RecordingHandler recordingHandler, ILoggerFactory loggerFactory)
+        {
+            _recordingHandler = recordingHandler;
+            _logger = loggerFactory.CreateLogger<Record>();
+        }
+
+        [HttpGet]
+        public async Task GetAuditLogs()
+        {
+
+            var allAuditSessions = _recordingHandler.RetrieveOngoingAuditLogs();
+            allAuditSessions.AddRange(_recordingHandler.AuditSessions.Values);
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            foreach (var auditLogQueue in allAuditSessions) {
+                while (auditLogQueue.TryDequeue(out var logItem))
+                {
+                    stringBuilder.Append(logItem.ToCsvString() + Environment.NewLine);
+                }
+            }
+
+            Response.ContentType = "text/plain";
+
+            await Response.WriteAsync(stringBuilder.ToString());
+        }
+
+
+        [HttpPost]
+        public async Task Push([FromBody()] IDictionary<string, object> options = null)
+        {
+            DebugLogger.LogAdminRequestDetails(_logger, Request);
+
+            var pathToAssets = RecordingHandler.GetAssetsJsonLocation(StoreResolver.ParseAssetsJsonBody(options), _recordingHandler.ContextDirectory);
+
+            await _recordingHandler.Store.Push(pathToAssets);
+        }
+
+        [HttpPost]
+        [AllowEmptyBody]
+        public async Task Stop([FromBody()] IDictionary<string, string> variables = null)
+        {
+            string id = RecordingHandler.GetHeader(Request, "x-recording-id");
+            bool save = true;
+            EntryRecordMode mode = RecordingHandler.GetRecordMode(Request);
+
+            if (mode != EntryRecordMode.Record && mode != EntryRecordMode.DontRecord)
+            {
+                throw new HttpException(HttpStatusCode.BadRequest, "When stopping a recording and providing a \"x-recording-skip\" value, only value \"request-response\" is accepted.");
+            }
+
+            if (mode == EntryRecordMode.DontRecord)
+            {
+                save = false;
+            }
+
+            DebugLogger.LogAdminRequestDetails(_logger, Request);
+
+            await _recordingHandler.StopRecording(id, variables: variables, saveRecording: save);
+        }
+
+        public async Task HandleRequest()
+        {
+            string id = RecordingHandler.GetHeader(Request, "x-recording-id");
+
+            await _recordingHandler.HandleRecordRequestAsync(id, Request, Response);
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Audit.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Audit.cs
@@ -7,7 +7,6 @@ using Azure.Sdk.Tools.TestProxy.Store;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 using System;
 using System.Collections.Generic;
 using System.Net;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Audit.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Audit.cs
@@ -29,7 +29,7 @@ namespace Azure.Sdk.Tools.TestProxy
         }
 
         [HttpGet]
-        public async Task GetAuditLogs()
+        public async Task Logs()
         {
 
             var allAuditSessions = _recordingHandler.RetrieveOngoingAuditLogs();
@@ -47,47 +47,6 @@ namespace Azure.Sdk.Tools.TestProxy
             Response.ContentType = "text/plain";
 
             await Response.WriteAsync(stringBuilder.ToString());
-        }
-
-
-        [HttpPost]
-        public async Task Push([FromBody()] IDictionary<string, object> options = null)
-        {
-            DebugLogger.LogAdminRequestDetails(_logger, Request);
-
-            var pathToAssets = RecordingHandler.GetAssetsJsonLocation(StoreResolver.ParseAssetsJsonBody(options), _recordingHandler.ContextDirectory);
-
-            await _recordingHandler.Store.Push(pathToAssets);
-        }
-
-        [HttpPost]
-        [AllowEmptyBody]
-        public async Task Stop([FromBody()] IDictionary<string, string> variables = null)
-        {
-            string id = RecordingHandler.GetHeader(Request, "x-recording-id");
-            bool save = true;
-            EntryRecordMode mode = RecordingHandler.GetRecordMode(Request);
-
-            if (mode != EntryRecordMode.Record && mode != EntryRecordMode.DontRecord)
-            {
-                throw new HttpException(HttpStatusCode.BadRequest, "When stopping a recording and providing a \"x-recording-skip\" value, only value \"request-response\" is accepted.");
-            }
-
-            if (mode == EntryRecordMode.DontRecord)
-            {
-                save = false;
-            }
-
-            DebugLogger.LogAdminRequestDetails(_logger, Request);
-
-            await _recordingHandler.StopRecording(id, variables: variables, saveRecording: save);
-        }
-
-        public async Task HandleRequest()
-        {
-            string id = RecordingHandler.GetHeader(Request, "x-recording-id");
-
-            await _recordingHandler.HandleRecordRequestAsync(id, Request, Response);
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Audit.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Audit.cs
@@ -19,13 +19,11 @@ namespace Azure.Sdk.Tools.TestProxy
     [Route("[controller]/[action]")]
     public sealed class Audit : ControllerBase
     {
-        private readonly ILogger _logger;
         private readonly RecordingHandler _recordingHandler;
 
-        public Audit(RecordingHandler recordingHandler, ILoggerFactory loggerFactory)
+        public Audit(RecordingHandler recordingHandler)
         {
             _recordingHandler = recordingHandler;
-            _logger = loggerFactory.CreateLogger<Record>();
         }
 
         [HttpGet]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AuditLogItem.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AuditLogItem.cs
@@ -1,0 +1,41 @@
+using System;
+using System.Collections.Concurrent;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
+
+namespace Azure.Sdk.Tools.TestProxy.Common
+{
+    public class AuditLogItem
+    {
+        public string RecordingId { get; set; }
+
+        public DateTime Timestamp { get; set; }
+
+        public string Uri { get; set; }
+
+        public string Verb { get; set; }
+
+        public string Message { get; set; }
+
+        public AuditLogItem(string recordingId, string requestUri, string requestMethod) {
+            RecordingId = recordingId;
+            Timestamp = DateTime.UtcNow;
+
+            Uri = requestUri;
+            Verb = requestMethod;
+        }
+
+        public string ToCsvString()
+        {
+            return $"{RecordingId},{Timestamp.ToString("o")},{Verb},{Uri},{Message}";
+        }
+
+        public AuditLogItem(string recordingId, string message)
+        {
+            RecordingId = recordingId;
+            Timestamp = DateTime.UtcNow;
+
+            Message = message;
+        }
+
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AuditLogItem.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AuditLogItem.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Concurrent;
-using Microsoft.AspNetCore.Mvc.ModelBinding;
 
 namespace Azure.Sdk.Tools.TestProxy.Common
 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/DebugLogger.cs
@@ -5,6 +5,7 @@ using System;
 using System.Collections.Generic;
 using System.Text.Json;
 using Microsoft.AspNetCore.Http.Extensions;
+using System.Collections.Concurrent;
 
 namespace Azure.Sdk.Tools.TestProxy.Common
 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ModifiableRecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ModifiableRecordSession.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net.Http;
@@ -9,13 +10,13 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 {
     public class ModifiableRecordSession
     {
-        public RecordMatcher CustomMatcher { get; set;}
+        public RecordMatcher CustomMatcher { get; set; }
 
         public RecordSession Session { get; }
 
         public ModifiableRecordSession(SanitizerDictionary sanitizerRegistry, string sessionId)
         {
-            lock(sanitizerRegistry.SessionSanitizerLock)
+            lock (sanitizerRegistry.SessionSanitizerLock)
             {
                 this.AppliedSanitizers = sanitizerRegistry.SessionSanitizers.ToList();
             }
@@ -49,6 +50,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
         public int PlaybackResponseTime { get; set; }
 
+        public ConcurrentQueue<AuditLogItem> AuditLog { get; set; } = new ConcurrentQueue<AuditLogItem>();
         public async void ResetExtensions(SanitizerDictionary sanitizerDictionary)
         {
             await Session.EntryLock.WaitAsync();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ModifiableRecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/ModifiableRecordSession.cs
@@ -42,8 +42,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
         public List<ResponseTransform> AdditionalTransforms { get; } = new List<ResponseTransform>();
 
-        public SemaphoreSlim SanitizerLock = new SemaphoreSlim(1);
-
         public List<string> AppliedSanitizers { get; set; } = new List<string>();
         public List<string> ForRemoval { get; } = new List<string>();
 
@@ -53,7 +51,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
         public async void ResetExtensions(SanitizerDictionary sanitizerDictionary)
         {
-            await SanitizerLock.WaitAsync();
+            await Session.EntryLock.WaitAsync();
             try
             {
                 AdditionalTransforms.Clear();
@@ -66,7 +64,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             }
             finally
             {
-                SanitizerLock.Release();
+                Session.EntryLock.Release();
             }
         }
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
@@ -3,8 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
@@ -892,7 +892,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 SessionSanitizerLock.Release();
             }
 
-            throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"The requested sanitizer for removal \"{sanitizerId}\" is not active at the session level.");
+            return string.Empty;
         }
 
         /// <summary>
@@ -918,7 +918,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 session.SanitizerLock.Release();
             }
 
-            throw new HttpException(System.Net.HttpStatusCode.BadRequest, $"The requested sanitizer for removal \"{sanitizerId}\" is not active on recording/playback with id \"{session.SessionId}\".");
+            return string.Empty;
         }
 
         /// <summary>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
@@ -851,6 +851,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// </summary>
         /// <param name="session"></param>
         /// <param name="sanitizer"></param>
+        /// <param name="shouldLock"></param>
         /// <returns>The Id of the newly registered sanitizer.</returns>
         /// <exception cref="HttpException"></exception>
         public async Task<string> Register(ModifiableRecordSession session, RecordedTestSanitizer sanitizer, bool shouldLock = true)

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
@@ -850,6 +850,8 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         {
             var strCurrent = IdFactory.GetNextId().ToString();
 
+            session.AuditLog.Enqueue(new AuditLogItem(session.SessionId, $"Starting registration of sanitizerId {strCurrent}"));
+
             await SessionSanitizerLock.WaitAsync();
             try
             {
@@ -867,6 +869,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 SessionSanitizerLock.Release();
             }
 
+            session.AuditLog.Enqueue(new AuditLogItem(session.SessionId, $"Finished registration of sanitizerId {strCurrent}"));
             return string.Empty;
         }
 
@@ -917,6 +920,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             {
                 session.Session.EntryLock.Release();
             }
+            session.AuditLog.Enqueue(new AuditLogItem(session.SessionId, $"Starting unregister of {sanitizerId}."));
 
             return string.Empty;
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
@@ -749,7 +749,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// <returns></returns>
         public async Task<List<RegisteredSanitizer>> GetRegisteredSanitizers(ModifiableRecordSession session)
         {
-            await session.SanitizerLock.WaitAsync();
+            await session.Session.EntryLock.WaitAsync();
             try
             {
                 var sanitizers = new List<RegisteredSanitizer>();
@@ -770,7 +770,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             }
             finally
             {
-                session.SanitizerLock.Release();
+                session.Session.EntryLock.Release();
             }
         }
 
@@ -904,7 +904,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         /// <exception cref="HttpException"></exception>
         public async Task<string> Unregister(string sanitizerId, ModifiableRecordSession session)
         {
-            await session.SanitizerLock.WaitAsync();
+            await session.Session.EntryLock.WaitAsync();
             try
             {
                 if (session.AppliedSanitizers.Contains(sanitizerId))
@@ -915,7 +915,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             }
             finally
             {
-                session.SanitizerLock.Release();
+                session.Session.EntryLock.Release();
             }
 
             return string.Empty;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SanitizerDictionary.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Sdk.Tools.TestProxy.Common.Exceptions;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Playback.cs
@@ -55,14 +55,14 @@ namespace Azure.Sdk.Tools.TestProxy
         }
 
         [HttpPost]
-        public void Stop()
+        public async Task Stop()
         {
             DebugLogger.LogAdminRequestDetails(_logger, Request);
 
             string id = RecordingHandler.GetHeader(Request, "x-recording-id");
             bool.TryParse(RecordingHandler.GetHeader(Request, "x-purge-inmemory-recording", true), out var shouldPurgeRecording);
 
-            _recordingHandler.StopPlayback(id, purgeMemoryStore: shouldPurgeRecording);
+            await _recordingHandler.StopPlayback(id, purgeMemoryStore: shouldPurgeRecording);
         }
 
         [HttpPost]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -2,6 +2,7 @@
   "profiles": {
     "Azure.Sdk.Tools.TestProxy": {
       "commandName": "Project",
+      "commandLineArgs": "--storage-location=C:/repo/azure-sdk-for-python",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "Logging__LogLevel__Microsoft": "Information"

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "Azure.Sdk.Tools.TestProxy": {
       "commandName": "Project",
-      "commandLineArgs": "--storage-location=C:/repo/azure-sdk-for-python",
+      "commandLineArgs": "",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "Logging__LogLevel__Microsoft": "Information"

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Features;
 using Microsoft.Extensions.Primitives;
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -16,13 +15,11 @@ using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Security;
-using System.Reflection.Metadata.Ecma335;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using static System.Collections.Specialized.BitVector32;
 
 namespace Azure.Sdk.Tools.TestProxy
 {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -461,7 +461,7 @@ namespace Azure.Sdk.Tools.TestProxy
             if (!session.IsSanitized)
             {
                 // we don't need to re-sanitize with recording-applicable sanitizers every time. just the very first one
-                await session.SanitizerLock.WaitAsync();
+                await session.Session.EntryLock.WaitAsync();
                 try
                 {
                     if (!session.IsSanitized)
@@ -472,7 +472,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 }
                 finally
                 {
-                    session.SanitizerLock.Release();
+                    session.Session.EntryLock.Release();
                 }
             }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -416,7 +416,7 @@ namespace Azure.Sdk.Tools.TestProxy
             DebugLogger.LogTrace($"PLAYBACK START BEGIN {id}.");
 
             ModifiableRecordSession session = new ModifiableRecordSession(SanitizerRegistry, id);
-            var auditEntry = new AuditLogItem(id, $"Starting playback for path {assetsPath}, which will return recordingId {id}.");
+            var auditEntry = new AuditLogItem(id, $"Starting playback for path {sessionId}, which will return recordingId {id}.");
 
             if (mode == RecordingType.InMemory)
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -583,7 +583,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
                 if (remove)
                 {
-                    session.AuditLog.Enqueue(new AuditLogItem(recordingId, $"Now popping entry {match.RequestUri} from entries for {recordingId}."));
+                    session.AuditLog.Enqueue(new AuditLogItem(recordingId, $"Now popping entry {entry.RequestMethod} {match.RequestUri} from entries for {recordingId}."));
                     await session.Session.Remove(match, shouldLock: false);
                 }
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -416,7 +416,7 @@ namespace Azure.Sdk.Tools.TestProxy
             DebugLogger.LogTrace($"PLAYBACK START BEGIN {id}.");
 
             ModifiableRecordSession session = new ModifiableRecordSession(SanitizerRegistry, id);
-            session.AuditLog.Enqueue(new AuditLogItem(id, $"Starting playback for path {assetsPath}, which will return recordingId {id}."));
+            var auditEntry = new AuditLogItem(id, $"Starting playback for path {assetsPath}, which will return recordingId {id}.");
 
             if (mode == RecordingType.InMemory)
             {
@@ -443,6 +443,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 {
                     Path = path
                 };
+                session.AuditLog.Enqueue(auditEntry);
             }
 
             if (!PlaybackSessions.TryAdd(id, session))

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -82,7 +82,6 @@ namespace Azure.Sdk.Tools.TestProxy
         public readonly ConcurrentDictionary<string, ModifiableRecordSession> PlaybackSessions
             = new ConcurrentDictionary<string, ModifiableRecordSession>();
 
-        // as sessions are popped off, 
         public readonly ConcurrentDictionary<string, ConcurrentQueue<AuditLogItem>> AuditSessions
             = new ConcurrentDictionary<string, ConcurrentQueue<AuditLogItem>>();
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -156,8 +156,11 @@ namespace Azure.Sdk.Tools.TestProxy
                 return;
             }
 
-
             recordingSession.AuditLog.Enqueue(new AuditLogItem(sessionId, $"Stopping recording for {sessionId}."));
+            if (!AuditSessions.TryAdd(sessionId, recordingSession.AuditLog))
+            {
+                DebugLogger.LogError($"Unable to save audit log for {sessionId}");
+            }
 
             var sanitizers = await SanitizerRegistry.GetSanitizers(recordingSession);
             await recordingSession.Session.Sanitize(sanitizers);

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -416,6 +416,7 @@ namespace Azure.Sdk.Tools.TestProxy
             DebugLogger.LogTrace($"PLAYBACK START BEGIN {id}.");
 
             ModifiableRecordSession session = new ModifiableRecordSession(SanitizerRegistry, id);
+            session.AuditLog.Enqueue(new AuditLogItem(id, $"Starting playback for path {assetsPath}, which will return recordingId {id}."));
 
             if (mode == RecordingType.InMemory)
             {
@@ -471,6 +472,8 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 throw new HttpException(HttpStatusCode.BadRequest, $"There is no active playback session under recording id {recordingId}.");
             }
+
+            session.AuditLog.Enqueue(new AuditLogItem(recordingId, $"Stopping playback for {recordingId}."));
 
             if (!AuditSessions.TryAdd(recordingId, session.AuditLog))
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -493,17 +493,12 @@ namespace Azure.Sdk.Tools.TestProxy
 
                 if (!String.IsNullOrEmpty(session.SourceRecordingId) && purgeMemoryStore)
                 {
-                    if (!InMemorySessions.TryGetValue(session.SourceRecordingId, out var inMemorySession))
-                    {
-                        throw new HttpException(HttpStatusCode.InternalServerError, $"Unexpectedly failed to retrieve in-memory session {session.SourceRecordingId}.");
-                    }
-
-                    Interlocked.Add(ref Startup.RequestsRecorded, -1 * inMemorySession.Session.Entries.Count);
-
-                    if (!InMemorySessions.TryRemove(session.SourceRecordingId, out _))
+                    if (!InMemorySessions.TryRemove(session.SourceRecordingId, out var inMemorySession))
                     {
                         throw new HttpException(HttpStatusCode.InternalServerError, $"Unexpectedly failed to remove in-memory session {session.SourceRecordingId}.");
                     }
+
+                    Interlocked.Add(ref Startup.RequestsRecorded, -1 * inMemorySession.Session.Entries.Count);
 
                     GC.Collect();
                 }


### PR DESCRIPTION
This PR

- [x] Fixes an identified issue with not properly utilizing the session locks -- causing a serious perf degradation when adding a bunch of sanitizers to a bunch of tests. (like 10+ minutes per massive core job bad)
- [x] Fixes a serious problem that was allowing a test to be `stopped` while the last entry in the recording is still writing it's body. That location in the code has _already_ obtained a lock on the session, so merely adding the same to `playback/stop` prevents the test from being stopped while the last entry is being streamed back. This was the source of the `Channel Response timeout` issues that `java- core` was seeing @alzimmermsft (at least, it has not reproed in the 3 core runs since I added this fix 🤞 )
- [x] Add a concurrent queue for log messages that can be dumped. Currently this endlessly grows, but pulling with /Audit/GetAuditLogs will clean up that memory.
- [x] Add audit entries for `Record` code paths
- [x] Add a few tests for the new functionality
- [ ] Get signoff from @mikeharder about the always-on per-session audit logging. We were kinda laughing about chewing up memory, but...it's not that bad :P No affect to `java - core` which beats the absolute hell out of the server.

@mikeharder I need to add audit items to the `record` pathway, but I was laser focused on getting `playback` concurrency issues resolved for the java folks. Please take a look, see how I'm retaining the various locks on resources (by reducing to a single access lock to each playback session). I _think_ I've nailed most of the edge cases. 

@alzimmermsft looking at the latest `java - core` failures running with this version of the test-proxy, I don't think the proxy is related to those. I'm not declaring total victory with this PR but the issues are seriously reduced.

This version is standing up to multiple storage runs: 
<img width="880" alt="image" src="https://github.com/user-attachments/assets/cd0a9a00-e588-472a-b056-b7eaaf1a63af">
