### PR TITLE
Escape parentheses in includes to fix issues in publishing

### DIFF
--- a/eng/common/scripts/Helpers/Service-Level-Readme-Automation-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Service-Level-Readme-Automation-Helpers.ps1
@@ -11,7 +11,7 @@ function create-service-readme(
   $readmePath = Join-Path $readmeFolder -ChildPath $readmeName
   $content = ""
   if (Test-Path (Join-Path $readmeFolder -ChildPath $indexTableLink)) {
-    $escapedIndexTableLink = $indexTableLink -replace '\(', '\(' -replace '\)', '\)'
+    $escapedIndexTableLink = $indexTableLink -replace '\)', '\)'
 
     $content = "## Packages - $moniker`r`n"
     $content += "[!INCLUDE [packages]($escapedIndexTableLink)]"

--- a/eng/common/scripts/Helpers/Service-Level-Readme-Automation-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Service-Level-Readme-Automation-Helpers.ps1
@@ -11,6 +11,13 @@ function create-service-readme(
   $readmePath = Join-Path $readmeFolder -ChildPath $readmeName
   $content = ""
   if (Test-Path (Join-Path $readmeFolder -ChildPath $indexTableLink)) {
+    # Escape the close parentheses in the URL. This is required by docs
+    # https://github.com/Azure/azure-sdk-tools/issues/5433
+    # This line looks incorrect but the left parameter is a regex and must
+    # escape the parentheses. The right is a literal string and, since this is
+    # PowerShell, the backslash does not itself need to be escaped.
+
+    # Example: "filename-with-(parens).md" -> "filename-with-(parens\).md"
     $escapedIndexTableLink = $indexTableLink -replace '\)', '\)'
 
     $content = "## Packages - $moniker`r`n"

--- a/eng/common/scripts/Helpers/Service-Level-Readme-Automation-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Service-Level-Readme-Automation-Helpers.ps1
@@ -11,8 +11,10 @@ function create-service-readme(
   $readmePath = Join-Path $readmeFolder -ChildPath $readmeName
   $content = ""
   if (Test-Path (Join-Path $readmeFolder -ChildPath $indexTableLink)) {
+    $escapedIndexTableLink = $indexTableLink -replace '\(', '\(' -replace '\)', '\)'
+
     $content = "## Packages - $moniker`r`n"
-    $content += "[!INCLUDE [packages]($indexTableLink)]"
+    $content += "[!INCLUDE [packages]($escapedIndexTableLink)]"
   }
   if (!$content) {
     LogError "There are no packages under service '$serviceName'. "
@@ -101,15 +103,15 @@ function generate-service-level-readme(
   $readmeFolder = "$docRepoLocation/$pathPrefix/$moniker/"
   $serviceReadme = "$readmeBaseName.md"
   $indexReadme  = "$readmeBaseName-index.md"
- 
+
   if ($packageInfos) {
     generate-markdown-table `
       -readmeFolder $readmeFolder `
       -readmeName $indexReadme `
       -packageInfos $packageInfos `
-      -moniker $moniker  
+      -moniker $moniker
   }
-  
+
   if (!(Test-Path "$readmeFolder$serviceReadme") -and $packageInfos) {
     create-service-readme `
       -readmeFolder $readmeFolder `


### PR DESCRIPTION
Includes whitespace changes

Fixes https://github.com/Azure/azure-sdk-tools/issues/5433

Testing. Left is the live site, right is the same page with escaped parentheses in the filename: 

![image](https://github.com/user-attachments/assets/e2d0e5cc-f531-43d0-bc2c-7314fe91392d)
