### PR TITLE
Rename autorest.csharp branch feature/v3 to main

### DIFF
--- a/eng/pipelines/tools-repo-versioning.yml
+++ b/eng/pipelines/tools-repo-versioning.yml
@@ -40,4 +40,3 @@ jobs:
           azure-sdk-for-net:
           azure-sdk-for-python:
           autorest.csharp:
-            branch: feature/v3


### PR DESCRIPTION
The default branch for autorest.csharp is being renamed from feature/v3 to main