### PR TITLE
Add FilePattern support for .github\workflow sync

### DIFF
--- a/eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
+++ b/eng/common/pipelines/templates/steps/eng-common-workflow-enforcer.yml
@@ -21,7 +21,7 @@ steps:
         }
         if ((!"$(System.PullRequest.SourceBranch)".StartsWith("sync-.github/workflows")) -and "$(System.PullRequest.TargetBranch)" -match "^(refs/heads/)?$(DefaultBranch)$")
         {
-          $filesInCommonDir  = & "eng/common/scripts/get-changedfiles.ps1" -DiffPath '.github/workflows/*' -DiffFilterType ""
+          $filesInCommonDir  = & "eng/common/scripts/get-changedfiles.ps1" -DiffPath '.github/workflows/*event*' -DiffFilterType ""
           if (($LASTEXITCODE -eq 0) -and ($filesInCommonDir.Count -gt 0))
           {
             Write-Host "##vso[task.LogIssue type=error;]Changes to files under '.github/workflows' directory should not be made in this Repo`n${filesInCommonDir}"

--- a/eng/pipelines/eng-workflows-sync.yml
+++ b/eng/pipelines/eng-workflows-sync.yml
@@ -6,6 +6,9 @@ parameters:
 - name: DirectoryToSync
   type: string
   default: .github/workflows
+- name: FilePattern
+  type: string
+  default: '/*event*'
 - name: Repos
   type: object
   default:
@@ -28,10 +31,11 @@ pr:
       - main
   paths:
     include:
-      - .github/workflows
+      - .github/workflows/*event*
 
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
   parameters:
     DirectoryToSync: ${{ parameters.DirectoryToSync }}
+    FilePattern: ${{ parameters.FilePattern }}
     Repos: ${{ parameters.Repos }}

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
@@ -193,11 +193,6 @@ stages:
             vmImage: ubuntu-22.04
 
           steps:
-            - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-              parameters:
-                Paths:
-                  - ${{ parameters.DirectoryToSync }}
-
             - template: /eng/pipelines/templates/steps/sync-directory.yml
               parameters:
                 CommitMessage: Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools repository

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
@@ -13,7 +13,7 @@ parameters:
   default: ''
 - name: BaseBranchName
   type: string
-  default: $(Build.SourceBranch)
+  default: $(DefaultBranch)
 - name: Repos
   type: object
   default: []

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-repo-sync.yml
@@ -8,6 +8,9 @@ parameters:
 - name: DirectoryToSync
   type: string
   default: not-specified
+- name: FilePattern
+  type: string
+  default: ''
 - name: BaseBranchName
   type: string
   default: $(Build.SourceBranch)
@@ -35,7 +38,7 @@ stages:
             - pwsh: |
                 Set-PsDebug -Trace 1
                 $patchDir = "$(Build.ArtifactStagingDirectory)/patchfiles"
-                $patchfiles = git format-patch --output-directory $patchDir HEAD...origin/$(system.pullRequest.targetBranch) -- "${{ parameters.DirectoryToSync }}"
+                $patchfiles = git format-patch --output-directory $patchDir HEAD...origin/$(system.pullRequest.targetBranch) -- "${{ parameters.DirectoryToSync }}${{ parameters.FilePattern }}"
                 if ($patchfiles -and ($LASTEXITCODE -eq 0)) {
                   echo "##vso[task.setvariable variable=PatchFilesLocation]$patchDir"
                   echo "Setting PatchFilesLocation"
@@ -57,6 +60,7 @@ stages:
               parameters:
                 CommitMessage: "Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools repository for Tools PR $(System.PullRequest.PullRequestNumber)"
                 DirectoryToSync: ${{ parameters.DirectoryToSync }}
+                FilePattern: ${{ parameters.FilePattern }}
                 UpstreamBranchName: "sync-${{ parameters.DirectoryToSync }}-$(System.PullRequest.SourceBranch)-$(System.PullRequest.PullRequestNumber)"
                 BaseBranchName: $(system.pullRequest.targetBranch)
                 SkipCheckingForChanges: true
@@ -198,6 +202,7 @@ stages:
               parameters:
                 CommitMessage: Sync ${{ parameters.DirectoryToSync }} directory with azure-sdk-tools repository
                 DirectoryToSync: ${{ parameters.DirectoryToSync }}
+                FilePattern: ${{ parameters.FilePattern }}
                 UpstreamBranchName: "sync-${{ parameters.DirectoryToSync }}"
                 BaseBranchName: ${{ parameters.BaseBranchName }}
                 Repos: ${{ parameters.Repos }}

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -140,9 +140,6 @@ steps:
       Paths:
         - ${{ parameters.DirectoryToSync }}
       Repositories:
-        - Name: $(Build.Repository.Name)
-          Commitish: $(Build.SourceVersion)
-          WorkingDirectory: $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)
         - ${{ each repo in parameters.Repos }}:
           - Name: ${{ parameters.PROwner }}/${{ repo }}
             Commitish: ${{ parameters.BaseBranchName }}

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -140,6 +140,9 @@ steps:
       Paths:
         - ${{ parameters.DirectoryToSync }}
       Repositories:
+        - Name: $(Build.Repository.Name)
+          Commitish: $(Build.SourceVersion)
+          WorkingDirectory: $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)
         - ${{ each repo in parameters.Repos }}:
           - Name: ${{ parameters.PROwner }}/${{ repo }}
             Commitish: ${{ parameters.BaseBranchName }}

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -1,6 +1,7 @@
 parameters:
   Repos: []
   DirectoryToSync: eng/common
+  FilePattern: ''
   CommitMessage: commit-message-not-set
   UpstreamBranchName: branch-name-not-set
   BaseBranchName: $(DefaultBranch)
@@ -27,7 +28,6 @@ steps:
 
   - ${{ each repo in parameters.Repos }}:
     - pwsh: |
-        $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
         if (Test-Path '$(PatchFilesLocation)')
         {
           pushd ${{ repo }}
@@ -151,10 +151,10 @@ steps:
   - ${{ each repo in parameters.Repos }}:
     - pwsh: |
         Set-PsDebug -Trace 1
-        $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
+        $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}${{ parameters.FilePattern }}"
         Remove-Item -v -r -ErrorAction Ignore $repoPath
         Copy-Item -v -r `
-          $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)/${{ parameters.DirectoryToSync }} `
+          $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)/${{ parameters.DirectoryToSync }}${{ parameters.FilePattern }} `
           $repoPath
         Get-ChildItem -r $repoPath
       displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}

--- a/eng/pipelines/templates/steps/sync-directory.yml
+++ b/eng/pipelines/templates/steps/sync-directory.yml
@@ -151,10 +151,10 @@ steps:
   - ${{ each repo in parameters.Repos }}:
     - pwsh: |
         Set-PsDebug -Trace 1
-        $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}${{ parameters.FilePattern }}"
-        Remove-Item -v -r -ErrorAction Ignore $repoPath
+        $repoPath = "${{ repo }}/${{ parameters.DirectoryToSync }}"
+        Remove-Item -v -r -ErrorAction Ignore "$repoPath${{ parameters.FilePattern }}"
         Copy-Item -v -r `
-          $(System.DefaultWorkingDirectory)/$(Build.Repository.Name)/${{ parameters.DirectoryToSync }}${{ parameters.FilePattern }} `
+          "$(System.DefaultWorkingDirectory)/$(Build.Repository.Name)/${{ parameters.DirectoryToSync }}${{ parameters.FilePattern }}" `
           $repoPath
         Get-ChildItem -r $repoPath
       displayName: Copy ${{ parameters.DirectoryToSync }} from azure-sdk-tools to ${{ repo }}


### PR DESCRIPTION
Given we cannot create subfolders under .github\workflow folder and we have repos that want additional workflows then we have in the tools repo we need to setup a file pattern matching for the sync processing to only sync the ones we want to be common.

For now just use the existing *event* pattern but we can move them to another pattern similar to *common* or *sync* in the future as we add more common workflows.