### PR TITLE
Include empty requestMessage for private endpoint

### DIFF
--- a/tools/pipeline-witness/infrastructure/bicep/logsResourceGroup.bicep
+++ b/tools/pipeline-witness/infrastructure/bicep/logsResourceGroup.bicep
@@ -175,6 +175,7 @@ resource kustoCluster 'Microsoft.Kusto/Clusters@2022-02-01' = {
     properties: {
       groupId: 'blob'
       privateLinkResourceId: logsStorageAccount.id
+      requestMessage: ''
     }
   }
 }


### PR DESCRIPTION
If the requestMessage property isn't included on the managed private endpoint resource, the resource provider interprets that as setting the requestMessage to null.    The requestMessage property can't be changed after creation, so you must include the property and it must match the existing value if the resource already exists.