### PR TITLE
Handle only "service" level changes

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -130,7 +130,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
         {
             $filePath = Resolve-Path (Join-Path $RepoRoot $file)
             $shouldInclude = $filePath -like "$pkgDirectory*"
-            $pathComponents = $filel -split "/"
+            $pathComponents = $file -split "/"
 
             # sdk/<service>/<file.extension>
             if ($pathComponents.Length -eq 3 -and $pathComponents[0] -eq "sdk") {

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -134,7 +134,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
 
             # sdk/<service>/<file.extension>
             if ($pathComponents.Length -eq 3 -and $pathComponents[0] -eq "sdk") {
-                $servicePkgs = $allPackageProperties | ? { $_.ServiceDirectory -eq $pathComponents[1] } | Foreach-Object { $_.Name }
+                $servicePkgs = $allPackageProperties | Where-Object { $_.ServiceDirectory -eq $pathComponents[1] } | ForEach-Object { $_.Name }
 
                 if ($servicePkgs) {
                     $additionalValidationPackages += $servicePkgs

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -120,7 +120,6 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     $additionalValidationPackages = @()
     $lookup = @{}
 
-    # find all packages that have via comparison with changed files
     foreach ($pkg in $allPackageProperties)
     {
         $pkgDirectory = Resolve-Path "$($pkg.DirectoryPath)"


### PR DESCRIPTION
...where the package directory doesn't have a changed file, but the service does.

This is relevant for changes to `ci.yml` or the like.

I decided that because _everyone_ will hit this, I'd put it in the common Get-PrPkgProperties. I originally was going to place this specificity in `AdditionalValidationPackagesFromPackageSetFn` in each language, to allow folks to select a _subselection_ of packages in the touched service directory. (Eg only include `@azure/core-lro`, instead of all js packages under `core`)

Which would you prefer? I have a bad feeling that adding all the packages will begin overaggressive.