### PR TITLE
Include RenderClasses in serialized JSON code file

### DIFF
--- a/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
+++ b/src/dotnet/APIView/APIView/Model/V2/ReviewToken.cs
@@ -57,7 +57,7 @@ namespace APIView.Model.V2
         /// <summary>
         /// Language specific style css class names
         /// </summary>
-        public List<string> RenderClasses = [];
+        public List<string> RenderClasses { get; set; } = [];
 
         public static ReviewToken CreateTextToken(string value, string navigateToId = null, bool hasSuffixSpace = true)
         {

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CodeFileTests.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CodeFileTests.cs
@@ -6,6 +6,7 @@ using System.Text.Json.Nodes;
 using Newtonsoft.Json.Schema;
 using Newtonsoft.Json.Linq;
 using System.Text.Json.Serialization;
+using APIView.Model.V2;
 
 
 namespace CSharpAPIParserTests
@@ -125,6 +126,26 @@ namespace Microsoft.Extensions.Azure {
                 }
             }
             return isValid;
+        }
+
+        [Fact]
+        public void TestNavigatonNodeHasRenderingClass()
+        {
+            var jsonString = JsonSerializer.Serialize(codeFile);
+            var parsedCodeFile = JsonSerializer.Deserialize<CodeFile>(jsonString);
+            Assert.Equal(8, CountNavigationNodes(parsedCodeFile.ReviewLines));
+        }
+
+        private int  CountNavigationNodes(List<ReviewLine> lines)
+        {
+            int count = 0;
+            foreach (var line in lines)
+            {
+                var navTokens = line.Tokens.Where(x=> x.NavigationDisplayName != null);
+                count += navTokens.Count(x => x.RenderClasses.Any());
+                count += CountNavigationNodes(line.Children);
+            }
+            return count;
         }
     }
 }


### PR DESCRIPTION
RenderClasses were not included in serialized code file due to missing get and set. PR also has the added test case to verify render class is set for all navigation nodes.