### PR TITLE
Update projects targeting net6 to net8 - part 2

### DIFF
--- a/tools/agent-time-extractor/AgentTimeExtractor/AgentTimeExtractor.csproj
+++ b/tools/agent-time-extractor/AgentTimeExtractor/AgentTimeExtractor.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.159.1-preview" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
   </ItemGroup>
 
 </Project>

--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/Azure.Sdk.Tools.HttpFaultInjector.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>0.2.0</VersionPrefix>
 
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>

--- a/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/FaultInjectingMiddleware.cs
+++ b/tools/http-fault-injector/Azure.Sdk.Tools.HttpFaultInjector/FaultInjectingMiddleware.cs
@@ -239,7 +239,7 @@ namespace Azure.Sdk.Tools.HttpFaultInjector
             response.StatusCode = upstreamResponse.StatusCode;
             foreach (var header in upstreamResponse.Headers)
             {
-                response.Headers.Add(header.Key, header.Value);
+                response.Headers.Append(header.Key, header.Value);
             }
 
             _logger.LogInformation("Started writing response body, {actualLength}", contentBytes);

--- a/tools/http-fault-injector/sample-clients/net/storage-blobs/Azure.Sdk.Tools.HttpFaultInjector.StorageBlobsSample.csproj
+++ b/tools/http-fault-injector/sample-clients/net/storage-blobs/Azure.Sdk.Tools.HttpFaultInjector.StorageBlobsSample.csproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.13.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.0" />
   </ItemGroup>
 
 </Project>

--- a/tools/http-fault-injector/sample-servers/net/http-server/Azure.Sdk.Tools.HttpFaultInjector.HttpServerSample.csproj
+++ b/tools/http-fault-injector/sample-servers/net/http-server/Azure.Sdk.Tools.HttpFaultInjector.HttpServerSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen.Tests/Azure.SDK.Management.ChangelogGen.Tests.csproj
+++ b/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen.Tests/Azure.SDK.Management.ChangelogGen.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 

--- a/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen/Azure.SDK.Management.ChangelogGen.csproj
+++ b/tools/net-changelog-gen-mgmt/Azure.SDK.Management.ChangelogGen/Azure.SDK.Management.ChangelogGen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <PackAsTool>True</PackAsTool>

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation.Tests/Azure.Sdk.Tools.PerfAutomation.Tests.csproj
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation.Tests/Azure.Sdk.Tools.PerfAutomation.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Azure.Sdk.Tools.PerfAutomation.csproj
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Azure.Sdk.Tools.PerfAutomation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Azure.Sdk.Tools.PipelineGenerator.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>pipeline-generator</ToolCommandName>

--- a/tools/pixel-server/PixelServer/PixelServer.csproj
+++ b/tools/pixel-server/PixelServer/PixelServer.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationInsightsResourceId>/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourcegroups/sdk-bi-data/providers/microsoft.insights/components/azure-sdk-bi</ApplicationInsightsResourceId>
     <ApplicationInsightsAnnotationResourceId>/subscriptions/a18897a6-7e44-457d-9260-f2854c0aca42/resourcegroups/sdk-bi-data/providers/microsoft.insights/components/azure-sdk-bi</ApplicationInsightsAnnotationResourceId>
     <UserSecretsId>317bfab0-0fc1-4048-b61e-67e8f96c2b3a</UserSecretsId>
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
   </ItemGroup>
 

--- a/tools/pixel-server/PixelServer/Startup.cs
+++ b/tools/pixel-server/PixelServer/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +10,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
+using Microsoft.Extensions.Hosting;
 
 namespace PixelServer
 {
@@ -27,11 +28,11 @@ namespace PixelServer
         {
             services.AddMemoryCache();
             services.AddApplicationInsightsTelemetry(Configuration);
-            services.AddMvcCore();
+            services.AddMvcCore(options => options.EnableEndpointRouting = false);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IHostingEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
         {
             if (env.IsDevelopment())
             {

--- a/tools/secret-management/Azure.Sdk.Tools.AccessManagement.Tests/Azure.Sdk.Tools.AccessManagement.Tests.csproj
+++ b/tools/secret-management/Azure.Sdk.Tools.AccessManagement.Tests/Azure.Sdk.Tools.AccessManagement.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
 
     <IsPackable>false</IsPackable>

--- a/tools/secret-management/Azure.Sdk.Tools.AccessManagement/Azure.Sdk.Tools.AccessManagement.csproj
+++ b/tools/secret-management/Azure.Sdk.Tools.AccessManagement/Azure.Sdk.Tools.AccessManagement.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.ResourceManager.Authorization" Version="1.0.1" />

--- a/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Azure.Sdk.Tools.SecretManagement.Cli.csproj
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Azure.Sdk.Tools.SecretManagement.Cli.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>

--- a/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Commands/RotateCommand.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Commands/RotateCommand.cs
@@ -3,7 +3,6 @@ using System.CommandLine.Invocation;
 using Azure.Sdk.Tools.SecretRotation.Configuration;
 using Azure.Sdk.Tools.SecretRotation.Core;
 using Microsoft.Extensions.Logging;
-using TimeProvider = Azure.Sdk.Tools.SecretRotation.Core.TimeProvider;
 
 namespace Azure.Sdk.Tools.SecretManagement.Cli.Commands;
 
@@ -24,7 +23,7 @@ public class RotateCommand : RotationCommandBase
         bool onlyRotateExpiring = invocationContext.ParseResult.GetValueForOption(this.expiringOption);
         bool whatIf = invocationContext.ParseResult.GetValueForOption(this.whatIfOption);
 
-        var timeProvider = new TimeProvider();
+        var timeProvider = TimeProvider.System;
 
         IEnumerable<RotationPlan> plans = rotationConfiguration.GetAllRotationPlans(logger, timeProvider);
         bool success = true;

--- a/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Commands/RotateCommand.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Commands/RotateCommand.cs
@@ -3,6 +3,7 @@ using System.CommandLine.Invocation;
 using Azure.Sdk.Tools.SecretRotation.Configuration;
 using Azure.Sdk.Tools.SecretRotation.Core;
 using Microsoft.Extensions.Logging;
+using TimeProvider = Azure.Sdk.Tools.SecretRotation.Core.TimeProvider;
 
 namespace Azure.Sdk.Tools.SecretManagement.Cli.Commands;
 

--- a/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Commands/StatusCommand.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Commands/StatusCommand.cs
@@ -2,7 +2,6 @@ using System.CommandLine.Invocation;
 using System.Text;
 using Azure.Sdk.Tools.SecretRotation.Configuration;
 using Azure.Sdk.Tools.SecretRotation.Core;
-using TimeProvider = Azure.Sdk.Tools.SecretRotation.Core.TimeProvider;
 
 namespace Azure.Sdk.Tools.SecretManagement.Cli.Commands;
 
@@ -15,7 +14,7 @@ public class StatusCommand : RotationCommandBase
     protected override async Task HandleCommandAsync(ILogger logger, RotationConfiguration rotationConfiguration,
         InvocationContext invocationContext)
     {
-        var timeProvider = new TimeProvider();
+        var timeProvider = TimeProvider.System;
         RotationPlan[] plans = rotationConfiguration.GetAllRotationPlans(logger, timeProvider).ToArray();
 
         logger.LogInformation($"Getting status for {plans.Length} plans");

--- a/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Commands/StatusCommand.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretManagement.Cli/Commands/StatusCommand.cs
@@ -2,6 +2,7 @@ using System.CommandLine.Invocation;
 using System.Text;
 using Azure.Sdk.Tools.SecretRotation.Configuration;
 using Azure.Sdk.Tools.SecretRotation.Core;
+using TimeProvider = Azure.Sdk.Tools.SecretRotation.Core.TimeProvider;
 
 namespace Azure.Sdk.Tools.SecretManagement.Cli.Commands;
 

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Azure/Azure.Sdk.Tools.SecretRotation.Azure.csproj
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Azure/Azure.Sdk.Tools.SecretRotation.Azure.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.40.0" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Configuration/Azure.Sdk.Tools.SecretRotation.Configuration.csproj
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Configuration/Azure.Sdk.Tools.SecretRotation.Configuration.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Azure.Sdk.Tools.SecretRotation.Core\Azure.Sdk.Tools.SecretRotation.Core.csproj" />
   </ItemGroup>

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Configuration/RotationConfiguration.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Configuration/RotationConfiguration.cs
@@ -1,7 +1,6 @@
 using System.Collections.ObjectModel;
 using Azure.Sdk.Tools.SecretRotation.Core;
 using Microsoft.Extensions.Logging;
-using TimeProvider = Azure.Sdk.Tools.SecretRotation.Core.TimeProvider;
 
 namespace Azure.Sdk.Tools.SecretRotation.Configuration;
 

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Configuration/RotationConfiguration.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Configuration/RotationConfiguration.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using Azure.Sdk.Tools.SecretRotation.Core;
 using Microsoft.Extensions.Logging;
+using TimeProvider = Azure.Sdk.Tools.SecretRotation.Core.TimeProvider;
 
 namespace Azure.Sdk.Tools.SecretRotation.Configuration;
 

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/Azure.Sdk.Tools.SecretRotation.Core.csproj
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/Azure.Sdk.Tools.SecretRotation.Core.csproj
@@ -1,5 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
   </ItemGroup>

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationPlan.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/RotationPlan.cs
@@ -54,7 +54,7 @@ public class RotationPlan
         using IDisposable? loggingScope = this.logger.BeginScope(operationId);
         this.logger.LogInformation("\nProcessing rotation plan '{PlanName}'", Name);
 
-        DateTimeOffset shouldRotateDate = this.timeProvider.GetCurrentDateTimeOffset().Add(RotationThreshold);
+        DateTimeOffset shouldRotateDate = this.timeProvider.GetUtcNow().Add(RotationThreshold);
 
         this.logger.LogInformation("Getting current state of plan");
 
@@ -88,7 +88,7 @@ public class RotationPlan
     {
         try
         {
-            DateTimeOffset invocationTime = this.timeProvider.GetCurrentDateTimeOffset();
+            DateTimeOffset invocationTime = this.timeProvider.GetUtcNow();
 
             SecretState primaryStoreState = await PrimaryStore.GetCurrentStateAsync();
 
@@ -106,9 +106,9 @@ public class RotationPlan
 
             SecretState[] allStates = secondaryStoreStates.Prepend(primaryStoreState).ToArray();
 
-            DateTimeOffset rotationThresholdDate = this.timeProvider.GetCurrentDateTimeOffset().Add(RotationThreshold);
+            DateTimeOffset rotationThresholdDate = this.timeProvider.GetUtcNow().Add(RotationThreshold);
 
-            DateTimeOffset warningThresholdDate = this.timeProvider.GetCurrentDateTimeOffset().Add(WarningThreshold);
+            DateTimeOffset warningThresholdDate = this.timeProvider.GetUtcNow().Add(WarningThreshold);
 
             DateTimeOffset? minExpirationDate = allStates
                 .Where(x => x.ExpirationDate.HasValue)
@@ -159,7 +159,7 @@ public class RotationPlan
          *     A user can combine origin and primary only when origin can be marked as complete in some way (e.g. Key Vault Certificates can be tagged)
          */
 
-        DateTimeOffset invocationTime = this.timeProvider.GetCurrentDateTimeOffset();
+        DateTimeOffset invocationTime = this.timeProvider.GetUtcNow();
 
         SecretValue newValue = await OriginateNewValueAsync(operationId, invocationTime, currentState, whatIf);
         // TODO: some providers will issue secrets for longer than we requested. Should we propagate the real expiration date, or the desired expiration date?
@@ -244,7 +244,7 @@ public class RotationPlan
 
     private async Task RevokeRotationArtifactsAsync(bool whatIf)
     {
-        DateTimeOffset invocationTime = this.timeProvider.GetCurrentDateTimeOffset();
+        DateTimeOffset invocationTime = this.timeProvider.GetUtcNow();
 
         IEnumerable<SecretState> rotationArtifacts = await PrimaryStore.GetRotationArtifactsAsync();
 

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/TimeProvider.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Core/TimeProvider.cs
@@ -1,9 +1,0 @@
-﻿namespace Azure.Sdk.Tools.SecretRotation.Core;
-
-public class TimeProvider
-{
-    public virtual DateTimeOffset GetCurrentDateTimeOffset()
-    {
-        return DateTimeOffset.UtcNow;
-    }
-}

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/Azure.Sdk.Tools.SecretRotation.Tests.csproj
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/Azure.Sdk.Tools.SecretRotation.Tests.csproj
@@ -1,5 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
     <PackageReference Include="Moq" Version="4.18.3" />

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationConfigurationTests.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationConfigurationTests.cs
@@ -1,6 +1,7 @@
 using Azure.Sdk.Tools.SecretRotation.Configuration;
 using Azure.Sdk.Tools.SecretRotation.Core;
 using Microsoft.Extensions.Logging;
+using TimeProvider = Azure.Sdk.Tools.SecretRotation.Core.TimeProvider;
 
 namespace Azure.Sdk.Tools.SecretRotation.Tests.CoreTests;
 

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationConfigurationTests.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationConfigurationTests.cs
@@ -1,7 +1,6 @@
 using Azure.Sdk.Tools.SecretRotation.Configuration;
 using Azure.Sdk.Tools.SecretRotation.Core;
 using Microsoft.Extensions.Logging;
-using TimeProvider = Azure.Sdk.Tools.SecretRotation.Core.TimeProvider;
 
 namespace Azure.Sdk.Tools.SecretRotation.Tests.CoreTests;
 
@@ -159,7 +158,7 @@ public class RotationConfigurationTests
         RotationConfiguration configuration = RotationConfiguration.From(names, tags, configRoot, storeFactories);
 
         // Act
-        IEnumerable<RotationPlan> plans = configuration.GetAllRotationPlans(Mock.Of<ILogger>(), new TimeProvider());
+        IEnumerable<RotationPlan> plans = configuration.GetAllRotationPlans(Mock.Of<ILogger>(), TimeProvider.System);
 
         Assert.AreEqual(1, plans.Count());
     }

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationPlanTests.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationPlanTests.cs
@@ -1,5 +1,6 @@
 using Azure.Sdk.Tools.SecretRotation.Core;
 using Microsoft.Extensions.Logging;
+using TimeProvider = Azure.Sdk.Tools.SecretRotation.Core.TimeProvider;
 
 namespace Azure.Sdk.Tools.SecretRotation.Tests.CoreTests;
 

--- a/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationPlanTests.cs
+++ b/tools/secret-management/Azure.Sdk.Tools.SecretRotation.Tests/CoreTests/RotationPlanTests.cs
@@ -1,6 +1,5 @@
 using Azure.Sdk.Tools.SecretRotation.Core;
 using Microsoft.Extensions.Logging;
-using TimeProvider = Azure.Sdk.Tools.SecretRotation.Core.TimeProvider;
 
 namespace Azure.Sdk.Tools.SecretRotation.Tests.CoreTests;
 
@@ -59,7 +58,7 @@ public class RotationPlanTests
 
         var rotationPlan = new RotationPlan(
             Mock.Of<ILogger>(),
-            Mock.Of<TimeProvider>(x => x.GetCurrentDateTimeOffset() == staticTestTime),
+            Mock.Of<TimeProvider>(x => x.GetUtcNow() == staticTestTime),
             "TestPlan",
             Mock.Of<SecretStore>(),
             Mock.Of<SecretStore>(x => x.GetCurrentStateAsync() == Task.FromResult(primaryState)),
@@ -102,7 +101,7 @@ public class RotationPlanTests
 
         var rotationPlan = new RotationPlan(
             Mock.Of<ILogger>(),
-            Mock.Of<TimeProvider>(x => x.GetCurrentDateTimeOffset() == staticTestTime),
+            Mock.Of<TimeProvider>(x => x.GetUtcNow() == staticTestTime),
             "TestPlan",
             Mock.Of<SecretStore>(),
             Mock.Of<SecretStore>(
@@ -162,7 +161,7 @@ public class RotationPlanTests
 
         var rotationPlan = new RotationPlan(
             Mock.Of<ILogger>(),
-            Mock.Of<TimeProvider>(x => x.GetCurrentDateTimeOffset() == staticTestTime),
+            Mock.Of<TimeProvider>(x => x.GetUtcNow() == staticTestTime),
             "TestPlan",
             originStore,
             primaryStore,

--- a/tools/secret-management/Directory.Build.props
+++ b/tools/secret-management/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/Azure.Sdk.Tools.SnippetGenerator.Tests.csproj
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator.Tests/Azure.Sdk.Tools.SnippetGenerator.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <IsPackable>false</IsPackable>
     </PropertyGroup>
 

--- a/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Azure.Sdk.Tools.SnippetGenerator.csproj
+++ b/tools/snippet-generator/Azure.Sdk.Tools.SnippetGenerator/Azure.Sdk.Tools.SnippetGenerator.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <Description>Generates code snippets for readmes in the azure-sdk-for-net repo.</Description>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>snippet-generator</ToolCommandName>
     <VersionPrefix>1.0.0</VersionPrefix>


### PR DESCRIPTION
net6 hits EOL in November, 2024 and this is to update things to net8. This is the second round of projects. 

About tools/pixel-server/PixelServer/Startup.cs: These warnings should have been fixed when the project was upgraded to Net6 and weren't. I'm fixing them now.

- using Microsoft.Extensions.Hosting; was required to use IsDevelopment()
- The UseMVC now requires options => options.EnableEndpointRouting = false set in the services.AddMvcCore call


Contributes to https://github.com/Azure/azure-sdk-tools/issues/8606