### PR TITLE
Refactor PackageProps to make the Yaml loading and processing methods common

### DIFF
--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -110,9 +110,9 @@ CompatibleConvertFrom-Yaml call or $null if there was an issue with the convert.
 The full path of the yml file to load.
 
 .EXAMPLE
-CompatibleLoadAndConvertFrom-Yaml -YmlFile path/to/file.yml
+LoadFrom-Yaml -YmlFile path/to/file.yml
 #>
-function LoadAndCompatibleConvertFrom-Yaml {
+function LoadFrom-Yaml {
   param(
     [Parameter(Mandatory=$true)]
     [string]$YmlFile
@@ -122,11 +122,11 @@ function LoadAndCompatibleConvertFrom-Yaml {
       return Get-Content -Raw -Path $YmlFile | CompatibleConvertFrom-Yaml
     }
     catch {
-      Write-Host "CompatibleLoadAndConvertFrom-Yaml::Exception while parsing yml file $($YmlFile): $_"
+      Write-Host "LoadFrom-Yaml::Exception while parsing yml file $($YmlFile): $_"
     }
   }
   else {
-    Write-Host "CompatibleLoadAndConvertFrom-Yaml::YmlFile '$YmlFile' does not exist."
+    Write-Host "LoadFrom-Yaml::YmlFile '$YmlFile' does not exist."
   }
   return $null
 }
@@ -139,17 +139,17 @@ return the value if it exist or null if it doesn't.
 .DESCRIPTION
 The Yaml file needs to be loaded via CompatibleConvertFrom-Yaml which returns the file as
 as hashtable. The Keys are basically the path in the yaml file whose value to return, or
-null if it doesn't exist. This function does is safely traverses the path, outputting an
-error if there's an issue or returning the object representing the result if successful.
-This function loops through the Keys safely trying to get values, checking each piece of
-the path to ensure it exists. Normally one would just do
+null if it doesn't exist. This function safely traverses the path, outputting an error
+if there's an issue or returning the object representing the result if successful. This
+function loops through the Keys safely trying to get values, checking each piece of the
+path to ensure it exists. Normally one would just do
 $Yml["extends"]["parameters"]["artifacts"]
 but if something was off it would throw. Doing it this way allows more succinct error
 reporting if a piece of the path didn't exist
 
 .PARAMETER YamlContentAsHashtable
-The hashtable representing the yaml file contents loaded through LoadAndCompatibleConvertFrom-Yaml
-or CompatibleConvertFrom-Yaml, which is what LoadAndCompatibleConvertFrom-Yaml calls.
+The hashtable representing the yaml file contents loaded through LoadFrom-Yaml
+or CompatibleConvertFrom-Yaml, which is what LoadFrom-Yaml calls.
 
 .PARAMETER Keys
 String array representation of the path in the yaml file whose value we're trying to retrieve.

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -17,7 +17,8 @@ class PackageProps
     [string]$ReleaseStatus
     # was this package purely included because other packages included it as an AdditionalValidationPackage?
     [boolean]$IncludedForValidation
-    # does this package include other packages that we should trigger validation for?
+    # does this package include other packages that we should trigger validation for or
+    # additional packages required for validation of this one
     [string[]]$AdditionalValidationPackages
     [HashTable]$ArtifactDetails
 
@@ -83,42 +84,21 @@ class PackageProps
         $this.Group = $group
     }
 
-    hidden [object]GetValueSafely($hashtable, [string[]]$keys) {
-        $current = $hashtable
-        foreach ($key in $keys) {
-            if ($current.ContainsKey($key) -or $current[$key]) {
-                $current = $current[$key]
-            }
-            else {
-                return $null
-            }
-        }
-
-        return $current
-    }
-
     hidden [HashTable]ParseYmlForArtifact([string]$ymlPath) {
-        if (Test-Path -Path $ymlPath) {
-            try {
-                $content = Get-Content -Raw -Path $ymlPath | CompatibleConvertFrom-Yaml
-                if ($content) {
-                    $artifacts = $this.GetValueSafely($content, @("extends", "parameters", "Artifacts"))
-                    $artifactForCurrentPackage = $null
 
-                    if ($artifacts) {
-                        $artifactForCurrentPackage = $artifacts | Where-Object { $_["name"] -eq $this.ArtifactName -or $_["name"] -eq $this.Name }
-                    }
+        $content = LoadAndCompatibleConvertFrom-Yaml $ymlPath
+        if ($content) {
+            $artifacts = GetValueSafelyFrom-Yaml $content @("extends", "parameters", "Artifacts")
+            $artifactForCurrentPackage = $null
 
-                    if ($artifactForCurrentPackage) {
-                        return [HashTable]$artifactForCurrentPackage
-                    }
-                }
+            if ($artifacts) {
+                $artifactForCurrentPackage = $artifacts | Where-Object { $_["name"] -eq $this.ArtifactName -or $_["name"] -eq $this.Name }
             }
-            catch {
-              Write-Host "Exception while parsing yml file $($ymlPath): $_"
+
+            if ($artifactForCurrentPackage) {
+                return [HashTable]$artifactForCurrentPackage
             }
         }
-
         return $null
     }
 

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -86,7 +86,7 @@ class PackageProps
 
     hidden [HashTable]ParseYmlForArtifact([string]$ymlPath) {
 
-        $content = LoadAndCompatibleConvertFrom-Yaml $ymlPath
+        $content = LoadFrom-Yaml $ymlPath
         if ($content) {
             $artifacts = GetValueSafelyFrom-Yaml $content @("extends", "parameters", "Artifacts")
             $artifactForCurrentPackage = $null


### PR DESCRIPTION
All I'm doing here is refactoring some of the code that was in PackageProps, specifically around Yaml loading and processing, hoisting it out to be common and usable outside of that class. Specifically, I'm going to be using the yaml loading and processing for the Get-AllPackageInfoFromRepo I'm implementing for Java.

The changes are as follows:

1.  LoadAndCompatibleConvertFrom-Yaml (this was renamed to LoadFrom-Yaml as per feedback) - this was originally part of the PackageProps::ParseYmlForArtifact function. I moved the Test-Path verification of the yml file and try/catch surrounding the call to CompatibleConvertFrom-Yaml into a common function. That way anyone using the CompatibleConvertFrom-Yaml doesn't have to dupe the checks or the try catch.
2. GetValueSafelyFrom-Yaml - this was originally PackageProps::GetValueSafely and hidden. I could have changed the class to unhide and make the function static but it seemed better to be hoisted out and sit alongside the rest of the functions in Package-Helpers. The one thing I changed in this function was that if the key isn't found or the value is null, it writes the key and the full path into the output. In theory this could have thrown but there are scenarios where we can look for something that might not exist in a yml file. An example of this would Java's AdditionalModules which may or may not exist.

For testing, to ensure I was running the code path our pipelines run, I just executed /eng/common/scripts/Save-Package-Properties.ps1 locally against my Java repo to create the PackageInfo json files for various service directories. I pulled the PackageInfo directories directly from their respective pipelines and used Beyond Compare to verify the output. The differences were that the json files from the pipelines had Namespaces and this was expected. In a Java pipeline, the PackageInfo files are created before the build and Namespaces are added to them after the build.