### PR TITLE
Fix issue in attribute line with attribute class name

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CSharpLanguageService.cs
@@ -17,7 +17,7 @@ namespace APIViewWeb
         public override string Name { get; } = "C#";
         public override string[] Extensions { get; } = { ".dll" };
         public override string ProcessName => _csharpParserToolPath;
-        public override string VersionString { get; } = "29";
+        public override string VersionString { get; } = "29.1";
 
         public CSharpLanguageService(IConfiguration configuration, TelemetryClient telemetryClient) : base(telemetryClient)
         {

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -47,7 +47,7 @@ namespace CSharpAPIParser.TreeToken
 
         public ICodeFileBuilderSymbolOrderProvider SymbolOrderProvider { get; set; } = new CodeFileBuilderSymbolOrderProvider();
 
-        public const string CurrentVersion = "29";
+        public const string CurrentVersion = "29.1";
 
         private IEnumerable<INamespaceSymbol> EnumerateNamespaces(IAssemblySymbol assemblySymbol)
         {

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -575,7 +575,7 @@ namespace CSharpAPIParser.TreeToken
             }
             else if (typedConstant.Kind == TypedConstantKind.Array)
             {
-                tokenList.Add(ReviewToken.CreateKeywordToken(SyntaxKind.NewKeyword, false));
+                tokenList.Add(ReviewToken.CreateKeywordToken(SyntaxKind.NewKeyword));
                 tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.OpenBracketToken, false));
                 tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.CloseBracketToken));
                 tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.OpenBraceToken));
@@ -828,7 +828,9 @@ namespace CSharpAPIParser.TreeToken
 
             protected override void AddBitwiseOr()
             {
-                _tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.BarToken, false));
+                if(_tokenList.Count > 0)
+                    _tokenList.Last().HasSuffixSpace = true;
+                _tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.BarToken));
             }
 
             public override void VisitField(IFieldSymbol symbol)

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -298,9 +298,7 @@ namespace CSharpAPIParser.TreeToken
             {
                 typeToken.NavigationDisplayName = namedType.ToDisplayString(SymbolDisplayFormat.MinimallyQualifiedFormat);
                 typeToken.RenderClasses.Add(namedType.TypeKind.ToString().ToLowerInvariant());
-                typeToken.HasSuffixSpace = true;
             }
-
             if (namedType.TypeKind == TypeKind.Delegate)
             {
                 reviewLine.Tokens.Last().HasSuffixSpace = false;
@@ -309,6 +307,7 @@ namespace CSharpAPIParser.TreeToken
                 return;
             }
 
+            reviewLine.Tokens.Last().HasSuffixSpace = true;
             BuildBaseType(reviewLine, namedType);
             reviewLine.Tokens.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.OpenBraceToken));
             foreach (var namedTypeSymbol in SymbolOrderProvider.OrderTypes(namedType.GetTypeMembers()))

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -517,8 +517,10 @@ namespace CSharpAPIParser.TreeToken
                             attributeLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.EqualsToken));
                             BuildTypedConstant(attributeLine, argument.Value);
                         }
+                        attributeLine.Tokens.Last().HasSuffixSpace = false;
                         attributeLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.CloseParenToken));
                     }
+                    attributeLine.Tokens.Last().HasSuffixSpace = false;
                     attributeLine.AddToken(ReviewToken.CreatePunctuationToken(SyntaxKind.CloseBracketToken));
                     attributeLine.RelatedToLine = relatedTo;
                     //Add current attribute line to review lines
@@ -826,14 +828,14 @@ namespace CSharpAPIParser.TreeToken
 
             protected override void AddBitwiseOr()
             {
-                _tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.BarToken));
+                _tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.BarToken, false));
             }
 
             public override void VisitField(IFieldSymbol symbol)
             {
-                _tokenList.Add(ReviewToken.CreateTypeNameToken(symbol.Type.Name));
-                _tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.DotToken));
-                _tokenList.Add(ReviewToken.CreateMemberNameToken(symbol.Name));
+                _tokenList.Add(ReviewToken.CreateTypeNameToken(symbol.Type.Name, false));
+                _tokenList.Add(ReviewToken.CreatePunctuationToken(SyntaxKind.DotToken, false));
+                _tokenList.Add(ReviewToken.CreateMemberNameToken(symbol.Name, false));
             }
 
             public void Format(ITypeSymbol? type, object? typedConstantValue)

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CSharpAPIParserTests.csproj
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CSharpAPIParserTests.csproj
@@ -11,6 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.42.0" />
+    <PackageReference Include="Azure.Core.Expressions.DataFactory" Version="1.0.0" />
     <PackageReference Include="Azure.Security.Attestation" Version="1.0.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Template" Version="1.0.3-beta.4055065" />

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CodeFileTests.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CodeFileTests.cs
@@ -345,5 +345,25 @@ namespace Microsoft.Extensions.Azure {
                 Assert.True(relatedLine?.IsHidden);
             }
         }
+
+        [Fact]
+        public void VerifyTemplateClassLine()
+        {
+            var coreExprAssembly = Assembly.Load("Azure.Core.Expressions.DataFactory");
+            var dllStream = coreExprAssembly.GetFile("Azure.Core.Expressions.DataFactory.dll");
+            var assemblySymbol = CompilationFactory.GetCompilation(dllStream, null);
+            var codeFile = new CSharpAPIParser.TreeToken.CodeFileBuilder().Build(assemblySymbol, true, null);
+
+            var lines = codeFile.ReviewLines;
+            var namespaceLine = lines.Where(lines => lines.LineId == "Azure.Core.Expressions.DataFactory").FirstOrDefault();
+            Assert.NotNull(namespaceLine);
+            var classLine = namespaceLine.Children.Where(lines => lines.LineId.StartsWith("Azure.Core.Expressions.DataFactory.DataFactoryElement")).FirstOrDefault();
+            Assert.NotNull(classLine);
+            Assert.Equal("public sealed class DataFactoryElement<T> {", classLine.ToString().Trim());
+
+            var methodLine = classLine.Children.Where(lines => lines.LineId == "Azure.Core.Expressions.DataFactory.DataFactoryElement<T>.FromKeyVaultSecret(Azure.Core.Expressions.DataFactory.DataFactoryKeyVaultSecret)").FirstOrDefault();
+            Assert.NotNull(methodLine);
+            Assert.Equal("public static DataFactoryElement<string?> FromKeyVaultSecret(DataFactoryKeyVaultSecret secret);", methodLine.ToString().Trim());
+        }
     }
 }


### PR DESCRIPTION
Fixes following issue in attribute line 

Attribute line is shown as `[AttributeUsage(AttributeTargets . Class ) ]` instead of `[AttributeUsage(AttributeTargets.Class )]`