### PR TITLE
Avoid destructive language-repo origin updates

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -392,13 +392,30 @@ namespace Azure.Sdk.Tools.TestProxy.Store
         private void SetOrigin(GitAssetsConfiguration config)
         {
             var cloneUrl = GetCloneUrl(config.AssetsRepo, config.RepoRoot);
-            GitHandler.Run($"remote set-url origin {cloneUrl}", config);
+
+            // in cases of failure to initialize a real git repo. we need to NOT run git remote set-url
+            if (config.IsAssetsRepoInitialized())
+            {
+                GitHandler.Run($"remote set-url origin {cloneUrl}", config);
+            }
+            else
+            {
+                _consoleWrapper.WriteLine($"The assets folder within \"{config.AssetsRepoLocation.ToString()}\" was not properly initialized, and as such the proxy is skipping override of the origin url.");
+            }
         }
 
         private void HideOrigin(GitAssetsConfiguration config)
         {
             var publicOrigin = GetCloneUrl(config.AssetsRepo, config.RepoRoot, honorToken: false);
-            GitHandler.Run($"remote set-url origin {publicOrigin}", config);
+            
+            if (config.IsAssetsRepoInitialized())
+            {
+                GitHandler.Run($"remote set-url origin {publicOrigin}", config);
+            }
+            else
+            {
+                _consoleWrapper.WriteLine($"The assets folder within \"{config.AssetsRepoLocation.ToString()}\" was not properly initialized, and as such the proxy is skipping override of the origin url.");
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
I'm chasing a hidden `GitProcessException` in #9208 . I have a hunch that that combined with a failure to properly get the target repo is causing `git` to get into an irreconcilable state. When that happens, and `git remote set` runs, it escapes the `<languagerepo>/.assets/sliceId/` folder because there _isn't_  a real git repo initialized there.

when that occurs, and we still invoke `git remote set-url`, that'll override the language repo origin. @alzimmermsft this should at least reduce the impact when something goes wrong. I'm still chasing the real origin of it all though.