### PR TITLE
sample-automation, bug fix on wrong api version folder

### DIFF
--- a/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
@@ -20,7 +20,7 @@ def try_find_resource_manager_example(
             if tsp_dir:
                 # find example under directory
                 # e.g. example_path = "specification/mongocluster/DocumentDB.MongoCluster.Management/examples/2024-03-01-preview/MongoClusters_ListConnectionStrings.json"
-                example_paths = glob.glob(f"{path.join(specs_path, tsp_dir)}/**/{example_filename}", recursive=True)
+                example_paths = glob.glob(f"{path.join(specs_path, tsp_dir)}/**/examples/{example_dir}/{example_filename}", recursive=True)
 
                 if len(example_paths) > 0:
                     example_path = example_paths[0]

--- a/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
@@ -46,5 +46,7 @@ def try_find_resource_manager_example(
                         if len(candidate_resource_manager_filename) > 0:
                             example_path, _ = path.split(candidate_resource_manager_filename[0])
                             example_dir = path.relpath(example_path, specs_path).replace("\\", "/")
+        else:
+            raise RuntimeError(f"tsp-location.yaml not found in SDK package folder {sdk_package_path}")
 
     return example_dir

--- a/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
@@ -20,7 +20,9 @@ def try_find_resource_manager_example(
             if tsp_dir:
                 # find example under directory
                 # e.g. example_path = "specification/mongocluster/DocumentDB.MongoCluster.Management/examples/2024-03-01-preview/MongoClusters_ListConnectionStrings.json"
-                example_paths = glob.glob(f"{path.join(specs_path, tsp_dir)}/**/examples/{example_dir}/{example_filename}", recursive=True)
+                example_paths = glob.glob(
+                    f"{path.join(specs_path, tsp_dir)}/**/examples/{example_dir}/{example_filename}", recursive=True
+                )
 
                 if len(example_paths) > 0:
                     example_path = example_paths[0]

--- a/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
@@ -5,14 +5,13 @@ from os import path, makedirs
 from examples_dir import try_find_resource_manager_example
 
 
-def create_mock_test_folder() -> tempfile.TemporaryDirectory:
-    tsp_location_file_content = """directory: specification/mongocluster/DocumentDB.MongoCluster.Management
+tsp_location_file_content = """directory: specification/mongocluster/DocumentDB.MongoCluster.Management
 commit: 7ed015e3dd1b8b1b0e71c9b5e6b6c5ccb8968b3a
 repo: Azure/azure-rest-api-specs
 additionalDirectories: null
 """
 
-    json_example_file_content = """{
+json_example_file_content = """{
   "operationId": "MongoClusters_ListConnectionStrings",
   "title": "List the available connection strings for the Mongo Cluster resource.",
   "parameters": {
@@ -36,6 +35,7 @@ additionalDirectories: null
 }
 """
 
+def create_mock_test_folder() -> tempfile.TemporaryDirectory:
     tmp_path = path.abspath(".")
     tmp_dir = tempfile.TemporaryDirectory(dir=tmp_path)
     try:
@@ -80,6 +80,16 @@ class TestExamplesDir(unittest.TestCase):
             self.assertEqual(
                 "specification/mongocluster/resource-manager/Microsoft.DocumentDB/preview/2024-03-01-preview/examples",
                 example_dir,
+            )
+
+    def test_find_resource_manager_example_typespec_no_tsp_location(self):
+        mock_path = path.abspath(".")
+        with self.assertRaises(RuntimeError) as context:
+            example_dir = try_find_resource_manager_example(
+                path.join(mock_path, "azure-rest-api-specs"),
+                path.join(mock_path, "azure-sdk-for-java/sdk/mongocluster/azure-resourcemanager-mongocluster"),
+                "2024-03-01-preview",
+                "MongoClusters_ListConnectionStrings.json",
             )
 
     def test_find_resource_manager_example_swagger(self):

--- a/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
@@ -35,6 +35,7 @@ json_example_file_content = """{
 }
 """
 
+
 def create_mock_test_folder() -> tempfile.TemporaryDirectory:
     tmp_path = path.abspath(".")
     tmp_dir = tempfile.TemporaryDirectory(dir=tmp_path)

--- a/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
@@ -6,7 +6,7 @@ from examples_dir import try_find_resource_manager_example
 
 
 tsp_location_file_content = """directory: specification/mongocluster/DocumentDB.MongoCluster.Management
-commit: 7ed015e3dd1b8b1b0e71c9b5e6b6c5ccb8968b3a
+commit: 07bdede4651ce2ea0e4039d76e81a69df23a3d6e
 repo: Azure/azure-rest-api-specs
 additionalDirectories: null
 """
@@ -18,7 +18,7 @@ json_example_file_content = """{
     "subscriptionId": "ffffffff-ffff-ffff-ffff-ffffffffffff",
     "resourceGroupName": "TestGroup",
     "mongoClusterName": "myMongoCluster",
-    "api-version": "2024-03-01-preview"
+    "api-version": "2024-07-01"
   },
   "responses": {
     "200": {
@@ -44,6 +44,7 @@ def create_mock_test_folder() -> tempfile.TemporaryDirectory:
         with open(path.join(sdk_path, "tsp-location.yaml"), "w+", encoding="utf-8") as file:
             file.write(tsp_location_file_content)
 
+        # api-version 2024-03-01-preview
         specs_path = path.join(
             tmp_dir.name,
             "azure-rest-api-specs/specification/mongocluster/DocumentDB.MongoCluster.Management/examples/2024-03-01-preview",
@@ -55,6 +56,23 @@ def create_mock_test_folder() -> tempfile.TemporaryDirectory:
         specs_path = path.join(
             tmp_dir.name,
             "azure-rest-api-specs/specification/mongocluster/resource-manager/Microsoft.DocumentDB/preview/2024-03-01-preview/examples",
+        )
+        makedirs(specs_path)
+        with open(path.join(specs_path, "MongoClusters_ListConnectionStrings.json"), "w+", encoding="utf-8") as file:
+            file.write(json_example_file_content)
+
+        # api-version 2024-07-01
+        specs_path = path.join(
+            tmp_dir.name,
+            "azure-rest-api-specs/specification/mongocluster/DocumentDB.MongoCluster.Management/examples/2024-07-01",
+        )
+        makedirs(specs_path)
+        with open(path.join(specs_path, "MongoClusters_ListConnectionStrings.json"), "w+", encoding="utf-8") as file:
+            file.write(json_example_file_content)
+
+        specs_path = path.join(
+            tmp_dir.name,
+            "azure-rest-api-specs/specification/mongocluster/resource-manager/Microsoft.DocumentDB/preview/2024-07-01/examples",
         )
         makedirs(specs_path)
         with open(path.join(specs_path, "MongoClusters_ListConnectionStrings.json"), "w+", encoding="utf-8") as file:
@@ -73,12 +91,12 @@ class TestExamplesDir(unittest.TestCase):
             example_dir = try_find_resource_manager_example(
                 path.join(tmp_dir_name, "azure-rest-api-specs"),
                 path.join(tmp_dir_name, "azure-sdk-for-java/sdk/mongocluster/azure-resourcemanager-mongocluster"),
-                "2024-03-01-preview",
+                "2024-07-01",
                 "MongoClusters_ListConnectionStrings.json",
             )
 
             self.assertEqual(
-                "specification/mongocluster/resource-manager/Microsoft.DocumentDB/preview/2024-03-01-preview/examples",
+                "specification/mongocluster/resource-manager/Microsoft.DocumentDB/preview/2024-07-01/examples",
                 example_dir,
             )
 
@@ -88,7 +106,7 @@ class TestExamplesDir(unittest.TestCase):
             example_dir = try_find_resource_manager_example(
                 path.join(mock_path, "azure-rest-api-specs"),
                 path.join(mock_path, "azure-sdk-for-java/sdk/mongocluster/azure-resourcemanager-mongocluster"),
-                "2024-03-01-preview",
+                "2024-07-01",
                 "MongoClusters_ListConnectionStrings.json",
             )
 


### PR DESCRIPTION
fix https://github.com/Azure/azure-sdk-tools/issues/9150

1. raise Error, if no tsp-location.yaml found (it happens to 1 js package, it is their problem but we need to guard against this)
2. fix bug that automation didn't scope the api-version when searching the typespec example JSON