### PR TITLE
Batching adjustments for Create-PRJobMatrix

### DIFF
--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -490,7 +490,7 @@ function CloneOrderedDictionary([System.Collections.Specialized.OrderedDictionar
 function SerializePipelineMatrix([Array]$matrix) {
     $pipelineMatrix = [Ordered]@{}
     foreach ($entry in $matrix) {
-        if ($pipelineMatrix.Contains($entry.Name)) {
+        if ($pipelineMatrix.Contains($entry.name)) {
             Write-Warning "Found duplicate configurations for job `"$($entry.name)`". Multiple values may have been replaced with the same value."
             continue
         }


### PR DESCRIPTION
I noticed something _odd_ about how my PR to use the common create-prmatrix instead of custom `distribute-packages-to-matrix` over in Azure/azure-sdk-for-python#38324 

It looked like only the second batch ran?

This PR resolves the oddness.

Details as to what this fixes:
- batches are stomping on each other.
