### PR TITLE
Upgrade revision when revision is requested and if a new parser is re…

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -990,7 +990,9 @@ namespace APIViewWeb.Managers
         private async Task<APIRevisionListItemModel> UpgradeAPIRevisionIfRequired(APIRevisionListItemModel revisionModel)
         {
             if (revisionModel == null)
+            {
                 return revisionModel;
+            }
             var codeFileDetails = revisionModel.Files[0];
             var languageService = LanguageServiceHelpers.GetLanguageService(codeFileDetails.Language, _languageServices);
             if (languageService != null && languageService.CanUpdate(codeFileDetails.VersionString))

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -153,12 +153,14 @@ namespace APIViewWeb.Managers
             {
                 throw new UnauthorizedAccessException();
             }
-            return await _apiRevisionsRepository.GetAPIRevisionAsync(apiRevisionId);
+            var revisionModel = await _apiRevisionsRepository.GetAPIRevisionAsync(apiRevisionId);
+            return await UpgradeAPIRevisionIfRequired(revisionModel);
         }
 
         public async Task<APIRevisionListItemModel> GetAPIRevisionAsync(string apiRevisionId)
         {
-            return await _apiRevisionsRepository.GetAPIRevisionAsync(apiRevisionId);
+            var revisionModel = await _apiRevisionsRepository.GetAPIRevisionAsync(apiRevisionId);
+            return await UpgradeAPIRevisionIfRequired(revisionModel);
         }
 
         /// <summary>
@@ -984,6 +986,19 @@ namespace APIViewWeb.Managers
                 }
             }
             return result;
+        }
+        private async Task<APIRevisionListItemModel> UpgradeAPIRevisionIfRequired(APIRevisionListItemModel revisionModel)
+        {
+            if (revisionModel == null)
+                return revisionModel;
+            var codeFileDetails = revisionModel.Files[0];
+            var languageService = LanguageServiceHelpers.GetLanguageService(codeFileDetails.Language, _languageServices);
+            if (languageService != null && languageService.CanUpdate(codeFileDetails.VersionString))
+            {
+                await UpdateAPIRevisionAsync(revisionModel, languageService, false);
+                revisionModel = await _apiRevisionsRepository.GetAPIRevisionAsync(revisionModel.Id);
+            }
+            return revisionModel;
         }
     }
 }


### PR DESCRIPTION
Self-heal approach to upgrade a requested revision if that revision is still using old parser version. This will help to avoid mismatch issue when a revision is still using old parser version, and a new parser is released.