### PR TITLE
Update CodeownersLinter for net6 to net8 update

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -31,7 +31,7 @@ stages:
       vmImage: ubuntu-22.04
 
     variables:
-      CodeownersLinterVersion: '1.0.0-dev.20240614.4'
+      CodeownersLinterVersion: '1.0.0-dev.20240917.2'
       DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
       RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
       TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"


### PR DESCRIPTION
This was the [PR](https://github.com/Azure/azure-sdk-tools/pull/8991) that updated the tools and caused new versions to be processed. This just updates the linter pipeline to use the new published version.