### PR TITLE
Do not try to purge keyvaults with purge protection

### DIFF
--- a/eng/common/scripts/Helpers/Resource-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Resource-Helpers.ps1
@@ -123,8 +123,8 @@ filter Remove-PurgeableResources {
     switch ($r.AzsdkResourceType) {
       'Key Vault' {
         if ($r.EnablePurgeProtection) {
-          # We will try anyway but will ignore errors.
           Write-Warning "Key Vault '$($r.VaultName)' has purge protection enabled and may not be purged until $($r.ScheduledPurgeDate)"
+          continue
         }
 
         # Use `-AsJob` to start a lightweight, cancellable job and pass to `Wait-PurgeableResoruceJob` for consistent behavior.
@@ -134,8 +134,8 @@ filter Remove-PurgeableResources {
 
       'Managed HSM' {
         if ($r.EnablePurgeProtection) {
-          # We will try anyway but will ignore errors.
           Write-Warning "Managed HSM '$($r.Name)' has purge protection enabled and may not be purged until $($r.ScheduledPurgeDate)"
+          continue
         }
 
         # Use `GetNewClosure()` on the `-Action` ScriptBlock to make sure variables are captured.


### PR DESCRIPTION
There's no point in trying to purge these keyvaults with delete protection, it will always fail. The error message that comes after  (`InvalidOperation: Operation 'DeletedVaultPurge' is not allowed.`) marks our cleanup builds with a skipped fail which makes it more annoying to see if there are new issues at a glance:
![image](https://github.com/user-attachments/assets/95093610-425f-43e9-ac6e-9a3c0c5e0ed0)
