### PR TITLE
Add AdditionalTags processing

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/AzurePipelines/BuildCompleteQueueWorker.cs
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/AzurePipelines/BuildCompleteQueueWorker.cs
@@ -63,6 +63,8 @@ namespace Azure.Sdk.Tools.PipelineWitness.AzurePipelines
             }
 
             await this.runProcessor.UploadBuildBlobsAsync(queueMessage.Account, queueMessage.ProjectId, queueMessage.BuildId);
+
+            await this.runProcessor.AddAdditionalBuildTagsAsync(queueMessage.Account, queueMessage.ProjectId, queueMessage.BuildId);
         }
     }
 }


### PR DESCRIPTION
Because public builds don't have permission to edit their own tags but they can add build attachments, we use an attachment to hold "additional tags" and process them in Pipeline Witness