### PR TITLE
Hide the navigation nodes for unmodified nodes in diff

### DIFF
--- a/src/dotnet/APIView/APIView/Model/CodeFile.cs
+++ b/src/dotnet/APIView/APIView/Model/CodeFile.cs
@@ -186,6 +186,9 @@ namespace ApiView
             List<ReviewToken> currentLineTokens = new List<ReviewToken>();
             foreach(var oldToken in Tokens)
             {
+                //Don't include documentation in converted code file due to incorrect documentation formatting used in previous model.
+                if (isDocumentation && oldToken.Kind != CodeFileTokenKind.DocumentRangeEnd)
+                    continue;
                 ReviewToken token = null;
                 switch(oldToken.Kind)
                 {
@@ -268,6 +271,13 @@ namespace ApiView
                         {
                             parent.Children.Add(reviewLine);
                             reviewLine.parentLine = parent;
+                        }
+
+                        //Handle specific cases for C++ line with 'public:' and '{' to mark related line
+                        if ((currentLineTokens.Count == 1 && currentLineTokens.First().Value == "{") ||
+                            (currentLineTokens.Count == 2 && currentLineTokens.Any(t => t.Kind == TokenKind.Keyword && t.Value == "public")))
+                        {
+                            reviewLine.RelatedToLine = previousLine?.LineId;
                         }
 
                         if (currentLineTokens.Count == 0)

--- a/src/dotnet/APIView/ClientSPA/src/app/_models/navigationTreeModels.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_models/navigationTreeModels.ts
@@ -9,4 +9,5 @@ export class NavigationTreeNode {
   data: NavigationTreeNodeData = new NavigationTreeNodeData();
   expanded: boolean = false;
   children: NavigationTreeNode[] = [];
+  visible: boolean = true;
 }


### PR DESCRIPTION
Hive the nodes if a corresponding code line is not visible in case of custom navigation tree. This PR also has the changes to exclude documentation when converting tokens from old model to streamline the token structure. Old token model has incorrect documentation line with partial code line.