### PR TITLE
Disable Caching When Pulling Compressed Files

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
@@ -11,8 +11,6 @@ using APIViewWeb.Managers.Interfaces;
 using Microsoft.Extensions.Configuration;
 using APIViewWeb.Hubs;
 using Microsoft.AspNetCore.SignalR;
-using System.Diagnostics;
-using System;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Hosting;
 using System.Collections.Generic;
@@ -139,7 +137,7 @@ namespace APIViewWeb.LeanControllers
             {
                 var comments = await _commentsManager.GetCommentsAsync(reviewId);
 
-                var activeRevisionReviewCodeFile = await _codeFileRepository.GetCodeFileWithCompressionAsync(activeAPIRevision.Id, activeAPIRevision.Files[0].FileId, _env.IsProduction());
+                var activeRevisionReviewCodeFile = await _codeFileRepository.GetCodeFileWithCompressionAsync(revisionId: activeAPIRevision.Id, codeFileId: activeAPIRevision.Files[0].FileId); 
 
                 var result = new CodePanelData();
 
@@ -154,7 +152,8 @@ namespace APIViewWeb.LeanControllers
                 if (!string.IsNullOrEmpty(diffApiRevisionId))
                 {
                     var diffAPIRevision = await _apiRevisionsManager.GetAPIRevisionAsync(User, diffApiRevisionId);
-                    var diffRevisionReviewCodeFile = await _codeFileRepository.GetCodeFileWithCompressionAsync(diffAPIRevision.Id, diffAPIRevision.Files[0].FileId, _env.IsProduction());
+
+                    var diffRevisionReviewCodeFile = await _codeFileRepository.GetCodeFileWithCompressionAsync(revisionId: diffAPIRevision.Id, codeFileId: diffAPIRevision.Files[0].FileId);
                     codePanelRawData.APIForest = CodeFileHelpers.ComputeAPIForestDiff(diffRevisionReviewCodeFile.APIForest, activeRevisionReviewCodeFile.APIForest);
                 }
 

--- a/src/dotnet/APIView/APIViewWeb/Repositories/BlobCodeFileRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/BlobCodeFileRepository.cs
@@ -57,23 +57,11 @@ namespace APIViewWeb
             return codeFile;
         }
 
-        public async Task<CodeFile> GetCodeFileWithCompressionAsync(string revisionId, string codeFileId, bool updateCache = true)
+        public async Task<CodeFile> GetCodeFileWithCompressionAsync(string revisionId, string codeFileId)
         {
             var client = GetBlobClient(revisionId, codeFileId, out var key);
-
-            if (_cache.TryGetValue<CodeFile>(key, out var codeFile))
-            {
-                return codeFile;
-            }
             var info = await client.DownloadAsync();
-            codeFile = await CodeFile.DeserializeAsync(info.Value.Content, doTreeStyleParserDeserialization: true);
-            if (updateCache)
-            {
-                using var _ = _cache.CreateEntry(key)
-                    .SetSlidingExpiration(TimeSpan.FromMinutes(10))
-                    .SetValue(codeFile);
-            }
-            return codeFile;
+            return await CodeFile.DeserializeAsync(info.Value.Content, doTreeStyleParserDeserialization: true);
         }
 
         public async Task UpsertCodeFileAsync(string revisionId, string codeFileId, CodeFile codeFile)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/Interfaces/IBlobCodeFileRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/Interfaces/IBlobCodeFileRepository.cs
@@ -10,7 +10,7 @@ namespace APIViewWeb.Repositories
     {
         public Task<RenderedCodeFile> GetCodeFileAsync(APIRevisionListItemModel revision, bool updateCache = true);
         public Task<RenderedCodeFile> GetCodeFileAsync(string revisionId, APICodeFileModel apiCodeFile, string language, bool updateCache = true);
-        public Task<CodeFile> GetCodeFileWithCompressionAsync(string revisionId, string codeFileId, bool updateCache = true);
+        public Task<CodeFile> GetCodeFileWithCompressionAsync(string revisionId, string codeFileId);
         public Task UpsertCodeFileAsync(string revisionId, string codeFileId, CodeFile codeFile);
         public Task DeleteCodeFileAsync(string revisionId, string codeFileId);
     }


### PR DESCRIPTION
- Disable cache when retrieving compressed files.
- Should resolve https://github.com/Azure/azure-sdk-tools/issues/8724