### PR TITLE
Add basic reason why package has been included to Package-Properties

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -15,7 +15,6 @@ class PackageProps
     [boolean]$IsNewSdk
     [string]$ArtifactName
     [string]$ReleaseStatus
-    [boolean]$BuildDocs
     # was this package purely included because other packages included it as an AdditionalValidationPackage?
     [boolean]$IncludedForValidation
     # does this package include other packages that we should trigger validation for?
@@ -81,41 +80,6 @@ class PackageProps
     {
         $this.Initialize($name, $version, $directoryPath, $serviceDirectory)
         $this.Group = $group
-    }
-
-    hidden [void]InitializeBuildDocs(
-        [string]$ServiceDirectory
-    )
-    {
-        # parse the relevant ci.yml file to determine if the package should build docs
-        $ciYmlPath = Join-Path $ServiceDirectory ".ci.yml"
-
-        if (Test-Path $ciYmlPath)
-        {
-            $ciYml = ConvertFrom-Yaml (Get-Content $ciYmlPath -Raw)
-
-            if ($ciYml.extends -and $ciYml.extends.parameters -and $ciYml.extends.parameters.Artifacts) {
-                $packagesBuildingDocs = $ciYml.extends.parameters.Artifacts `
-                    | Where-Object {
-                        if ($_.PSObject.Properties["skipPublishDocsMs"]) {
-                            $false
-                        }
-                        else {
-                            $true
-                        }
-                    } `
-                    | Select-Object -ExpandProperty name
-
-                if ($packagesBuildingDocs -contains $this.Name)
-                {
-                    $this.BuildDocs = $true
-                }
-            }
-        }
-        else
-        {
-            $this.BuildDocs = $false
-        }
     }
 }
 

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -66,8 +66,6 @@ class PackageProps
         {
             $this.ChangeLogPath = $null
         }
-
-        $this.InitializeBuildDocs($ServiceDirectory)
     }
 
     hidden [void]Initialize(


### PR DESCRIPTION
This PR does two things:

1) Makes us able to discern when a package is directly included or included as a validation package (`IncludedForValidation`, defaults to `false`)
2) ~~Add `BuildDocs` property, which is calculated when a package props class is instantiated.~~
  - ~~I have a fairly strong suspicion, because of the necessary inclusion of `Install-ModuleIfNotInstalled "powershell-yaml" "0.4.1" | Import-Module`, that we will just want to put this artifact parsing in the [docs namespace update directly.]~~(https://github.com/Azure/azure-sdk-for-python/blob/main/eng/scripts/Save-Package-Namespaces-Property.ps1)

I ripped out `BuildDocs` because it implies that `powershell-yaml` will become a base requirement of our `Save-Package-Properties` namespace. We ALREADY see some failures to install modules just based on normal usage in a few select pipelines. I feel like if I force every single pipeline to go through installing powershell-yaml, our random issues are going to skyrocket.

What do ya'll think? @weshaggard @benbp 