### PR TITLE
fix(.net analyzer): only check `Options` suffix for mgmt sdk

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0030OptionsTest.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0030OptionsTest.cs
@@ -12,54 +12,75 @@ namespace Azure.ClientSdk.Analyzers.Tests.ModelName
     {
         private const string diagnosticId = "AZC0030";
 
-        [Fact]
-        public async Task WithoutAnySerialization()
+        [Theory]
+        [InlineData("Azure.DataPlane.Models")]
+        [InlineData("Azure.ResourceManager.Models")]
+        public async Task WithoutAnySerialization(string ns)
         {
-            var test = @"using System.Text.Json;
-namespace Azure.ResourceManager.Models;
+            var test = $@"using System.Text.Json;
+namespace {ns};
 
 public class DiskOptions
-{
-}";
+{{
+}}";
             await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
-        [Fact]
-        public async Task WithDeserializationMethod()
+
+        [Theory]
+        [InlineData("Azure.DataPlane.Models", false)]
+        [InlineData("Azure.ResourceManager.Network.Models", true)]
+        public async Task WithDeserializationMethod(string ns, bool hasError)
         {
-            var test = @"using System.Text.Json;
-namespace Azure.ResourceManager
-{
+            var test = $@"using System.Text.Json;
+namespace {ns}
+{{
     public class ResponseOptions
-    {
+    {{
         public static ResponseOptions DeserializeResponseOptions(JsonElement element)
-        {
+        {{
             return null;
-        }
-    }
-}";
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(4, 18, 4, 33).WithArguments("ResponseOptions", "Options", "'ResponseConfig'");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }}
+    }}
+}}";
+            if (hasError)
+            {
+                var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(4, 18, 4, 33).WithArguments("ResponseOptions", "Options", "'ResponseConfig'");
+                await VerifyCS.VerifyAnalyzerAsync(test, expected);
+            }
+            else
+            {
+                await VerifyCS.VerifyAnalyzerAsync(test);
+            }
         }
 
-        [Fact]
-        public async Task WithSerializationMethod()
+        [Theory]
+        [InlineData("Azure.DataPlane.Models", false)]
+        [InlineData("Azure.ResourceManager.Batch.Models", true)]
+        public async Task WithSerializationMethod(string ns, bool hasError)
         {
-            var test = @"using System.Text.Json;
-namespace Azure.ResourceManager.Models
-{
+            var test = $@"using System.Text.Json;
+namespace {ns}
+{{
     internal interface IUtf8JsonSerializable
-    {
+    {{
         void Write(Utf8JsonWriter writer);
-    };
+    }};
 
     public class DiskOptions: IUtf8JsonSerializable
-    {
-        void IUtf8JsonSerializable.Write(Utf8JsonWriter writer) {}
-    }
-}";
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(9, 18, 9, 29).WithArguments("DiskOptions", "Options", "'DiskConfig'");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+    {{
+        void IUtf8JsonSerializable.Write(Utf8JsonWriter writer) {{}}
+    }}
+}}";
+            if (hasError)
+            {
+                var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(9, 18, 9, 29).WithArguments("DiskOptions", "Options", "'DiskConfig'");
+                await VerifyCS.VerifyAnalyzerAsync(test, expected);
+            }
+            else
+            {
+                await VerifyCS.VerifyAnalyzerAsync(test);
+            }
         }
     }
 }


### PR DESCRIPTION
- update analyzer to only check `Options` suffix if the class is under a mgmt SDK namespace
- update test cases accordingly

fix #9335
