### PR TITLE
Compare json object values instead of byte streams when matching bodies that are content-type `json`

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/SanitizerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/SanitizerTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/SanitizerTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/SanitizerTests.cs
@@ -689,8 +689,10 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             Assert.Equal(0, matcher.CompareHeaderDictionaries(targetUntouchedEntry.Request.Headers, targetEntry.Request.Headers, new HashSet<string>(), new HashSet<string>()));
             Assert.Equal(0, matcher.CompareHeaderDictionaries(targetUntouchedEntry.Response.Headers, targetEntry.Response.Headers, new HashSet<string>(), new HashSet<string>()));
-            Assert.Equal(0, matcher.CompareBodies(targetUntouchedEntry.Request.Body, targetEntry.Request.Body));
-            Assert.Equal(0, matcher.CompareBodies(targetUntouchedEntry.Response.Body, targetEntry.Response.Body));
+            
+            targetUntouchedEntry.Request.TryGetContentType(out var contentType);
+            Assert.Equal(0, matcher.CompareBodies(targetUntouchedEntry.Request.Body, targetEntry.Request.Body, contentType));
+            Assert.Equal(0, matcher.CompareBodies(targetUntouchedEntry.Response.Body, targetEntry.Response.Body, contentType));
             Assert.Equal(targetUntouchedEntry.RequestUri, targetEntry.RequestUri);
         }
 
@@ -769,8 +771,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             await session.Session.Sanitize(sanitizer);
 
             var resultBodyValue = Encoding.UTF8.GetString(targetEntry.Request.Body);
-            Assert.Equal(0, matcher.CompareBodies(targetUntouchedEntry.Request.Body, targetEntry.Request.Body));
-            Assert.Equal(0, matcher.CompareBodies(targetUntouchedEntry.Response.Body, targetEntry.Response.Body));
+            targetUntouchedEntry.Request.TryGetContentType(out var contentType);
+            Assert.Equal(0, matcher.CompareBodies(targetUntouchedEntry.Request.Body, targetEntry.Request.Body, contentType));
+            Assert.Equal(0, matcher.CompareBodies(targetUntouchedEntry.Response.Body, targetEntry.Response.Body, contentType));
         }
 
         [Fact]

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/JsonComparer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/JsonComparer.cs
@@ -93,12 +93,39 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
                         break;
                     }
+                case JsonValueKind.String:
+                    {
+                        if (element1.GetString() != element2.GetString())
+                        {
+                            differences.Add($"{path}: \"{element1.GetString()}\" != \"{element2.GetString()}\"");
+                        }
+                        break;
+                    }
+                case JsonValueKind.Number:
+                    {
+                        if (element1.GetDecimal() != element2.GetDecimal())
+                        {
+                            differences.Add($"{path}: {element1.GetDecimal()} != {element2.GetDecimal()}");
+                        }
+                        break;
+                    }
+                case JsonValueKind.True:
+                case JsonValueKind.False:
+                    {
+                        if (element1.GetBoolean() != element2.GetBoolean())
+                        {
+                            differences.Add($"{path}: {element1.GetBoolean()} != {element2.GetBoolean()}");
+                        }
+                        break;
+                    }
+                case JsonValueKind.Null:
+                    {
+                        // Both are null, nothing to compare
+                        break;
+                    }
                 default:
                     {
-                        if (!element1.Equals(element2))
-                        {
-                            differences.Add($"{path}: {element1} != {element2}");
-                        }
+                        differences.Add($"{path}: Unhandled value kind {element1.ValueKind}");
                         break;
                     }
             }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/JsonComparer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/JsonComparer.cs
@@ -1,0 +1,107 @@
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace Azure.Sdk.Tools.TestProxy.Common
+{
+    public class JsonComparer
+    {
+        public static List<string> CompareJson(byte[] json1, byte[] json2)
+        {
+            // Deserialize the byte arrays to JsonDocument
+            JsonDocument doc1 = JsonDocument.Parse(json1);
+            JsonDocument doc2 = JsonDocument.Parse(json2);
+
+            // Compare the JSON objects
+            var differences = new List<string>();
+            CompareElements(doc1.RootElement, doc2.RootElement, differences, "");
+
+            return differences;
+        }
+
+        private static void CompareElements(JsonElement element1, JsonElement element2, List<string> differences, string path)
+        {
+            if (element1.ValueKind != element2.ValueKind)
+            {
+                differences.Add($"{path}: Request and record have different types.");
+                return;
+            }
+
+            switch (element1.ValueKind)
+            {
+                case JsonValueKind.Object:
+                    {
+                        var properties1 = element1.EnumerateObject();
+                        var properties2 = element2.EnumerateObject();
+
+                        var propDict1 = new Dictionary<string, JsonElement>();
+                        var propDict2 = new Dictionary<string, JsonElement>();
+
+                        foreach (var prop in properties1)
+                            propDict1[prop.Name] = prop.Value;
+
+                        foreach (var prop in properties2)
+                            propDict2[prop.Name] = prop.Value;
+
+                        foreach (var key in propDict1.Keys)
+                        {
+                            if (propDict2.ContainsKey(key))
+                            {
+                                CompareElements(propDict1[key], propDict2[key], differences, $"{path}.{key}");
+                            }
+                            else
+                            {
+                                differences.Add($"{path}.{key}: Missing in request JSON");
+                            }
+                        }
+
+                        foreach (var key in propDict2.Keys)
+                        {
+                            if (!propDict1.ContainsKey(key))
+                            {
+                                differences.Add($"{path}.{key}: Missing in record JSON");
+                            }
+                        }
+
+                        break;
+                    }
+                case JsonValueKind.Array:
+                    {
+                        var array1 = element1.EnumerateArray();
+                        var array2 = element2.EnumerateArray();
+
+                        int index = 0;
+                        var enum1 = array1.GetEnumerator();
+                        var enum2 = array2.GetEnumerator();
+
+                        while (enum1.MoveNext() && enum2.MoveNext())
+                        {
+                            CompareElements(enum1.Current, enum2.Current, differences, $"{path}[{index}]");
+                            index++;
+                        }
+
+                        while (enum1.MoveNext())
+                        {
+                            differences.Add($"{path}[{index}]: Extra element in request JSON");
+                            index++;
+                        }
+
+                        while (enum2.MoveNext())
+                        {
+                            differences.Add($"{path}[{index}]: Extra element in record JSON");
+                            index++;
+                        }
+
+                        break;
+                    }
+                default:
+                    {
+                        if (!element1.Equals(element2))
+                        {
+                            differences.Add($"{path}: {element1} != {element2}");
+                        }
+                        break;
+                    }
+            }
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/JsonComparer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/JsonComparer.cs
@@ -1,4 +1,7 @@
+using System;
 using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
 using System.Text.Json;
 
 namespace Azure.Sdk.Tools.TestProxy.Common
@@ -7,12 +10,32 @@ namespace Azure.Sdk.Tools.TestProxy.Common
     {
         public static List<string> CompareJson(byte[] json1, byte[] json2)
         {
-            // Deserialize the byte arrays to JsonDocument
-            JsonDocument doc1 = JsonDocument.Parse(json1);
-            JsonDocument doc2 = JsonDocument.Parse(json2);
-
-            // Compare the JSON objects
             var differences = new List<string>();
+            JsonDocument doc1;
+            JsonDocument doc2;
+
+            // Deserialize the byte arrays to JsonDocument
+            try
+            {
+                doc1 = JsonDocument.Parse(json1);
+            }
+            catch(Exception ex)
+            {
+                differences.Add($"Unable to parse the request json body. Content \"{Encoding.UTF8.GetString(json1)}.\" Exception: {ex.Message}");
+                return differences;
+            }
+
+            try
+            {
+                doc2 = JsonDocument.Parse(json2);
+            }
+            
+            catch (Exception ex)
+            {
+                differences.Add($"Unable to parse the record json body. Content \"{Encoding.UTF8.GetString(json2)}.\" Exception: {ex.Message}");
+                return differences;
+            }
+
             CompareElements(doc1.RootElement, doc2.RootElement, differences, "");
 
             return differences;

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -273,7 +273,8 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
             builder.AppendLine("Body differences:");
 
-            CompareBodies(request.Request.Body, bestScoreEntry.Request.Body, builder);
+            request.Request.TryGetContentType(out var contentType);
+            CompareBodies(request.Request.Body, bestScoreEntry.Request.Body, contentType, descriptionBuilder: builder);
 
             return builder.ToString();
         }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -6,7 +6,6 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
-using System.Net.Mime;
 using System.Text;
 using System.Web;
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
@@ -103,6 +103,9 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 sanitizer.Sanitize(requestEntry);
             }
 
+            // normalize request body with STJ using relaxed escaping to match behavior when Deserializing from session files
+            RecordEntry.NormalizeJsonBody(requestEntry.Request);
+
             RecordEntry entry = matcher.FindMatch(requestEntry, Entries);
             if (remove)
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordSession.cs
@@ -102,9 +102,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             {
                 sanitizer.Sanitize(requestEntry);
             }
-            // normalize request body with STJ using relaxed escaping to match behavior when Deserializing from session files
-            RecordEntry.NormalizeJsonBody(requestEntry.Request);
-
 
             RecordEntry entry = matcher.FindMatch(requestEntry, Entries);
             if (remove)


### PR DESCRIPTION
Resolves #3171