### PR TITLE
examples-automation, handle corner cases and invalid cases from upstream

### DIFF
--- a/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
@@ -20,8 +20,9 @@ def try_find_resource_manager_example(
             if tsp_dir:
                 # find example under directory
                 # e.g. example_path = "specification/mongocluster/DocumentDB.MongoCluster.Management/examples/2024-03-01-preview/MongoClusters_ListConnectionStrings.json"
+                example_search_glob = f"{path.join(specs_path, tsp_dir)}/**/examples/{example_dir}/{example_filename}"
                 example_paths = glob.glob(
-                    f"{path.join(specs_path, tsp_dir)}/**/examples/{example_dir}/{example_filename}", recursive=True
+                    example_search_glob, recursive=True
                 )
 
                 if len(example_paths) > 0:
@@ -48,6 +49,10 @@ def try_find_resource_manager_example(
                         if len(candidate_resource_manager_filename) > 0:
                             example_path, _ = path.split(candidate_resource_manager_filename[0])
                             example_dir = path.relpath(example_path, specs_path).replace("\\", "/")
+                else:
+                    raise RuntimeError(f"Example file not found at path {example_search_glob}")
+            else:
+                raise RuntimeError("'directory' property not found in tsp-location.yaml")
         else:
             raise RuntimeError(f"tsp-location.yaml not found in SDK package folder {sdk_package_path}")
 

--- a/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
@@ -56,6 +56,7 @@ def try_find_resource_manager_example(
         else:
             raise RuntimeError(f"tsp-location.yaml not found in SDK package folder {sdk_package_path}")
 
+    example_dir = example_dir.replace("\\", "/")
     if re.search(r"[:\"*?<>|]+", example_dir):
         # invalid character in windows path < > : " | ? *
         raise RuntimeError(f"Example directory contains invalid character {example_dir}")

--- a/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
@@ -23,9 +23,7 @@ def try_find_resource_manager_example(
                 # find example under directory
                 # e.g. example_path = "specification/mongocluster/DocumentDB.MongoCluster.Management/examples/2024-03-01-preview/MongoClusters_ListConnectionStrings.json"
                 example_search_glob = f"{path.join(specs_path, tsp_dir)}/**/examples/{example_dir}/{example_filename}"
-                example_paths = glob.glob(
-                    example_search_glob, recursive=True
-                )
+                example_paths = glob.glob(example_search_glob, recursive=True)
 
                 if len(example_paths) > 0:
                     example_path = example_paths[0]

--- a/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
@@ -58,4 +58,8 @@ def try_find_resource_manager_example(
         else:
             raise RuntimeError(f"tsp-location.yaml not found in SDK package folder {sdk_package_path}")
 
+    if re.search(r"[:\"*?<>|]+", example_dir):
+        # invalid character in windows path < > : " | ? *
+        raise RuntimeError(f"Example directory contains invalid character {example_dir}")
+
     return example_dir

--- a/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/examples_dir.py
@@ -18,6 +18,8 @@ def try_find_resource_manager_example(
             tsp_dir = yaml_json["directory"]
 
             if tsp_dir:
+                tsp_dir = tsp_dir.replace("\\", "/")
+
                 # find example under directory
                 # e.g. example_path = "specification/mongocluster/DocumentDB.MongoCluster.Management/examples/2024-03-01-preview/MongoClusters_ListConnectionStrings.json"
                 example_search_glob = f"{path.join(specs_path, tsp_dir)}/**/examples/{example_dir}/{example_filename}"

--- a/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
@@ -119,7 +119,7 @@ class TestExamplesDir(unittest.TestCase):
             )
             with open(tsp_location_path, "w+", encoding="utf-8") as file:
                 file.write(
-                    """directory: specification/mongocluster/DocumentDB.MongoCluster.Management
+                    """directory: specification\mongocluster\DocumentDB.MongoCluster.Management
 commit: 07bdede4651ce2ea0e4039d76e81a69df23a3d6e
 repo: Azure/azure-rest-api-specs
 additionalDirectories: null

--- a/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
@@ -114,13 +114,17 @@ class TestExamplesDir(unittest.TestCase):
     def test_find_resource_manager_example_typespec_windows_directory_separator(self):
         with create_mock_test_folder() as tmp_dir_name:
             # use windows directory separator
-            tsp_location_path = path.join(tmp_dir_name, "azure-sdk-for-java/sdk/mongocluster/azure-resourcemanager-mongocluster/tsp-location.yaml")
+            tsp_location_path = path.join(
+                tmp_dir_name, "azure-sdk-for-java/sdk/mongocluster/azure-resourcemanager-mongocluster/tsp-location.yaml"
+            )
             with open(tsp_location_path, "w+", encoding="utf-8") as file:
-                file.write("""directory: specification/mongocluster/DocumentDB.MongoCluster.Management
+                file.write(
+                    """directory: specification/mongocluster/DocumentDB.MongoCluster.Management
 commit: 07bdede4651ce2ea0e4039d76e81a69df23a3d6e
 repo: Azure/azure-rest-api-specs
 additionalDirectories: null
-""")
+"""
+                )
 
             example_dir = try_find_resource_manager_example(
                 path.join(tmp_dir_name, "azure-rest-api-specs"),

--- a/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
@@ -103,7 +103,7 @@ class TestExamplesDir(unittest.TestCase):
 
     def test_find_resource_manager_example_typespec_no_tsp_location(self):
         mock_path = path.abspath(".")
-        with self.assertRaises(RuntimeError) as context:
+        with self.assertRaises(RuntimeError):
             example_dir = try_find_resource_manager_example(
                 path.join(mock_path, "azure-rest-api-specs"),
                 path.join(mock_path, "azure-sdk-for-java/sdk/mongocluster/azure-resourcemanager-mongocluster"),
@@ -146,3 +146,12 @@ additionalDirectories: null
             "specification/mongocluster/resource-manager/Microsoft.DocumentDB/preview/2024-03-01-preview/examples",
             example_dir,
         )
+
+    def test_find_resource_manager_example_swagger_invalid_path(self):
+        with self.assertRaises(RuntimeError):
+            example_dir = try_find_resource_manager_example(
+                "not_used",
+                "not_used",
+                "D:/w/Azure/azure-rest-api-specs/specification/mongocluster/resource-manager/Microsoft.DocumentDB/preview/2024-03-01-preview/examples",
+                "MongoClusters_ListConnectionStrings.json",
+            )

--- a/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
@@ -111,6 +111,29 @@ class TestExamplesDir(unittest.TestCase):
                 "MongoClusters_ListConnectionStrings.json",
             )
 
+    def test_find_resource_manager_example_typespec_windows_directory_separator(self):
+        with create_mock_test_folder() as tmp_dir_name:
+            # use windows directory separator
+            tsp_location_path = path.join(tmp_dir_name, "azure-sdk-for-java/sdk/mongocluster/azure-resourcemanager-mongocluster/tsp-location.yaml")
+            with open(tsp_location_path, "w+", encoding="utf-8") as file:
+                file.write("""directory: specification/mongocluster/DocumentDB.MongoCluster.Management
+commit: 07bdede4651ce2ea0e4039d76e81a69df23a3d6e
+repo: Azure/azure-rest-api-specs
+additionalDirectories: null
+""")
+
+            example_dir = try_find_resource_manager_example(
+                path.join(tmp_dir_name, "azure-rest-api-specs"),
+                path.join(tmp_dir_name, "azure-sdk-for-java/sdk/mongocluster/azure-resourcemanager-mongocluster"),
+                "2024-07-01",
+                "MongoClusters_ListConnectionStrings.json",
+            )
+
+            self.assertEqual(
+                "specification/mongocluster/resource-manager/Microsoft.DocumentDB/preview/2024-07-01/examples",
+                example_dir,
+            )
+
     def test_find_resource_manager_example_swagger(self):
         example_dir = try_find_resource_manager_example(
             "c:/github/azure-rest-api-specs",

--- a/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
+++ b/tools/azure-rest-api-specs-examples-automation/directory/test_examples_dir.py
@@ -136,8 +136,8 @@ additionalDirectories: null
 
     def test_find_resource_manager_example_swagger(self):
         example_dir = try_find_resource_manager_example(
-            "c:/github/azure-rest-api-specs",
-            "c:/github/azure-sdk-for-java/sdk/mongocluster/azure-resourcemanager-mongocluster",
+            "not_used",
+            "not_used",
             "specification/mongocluster/resource-manager/Microsoft.DocumentDB/preview/2024-03-01-preview/examples",
             "MongoClusters_ListConnectionStrings.json",
         )


### PR DESCRIPTION
1. "directory" in tsp-location could be windows format (with `\`)
2. golang has invalid path like `D:/w/Azure/azure-sdk-for-go/sdk/resourcemanager/computefleet/armcomputefleet/TempTypeSpecFiles/AzureFleet.Management/examples/2024-11-01/Fleets_Update.json` in file, due to bug in codegen -- this result in pipeline failure on doc site
    They had fixed, but we'd better to have more protection.

ref https://github.com/Azure/azure-rest-api-specs-examples/pull/5066