### PR TITLE
Fix issues in diff when end of context line has diff

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Helpers/CodeFileHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/CodeFileHelpers.cs
@@ -7,7 +7,6 @@ using APIViewWeb.Extensions;
 using APIViewWeb.LeanModels;
 using System;
 using System.Collections.Generic;
-using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
 
@@ -117,13 +116,25 @@ namespace APIViewWeb.Helpers
             {
                 //Set current line as bottom token if it is end of context line.
                 codePanelData.NodeMetaDataObj[prevNodeHashId].BottomTokenNodeIdHash = nodeIdHashed;
+                codePanelData.NodeMetaDataObj[nodeIdHashed].RelatedNodeIdHash = prevNodeHashId;
+                if (reviewLine.DiffKind != DiffKind.NoneDiff)
+                {
+                    codePanelData.NodeMetaDataObj[prevNodeHashId].IsNodeWithDiffInDescendants = true;
+                    codePanelData.NodeMetaDataObj[prevNodeHashId].IsNodeWithNoneDocDiffInDescendants = true;
+                }
                 //Copy added removed classes from parent node to bottom node.
                 var classes = codePanelData.NodeMetaDataObj[prevNodeHashId].CodeLinesObj.LastOrDefault()?.RowClassesObj;
-                if (classes != null)
+                if (classes != null && reviewLine.DiffKind == DiffKind.NoneDiff)
                 {
                     classes = classes.Where(c => c == "added" || c == "removed").ToHashSet();
                     codePanelData.NodeMetaDataObj[nodeIdHashed].CodeLinesObj.LastOrDefault()?.RowClassesObj.UnionWith(classes);
                 }
+            }
+
+            //Set previous node as related if current line is empty and if parser didn't set a related line ID for empty line.
+            if (reviewLine.Tokens.Count == 0 && string.IsNullOrEmpty(reviewLine.RelatedToLine))
+            {
+                codePanelData.NodeMetaDataObj[nodeIdHashed].RelatedNodeIdHash = prevNodeHashId;
             }
 
             return nodeIdHashed;

--- a/src/dotnet/APIView/APIViewWeb/LeanModels/CodePanelModels.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanModels/CodePanelModels.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json.Serialization;
 using ApiView;
 using System.Text;
+using APIView.Model.V2;
 
 namespace APIViewWeb.LeanModels
 {
@@ -129,7 +130,12 @@ namespace APIViewWeb.LeanModels
             var relatedNodeHashId = GetNodeIdHashFromLineId(relatedLine);
             if (!string.IsNullOrEmpty(relatedNodeHashId) && NodeMetaDataObj.ContainsKey(nodeIdHashed))
             {
-                NodeMetaDataObj[nodeIdHashed].RelatedNodeIdHash = relatedNodeHashId;
+                var node = NodeMetaDataObj[nodeIdHashed];
+                node.RelatedNodeIdHash = relatedNodeHashId;
+                if (node.IsNodeWithDiff)
+                {
+                    NodeMetaDataObj[relatedNodeHashId].IsNodeWithDiffInDescendants = true;
+                }
             }
         }
 


### PR DESCRIPTION
Diff is showing added line as removed when diff is in end of context line. Empty lines from untouched classes are not removed from node and tree view if parser doesn't set empty lines as related to the node line.