### PR TITLE
Export the subscription data from the service connection

### DIFF
--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -59,6 +59,20 @@ steps:
             ${{ parameters.SubscriptionConfiguration }}
           '@ | ConvertFrom-Json -AsHashtable;
 
+          $context = (Get-AzContext)
+          $subscriptionConfiguration["SubscriptionId"] = $context.Subscription.Id
+          $subscriptionConfiguration["TenantId"] =$context.Subscription.TenantId
+          $subscriptionConfiguration["TestApplicationId"] = $context.Account.Id
+          $subscriptionConfiguration["ProvisionerApplicationId"] = $context.Account.Id
+
+          $principal = Get-AzADServicePrincipal -ApplicationId $context.Account.Id
+          $subscriptionConfiguration["TestApplicationOid"] = $principal.Id
+          $subscriptionConfiguration["ProvisionerApplicationOid"] = $principal.Id
+
+          Write-Host ($subscriptionConfiguration | ConvertTo-Json)
+          # Write the new SubscriptionConfiguration to be used by the remove test resources
+          Write-Host "##vso[task.setvariable variable=SubscriptionConfiguration;]$($subscriptionConfiguration | ConvertTo-Json -Compress)"
+
           # The subscriptionConfiguration may have ArmTemplateParameters defined, so
           # pass those in via the ArmTemplateParameters flag, and handle any
           # additional parameters from the pipelines via AdditionalParameters

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -59,9 +59,9 @@ steps:
             ${{ parameters.SubscriptionConfiguration }}
           '@ | ConvertFrom-Json -AsHashtable;
 
-          $context = (Get-AzContext)
+          $context = Get-AzContext
           $subscriptionConfiguration["SubscriptionId"] = $context.Subscription.Id
-          $subscriptionConfiguration["TenantId"] =$context.Subscription.TenantId
+          $subscriptionConfiguration["TenantId"] = $context.Subscription.TenantId
           $subscriptionConfiguration["TestApplicationId"] = $context.Account.Id
           $subscriptionConfiguration["ProvisionerApplicationId"] = $context.Account.Id
 


### PR DESCRIPTION
This will allow us to not need to provide static subscription data files and keep them in sync with the service connection. 

Once we adopt this new method, we can delete all the sub config files we have. 