### PR TITLE
Update projects targeting net6 to net8 - part 1

### DIFF
--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter.Tests/Azure.Sdk.Tools.CodeownersUtils.Tests.csproj
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter.Tests/Azure.Sdk.Tools.CodeownersUtils.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
 

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter/Azure.Sdk.Tools.CodeownersLinter.csproj
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersLinter/Azure.Sdk.Tools.CodeownersLinter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>codeowners-linter</ToolCommandName>

--- a/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Azure.Sdk.Tools.CodeownersUtils.csproj
+++ b/tools/codeowners-utils/Azure.Sdk.Tools.CodeownersUtils/Azure.Sdk.Tools.CodeownersUtils.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <IsPackable>false</IsPackable>

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Azure.Sdk.Tools.GitHubEventProcessor.Tests.csproj
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Azure.Sdk.Tools.GitHubEventProcessor.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Azure.Sdk.Tools.GitHubEventProcessor.csproj
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/Azure.Sdk.Tools.GitHubEventProcessor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>github-event-processor</ToolCommandName>
   </PropertyGroup>

--- a/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/GitHubTeamUserStore.csproj
+++ b/tools/github-team-user-store/GitHubTeamUserStore/GitHubTeamUserStore/GitHubTeamUserStore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <ToolCommandName>github-team-user-store</ToolCommandName>
   </PropertyGroup>

--- a/tools/identity-resolution/identity-resolution.csproj
+++ b/tools/identity-resolution/identity-resolution.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
      <IsPackable>false</IsPackable>
-     <TargetFramework>net6.0</TargetFramework>
+     <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/notification-configuration/notification-creator.Tests/Azure.Sdk.Tools.NotificationConfiguration.Tests.csproj
+++ b/tools/notification-configuration/notification-creator.Tests/Azure.Sdk.Tools.NotificationConfiguration.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>Nullable</WarningsAsErrors>
     <IsPackable>false</IsPackable>

--- a/tools/notification-configuration/notification-creator/Azure.Sdk.Tools.NotificationConfiguration.csproj
+++ b/tools/notification-configuration/notification-creator/Azure.Sdk.Tools.NotificationConfiguration.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>notification-creator</ToolCommandName>
     <RootNamespace>Azure.Sdk.Tools.NotificationConfiguration</RootNamespace>

--- a/tools/pipeline-owners-extractor/Azure.Sdk.Tools.PipelineOwnersExtractor/Azure.Sdk.Tools.PipelineOwnersExtractor.csproj
+++ b/tools/pipeline-owners-extractor/Azure.Sdk.Tools.PipelineOwnersExtractor/Azure.Sdk.Tools.PipelineOwnersExtractor.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pipeline-owners-extractor</ToolCommandName>
   </PropertyGroup>


### PR DESCRIPTION
net6 hits EOL in November, 2024 and this is to update things to net8. This is only the first round of projects. This particular set is related because of the use of CodeownersUtils. None of these projects required code changes from the runtime update from 6->8

Contributes to https://github.com/Azure/azure-sdk-tools/issues/8606