### PR TITLE
Fix read original changelog content issue

### DIFF
--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.7.12",
+  "version": "2.7.13",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/src/common/utils.ts
+++ b/tools/js-sdk-release-tools/src/common/utils.ts
@@ -119,8 +119,7 @@ export function fixChangelogFormat(content: string) {
     return content;
 }
 
-export function tryReadNpmPackageChangelog(packageFolderPath: string): string {
-    const changelogPath = path.join(packageFolderPath, 'changelog-temp', 'package', 'CHANGELOG.md');
+export function tryReadNpmPackageChangelog(changelogPath: string): string {
     try {
         if (!fs.existsSync(changelogPath)) {
             logger.warn(`NPM package's changelog '${changelogPath}' does not exist.`);

--- a/tools/js-sdk-release-tools/src/hlc/utils/automaticGenerateChangeLogAndBumpVersion.ts
+++ b/tools/js-sdk-release-tools/src/hlc/utils/automaticGenerateChangeLogAndBumpVersion.ts
@@ -67,7 +67,8 @@ export async function generateChangelogAndBumpVersion(packageFolderPath: string)
                 const oldSDKType = getSDKType(npmPackageRoot);
                 const newSDKType = getSDKType(packageFolderPath);
                 const changelog: Changelog = await extractExportAndGenerateChangelog(apiMdFileNPM, apiMdFileLocal, oldSDKType, newSDKType);
-                let originalChangeLogContent = tryReadNpmPackageChangelog(packageFolderPath);
+                const changelogPath = path.join(npmPackageRoot, 'CHANGELOG.md');
+                let originalChangeLogContent = tryReadNpmPackageChangelog(changelogPath);
                 if(nextVersion){
                     shell.cd(path.join(packageFolderPath, 'changelog-temp'));
                     shell.mkdir(path.join(packageFolderPath, 'changelog-temp', 'next'));
@@ -81,7 +82,8 @@ export async function generateChangelogAndBumpVersion(packageFolderPath: string)
                     const latestDate = getversionDate(npmViewResult, stableVersion);
                     const nextDate = getversionDate(npmViewResult,nextVersion);
                     if (latestDate && nextDate && latestDate <= nextDate){
-                        originalChangeLogContent = tryReadNpmPackageChangelog(packageFolderPath);
+                        const nextChangelogPath = path.join(packageFolderPath,'changelog-temp', 'next', 'package', 'CHANGELOG.md');
+                        originalChangeLogContent = tryReadNpmPackageChangelog(nextChangelogPath);
                         logger.info('Keep previous preview changelog.');
                     }
                 }

--- a/tools/js-sdk-release-tools/src/test/changelog/changelogGenerator.test.ts
+++ b/tools/js-sdk-release-tools/src/test/changelog/changelogGenerator.test.ts
@@ -1,11 +1,10 @@
 import { expect, test } from "vitest";
 import { extractExportAndGenerateChangelog } from "../../changelog/extractMetaData";
-import path, { join } from "path";
+import path from "path";
 import { SDKType } from "../../common/types";
 import { describe } from "node:test";
 import { tryReadNpmPackageChangelog } from "../../common/utils";
-import { ensureDirSync, removeSync, outputFileSync } from "fs-extra";
-import { getRandomInt } from "../utils/utils";
+import { removeSync, outputFileSync } from "fs-extra";
 
 describe("Breaking change detection", () => {
     test("HLC -> Modular: Rename", async () => {
@@ -136,20 +135,18 @@ describe("Breaking change detection", () => {
 
 describe("Changelog reading", () => {
         test("Read changelog that doesn't exist", () => {
-            const content = tryReadNpmPackageChangelog('./do/not/exist');
+            const content = tryReadNpmPackageChangelog('./do/not/exist/CHANGELOG.md');
             expect(content).toBe("");
         });
     
         test("Read changelog that exists", () => {
-            const tempPackageFolder = path.join(__dirname, `tmp/package-${getRandomInt(10000)}`);
+            const changelogPath = path.join('CHANGELOG.md')
             try {
-                ensureDirSync(tempPackageFolder);
-                const changelogPath = path.join(tempPackageFolder, 'changelog-temp', 'package', 'CHANGELOG.md')
                 outputFileSync(changelogPath, 'aaa', 'utf-8');
-                const content = tryReadNpmPackageChangelog(tempPackageFolder);
+                const content = tryReadNpmPackageChangelog(changelogPath);
                 expect(content).toBe("aaa");
             } finally {
-                removeSync(tempPackageFolder);
+                removeSync(changelogPath);
             }
         })
 });


### PR DESCRIPTION
Problem: always read stable version's changelog
Fix: read beta version's changelog if the current package is beta