### PR TITLE
`Create-PrJobMatrix`

### DIFF
--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -48,6 +48,7 @@ parameters:
 - name: PRMatrixSetting
   type: string
   default: 'ArtifactPackageNames'
+# Mappings to OS name required at template compile time by 1es pipeline templates
 - name: Pools
   type: object
   default:

--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -45,9 +45,9 @@ parameters:
 - name: EnablePRGeneration
   type: boolean
   default: false
-- name: PRMatrix
-  type: object
-# Mappings to OS name required at template compile time by 1es pipeline templates
+- name: PRMatrixSetting
+  type: string
+  default: 'ArtifactPackageNames'
 - name: Pools
   type: object
   default:
@@ -124,16 +124,16 @@ jobs:
       # Not currently not hardcoded, so not doing the needful and populating this folder before we hit this step will result in generation errors.
     - ${{ else }}:
       - ${{ each pool in parameters.Pools }}:
-        - task: Powershell@2
-          inputs:
-            pwsh: true
-            filePath: eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
-            arguments: >
-              -PackagePropertiesFolder $(Build.ArtifactStagingDirectory)/PackageInfo
-              -PRMatrixFile ${{ parameters.PRMatrix.Path }}
-              -PRMatrixSetting ${{ parameters.PRMatrix.Setting }}
-              -DisplayNameFilter '$(displayNameFilter)'
-              -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}'
+        - pwsh: |
+            # dump the conglomerated CI matrix
+            '${{ convertToJson(parameters.MatrixConfigs) }}' | Set-Content matrix.json
+
+            ./eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1 `
+              -PackagePropertiesFolder $(Build.ArtifactStagingDirectory)/PackageInfo `
+              -PRMatrixFile matrix.json `
+              -PRMatrixSetting ${{ parameters.PRMatrixSetting }} `
+              -DisplayNameFilter '$(displayNameFilter)' `
+              -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}' `
               -Replace '${{ join(''',''', parameters.MatrixReplace) }}'
           displayName: Create ${{ pool.name }} PR Matrix
           name: vm_job_matrix_pr_${{ pool.name }}

--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -42,6 +42,11 @@ parameters:
 - name: PreGenerationSteps
   type: stepList
   default: []
+- name: EnablePRGeneration
+  type: boolean
+  default: false
+- name: PRMatrix
+  type: object
 # Mappings to OS name required at template compile time by 1es pipeline templates
 - name: Pools
   type: object
@@ -84,57 +89,87 @@ jobs:
 
     - ${{ parameters.PreGenerationSteps }}
 
-    - ${{ each config in parameters.MatrixConfigs }}:
+    - ${{ if eq(parameters.EnablePRGeneration, false) }}:
+      - ${{ each config in parameters.MatrixConfigs }}:
+        - ${{ each pool in parameters.Pools }}:
+          - ${{ if eq(config.GenerateVMJobs, 'true') }}:
+            - task: Powershell@2
+              inputs:
+                pwsh: true
+                filePath: eng/common/scripts/job-matrix/Create-JobMatrix.ps1
+                arguments: >
+                  -ConfigPath ${{ config.Path }}
+                  -Selection ${{ config.Selection }}
+                  -DisplayNameFilter '$(displayNameFilter)'
+                  -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}'
+                  -Replace '${{ join(''',''', parameters.MatrixReplace) }}'
+                  -NonSparseParameters '${{ join(''',''', config.NonSparseParameters) }}'
+              displayName: Create ${{ pool.name }} Matrix ${{ config.Name }}
+              name: vm_job_matrix_${{ config.Name }}_${{ pool.name }}
+          - ${{ if eq(config.GenerateContainerJobs, 'true') }}:
+            - task: Powershell@2
+              inputs:
+                pwsh: true
+                filePath: eng/common/scripts/job-matrix/Create-JobMatrix.ps1
+                arguments: >
+                  -ConfigPath ${{ config.Path }}
+                  -Selection ${{ config.Selection }}
+                  -DisplayNameFilter '$(displayNameFilter)'
+                  -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}'
+                  -NonSparseParameters '${{ join(''',''', config.NonSparseParameters) }}'
+              displayName: Create ${{ pool.name }} Container Matrix ${{ config.Name }}
+              name: container_job_matrix_${{ config.Name }}_${{ pool.name }}
+
+      # This else being set also currently assumes that the $(Build.ArtifactStagingDirectory)/PackageInfo folder is populated by PreGenerationSteps.
+      # Not currently not hardcoded, so not doing the needful and populating this folder before we hit this step will result in generation errors.
+    - ${{ else }}:
       - ${{ each pool in parameters.Pools }}:
-        - ${{ if eq(config.GenerateVMJobs, 'true') }}:
-          - task: Powershell@2
-            inputs:
-              pwsh: true
-              filePath: eng/common/scripts/job-matrix/Create-JobMatrix.ps1
-              arguments: >
-                -ConfigPath ${{ config.Path }}
-                -Selection ${{ config.Selection }}
-                -DisplayNameFilter '$(displayNameFilter)'
-                -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}'
-                -Replace '${{ join(''',''', parameters.MatrixReplace) }}'
-                -NonSparseParameters '${{ join(''',''', config.NonSparseParameters) }}'
-            displayName: Create ${{ pool.name }} Matrix ${{ config.Name }}
-            name: vm_job_matrix_${{ config.Name }}_${{ pool.name }}
+        - task: Powershell@2
+          inputs:
+            pwsh: true
+            filePath: eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+            arguments: >
+              -PackagePropertiesFolder $(Build.ArtifactStagingDirectory)/PackageInfo
+              -PRMatrixFile ${{ parameters.PRMatrix.Path }}
+              -PRMatrixSetting ${{ parameters.PRMatrix.Setting }}
+              -DisplayNameFilter '$(displayNameFilter)'
+              -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}'
+              -Replace '${{ join(''',''', parameters.MatrixReplace) }}'
+          displayName: Create ${{ pool.name }} PR Matrix
+          name: vm_job_matrix_pr_${{ pool.name }}
 
-        - ${{ if eq(config.GenerateContainerJobs, 'true') }}:
-          - task: Powershell@2
-            inputs:
-              pwsh: true
-              filePath: eng/common/scripts/job-matrix/Create-JobMatrix.ps1
-              arguments: >
-                -ConfigPath ${{ config.Path }}
-                -Selection ${{ config.Selection }}
-                -DisplayNameFilter '$(displayNameFilter)'
-                -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}'
-                -NonSparseParameters '${{ join(''',''', config.NonSparseParameters) }}'
-            displayName: Create ${{ pool.name }} Container Matrix ${{ config.Name }}
-            name: container_job_matrix_${{ config.Name }}_${{ pool.name }}
+- ${{ if eq(parameters.EnablePRGeneration, false) }}:
+  - ${{ each config in parameters.MatrixConfigs }}:
+    - ${{ each pool in parameters.Pools }}:
+      - ${{ if eq(config.GenerateVMJobs, 'true') }}:
+        - template: ${{ parameters.JobTemplatePath }}
+          parameters:
+            UsePlatformContainer: false
+            OSName: ${{ pool.os }}
+            Matrix: dependencies.${{ parameters.GenerateJobName }}.outputs['vm_job_matrix_${{ config.Name }}_${{ pool.name }}.matrix']
+            DependsOn: ${{ parameters.GenerateJobName }}
+            CloudConfig: ${{ parameters.CloudConfig }}
+            ${{ each param in parameters.AdditionalParameters }}:
+              ${{ param.key }}: ${{ param.value }}
 
-- ${{ each config in parameters.MatrixConfigs }}:
+      - ${{ if eq(config.GenerateContainerJobs, 'true') }}:
+        - template: ${{ parameters.JobTemplatePath }}
+          parameters:
+            UsePlatformContainer: true
+            OSName: ${{ pool.os }}
+            Matrix: dependencies.${{ parameters.GenerateJobName }}.outputs['vm_job_matrix_${{ config.Name }}_${{ pool.name }}.matrix']
+            DependsOn: ${{ parameters.GenerateJobName }}
+            CloudConfig: ${{ parameters.CloudConfig }}
+            ${{ each param in parameters.AdditionalParameters }}:
+              ${{ param.key }}: ${{ param.value }}
+- ${{ else }}:
   - ${{ each pool in parameters.Pools }}:
-    - ${{ if eq(config.GenerateVMJobs, 'true') }}:
-      - template: ${{ parameters.JobTemplatePath }}
-        parameters:
-          UsePlatformContainer: false
-          OSName: ${{ pool.os }}
-          Matrix: dependencies.${{ parameters.GenerateJobName }}.outputs['vm_job_matrix_${{ config.Name }}_${{ pool.name }}.matrix']
-          DependsOn: ${{ parameters.GenerateJobName }}
-          CloudConfig: ${{ parameters.CloudConfig }}
-          ${{ each param in parameters.AdditionalParameters }}:
-            ${{ param.key }}: ${{ param.value }}
-
-    - ${{ if eq(config.GenerateContainerJobs, 'true') }}:
-      - template: ${{ parameters.JobTemplatePath }}
-        parameters:
-          UsePlatformContainer: true
-          OSName: ${{ pool.os }}
-          Matrix: dependencies.${{ parameters.GenerateJobName }}.outputs['vm_job_matrix_${{ config.Name }}_${{ pool.name }}.matrix']
-          DependsOn: ${{ parameters.GenerateJobName }}
-          CloudConfig: ${{ parameters.CloudConfig }}
-          ${{ each param in parameters.AdditionalParameters }}:
-            ${{ param.key }}: ${{ param.value }}
+    - template: ${{ parameters.JobTemplatePath }}
+      parameters:
+        UsePlatformContainer: false
+        OSName: ${{ pool.os }}
+        Matrix: dependencies.${{ parameters.GenerateJobName }}.outputs['vm_job_matrix_pr_${{ pool.name }}.matrix']
+        DependsOn: ${{ parameters.GenerateJobName }}
+        CloudConfig: ${{ parameters.CloudConfig }}
+        ${{ each param in parameters.AdditionalParameters }}:
+          ${{ param.key }}: ${{ param.value }}

--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -170,7 +170,6 @@ function GetValueSafelyFrom-Yaml {
         $current = $current[$key]
       }
       else {
-        Write-Host "The '$key' part of the path $($Keys -join "/") doesn't exist or is null."
         return $null
       }
   }

--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -177,3 +177,80 @@ function GetValueSafelyFrom-Yaml {
 
   return [object]$current
 }
+
+function Get-ObjectKey {
+  param (
+    [Parameter(Mandatory = $true)]
+    [object]$Object
+  )
+
+  if (-not $Object) {
+    return "unset"
+  }
+
+  if ($Object -is [hashtable] -or $Object -is [System.Collections.Specialized.OrderedDictionary]) {
+    $sortedEntries = $Object.GetEnumerator() | Sort-Object Name
+    $hashString = ($sortedEntries | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ";"
+    return $hashString.GetHashCode()
+  }
+
+  elseif ($Object -is [PSCustomObject]) {
+    $sortedProperties = $Object.PSObject.Properties | Sort-Object Name
+    $propertyString = ($sortedProperties | ForEach-Object { "$($_.Name)=$($_.Value)" }) -join ";"
+    return $propertyString.GetHashCode()
+  }
+
+  elseif ($Object -is [array]) {
+    $arrayString = ($Object | ForEach-Object { Get-ObjectKey $_ }) -join ";"
+    return $arrayString.GetHashCode()
+  }
+
+  else {
+    return $Object.GetHashCode()
+  }
+}
+
+function Group-ByObjectKey {
+  param (
+    [Parameter(Mandatory)]
+    [array]$Items,
+
+    [Parameter(Mandatory)]
+    [string]$GroupByProperty
+  )
+
+  $groupedDictionary = @{}
+
+  foreach ($item in $Items) {
+    $key = Get-ObjectKey $item."$GroupByProperty"
+
+    if (-not $groupedDictionary.ContainsKey($key)) {
+      $groupedDictionary[$key] = @()
+    }
+
+    # Add the current item to the array for this key
+    $groupedDictionary[$key] += $item
+  }
+
+  return $groupedDictionary
+}
+
+function Split-ArrayIntoBatches {
+  param (
+    [Parameter(Mandatory = $true)]
+    [Object[]]$InputArray,
+
+    [Parameter(Mandatory = $true)]
+    [int]$BatchSize
+  )
+
+  $batches = @()
+
+  for ($i = 0; $i -lt $InputArray.Count; $i += $BatchSize) {
+    $batch = $InputArray[$i..[math]::Min($i + $BatchSize - 1, $InputArray.Count - 1)]
+
+    $batches += , $batch
+  }
+
+  return , $batches
+}

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -21,6 +21,7 @@ class PackageProps
     # additional packages required for validation of this one
     [string[]]$AdditionalValidationPackages
     [HashTable]$ArtifactDetails
+    [HashTable[]]$CIMatrixConfigs
 
     PackageProps([string]$name, [string]$version, [string]$directoryPath, [string]$serviceDirectory)
     {

--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -49,18 +49,14 @@ if (!(Test-Path $PackagePropertiesFolder)) {
   exit 1
 }
 
+if (!(Test-Path $PRMatrixFile)) {
+  Write-Error "PR Matrix file doesn't exist"
+  exit 1
+}
+
 Write-Host "Generating PR job matrix for $PackagePropertiesFolder"
 
-# this will become a parameter in the future, we will pass MatrixConfigs as a parameter
-# these will be the "default" matrices that we will use to generate the PR matrix in lieu of
-# a matrix file
-$configs = @(
-  [PsCustomObject]@{
-    Name      = "default_platform_matrix"
-    Path      = $PRMatrixFile
-    Selection = "sparse"
-  }
-)
+$configs = Get-Content -Raw $PRMatrixFile | ConvertFrom-Json | ForEach-Object { [PSCustomObject]$_ }
 
 # calculate general targeting information and create our batches prior to generating any matrix
 $packageProperties = Get-ChildItem -Recurse "$PackagePropertiesFolder" *.json `

--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -64,9 +64,7 @@ $packageProperties = Get-ChildItem -Recurse "$PackagePropertiesFolder" *.json `
 
 # set default matrix config for each package if there isn't an override
 $packageProperties | ForEach-Object {
-  if (-not $_.CIMatrixConfigs) {
-    $_.CIMatrixConfigs = $configs
-  }
+  $_.CIMatrixConfigs = $_.CIMatrixConfigs ?? $configs
 }
 
 # The key here is that after we group the packages by the matrix config objects, we can use the first item's MatrixConfig

--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -63,7 +63,6 @@ $configs = @(
 )
 
 # calculate general targeting information and create our batches prior to generating any matrix
-# this prototype doesn't handle direct and indirect, it just batches for simplicity of the proto
 $packageProperties = Get-ChildItem -Recurse "$PackagePropertiesFolder" *.json `
 | ForEach-Object { Get-Content -Path $_.FullName | ConvertFrom-Json } `
 | ForEach-Object { [PSCustomObject]$_ }

--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -56,12 +56,11 @@ if (!(Test-Path $PRMatrixFile)) {
 
 Write-Host "Generating PR job matrix for $PackagePropertiesFolder"
 
-$configs = Get-Content -Raw $PRMatrixFile | ConvertFrom-Json | ForEach-Object { [PSCustomObject]$_ }
+$configs = Get-Content -Raw $PRMatrixFile | ConvertFrom-Json
 
 # calculate general targeting information and create our batches prior to generating any matrix
 $packageProperties = Get-ChildItem -Recurse "$PackagePropertiesFolder" *.json `
-| ForEach-Object { Get-Content -Path $_.FullName | ConvertFrom-Json } `
-| ForEach-Object { [PSCustomObject]$_ }
+| ForEach-Object { Get-Content -Path $_.FullName | ConvertFrom-Json }
 
 # set default matrix config for each package if there isn't an override
 $packageProperties | ForEach-Object {

--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -1,0 +1,134 @@
+<#
+.SYNOPSIS
+Generates a combined PR job matrix from a package properties folder. It is effectively a combination of
+Create-JobMatrix and distribute-packages-to-matrix.
+
+.DESCRIPTION
+Create-JobMatrix has a limitation in that it accepts one or multiple matrix files, but it doesn't allow runtime
+selection of the matrix file based on what is being built. Due to this, this script exists to provide exactly
+that mapping.
+
+It should be called from a PR build only.
+
+It generates the matrix by the following algorithm:
+  - load all package properties files
+  - group the package properties by their targeted CI Matrix Configs
+    - for each package group, generate the matrix for each matrix config in the group (remember MatrixConfigs is a list not a single object)
+      - for each matrix config, generate the matrix
+        - calculate if batching is necessary for this matrix config
+        - for each batch
+          - create combined property name for the batch
+          - walk each matrix item
+            - add suffixes for batch and matrix config if nececessary to the job name
+            - add the combined property name to the parameters of the matrix item
+            - add the matrix item to the overall result
+
+.EXAMPLE
+./eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1 `
+  -PackagePropertiesFolder "path/to/populated/PackageInfo" `
+  -PrMatrixSetting "<Name of variable to set in the matrix>"
+#>
+
+[CmdletBinding()]
+param (
+  [Parameter(Mandatory = $true)][string] $PackagePropertiesFolder,
+  [Parameter(Mandatory = $true)][string] $PRMatrixFile,
+  [Parameter(Mandatory = $true)][string] $PRMatrixSetting,
+  [Parameter(Mandatory = $False)][string] $DisplayNameFilter,
+  [Parameter(Mandatory = $False)][array] $Filters,
+  [Parameter(Mandatory = $False)][array] $Replace,
+  [Parameter()][switch] $CI = ($null -ne $env:SYSTEM_TEAMPROJECTID)
+)
+
+. $PSScriptRoot/job-matrix-functions.ps1
+. $PSScriptRoot/../Helpers/Package-Helpers.ps1
+$BATCHSIZE = 10
+
+if (!(Test-Path $PackagePropertiesFolder)) {
+  Write-Error "Package Properties folder doesn't exist"
+  exit 1
+}
+
+Write-Host "Generating PR job matrix for $PackagePropertiesFolder"
+
+# this will become a parameter in the future, we will pass MatrixConfigs as a parameter
+# these will be the "default" matrices that we will use to generate the PR matrix in lieu of
+# a matrix file
+$configs = @(
+  [PsCustomObject]@{
+    Name      = "default_platform_matrix"
+    Path      = $PRMatrixFile
+    Selection = "sparse"
+  }
+)
+
+# calculate general targeting information and create our batches prior to generating any matrix
+# this prototype doesn't handle direct and indirect, it just batches for simplicity of the proto
+$packageProperties = Get-ChildItem -Recurse "$PackagePropertiesFolder" *.json `
+| ForEach-Object { Get-Content -Path $_.FullName | ConvertFrom-Json } `
+| ForEach-Object { [PSCustomObject]$_ }
+
+# set default matrix config for each package if there isn't an override
+$packageProperties | ForEach-Object {
+  if (-not $_.CIMatrixConfigs) {
+    $_.CIMatrixConfigs = $configs
+  }
+}
+
+# The key here is that after we group the packages by the matrix config objects, we can use the first item's MatrixConfig
+# to generate the matrix for the group, no reason to have to parse the key value backwards to get the matrix config.
+$matrixBatchesByConfig = Group-ByObjectKey $packageProperties "CIMatrixConfigs"
+
+$OverallResult = @()
+foreach ($matrixBatchKey in $matrixBatchesByConfig.Keys) {
+  $matrixBatch = $matrixBatchesByConfig[$matrixBatchKey]
+  $matrixConfigs = $matrixBatch | Select-Object -First 1 -ExpandProperty CIMatrixConfigs
+
+  $matrixResults = @()
+  foreach ($matrixConfig in $matrixConfigs) {
+    Write-Host "Generating config for $($matrixConfig.Path)"
+    $matrixResults = GenerateMatrixForConfig `
+      -ConfigPath $matrixConfig.Path `
+      -Selection $matrixConfig.Selection `
+      -DisplayNameFilter $DisplayNameFilter `
+      -Filters $Filters `
+      -Replace $Replace
+
+    $packageBatches = Split-ArrayIntoBatches -InputArray $matrixBatch -BatchSize $BATCHSIZE
+
+    # we only need to modify the generated job name if there is more than one matrix config or batch in the matrix
+    $matrixSuffixNecessary = $matrixConfigs.Count -gt 1
+    $batchSuffixNecessary = $packageBatches.Length -gt 1
+
+    foreach ($batch in $packageBatches) {
+      # to understand this iteration, one must understand that the matrix is a list of hashtables, each with a couple keys:
+      # [
+      #  { "name": "jobname", "parameters": { matrixSetting1: matrixValue1, ...} },
+      # ]
+      foreach ($matrixOutputItem in $matrixResults) {
+        $namesForBatch = ($batch | ForEach-Object { $_.ArtifactName }) -join "-"
+        # we just need to iterate across them, grab the parameters hashtable, and add the new key
+        # if there is more than one batch, we will need to add a suffix including the batch name to the job name
+        $matrixOutputItem["parameters"]["$PRMatrixSetting"] = $namesForBatch
+
+        if ($matrixSuffixNecessary) {
+          $matrixOutputItem["name"] = $matrixOutputItem["name"] + $matrixConfig.Name
+        }
+
+        if ($batchSuffixNecessary) {
+          $matrixOutputItem["name"] = $matrixOutputItem["name"] + $namesForBatch
+        }
+
+        $OverallResult += $matrixOutputItem
+      }
+    }
+  }
+}
+
+$serialized = SerializePipelineMatrix $OverallResult
+
+Write-Output $serialized.pretty
+
+if ($CI) {
+  Write-Output "##vso[task.setVariable variable=matrix;isOutput=true]$($serialized.compressed)"
+}


### PR DESCRIPTION
This PR addresses a lot of the boilerplate code that would be necessary to distribute packages to one or multiple matrix files.

We allow our users to customize their platform using `ci.yml -> MatrixConfigs` params, but we _don't_ honor those in the PR build (which is a single unified matrix).

This PR allows the PR build to automatically use the correct matrix. Here it is [in use.](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4283836&view=results)

Pardon the long runtime, I have further fixes from my other sdk-for-js branch that aren't there, which is why the builds are timing out. Nothing to do with this matrix logic 👍 