### PR TITLE
Disable `InitializeCIArtifacts` on Non-CI Builds

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -106,7 +106,7 @@ class PackageProps {
     }
 
     [void]InitializeCIArtifacts() {
-        if ($env:SYSTEM_TEAMPROJECTID  -or $env:GITHUB_ACTIONS) {
+        if (-not $env:SYSTEM_TEAMPROJECTID  -and -not $env:GITHUB_ACTIONS) {
             return
         }
 

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -106,22 +106,24 @@ class PackageProps {
     }
 
     [void]InitializeCIArtifacts() {
-        if ($env:TF_BUILD -or $env:GITHUB_ACTIONS) {
-            $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot ".." ".." "..")
+        if ($env:SYSTEM_TEAMPROJECTID  -or $env:GITHUB_ACTIONS) {
+            return
+        }
 
-            $ciFolderPath = Join-Path -Path $RepoRoot -ChildPath (Join-Path "sdk" $this.ServiceDirectory)
-            $ciFiles = Get-ChildItem -Path $ciFolderPath -Filter "ci*.yml" -File
+        $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot ".." ".." "..")
 
-            if (-not $this.ArtifactDetails) {
-                foreach ($ciFile in $ciFiles) {
-                    $ciArtifactResult = $this.ParseYmlForArtifact($ciFile.FullName)
-                    if ($ciArtifactResult) {
-                        $this.ArtifactDetails = [Hashtable]$ciArtifactResult.ArtifactConfig
-                        $this.CIMatrixConfigs = $ciArtifactResult.MatrixConfigs
-                        # if this package appeared in this ci file, then we should
-                        # treat this CI file as the source of the Matrix for this package
-                        break
-                    }
+        $ciFolderPath = Join-Path -Path $RepoRoot -ChildPath (Join-Path "sdk" $this.ServiceDirectory)
+        $ciFiles = Get-ChildItem -Path $ciFolderPath -Filter "ci*.yml" -File
+
+        if (-not $this.ArtifactDetails) {
+            foreach ($ciFile in $ciFiles) {
+                $ciArtifactResult = $this.ParseYmlForArtifact($ciFile.FullName)
+                if ($ciArtifactResult) {
+                    $this.ArtifactDetails = [Hashtable]$ciArtifactResult.ArtifactConfig
+                    $this.CIMatrixConfigs = $ciArtifactResult.MatrixConfigs
+                    # if this package appeared in this ci file, then we should
+                    # treat this CI file as the source of the Matrix for this package
+                    break
                 }
             }
         }

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -106,20 +106,22 @@ class PackageProps {
     }
 
     [void]InitializeCIArtifacts() {
-        $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot ".." ".." "..")
+        if ($env:TF_BUILD -or $env:GITHUB_ACTIONS) {
+            $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot ".." ".." "..")
 
-        $ciFolderPath = Join-Path -Path $RepoRoot -ChildPath (Join-Path "sdk" $this.ServiceDirectory)
-        $ciFiles = Get-ChildItem -Path $ciFolderPath -Filter "ci*.yml" -File
+            $ciFolderPath = Join-Path -Path $RepoRoot -ChildPath (Join-Path "sdk" $this.ServiceDirectory)
+            $ciFiles = Get-ChildItem -Path $ciFolderPath -Filter "ci*.yml" -File
 
-        if (-not $this.ArtifactDetails) {
-            foreach ($ciFile in $ciFiles) {
-                $ciArtifactResult = $this.ParseYmlForArtifact($ciFile.FullName)
-                if ($ciArtifactResult) {
-                    $this.ArtifactDetails = [Hashtable]$ciArtifactResult.ArtifactConfig
-                    $this.CIMatrixConfigs = $ciArtifactResult.MatrixConfigs
-                    # if this package appeared in this ci file, then we should
-                    # treat this CI file as the source of the Matrix for this package
-                    break
+            if (-not $this.ArtifactDetails) {
+                foreach ($ciFile in $ciFiles) {
+                    $ciArtifactResult = $this.ParseYmlForArtifact($ciFile.FullName)
+                    if ($ciArtifactResult) {
+                        $this.ArtifactDetails = [Hashtable]$ciArtifactResult.ArtifactConfig
+                        $this.CIMatrixConfigs = $ciArtifactResult.MatrixConfigs
+                        # if this package appeared in this ci file, then we should
+                        # treat this CI file as the source of the Matrix for this package
+                        break
+                    }
                 }
             }
         }


### PR DESCRIPTION
Until we fix up the loop for usage of `yq` vs `ConvertFrom-Yaml` within `Package-Properties.ps1`.