### PR TITLE
Add SparseCheckoutPaths to archetype-typespec-emitter.yml

### DIFF
--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -62,6 +62,11 @@ parameters:
   type: boolean
   default: false
 
+# Paths to sparse checkout
+- name: SparseCheckoutPaths
+  type: object
+  default: []
+
 extends:
   template: /eng/pipelines/templates/stages/1es-redirect.yml
   parameters:
@@ -79,6 +84,8 @@ extends:
       - job: Build
         steps:
         - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
+          parameters:
+            Paths: ${{ parameters.SparseCheckoutPaths }}
 
         - ${{ parameters.InitializationSteps }}
 
@@ -411,7 +418,9 @@ extends:
             buildArtifactsPath: $(Pipeline.Workspace)/build_artifacts
           steps:
           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
-            
+            parameters:
+              Paths: ${{ parameters.SparseCheckoutPaths }}
+
           - download: current
             artifact: build_artifacts
             displayName: Download build artifacts


### PR DESCRIPTION
For http-client-csharp typespec emitter, we have needs to sparse-checkout extra paths while applying archetype-typespec-emitter.yml.
The detailed usage can be found in https://github.com/Azure/azure-sdk-for-net/pull/47136
