### PR TITLE
Use local version of format diagnostic for tsp-client

### DIFF
--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -1,9 +1,4 @@
-import {
-  resolvePath,
-  getDirectoryPath,
-  ResolveCompilerOptionsOptions,
-  formatDiagnostic,
-} from "@typespec/compiler";
+import { resolvePath, getDirectoryPath, ResolveCompilerOptionsOptions } from "@typespec/compiler";
 import {
   ModuleResolutionResult,
   resolveModule,
@@ -75,7 +70,8 @@ export async function compileTsp({
   saveInputs?: boolean;
 }): Promise<boolean> {
   const parsedEntrypoint = getDirectoryPath(resolvedMainFilePath);
-  const { compile, NodeHost, resolveCompilerOptions } = await importTsp(parsedEntrypoint);
+  const { compile, NodeHost, resolveCompilerOptions, formatDiagnostic } =
+    await importTsp(parsedEntrypoint);
 
   const outputDir = resolvePath(outputPath);
   const overrideOptions: Record<string, Record<string, string>> = {


### PR DESCRIPTION
fix https://github.com/microsoft/typespec/issues/5007

This cause an issue where we load the version of formatDiagnostic which expect typespec types to have new properties not availaible in the currently loaded version