### PR TITLE
Reduce ingestion costs by disabling auto dependency call tracing

### DIFF
--- a/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.json
+++ b/tools/pipeline-witness/Azure.Sdk.Tools.PipelineWitness/appsettings.json
@@ -15,7 +15,8 @@
     }
   },
   "ApplicationInsights": {
-    "EnableAdaptiveSampling": false
+    "EnableAdaptiveSampling": false,
+    "EnableDependencyTrackingTelemetryModule": false
   },
   "AllowedHosts": "*",
   "PipelineWitness": {


### PR DESCRIPTION
Removing adaptive sampling caused a 10x increase in our telemetry ingestion rate and cost.   The largest category of telemetry is our automatic dependency tracing (azure blob / queue, etc).  This change will stop the automatic collection of dependency telemetry.