### PR TITLE
Handle empty/null alias in function

### DIFF
--- a/eng/scripts/live-test-resource-cleanup.ps1
+++ b/eng/scripts/live-test-resource-cleanup.ps1
@@ -113,13 +113,12 @@ function Log($Message) {
   Write-Host $Message
 }
 
-function IsValidAlias
+function IsValidAlias([string]$Alias)
 {
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$Alias
-  )
-
+  if (!$Alias) { 
+    return $false 
+  }
+  
   if ($OwnerAliasCache.ContainsKey($Alias)) {
     return $OwnerAliasCache[$Alias]
   }


### PR DESCRIPTION
Currently we are hitting an error in the clean-up which is preventing any clean-up from happening.

![image](https://github.com/user-attachments/assets/170ce72f-52cc-4f65-8fc7-48a172780368)

This update handles the empty/null alias. 

