### PR TITLE
Discovered another issue with `AdditionalValidationPackagesFromPackageSetFn`

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -154,7 +154,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
 
     if ($AdditionalValidationPackagesFromPackageSetFn -and (Test-Path "Function:$AdditionalValidationPackagesFromPackageSetFn"))
     {
-        $packagesWithChanges += &$AdditionalValidationPackagesFromPackageSetFn $packagesWithChanges $diff
+        $packagesWithChanges += &$AdditionalValidationPackagesFromPackageSetFn $packagesWithChanges $diff $allPackageProperties
     }
 
     return $packagesWithChanges


### PR DESCRIPTION
What happens when we don't have metadata for a package that we want to include? Welp we're screwed! I don't want to call Get-AllPkgProperties in my custom function when we CAN PASS IT IN.

