### PR TITLE
.NET API review parser changes to use new token schema

### DIFF
--- a/src/dotnet/APIView/APIView.sln
+++ b/src/dotnet/APIView/APIView.sln
@@ -17,6 +17,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "APIViewIntegrationTests", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "APIViewUITests", "APIViewUITests\APIViewUITests.csproj", "{7246F62A-99BF-4C4F-B9AD-1996166E767E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpAPIParser", "..\..\..\tools\apiview\parsers\csharp-api-parser\CSharpAPIParser\CSharpAPIParser.csproj", "{0D5CD780-15F9-49F5-9C4F-126D8224A31E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CSharpAPIParserTests", "..\..\..\tools\apiview\parsers\csharp-api-parser\CSharpAPIParserTests\CSharpAPIParserTests.csproj", "{4F057169-032D-4971-B7D9-71AF850D411E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestReferenceWithInternalsVisibleTo", "..\Azure.ClientSdk.Analyzers\TestReferenceWithInternalsVisibleTo\TestReferenceWithInternalsVisibleTo.csproj", "{0FE36A2D-EB25-4119-A7DA-2605BB2516C2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +57,18 @@ Global
 		{7246F62A-99BF-4C4F-B9AD-1996166E767E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7246F62A-99BF-4C4F-B9AD-1996166E767E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7246F62A-99BF-4C4F-B9AD-1996166E767E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0D5CD780-15F9-49F5-9C4F-126D8224A31E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0D5CD780-15F9-49F5-9C4F-126D8224A31E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0D5CD780-15F9-49F5-9C4F-126D8224A31E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0D5CD780-15F9-49F5-9C4F-126D8224A31E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F057169-032D-4971-B7D9-71AF850D411E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F057169-032D-4971-B7D9-71AF850D411E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F057169-032D-4971-B7D9-71AF850D411E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F057169-032D-4971-B7D9-71AF850D411E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0FE36A2D-EB25-4119-A7DA-2605BB2516C2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0FE36A2D-EB25-4119-A7DA-2605BB2516C2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0FE36A2D-EB25-4119-A7DA-2605BB2516C2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0FE36A2D-EB25-4119-A7DA-2605BB2516C2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/dotnet/APIView/APIView/Model/CodeFile.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFile.cs
@@ -144,9 +144,10 @@ namespace ApiView
             await JsonSerializer.SerializeAsync(stream, this, _serializerOptions);
         }
 
-        /***GetApiText method will generate complete text representation of API surface to help generating the content.
-        * One use case of this function will be to support download request of entire API review surface.
-        */
+        /// <summary>
+        /// Generates a complete text representation of API surface to help generating the content.
+        /// One use case of this function will be to support download request of entire API review surface.
+        /// </summary>
         public string GetApiText()
         {
             StringBuilder sb = new();

--- a/src/dotnet/APIView/APIView/Model/CodeFile.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFile.cs
@@ -153,7 +153,7 @@ namespace ApiView
             StringBuilder sb = new();
             foreach (var line in ReviewLines)
             {
-                line.GetApiText(sb, 0, true);
+                line.AppendApiTextToBuilder(sb, 0, true);
             }
             return sb.ToString();
         }       

--- a/src/dotnet/APIView/APIView/Model/V2/ReviewLine.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewLine.cs
@@ -6,27 +6,35 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.Json.Serialization;
+using System.Xml;
 using APIView.TreeToken;
 
 namespace APIView.Model.V2
 {
-    /*** Review line object corresponds to each line displayed on API review. If an empty line is required then 
-     * add a review line object without any token. */
+    /// <summary>
+    /// Review line object corresponds to each line displayed on API review. If an empty line is required then add a review line object without any token.
+    /// </summary>
     public class ReviewLine
     {
-        /*** LineId is only required if we need to support commenting on a line that contains this token. 
-         *  Usually code line for documentation or just punctuation is not required to have lineId. lineId should be a unique value within 
-         *  the review token file to use it assign to review comments as well as navigation Id within the review page.
-         *  for e.g Azure.Core.HttpHeader.Common, azure.template.template_main
-         */
+        /// <summary>
+        /// LineId is only required if we need to support commenting on a line that contains this token. 
+        /// Usually code line for documentation or just punctuation is not required to have lineId.lineId should be a unique value within
+        /// the review token file to use it assign to review comments as well as navigation Id within the review page.        /// for e.g Azure.Core.HttpHeader.Common, azure.template.template_main
+        /// </summary>
         public string LineId { get; set; }
         public string CrossLanguageId { get; set; }
-        /*** list of tokens that constructs a line in API review */
+        /// <summary>
+        /// List of tokens that constructs a line in API review
+        /// </summary>
         public List<ReviewToken> Tokens { get; set; } = [];
-        /*** Add any child lines as children. For e.g. all classes and namespace level methods are added as a children of namespace(module) level code line. 
-         *  Similarly all method level code lines are added as children of it's class code line.*/
+        /// <summary>
+        /// Add any child lines as children. For e.g. all classes and namespace level methods are added as a children of namespace(module) level code line.
+        /// Similarly all method level code lines are added as children of it's class code line.
+        /// </summary>
         public List<ReviewLine> Children { get; set; } = [];
-        /*** This is set if API is marked as hidden */
+        /// <summary>
+        /// This is set if API is marked as hidden
+        /// </summary>
         public bool? IsHidden { get; set; }
 
         // Following properties are helper methods that's used to render review lines to UI required format.

--- a/src/dotnet/APIView/APIView/Model/V2/ReviewLine.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewLine.cs
@@ -54,22 +54,6 @@ namespace APIView.Model.V2
             Tokens.Add(token);
         }
 
-        public void RemoveSuffixSpace()
-        {
-            if (Tokens.Count > 0)
-            {
-                Tokens[Tokens.Count - 1].HasSuffixSpace = false;
-            }
-        }
-
-        public void AddSuffixSpace()
-        {
-            if (Tokens.Count > 0)
-            {
-                Tokens[Tokens.Count - 1].HasSuffixSpace = true;
-            }
-        }
-
         public void AppendApiTextToBuilder(StringBuilder sb, int indent = 0, bool skipDocs = true)
         {
             if (skipDocs && Tokens.Count > 0 && Tokens[0].IsDocumentation == true)

--- a/src/dotnet/APIView/APIView/Model/V2/ReviewLine.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewLine.cs
@@ -36,7 +36,10 @@ namespace APIView.Model.V2
         /// This is set if API is marked as hidden
         /// </summary>
         public bool? IsHidden { get; set; }
-
+        /// <summary>
+        /// This is set if a line is end of context. For e.g. end of a class or name space line "}"
+        /// </summary>
+        public bool? IsContextEndLine { get; set; }
         // Following properties are helper methods that's used to render review lines to UI required format.
         [JsonIgnore]
         public DiffKind DiffKind { get; set; } = DiffKind.NoneDiff;
@@ -131,9 +134,9 @@ namespace APIView.Model.V2
             return hash + parentNodeIdHash.Replace("nId", "").Replace("root", ""); // Append the parent node Id to ensure uniqueness
         }
 
-        private string CreateHashFromString(string inputString)
+        private static string CreateHashFromString(string inputString)
         {
-            int hash = HashCode.Combine(inputString);
+            int hash = inputString.GetHashCode();
             return "nId" + hash.ToString();
         }
     }

--- a/src/dotnet/APIView/APIView/Model/V2/ReviewLine.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewLine.cs
@@ -49,7 +49,7 @@ namespace APIView.Model.V2
         [JsonIgnore]
         public bool Processed { get; set; } = false;
 
-        public void Add(ReviewToken token)
+        public void AddToken(ReviewToken token)
         {
             Tokens.Add(token);
         }
@@ -70,7 +70,7 @@ namespace APIView.Model.V2
             }
         }
 
-        public void GetApiText(StringBuilder sb, int indent = 0, bool skipDocs = true)
+        public void AppendApiTextToBuilder(StringBuilder sb, int indent = 0, bool skipDocs = true)
         {
             if (skipDocs && Tokens.Count > 0 && Tokens[0].IsDocumentation == true)
             {
@@ -94,22 +94,22 @@ namespace APIView.Model.V2
             sb.Append(Environment.NewLine);
             foreach (var child in Children)
             {
-                child.GetApiText(sb, indent + 1, skipDocs);
+                child.AppendApiTextToBuilder(sb, indent + 1, skipDocs);
             }
         }
 
         private string ToString(bool includeAllTokens)
         {
-            var filterdTokens = Tokens.Where(x => includeAllTokens || x.SkipDiff != true);
+            var filterdTokens = includeAllTokens ? Tokens: Tokens.Where(x => x.SkipDiff != true);
             if (!filterdTokens.Any())
             {
-                return "";
+                return string.Empty;
             }
             StringBuilder sb = new();
             foreach (var token in filterdTokens)
             {
                 sb.Append(token.Value);
-                sb.Append(token.HasSuffixSpace == true ? " " : "");
+                sb.Append(token.HasSuffixSpace == true ? " " : string.Empty);
             }
             return sb.ToString();
         }

--- a/src/dotnet/APIView/APIView/Model/V2/ReviewLine.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewLine.cs
@@ -1,0 +1,148 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.Json.Serialization;
+using APIView.TreeToken;
+
+namespace APIView.Model.V2
+{
+    /*** Review line object corresponds to each line displayed on API review. If an empty line is required then 
+     * add a review line object without any token. */
+    public class ReviewLine
+    {
+        /*** LineId is only required if we need to support commenting on a line that contains this token. 
+         *  Usually code line for documentation or just punctuation is not required to have lineId. lineId should be a unique value within 
+         *  the review token file to use it assign to review comments as well as navigation Id within the review page.
+         *  for e.g Azure.Core.HttpHeader.Common, azure.template.template_main
+         */
+        public string LineId { get; set; }
+        public string CrossLanguageId { get; set; }
+        /*** list of tokens that constructs a line in API review */
+        public List<ReviewToken> Tokens { get; set; } = [];
+        /*** Add any child lines as children. For e.g. all classes and namespace level methods are added as a children of namespace(module) level code line. 
+         *  Similarly all method level code lines are added as children of it's class code line.*/
+        public List<ReviewLine> Children { get; set; } = [];
+        /*** This is set if API is marked as hidden */
+        public bool? IsHidden { get; set; }
+
+        // Following properties are helper methods that's used to render review lines to UI required format.
+        [JsonIgnore]
+        public DiffKind DiffKind { get; set; } = DiffKind.NoneDiff;
+        [JsonIgnore]
+        public bool IsActiveRevisionLine = true;
+        [JsonIgnore]
+        public bool IsDocumentation => Tokens.Count > 0 && Tokens[0].IsDocumentation == true;
+        [JsonIgnore]
+        public bool IsEmpty => Tokens.Count == 0 || !Tokens.Any( t => t.SkipDiff != true);
+        [JsonIgnore]
+        public bool Processed { get; set; } = false;
+
+        public void Add(ReviewToken token)
+        {
+            Tokens.Add(token);
+        }
+
+        public void RemoveSuffixSpace()
+        {
+            if (Tokens.Count > 0)
+            {
+                Tokens[Tokens.Count - 1].HasSuffixSpace = false;
+            }
+        }
+
+        public void AddSuffixSpace()
+        {
+            if (Tokens.Count > 0)
+            {
+                Tokens[Tokens.Count - 1].HasSuffixSpace = true;
+            }
+        }
+
+        public void GetApiText(StringBuilder sb, int indent = 0, bool skipDocs = true)
+        {
+            if (skipDocs && Tokens.Count > 0 && Tokens[0].IsDocumentation == true)
+            {
+                return;
+            }
+
+            //Add empty line in case of review line without tokens
+            if (Tokens.Count == 0)
+            {
+                sb.Append(Environment.NewLine);
+                return;
+            }
+            //Add spaces for indentation
+            for (int i = 0; i < indent; i++)
+            {
+                sb.Append("    ");
+            }
+            //Process all tokens
+            sb.Append(ToString(true));
+            
+            sb.Append(Environment.NewLine);
+            foreach (var child in Children)
+            {
+                child.GetApiText(sb, indent + 1, skipDocs);
+            }
+        }
+
+        private string ToString(bool includeAllTokens)
+        {
+            var filterdTokens = Tokens.Where(x => includeAllTokens || x.SkipDiff != true);
+            if (!filterdTokens.Any())
+            {
+                return "";
+            }
+            StringBuilder sb = new();
+            foreach (var token in filterdTokens)
+            {
+                sb.Append(token.Value);
+                sb.Append(token.HasSuffixSpace == true ? " " : "");
+            }
+            return sb.ToString();
+        }
+
+        
+        public override string ToString()
+        {
+            return ToString(false);
+        }
+
+        public override bool Equals(object obj)
+        {
+            if(obj is ReviewLine other)
+            {
+                return ToString() == other.ToString();
+            }
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return ToString().GetHashCode();
+        }
+
+        public string GetTokenNodeIdHash(string parentNodeIdHash, int lineIndex)
+        {
+            var idPart = LineId;
+            var token = Tokens.FirstOrDefault(t => t.RenderClasses.Count > 0);
+            if (token != null)
+            {
+                idPart = $"{idPart}-{token.RenderClasses.First()}";
+            }
+            idPart = $"{idPart}-{lineIndex}-{DiffKind}";
+            var hash = CreateHashFromString(idPart);
+            return hash + parentNodeIdHash.Replace("nId", "").Replace("root", ""); // Append the parent node Id to ensure uniqueness
+        }
+
+        private string CreateHashFromString(string inputString)
+        {
+            int hash = HashCode.Combine(inputString);
+            return "nId" + hash.ToString();
+        }
+    }
+}

--- a/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
@@ -47,7 +47,7 @@ namespace APIView.Model.V2
         /// <summary>
         /// Set this to false if there is no suffix space required before next token. For e.g, punctuation right after method name
         /// </summary>
-        public bool? HasSuffixSpace { get; set; }
+        public bool HasSuffixSpace { get; set; } = true;
 
         /// <summary>
         /// Set isDocumentation to true if current token is part of documentation

--- a/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
@@ -5,12 +5,13 @@
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
+using static System.Net.Mime.MediaTypeNames;
 
 namespace APIView.Model.V2
 {
-    /*** Token corresponds to each component within a code line. A separate token is required for keyword, 
-     * punctuation, type name, text etc. */
-
+    /// <summary>
+    /// Token corresponds to each component within a code line. A separate token is required for keyword, punctuation, type name, text etc.
+    /// </summary>
     public class ReviewToken
     {
         public ReviewToken() { }
@@ -21,21 +22,34 @@ namespace APIView.Model.V2
         }
         public TokenKind Kind { get; set; }
         public string Value { get; set; }
-        /*** NavigationDisplayName property is to add a short name for the token that will be displayed in the navigation object. */
+        /// <summary>
+        /// NavigationDisplayName property is to add a short name for the token that will be displayed in the navigation object.
+        /// </summary>
         public string NavigationDisplayName { get; set; }
-        /*** navigateToId should be set if the underlying token is required to be displayed as HREF to another type within the review.
-        * For e.g. a param type which is class name in the same package */
+        /// <summary>
+        /// navigateToId should be set if the underlying token is required to be displayed as HREF to another type within the review.
+        /// </summary>
         public string NavigateToId { get; set; }
-        /*** set skipDiff to true if underlying token needs to be ignored from diff calculation. For e.g. package metadata or dependency versions 
-        * are usually not required to be excluded when comparing two revisions to avoid reporting them as API changes*/
+        /// <summary>
+        /// set skipDiff to true if underlying token needs to be ignored from diff calculation. 
+        /// For e.g. package metadata or dependency versions are usually not required to be excluded when comparing two revisions to avoid reporting them as API changes
+        /// </summary>
         public bool? SkipDiff { get; set; }
-        /*** This is set if API is marked as deprecated */
+        /// <summary>
+        /// This is set if API is marked as deprecated
+        /// </summary>
         public bool? IsDeprecated { get; set; }
-        /*** Set this to false if there is no suffix space required before next token. For e.g, punctuation right after method name */
+        /// <summary>
+        /// Set this to false if there is no suffix space required before next token. For e.g, punctuation right after method name
+        /// </summary>
         public bool? HasSuffixSpace { get; set; }
-        /*** Set isDocumentation to true if current token is part of documentation */
+        /// <summary>
+        /// Set isDocumentation to true if current token is part of documentation
+        /// </summary>
         public bool? IsDocumentation { get; set; }
-        /*** Language specific style css class names */
+        /// <summary>
+        /// Language specific style css class names
+        /// </summary>
         public HashSet<string> RenderClasses { get; set; } = new HashSet<string>();
 
         public static ReviewToken CreateTextToken(string value, string navigateToId = null, bool hasSuffixSpace = true)

--- a/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 
+using System;
 using System.Collections.Generic;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using static System.Net.Mime.MediaTypeNames;
 
 namespace APIView.Model.V2
 {
@@ -57,7 +57,7 @@ namespace APIView.Model.V2
         /// <summary>
         /// Language specific style css class names
         /// </summary>
-        public HashSet<string> RenderClasses { get; set; } = new HashSet<string>();
+        public List<string> RenderClasses = [];
 
         public static ReviewToken CreateTextToken(string value, string navigateToId = null, bool hasSuffixSpace = true)
         {

--- a/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
@@ -22,31 +22,38 @@ namespace APIView.Model.V2
         }
         public TokenKind Kind { get; set; }
         public string Value { get; set; }
+
         /// <summary>
         /// NavigationDisplayName property is to add a short name for the token that will be displayed in the navigation object.
         /// </summary>
         public string NavigationDisplayName { get; set; }
+
         /// <summary>
         /// navigateToId should be set if the underlying token is required to be displayed as HREF to another type within the review.
         /// </summary>
         public string NavigateToId { get; set; }
+
         /// <summary>
         /// set skipDiff to true if underlying token needs to be ignored from diff calculation. 
         /// For e.g. package metadata or dependency versions are usually not required to be excluded when comparing two revisions to avoid reporting them as API changes
         /// </summary>
         public bool? SkipDiff { get; set; }
+
         /// <summary>
         /// This is set if API is marked as deprecated
         /// </summary>
         public bool? IsDeprecated { get; set; }
+
         /// <summary>
         /// Set this to false if there is no suffix space required before next token. For e.g, punctuation right after method name
         /// </summary>
         public bool? HasSuffixSpace { get; set; }
+
         /// <summary>
         /// Set isDocumentation to true if current token is part of documentation
         /// </summary>
         public bool? IsDocumentation { get; set; }
+
         /// <summary>
         /// Language specific style css class names
         /// </summary>

--- a/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
@@ -1,0 +1,117 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+namespace APIView.Model.V2
+{
+    /*** Token corresponds to each component within a code line. A separate token is required for keyword, 
+     * punctuation, type name, text etc. */
+
+    public class ReviewToken
+    {
+        public ReviewToken() { }
+        public ReviewToken(string value, TokenKind kind)
+        {
+            Value = value;
+            Kind = kind;
+        }
+        public TokenKind Kind { get; set; }
+        public string Value { get; set; }
+        /*** NavigationDisplayName property is to add a short name for the token that will be displayed in the navigation object. */
+        public string NavigationDisplayName { get; set; }
+        /*** navigateToId should be set if the underlying token is required to be displayed as HREF to another type within the review.
+        * For e.g. a param type which is class name in the same package */
+        public string NavigateToId { get; set; }
+        /*** set skipDiff to true if underlying token needs to be ignored from diff calculation. For e.g. package metadata or dependency versions 
+        * are usually not required to be excluded when comparing two revisions to avoid reporting them as API changes*/
+        public bool? SkipDiff { get; set; }
+        /*** This is set if API is marked as deprecated */
+        public bool? IsDeprecated { get; set; }
+        /*** Set this to false if there is no suffix space required before next token. For e.g, punctuation right after method name */
+        public bool? HasSuffixSpace { get; set; }
+        /*** Set isDocumentation to true if current token is part of documentation */
+        public bool? IsDocumentation { get; set; }
+        /*** Language specific style css class names */
+        public HashSet<string> RenderClasses { get; set; } = new HashSet<string>();
+
+        public static ReviewToken CreateTextToken(string value, string navigateToId = null, bool hasSuffixSpace = true)
+        {
+            var token = new ReviewToken(value, TokenKind.Text);
+            if (!string.IsNullOrEmpty(navigateToId))
+            {
+                token.NavigateToId = navigateToId;
+            }
+            token.HasSuffixSpace = hasSuffixSpace;
+            return token;
+        }
+
+        public static ReviewToken CreateKeywordToken(string value, bool hasSuffixSpace = true)
+        {
+            var token = new ReviewToken(value, TokenKind.Keyword);
+            token.HasSuffixSpace = hasSuffixSpace;
+            return token;
+        }
+
+        public static ReviewToken CreateKeywordToken(SyntaxKind syntaxKind, bool hasSuffixSpace = true)
+        {
+            return CreateKeywordToken(SyntaxFacts.GetText(syntaxKind), hasSuffixSpace);
+        }
+
+        public static ReviewToken CreateKeywordToken(Accessibility accessibility)
+        {
+            return CreateKeywordToken(SyntaxFacts.GetText(accessibility));
+        }
+
+        public static ReviewToken CreatePunctuationToken(string value, bool hasSuffixSpace = true)
+        {
+            var token = new ReviewToken(value, TokenKind.Punctuation);
+            token.HasSuffixSpace = hasSuffixSpace;
+            return token;
+        }
+
+        public static ReviewToken CreatePunctuationToken(SyntaxKind syntaxKind, bool hasSuffixSpace = true)
+        {
+            var token = CreatePunctuationToken(SyntaxFacts.GetText(syntaxKind), hasSuffixSpace);
+            return token;
+        }
+
+        public static ReviewToken CreateTypeNameToken(string value, bool hasSuffixSpace = true)
+        {
+            var token = new ReviewToken(value, TokenKind.TypeName);
+            token.HasSuffixSpace = hasSuffixSpace;
+            return token;
+        }
+
+        public static ReviewToken CreateMemberNameToken(string value, bool hasSuffixSpace = true)
+        {
+            var token = new ReviewToken(value, TokenKind.MemberName);
+            token.HasSuffixSpace = hasSuffixSpace;
+            return token;
+        }
+
+        public static ReviewToken CreateLiteralToken(string value, bool hasSuffixSpace = true)
+        {
+            var token = new ReviewToken(value, TokenKind.Literal);
+            token.HasSuffixSpace = hasSuffixSpace;
+            return token;
+        }
+
+        public static ReviewToken CreateStringLiteralToken(string value, bool hasSuffixSpace = true)
+        {
+            var token = new ReviewToken(value, TokenKind.StringLiteral);
+            token.HasSuffixSpace = hasSuffixSpace;
+            return token;
+        }
+
+        public static ReviewToken CreateCommentToken(string value, bool hasSuffixSpace = true)
+        {
+            var token = new ReviewToken(value, TokenKind.Comment);
+            token.HasSuffixSpace = hasSuffixSpace;
+            return token;
+        }
+    }
+}

--- a/src/dotnet/APIView/APIView/Model/V2/TokenKind.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/TokenKind.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace APIView.Model.V2
+{
+    public enum TokenKind
+    {
+        Text = 0,
+        Punctuation = 1,
+        Keyword = 2,
+        TypeName = 3,
+        MemberName = 4,
+        StringLiteral = 5,
+        Literal = 6,
+        Comment = 7
+    }
+}

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
@@ -14,6 +14,10 @@ using NuGet.Versioning;
 
 public static class Program
 {
+    // Regex parser nuget file name without extension to two groups
+    // package name and package version
+    // for e.g Azure.Core.1.0.0 to ["Azure.Core", "1.0.0"]
+    // or Azure.Storage.Blobs.12.0.0 to ["Azure.Storage.Blobs", "12.0.0"]
     private static Regex _packageNameParser = new Regex("([A-Za-z.]*[a-z]).([\\S]*)", RegexOptions.Compiled);
 
     public static int Main(string[] args)

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/Program.cs
@@ -75,7 +75,7 @@ public static class Program
                     Console.Error.WriteLine($"PackageFile {packageFilePath.FullName} contains no dll. Creating a meta package API review file.");
                     var codeFile = CreateDummyCodeFile(packageFilePath.FullName, $"Package {packageFilePath.Name} does not contain any dll to create API review.");
                     outputFileName = string.IsNullOrEmpty(outputFileName) ? nuspecEntry.Name : outputFileName;
-                    await CreateOutPutFile(OutputDirectory.FullName, outputFileName, codeFile);
+                    await CreateOutputFile(OutputDirectory.FullName, outputFileName, codeFile);
                     return;
                 }
 
@@ -128,13 +128,13 @@ public static class Program
                 Console.Error.WriteLine($"PackageFile {packageFilePath.FullName} contains no Assembly Symbol.");
                 var codeFile = CreateDummyCodeFile(packageFilePath.FullName, $"Package {packageFilePath.Name} does not contain any assembly symbol to create API review.");
                 outputFileName = string.IsNullOrEmpty(outputFileName) ? packageFilePath.Name : outputFileName;
-                await CreateOutPutFile(OutputDirectory.FullName, outputFileName, codeFile);
+                await CreateOutputFile(OutputDirectory.FullName, outputFileName, codeFile);
                 return;
             }
 
             var parsedFileName = string.IsNullOrEmpty(outputFileName) ? assemblySymbol.Name : outputFileName;
             var treeTokenCodeFile = new CSharpAPIParser.TreeToken.CodeFileBuilder().Build(assemblySymbol, runAnalysis, dependencies);
-            await CreateOutPutFile(OutputDirectory.FullName, parsedFileName, treeTokenCodeFile);
+            await CreateOutputFile(OutputDirectory.FullName, parsedFileName, treeTokenCodeFile);
         }
         catch (Exception ex)
         {
@@ -151,7 +151,7 @@ public static class Program
         }
     }
 
-    static async Task CreateOutPutFile(string outputPath, string outputFileNamePrefix, CodeFile apiViewFile)
+    static async Task CreateOutputFile(string outputPath, string outputFileNamePrefix, CodeFile apiViewFile)
     {
         var jsonTokenFilePath = Path.Combine(outputPath, $"{outputFileNamePrefix}.json");
         await using FileStream fileStream = new(jsonTokenFilePath, FileMode.Create, FileAccess.Write);

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -206,7 +206,7 @@ namespace CSharpAPIParser.TreeToken
                 nameSpaceToken.RenderClasses.Add("namespace");
                 nameSpaceToken.NavigationDisplayName = namespaceSymbol.ToDisplayString();
             }
-            namespaceLine.AddSuffixSpace();
+            namespaceLine.Tokens.Last().HasSuffixSpace = true;
             namespaceLine.Tokens.Add(ReviewToken.CreatePunctuationToken("{"));
 
             // Add each members in the namespace
@@ -311,7 +311,7 @@ namespace CSharpAPIParser.TreeToken
 
             if (namedType.TypeKind == TypeKind.Delegate)
             {
-                reviewLine.RemoveSuffixSpace();
+                reviewLine.Tokens.Last().HasSuffixSpace = false;
                 reviewLine.Tokens.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.SemicolonToken));
                 return;
             }
@@ -400,7 +400,7 @@ namespace CSharpAPIParser.TreeToken
                 reviewLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.ColonToken));
                 first = false;
                 DisplayName(reviewLine, namedType.BaseType);
-                reviewLine.AddSuffixSpace();
+                reviewLine.Tokens.Last().HasSuffixSpace = true;
             }
 
             foreach (var typeInterface in namedType.Interfaces)
@@ -409,7 +409,7 @@ namespace CSharpAPIParser.TreeToken
 
                 if (!first)
                 {
-                    reviewLine.RemoveSuffixSpace();
+                    reviewLine.Tokens.Last().HasSuffixSpace = false;
                     reviewLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.CommaToken));
                 }
                 else
@@ -418,7 +418,7 @@ namespace CSharpAPIParser.TreeToken
                     first = false;
                 }
                 DisplayName(reviewLine, typeInterface);
-                reviewLine.AddSuffixSpace();
+                reviewLine.Tokens.Last().HasSuffixSpace = true;
             }
         }
 
@@ -435,7 +435,7 @@ namespace CSharpAPIParser.TreeToken
             BuildAttributes(reviewLines, member.GetAttributes(), isHidden);
             reviewLines.Add(reviewLine);
             DisplayName(reviewLine, member);
-            reviewLine.RemoveSuffixSpace();
+            reviewLine.Tokens.Last().HasSuffixSpace = false;
 
             // Set member sub kind class for render class styling
             var memToken = reviewLine.Tokens.FirstOrDefault(m => m.Kind == TokenKind.MemberName);
@@ -569,7 +569,7 @@ namespace CSharpAPIParser.TreeToken
                 tokenList.Add(ReviewToken.CreateKeywordToken(SyntaxKind.TypeOfKeyword, false));
                 tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.OpenParenToken, false));
                 DisplayName(reviewLine, (ITypeSymbol)typedConstant.Value!);
-                reviewLine.RemoveSuffixSpace();
+                reviewLine.Tokens.Last().HasSuffixSpace = false;
                 tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.CloseParenToken, false));
             }
             else if (typedConstant.Kind == TypedConstantKind.Array)
@@ -593,7 +593,7 @@ namespace CSharpAPIParser.TreeToken
                     }
 
                     BuildTypedConstant(reviewLine, value);
-                    reviewLine.RemoveSuffixSpace();
+                    reviewLine.Tokens.Last().HasSuffixSpace = false;
                 }
                 tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.CloseBraceToken, false));
             }

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -230,8 +230,7 @@ namespace CSharpAPIParser.TreeToken
             if (!namespaceSymbol.ContainingNamespace.IsGlobalNamespace)
             {
                 BuildNamespaceName(namespaceLine, namespaceSymbol.ContainingNamespace);
-                var punctuation = ReviewToken.CreatePunctuationToken(".");
-                punctuation.HasSuffixSpace = false;
+                var punctuation = ReviewToken.CreatePunctuationToken(".", false);
                 namespaceLine.Tokens.Add(punctuation);
             }
             DisplayName(namespaceLine, namespaceSymbol, namespaceSymbol);
@@ -267,7 +266,6 @@ namespace CSharpAPIParser.TreeToken
             var reviewLine = new ReviewLine()
             {
                 LineId = namedType.GetId(),
-                Tokens = [],
                 IsHidden = isHidden
             };
 

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -12,7 +12,7 @@ using ApiView;
 
 namespace CSharpAPIParser.TreeToken
 {
-    internal class CodeFileBuilder
+    public class CodeFileBuilder
     {
         private static readonly char[] _newlineChars = new char[] { '\r', '\n' };
 

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -399,7 +399,7 @@ namespace CSharpAPIParser.TreeToken
             if (namedType.BaseType != null &&
                 namedType.BaseType.SpecialType == SpecialType.None)
             {
-                reviewLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.ColonToken));
+                reviewLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.ColonToken));
                 first = false;
                 DisplayName(reviewLine, namedType.BaseType);
                 reviewLine.AddSuffixSpace();
@@ -412,11 +412,11 @@ namespace CSharpAPIParser.TreeToken
                 if (!first)
                 {
                     reviewLine.RemoveSuffixSpace();
-                    reviewLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.CommaToken));
+                    reviewLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.CommaToken));
                 }
                 else
                 {
-                    reviewLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.ColonToken));
+                    reviewLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.ColonToken));
                     first = false;
                 }
                 DisplayName(reviewLine, typeInterface);
@@ -448,11 +448,11 @@ namespace CSharpAPIParser.TreeToken
 
             if (member.Kind == SymbolKind.Field && member.ContainingType.TypeKind == TypeKind.Enum)
             {
-                reviewLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.CommaToken));
+                reviewLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.CommaToken));
             }
             else if (member.Kind != SymbolKind.Property)
             {
-                reviewLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.SemicolonToken));
+                reviewLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.SemicolonToken));
             }
         }
 
@@ -479,26 +479,26 @@ namespace CSharpAPIParser.TreeToken
 
                     if (attribute.AttributeClass.DeclaredAccessibility == Accessibility.Internal || attribute.AttributeClass.DeclaredAccessibility == Accessibility.Friend)
                     {
-                        attributeLine.Add(ReviewToken.CreateKeywordToken("internal"));
+                        attributeLine.AddToken(ReviewToken.CreateKeywordToken("internal"));
                     }
 
-                    attributeLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.OpenBracketToken, false));
+                    attributeLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.OpenBracketToken, false));
                     var name = attribute.AttributeClass.Name;
                     if (name.EndsWith(attributeSuffix))
                     {
                         name = name.Substring(0, name.Length - attributeSuffix.Length);
                     }
-                    attributeLine.Add(ReviewToken.CreateTypeNameToken(name, false));
+                    attributeLine.AddToken(ReviewToken.CreateTypeNameToken(name, false));
                     if (attribute.ConstructorArguments.Any())
                     {
-                        attributeLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.OpenParenToken, false));
+                        attributeLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.OpenParenToken, false));
                         bool first = true;
 
                         foreach (var argument in attribute.ConstructorArguments)
                         {
                             if (!first)
                             {
-                                attributeLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.CommaToken));
+                                attributeLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.CommaToken));
                             }
                             else
                             {
@@ -511,19 +511,19 @@ namespace CSharpAPIParser.TreeToken
                         {
                             if (!first)
                             {
-                                attributeLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.CommaToken));
+                                attributeLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.CommaToken));
                             }
                             else
                             {
                                 first = false;
                             }
-                            attributeLine.Add(ReviewToken.CreateTextToken(argument.Key));
-                            attributeLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.EqualsToken));
+                            attributeLine.AddToken(ReviewToken.CreateTextToken(argument.Key));
+                            attributeLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.EqualsToken));
                             BuildTypedConstant(attributeLine, argument.Value);
                         }
-                        attributeLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.CloseParenToken));
+                        attributeLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.CloseParenToken));
                     }
-                    attributeLine.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.CloseBracketToken));
+                    attributeLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.CloseBracketToken));
                     //Add current attribute line to review lines
                     reviewLines.Add(attributeLine);
                 }

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -221,7 +221,8 @@ namespace CSharpAPIParser.TreeToken
                 Tokens = [
                     ReviewToken.CreateStringLiteralToken("}")
                 ],
-                IsHidden = isHidden
+                IsHidden = isHidden,
+                IsContextEndLine = true
             });
         }
 
@@ -345,7 +346,8 @@ namespace CSharpAPIParser.TreeToken
                 Tokens = [
                     ReviewToken.CreateStringLiteralToken("}")
                 ],
-                IsHidden = isHidden
+                IsHidden = isHidden,
+                IsContextEndLine = true
             });
         }
 

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CSharpAPIParserTests.csproj
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CSharpAPIParserTests.csproj
@@ -13,6 +13,7 @@
     <PackageReference Include="Azure.Template" Version="1.0.3-beta.4055065" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Newtonsoft.Json.Schema" Version="4.0.1" />
     <PackageReference Include="xunit" Version="2.5.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3" />
   </ItemGroup>

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CSharpAPIParserTests.csproj
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CSharpAPIParserTests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Template" Version="1.0.3-beta.4055065" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="xunit" Version="2.5.3" />

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CSharpAPIParserTests.csproj
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CSharpAPIParserTests.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Template" Version="1.0.3-beta.4055065" />
     <PackageReference Include="coverlet.collector" Version="6.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CodeFileTests.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CodeFileTests.cs
@@ -82,7 +82,27 @@ namespace Microsoft.Extensions.Azure {
         [Fact]
         public void TestCodeFileJsonSchema()
         {
-            var json = JsonSerializer.Serialize(codeFile, new JsonSerializerOptions {
+            //Verify JSON file generated for Azure.Template
+            var isValid = validateSchema(codeFile);
+            Assert.True(isValid);
+        }
+
+        [Fact]
+        public void TestCodeFileJsonSchema2()
+        {
+            //Verify JSON file generated for Azure.Storage.Blobs
+            var storageAssembly = Assembly.Load("Azure.Storage.Blobs");
+            var dllStream = storageAssembly.GetFile("Azure.Storage.Blobs.dll");
+            var assemblySymbol = CompilationFactory.GetCompilation(dllStream, null);
+            var storageCodeFile = new CSharpAPIParser.TreeToken.CodeFileBuilder().Build(assemblySymbol, true, null);
+            var isValid = validateSchema(storageCodeFile);
+            Assert.True(isValid);
+        }
+
+        private bool validateSchema(CodeFile codeFile)
+        {
+            var json = JsonSerializer.Serialize(codeFile, new JsonSerializerOptions
+            {
                 AllowTrailingCommas = true,
                 ReadCommentHandling = JsonCommentHandling.Skip,
                 DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull
@@ -104,7 +124,7 @@ namespace Microsoft.Extensions.Azure {
                     Console.WriteLine(error);
                 }
             }
-            Assert.True(isValid);
+            return isValid;
         }
     }
 }

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/PackageDetailsTests.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/PackageDetailsTests.cs
@@ -1,0 +1,75 @@
+using System.Reflection;
+using ApiView;
+
+namespace CSharpAPIParserTests
+{
+    public class PackageDetailsTests
+    {
+        private CodeFile codeFile;
+        public Assembly assembly { get; set; }
+
+        public PackageDetailsTests()
+        {
+            assembly = Assembly.Load("Azure.Template");
+            var dllStream = assembly.GetFile("Azure.Template.dll");
+            var assemblySymbol = CompilationFactory.GetCompilation(dllStream, null);
+            codeFile = new CSharpAPIParser.TreeToken.CodeFileBuilder().Build(assemblySymbol, true, null);
+        }
+
+        [Fact]
+        public void TestPackageName()
+        {
+            Assert.Equal("Azure.Template", codeFile.PackageName);
+        }
+
+        [Fact]
+        public void TestTopLevelReviewLineCount()
+        {
+            Assert.Equal(8, codeFile.ReviewLines.Count());
+        }
+
+        [Fact]
+        public void TestAPIReviewContent()
+        {
+            string expected = @"namespace Azure.Template { 
+    public class TemplateClient { 
+        public TemplateClient(string vaultBaseUrl, TokenCredential credential); 
+        public TemplateClient(string vaultBaseUrl, TokenCredential credential, TemplateClientOptions options); 
+        protected TemplateClient(); 
+        public virtual HttpPipeline Pipeline { get; }
+        public virtual Response GetSecret(string secretName, RequestContext context); 
+        public virtual Task<Response> GetSecretAsync(string secretName, RequestContext context); 
+        public virtual Response<SecretBundle> GetSecretValue(string secretName, CancellationToken cancellationToken = default); 
+        public virtual Task<Response<SecretBundle>> GetSecretValueAsync(string secretName, CancellationToken cancellationToken = default); 
+    } 
+
+    public class TemplateClientOptions : ClientOptions { 
+        public enum ServiceVersion { 
+            V7_0 = 1, 
+        } 
+        public TemplateClientOptions(ServiceVersion version = V7_0); 
+    } 
+} 
+
+namespace Azure.Template.Models { 
+    public class SecretBundle { 
+        public string ContentType { get; }
+        public string Id { get; }
+        public string Kid { get; }
+        public bool? Managed { get; }
+        public IReadOnlyDictionary<string, string> Tags { get; }
+        public string Value { get; }
+    } 
+} 
+
+namespace Microsoft.Extensions.Azure { 
+    public static class TemplateClientBuilderExtensions { 
+        public static IAzureClientBuilder<TemplateClient, TemplateClientOptions> AddTemplateClient<TBuilder>(this TBuilder builder, string vaultBaseUrl) where TBuilder : IAzureClientFactoryBuilderWithCredential; 
+        public static IAzureClientBuilder<TemplateClient, TemplateClientOptions> AddTemplateClient<TBuilder, TConfiguration>(this TBuilder builder, TConfiguration configuration) where TBuilder : IAzureClientFactoryBuilderWithConfiguration<TConfiguration>; 
+    } 
+} 
+";
+            Assert.Equal(expected, codeFile.GetApiText());
+        }
+    }
+}

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/ProgramTests.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/ProgramTests.cs
@@ -1,5 +1,3 @@
-using CSharpAPIParser;
-
 namespace CSharpAPIParserTests
 {
     public class ProgramTests

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/TestData.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/TestData.cs
@@ -1,0 +1,255 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace CSharpAPIParserTests
+{
+    internal class TestData
+    {
+        public static string TokenJsonSchema = @"{
+    ""$schema"": ""https://json-schema.org/draft/2020-12/schema"",
+    ""$id"": ""CodeFile.json"",
+    ""type"": ""object"",
+    ""properties"": {
+        ""PackageName"": {
+            ""type"": ""string""
+        },
+        ""PackageVersion"": {
+            ""type"": ""string""
+        },
+        ""ParserVersion"": {
+            ""type"": ""string"",
+            ""description"": ""version of the APIview language parser used to create token file""
+        },
+        ""Language"": {
+            ""anyOf"": [
+                {
+                    ""type"": ""string"",
+                    ""const"": ""C""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""C++""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""C#""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""Go""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""Java""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""JavaScript""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""Kotlin""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""Python""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""Swagger""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""Swift""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""TypeSpec""
+                }
+            ]
+        },
+        ""LanguageVariant"": {
+            ""anyOf"": [
+                {
+                    ""type"": ""string"",
+                    ""const"": ""None""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""Spring""
+                },
+                {
+                    ""type"": ""string"",
+                    ""const"": ""Android""
+                }
+            ],
+            ""default"": ""None"",
+            ""description"": ""Language variant is applicable only for java variants""
+        },
+        ""CrossLanguagePackageId"": {
+            ""type"": ""string""
+        },
+        ""ReviewLines"": {
+            ""type"": ""array"",
+            ""items"": {
+                ""$ref"": ""#/$defs/ReviewLine""
+            }
+        },
+        ""Diagnostics"": {
+            ""type"": ""array"",
+            ""items"": {
+                ""$ref"": ""#/$defs/CodeDiagnostic""
+            },
+            ""description"": ""Add any system generated comments. Each comment is linked to review line ID""
+        }
+    },
+    ""required"": [
+        ""PackageName"",
+        ""PackageVersion"",
+        ""ParserVersion"",
+        ""Language"",
+        ""ReviewLines""
+    ],
+    ""description"": ""ReviewFile represents entire API review object. This will be processed to render review lines."",
+    ""$defs"": {
+        ""ReviewLine"": {
+            ""type"": ""object"",
+            ""properties"": {
+                ""LineId"": {
+                    ""type"": ""string"",
+                    ""description"": ""lineId is only required if we need to support commenting on a line that contains this token. \nUsually code line for documentation or just punctuation is not required to have lineId. lineId should be a unique value within \nthe review token file to use it assign to review comments as well as navigation Id within the review page.\nfor e.g Azure.Core.HttpHeader.Common, azure.template.template_main""
+                },
+                ""CrossLanguageId"": {
+                    ""type"": ""string""
+                },
+                ""Tokens"": {
+                    ""type"": ""array"",
+                    ""items"": {
+                        ""$ref"": ""#/$defs/ReviewToken""
+                    },
+                    ""description"": ""list of tokens that constructs a line in API review""
+                },
+                ""Children"": {
+                    ""type"": ""array"",
+                    ""items"": {
+                        ""$ref"": ""#/$defs/ReviewLine""
+                    },
+                    ""description"": ""Add any child lines as children. For e.g. all classes and namespace level methods are added as a children of namespace(module) level code line. \nSimilarly all method level code lines are added as children of it's class code line.""
+                },
+                ""IsHidden"": {
+                    ""type"": ""boolean"",
+                    ""description"": ""Set current line as hidden code line by default. .NET has hidden APIs and architects does not want to see them by default.""
+                }
+            },
+            ""required"": [
+                ""Tokens""
+            ],
+            ""description"": ""ReviewLine object corresponds to each line displayed on API review. If an empty line is required then add a code line object without any token.""
+        },
+        ""CodeDiagnostic"": {
+            ""type"": ""object"",
+            ""properties"": {
+                ""DiagnosticId"": {
+                    ""type"": ""string""
+                },
+                ""TargetId"": {
+                    ""type"": ""string"",
+                    ""description"": ""Id of ReviewLine object where this diagnostic needs to be displayed(Options""
+                },
+                ""Text"": {
+                    ""type"": ""string""
+                },
+                ""Level"": {
+                    ""$ref"": ""#/$defs/CodeDiagnosticLevel""
+                },
+                ""HelpLinkUri"": {
+                    ""type"": ""string""
+                }
+            },
+            ""required"": [
+                ""TargetId"",
+                ""Text"",
+                ""Level""
+            ],
+            ""description"": ""System comment object is to add system generated comment. It can be one of the 4 different types of system comments.""
+        },
+        ""ReviewToken"": {
+            ""type"": ""object"",
+            ""properties"": {
+                ""Kind"": {
+                    ""$ref"": ""#/$defs/TokenKind""
+                },
+                ""Value"": {
+                    ""type"": ""string""
+                },
+                ""NavigationDisplayName"": {
+                    ""type"": ""string"",
+                    ""description"": ""NavigationDisplayName can be used set navigation dispaly name to be used in navigation tree.\nThis value will be used in the navigation if NavigationDisplayName is not set.""
+                },
+                ""NavigateToId"": {
+                    ""type"": ""string"",
+                    ""description"": ""navigateToId should be set if the underlying token is required to be displayed as HREF to another type within the review.\nFor e.g. a param type which is class name in the same package""
+                },
+                ""SkipDiff"": {
+                    ""type"": ""boolean"",
+                    ""default"": false,
+                    ""description"": ""set skipDiff to true if underlying token needs to be ignored from diff calculation. For e.g. package metadata or dependency versions \nare usually excluded when comparing two revisions to avoid reporting them as API changes""
+                },
+                ""IsDeprecated"": {
+                    ""type"": ""boolean"",
+                    ""default"": false,
+                    ""description"": ""This is set if API is marked as deprecated""
+                },
+                ""HasSuffixSpace"": {
+                    ""type"": ""boolean"",
+                    ""default"": true,
+                    ""description"": ""Set this to false if there is no suffix space required before next token. For e.g, punctuation right after method name""
+                },
+                ""IsDocumentation"": {
+                    ""type"": ""boolean"",
+                    ""default"": false,
+                    ""description"": ""Set isDocumentation to true if current token is part of documentation""
+                },
+                ""RenderClasses"": {
+                    ""type"": ""array"",
+                    ""items"": {
+                        ""type"": ""string""
+                    },
+                    ""description"": ""Language specific style css class names""
+                }
+            },
+            ""required"": [
+                ""Kind"",
+                ""Value""
+            ],
+            ""description"": ""Token corresponds to each component within a code line. A separate token is required for keyword, punctuation, type name, text etc.""
+        },
+        ""CodeDiagnosticLevel"": {
+            ""type"": ""number"",
+            ""enum"": [
+                1,
+                2,
+                3,
+                4
+            ]
+        },
+        ""TokenKind"": {
+            ""type"": ""number"",
+            ""enum"": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7
+            ]
+        }
+    }
+}";
+    }
+}


### PR DESCRIPTION
This PR is to modify .NET API review parser to create tokens based on new schema that's outlined in the PR https://github.com/Azure/azure-sdk-tools/pull/8816

Goal is to simplify token schema structure. Above PR also has sample token JSON file created as per the schema.

PR for changes to token models: https://github.com/Azure/azure-sdk-tools/pull/8852
