### PR TITLE
Disable adaptive sampling to AppInsights

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.json
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.json
@@ -14,6 +14,9 @@
       }
     }
   },
+  "ApplicationInsights": {
+    "EnableAdaptiveSampling": false
+  },
   "AllowedHosts": "*",
   "PipelineWitness": {
     "QueueStorageAccountUri": "https://pipelinewitnessprod.queue.core.windows.net",


### PR DESCRIPTION
Adaptive Sampling was causing PipelineWitness to drop a large portion of its happy-path telemetry before sending it to AppInsights.  This made it difficult to search for trace messages related to specific build processing as there was a good chance that the trace logs from processing the build were sampled away.

By disabling adaptive sampling, we're telling the app to send all emitted telemetry to the AppInsights collector for processing.