### PR TITLE
Run perf tests under federated auth

### DIFF
--- a/eng/common/pipelines/templates/jobs/perf.yml
+++ b/eng/common/pipelines/templates/jobs/perf.yml
@@ -144,7 +144,7 @@ jobs:
         --iterations ${{ parameters.Iterations }}
         $(Profile)
         ${{ parameters.AdditionalArguments }}
-    workingDirectory: azure-sdk-tools/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation
+      workingDirectory: azure-sdk-tools/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation
     displayName: Run perf tests
     env:
       SYSTEM_ACCESSTOKEN: $(System.AccessToken)

--- a/eng/common/pipelines/templates/jobs/perf.yml
+++ b/eng/common/pipelines/templates/jobs/perf.yml
@@ -122,23 +122,34 @@ jobs:
       ResourceType: perf
       ServiceConnection: azure-sdk-tests-public
 
-  - script: >-
-      dotnet run -- run
-      --language ${{ parameters.Language }}
-      --language-version ${{ parameters.LanguageVersion }}
-      --repo-root $(System.DefaultWorkingDirectory)
-      --tests-file $(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/perf-tests.yml
-      --package-versions "${{ parameters.PackageVersions }}"
-      --tests "${{ parameters.Tests }}"
-      --arguments "${{ parameters.Arguments }}"
-      --iterations ${{ parameters.Iterations }}
-      $(Profile)
-      ${{ parameters.AdditionalArguments }}
+  - task: AzurePowerShell@5
+    inputs:
+      azureSubscription: azure-sdk-tests-public
+      azurePowerShellVersion: LatestVersion
+      pwsh: true
+      ScriptType: InlineScript
+      Inline: >-
+        $account = (Get-AzContext).Account;
+        $env:AZURESUBSCRIPTION_CLIENT_ID = $account.Id;
+        $env:AZURESUBSCRIPTION_TENANT_ID = $account.Tenants;
+
+        dotnet run -- run
+        --language ${{ parameters.Language }}
+        --language-version ${{ parameters.LanguageVersion }}
+        --repo-root $(System.DefaultWorkingDirectory)
+        --tests-file $(System.DefaultWorkingDirectory)/sdk/${{ parameters.ServiceDirectory }}/perf-tests.yml
+        --package-versions "${{ parameters.PackageVersions }}"
+        --tests "${{ parameters.Tests }}"
+        --arguments "${{ parameters.Arguments }}"
+        --iterations ${{ parameters.Iterations }}
+        $(Profile)
+        ${{ parameters.AdditionalArguments }}
     workingDirectory: azure-sdk-tools/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation
+    displayName: Run perf tests
     env:
+      SYSTEM_ACCESSTOKEN: $(System.AccessToken)
       ${{ each var in parameters.EnvVars }}:
         ${{ var.key }}: ${{ var.value }}
-    displayName: Run perf tests
 
   - pwsh: |
       get-content results.txt


### PR DESCRIPTION
Run the tests under the same federated auth used to deploy the tests and setup the variables needed to configure AzurePipelineCredential.