### PR TITLE
Ensure that ScanPaths are always populated in `verify-readmes`

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-readmes.yml
+++ b/eng/common/pipelines/templates/steps/verify-readmes.yml
@@ -29,6 +29,7 @@ steps:
     $scanPaths = $paths -join ","
     Write-Host "##vso[task.setvariable variable=ScanPathArgument;]$scanPaths"
   displayName: Populate Scan Paths
+  condition: ${{ parameters.Condition }}
 
 - task: PowerShell@2
   displayName: "Verify Readmes"


### PR DESCRIPTION
What happens if a task above the call to `verify-readmes` fails? Well before this change we would SKIP populating the scan paths, which would then also cause the call to verify readmes to _always_ fail because of no populated ScanPath argument.

This PR matches up the condition to avoid this issue.