### PR TITLE
`Create-ApiReview` honors PackageProperty files

### DIFF
--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -320,7 +320,7 @@ else
     $artifactPackages = $ArtifactList | ForEach-Object { $_["name"] }
 
     foreach($propFile in $propFiles) {
-        $artifact = Get-Content $propFile.FullName | ConvertFrom-Json
+        $artifact = Get-Content $propFile.FullName -Raw | ConvertFrom-Json -AsHashtable
         if ($artifactPackages -contains $propFile.Name.Replace(".json", ""))
         {
             Write-Host "Processing $($artifact.ArtifactName)"

--- a/eng/common/scripts/Create-APIReview.ps1
+++ b/eng/common/scripts/Create-APIReview.ps1
@@ -320,11 +320,12 @@ else
     $artifactPackages = $ArtifactList | ForEach-Object { $_["name"] }
 
     foreach($propFile in $propFiles) {
+        $artifact = Get-Content $propFile.FullName | ConvertFrom-Json
         if ($artifactPackages -contains $propFile.Name.Replace(".json", ""))
         {
-            Write-Host "Processing $($artifact.name)"
-            $result = ProcessPackage -packageName $artifact.name
-            $responses[$artifact.name] = $result
+            Write-Host "Processing $($artifact.ArtifactName)"
+            $result = ProcessPackage -packageName $artifact.ArtifactName
+            $responses[$artifact.ArtifactName] = $result
         }
     }
 }


### PR DESCRIPTION
See title.

@praveenkuttappan Detect-Api-Changes [explicitly walks the prop files](https://github.com/Azure/azure-sdk-tools/blob/715cecc17bd9175dd5c6e90d4cb9e3cc324587ec/eng/common/scripts/Detect-Api-Changes.ps1#L109) to begin with. So we're already covered there.

Pardon the other spacing updates. My `powershell` vscode extension is aggressive 👍 