### PR TITLE
Docs onboarding cleanup final: Rename ValidatePackageForOnboarding2

### DIFF
--- a/eng/common/scripts/Update-DocsMsPackages.ps1
+++ b/eng/common/scripts/Update-DocsMsPackages.ps1
@@ -54,7 +54,7 @@ function GetMetadata($moniker) {
   return $metadata
 }
 
-function ValidatePackageForOnboarding2($package) {
+function PackageIsValidForDocsOnboarding($package) {
   if (!(Test-Path "Function:$ValidateDocsMsPackagesFn")) {
     return $true
   }
@@ -88,7 +88,7 @@ foreach ($moniker in $MONIKERS) {
         if ($package.ContainsKey('_SkipDocsValidation') -and $true -eq $package['_SkipDocsValidation']) {
           Write-Host "Skip validation for package: $($packageIdentity)"
         }
-        elseif (!(ValidatePackageForOnboarding2 $package)) {
+        elseif (!(PackageIsValidForDocsOnboarding $package)) {
           LogWarning "Skip adding package that did not pass validation: $($packageIdentity)"
           continue
         }
@@ -101,7 +101,7 @@ foreach ($moniker in $MONIKERS) {
       $oldPackage = $alreadyOnboardedPackages[$packageIdentity]
 
       if ($oldPackage.Version -ne $package.Version) {
-        if (!(ValidatePackageForOnboarding2 $package)) {
+        if (!(PackageIsValidForDocsOnboarding $package)) {
           LogWarning "Omitting package that failed validation: $($packageIdentity)@$($package.Version)"
           continue
         }


### PR DESCRIPTION
There was a `ValidatePackageForOnboarding` declared in a `Language-Settings.ps1` file at the time of the onboarding refactor. This uses a different name for the function which doesn't end in "2": `PackageIsValidForDocsOnboarding` 

Code search of potentially impacted repositories shows no collisions: 
* https://github.com/search?q=repo%3AAzure%2Fazure-sdk-for-net%20PackageIsValidForDocsOnboarding&type=code
* https://github.com/search?q=repo%3AAzure%2Fazure-sdk-for-net%20PackageIsValidForDocsOnboarding&type=code
* https://github.com/search?q=repo%3AAzure%2Fazure-sdk-for-js%20PackageIsValidForDocsOnboarding&type=code
* https://github.com/search?q=repo%3AAzure%2Fazure-sdk-for-python%20PackageIsValidForDocsOnboarding&type=code
* https://github.com/search?q=repo%3AAzure%2Fazure-sdk-tools%20PackageIsValidForDocsOnboarding&type=code

Fixes https://github.com/Azure/azure-sdk-tools/issues/6800