### PR TITLE
Handle non-presence of artifacts without exception

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -103,8 +103,11 @@ class PackageProps
                 $content = Get-Content -Raw -Path $ymlPath | CompatibleConvertFrom-Yaml
                 if ($content) {
                     $artifacts = $this.GetValueSafely($content, @("extends", "parameters", "Artifacts"))
+                    $artifactForCurrentPackage = $null
 
-                    $artifactForCurrentPackage = $artifacts | Where-Object { $_["name"] -eq $this.ArtifactName -or $_["name"] -eq $this.Name }
+                    if ($artifacts) {
+                        $artifactForCurrentPackage = $artifacts | Where-Object { $_["name"] -eq $this.ArtifactName -or $_["name"] -eq $this.Name }
+                    }
 
                     if ($artifactForCurrentPackage) {
                         return [HashTable]$artifactForCurrentPackage


### PR DESCRIPTION
Eliminating messages like [this one](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4230273&view=logs&j=1dca5ef1-3811-5712-152d-1052a5815ba2&t=ec532db5-809f-5036-2be0-84730b472e44&l=192)

![image](https://github.com/user-attachments/assets/7c97faa4-811a-4fca-91c8-57c47f7ddb69)
