### PR TITLE
add quotes to powershell args

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -31,8 +31,8 @@ steps:
         inputs:
           filePath: ${{ parameters.ScriptDirectory }}/Save-Package-Properties.ps1
           arguments: >
-            -PrDiff ${{ parameters.DiffDirectory }}/diff.json
-            -OutDirectory ${{ parameters.PackageInfoDirectory }}
+            -PrDiff '${{ parameters.DiffDirectory }}/diff.json'
+            -OutDirectory '${{ parameters.PackageInfoDirectory }}'
           pwsh: true
   - ${{ else }}:
       - task: Powershell@2
@@ -40,7 +40,7 @@ steps:
         inputs:
           filePath: ${{ parameters.ScriptDirectory }}/Save-Package-Properties.ps1
           arguments: >
-            -ServiceDirectory ${{parameters.ServiceDirectory}}
-            -OutDirectory ${{ parameters.PackageInfoDirectory }}
+            -ServiceDirectory '${{parameters.ServiceDirectory}}'
+            -OutDirectory '${{ parameters.PackageInfoDirectory }}'
             -AddDevVersion:$${{ eq(variables['SetDevVersion'],'true') }}
           pwsh: true


### PR DESCRIPTION
when ServiceDirectory is empty, powershell doesn't parse this command correctly

```
filePath: ${{ parameters.ScriptDirectory }}/Save-Package-Properties.ps1
arguments: >
  -ServiceDirectory ${{parameters.ServiceDirectory}}
  -OutDirectory ${{ parameters.PackageInfoDirectory }}
```

It's parsed like
```
Save-Package-Properties.ps1 -ServiceDirectory -OutDirectory ...
```