### PR TITLE
Fix the bug when package level review line had documentation

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/APIViewUnitTests.csproj
+++ b/src/dotnet/APIView/APIViewUnitTests/APIViewUnitTests.csproj
@@ -39,6 +39,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Update="SampleTestFiles\azure-core-1.47.0-sources4.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="SampleTestFiles\azure.data.tables.12.9.0_doc_change.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/src/dotnet/APIView/APIViewUnitTests/CodeFileHelpersTest.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CodeFileHelpersTest.cs
@@ -322,5 +322,25 @@ namespace APIViewUnitTests
             var navTreeNodeCount = result.NodeMetaData.Values.Count(n => n.NavigationTreeNode != null);
             Assert.Equal(42, navTreeNodeCount);
         }
+
+
+        [Fact]
+        public async void VerifyJavaPackageReviewLineCount()
+        {
+            var testCodeFilePath = Path.Combine("SampleTestFiles", "azure-core-1.47.0-sources4.json");
+            FileInfo fileInfo = new FileInfo(testCodeFilePath);
+            var codeFile = await CodeFile.DeserializeAsync(fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.Read));
+            //Assert.Equal(20, codeFile.ReviewLines.Count());
+
+            CodePanelRawData codePanelRawData = new CodePanelRawData()
+            {
+                activeRevisionCodeFile = codeFile
+            };
+            var result = await CodeFileHelpers.GenerateCodePanelDataAsync(codePanelRawData);
+            Assert.NotNull(result);
+            Assert.False(result.HasDiff);
+            Assert.Equal(2159, result.NodeMetaData.Count);
+        }
+
     }
 }

--- a/src/dotnet/APIView/APIViewUnitTests/CodeFileHelpersTest.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CodeFileHelpersTest.cs
@@ -330,7 +330,6 @@ namespace APIViewUnitTests
             var testCodeFilePath = Path.Combine("SampleTestFiles", "azure-core-1.47.0-sources4.json");
             FileInfo fileInfo = new FileInfo(testCodeFilePath);
             var codeFile = await CodeFile.DeserializeAsync(fileInfo.Open(FileMode.Open, FileAccess.Read, FileShare.Read));
-            //Assert.Equal(20, codeFile.ReviewLines.Count());
 
             CodePanelRawData codePanelRawData = new CodePanelRawData()
             {

--- a/src/dotnet/APIView/APIViewUnitTests/CodeFileHelpersTest.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/CodeFileHelpersTest.cs
@@ -325,7 +325,7 @@ namespace APIViewUnitTests
 
 
         [Fact]
-        public async void VerifyJavaPackageReviewLineCount()
+        public async void VerifyPackageReviewLineCount()
         {
             var testCodeFilePath = Path.Combine("SampleTestFiles", "azure-core-1.47.0-sources4.json");
             FileInfo fileInfo = new FileInfo(testCodeFilePath);

--- a/src/dotnet/APIView/APIViewWeb/Helpers/CodeFileHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/CodeFileHelpers.cs
@@ -57,7 +57,7 @@ namespace APIViewWeb.Helpers
             foreach (var reviewLine in reviewLines)
             {
                 if (reviewLine.IsDocumentation) continue;
-                nodeHashId = await BuildAPITree(codePanelData: codePanelData, codePanelRawData: codePanelRawData, reviewLine: reviewLines[idx],
+                nodeHashId = await BuildAPITree(codePanelData: codePanelData, codePanelRawData: codePanelRawData, reviewLine: reviewLine,
                     parentNodeIdHashed: rootNodeId, nodePositionAtLevel: idx, prevNodeHashId: nodeHashId, relatedLineMap: relatedLineMap);
                 idx++;
             }


### PR DESCRIPTION
Fix the bug when processing review lines at top level and if top level contains documentation.