### PR TITLE
Put repo processing in try/catch

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/GitHubActions/MissingGitHubActionsWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/GitHubActions/MissingGitHubActionsWorker.cs
@@ -63,21 +63,11 @@ namespace Azure.Sdk.Tools.PipelineWitness.GitHubActions
 
                     string[] knownBlobs = await this.processor.GetRunBlobNamesAsync(ownerAndRepository, runMinTime, runMaxTime, cancellationToken);
 
-                    WorkflowRunsResponse listRunsResponse;
-
-                    try
+                    WorkflowRunsResponse listRunsResponse = await this.client.Actions.Workflows.Runs.List(owner, repository, new WorkflowRunsRequest
                     {
-                        listRunsResponse = await this.client.Actions.Workflows.Runs.List(owner, repository, new WorkflowRunsRequest
-                        {
-                            Created = $"{runMinTime:o}..{runMaxTime:o}",
-                            Status = CheckRunStatusFilter.Completed,
-                        });
-                    }
-                    catch (Exception ex)
-                    {
-                        this.logger.LogError(ex, "Error listing runs for repository {Repository}", ownerAndRepository);
-                        continue;
-                    }
+                        Created = $"{runMinTime:o}..{runMaxTime:o}",
+                        Status = CheckRunStatusFilter.Completed,
+                    });
                 
                     var skipCount = 0;
                     var enqueueCount = 0;

--- a/tools/pipeline-witness/ci.yml
+++ b/tools/pipeline-witness/ci.yml
@@ -20,6 +20,9 @@ pr:
   paths:
     include:
       - tools/pipeline-witness
+    exclude:
+      - tools/pipeline-witness/monitored-repos.json
+      - tools/pipeline-witness/docs/*
   
 extends:
   template: ../../eng/pipelines/templates/stages/archetype-sdk-tool-azure-webapp.yml


### PR DESCRIPTION
Currently, GitHub gap filling processes repos in a foreach loop without any exception handling.  This causes the process to break on the first missing repo or repo with auth issues.   Adding a try/catch with error logging ensures that all of the repos are attempted while still reporting failures to App Insights.