### PR TITLE
[GitHub] Add common service label

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -72,6 +72,7 @@ Communication - Resource Manager,,e99695
 Community Contribution,Community members are working on the issue,1aa874
 Compute,,e99695
 Compute - Extensions,,e99695
+Compute - Fleet,,e99695
 Compute - Images,,e99695
 Compute - Managed Disks,,e99695
 Compute - RDFE,,e99695


### PR DESCRIPTION
# Summary

The focus of these changes is to add the common service label for the "Compute - Fleet" resource provider.