### PR TITLE
[stress] Sync namespace federated credentials periodically and on startup

### DIFF
--- a/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.lock
+++ b/tools/stress-cluster/chaos/examples/stress-deployment-example/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: stress-test-addons
   repository: https://stresstestcharts.blob.core.windows.net/helm/
-  version: 0.3.2
-digest: sha256:6eee71a7e8a4c0dc06d5fbbce39ef63237a0db0b7fc2da66e98e96b68985b764
-generated: "2024-05-23T11:37:41.371010465-04:00"
+  version: 0.3.3
+digest: sha256:1cffb5ed8ea74953ab7611f9e2de2163af2c3f0918afb9928f71210da9c19a4a
+generated: "2024-10-02T16:18:41.429777815-04:00"

--- a/tools/stress-cluster/cluster/azure/cluster/cluster.bicep
+++ b/tools/stress-cluster/cluster/azure/cluster/cluster.bicep
@@ -13,7 +13,7 @@ param updateNodes bool = false
 // monitoring parameters
 param workspaceId string
 
-var kubernetesVersion = '1.29.4'
+var kubernetesVersion = '1.29.8'
 var nodeResourceGroup = 'rg-nodes-${dnsPrefix}-${clusterName}-${groupSuffix}'
 
 var systemAgentPool = {

--- a/tools/stress-cluster/services/Stress.Watcher/Dockerfile
+++ b/tools/stress-cluster/services/Stress.Watcher/Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/sdk:6.0-cbl-mariner2.0 AS build
+FROM mcr.microsoft.com/dotnet/sdk:8.0-cbl-mariner2.0 AS build
 
 COPY ./src /src
 
-RUN cd /src && dotnet publish -c Release -o /stresswatcher -r linux-x64 -f net6.0 -p:PublishSingleFile=true --self-contained
+RUN cd /src && dotnet publish -c Release -o /stresswatcher -r linux-x64 -f net8.0 -p:PublishSingleFile=true --self-contained
 
 FROM mcr.microsoft.com/azure-cli:cbl-mariner2.0
 

--- a/tools/stress-cluster/services/Stress.Watcher/src/Program.cs
+++ b/tools/stress-cluster/services/Stress.Watcher/src/Program.cs
@@ -79,6 +79,8 @@ namespace Stress.Watcher
             var namespaceEventHandler = new NamespaceEventHandler(
                 client, armClient, workloadConfig.SubscriptionId, workloadConfig.ClusterGroup,
                 workloadConfig.WorkloadAppPool, workloadConfig.WorkloadAppIssuer, options.Namespace);
+            await namespaceEventHandler.SyncCredentials();
+            _ = PollAndSyncCredentials(namespaceEventHandler, 288);  // poll every 12 hours
 
             var cts = new CancellationTokenSource();
             var taskList = new List<Task>
@@ -163,6 +165,15 @@ namespace Stress.Watcher
                 SubscriptionId = subscriptionId,
                 ClusterGroup = clusterGroup
             };
+        }
+
+        static async Task PollAndSyncCredentials(NamespaceEventHandler namespaceHandler, int minutes)
+        {
+            while (true)
+            {
+                await Task.Delay(TimeSpan.FromMinutes(minutes));
+                await namespaceHandler.SyncCredentials();
+            }
         }
     }
 }


### PR DESCRIPTION
The original implementation was skipping lookups to see if credentials already existed, on the assumption that deletion was always being handled. This resulted in multiple credentials being created for the same namespace.

Instead we can simply poll to make sure deleted namespaces don't continue to take up a federated identity credential slot as a failsafe. We also sync credential state on startup and keep an in-memory cache, so that namespace deletions/creations re-use existing credentials. There could be some edge cases here with the cache, but I think it's a better trade-off than always querying the managed identity pool every time a namespace is created, as the operation is slow and can increase stress deploy times (we need to wait on completion before deploying otherwise there is a race condition with the credential being created and the deploy container running).

EDIT: my original changes assumed DELETE events weren't being caught, but it's actually because I had added the below code. Now that is removed and the delete event handler method has been added back.

```
if (ns.Status?.Phase == "Terminating")
{
    return;
}
```