### PR TITLE
Avoid adding the same package twice, use TrimStart instead of substring

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -119,7 +119,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     foreach ($pkg in $allPackageProperties)
     {
         $pkgDirectory = Resolve-Path "$($pkg.DirectoryPath)"
-        $lookupKey = ($pkg.DirectoryPath).Replace($RepoRoot, "").SubString(1)
+        $lookupKey = ($pkg.DirectoryPath).Replace($RepoRoot, "").TrimStart('\/')
         $lookup[$lookupKey] = $pkg
 
         foreach ($file in $targetedFiles)
@@ -132,12 +132,15 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
                 if ($pkg.AdditionalValidationPackages) {
                     $additionalValidationPackages += $pkg.AdditionalValidationPackages
                 }
+
+                # avoid adding the same package multiple times
+                break
             }
         }
     }
 
     foreach ($addition in $additionalValidationPackages) {
-        $key = $addition.Replace($RepoRoot, "").SubString(1)
+        $key = $addition.Replace($RepoRoot, "").TrimStart('\/')
 
         if ($lookup[$key]) {
             $packagesWithChanges += $lookup[$key]


### PR DESCRIPTION
Get-PrPkgProperties was adding a package to $packagesWithChanges for every matched file in the pr diff.   To prevent duplicate entries, we break the for loop on the first matched file.

If the input path didn't start with $RepoRoot, the key function `<path>.Replace($RepoRoot, "").SubString(1)` was removing the first character of a relative path.

`sdk/some/package` => `dk/some/package`

`.TrimStart('\/')` will remove the starting path separator only if it exists. 