### PR TITLE
feat(pylint): Add httpx as a blocked networking import

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release History
 
+## 0.5.0 (unreleased)
+
+- Feature: Add `httpx` as an import flagged by C4749(networking-import-outside-azure-core-transport)
+
 ## 0.4.1 (2024-04-17)
 
 - Bug fix for typing under TYPE_CHECKING block.

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -2376,7 +2376,7 @@ class NonCoreNetworkImport(BaseChecker):
             "This import is only allowed in azure.core.pipeline.transport.",
         ),
     }
-    BLOCKED_MODULES = ["aiohttp", "requests", "trio"]
+    BLOCKED_MODULES = ["aiohttp", "requests", "trio", "httpx"]
     AZURE_CORE_TRANSPORT_NAME = "azure.core.pipeline.transport"
 
     def visit_import(self, node):

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -4052,18 +4052,31 @@ class TestCheckNonCoreNetworkImport(pylint.testutils.CheckerTestCase):
     def test_disallowed_imports(self):
         """Check that illegal imports raise warnings"""
         # Blocked import ouside of core.
-        import_node = astroid.extract_node("import requests")
+        requests_import_node = astroid.extract_node("import requests")
         with self.assertAddsMessages(
             pylint.testutils.MessageTest(
                 msg_id="networking-import-outside-azure-core-transport",
                 line=1,
-                node=import_node,
+                node=requests_import_node,
                 col_offset=0,
                 end_line=1,
                 end_col_offset=15,
             )
         ):
-            self.checker.visit_import(import_node)
+            self.checker.visit_import(requests_import_node)
+
+        httpx_import_node = astroid.extract_node("import httpx")
+        with self.assertAddsMessages(
+            pylint.testutils.MessageTest(
+                msg_id="networking-import-outside-azure-core-transport",
+                line=1,
+                node=httpx_import_node,
+                col_offset=0,
+                end_line=1,
+                end_col_offset=12,
+            )
+        ):
+            self.checker.visit_import(httpx_import_node)
 
         # blocked import from outside of core.
         importfrom_node = astroid.extract_node("from aiohttp import get")


### PR DESCRIPTION
# Description

This pull request extends code `C4749` of `azure-pylint-guidelines-checker` to also disallow imports of the [`httpx`](https://pypi.org/project/httpx/) package, "a fully featured HTTP client library for Python 3".

This change should have **no** impact on any SDK currently in the azure-sdk-for-python (as of commit [99bfd773](https://github.com/Azure/azure-sdk-for-python/tree/99bfd773d83b7e4d3155781ac432e3bc1c2d9fb8)), since no SDK directly imports `httpx`.


# Background

My team is currently working on adding a new SDK to azure-sdk-for-python, and I noticed that `C4749` wasn't flagging our use of `httpx` that would need to be changed per the Azure SDK guidelines around networking imports.


cc: @l0lawrence 