### PR TITLE
Update CodeownersLinter to 1.0.0-dev.20240926.2

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -31,7 +31,7 @@ stages:
       vmImage: ubuntu-22.04
 
     variables:
-      CodeownersLinterVersion: '1.0.0-dev.20240917.2'
+      CodeownersLinterVersion: '1.0.0-dev.20240926.2'
       DotNetDevOpsFeed: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json"
       RepoLabelUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/repository-labels-blob"
       TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"


### PR DESCRIPTION
This updated version of the CodeownersLinter is for the following [PR](https://github.com/Azure/azure-sdk-tools/pull/9040) which improves DevOps logging for the linter in the following ways:

1. Add the linter error messages to the run errors so they're immediately available when someone looks at the run instead of having to open the step.
![image](https://github.com/user-attachments/assets/32b2c3be-6048-4b44-9e3a-533f1709a2b0)

2. DevOps will show the first few errors as annotations (4 but the first error with the aka.ms link means it'll only show the first 3 as annotations)
![image](https://github.com/user-attachments/assets/d5d38892-f0a1-4751-87da-227ee9ad6c98)

