### PR TITLE
Fix sparse-checkout commit

### DIFF
--- a/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
@@ -5,6 +5,9 @@ parameters:
   - name: RepositoryPath
     type: string
     default: 'sdk'
+  - name: RepositoryCommitish
+    type: string
+    default: $(Build.SourceVersion)
 
 jobs:
 - job:
@@ -36,6 +39,7 @@ jobs:
       parameters:
         Repositories:
           - Name: ${{ parameters.Repository }}
+            Commitish: ${{ parameters.RepositoryCommitish }}
             WorkingDirectory: $(System.DefaultWorkingDirectory)
         Paths:
           - 'sdk/**/*.yml'

--- a/eng/pipelines/pipeline-generation-single.yml
+++ b/eng/pipelines/pipeline-generation-single.yml
@@ -2,15 +2,15 @@ pr: none
 trigger: none
 
 parameters:
-- name: Branch
-  type: string
-  default: main
 - name: RepositoryName
   type: string
   default: azure-sdk-for-<lang>
 - name: RepositoryPath
   type: string
   default: 'sdk/<service>'
+- name: RepositoryCommitish
+  type: string
+  default: $(Build.SourceVersion)
 
 variables:
 - template: /eng/pipelines/templates/variables/image.yml
@@ -24,3 +24,4 @@ jobs:
   parameters:
     Repository: Azure/${{ parameters.RepositoryName }}
     RepositoryPath: ${{ parameters.RepositoryPath }}
+    RepositoryCommitish: ${{ paramters.RepositoryCommitish }}

--- a/eng/pipelines/pipeline-generation-single.yml
+++ b/eng/pipelines/pipeline-generation-single.yml
@@ -24,4 +24,4 @@ jobs:
   parameters:
     Repository: Azure/${{ parameters.RepositoryName }}
     RepositoryPath: ${{ parameters.RepositoryPath }}
-    RepositoryCommitish: ${{ paramters.RepositoryCommitish }}
+    RepositoryCommitish: ${{ parameters.RepositoryCommitish }}

--- a/eng/pipelines/pipeline-generation-single.yml
+++ b/eng/pipelines/pipeline-generation-single.yml
@@ -10,7 +10,7 @@ parameters:
   default: 'sdk/<service>'
 - name: RepositoryCommitish
   type: string
-  default: $(Build.SourceVersion)
+  default: main
 
 variables:
 - template: /eng/pipelines/templates/variables/image.yml

--- a/eng/pipelines/pipeline-generation.yml
+++ b/eng/pipelines/pipeline-generation.yml
@@ -29,3 +29,4 @@ jobs:
   - template: /eng/common/pipelines/templates/jobs/prepare-pipelines.yml
     parameters:
       Repository: ${{ repo }}
+      RepositoryCommitish: main


### PR DESCRIPTION
When using the template in prepare-pipelines we need to use `$(Build.SourceVersion)` as our checkout so that people can trigger on their pull requests. 

For the pipeline generation automation pipelines we want to default those to the main branches in the sdk repos. 