### PR TITLE
Tool version updates for net6 to net8 updates part 1

### DIFF
--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,5 +1,5 @@
 variables:
   OfficialBuildId: $(Build.BuildNumber)
   skipComponentGovernanceDetection: true
-  NotificationsCreatorVersion: '1.0.0-dev.20240529.1'
-  PipelineOwnersExtractorVersion: '1.0.0-dev.20240529.1'
+  NotificationsCreatorVersion: '1.0.0-dev.20240917.1'
+  PipelineOwnersExtractorVersion: '1.0.0-dev.20240917.1'


### PR DESCRIPTION
This was the [PR](https://github.com/Azure/azure-sdk-tools/pull/8991) that updated the tools and caused new versions to be processed. This PR updates the versions Azure.Sdk.Tools.NotificationConfiguration and Azure.Sdk.Tools.PipelineOwnersExtractor to install based the publish from the first PR.