### PR TITLE
Clean-up publish-blobs.yml to have better defaults

### DIFF
--- a/eng/common/pipelines/templates/steps/publish-blobs.yml
+++ b/eng/common/pipelines/templates/steps/publish-blobs.yml
@@ -2,7 +2,7 @@ parameters:
   FolderForUpload: ''
   TargetLanguage: ''
   BlobName: '' # To be removed once all usages are removed in the languages
-  StorageAccount: 'https://azuresdkdocs.blob.core.windows.net'
+  BlobAccountName: 'https://azuresdkdocs.blob.core.windows.net'
   ScriptPath: 'eng/common/scripts/copy-docs-to-blobstorage.ps1'
   ArtifactLocation: ''
   RepoId: $(Build.Repository.Name)
@@ -19,7 +19,7 @@ steps:
     ScriptPath: ${{ parameters.ScriptPath }}
     ScriptArguments: >
       -DocLocation "${{ parameters.FolderForUpload }}"
-      -BlobName "${{ parameters.BlobName }}"
+      -BlobAccountName "${{ parameters.BlobAccountName }}"
       -PublicArtifactLocation "${{ parameters.ArtifactLocation }}"
       -RepoReplaceRegex "(https://github.com/${{ parameters.RepoId }}/(?:blob|tree)/)$(DefaultBranch)"
     azurePowerShellVersion: latestVersion

--- a/eng/common/pipelines/templates/steps/publish-blobs.yml
+++ b/eng/common/pipelines/templates/steps/publish-blobs.yml
@@ -1,20 +1,14 @@
 parameters:
   FolderForUpload: ''
   TargetLanguage: ''
-  BlobName: ''
-  ScriptPath: ''
+  BlobName: '' # To be removed once all usages are removed in the languages
+  StorageAccount: 'https://azuresdkdocs.blob.core.windows.net'
+  ScriptPath: 'eng/common/scripts/copy-docs-to-blobstorage.ps1'
   ArtifactLocation: ''
   RepoId: $(Build.Repository.Name)
 
 steps:
 - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
-- pwsh: |
-    if (!(Test-Path '$(Build.BinariesDirectory)/azcopy/azcopy_windows_amd64_*/azcopy.exe')) {
-      Invoke-WebRequest -MaximumRetryCount 10 -Uri "https://aka.ms/downloadazcopy-v10-windows" -OutFile "azcopy.zip" | Wait-Process;
-      Expand-Archive -Path "azcopy.zip" -DestinationPath "$(Build.BinariesDirectory)/azcopy/" -Force
-    }
-  workingDirectory: $(Build.BinariesDirectory)
-  displayName: Download and Extract azcopy Zip
 
 - task: AzurePowerShell@5
   displayName: 'Copy Docs to Blob Storage'
@@ -24,7 +18,6 @@ steps:
     ScriptType: 'FilePath'
     ScriptPath: ${{ parameters.ScriptPath }}
     ScriptArguments: >
-      -AzCopy $(Resolve-Path "$(Build.BinariesDirectory)/azcopy/azcopy_windows_amd64_*/azcopy.exe")[0]
       -DocLocation "${{ parameters.FolderForUpload }}"
       -BlobName "${{ parameters.BlobName }}"
       -PublicArtifactLocation "${{ parameters.ArtifactLocation }}"

--- a/eng/common/scripts/copy-docs-to-blobstorage.ps1
+++ b/eng/common/scripts/copy-docs-to-blobstorage.ps1
@@ -2,9 +2,8 @@
 # powershell core is a requirement for successful execution.
 [CmdletBinding()]
 param (
-  $AzCopy,
   $DocLocation,
-  $BlobName,
+  $BlobAccountName = "https://azuresdkdocs.blob.core.windows.net",
   $ExitOnError=1,
   $UploadLatest=1,
   $PublicArtifactLocation = "",
@@ -117,7 +116,7 @@ function Get-Existing-Versions
     Param (
         [Parameter(Mandatory=$true)] [String]$PkgName
     )
-    $versionUri = "$($BlobName)/`$web/$($Language)/$($PkgName)/versioning/versions"
+    $versionUri = "${BlobAccountName}/`$web/$($Language)/$($PkgName)/versioning/versions"
     LogDebug "Heading to $versionUri to retrieve known versions"
 
     try {
@@ -175,9 +174,9 @@ function Update-Existing-Versions
     $sortedVersionObj.LatestGAPackage | Out-File -File "$($DocLocation)/latest-ga" -Force -NoNewLine
     $sortedVersionObj.LatestPreviewPackage | Out-File -File "$($DocLocation)/latest-preview" -Force -NoNewLine
 
-    & $($AzCopy) cp "$($DocLocation)/versions" "$($DocDest)/$($PkgName)/versioning/versions" --cache-control "max-age=300, must-revalidate"
-    & $($AzCopy) cp "$($DocLocation)/latest-preview" "$($DocDest)/$($PkgName)/versioning/latest-preview" --cache-control "max-age=300, must-revalidate"
-    & $($AzCopy) cp "$($DocLocation)/latest-ga" "$($DocDest)/$($PkgName)/versioning/latest-ga" --cache-control "max-age=300, must-revalidate"
+    azcopy cp "$($DocLocation)/versions" "$($DocDest)/$($PkgName)/versioning/versions" --cache-control "max-age=300, must-revalidate"
+    azcopy cp "$($DocLocation)/latest-preview" "$($DocDest)/$($PkgName)/versioning/latest-preview" --cache-control "max-age=300, must-revalidate"
+    azcopy cp "$($DocLocation)/latest-ga" "$($DocDest)/$($PkgName)/versioning/latest-ga" --cache-control "max-age=300, must-revalidate"
     return $sortedVersionObj
 }
 
@@ -189,8 +188,7 @@ function Upload-Blobs
         [Parameter(Mandatory=$true)] [String]$DocVersion,
         [Parameter(Mandatory=$false)] [String]$ReleaseTag
     )
-    #eg : $BlobName = "https://azuresdkdocs.blob.core.windows.net"
-    $DocDest = "$($BlobName)/`$web/$($Language)"
+    $DocDest = "${BlobAccountName}/`$web/$($Language)"
 
     LogDebug "DocDest $($DocDest)"
     LogDebug "PkgName $($PkgName)"
@@ -215,7 +213,7 @@ function Upload-Blobs
     }
 
     LogDebug "Uploading $($PkgName)/$($DocVersion) to $($DocDest)..."
-    & $($AzCopy) cp "$($DocDir)/**" "$($DocDest)/$($PkgName)/$($DocVersion)" --recursive=true --cache-control "max-age=300, must-revalidate"
+    azcopy cp "$($DocDir)/**" "$($DocDest)/$($PkgName)/$($DocVersion)" --recursive=true --cache-control "max-age=300, must-revalidate"
 
     LogDebug "Handling versioning files under $($DocDest)/$($PkgName)/versioning/"
     $versionsObj = (Update-Existing-Versions -PkgName $PkgName -PkgVersion $DocVersion -DocDest $DocDest)
@@ -228,7 +226,7 @@ function Upload-Blobs
     if ($UploadLatest -and ($latestVersion -eq $DocVersion))
     {
         LogDebug "Uploading $($PkgName) to latest folder in $($DocDest)..."
-        & $($AzCopy) cp "$($DocDir)/**" "$($DocDest)/$($PkgName)/latest" --recursive=true --cache-control "max-age=300, must-revalidate"
+        azcopy cp "$($DocDir)/**" "$($DocDest)/$($PkgName)/latest" --recursive=true --cache-control "max-age=300, must-revalidate"
     }
 }
 


### PR DESCRIPTION
Cleaning this up in order to remove azure-sdk-docs-prod-blob-name from the keyvault. Need to do this first and then I can remove all the references to that value in all the language repos.