### PR TITLE
[tsp-client] Fix tool version

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2024-08-12 - 0.11.2
+
+- Fix `--version` flag. (#8814)
+
 ## 2024-08-08 - 0.11.1
 
 - Removed `compare` command.

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -10,8 +10,15 @@ import {
   syncCommand,
   updateCommand,
 } from "./commands.js";
-import { normalizePath, resolvePath } from "@typespec/compiler";
+import { joinPaths, normalizePath, resolvePath } from "@typespec/compiler";
 import PromptSync from "prompt-sync";
+import { readFile } from "fs/promises";
+import { fileURLToPath } from "url";
+import { dirname } from "path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const { version } = JSON.parse(await readFile(joinPaths(__dirname, "..", "package.json"), "utf8"));
 
 function commandPreamble(argv: any) {
   checkDebugLogging(argv);
@@ -49,6 +56,8 @@ export function resolveOutputDir(argv: any): string {
 }
 
 const parser = yargs(hideBin(process.argv))
+  .version(version)
+  .alias("v", "version")
   .scriptName("")
   .usage(usageText)
   .option("debug", {


### PR DESCRIPTION
After the yargs migration, seems we arent getting the right reference to the package version. Fixing in this PR.

Fixes #8814