### PR TITLE
[apiview-js-parser] fix some bugs

### DIFF
--- a/tools/apiview/parsers/js-api-parser/CHANGELOG.md
+++ b/tools/apiview/parsers/js-api-parser/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.0.2
+
+- fix issue where `type` is not treated as keyword.
+
 # 2.0.1
 
 - fix incorrect token type for members of types.

--- a/tools/apiview/parsers/js-api-parser/package.json
+++ b/tools/apiview/parsers/js-api-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/ts-genapi",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "",
   "main": "index.js",
   "publishConfig": {

--- a/tools/apiview/parsers/js-api-parser/src/generate.ts
+++ b/tools/apiview/parsers/js-api-parser/src/generate.ts
@@ -285,19 +285,20 @@ function buildMember(reviewLines: ReviewLine[], item: ApiItem) {
       line.Tokens[line.Tokens.length - 1].HasSuffixSpace = true;
     }
     if (item.members.length > 0) {
-      line.Tokens.push(buildToken({ Kind: TokenKind.Punctuation, Value: `{` }));
+      line.Tokens.push(buildToken({ Kind: TokenKind.Punctuation, Value: "{" }));
       for (const member of item.members) {
         buildMember(line.Children!, member);
       }
       reviewLines.push(line);
       reviewLines.push({
-        Tokens: [buildToken({ Kind: TokenKind.Punctuation, Value: `}` })],
+        Tokens: [buildToken({ Kind: TokenKind.Punctuation, Value: "}" })],
         RelatedToLine: line.LineId,
+        IsContextEndLine: true,
       });
     } else {
       line.Tokens.push(
-        buildToken({ Kind: TokenKind.Punctuation, Value: `{`, HasSuffixSpace: true }),
-        buildToken({ Kind: TokenKind.Punctuation, Value: `}` }),
+        buildToken({ Kind: TokenKind.Punctuation, Value: "{", HasSuffixSpace: true }),
+        buildToken({ Kind: TokenKind.Punctuation, Value: "}" }),
       );
       reviewLines.push(line);
     }

--- a/tools/apiview/parsers/js-api-parser/src/jstokens.ts
+++ b/tools/apiview/parsers/js-api-parser/src/jstokens.ts
@@ -75,6 +75,7 @@ const TS_KEYWORDS = new Set<string>([
   "throw",
   "true",
   "try",
+  "type",
   "typeof",
   "undefined",
   "unique",


### PR DESCRIPTION
- add missing `type` keyword
- set `IsContextEndLine: true` for closing brace