### PR TITLE
Use equality function check for persist oidc token step

### DIFF
--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -42,7 +42,7 @@ steps:
 
   - template: /eng/common/TestResources/setup-environments.yml
 
-  - ${{ if parameters.PersistOidcToken }}:
+  - ${{ if eq(parameters.PersistOidcToken, true) }}:
     - task: AzureCLI@2
       displayName: Set OIDC token
       env:
@@ -61,7 +61,7 @@ steps:
       env:
         TEMP: $(Agent.TempDirectory)
         PoolSubnet: $(PoolSubnet)
-        ${{ if parameters.PersistOidcToken }}:
+        ${{ if eq(parameters.PersistOidcToken, true) }}:
           ARM_OIDC_TOKEN: $(ARM_OIDC_TOKEN)
         ${{ insert }}: ${{ parameters.EnvVars }}
       inputs:


### PR DESCRIPTION
Use equality function check for persist oidc token step

This is breaking the conditional evaluation of `${{ if parameters.PersistOidcToken }}` because it is getting stringified.