### PR TITLE
Use new ADO credential type for connections over azure credentials

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Azure.Sdk.Tools.PipelineWitness.csproj
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Azure.Sdk.Tools.PipelineWitness.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -14,8 +14,9 @@
     <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.29.0" />
     <PackageReference Include="Microsoft.Extensions.Azure" Version="1.3.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
-    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.225.1" />
+    <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.244.0-preview" />
+    <PackageReference Include="Microsoft.VisualStudio.Services.InteractiveClient" Version="19.244.0-preview" />
+    <PackageReference Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Octokit" Version="12.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/AzurePipelines/AzurePipelinesProcessor.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/AzurePipelines/AzurePipelinesProcessor.cs
@@ -23,6 +23,7 @@ using Microsoft.VisualStudio.Services.WebApi;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
 using Newtonsoft.Json.Serialization;
+using Timeline = Microsoft.TeamFoundation.Build.WebApi.Timeline;
 
 namespace Azure.Sdk.Tools.PipelineWitness.AzurePipelines
 {

--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/Startup.cs
@@ -20,7 +20,6 @@ using Microsoft.Extensions.Options;
 using Microsoft.VisualStudio.Services.Client;
 using Microsoft.VisualStudio.Services.Common;
 using Microsoft.VisualStudio.Services.WebApi;
-using Octokit;
 
 namespace Azure.Sdk.Tools.PipelineWitness;
 
@@ -86,12 +85,9 @@ public static class Startup
 
     private static VssConnection CreateVssConnection(IServiceProvider provider)
     {
-        TokenCredential azureCredential = provider.GetRequiredService<TokenCredential>();
-        TokenRequestContext tokenRequestContext = new(VssAadSettings.DefaultScopes);
-        Azure.Core.AccessToken token = azureCredential.GetToken(tokenRequestContext, CancellationToken.None);
-
         Uri organizationUrl = new("https://dev.azure.com/azure-sdk");
-        VssAadCredential vssCredential = new(new VssAadToken("Bearer", token.Token));
+        TokenCredential azureCredential = provider.GetRequiredService<TokenCredential>();
+        VssAzureIdentityCredential vssCredential = new(azureCredential);
         VssHttpRequestSettings settings = VssClientHttpRequestSettings.Default.Clone();
 
         return new VssConnection(organizationUrl, vssCredential, settings);


### PR DESCRIPTION
Backround workers are persistent and hold a reference to a Processor.
Processors hold VssConnections and VssConnections hold a reference to a credential.  When that credential is baked around a token, the whole token -> credential -> connection -> processor -> worker chain needs to be recreated when the token expires.

We weren't doing this and the service would throw vss unauthorized exceptions when the token expired after 24 hours.  Rather than reconstruct the whole chain or shim factories in the mix, we can use the preview version of the ado client libraries that support Azure Identity credentials and dynamic token requests.