### PR TITLE
[Python ApiView] handle complex argtypes in ivar

### DIFF
--- a/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/models/_models.py
@@ -68,7 +68,20 @@ class PublicCaseInsensitiveEnumMeta(EnumMeta):
 
 class DocstringClass:
     """A class for testing docstring behavior.
+
+    :param str or None name: Dummy name.
+    :keyword dict[str, str] or None values: Dummy values. Defaults
+     to None.
+
+    :ivar str name: Dummy name. If None, sets to "Contoso".
+    :ivar dict[str, str] or None values: Dummy values, defaults to
+     None.
+    :rtype: None
     """
+
+    def __init__(self, name: Optional[str], *args: Any, values: Optional[Dict[str, str]] = None) -> None:
+        self.name: str = name if name else "Contoso"
+        self.values: Dict[str, str] = values
 
     def docstring_with_default_formal(self, value, another, some_class, **kwargs) -> str:
         """Docstring containing a formal default.

--- a/packages/python-packages/apiview-stub-generator/apistub/_apiview.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_apiview.py
@@ -173,8 +173,19 @@ class ApiView:
         # Encode multiple types with or separator into Union
         if TYPE_OR_SEPARATOR in type_name:
             types = [t.strip() for t in type_name.split(TYPE_OR_SEPARATOR) if t != TYPE_OR_SEPARATOR]
-            # Make a Union of types if multiple types are present
-            type_name = "Union[{}]".format(", ".join(types))
+            # Check if one of the types is None
+            has_none = False
+            if "None" in types:
+                has_none = True
+                types.remove("None")
+            # Make a Union of types if multiple non-None types are present, otherwise use the single type
+            if len(types) > 1:
+                type_name = "Union[{}]".format(", ".join(types))
+            else:
+                type_name = types[0]
+            # If one of the types is None, wrap the Union type in Optional
+            if has_none:
+                type_name = "Optional[{}]".format(type_name)
 
         cross_language_id = self.metadata_map.cross_language_map.get(line_id, None)
         self._add_type_token(type_name, line_id, cross_language_id)

--- a/packages/python-packages/apiview-stub-generator/apistub/_token.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_token.py
@@ -4,6 +4,18 @@ from ._token_kind import TokenKind
 class Token:
     """Entity class to hold individual token information
     """
+    rendered_kinds = [
+        TokenKind.Text,
+        TokenKind.Newline,
+        TokenKind.Whitespace,
+        TokenKind.Keyword,
+        TokenKind.TypeName,
+        TokenKind.MemberName,
+        TokenKind.StringLiteral,
+        TokenKind.Literal,
+        TokenKind.Comment,
+        TokenKind.Punctuation
+    ]
 
     def __init__(self, value="", kind=TokenKind.Text):
         self.kind = kind
@@ -13,21 +25,9 @@ class Token:
         self.value = value
 
     def render(self):
-        rendered_kinds = [
-            TokenKind.Text,
-            TokenKind.Newline,
-            TokenKind.Whitespace,
-            TokenKind.Keyword,
-            TokenKind.TypeName,
-            TokenKind.MemberName,
-            TokenKind.StringLiteral,
-            TokenKind.Literal,
-            TokenKind.Comment,
-            TokenKind.Punctuation
-        ]
         if self.kind == TokenKind.Newline:
             return "\n"
-        elif self.kind in rendered_kinds:
+        elif self.kind in Token.rendered_kinds:
             return self.value
         else:
             return ""

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_class_node.py
@@ -268,9 +268,7 @@ class ClassNode(NodeEntityBase):
         docstring = getattr(self.obj, "__doc__")
         if docstring:
             docstring_parser = DocstringParser(docstring)
-            print(docstring_parser.ivars.items())
             for key, var in docstring_parser.ivars.items():
-                print(key, var)
                 ivar_node = VariableNode(
                     namespace=self.namespace,
                     parent_node=self,
@@ -279,7 +277,6 @@ class ClassNode(NodeEntityBase):
                     value=None,
                     is_ivar=True
                 )
-                print(ivar_node)
                 self.child_nodes.append(ivar_node)
 
     def _sort_elements(self):
@@ -344,7 +341,6 @@ class ClassNode(NodeEntityBase):
         # Generate token for child nodes
         if self.child_nodes:
             self._generate_child_tokens(apiview)
-        print(apiview.metadata_map)
 
 
     def _generate_child_tokens(self, apiview):

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_class_node.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_class_node.py
@@ -268,7 +268,9 @@ class ClassNode(NodeEntityBase):
         docstring = getattr(self.obj, "__doc__")
         if docstring:
             docstring_parser = DocstringParser(docstring)
+            print(docstring_parser.ivars.items())
             for key, var in docstring_parser.ivars.items():
+                print(key, var)
                 ivar_node = VariableNode(
                     namespace=self.namespace,
                     parent_node=self,
@@ -277,6 +279,7 @@ class ClassNode(NodeEntityBase):
                     value=None,
                     is_ivar=True
                 )
+                print(ivar_node)
                 self.child_nodes.append(ivar_node)
 
     def _sort_elements(self):
@@ -341,6 +344,7 @@ class ClassNode(NodeEntityBase):
         # Generate token for child nodes
         if self.child_nodes:
             self._generate_child_tokens(apiview)
+        print(apiview.metadata_map)
 
 
     def _generate_child_tokens(self, apiview):

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_docstring_parser.py
@@ -127,7 +127,8 @@ class DocstringParser:
             # keyword aguments.
             arg.default = "..."
             if arg.argtype and not arg.argtype.startswith("Optional["):
-                arg.argtype = f"Optional[{arg.argtype}]"
+                strip_none = arg.argtype.replace(" or None", "").replace("None or ", "")
+                arg.argtype = f"Optional[{strip_none}]"
             self.kwargs[arg.argname] = arg
         else:
             logging.error(f"Unexpected keyword: {keyword}")

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_docstring_parser.py
@@ -102,8 +102,9 @@ class DocstringParser:
 
     def _process_arg_triple(self, tag, default):
         # When three items are found, all necessary info is found
-        # and there can only be one simple type
+        # and there can be a simple or complex type
         # Example: :param str name: The name of the thing.
+        # OR :param dict[str, str] or None properties: The properties of the thing.
         (keyword, typename, name) = tag
         arg = ArgType(name=name, argtype=typename, default=default, keyword=keyword)
         self._update_arg(arg, keyword)
@@ -162,6 +163,11 @@ class DocstringParser:
 
             (tag, line1) = tag_match.groups()
             split_tag = tag.split()
+            if len(split_tag) > 3:
+                # argtype may include spaces or commas
+                argtype = " ".join(split_tag[1:-1])
+                self._process_arg_triple((split_tag[0], argtype, split_tag[-1]), default)
+                continue
             if len(split_tag) == 3:
                 self._process_arg_triple(split_tag, default)
                 continue
@@ -177,15 +183,24 @@ class DocstringParser:
             elif len(split_tag) == 1 and split_tag[0] == "rtype":
                 self.ret_type = self._process_return_type(line1.strip(), line2)
 
-    def type_for(self, name):
-        arg = (
-            self.ivars.get(name, None) or
-            self.pos_args.get(name, None) or
-            self.kwargs.get(name, None)
-        )
+    def type_for(self, name, keyword=None):
+        if not keyword:
+            arg = (
+                self.ivars.get(name, None) or
+                self.pos_args.get(name, None) or
+                self.kwargs.get(name, None)
+            )
+        else:
+            if keyword == "param":
+                arg = self.pos_args.get(name, None)
+            elif keyword == "ivar":
+                arg = self.ivars.get(name, None)
+            elif keyword == "keyword":
+                arg = self.kwargs.get(name, None)
         return arg.argtype if arg else arg
 
     def default_for(self, name):
+        print('in default for')
         arg = (
             self.ivars.get(name, None) or
             self.pos_args.get(name, None) or
@@ -194,6 +209,7 @@ class DocstringParser:
         if not arg:
             return None
         argtype = arg.argtype or self.type_for(name)
+        print(f'argtype: {argtype}')
         if not argtype:
             return arg.default
         try:

--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_docstring_parser.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_docstring_parser.py
@@ -200,7 +200,6 @@ class DocstringParser:
         return arg.argtype if arg else arg
 
     def default_for(self, name):
-        print('in default for')
         arg = (
             self.ivars.get(name, None) or
             self.pos_args.get(name, None) or
@@ -209,7 +208,6 @@ class DocstringParser:
         if not arg:
             return None
         argtype = arg.argtype or self.type_for(name)
-        print(f'argtype: {argtype}')
         if not argtype:
             return arg.default
         try:

--- a/packages/python-packages/apiview-stub-generator/tests/_test_util.py
+++ b/packages/python-packages/apiview-stub-generator/tests/_test_util.py
@@ -33,3 +33,8 @@ def _merge_lines(lines) -> str:
 
 def _check(actual, expected, client):
     assert actual.lstrip() == expected, f"\n*******\nClient: {client.__name__}\nActual:   {actual}\nExpected: {expected}\n*******"    
+
+def _check_all(actual, expect, obj):
+    for (idx, exp) in enumerate(expect):
+        act = actual[idx]
+        _check(act.lstrip(), exp, obj)

--- a/packages/python-packages/apiview-stub-generator/tests/class_parsing_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/class_parsing_test.py
@@ -28,13 +28,7 @@ from apistubgentest.models import (
 
 from pytest import fail
 
-from ._test_util import _check, _tokenize, _merge_lines, _render_lines
-
-
-def _check_all(actual, expect, obj):
-    for (idx, exp) in enumerate(expect):
-        act = actual[idx]
-        _check(act.lstrip(), exp, obj)
+from ._test_util import _check, _tokenize, _merge_lines, _render_lines, _check_all
 
 
 class TestClassParsing:

--- a/packages/python-packages/apiview-stub-generator/tests/dataclass_parsing_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/dataclass_parsing_test.py
@@ -9,13 +9,7 @@ from apistubgentest.models import (
     DataClassSimple, DataClassWithFields, DataClassDynamic, DataClassWithKeywordOnly, DataClassWithPostInit
 )
 
-from ._test_util import _check, _tokenize, _merge_lines, _render_lines, _render_string
-
-
-def _check_all(actual, expect, obj):
-    for (idx, exp) in enumerate(expect):
-        act = actual[idx]
-        _check(act.lstrip(), exp, obj)
+from ._test_util import _tokenize, _merge_lines, _render_lines, _check_all
 
 
 class TestDataClassParsing:

--- a/packages/python-packages/apiview-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/docstring_parser_test.py
@@ -5,7 +5,10 @@
 # --------------------------------------------------------------------------
 
 from pydoc import Doc
-from apistub.nodes import DocstringParser
+from apistub.nodes import DocstringParser, ClassNode
+from apistubgentest.models import DocstringClass 
+
+from ._test_util import _tokenize, _render_lines, _check_all
 
 
 docstring_default_legacy = """
@@ -130,14 +133,9 @@ docstring_type_with_quotes = """
 :rtype: list[`str`]
 """
 
-docstring_with_complex_argtype_ivar = """
-:param dict[str, str] or None name: Dummy name param
-:keyword str or None name2: Dummy name param
-:ivar dict[str, str] or None name: Value type
-:ivar str name2: Value type
-"""
-
 class TestDocstringParser:
+
+    pkg_namespace = "apistubgentest.models"
 
     def _test_variable_type(self, docstring, expected):
         parser = DocstringParser(docstring)
@@ -226,9 +224,31 @@ class TestDocstringParser:
         assert parser.default_for("some_class") == ":py:class:`apistubgen.test.models.FakeObject`"
 
     def test_docstring_complex_argtype_ivar(self):
-        parser = DocstringParser(docstring_with_complex_argtype_ivar)
-        assert parser.type_for("name", keyword="param") == "dict[str, str] or None"
+        obj = DocstringClass
+        class_node = ClassNode(name=obj.__name__, namespace=obj.__name__, parent_node=None, obj=obj, pkg_root_namespace=self.pkg_namespace)
+        actuals = _render_lines(_tokenize(class_node))
+        expected = [
+            "class DocstringClass:",
+            "ivar name: str",
+            "ivar values: Union[dict[str, str], None]",  # TODO: Union "or None" should be Optional
+        ]
+        _check_all(actuals, expected, obj)
+
+        expected_init = [
+            "def __init__(",
+            "self, ",
+            "name: Optional[str], ",
+            "*args: Any, ",
+            "*, ", # TODO: Second asterisk should be removed
+            "values: Optional[Dict[str, str]] = ...",
+            ") -> None"
+        ]
+        _check_all(actuals[4:11], expected_init, obj)
+        # check that type_for returns the correct type for the given ivar
+        complex_ivar_docstring = obj.__doc__
+        parser = DocstringParser(complex_ivar_docstring)
+        assert parser.type_for("name", keyword="param") == "str or None"
         # docstring parser wraps kwargs in Optional by default, so None should be stripped
-        assert parser.type_for("name2", keyword="keyword") == "Optional[str]"
-        assert parser.type_for("name", keyword="ivar") == "dict[str, str] or None"
-        assert parser.type_for("name2", keyword="ivar") == "str"
+        assert parser.type_for("values", keyword="keyword") == "Optional[dict[str, str]]"
+        assert parser.type_for("name", keyword="ivar") == "str"
+        assert parser.type_for("values", keyword="ivar") == "dict[str, str] or None"

--- a/packages/python-packages/apiview-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/docstring_parser_test.py
@@ -130,6 +130,13 @@ docstring_type_with_quotes = """
 :rtype: list[`str`]
 """
 
+docstring_with_complex_argtype_ivar = """
+:param dict[str, str] or None name: Dummy name param
+:keyword str or None name2: Dummy name param
+:ivar dict[str, str] or None name: Value type
+:ivar str name2: Value type
+"""
+
 class TestDocstringParser:
 
     def _test_variable_type(self, docstring, expected):
@@ -217,3 +224,10 @@ class TestDocstringParser:
         assert parser.default_for("value") == "cat"
         assert parser.default_for("another") == "dog"
         assert parser.default_for("some_class") == ":py:class:`apistubgen.test.models.FakeObject`"
+
+    def test_docstring_complex_argtype_ivar(self):
+        parser = DocstringParser(docstring_with_complex_argtype_ivar)
+        assert parser.type_for("name", keyword="param") == "dict[str, str] or None"
+        assert parser.type_for("name2", keyword="keyword") == "union[str, None]"
+        assert parser.type_for("name", keyword="ivar") == "union[dict[str, str], None]"
+        assert parser.type_for("name2", keyword="ivar") == "str"

--- a/packages/python-packages/apiview-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/docstring_parser_test.py
@@ -228,6 +228,7 @@ class TestDocstringParser:
     def test_docstring_complex_argtype_ivar(self):
         parser = DocstringParser(docstring_with_complex_argtype_ivar)
         assert parser.type_for("name", keyword="param") == "dict[str, str] or None"
-        assert parser.type_for("name2", keyword="keyword") == "union[str, None]"
-        assert parser.type_for("name", keyword="ivar") == "union[dict[str, str], None]"
+        # docstring parser wraps kwargs in Optional by default, so None should be stripped
+        assert parser.type_for("name2", keyword="keyword") == "Optional[str]"
+        assert parser.type_for("name", keyword="ivar") == "dict[str, str] or None"
         assert parser.type_for("name2", keyword="ivar") == "str"

--- a/packages/python-packages/apiview-stub-generator/tests/docstring_parser_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/docstring_parser_test.py
@@ -230,7 +230,7 @@ class TestDocstringParser:
         expected = [
             "class DocstringClass:",
             "ivar name: str",
-            "ivar values: Union[dict[str, str], None]",  # TODO: Union "or None" should be Optional
+            "ivar values: Optional[dict[str, str]]", # TODO: Should Dict vs. dict be mixed in like this?
         ]
         _check_all(actuals, expected, obj)
 


### PR DESCRIPTION
TODO:
- update once #9146 is merged

partially addresses: #8574

Fixed:
- [x] ivar type with spaces/commas was being parsed incorrectly and ivar was not rendered
- [x] Union or None should be updated to Optional for ivar
- [x] Dict in kwargs vs. dict in ivar?  --> Letting these differ, since we're not ready to drop 3.8 yet, but we don't want the extra work of the dict -> Dict -> dict conversion.

In a separate PR:
- [ ] The extra * after *args needs to be removed.