### PR TITLE
Update Stress.Watcher from net6 to net8

### DIFF
--- a/tools/stress-cluster/services/Stress.Watcher/src/Stress.Watcher.csproj
+++ b/tools/stress-cluster/services/Stress.Watcher/src/Stress.Watcher.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Stress.Watcher</RootNamespace>
   </PropertyGroup>
 

--- a/tools/stress-cluster/services/Stress.Watcher/tests/Stress.Watcher.Tests.csproj
+++ b/tools/stress-cluster/services/Stress.Watcher/tests/Stress.Watcher.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
net6 hits EOL in November, 2024 and this is to update things to net8.

Contributes to https://github.com/Azure/azure-sdk-tools/issues/8606