### PR TITLE
Disable sbom generation for forked PR builds

### DIFF
--- a/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -11,7 +11,11 @@ parameters:
   ArtifactName: ''
   ArtifactPath: ''
   CustomCondition: true
-  SbomEnabled: true
+  # Disable sbom generation by default for forked PR builds to avoid a bunch of warnings
+  ${{ if and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True')) }}:
+    SbomEnabled: false
+  ${{ else }}:
+    SbonEnabled: true
 
 steps:
   - pwsh: |

--- a/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -11,11 +11,7 @@ parameters:
   ArtifactName: ''
   ArtifactPath: ''
   CustomCondition: true
-  # Disable sbom generation by default for forked PR builds to avoid a bunch of warnings
-  ${{ if and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True')) }}:
-    SbomEnabled: false
-  ${{ else }}:
-    SbonEnabled: true
+  SbomEnabled: true
 
 steps:
   - pwsh: |
@@ -35,4 +31,6 @@ steps:
     inputs:
       artifactName: '$(PublishArtifactName)'
       targetPath: '${{ parameters.ArtifactPath }}'
-      sbomEnabled: ${{ parameters.SbomEnabled }}
+      # Disable sbom generation by default for forked PR builds to avoid a bunch of warnings
+      ${{ if not(and(eq(variables['Build.Reason'],'PullRequest'), eq(variables['System.PullRequest.IsFork'], 'True'))) }}:
+        sbomEnabled: ${{ parameters.SbomEnabled }}


### PR DESCRIPTION
Disabling this to avoid a bunch of warnings during these builds