### PR TITLE
Fix Integration Issue w/ `Create-PRJobMatrix`

### DIFF
--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -64,7 +64,9 @@ $packageProperties = Get-ChildItem -Recurse "$PackagePropertiesFolder" *.json `
 
 # set default matrix config for each package if there isn't an override
 $packageProperties | ForEach-Object {
-  $_.CIMatrixConfigs = $_.CIMatrixConfigs ?? $configs
+  if (-not $_.CIMatrixConfigs) {
+    $_.CIMatrixConfigs = $configs
+  }
 }
 
 # The key here is that after we group the packages by the matrix config objects, we can use the first item's MatrixConfig

--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -764,4 +764,4 @@ function GenerateMatrixForConfig {
       -replace $Replace
 
     return , $matrix
-  }
+}

--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -740,3 +740,28 @@ function Get4dMatrixIndex([int]$index, [Array]$dimensions) {
     return @($page3, $page2, $page1, $remainder)
 }
 
+function GenerateMatrixForConfig {
+    param (
+      [Parameter(Mandatory = $true)][string] $ConfigPath,
+      [Parameter(Mandatory = $True)][string] $Selection,
+      [Parameter(Mandatory = $false)][string] $DisplayNameFilter,
+      [Parameter(Mandatory = $false)][array] $Filters,
+      [Parameter(Mandatory = $false)][array] $Replace
+    )
+    $matrixFile = Join-Path $PSScriptRoot ".." ".." ".." ".." $ConfigPath
+
+    $resolvedMatrixFile = Resolve-Path $matrixFile
+
+    $config = GetMatrixConfigFromFile (Get-Content $resolvedMatrixFile -Raw)
+    # Strip empty string filters in order to be able to use azure pipelines yaml join()
+    $Filters = $Filters | Where-Object { $_ }
+
+    [array]$matrix = GenerateMatrix `
+      -config $config `
+      -selectFromMatrixType $Selection `
+      -displayNameFilter $DisplayNameFilter `
+      -filters $Filters `
+      -replace $Replace
+
+    return , $matrix
+  }


### PR DESCRIPTION
Resolving: https://github.com/Azure/azure-sdk-tools/pull/9281/commits/2c03facb7fd54a5888cb4e7c20aee6b6c6bebf18#r1823660311

And due to the fact that because we were nulling out the matrix configs, we weren't iterating over it and calling GenerateMatrixForConfig.

If not using this PR, we get: https://dev.azure.com/azure-sdk/public/_build/results?buildId=4284719&view=logs&j=76992fd1-2312-5fae-7c45-7baba86b87ae&t=6c294a88-3151-521e-fcd8-a6c587ba9418

