### PR TITLE
Remove default sub config sub-config-azure-cloud-test-resources

### DIFF
--- a/doc/common/matrix_generator.md
+++ b/doc/common/matrix_generator.md
@@ -92,7 +92,7 @@ jobs:
       JobTemplatePath: /eng/common-tests/matrix-generator/samples/matrix-job-sample.yml
       AdditionalParameters: []
       CloudConfig:
-        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        ServiceConnection: azure-sdk-tests-public
         Location: eastus2
         Cloud: Public
       MatrixFilters: []

--- a/eng/common-tests/matrix-generator/samples/matrix-test.yml
+++ b/eng/common-tests/matrix-generator/samples/matrix-test.yml
@@ -11,7 +11,7 @@ jobs:
       Pool: Azure Pipelines
       OsVmImage: ubuntu-20.04
       CloudConfig:
-        SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+        ServiceConnection: azure-sdk-tests-public
         Location: eastus2
         Cloud: Public
       MatrixFilters:

--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: SubscriptionConfiguration
     type: string
-    default: {}
+    default: '{}'
   - name: SubscriptionConfigurations
     type: object
     default: null

--- a/eng/common/TestResources/build-test-resource-config.yml
+++ b/eng/common/TestResources/build-test-resource-config.yml
@@ -1,7 +1,7 @@
 parameters:
   - name: SubscriptionConfiguration
     type: string
-    default: $(sub-config-azure-cloud-test-resources)
+    default: {}
   - name: SubscriptionConfigurations
     type: object
     default: null

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -4,7 +4,7 @@ parameters:
   DeleteAfterHours: 8
   Location: ''
   EnvVars: {}
-  SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+  SubscriptionConfiguration: {}
   ServiceConnection: not-specified
   ResourceType: test
   UseFederatedAuth: true
@@ -35,7 +35,6 @@ parameters:
 #       "keyVaultEndpointSuffix": "<keyVaultEndpointSuffix>"
 #   }
 # }
-
 
 steps:
   - template: /eng/common/pipelines/templates/steps/cache-ps-modules.yml

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -4,7 +4,7 @@ parameters:
   DeleteAfterHours: 8
   Location: ''
   EnvVars: {}
-  SubscriptionConfiguration: {}
+  SubscriptionConfiguration: '{}'
   ServiceConnection: not-specified
   ResourceType: test
   UseFederatedAuth: true

--- a/eng/common/TestResources/remove-test-resources.yml
+++ b/eng/common/TestResources/remove-test-resources.yml
@@ -3,7 +3,7 @@
 
 parameters:
   ServiceDirectory: ''
-  SubscriptionConfiguration: $(sub-config-azure-cloud-test-resources)
+  SubscriptionConfiguration: $(SubscriptionConfiguration)
   ServiceConnection: not-specified
   ResourceType: test
   EnvVars: {}

--- a/eng/pipelines/live-test-cleanup.yml
+++ b/eng/pipelines/live-test-cleanup.yml
@@ -43,16 +43,13 @@ parameters:
       - DisplayName: AzureCloud ACS - Resource Cleanup
         ServiceConnection: azure-sdk-tests-communication
         SubscriptionConfigurations:
-          - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-communication-services-cloud-test-resources-common)
       - DisplayName: AzureCloud Cosmos - Resource Cleanup
         ServiceConnection: azure-sdk-tests-cosmos
         SubscriptionConfigurations:
-          - $(sub-config-azure-cloud-test-resources)
           - $(sub-config-cosmos-azure-cloud-test-resources)
       # - DisplayName: AzureCloud Storage NET - Resource Cleanup
       #   SubscriptionConfigurations:
-      #     - $(sub-config-azure-cloud-test-resources)
       #     - $(sub-config-storage-test-resources-net)
 
 stages:


### PR DESCRIPTION
We no longer want to default the configuration and instead default from the service connection which had the info we need.