### PR TITLE
Support override of powershell module feeds

### DIFF
--- a/eng/common/scripts/Helpers/PSModule-Helpers.ps1
+++ b/eng/common/scripts/Helpers/PSModule-Helpers.ps1
@@ -102,6 +102,10 @@ function installModule([string]$moduleName, [string]$version, $repoUrl) {
     throw "Failed to install module $moduleName with version $version"
   }
 
+  # Unregister repository as it can cause overlap issues with `dotnet tool install`
+  # commands using the same devops feed
+  Unregister-PSRepository -Name $repoUrl
+
   return $modules[0]
 }
 

--- a/eng/common/scripts/Helpers/PSModule-Helpers.ps1
+++ b/eng/common/scripts/Helpers/PSModule-Helpers.ps1
@@ -59,8 +59,8 @@ function Install-ModuleIfNotInstalled()
   )
 
   # List of modules+versions we want to replace with internal feed sources for reliability, security, etc.
-  $mirrorFeedOverrides = @{
-    'powershell-yaml;0.4.7' = 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-tools/nuget/v2'
+  $packageFeedOverrides = @{
+    'powershell-yaml' = 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-tools/nuget/v2'
   }
 
   try {
@@ -81,8 +81,8 @@ function Install-ModuleIfNotInstalled()
 
     $repositoryUrl = if ($repositoryUrl) {
       $repositoryUrl
-    } elseif ($mirrorFeedOverrides.Contains("${moduleName};${version}")) {
-      $mirrorFeedOverrides["${moduleName};${version}"]
+    } elseif ($mirrorFeedOverrides.Contains("${moduleName}")) {
+      $mirrorFeedOverrides["${moduleName}"]
     } else {
       $DefaultPSRepositoryUrl
     }


### PR DESCRIPTION
Adding an override list of ps modules we want to redirect to our devops mirror feed.

Also simplified the module existence check (still thread safe), but I'm thinking that maybe the double existence check was there so we wouldn't have a giant lock request backlog if a ton of threads all do a module check at the same time (given it takes 1 sec to do the check if it's behind the lock). @mikeharder any recollection on this? From https://github.com/Azure/azure-sdk-tools/pull/6521