### PR TITLE
Add ability to not trigger `PR` diff generation if the incoming service isn't `auto`

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -16,6 +16,12 @@ parameters:
     default: eng/common/scripts
 
 steps:
+  # There will be transitory period for every language repo where the <language> - pullrequest build definition will run
+  # alongside the <language> - <service> - ci definitions. These pullrequest build definitions will have the ServiceDirectory parameter
+  # set to 'auto', which will allow the expanding and contracting based on PR Diff.
+
+  # The other public CI builds will pass a real service directory, which will not activate the PR diff logic and as such will operate
+  # as before this change.
   - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
       - task: Powershell@2
         displayName: Generate PR Diff

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -14,9 +14,12 @@ parameters:
   - name: ScriptDirectory
     type: string
     default: eng/common/scripts
+  - name: ServiceDirectoryFilter
+    type: string
+    default: ""
 
 steps:
-  - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
+  - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), or(eq(parameters.ServiceDirectoryFilter, ''), eq(parameters.ServiceDirectory, parameters.ServiceDirectoryFilter))) }}:
       - task: Powershell@2
         displayName: Generate PR Diff
         inputs:

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -14,12 +14,9 @@ parameters:
   - name: ScriptDirectory
     type: string
     default: eng/common/scripts
-  - name: ServiceDirectoryFilter
-    type: string
-    default: ""
 
 steps:
-  - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), or(eq(parameters.ServiceDirectoryFilter, ''), eq(parameters.ServiceDirectory, parameters.ServiceDirectoryFilter))) }}:
+  - ${{ if and(eq(variables['Build.Reason'], 'PullRequest'), eq(parameters.ServiceDirectory, 'auto')) }}:
       - task: Powershell@2
         displayName: Generate PR Diff
         inputs:


### PR DESCRIPTION
It has been really nice in the `python` repo to maintain the _same_ package properties code, but only activate the new diff logic if the service directory is one we expect.

EG: sdk/pullrequest.yml -> passes servicedirectory `auto`, we call `Save-Package-Properties.yml` with the ServiceDirectoryFilter of `auto`. This ensures the new logic will only trigger if running from a specific servicedirectory.

In the case where we are running _both_ alongside each other for integration checks, this will allow us to use the save-package-properties template while still merging to `main`. Any of the `<language> - <service> - ci` jobs will resolve the same targeted set that they _currently_ do if we set this to `auto` or some other value that only the `pullrequest` build will provide.