### PR TITLE
examples-automation, use goimports 0.24.0

### DIFF
--- a/tools/azure-rest-api-specs-examples-automation/go/validate.py
+++ b/tools/azure-rest-api-specs-examples-automation/go/validate.py
@@ -79,7 +79,7 @@ class GoVet:
 
                 logging.info("Run goimports")
                 # goimports
-                cmd = ["go", "install", "golang.org/x/tools/cmd/goimports@latest"]
+                cmd = ["go", "install", "golang.org/x/tools/cmd/goimports@v0.24.0"]
                 check_call(cmd, tmp_dir_name)
 
                 cmd = ["goimports", "-w", "."]


### PR DESCRIPTION
Get it work first.

Task to upgrade the golang runtime to 1.22.0 https://github.com/Azure/azure-sdk-tools/issues/9019