### PR TITLE
Update TestProxy from Net6 to Net8

### DIFF
--- a/tools/assets-automation/assets-maintenance-tool/Azure.Sdk.Tools.Assets.MaintenanceTool.Tests/Azure.Sdk.Tools.Assets.MaintenanceTool.Tests.csproj
+++ b/tools/assets-automation/assets-maintenance-tool/Azure.Sdk.Tools.Assets.MaintenanceTool.Tests/Azure.Sdk.Tools.Assets.MaintenanceTool.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tools/assets-automation/assets-maintenance-tool/Azure.Sdk.Tools.Assets.MaintenanceTool/Azure.Sdk.Tools.Assets.MaintenanceTool.csproj
+++ b/tools/assets-automation/assets-maintenance-tool/Azure.Sdk.Tools.Assets.MaintenanceTool/Azure.Sdk.Tools.Assets.MaintenanceTool.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>nullable</WarningsAsErrors>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Azure.Sdk.Tools.TestProxy.Tests.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/Azure.Sdk.Tools.TestProxy.Tests.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
   </PropertyGroup>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/MatcherTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/MatcherTests.cs
@@ -287,7 +287,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             foreach (var kvp in requestHeaders)
             {
-                playbackContext.Request.Headers.Add(kvp.Key, kvp.Value);
+                playbackContext.Request.Headers.Append(kvp.Key, kvp.Value);
             }
             playbackContext.Request.Method = "POST";
 
@@ -332,7 +332,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             foreach (var kvp in requestHeaders)
             {
-                playbackContext.Request.Headers.Add(kvp.Key, kvp.Value);
+                playbackContext.Request.Headers.Append(kvp.Key, kvp.Value);
             }
             var queryString = "?api-version=1.0&year=2023&basinId=AL&govId=5";
             var path = "/weather/tropical/storms/json";

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordTests.cs
@@ -212,7 +212,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             };
             foreach (var kvp in requestHeaders)
             {
-                playbackContext.Request.Headers.Add(kvp.Key, kvp.Value);
+                playbackContext.Request.Headers.Append(kvp.Key, kvp.Value);
             }
             playbackContext.Request.Method = "POST";
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -166,7 +166,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (recordingId != null)
             {
-                Response.Headers.Add("x-recording-id", recordingId);
+                Response.Headers.Append("x-recording-id", recordingId);
             }
 
             var json = JsonSerializer.Serialize(new { Sanitizers = registeredSanitizers });

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <NoWarn>$(NoWarn);1591;AZC0001;AZC0012;CA1724;CA1801;CA1812;CA1822;SA1028</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <IsPackable>true</IsPackable>
@@ -12,18 +12,10 @@
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)'=='net5.0'">
-    <PackageReference Include="Azure.Core" Version="1.24.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="5.0.2" />
-  </ItemGroup>
-  
-  <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
-    <PackageReference Include="Azure.Core" Version="1.24.0" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="6.0.0" />
-  </ItemGroup>
-  
   <ItemGroup>
     <PackageReference Include="Microsoft.Security.Utilities.Core" Version="1.4.14" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="Azure.Core" Version="1.43.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="8.0.5" />
   </ItemGroup>
 </Project>

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/Exceptions/HttpException.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/Exceptions/HttpException.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Net;
@@ -36,11 +36,5 @@ namespace Azure.Sdk.Tools.TestProxy.Common.Exceptions
         {
             StatusCode = statusCode;
         }
-
-        protected HttpException(HttpStatusCode statusCode, SerializationInfo info, StreamingContext context) : base(info, context)
-        {
-            StatusCode = statusCode;
-        }
-
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
@@ -48,13 +48,13 @@ namespace Azure.Sdk.Tools.TestProxy.Common
 
                 if (e is TestRecordingMismatchException)
                 {
-                    response.Headers.Add("x-request-mismatch", "true");
-                    response.Headers.Add("x-request-mismatch-error", encodedException);
+                    response.Headers.Append("x-request-mismatch", "true");
+                    response.Headers.Append("x-request-mismatch-error", encodedException);
                 }
                 else
                 {
-                    response.Headers.Add("x-request-known-exception", "true");
-                    response.Headers.Add("x-request-known-exception-error", encodedException);
+                    response.Headers.Append("x-request-known-exception", "true");
+                    response.Headers.Append("x-request-known-exception-error", encodedException);
                 }
                 
                 var bodyObj = new
@@ -77,8 +77,8 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 response.StatusCode = unexpectedStatusCode;
                 response.ContentType = "application/json";
 
-                response.Headers.Add("x-request-exception", "true");
-                response.Headers.Add("x-request-exception-error", Convert.ToBase64String(Encoding.UTF8.GetBytes(e.Message)));
+                response.Headers.Append("x-request-exception", "true");
+                response.Headers.Append("x-request-exception-error", Convert.ToBase64String(Encoding.UTF8.GetBytes(e.Message)));
 
                 DebugLogger.LogError(unexpectedStatusCode, e);
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SecretScanner.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/SecretScanner.cs
@@ -7,7 +7,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Sdk.Tools.TestProxy.Console;
-using Microsoft.Build.Tasks;
 using Microsoft.Security.Utilities;
 
 namespace Azure.Sdk.Tools.TestProxy.Common

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/TestRecordingMismatchException.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/TestRecordingMismatchException.cs
@@ -22,9 +22,5 @@ namespace Azure.Sdk.Tools.TestProxy.Common
         public TestRecordingMismatchException(string message, Exception innerException) : base(HttpStatusCode.NotFound, message, innerException)
         {
         }
-
-        protected TestRecordingMismatchException(SerializationInfo info, StreamingContext context) : base(HttpStatusCode.NotFound, info, context)
-        {
-        }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -239,7 +239,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
 
             DebugLogger.LogTrace($"RECORD START END {id}.");
-            outgoingResponse.Headers.Add("x-recording-id", id);
+            outgoingResponse.Headers.Append("x-recording-id", id);
         }
 
         public async Task HandleRecordRequestAsync(string recordingId, HttpRequest incomingRequest, HttpResponse outgoingResponse)
@@ -328,7 +328,7 @@ namespace Azure.Sdk.Tools.TestProxy
             foreach (var header in upstreamResponse.Headers.Concat(upstreamResponse.Content.Headers))
             {
                 var values = new StringValues(header.Value.ToArray());
-                outgoingResponse.Headers.Add(header.Key, values);
+                outgoingResponse.Headers.Append(header.Key, values);
                 entry.Response.Headers.Add(header.Key, values);
             }
 
@@ -445,7 +445,7 @@ namespace Azure.Sdk.Tools.TestProxy
                 await RestoreAssetsJson(assetsPath, true);
                 var path = await GetRecordingPath(sessionId, assetsPath);
                 var base64path = Convert.ToBase64String(Encoding.UTF8.GetBytes(path));
-                outgoingResponse.Headers.Add("x-base64-recording-file-location", base64path);
+                outgoingResponse.Headers.Append("x-base64-recording-file-location", base64path);
                 if (!File.Exists(path))
                 {
                     throw new TestRecordingMismatchException($"Recording file path {path} does not exist.");
@@ -465,11 +465,11 @@ namespace Azure.Sdk.Tools.TestProxy
                 throw new HttpException(HttpStatusCode.InternalServerError, $"Unexpectedly failed to add new playback session under id {id}.");
             }
 
-            outgoingResponse.Headers.Add("x-recording-id", id);
+            outgoingResponse.Headers.Append("x-recording-id", id);
 
 
             var json = JsonSerializer.Serialize(session.Session.Variables);
-            outgoingResponse.Headers.Add("Content-Type", "application/json");
+            outgoingResponse.Headers.Append("Content-Type", "application/json");
 
             // Write to the response
             await outgoingResponse.WriteAsync(json);
@@ -577,7 +577,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
                 foreach (var header in match.Response.Headers)
                 {
-                    outgoingResponse.Headers.Add(header.Key, header.Value.ToArray());
+                    outgoingResponse.Headers.Append(header.Key, header.Value.ToArray());
                 }
 
                 outgoingResponse.Headers.Remove("Transfer-Encoding");

--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -28,19 +28,19 @@ extends:
     ReleaseBinaries: true
     StandaloneExeMatrix:
     - rid: osx-x64
-      framework: net6.0
+      framework: net8.0
       assembly: Azure.Sdk.Tools.TestProxy
     - rid: osx-arm64
-      framework: net6.0
+      framework: net8.0
       assembly: Azure.Sdk.Tools.TestProxy
     - rid: win-x64
-      framework: net6.0
+      framework: net8.0
       assembly: Azure.Sdk.Tools.TestProxy
     - rid: linux-x64
-      framework: net6.0
+      framework: net8.0
       assembly: Azure.Sdk.Tools.TestProxy
     - rid: linux-arm64
-      framework: net6.0
+      framework: net8.0
       assembly: Azure.Sdk.Tools.TestProxy
     TestPreSteps:
       - pwsh: |

--- a/tools/test-proxy/sample-clients/net/http-client/Azure.Sdk.Tools.TestProxy.HttpClientSample.csproj
+++ b/tools/test-proxy/sample-clients/net/http-client/Azure.Sdk.Tools.TestProxy.HttpClientSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/tools/test-proxy/sample-clients/net/http-pipeline/Azure.Sdk.Tools.TestProxy.HttpPipelineSample/Azure.Sdk.Tools.TestProxy.HttpPipelineSample.csproj
+++ b/tools/test-proxy/sample-clients/net/http-pipeline/Azure.Sdk.Tools.TestProxy.HttpPipelineSample/Azure.Sdk.Tools.TestProxy.HttpPipelineSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/test-proxy/sample-clients/net/http-pipeline/Azure.Sdk.Tools.TestProxy.HttpPipelineTestsExample/Azure.Sdk.Tools.TestProxy.HttpPipelineTestsExample.csproj
+++ b/tools/test-proxy/sample-clients/net/http-pipeline/Azure.Sdk.Tools.TestProxy.HttpPipelineTestsExample/Azure.Sdk.Tools.TestProxy.HttpPipelineTestsExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
 
     <IsPackable>false</IsPackable>

--- a/tools/test-proxy/sample-clients/net/storage-blob/Azure.Sdk.Tools.TestProxy.StorageBlobSample.csproj
+++ b/tools/test-proxy/sample-clients/net/storage-blob/Azure.Sdk.Tools.TestProxy.StorageBlobSample.csproj
@@ -2,12 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.10.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
+    <PackageReference Include="Azure.Core" Version="1.43.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I was going to update TestProxy by itself in its own PR but, unfortunately, Azure.Sdk.Tools.Assets.MaintenanceTool.sln has a dependency on TestProxy which required both projects to be updated.

I removed the conditional includes from the TestProxy since net5 is deader than disco. When upgrading the framework to Net8 I also updated Azure.Core and Microsoft.VisualStudio.Web.CodeGeneration.Design to their latest RTM versions.

- `using Microsoft.Build.Tasks;` was removed because it no longer exists but was also a superfluous using.
- response.Headers.Add is now response.Headers.Append
- ['Exception.Exception(SerializationInfo, StreamingContext)' is now obsolete](https://github.com/dotnet/docs/issues/34893)

I also updated the version of Azure.Code and Azure.Storage.Blobs Azure.Sdk.Tools.TestProxy.StorageBlobSample.csproj to later versions which also did not require code changes.

@scbedd - I know once this is merged and published that I need to create another PR to update [eng/common/testproxy/target_version.txt](https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/testproxy/target_version.txt) with that version.