### PR TITLE
Update CODEOWNERS of sdk-testgen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,7 +43,7 @@
 /tools/pipeline-generator/             @weshaggard @benbp
 /tools/pipeline-witness/               @hallipr
 /tools/sdk-ai-bots/                    @raych1
-/tools/sdk-testgen/                    @raych1 @tadelesh
+/tools/sdk-testgen/                    @lirenhe @tadelesh
 /tools/test-proxy/                     @scbedd @mikeharder @benbp
 /tools/tsp-client/                     @catalinaperalta
 /tools/webhook-router/                 @praveenkuttappan @weshaggard


### PR DESCRIPTION
Update the code owner of sdk-testgen to enable more effective code merge.
Remove Ray as he no longer works in this area.