### PR TITLE
Fix the issue in sorting revisions with more than one approver in req…

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/RequestedReviews.cshtml.cs
@@ -30,11 +30,12 @@ namespace APIViewWeb.Pages.Assemblies
 
         public async Task<IActionResult> OnGetAsync()
         {
-            APIRevisions = await _apiRevisionsManager.GetAPIRevisionsAssignedToUser(User.GetGitHubLogin());
+            var userId = User.GetGitHubLogin();
+            APIRevisions = await _apiRevisionsManager.GetAPIRevisionsAssignedToUser(userId);
 
             List<APIRevisionListItemModel> activeAPIRevs = new List<APIRevisionListItemModel>();
             List<APIRevisionListItemModel> approvedAPIRevs = new List<APIRevisionListItemModel>();
-            foreach (var apiRevison in APIRevisions.OrderByDescending(r => r.AssignedReviewers.Select(x => x.AssingedOn)))
+            foreach (var apiRevison in APIRevisions.OrderByDescending(r => r.AssignedReviewers.First(x => x.AssingedTo.Equals(userId)).AssingedOn))
             {
                 if (!apiRevison.IsApproved)
                 {

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosAPIRevisionsRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosAPIRevisionsRepository.cs
@@ -242,7 +242,7 @@ namespace APIViewWeb
         /// <returns></returns>
         public async Task<IEnumerable<APIRevisionListItemModel>> GetAPIRevisionsAssignedToUser(string userName)
         {
-            var query = "SELECT * FROM Revisions r WHERE ARRAY_CONTAINS(r.AssignedReviewers, { 'AssingedTo': '" + userName + "' }, true)";
+            var query = "SELECT * FROM Revisions r WHERE r.IsDeleted = false and ARRAY_CONTAINS(r.AssignedReviewers, { 'AssingedTo': '" + userName + "' }, true)";
 
             var apiRevisions = new List<APIRevisionListItemModel>();
             var queryDefinition = new QueryDefinition(query).WithParameter("@userName", userName);


### PR DESCRIPTION
Revisions cannot be sorted when there is more than one approver in the requested list and this throws an exception `Failed to compare two elements in the array`.

Fix is to filter and project the sorting key based on the logged in user to correctly show the revisions in requested order for the logged in user.