### PR TITLE
Fix apiviewgo download paths

### DIFF
--- a/src/go/cmd/download.go
+++ b/src/go/cmd/download.go
@@ -139,13 +139,14 @@ func mustEscape(modPath string) string {
 // downloadDir creates a directory to store downloaded module zips and source.
 // Callers are responsible for removing the directory when they're done with it.
 func downloadDir() (string, error) {
-	root, err := os.UserHomeDir()
+	root := os.TempDir()
+	err := os.MkdirAll(root, 0700)
 	if err != nil {
-		root = os.TempDir()
+		return "", fmt.Errorf("failed to create root directory %q for downloads: %w", root, err)
 	}
 	d, err := os.MkdirTemp(root, "apiviewgo")
 	if err != nil {
-		err = fmt.Errorf("failed to create download directory: %w", err)
+		err = fmt.Errorf("failed to create download directory %q: %w", d, err)
 	}
 	return d, err
 }

--- a/src/go/cmd/module.go
+++ b/src/go/cmd/module.go
@@ -89,7 +89,7 @@ func NewModule(dir string) (*Module, error) {
 					return filepath.SkipDir
 				}
 			}
-			p, err := NewPkg(path, m.ModFile.Module.Mod.Path)
+			p, err := NewPkg(path, m.ModFile.Module.Mod.Path, dir)
 			if err == nil {
 				m.Packages[baseImportPath+p.Name()] = p
 			} else if !errors.Is(err, ErrNoPackages) {

--- a/src/go/cmd/pkg.go
+++ b/src/go/cmd/pkg.go
@@ -51,8 +51,11 @@ type Pkg struct {
 }
 
 // NewPkg loads the package in the specified directory.
-// It's required there is only one package in the directory.
-func NewPkg(dir, modulePath string) (*Pkg, error) {
+//
+//   - dir is the directory containing the package
+//   - modulePath is the import path of the module containing the package
+//   - moduleRoot is the root directory of the module on disk i.e., the directory containing its go.mod
+func NewPkg(dir, modulePath, moduleRoot string) (*Pkg, error) {
 	pk := &Pkg{
 		modulePath:  modulePath,
 		c:           newContent(),
@@ -61,12 +64,8 @@ func NewPkg(dir, modulePath string) (*Pkg, error) {
 	}
 	modulePathWithoutVersion := strings.TrimSuffix(versionReg.ReplaceAllString(modulePath, "/"), "/")
 	moduleName := filepath.Base(modulePathWithoutVersion)
-	if _, after, found := strings.Cut(dir, moduleName); found {
-		pk.relName = moduleName
-		if after != "" && after[0] != '@' {
-			pk.relName += after
-		}
-		pk.relName = strings.ReplaceAll(pk.relName, "\\", "/")
+	if _, after, found := strings.Cut(dir, moduleRoot); found {
+		pk.relName = strings.ReplaceAll(moduleName+after, "\\", "/")
 	} else {
 		return nil, errors.New(dir + " isn't part of module " + moduleName)
 	}

--- a/src/go/cmd/pkg_test.go
+++ b/src/go/cmd/pkg_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package cmd
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestName(t *testing.T) {
+	for _, test := range []struct {
+		modulePath, moduleRoot, pkgPath, want string
+	}{
+		{
+			modulePath: "test_package_name",
+			moduleRoot: "testdata/test_package_name/test_package_name@v1.0.0",
+			want:       "test_package_name",
+		},
+		{
+			modulePath: "test_package_name",
+			moduleRoot: "testdata/test_package_name/test_package_name@v1.0.0",
+			pkgPath:    "subpackage",
+			want:       "test_package_name/subpackage",
+		},
+		{
+			modulePath: "test_subpackage",
+			moduleRoot: "testdata/test_subpackage",
+			want:       "test_subpackage",
+		},
+		{
+			modulePath: "test_subpackage",
+			moduleRoot: "testdata/test_subpackage",
+			pkgPath:    "subpackage",
+			want:       "test_subpackage/subpackage",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			d, err := filepath.Abs(test.moduleRoot)
+			require.NoError(t, err)
+			p, err := NewPkg(filepath.Join(d, test.pkgPath), test.modulePath, d)
+			require.NoError(t, err)
+			require.Equal(t, test.want, p.Name())
+		})
+	}
+}

--- a/src/go/cmd/testdata/test_package_name/test_package_name@v1.0.0/go.mod
+++ b/src/go/cmd/testdata/test_package_name/test_package_name@v1.0.0/go.mod
@@ -1,0 +1,3 @@
+module test_package_name
+
+go 1.18

--- a/src/go/cmd/testdata/test_package_name/test_package_name@v1.0.0/subpackage/test.go
+++ b/src/go/cmd/testdata/test_package_name/test_package_name@v1.0.0/subpackage/test.go
@@ -1,0 +1,3 @@
+package subpackage
+
+type S string

--- a/src/go/cmd/testdata/test_package_name/test_package_name@v1.0.0/test.go
+++ b/src/go/cmd/testdata/test_package_name/test_package_name@v1.0.0/test.go
@@ -1,0 +1,3 @@
+package test_package_name
+
+type S string


### PR DESCRIPTION
This fixes a couple problems causing `apiviewgo` to fail when run by APIView:
- `os.UserHomeDir` returns an unwriteable path on APIView's production VMs. Fixed this by instead (trying to) write to `os.TempDir` (%TMPDIR% is writeable on those VMs)
- Code for computing a package's name relative to its module (e.g. "azcore/log") assumed the module name appears exactly once in the module's disk path and that the disk path includes the module path verbatim. Neither assumption holds true for downloaded code, and in general disk and module paths are unrelated. Fixed this by making module and disk path separate parameters of `NewPkg()` (this is much simpler than having `NewPkg()` figure out the difference)