### PR TITLE
[tsp-client] add combine-swaggers command

### DIFF
--- a/tools/tsp-client/README.md
+++ b/tools/tsp-client/README.md
@@ -67,6 +67,12 @@ Sort an existing swagger specification to be the same content order with TypeSpe
 
 Generate an emitter-package-lock.json under the eng/ directory based on existing `<repo-root>/eng/emitter-package.json`.
 
+### combine-swaggers
+
+Combine 2 or more existing swagger specifications into a single swagger specification. The contents will be in the same order as a TypeSpec generated swagger.
+
+This only merges the contents of top-level fields in the swagger specs. For array values, contents will be concatenated. No array value deduplication occurs. For object values, both objects will be merged. A warning will be logged if the same key exists in both object values.
+
 ## Options
 
 ```

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -2,6 +2,7 @@ import yargs from "yargs/yargs";
 import { hideBin } from "yargs/helpers";
 import { checkDebugLogging, Logger, printBanner, usageText } from "./log.js";
 import {
+    combineSwaggersCommand,
   compareCommand,
   convertCommand,
   generateCommand,
@@ -239,6 +240,20 @@ const parser = yargs(hideBin(process.argv))
       argv["output-dir"] = resolveOutputDir(argv);
       const rawArgs = process.argv.slice(3);
       await compareCommand(argv, rawArgs);
+    },
+  )
+  .command(
+    "combine-swaggers <swagger-files..>",
+    "Combine multiple swagger files into a single swagger file.",
+    (yargs: any) => {
+      return yargs.positional("swagger-files", {
+        type: "string",
+        description: "Path to the swagger file",
+      });
+    },
+    async (argv: any) => {
+        argv["output-dir"] = resolveOutputDir(argv);
+        await combineSwaggersCommand(argv);
     },
   )
   .demandCommand(1, "Please provide a command.")


### PR DESCRIPTION
This adds a quick and dirty `combine-swaggers` command to 'merge' multiple swagger files into a single swagger file. This is meant to make it easier to compare existing APIs split across multiple files with a TypeSpec-generated API that exists in a single file.

Only top-level fields are merged at this time, and no deduplication of array values is done.