### PR TITLE
Upload ChangedServices as an `attachment` for later processing by `Pipeline-Witness` 

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -36,6 +36,8 @@ steps:
       # However, the public identity does not have the permissions to attach tags to the build.
       # Instead, we will save the changed services to a file, attach it as an attachment named tags.json, and pipeline
       - pwsh: |
+          $changedServices = (Get-Content -Path '${{ parameters.DiffDirectory }}/diff.json' -Raw | ConvertFrom-Json).ChangedServices
+
           if ($changedServices) {
             Write-Host "Attaching changed service names to the build for additional tag generation."
             $changedServices | ConvertTo-Json | Out-File -FilePath $(System.DefaultWorkingDirectory)/tags.json -Encoding utf8

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -34,7 +34,7 @@ steps:
 
       # When running in PR node, we want the detected changed services to be attached to the build as tags.
       # However, the public identity does not have the permissions to attach tags to the build.
-      # Instead, we will save the changed services to a file, attach it as an attachment named tags.json, and pipeline
+      # Instead, we will save the changed services to a file, attach it as an attachment for PiplineWitness to pick up and utilize.
       - pwsh: |
           $changedServices = (Get-Content -Path '${{ parameters.DiffDirectory }}/diff.json' -Raw | ConvertFrom-Json).ChangedServices
 

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -45,10 +45,6 @@ steps:
           }
         displayName: Upload tags.json with changed services
 
-      - pwsh: |
-          Remove-Item -Force $(System.DefaultWorkingDirectory)/tags.json
-        displayName: Clean up tags.json
-
       - task: Powershell@2
         displayName: Save package properties filtered for PR
         inputs:

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -32,7 +32,7 @@ steps:
             -ArtifactPath '${{ parameters.DiffDirectory }}'
           pwsh: true
 
-      # When running in PR node, we want the detected changed services to be attached to the build as tags.
+      # When running in PR mode, we want the detected changed services to be attached to the build as tags.
       # However, the public identity does not have the permissions to attach tags to the build.
       # Instead, we will save the changed services to a file, attach it as an attachment for PiplineWitness to pick up and utilize.
       - pwsh: |

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -40,7 +40,7 @@ steps:
 
           if ($changedServices) {
             Write-Host "Attaching changed service names to the build for additional tag generation."
-            $changedServices | ConvertTo-Json | Out-File -FilePath $(System.DefaultWorkingDirectory)/tags.json -Encoding utf8
+            $changedServices | ConvertTo-Json -AsArray | Out-File -FilePath $(System.DefaultWorkingDirectory)/tags.json -Encoding utf8
             Write-Host '##vso[task.addattachment type=AdditionalTags;name=AdditionalTags;]$(System.DefaultWorkingDirectory)/tags.json'
           }
         displayName: Upload tags.json with changed services

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -32,6 +32,21 @@ steps:
             -ArtifactPath '${{ parameters.DiffDirectory }}'
           pwsh: true
 
+      # When running in PR node, we want the detected changed services to be attached to the build as tags.
+      # However, the public identity does not have the permissions to attach tags to the build.
+      # Instead, we will save the changed services to a file, attach it as an attachment named tags.json, and pipeline
+      - pwsh: |
+          if ($changedServices) {
+            Write-Host "Attaching changed service names to the build for additional tag generation."
+            $changedServices | ConvertTo-Json | Out-File -FilePath $(System.DefaultWorkingDirectory)/tags.json -Encoding utf8
+            Write-Host '##vso[task.addattachment type=AdditionalTags;name=AdditionalTags;]$(System.DefaultWorkingDirectory)/tags.json'
+          }
+        displayName: Upload tags.json with changed services
+
+      - pwsh: |
+          Remove-Item -Force $(System.DefaultWorkingDirectory)/tags.json
+        displayName: Clean up tags.json
+
       - task: Powershell@2
         displayName: Save package properties filtered for PR
         inputs:

--- a/eng/common/scripts/Generate-PR-Diff.ps1
+++ b/eng/common/scripts/Generate-PR-Diff.ps1
@@ -28,7 +28,7 @@ function Get-ChangedServices
     [string[]] $ChangedFiles
   )
 
-  $changedServices = $ChangedFiles | Foreach-Object { if ($_ -match "sdk/([^/]+)") { $matches[1] } } | Sort-Object -Unique
+  [string[]] $changedServices = $ChangedFiles | Foreach-Object { if ($_ -match "sdk/([^/]+)") { $matches[1] } } | Sort-Object -Unique
 
   return $changedServices
 }

--- a/eng/common/scripts/Generate-PR-Diff.ps1
+++ b/eng/common/scripts/Generate-PR-Diff.ps1
@@ -30,7 +30,7 @@ function Get-ChangedServices
 
   [string[]] $changedServices = $ChangedFiles | Foreach-Object { if ($_ -match "sdk/([^/]+)") { $matches[1] } } | Sort-Object -Unique
 
-  return $changedServices
+  return , $changedServices
 }
 
 if (!(Test-Path $ArtifactPath))


### PR DESCRIPTION
Enabling service tags on `<language - pullrequest` builds.

Thank you @hallipr for adding this feature!