### PR TITLE
[tsp-client] Miscellaneous fixes

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Fix `--version` flag. (#8814)
 - Added `compare` command to compare a hand-authored Swagger to a TypeSpec-generated Swagger to understand the relevant differences between them.
 - Floating `@azure-tools/typespec-autorest` dependency from `>=0.44.0 <1.0.0`.
+- Bump `@autorest/openapi-to-typespec` dependency to `0.9.0`.
 
 ## 2024-08-08 - 0.11.1
 

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Fix `--version` flag. (#8814)
 - Added `compare` command to compare a hand-authored Swagger to a TypeSpec-generated Swagger to understand the relevant differences between them.
+- Floating `@azure-tools/typespec-autorest` dependency from `>=0.44.0 <1.0.0`.
 
 ## 2024-08-08 - 0.11.1
 

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@autorest/csharp": "https://aka.ms/azsdk/openapi-to-typespec-csharp",
         "@autorest/openapi-to-typespec": "0.8.2",
-        "@azure-tools/typespec-autorest": "^0.44.0",
+        "@azure-tools/typespec-autorest": ">=0.44.0 <1.0.0",
         "@azure/core-rest-pipeline": "^1.12.0",
         "@types/yargs": "^17.0.32",
         "autorest": "^3.7.1",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -53,7 +53,7 @@
   "dependencies": {
     "@autorest/csharp": "https://aka.ms/azsdk/openapi-to-typespec-csharp",
     "@autorest/openapi-to-typespec": "0.8.2",
-    "@azure-tools/typespec-autorest": "^0.44.0",
+    "@azure-tools/typespec-autorest": ">=0.44.0 <1.0.0",
     "@azure/core-rest-pipeline": "^1.12.0",
     "@types/yargs": "^17.0.32",
     "autorest": "^3.7.1",

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -19,12 +19,12 @@ import { dirname } from "path";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const { version } = JSON.parse(await readFile(joinPaths(__dirname, "..", "package.json"), "utf8"));
+const packageJson = JSON.parse(await readFile(joinPaths(__dirname, "..", "package.json"), "utf8"));
 
 function commandPreamble(argv: any) {
   checkDebugLogging(argv);
   printBanner();
-  yargs().showVersion();
+  Logger.info(packageJson.version);
 }
 
 /** Ensure the output directory exists and allow interactive users to confirm or override the value. */
@@ -57,7 +57,7 @@ export function resolveOutputDir(argv: any): string {
 }
 
 const parser = yargs(hideBin(process.argv))
-  .version(version)
+  .version(packageJson.version)
   .alias("v", "version")
   .scriptName("")
   .usage(usageText)
@@ -225,6 +225,7 @@ const parser = yargs(hideBin(process.argv))
       });
     },
     async (argv: any) => {
+      commandPreamble(argv);
       await sortSwaggerCommand(argv);
     },
   )


### PR DESCRIPTION
- Fix version printing in banner
- Show banner in the sort-swagger command
- Update supported typespec-autorest versions

Follow up issue to support output directory in `sort-swagger`: https://github.com/Azure/azure-sdk-tools/issues/8824
