### PR TITLE
Revert "Use Tag for Token File OutPut"

### DIFF
--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/Program.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/Program.cs
@@ -19,9 +19,6 @@ namespace SwaggerApiParser
             var output = new Option<string>(name: "--output", description: "The output file path.",
                 getDefaultValue: () => "swagger.json");
 
-            var useTagForOutput = new Option<bool>(name: "--use-tag-for-output", description: "If set to true the output file will be named with the readmeTag used for the run",
-                getDefaultValue: () => false);
-
             var readmeFile = new Option<string>(name: "--readme", "The input readme file.");
 
             var readmeTag = new Option<string>(name: "--tag", description: "Readme tag used to generate swagger apiView",
@@ -40,7 +37,6 @@ namespace SwaggerApiParser
             {
                 swaggers,
                 output,
-                useTagForOutput,
                 packageName,
                 swaggerLinks,
                 readmeFile,
@@ -50,7 +46,7 @@ namespace SwaggerApiParser
 
             cmd.Description = "Parse swagger file into codefile.";
 
-            cmd.SetHandler(async (IEnumerable<string> swaggerFiles, string outputFile, bool useTagForOutputFileName, string package, IEnumerable<string> links, string readme, string tag) =>
+            cmd.SetHandler(async (IEnumerable<string> swaggerFiles, string outputFile, string package, IEnumerable<string> links, string readme, string tag) =>
             {
                 var swaggerLinksArray = links.ToList();
 
@@ -60,20 +56,20 @@ namespace SwaggerApiParser
                 {
                     readme = Path.GetFullPath(readme);
                 }
-                await HandleGenerateCodeFile(enumerable, outputFile, useTagForOutputFileName, package, swaggerLinksArray, readme, tag);
-            }, swaggers, output, useTagForOutput, packageName, swaggerLinks, readmeFile, readmeTag);
+                await HandleGenerateCodeFile(enumerable, outputFile, package, swaggerLinksArray, readme, tag);
+            }, swaggers, output, packageName, swaggerLinks, readmeFile, readmeTag);
 
             return Task.FromResult(cmd.Invoke(args));
         }
 
-        static async Task HandleGenerateCodeFile(IEnumerable<string> swaggers, string output, bool useTagForOutput, string packageName, List<string> swaggerLinks, string readmeFile, string readmeTag)
+        static async Task HandleGenerateCodeFile(IEnumerable<string> swaggers, string output, string packageName, List<string> swaggerLinks, string readmeFile, string readmeTag)
         {
           
             var swaggerFilePaths =  swaggers.ToList();
             if (readmeFile != null)
             {
                 var readmeFileDir = Path.GetDirectoryName(readmeFile);
-                var swaggerFiles = ReadmeParser.GetSwaggerFilesFromReadme(readmeFile, ref readmeTag);
+                var swaggerFiles = ReadmeParser.GetSwaggerFilesFromReadme(readmeFile, readmeTag);
                 swaggerFilePaths = swaggerFilePaths.Concat(swaggerFiles.Select(it => Path.Join(readmeFileDir, it))).ToList();
             }
             
@@ -118,13 +114,6 @@ namespace SwaggerApiParser
 
             var codeFile = root.GenerateCodeFile();
             var outputFilePath = Path.GetFullPath(output);
-
-            if (useTagForOutput)
-            {
-                output = $"{readmeTag}.json";
-                outputFilePath = Path.Combine(Path.GetDirectoryName(outputFilePath), output);
-            }
-
             await using FileStream writer = File.Open(outputFilePath, FileMode.Create);
             Console.WriteLine($"Generate codefile {output} successfully.");
             await codeFile.SerializeAsync(writer);

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/ReadmeParser.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParser/ReadmeParser.cs
@@ -43,17 +43,17 @@ namespace SwaggerApiParser
             return matchResult.Success ? matchResult.Groups[1].Value : "";
         }
 
-        public static IEnumerable<string> GetSwaggerFilesFromReadme(string readme, ref string tag)
+        public static IEnumerable<string> GetSwaggerFilesFromReadme(string readme, string tag)
         {
             ReadmeParser parser = new ReadmeParser(readme);
             parser.ParseReadmeConfig();
-
+            string readmeTag = tag;
             if (tag == "default" && parser.basicConfig != null)
             {
-                tag = parser.basicConfig.tag;
+                readmeTag = parser.basicConfig.tag;
             }
 
-            parser.inputSwaggerFilesMap.TryGetValue(tag, out InputSwaggerFiles inputFiles);
+            parser.inputSwaggerFilesMap.TryGetValue(readmeTag, out InputSwaggerFiles inputFiles);
             return inputFiles?.input ?? Enumerable.Empty<string>();
         }
         private void ParseReadmeConfig()

--- a/tools/apiview/parsers/swagger-api-parser/SwaggerApiParserTest/ReadmeParserTest.cs
+++ b/tools/apiview/parsers/swagger-api-parser/SwaggerApiParserTest/ReadmeParserTest.cs
@@ -18,8 +18,7 @@ public class ReadmeParserTest
     public void TestParseReadme()
     {
         const string readmeFilePath = "./fixtures/apimanagementReadme.md";
-        var tag = "default";
-        var inputFile = ReadmeParser.GetSwaggerFilesFromReadme(readmeFilePath, ref tag);
+        var inputFile = ReadmeParser.GetSwaggerFilesFromReadme(readmeFilePath, "default");
         Assert.Equal(43, inputFile.ToList().Count);
     }
 
@@ -27,14 +26,13 @@ public class ReadmeParserTest
     public void TestGetSwaggerFileFromReadmeForAppConfiguration()
     {
         const string readmeFilePath = "./fixtures/appconfigurationreadme.md";
-        var tag = "default";
-        var inputFile = ReadmeParser.GetSwaggerFilesFromReadme(readmeFilePath, ref tag);
+        var inputFile = ReadmeParser.GetSwaggerFilesFromReadme(readmeFilePath, "default");
         var enumerable = inputFile as string[] ?? inputFile.ToArray();
         Assert.Equal("Microsoft.AppConfiguration/stable/2022-05-01/appconfiguration.json", enumerable.ToArray()[0]);
         Assert.Single(enumerable.ToList());
 
-        tag = "package-2020-06-01";
-        inputFile = ReadmeParser.GetSwaggerFilesFromReadme(readmeFilePath, ref tag);
+
+        inputFile = ReadmeParser.GetSwaggerFilesFromReadme(readmeFilePath, "package-2020-06-01");
         enumerable = inputFile as string[] ?? inputFile.ToArray();
         Assert.Equal("Microsoft.AppConfiguration/stable/2020-06-01/appconfiguration.json", enumerable.ToArray()[0]);
         Assert.Single(enumerable.ToList());
@@ -79,22 +77,7 @@ public class ReadmeParserTest
     public void TestOrderedInputFiles()
     {
         const string readmeFilePath = "./fixtures/unordered.md";
-        var tag = "package-2023-02";
-        var inputFiles = ReadmeParser.GetSwaggerFilesFromReadme(readmeFilePath, ref tag);
+        var inputFiles = ReadmeParser.GetSwaggerFilesFromReadme(readmeFilePath, "package-2023-02");
         Assert.Collection(inputFiles, x => Assert.Equal("a.json", x), x => Assert.Equal("z.json", x));
-    }
-
-    [Fact]
-    public void TestTagRetrievalUsingGetSwaggerFilesFromReadme()
-    {
-        string readmeFilePath = "./fixtures/appconfigurationreadme.md";
-        var tag = "default";
-        var inputFile = ReadmeParser.GetSwaggerFilesFromReadme(readmeFilePath, ref tag);
-        Assert.Equal("package-2022-05-01", tag);
-
-        readmeFilePath = "./fixtures/unordered.md";
-        tag = "package-2023-02";
-        inputFile = ReadmeParser.GetSwaggerFilesFromReadme(readmeFilePath, ref tag);
-        Assert.Equal("package-2023-02", tag);
     }
 }


### PR DESCRIPTION
Reverts Azure/azure-sdk-tools#9274

Am no longer making use of this