### PR TITLE
Update batch title, set variable with appropriate separation

### DIFF
--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -93,6 +93,7 @@ foreach ($matrixBatchKey in $matrixBatchesByConfig.Keys) {
     # we only need to modify the generated job name if there is more than one matrix config or batch in the matrix
     $matrixSuffixNecessary = $matrixConfigs.Count -gt 1
     $batchSuffixNecessary = $packageBatches.Length -gt 1
+    $batchCounter = 1
 
     foreach ($batch in $packageBatches) {
       # to understand this iteration, one must understand that the matrix is a list of hashtables, each with a couple keys:
@@ -100,7 +101,7 @@ foreach ($matrixBatchKey in $matrixBatchesByConfig.Keys) {
       #  { "name": "jobname", "parameters": { matrixSetting1: matrixValue1, ...} },
       # ]
       foreach ($matrixOutputItem in $matrixResults) {
-        $namesForBatch = ($batch | ForEach-Object { $_.ArtifactName }) -join "-"
+        $namesForBatch = ($batch | ForEach-Object { $_.ArtifactName }) -join ","
         # we just need to iterate across them, grab the parameters hashtable, and add the new key
         # if there is more than one batch, we will need to add a suffix including the batch name to the job name
         $matrixOutputItem["parameters"]["$PRMatrixSetting"] = $namesForBatch
@@ -110,11 +111,12 @@ foreach ($matrixBatchKey in $matrixBatchesByConfig.Keys) {
         }
 
         if ($batchSuffixNecessary) {
-          $matrixOutputItem["name"] = $matrixOutputItem["name"] + $namesForBatch
+          $matrixOutputItem["name"] = $matrixOutputItem["name"] + "b$batchCounter"
         }
 
         $OverallResult += $matrixOutputItem
       }
+      $batchCounter += 1
     }
   }
 }


### PR DESCRIPTION
I was separating package names by `-`. How did I even introduce that bug.
