### PR TITLE
Update http-fault-injector's HttpClientSample from Net6 to Net8

### DIFF
--- a/tools/http-fault-injector/sample-clients/net/http-client/Azure.Sdk.Tools.HttpFaultInjector.HttpClientSample.csproj
+++ b/tools/http-fault-injector/sample-clients/net/http-client/Azure.Sdk.Tools.HttpFaultInjector.HttpClientSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
net6 hits EOL in November of 2024, this updates the project to net8.

Note: This was apparently missed when I'd updated the http-fault-injector's other projects last week.

Contributes to https://github.com/Azure/azure-sdk-tools/issues/8606.