### PR TITLE
Update GitHubEventProcessor to 1.0.0-dev.20240909.2

### DIFF
--- a/.github/workflows/event-processor.yml
+++ b/.github/workflows/event-processor.yml
@@ -58,7 +58,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20240708.1
+          --version 1.0.0-dev.20240909.2
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash
@@ -114,7 +114,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20240708.1
+          --version 1.0.0-dev.20240909.2
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash

--- a/.github/workflows/scheduled-event-processor.yml
+++ b/.github/workflows/scheduled-event-processor.yml
@@ -39,7 +39,7 @@ jobs:
         run: >
           dotnet tool install
           Azure.Sdk.Tools.GitHubEventProcessor
-          --version 1.0.0-dev.20240708.1
+          --version 1.0.0-dev.20240909.2
           --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json
           --global
         shell: bash


### PR DESCRIPTION
This is the [PR](https://github.com/Azure/azure-sdk-tools/pull/8941) that required a new version of the github-event-processor.

The description of the changes (copied from the PR):

PRs created by a BOT user shouldn't have the CustomerReported and CommunityContribution labels added, nor should they get the "Thank you for your contribution..." comment added. The fix for this and a test scenario have both been added.

This is an example of a BOT created https://github.com/Azure/azure-sdk-for-js/pull/31018#issuecomment-2334559745 that has both labels and the comment added and the reason for this change.