### PR TITLE
Utilize `ArtifactDetails` to avoid parsing issues in Verify-Changelogs.ps1

### DIFF
--- a/eng/common/scripts/Verify-ChangeLogs.ps1
+++ b/eng/common/scripts/Verify-ChangeLogs.ps1
@@ -7,15 +7,11 @@ Set-StrictMode -Version 3
 
 . (Join-Path $PSScriptRoot common.ps1)
 
+
 function ShouldVerifyChangeLog ($PkgArtifactDetails) {
   if ($PkgArtifactDetails) {
-    Write-Host $PkgArtifactDetails.Name
-    $possibleValue = $PkgArtifactDetails.PSObject.Properties["skipVerifyChangeLog"]
-
-    if ($possibleValue) {
-      if ($possibleValue -eq $true) {
-        return $false
-      }
+    if ($PkgArtifactDetails.PSObject.Properties["skipVerifyChangeLog"] -eq $true) {
+      return $false
     }
 
     return $true

--- a/eng/common/scripts/Verify-ChangeLogs.ps1
+++ b/eng/common/scripts/Verify-ChangeLogs.ps1
@@ -7,25 +7,6 @@ Set-StrictMode -Version 3
 
 . (Join-Path $PSScriptRoot common.ps1)
 
-function ShouldVerifyChangeLog ($PkgArtifactDetails, $PackageName) {
-    if (Test-Path $jsonCiYmlPath)
-    {
-        $ciYml = Get-Content $jsonCiYmlPath -Raw | CompatibleConvertFrom-Yaml
-
-        if ($ciYml.extends -and $ciYml.extends.parameters -and $ciYml.extends.parameters.Artifacts) {
-            $packagesCheckingChangeLog = $ciYml.extends.parameters.Artifacts `
-                | Where-Object { -not ($_["skipVerifyChangelog"] -eq $true) } `
-                | Select-Object -ExpandProperty name
-            if ($packagesCheckingChangeLog -contains $PackageName)
-            {
-                return $true
-            } else {
-                return $false
-            }
-        }
-    }
-}
-
 function ShouldVerifyChangeLog ($PkgArtifactDetails) {
   if ($PkgArtifactDetails) {
     Write-Host $PkgArtifactDetails.Name
@@ -42,7 +23,6 @@ function ShouldVerifyChangeLog ($PkgArtifactDetails) {
 
   return $false
 }
-
 
 # find which packages we need to confirm the changelog for
 $packageProperties = Get-ChildItem -Recurse "$PackagePropertiesFolder" *.json


### PR DESCRIPTION
[Exhibit A](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4331354&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=ac8f4042-9b76-5db4-27b1-2a4abaa9bb3c)

FYI @benbp 