### PR TITLE
[apiview-js-parser] more bug fixes

### DIFF
--- a/tools/apiview/parsers/js-api-parser/CHANGELOG.md
+++ b/tools/apiview/parsers/js-api-parser/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 2.0.3
+
+- add `SkipDiff: true` for dependency header line
+- set related line id for pre-release tags
+
+# 2.0.2
+
+- fix issue where `type` is not treated as keyword.
+
 # 2.0.1
 
 - fix incorrect token type for members of types.

--- a/tools/apiview/parsers/js-api-parser/package.json
+++ b/tools/apiview/parsers/js-api-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/ts-genapi",
-  "version": "2.0.1",
+  "version": "2.0.3",
   "description": "",
   "main": "index.js",
   "publishConfig": {

--- a/tools/apiview/parsers/js-api-parser/src/generate.ts
+++ b/tools/apiview/parsers/js-api-parser/src/generate.ts
@@ -57,6 +57,7 @@ function buildDependencies(reviewLines: ReviewLine[], dependencies: Record<strin
         Value: "Dependencies:",
         NavigationDisplayName: "Dependencies",
         RenderClasses: ["dependencies"],
+        SkipDiff: true,
       }),
     ],
   };
@@ -177,13 +178,14 @@ const ANNOTATION_TOKEN = "@";
  * Builds review line for a release tag
  * @param reviewLines The result array to push {@link ReviewLine}s to
  * @param tag release tag
+ * @param relatedLineId the id of the review line with which the release tag is associated
  */
-function buildReleaseTag(reviewLines: ReviewLine[], tag: string): void {
+function buildReleaseTag(reviewLines: ReviewLine[], tag: string, relatedLineId: string): void {
   const tagToken = buildToken({
     Kind: TokenKind.StringLiteral,
     Value: `${ANNOTATION_TOKEN}${tag}`,
   });
-  reviewLines.push({ Tokens: [tagToken] });
+  reviewLines.push({ Tokens: [tagToken], RelatedToLine: relatedLineId });
 }
 
 /**
@@ -275,7 +277,7 @@ function buildMember(reviewLines: ReviewLine[], item: ApiItem) {
   const releaseTag = getReleaseTag(item);
   const parentReleaseTag = getReleaseTag(item.parent);
   if (releaseTag && releaseTag !== parentReleaseTag) {
-    buildReleaseTag(reviewLines, releaseTag);
+    buildReleaseTag(reviewLines, releaseTag, line.LineId);
   }
 
   buildMemberLineTokens(line, item);


### PR DESCRIPTION
- skipDiff for dependency header
- attach pre-release tags with their related lines