### PR TITLE
Update Azure.ClientSdk.Analyzers.Tests from net6 to net8

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/Azure.ClientSdk.Analyzers.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <TargetFrameworks Condition="'$(OS)' == 'Windows_NT'">$(TargetFrameworks);net472</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>


### PR DESCRIPTION
Azure.ClientSdk.Analyzers.Tests was still using net6 as one of its targets which hits EOL in November of 2024. After updating the net6 target to net8 all of the tests targeting net8, and the others targeting net472, ran without issue. The other projects in the solution target netstandard2.0 but the test project cannot.