### PR TITLE
Apiview revision upgradability to new parser version test

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/ReviewBackgroundHostedService.cs
@@ -61,7 +61,7 @@ namespace APIViewWeb.HostedServices
             {
                 try
                 {
-                    await _reviewManager.UpdateReviewsInBackground(_upgradeDisabledLangs, _backgroundBatchProcessCount);
+                    await _reviewManager.UpdateReviewsInBackground(_upgradeDisabledLangs, _backgroundBatchProcessCount, false);
                     await ArchiveInactiveAPIReviews(stoppingToken, _autoArchiveInactiveGracePeriodMonths);
                 }
                 catch (Exception ex)

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -711,8 +711,9 @@ namespace APIViewWeb.Managers
         /// </summary>
         /// <param name="revision"></param>
         /// <param name="languageService"></param>
+        /// <param name="verifyUpgradabilityOnly"> </param>
         /// <returns></returns>
-        public async Task UpdateAPIRevisionAsync(APIRevisionListItemModel revision, LanguageService languageService)
+        public async Task UpdateAPIRevisionAsync(APIRevisionListItemModel revision, LanguageService languageService, bool verifyUpgradabilityOnly)
         {
             foreach (var file in revision.Files)
             {

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -772,7 +772,7 @@ namespace APIViewWeb.Managers
         public async Task AutoArchiveAPIRevisions(int archiveAfterMonths)
         {
             var lastUpdatedDate = DateTime.Now.Subtract(TimeSpan.FromDays(archiveAfterMonths * 30));
-            var manualRevisions = await _apiRevisionsRepository.GetAPIRevisionsAsync(lastUpdatedOn: lastUpdatedDate, apiRevisionType:  APIRevisionType.PullRequest);
+            var manualRevisions = await _apiRevisionsRepository.GetAPIRevisionsAsync(lastUpdatedOn: lastUpdatedDate, apiRevisionType:  APIRevisionType.Manual);
 
             // Find all inactive reviews
             foreach (var apiRevision in manualRevisions)

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -38,7 +38,7 @@ namespace APIViewWeb.Managers.Interfaces
         public TreeNode<InlineDiffLine<CodeLine>> ComputeSectionDiff(TreeNode<CodeLine> before, TreeNode<CodeLine> after, RenderedCodeFile beforeFile, RenderedCodeFile afterFile);
         public Task<APIRevisionListItemModel> CreateAPIRevisionAsync(string userName, string reviewId, APIRevisionType apiRevisionType, string label,
             MemoryStream memoryStream, CodeFile codeFile, string originalName = null, int? prNumber = null);
-        public Task UpdateAPIRevisionAsync(APIRevisionListItemModel revision, LanguageService languageService);
+        public Task UpdateAPIRevisionAsync(APIRevisionListItemModel revision, LanguageService languageService, bool verifyUpgradabilityOnly);
         public Task UpdateAPIRevisionAsync(APIRevisionListItemModel revision);
         public Task AutoArchiveAPIRevisions(int archiveAfterMonths);
         public Task AssignReviewersToAPIRevisionAsync(ClaimsPrincipal User, string apiRevisionId, HashSet<string> reviewers);

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IReviewManager.cs
@@ -25,6 +25,6 @@ namespace APIViewWeb.Managers
         public Task<ReviewListItemModel> ToggleReviewApprovalAsync(ClaimsPrincipal user, string id, string revisionId, string notes="");
         public Task ApproveReviewAsync(ClaimsPrincipal user, string reviewId, string notes = "");
         public Task<int> GenerateAIReview(string reviewId, string revisionId);
-        public Task UpdateReviewsInBackground(HashSet<string> updateDisabledLanguages, int backgroundBatchProcessCount);
+        public Task UpdateReviewsInBackground(HashSet<string> updateDisabledLanguages, int backgroundBatchProcessCount, bool verifyUpgradabilityOnly);
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IReviewManager.cs
@@ -25,6 +25,6 @@ namespace APIViewWeb.Managers
         public Task<ReviewListItemModel> ToggleReviewApprovalAsync(ClaimsPrincipal user, string id, string revisionId, string notes="");
         public Task ApproveReviewAsync(ClaimsPrincipal user, string reviewId, string notes = "");
         public Task<int> GenerateAIReview(string reviewId, string revisionId);
-        public Task UpdateReviewsInBackground(HashSet<string> updateDisabledLanguages, int backgroundBatchProcessCount, bool verifyUpgradabilityOnly);
+        public Task UpdateReviewsInBackground(HashSet<string> updateDisabledLanguages, int backgroundBatchProcessCount, bool verifyUpgradabilityOnly, string packageNameFilterForUpgrade);
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -398,6 +398,7 @@ namespace APIViewWeb.Managers
         /// <param name="updateDisabledLanguages"></param>
         /// <param name="backgroundBatchProcessCount"></param>
         /// <param name="verifyUpgradabilityOnly"></param>
+        /// <param name="packageNameFilterForUpgrade"
         /// <returns></returns>
         public async Task UpdateReviewsInBackground(HashSet<string> updateDisabledLanguages, int backgroundBatchProcessCount, bool verifyUpgradabilityOnly, string packageNameFilterForUpgrade = "")
         {

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -452,7 +452,7 @@ namespace APIViewWeb.Managers
                                 var operation = _telemetryClient.StartOperation(requestTelemetry);
                                 try
                                 {
-                                    await Task.Delay(500);
+                                    await Task.Delay(100);
                                     await _apiRevisionsManager.UpdateAPIRevisionAsync(revision, languageService, verifyUpgradabilityOnly);
                                 }
                                 catch (Exception e)

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -398,7 +398,7 @@ namespace APIViewWeb.Managers
         /// <param name="updateDisabledLanguages"></param>
         /// <param name="backgroundBatchProcessCount"></param>
         /// <param name="verifyUpgradabilityOnly"></param>
-        /// <param name="packageNameFilterForUpgrade"
+        /// <param name="packageNameFilterForUpgrade"></param>
         /// <returns></returns>
         public async Task UpdateReviewsInBackground(HashSet<string> updateDisabledLanguages, int backgroundBatchProcessCount, bool verifyUpgradabilityOnly, string packageNameFilterForUpgrade = "")
         {


### PR DESCRIPTION
Changes to run update of a revision code file to new parser in read only mode so it will run the test to verify if a revision can be upgraded without actually modifying the metadata.

