### PR TITLE
Timestamp should be a date field

### DIFF
--- a/tools/pipeline-witness/infrastructure/kusto/tables/GitHubActionsLogLine.kql
+++ b/tools/pipeline-witness/infrastructure/kusto/tables/GitHubActionsLogLine.kql
@@ -8,7 +8,7 @@
     StepNumber: int,
     LineNumber: int,
     Length: int,
-    Timestamp: string,
+    Timestamp: datetime,
     Message: string,
     EtlIngestDate: datetime
 ) with (folder='', docstring='')


### PR DESCRIPTION
The field has already been updated in the database.  This will prevent reverting the field to text on deployment.