### PR TITLE
Don't verify changelogs for packages not present in Artifacts

### DIFF
--- a/eng/common/pipelines/templates/steps/verify-changelogs.yml
+++ b/eng/common/pipelines/templates/steps/verify-changelogs.yml
@@ -6,6 +6,12 @@ parameters:
   default: succeeded()
 
 steps:
+  - pwsh: |
+      Get-ChildItem -Recurse -Path "$(Build.SourcesDirectory)/sdk" -Include ci.yml `
+        | % { Get-Content $_ | yq -o=json > "$($_.FullName).json" }
+    displayName: Generate ci.yml.json
+    condition: ${{ parameters.Condition }}
+
   - task: Powershell@2
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/common/scripts/Verify-ChangeLogs.ps1

--- a/eng/common/pipelines/templates/steps/verify-changelogs.yml
+++ b/eng/common/pipelines/templates/steps/verify-changelogs.yml
@@ -6,12 +6,6 @@ parameters:
   default: succeeded()
 
 steps:
-  - pwsh: |
-      Get-ChildItem -Recurse -Path "$(Build.SourcesDirectory)/sdk" -Include ci.yml `
-        | ForEach-Object { Get-Content $_ -Raw | yq -o=json > "$($_.FullName).json" }
-    displayName: Generate ci.yml.json
-    condition: ${{ parameters.Condition }}
-
   - task: Powershell@2
     inputs:
       filePath: $(Build.SourcesDirectory)/eng/common/scripts/Verify-ChangeLogs.ps1

--- a/eng/common/pipelines/templates/steps/verify-changelogs.yml
+++ b/eng/common/pipelines/templates/steps/verify-changelogs.yml
@@ -8,7 +8,7 @@ parameters:
 steps:
   - pwsh: |
       Get-ChildItem -Recurse -Path "$(Build.SourcesDirectory)/sdk" -Include ci.yml `
-        | % { Get-Content $_ | yq -o=json > "$($_.FullName).json" }
+        | ForEach-Object { Get-Content $_ -Raw | yq -o=json > "$($_.FullName).json" }
     displayName: Generate ci.yml.json
     condition: ${{ parameters.Condition }}
 

--- a/eng/common/scripts/Verify-ChangeLogs.ps1
+++ b/eng/common/scripts/Verify-ChangeLogs.ps1
@@ -14,8 +14,6 @@ function ShouldVerifyChangeLog ($ServiceDirectory, $PackageName) {
     {
         $ciYml = ConvertFrom-Json (Get-Content $jsonCiYmlPath -Raw)
 
-        Write-Host $jsonCiYmlPath
-
         if ($ciYml.extends -and $ciYml.extends.parameters -and $ciYml.extends.parameters.Artifacts) {
             # if parsed from a json file, this is a PSObject, not a PSCustomObject
             $packagesCheckingChangeLog = $ciYml.extends.parameters.Artifacts `
@@ -24,7 +22,6 @@ function ShouldVerifyChangeLog ($ServiceDirectory, $PackageName) {
 
             if ($packagesCheckingChangeLog -contains $PackageName)
             {
-                Write-Host $packagesCheckingChangeLog
                 return $true
             } else {
                 return $false

--- a/eng/common/scripts/Verify-ChangeLogs.ps1
+++ b/eng/common/scripts/Verify-ChangeLogs.ps1
@@ -37,8 +37,8 @@ $allPassing = $true
 foreach($propertiesFile in $packageProperties) {
   $PackageProp = Get-Content -Path $propertiesFile | ConvertFrom-Json
 
-  if (-not (ShouldVerifyChangeLog -ServiceDirectory (Join-Path $RepoRoot "sdk" $packageInfo.ServiceDirectory) -PackageName $packageInfo.Name)) {
-        Write-Host "Skipping changelog verification for $($packageInfo.Name)"
+  if (-not (ShouldVerifyChangeLog -ServiceDirectory (Join-Path $RepoRoot "sdk" $PackageProp.ServiceDirectory) -PackageName $PackageProp.Name)) {
+        Write-Host "Skipping changelog verification for $($PackageProp.Name)"
         continue
   }
 

--- a/eng/common/scripts/Verify-ChangeLogs.ps1
+++ b/eng/common/scripts/Verify-ChangeLogs.ps1
@@ -7,6 +7,29 @@ Set-StrictMode -Version 3
 
 . (Join-Path $PSScriptRoot common.ps1)
 
+function ShouldVerifyChangeLog ($ServiceDirectory, $PackageName) {
+    $jsonCiYmlPath = Join-Path $ServiceDirectory "ci.yml.json"
+
+    if (Test-Path $jsonCiYmlPath)
+    {
+        $ciYml = ConvertFrom-Json (Get-Content $jsonCiYmlPath -Raw)
+
+        if ($ciYml.extends -and $ciYml.extends.parameters -and $ciYml.extends.parameters.Artifacts) {
+            $packagesCheckingChangeLog = $ciYml.extends.parameters.Artifacts `
+                | Where-Object { -not ($_["skipVerifyChangelog"] -eq $true) }
+                | Select-Object -ExpandProperty name
+
+            if ($packagesCheckingChangeLog -contains $PackageName)
+            {
+                return $true
+            }
+            else {
+                return $false
+            }
+        }
+    }
+}
+
 # find which packages we need to confirm the changelog for
 $packageProperties = Get-ChildItem -Recurse "$PackagePropertiesFolder" *.json
 
@@ -15,13 +38,17 @@ $allPassing = $true
 foreach($propertiesFile in $packageProperties) {
   $PackageProp = Get-Content -Path $propertiesFile | ConvertFrom-Json
 
+  if (-not (ShouldVerifyChangeLog -ServiceDirectory (Join-Path $RepoRoot "sdk" $packageInfo.ServiceDirectory) -PackageName $packageInfo.Name)) {
+        Write-Host "Skipping changelog verification for $($packageInfo.Name)"
+        continue
+  }
+
   $validChangeLog =  Confirm-ChangeLogEntry -ChangeLogLocation $PackageProp.ChangeLogPath -VersionString $PackageProp.Version -ForRelease $false
 
   if (-not $validChangeLog) {
     $allPassing = $false
   }
 }
-
 
 if (!$allPassing)
 {

--- a/eng/common/scripts/Verify-ChangeLogs.ps1
+++ b/eng/common/scripts/Verify-ChangeLogs.ps1
@@ -22,8 +22,7 @@ function ShouldVerifyChangeLog ($ServiceDirectory, $PackageName) {
             if ($packagesCheckingChangeLog -contains $PackageName)
             {
                 return $true
-            }
-            else {
+            } else {
                 return $false
             }
         }

--- a/eng/common/scripts/Verify-ChangeLogs.ps1
+++ b/eng/common/scripts/Verify-ChangeLogs.ps1
@@ -14,13 +14,17 @@ function ShouldVerifyChangeLog ($ServiceDirectory, $PackageName) {
     {
         $ciYml = ConvertFrom-Json (Get-Content $jsonCiYmlPath -Raw)
 
+        Write-Host $jsonCiYmlPath
+
         if ($ciYml.extends -and $ciYml.extends.parameters -and $ciYml.extends.parameters.Artifacts) {
+            # if parsed from a json file, this is a PSObject, not a PSCustomObject
             $packagesCheckingChangeLog = $ciYml.extends.parameters.Artifacts `
-                | Where-Object { -not ($_["skipVerifyChangelog"] -eq $true) }
+                | Where-Object { -not ($_.PSObject.Properties["skipVerifyChangelog"] -and $_.skipVerifyChangelog -eq $true) } `
                 | Select-Object -ExpandProperty name
 
             if ($packagesCheckingChangeLog -contains $PackageName)
             {
+                Write-Host $packagesCheckingChangeLog
                 return $true
             } else {
                 return $false

--- a/eng/common/scripts/Verify-ChangeLogs.ps1
+++ b/eng/common/scripts/Verify-ChangeLogs.ps1
@@ -12,12 +12,11 @@ function ShouldVerifyChangeLog ($ServiceDirectory, $PackageName) {
 
     if (Test-Path $jsonCiYmlPath)
     {
-        $ciYml = ConvertFrom-Json (Get-Content $jsonCiYmlPath -Raw)
+        $ciYml = ConvertFrom-Json (Get-Content $jsonCiYmlPath -Raw) -AsHashTable
 
         if ($ciYml.extends -and $ciYml.extends.parameters -and $ciYml.extends.parameters.Artifacts) {
-            # if parsed from a json file, this is a PSObject, not a PSCustomObject
             $packagesCheckingChangeLog = $ciYml.extends.parameters.Artifacts `
-                | Where-Object { -not ($_.PSObject.Properties["skipVerifyChangelog"] -and $_.skipVerifyChangelog -eq $true) } `
+                | Where-Object { -not ($_["skipVerifyChangelog"] -eq $true) } `
                 | Select-Object -ExpandProperty name
 
             if ($packagesCheckingChangeLog -contains $PackageName)


### PR DESCRIPTION
Last blocker :tm: for pipelinev3 in the python repo. Got clean runs other than failing changelog verification against packages that are no longer published.

~~Along the lines of this PR...should we have a `ShouldInvokeCHeck` function that takes an `artifacts` property to check for? EG `skipVerifyChangelog` not true, `publishDocs` not `false. It's not necessarily common for each repo.~~

- ~~If in `CI`, `yq` will be present. `yq` a discovered `ci.yml` on the fly~~
- ~~If not in CI, use PSModules and install the powershell module for yml~~

~~If folks are good with above algo, I'll move the `ShouldInvokeCheck` to `common.ps1`. Otherwise this PR should work as-is.~~

The above may still stand, but we're just calling `yq` and erroring if not present on invoking machine in this PR now.