### PR TITLE
Fix naming for Azure/typespec-azure

### DIFF
--- a/tools/pipeline-witness/monitored-repos.json
+++ b/tools/pipeline-witness/monitored-repos.json
@@ -17,6 +17,6 @@
     "Azure/azure-sdk-for-python",
     "Azure/azure-sdk-for-rust",
     "Azure/azure-sdk-tools",
-    "Azure/typespec",
+    "Azure/typespec-azure",
     "Microsoft/typespec"
 ]


### PR DESCRIPTION
It was added as Azure/typespec