### PR TITLE
AZC0004 ensure that method signatures match

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0004Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0004Tests.cs
@@ -396,5 +396,60 @@ namespace RandomNamespace
             await Verifier.CreateAnalyzer(code)
                 .RunAsync();
         }
+
+        [Fact]
+        public async Task AZC0004ProducedForMethodsWithMismatchedReturnTypes()
+        {
+            const string code = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public virtual Task<string> {|AZC0004:GetAsync|}(CancellationToken cancellationToken = default)
+        {
+            return null;
+        }
+
+        public virtual int Get(CancellationToken cancellationToken = default)
+        {
+            return 0;
+        }
+    }
+}";
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
+        }
+
+        [Fact]
+        public async Task AZC0004ProducedForMethotsWithMismatchedParameters()
+        {
+            const string code = @"
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace RandomNamespace
+{
+    public class SomeClient
+    {
+        public virtual Task<string> {|AZC0004:GetAsync|}(CancellationToken cancellationToken = default)
+        {
+            return null;
+        }
+
+        public virtual string Get(string foo, CancellationToken cancellationToken = default)
+        {
+            return null;
+        }
+    }
+}";
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0015")
+                .RunAsync();
+        }
+
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -312,10 +312,7 @@ namespace Azure.ClientSdk.Analyzers
 
                     var syncMemberName = member.Name.Substring(0, member.Name.Length - AsyncSuffix.Length);
 
-                    var syncMember = FindMethod(
-                        type.GetMembers(syncMemberName).OfType<IMethodSymbol>(),
-                        methodSymbol.TypeParameters,
-                        methodSymbol.Parameters);
+                    var syncMember = FindMethod(type.GetMembers(syncMemberName).OfType<IMethodSymbol>(), methodSymbol.TypeParameters, methodSymbol.Parameters);
 
                     if (syncMember == null)
                     {
@@ -328,10 +325,6 @@ namespace Azure.ClientSdk.Analyzers
                             context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0004, member.Locations.First()), member);
                         }
 
-                        if (!methodSymbol.Parameters.SequenceEqual(syncMember.Parameters, ParameterEquivalenceComparer.Default))
-                        {
-                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0005, member.Locations.First()), member);
-                        }
                         CheckClientMethod(context, syncMember);
                     }
                 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -311,7 +311,22 @@ namespace Azure.ClientSdk.Analyzers
                 else
                 {
                     var asyncInnerType = asyncNamedType.TypeArguments.FirstOrDefault();
+
+                    string asyncInnerTypeName = asyncNamedType.Name;
+
                     return SymbolEqualityComparer.Default.Equals(asyncInnerType, syncReturnType);
+
+                }
+            }
+
+            // Add scenario to handle AsyncPageable<T> and Pageable<T> return types
+            if (asyncReturnType is INamedTypeSymbol asyncNamedTypeSymbol && asyncNamedTypeSymbol.IsGenericType && asyncNamedTypeSymbol.Name == AsyncPageableTypeName)
+            {
+                if (syncReturnType is INamedTypeSymbol syncNamedTypeSymbol && syncNamedTypeSymbol.IsGenericType && syncNamedTypeSymbol.Name == PageableTypeName)
+                {
+                    var asyncInnerType = asyncNamedTypeSymbol.TypeArguments.Single();
+                    var syncInnerType = syncNamedTypeSymbol.TypeArguments.Single();
+                    return SymbolEqualityComparer.Default.Equals(asyncInnerType, syncInnerType);
                 }
             }
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -341,7 +341,7 @@ namespace Azure.ClientSdk.Analyzers
                     }
                     return true;
                 }
-                else if (!asyncNamedTypeSymbol.IsGenericType && !syncNamedTypeSymbol.IsGenericType)
+                else if ((!asyncNamedTypeSymbol.IsGenericType) && (!syncNamedTypeSymbol.IsGenericType))
                 {
                     return true;
                 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -312,7 +312,10 @@ namespace Azure.ClientSdk.Analyzers
 
                     var syncMemberName = member.Name.Substring(0, member.Name.Length - AsyncSuffix.Length);
 
-                    var syncMember = FindMethod(type.GetMembers(syncMemberName).OfType<IMethodSymbol>(), methodSymbol.TypeParameters, methodSymbol.Parameters);
+                    var syncMember = FindMethod(
+                        type.GetMembers(syncMemberName).OfType<IMethodSymbol>(),
+                        methodSymbol.TypeParameters,
+                        methodSymbol.Parameters);
 
                     if (syncMember == null)
                     {
@@ -325,6 +328,10 @@ namespace Azure.ClientSdk.Analyzers
                             context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0004, member.Locations.First()), member);
                         }
 
+                        if (!methodSymbol.Parameters.SequenceEqual(syncMember.Parameters, ParameterEquivalenceComparer.Default))
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0005, member.Locations.First()), member);
+                        }
                         CheckClientMethod(context, syncMember);
                     }
                 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -295,31 +295,9 @@ namespace Azure.ClientSdk.Analyzers
             return false;
         }
 
-        private bool IsAmqpBasedLibrary(INamedTypeSymbol type)
-        {
-            var namespaceName = type.ContainingNamespace.ToDisplayString();
-
-            // List of AMQP-based libraries that are exempted from this rule.
-            if (namespaceName.StartsWith("Azure.Messaging.EventHubs") ||
-                namespaceName.StartsWith("Azure.Messaging.ServiceBus") ||
-                namespaceName.StartsWith("Azure.Messaging.WebPubSub"))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
         public override void AnalyzeCore(ISymbolAnalysisContext context)
         {
             INamedTypeSymbol type = (INamedTypeSymbol)context.Symbol;
-
-            // Skip the verification for AMQP-based SDKs
-            if (IsAmqpBasedLibrary(type))
-            {
-                return;
-            }
-
             foreach (var member in type.GetMembers())
             {
                 var methodSymbol = member as IMethodSymbol;

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -325,6 +325,11 @@ namespace Azure.ClientSdk.Analyzers
                             context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0004, member.Locations.First()), member);
                         }
 
+                        if (!methodSymbol.Parameters.SequenceEqual(syncMember.Parameters, ParameterEquivalenceComparer.Default))
+                        {
+                            context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0005, member.Locations.First()), member);
+                        }
+
                         CheckClientMethod(context, syncMember);
                     }
                 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ClientMethodsAnalyzer.cs
@@ -295,9 +295,31 @@ namespace Azure.ClientSdk.Analyzers
             return false;
         }
 
+        private bool IsAmqpBasedLibrary(INamedTypeSymbol type)
+        {
+            var namespaceName = type.ContainingNamespace.ToDisplayString();
+
+            // List of AMQP-based libraries that are exempted from this rule.
+            if (namespaceName.StartsWith("Azure.Messaging.EventHubs") ||
+                namespaceName.StartsWith("Azure.Messaging.ServiceBus") ||
+                namespaceName.StartsWith("Azure.Messaging.WebPubSub"))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
         public override void AnalyzeCore(ISymbolAnalysisContext context)
         {
             INamedTypeSymbol type = (INamedTypeSymbol)context.Symbol;
+
+            // Skip the verification for AMQP-based SDKs
+            if (IsAmqpBasedLibrary(type))
+            {
+                return;
+            }
+
             foreach (var member in type.GetMembers())
             {
                 var methodSymbol = member as IMethodSymbol;


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-tools/issues/6845

Currently, the analyzer does not ensure that both equivalent sync and async methods have the same return type and parameters. This PR adds a check for the return type and parameters of both methods to ensure that they match.