### PR TITLE
Skip documentation node id remapping if node is not changed

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Helpers/CodeFileHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/CodeFileHelpers.cs
@@ -509,7 +509,7 @@ namespace APIViewWeb.Helpers
                 line.DiffKind = diffKind;
                 var newHashId = line.GetTokenNodeIdHash(newParentId, idx);
 
-                if (documentationRowMap.ContainsKey(oldHashId))
+                if (documentationRowMap.ContainsKey(oldHashId) && !newHashId.Equals(oldHashId))
                 {
                     documentationRowMap[newHashId] = documentationRowMap[oldHashId];
                     documentationRowMap.Remove(oldHashId);


### PR DESCRIPTION
Doc nodes are removed incorrectly from collected document map when remapping node id hashed for documents lines in diff view. We don't need to update the map if old and new hash ids are same. This bug was incorrectly removing entries from map.