### PR TITLE
Add descriptive error when variable groups are not added to pipeline

### DIFF
--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -197,11 +197,11 @@ function UpdateSubscriptionConfigurationWithFiles([object]$baseSubConfig, [strin
 function BuildAndSetSubscriptionConfig([string]$baseSubConfigJson, [string]$additionalSubConfigsJson, [string]$subConfigFilesJson) {
   $finalConfig = @{}
 
-  if ($baseSubConfigJson) {
+  if ($baseSubConfigJson -and $baseSubConfigJson -ne '""') {
     # When variable groups are not added to the pipeline, secret references like
     # $(<my secret>) are passed as a string literal instead of being replaced by the keyvault secret value
-    if ($baseSubConfig -like '$(*') {
-      throw "Expected a json dictionary object but found '$baseSubConfig'. This probably means a subscription config secret was not downloaded. The pipeline is likely missing a variable group."
+    if ($baseSubConfigJson -notlike '{*') {
+      throw "Expected a json dictionary object but found '$baseSubConfigJson'. This probably means a subscription config secret was not downloaded. The pipeline is likely missing a variable group."
     }
     $baseSubConfig = $baseSubConfigJson | ConvertFrom-Json -AsHashtable
 
@@ -209,7 +209,7 @@ function BuildAndSetSubscriptionConfig([string]$baseSubConfigJson, [string]$addi
     $finalConfig = SetSubscriptionConfiguration $baseSubConfig
   }
 
-  if ($additionalSubConfigsJson) {
+  if ($additionalSubConfigsJson -and $additionalSubConfigsJson -ne '""') {
     $subConfigs = $additionalSubConfigsJson | ConvertFrom-Json -AsHashtable
 
     foreach ($subConfig in $subConfigs) {

--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -49,13 +49,5 @@ steps:
         ${{ convertToJson(parameters.SubscriptionConfigurationFilePaths) }}
       '@.Trim()
 
-      # When variable groups are not added to the pipeline, secret references like
-      # $(<my secret>) are passed as a string literal instead of being replaced by the keyvault secret value
-      $obj = @($additionalSubConfigsJson | ConvertFrom-Json -AsHashtable)
-      if ($baseSubConfigJson -like '$(*' `
-          -or @($obj | Where-Object { $_ -like '$(*' }).Count) {
-        throw 'A subscription config secret was not downloaded. The pipeline is likely missing a variable group.'
-      }
-
       BuildAndSetSubscriptionConfig $baseSubConfigJson $additionalSubConfigsJson $subConfigFilesJson
     displayName: Merge subscription configurations

--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -49,5 +49,13 @@ steps:
         ${{ convertToJson(parameters.SubscriptionConfigurationFilePaths) }}
       '@.Trim()
 
+      # When variable groups are not added to the pipeline, secret references like
+      # $(<my secret>) are passed as a string literal instead of being replaced by the keyvault secret value
+      $obj = @($additionalSubConfigsJson | ConvertFrom-Json -AsHashtable)
+      if ($baseSubConfigJson -like '$(*' `
+          -or @($obj | Where-Object { $_ -like '$(*' }).Count) {
+        throw 'A subscription config secret was not downloaded. The pipeline is likely missing a variable group.'
+      }
+
       BuildAndSetSubscriptionConfig $baseSubConfigJson $additionalSubConfigsJson $subConfigFilesJson
     displayName: Merge subscription configurations

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -43,7 +43,7 @@ steps:
 
   - ${{ if eq('true', parameters.UseFederatedAuth) }}:
     - task: AzurePowerShell@5
-      displayName: Deploy test resources
+      displayName: 🚀 Deploy test resources
       env:
         TEMP: $(Agent.TempDirectory)
         PoolSubnet: $(PoolSubnet)
@@ -96,7 +96,7 @@ steps:
           -ServicePrincipalAuth `
           -Force `
           -Verbose | Out-Null
-      displayName: Deploy test resources
+      displayName: 🚀 Deploy test resources
       env:
         TEMP: $(Agent.TempDirectory)
         PoolSubnet: $(PoolSubnet)


### PR DESCRIPTION
These errors are annoying to debug because we just see indirect null object failures when expecting a json string and receiving the `$(<var name>)` literal from devops.

CC @deyaaeldeen 