### PR TITLE
Avoid code file caching when for new tree style code files

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
@@ -137,8 +137,7 @@ namespace APIViewWeb.LeanControllers
             if (activeAPIRevision.Files[0].ParserStyle == ParserStyle.Tree)
             {
                 var comments = await _commentsManager.GetCommentsAsync(reviewId);
-                var cachedCodeFile = await _codeFileRepository.GetCodeFileAsync(revisionId: activeAPIRevision.Id, codeFileId: activeAPIRevision.Files[0].FileId);
-                var activeRevisionReviewCodeFile = cachedCodeFile.CodeFile;
+                var activeRevisionReviewCodeFile = await _codeFileRepository.GetCodeFileFromStorageAsync(revisionId: activeAPIRevision.Id, codeFileId: activeAPIRevision.Files[0].FileId);
 
                 var codePanelRawData = new CodePanelRawData()
                 {
@@ -149,8 +148,7 @@ namespace APIViewWeb.LeanControllers
                 if (!string.IsNullOrEmpty(diffApiRevisionId))
                 {
                     var diffAPIRevision = await _apiRevisionsManager.GetAPIRevisionAsync(User, diffApiRevisionId);
-                    var diffCodeFile = await _codeFileRepository.GetCodeFileAsync(revisionId: diffAPIRevision.Id, codeFileId: diffAPIRevision.Files[0].FileId);
-                    codePanelRawData.diffRevisionCodeFile = diffCodeFile.CodeFile;
+                    codePanelRawData.diffRevisionCodeFile = await _codeFileRepository.GetCodeFileFromStorageAsync(revisionId: diffAPIRevision.Id, codeFileId: diffAPIRevision.Files[0].FileId);
                 }
 
                 // Render the code files to generate UI token tree

--- a/src/dotnet/APIView/APIViewWeb/Repositories/Interfaces/IBlobCodeFileRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/Interfaces/IBlobCodeFileRepository.cs
@@ -9,8 +9,8 @@ namespace APIViewWeb.Repositories
     {
         public Task<RenderedCodeFile> GetCodeFileAsync(APIRevisionListItemModel revision, bool updateCache = true);
         public Task<RenderedCodeFile> GetCodeFileAsync(string revisionId, APICodeFileModel apiCodeFile, string language, bool updateCache = true);
-        public Task<RenderedCodeFile> GetCodeFileAsync(string revisionId, string codeFileId, bool updateCache = true, bool doTreeStyleParserDeserialization = true);
         public Task UpsertCodeFileAsync(string revisionId, string codeFileId, CodeFile codeFile);
         public Task DeleteCodeFileAsync(string revisionId, string codeFileId);
+        public Task<CodeFile> GetCodeFileFromStorageAsync(string revisionId, string codeFileId, bool doTreeStyleParserDeserialization = true);
     }
 }


### PR DESCRIPTION
Code file object is cached that gets altered when rendering the diff. We cannot use the cache as it is when code file is using tree style parser. This issue was already fixed in the production by my recent change broke this due to added caching. Removing the caching logic to resolve processing corrupted code files.