### PR TITLE
Remove a resolve-path from `Get-PrPkgProperties`

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -168,7 +168,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
         $lookup[$lookupKey] = $pkg
 
         foreach ($file in $targetedFiles) {
-            $filePath = Resolve-Path (Join-Path $RepoRoot $file)
+            $filePath = (Join-Path $RepoRoot $file)
             $shouldInclude = $filePath -like "$pkgDirectory*"
             if ($shouldInclude) {
                 $packagesWithChanges += $pkg


### PR DESCRIPTION
This PR will enable PR invocations of `generate-job-matrix` won't crash when the files don't actually exist on disk.

My only concern is the following scenario:

I have some FUD around a scenario where a `PkgProps` file is generated on `windows` and then we check `-like PkgProps.DirectoryPath` against a path checked out on a different OS.