### PR TITLE
[Swift APIView] Add automated tests

### DIFF
--- a/src/swift/SwiftAPIView/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
+++ b/src/swift/SwiftAPIView/SwiftAPIView.xcodeproj/xcshareddata/xcschemes/SwiftAPIView.xcscheme
@@ -57,7 +57,7 @@
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--source=/Users/travisprescott/Documents/AzureCommunicationCalling.xcframework"
-            isEnabled = "YES">
+            isEnabled = "NO">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--source=/Users/travisprescott/repos/communication-ui-library-ios/AzureCommunicationUI"
@@ -68,12 +68,12 @@
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "--package-name=AzureCommunicationCallingTEST"
+            argument = "--package-name=SwiftAPIViewTests"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
             argument = "--source=/Users/travisprescott/repos/azure-sdk-tools/src/swift/SwiftAPIViewTests/Sources"
-            isEnabled = "NO">
+            isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
       <LocationScenarioReference

--- a/src/swift/SwiftAPIViewCore/Sources/Models/APIViewModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/APIViewModel.swift
@@ -294,6 +294,7 @@ class APIViewModel: Tokenizable, Encodable {
 //        self.diagnostics.append(Diagnostic(line_id, text))
 
     func comment(_ text: String) {
+        checkIndent()
         var message = text
         if !text.starts(with: "\\") {
             message = "\\\\ \(message)"

--- a/src/swift/SwiftAPIViewCore/Sources/Models/DeclarationModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/DeclarationModel.swift
@@ -157,6 +157,7 @@ class DeclarationModel: Tokenizable, Linkable, Equatable {
                     let attrText = attr.withoutTrivia().description.filter { !$0.isWhitespace }
                     a.lineIdMarker(definitionId: "\(definitionId!).\(attrText)")
                     attr.tokenize(apiview: a, parent: parent)
+                    a.newline()
                     a.blankLines(set: 0)
                 }
             case .token:

--- a/src/swift/SwiftAPIViewCore/Sources/Models/DeclarationModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/DeclarationModel.swift
@@ -153,7 +153,8 @@ class DeclarationModel: Tokenizable, Linkable, Equatable {
             case .attributeList:
                 // attributes on declarations should have newlines
                 let obj = AttributeListSyntax(child)!
-                for attr in obj.children(viewMode: .sourceAccurate) {
+                let children = obj.children(viewMode: .sourceAccurate)
+                for attr in children {
                     let attrText = attr.withoutTrivia().description.filter { !$0.isWhitespace }
                     a.lineIdMarker(definitionId: "\(definitionId!).\(attrText)")
                     attr.tokenize(apiview: a, parent: parent)

--- a/src/swift/SwiftAPIViewCore/Sources/Models/DeclarationModel.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/Models/DeclarationModel.swift
@@ -154,9 +154,9 @@ class DeclarationModel: Tokenizable, Linkable, Equatable {
                 // attributes on declarations should have newlines
                 let obj = AttributeListSyntax(child)!
                 for attr in obj.children(viewMode: .sourceAccurate) {
-                    attr.tokenize(apiview: a, parent: parent)
                     let attrText = attr.withoutTrivia().description.filter { !$0.isWhitespace }
                     a.lineIdMarker(definitionId: "\(definitionId!).\(attrText)")
+                    attr.tokenize(apiview: a, parent: parent)
                     a.blankLines(set: 0)
                 }
             case .token:

--- a/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/SyntaxProtocol+Extensions.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/SyntaxProtocol+Extensions.swift
@@ -40,7 +40,7 @@ extension SyntaxProtocol {
             for child in self.children(viewMode: .sourceAccurate) {
                 if child.childNameInParent == "name" {
                     let attrName = child.withoutTrivia().description
-                    a.keyword(attrName, spacing: .Neither)
+                    a.keyword(attrName, spacing: .Trailing)
                 } else {
                     child.tokenize(apiview: a, parent: parent)
                 }

--- a/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/SyntaxProtocol+Extensions.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/SyntaxProtocol+Extensions.swift
@@ -186,6 +186,22 @@ extension SyntaxProtocol {
             tokenize(token: token, apiview: a, parent: (parent as? DeclarationModel))
         case .typealiasDecl:
             DeclarationModel(from: TypealiasDeclSyntax(self)!, parent: parent).tokenize(apiview: a, parent: parent)
+        case .accessorBlock:
+            let obj = AccessorBlockSyntax(self)!
+            for child in obj.children(viewMode: .sourceAccurate) {
+                if child.kind == .token {
+                    let token = TokenSyntax(child)!
+                    let tokenKind = token.tokenKind
+                    let tokenText = token.withoutTrivia().description
+                    if tokenKind == .leftBrace || tokenKind == .rightBrace {
+                        a.punctuation(tokenText, spacing: .Both)
+                    } else {
+                        child.tokenize(token: token, apiview: a, parent: nil)
+                    }
+                } else {
+                    child.tokenize(apiview: a, parent: parent)
+                }
+            }
         default:
             // default behavior for all nodes is to render all children
             tokenizeChildren(apiview: a, parent: parent)

--- a/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/SyntaxProtocol+Extensions.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/SyntaxProtocol+Extensions.swift
@@ -37,10 +37,12 @@ extension SyntaxProtocol {
         case .customAttribute: fallthrough
         case .attribute:
             // default implementation should not have newlines
-            for child in self.children(viewMode: .sourceAccurate) {
+            let children = self.children(viewMode: .sourceAccurate)
+            for child in children {
                 if child.childNameInParent == "name" {
                     let attrName = child.withoutTrivia().description
-                    a.keyword(attrName, spacing: .Neither)
+                    // don't add space if the attribute has parameters
+                    a.keyword(attrName, spacing: children.count == 2 ? .Trailing : .Neither)
                 } else {
                     child.tokenize(apiview: a, parent: parent)
                 }

--- a/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/SyntaxProtocol+Extensions.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/SyntaxProtocol+Extensions.swift
@@ -45,7 +45,6 @@ extension SyntaxProtocol {
                     child.tokenize(apiview: a, parent: parent)
                 }
             }
-            a.whitespace()
         case .classRestrictionType:
             // in this simple context, class should not have a trailing space
             a.keyword("class", spacing: .Neither)

--- a/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/TokenKind+Extensions.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/TokenKind+Extensions.swift
@@ -53,6 +53,7 @@ extension SwiftSyntax.TokenKind {
         case .arrow: return .Both
         case .postfixQuestionMark: return .TrimLeft
         case .leftBrace: return .Leading
+        case .leftParen: return .TrimLeft
         case .initKeyword: return .Leading
         case .wildcardKeyword: return .Neither
         case let .contextualKeyword(val):

--- a/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/TokenKind+Extensions.swift
+++ b/src/swift/SwiftAPIViewCore/Sources/SwiftSyntax+Extensions/TokenKind+Extensions.swift
@@ -60,6 +60,8 @@ extension SwiftSyntax.TokenKind {
             case "objc": return .TrimLeft
             case "lowerThan", "higherThan", "associativity": return .Neither
             case "available", "unavailable", "introduced", "deprecated", "obsoleted", "message", "renamed": return .Neither
+            case "willSet", "didSet", "get", "set":
+                return .Leading
             default: return .Both
             }
         default:

--- a/src/swift/SwiftAPIViewCore/SwiftAPIViewCore.xcodeproj/project.pbxproj
+++ b/src/swift/SwiftAPIViewCore/SwiftAPIViewCore.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 55;
+	objectVersion = 73;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -71,6 +71,95 @@
 		0AA1BFBD2953839E00AE8C11 /* ExtensionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionModel.swift; sourceTree = "<group>"; };
 		0AA1BFBF2953955500AE8C11 /* PatternBindingListSyntax+Extensions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PatternBindingListSyntax+Extensions.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		0ACFCCB72CFE32E2006BFBE8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AttributesTestFile.swifttxt,
+				EnumerationsTestFile.swifttxt,
+				ExtensionTestFile.swifttxt,
+				FunctionsTestFile.swifttxt,
+				GenericsTestFile.swifttxt,
+				InitializersTestFile.swifttxt,
+				OperatorTestFile.swifttxt,
+				PrivateInternalTestFile.swifttxt,
+				PropertiesTestFile.swifttxt,
+				ProtocolTestFile.swifttxt,
+			);
+			target = 0A8469E827879AE200C967A8 /* SwiftAPIViewCoreTests */;
+		};
+		0ACFCCBA2CFE332E006BFBE8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AttributesTestFile.swifttxt,
+				EnumerationsTestFile.swifttxt,
+				ExtensionTestFile.swifttxt,
+				FunctionsTestFile.swifttxt,
+				GenericsTestFile.swifttxt,
+				InitializersTestFile.swifttxt,
+				OperatorTestFile.swifttxt,
+				PrivateInternalTestFile.swifttxt,
+				PropertiesTestFile.swifttxt,
+				ProtocolTestFile.swifttxt,
+			);
+			target = 0A8469E027879AE200C967A8 /* SwiftAPIViewCore */;
+		};
+		0ACFCCBD2CFE3BC0006BFBE8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AttributesExpectFile.txt,
+				EnumerationsExpectFile.txt,
+				ExtensionExpectFile.txt,
+				FunctionsExpectFile.txt,
+				GenericsExpectFile.txt,
+				InitializersExpectFile.txt,
+				OperatorExpectFile.txt,
+				PrivateInternalExpectFile.txt,
+				PropertiesExpectFile.txt,
+				ProtocolExpectFile.txt,
+			);
+			target = 0A8469E827879AE200C967A8 /* SwiftAPIViewCoreTests */;
+		};
+		0ACFCCBF2CFE3BC3006BFBE8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				AttributesExpectFile.txt,
+				EnumerationsExpectFile.txt,
+				ExtensionExpectFile.txt,
+				FunctionsExpectFile.txt,
+				GenericsExpectFile.txt,
+				InitializersExpectFile.txt,
+				OperatorExpectFile.txt,
+				PrivateInternalExpectFile.txt,
+				PropertiesExpectFile.txt,
+				ProtocolExpectFile.txt,
+			);
+			target = 0A8469E027879AE200C967A8 /* SwiftAPIViewCore */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+		0ACFCCC22CFE614B006BFBE8 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */ = {
+			isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
+			buildPhase = 0A8469DD27879AE200C967A8 /* Sources */;
+			membershipExceptions = (
+				EnumerationsTestFile.swifttxt,
+				FunctionsTestFile.swifttxt,
+				GenericsTestFile.swifttxt,
+				InitializersTestFile.swifttxt,
+				OperatorTestFile.swifttxt,
+				PrivateInternalTestFile.swifttxt,
+				PropertiesTestFile.swifttxt,
+				ProtocolTestFile.swifttxt,
+			);
+		};
+/* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		0ACFCCB22CFE3288006BFBE8 /* TestFiles */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (0ACFCCBA2CFE332E006BFBE8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0ACFCCC22CFE614B006BFBE8 /* PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet */, 0ACFCCB72CFE32E2006BFBE8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = TestFiles; sourceTree = "<group>"; };
+		0ACFCCB32CFE32B9006BFBE8 /* ExpectFiles */ = {isa = PBXFileSystemSynchronizedRootGroup; exceptions = (0ACFCCBF2CFE3BC3006BFBE8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, 0ACFCCBD2CFE3BC0006BFBE8 /* PBXFileSystemSynchronizedBuildFileExceptionSet */, ); explicitFileTypes = {}; explicitFolders = (); path = ExpectFiles; sourceTree = "<group>"; };
+/* End PBXFileSystemSynchronizedRootGroup section */
 
 /* Begin PBXFrameworksBuildPhase section */
 		0A8469DE27879AE200C967A8 /* Frameworks */ = {
@@ -146,6 +235,8 @@
 		0A846A0227879D0400C967A8 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				0ACFCCB32CFE32B9006BFBE8 /* ExpectFiles */,
+				0ACFCCB22CFE3288006BFBE8 /* TestFiles */,
 				0A846A0327879D0400C967A8 /* SwiftAPIViewCoreTests.swift */,
 			);
 			path = Tests;
@@ -239,6 +330,10 @@
 			dependencies = (
 				0A8469EC27879AE200C967A8 /* PBXTargetDependency */,
 			);
+			fileSystemSynchronizedGroups = (
+				0ACFCCB22CFE3288006BFBE8 /* TestFiles */,
+				0ACFCCB32CFE32B9006BFBE8 /* ExpectFiles */,
+			);
 			name = SwiftAPIViewCoreTests;
 			productName = SwiftAPIViewCoreTests;
 			productReference = 0A8469E927879AE200C967A8 /* SwiftAPIViewCoreTests.xctest */;
@@ -263,7 +358,6 @@
 				};
 			};
 			buildConfigurationList = 0A8469DB27879AE200C967A8 /* Build configuration list for PBXProject "SwiftAPIViewCore" */;
-			compatibilityVersion = "Xcode 13.0";
 			developmentRegion = en;
 			hasScannedForEncodings = 0;
 			knownRegions = (
@@ -276,6 +370,7 @@
 				0A1CA129292D8B5800CC2367 /* XCRemoteSwiftPackageReference "swift-syntax" */,
 				0A6C6596292E98890075C56F /* XCRemoteSwiftPackageReference "SourceKitten" */,
 			);
+			preferredProjectObjectVersion = 55;
 			productRefGroup = 0A8469E227879AE200C967A8 /* Products */;
 			projectDirPath = "";
 			projectRoot = "";

--- a/src/swift/SwiftAPIViewCore/SwiftAPIViewCore.xcodeproj/project.pbxproj
+++ b/src/swift/SwiftAPIViewCore/SwiftAPIViewCore.xcodeproj/project.pbxproj
@@ -86,6 +86,7 @@
 				PrivateInternalTestFile.swifttxt,
 				PropertiesTestFile.swifttxt,
 				ProtocolTestFile.swifttxt,
+				SwiftUITestFile.swifttxt,
 			);
 			target = 0A8469E827879AE200C967A8 /* SwiftAPIViewCoreTests */;
 		};
@@ -102,6 +103,7 @@
 				PrivateInternalTestFile.swifttxt,
 				PropertiesTestFile.swifttxt,
 				ProtocolTestFile.swifttxt,
+				SwiftUITestFile.swifttxt,
 			);
 			target = 0A8469E027879AE200C967A8 /* SwiftAPIViewCore */;
 		};
@@ -118,6 +120,7 @@
 				PrivateInternalExpectFile.txt,
 				PropertiesExpectFile.txt,
 				ProtocolExpectFile.txt,
+				SwiftUIExpectFile.txt,
 			);
 			target = 0A8469E827879AE200C967A8 /* SwiftAPIViewCoreTests */;
 		};
@@ -134,6 +137,7 @@
 				PrivateInternalExpectFile.txt,
 				PropertiesExpectFile.txt,
 				ProtocolExpectFile.txt,
+				SwiftUIExpectFile.txt,
 			);
 			target = 0A8469E027879AE200C967A8 /* SwiftAPIViewCore */;
 		};
@@ -152,6 +156,7 @@
 				PrivateInternalTestFile.swifttxt,
 				PropertiesTestFile.swifttxt,
 				ProtocolTestFile.swifttxt,
+				SwiftUITestFile.swifttxt,
 			);
 		};
 /* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */

--- a/src/swift/SwiftAPIViewCore/SwiftAPIViewCore.xcodeproj/xcshareddata/xcschemes/SwiftAPIViewCore.xcscheme
+++ b/src/swift/SwiftAPIViewCore/SwiftAPIViewCore.xcodeproj/xcshareddata/xcschemes/SwiftAPIViewCore.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1610"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A8469E027879AE200C967A8"
+               BuildableName = "SwiftAPIViewCore.framework"
+               BlueprintName = "SwiftAPIViewCore"
+               ReferencedContainer = "container:SwiftAPIViewCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0A8469E827879AE200C967A8"
+               BuildableName = "SwiftAPIViewCoreTests.xctest"
+               BlueprintName = "SwiftAPIViewCoreTests"
+               ReferencedContainer = "container:SwiftAPIViewCore.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0A8469E027879AE200C967A8"
+            BuildableName = "SwiftAPIViewCore.framework"
+            BlueprintName = "SwiftAPIViewCore"
+            ReferencedContainer = "container:SwiftAPIViewCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/AttributesExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/AttributesExpectFile.txt
@@ -1,0 +1,25 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package AttributesTestFile.swifttxt {
+    public class ExampleClass: NSObject {
+        @objc public var enabled: Bool
+    }
+
+    @available(iOS 10.0, macOS 10.12, *)
+    public class MyClass
+
+    @available(*, unavailable, renamed: "MyRenamedProtocol")
+    public typealias MyProtocol = MyRenamedProtocol
+
+    public protocol MyRenamedProtocol {}
+
+    @available(swift 3.0.2)
+    @available(macOS 10.12, *)
+    public struct MyStruct {}
+
+    public class SomeSendable: @unchecked Sendable {
+        public let name: String
+        public init(name: String)
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/AttributesExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/AttributesExpectFile.txt
@@ -7,7 +7,7 @@ package AttributesTestFile.swifttxt {
     }
 
     @available(iOS 10.0, macOS 10.12, *)
-    public class MyClass
+    public class MyClass {}
 
     @available(*, unavailable, renamed: "MyRenamedProtocol")
     public typealias MyProtocol = MyRenamedProtocol

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/EnumerationsExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/EnumerationsExpectFile.txt
@@ -1,0 +1,39 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package EnumerationsTestFile.swifttxt {
+    public enum ArithmeticExpression {
+        case number(Int)
+        indirect case addition(ArithmeticExpression, ArithmeticExpression)
+        indirect case multiplication(ArithmeticExpression, ArithmeticExpression)
+    }
+
+    public enum ASCIIControlCharacter: Character {
+        case tab = "\t"
+        case lineFeed = "\n"
+        case carriageReturn = "\r"
+    }
+
+    public enum Barcode {
+        case upc(Int, Int, Int, Int)
+        case qrCode(String)
+    }
+
+    public enum CompassPoint {
+        case north
+        case south
+        case east
+        case west
+    }
+
+    public enum Planet: Int {
+        case mercury = 1,
+        venus,
+        earth,
+        mars,
+        jupiter,
+        saturn,
+        uranus,
+        neptune
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/EnumerationsExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/EnumerationsExpectFile.txt
@@ -2,16 +2,16 @@ Package parsed using Swift APIView (version 0.2.2)
 
 
 package EnumerationsTestFile.swifttxt {
-    public enum ArithmeticExpression {
-        case number(Int)
-        indirect case addition(ArithmeticExpression, ArithmeticExpression)
-        indirect case multiplication(ArithmeticExpression, ArithmeticExpression)
-    }
-
     public enum ASCIIControlCharacter: Character {
         case tab = "\t"
         case lineFeed = "\n"
         case carriageReturn = "\r"
+    }
+
+    public enum ArithmeticExpression {
+        case number(Int)
+        indirect case addition(ArithmeticExpression, ArithmeticExpression)
+        indirect case multiplication(ArithmeticExpression, ArithmeticExpression)
     }
 
     public enum Barcode {
@@ -27,13 +27,6 @@ package EnumerationsTestFile.swifttxt {
     }
 
     public enum Planet: Int {
-        case mercury = 1,
-        venus,
-        earth,
-        mars,
-        jupiter,
-        saturn,
-        uranus,
-        neptune
+        case mercury = 1, venus, earth, mars, jupiter, saturn, uranus, neptune
     }
 }

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/ExtensionExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/ExtensionExpectFile.txt
@@ -19,7 +19,7 @@ package ExtensionTestFile.swifttxt {
         public var width = 0.0, height = 0.0
     }
 
-\\ Non-package extensions
+    \\ Non-package extensions
     public extension Double {
         var km: Double
         var m: Double

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/ExtensionExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/ExtensionExpectFile.txt
@@ -30,17 +30,8 @@ package ExtensionTestFile.swifttxt {
 
     public extension Int {
         func repetitions(task: () -> Void)
-    }
-
-    extension Int {
         public mutating func square()
-    }
-
-    extension Int {
         public subscript(digitIndex: Int) -> Int
-    }
-
-    public extension Int {
         enum Kind {
             case negative, zero, positive
         }
@@ -49,13 +40,10 @@ package ExtensionTestFile.swifttxt {
 
     extension Stack {
         public var count: Int
-    }
-
-    public extension Stack {
         var underestimatedCount: Int
     }
 
     extension Stack where Element: Equatable {
-        public func isTop(_ item: Element) -> Bool
+        public func isTop(_: Element) -> Bool
     }
 }

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/ExtensionExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/ExtensionExpectFile.txt
@@ -1,0 +1,61 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package ExtensionTestFile.swifttxt {
+    public struct Point {
+        public var x = 0.0, y = 0.0
+    }
+
+    public struct Rect {
+        public var origin = Point()
+        public var size = Size()
+    }
+
+    public extension Rect {
+        init(center: Point, size: Size)
+    }
+
+    public struct Size {
+        public var width = 0.0, height = 0.0
+    }
+
+\\ Non-package extensions
+    public extension Double {
+        var km: Double
+        var m: Double
+        var cm: Double
+        var mm: Double
+        var ft: Double
+    }
+
+    public extension Int {
+        func repetitions(task: () -> Void)
+    }
+
+    extension Int {
+        public mutating func square()
+    }
+
+    extension Int {
+        public subscript(digitIndex: Int) -> Int
+    }
+
+    public extension Int {
+        enum Kind {
+            case negative, zero, positive
+        }
+        var kind: Kind
+    }
+
+    extension Stack {
+        public var count: Int
+    }
+
+    public extension Stack {
+        var underestimatedCount: Int
+    }
+
+    extension Stack where Element: Equatable {
+        public func isTop(_ item: Element) -> Bool
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/FunctionsExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/FunctionsExpectFile.txt
@@ -1,0 +1,27 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package FunctionsTestFile.swifttxt {
+    public struct FunctionTestClass {
+        public func funcWithoutParams() -> String
+        public func funcWithMultipleParams(person: String, alreadyGreeted: Bool) -> String
+        public func funcWithoutReturnValue(person: String)
+        public func funcWithReturnValue(string: String) -> Int
+        public func funcWithMultipleReturnValues(array: [Int]) -> (min: Int, max: Int)?
+        public func funcWithArgumentLabels(argumentLabel parameterName: Int)
+        public func funcWithoutArgumentLabels(_ firstParameterName: Int, _ secondParameterName: Int)
+        public func funcWithDefaultValue(parameterWithoutDefault: Int, parameterWithDefault: Int = 12)
+        public func funcWithVariadicParam(_ numbers: Double...) -> Double
+        public func funcWithInOutParams(_ a: inout Int, _ b: inout Int)
+        public func addTwoInts(_ a: Int, _ b: Int) -> Int
+        public var mathFunction: (Int, Int) -> Int
+        public func funcWithFuncTypeParam(_ mathFunction: (Int, Int) -> Int, _ a: Int, _ b: Int)
+        public func funcWithFuncReturnType(backward: Bool) -> (Int) -> Int {
+            func stepForward(input: Int) -> Int { return input + 1 }
+            func stepBackward(input: Int) -> Int { return input - 1 }
+            return backward ? stepBackward : stepForward
+        }
+        public func funcWithEscapingClosure(completionHandler: @escaping () -> Void)
+        public func funcWithAutoclosureEscapingClosure(_ customerProvider: @autoclosure @escaping () -> String)
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/FunctionsExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/FunctionsExpectFile.txt
@@ -8,20 +8,16 @@ package FunctionsTestFile.swifttxt {
         public func funcWithoutReturnValue(person: String)
         public func funcWithReturnValue(string: String) -> Int
         public func funcWithMultipleReturnValues(array: [Int]) -> (min: Int, max: Int)?
-        public func funcWithArgumentLabels(argumentLabel parameterName: Int)
-        public func funcWithoutArgumentLabels(_ firstParameterName: Int, _ secondParameterName: Int)
+        public func funcWithArgumentLabels(argumentLabel: Int)
+        public func funcWithoutArgumentLabels(_: Int, _: Int)
         public func funcWithDefaultValue(parameterWithoutDefault: Int, parameterWithDefault: Int = 12)
-        public func funcWithVariadicParam(_ numbers: Double...) -> Double
-        public func funcWithInOutParams(_ a: inout Int, _ b: inout Int)
-        public func addTwoInts(_ a: Int, _ b: Int) -> Int
+        public func funcWithVariadicParam(_: Double...) -> Double
+        public func funcWithInOutParams(_: inout Int, _: inout Int)
+        public func addTwoInts(_: Int, _: Int) -> Int
         public var mathFunction: (Int, Int) -> Int
-        public func funcWithFuncTypeParam(_ mathFunction: (Int, Int) -> Int, _ a: Int, _ b: Int)
-        public func funcWithFuncReturnType(backward: Bool) -> (Int) -> Int {
-            func stepForward(input: Int) -> Int { return input + 1 }
-            func stepBackward(input: Int) -> Int { return input - 1 }
-            return backward ? stepBackward : stepForward
-        }
+        public func funcWithFuncTypeParam(_: (Int, Int) -> Int, _: Int, _: Int)
+        public func funcWithFuncReturnType(backward: Bool) -> (Int) -> Int
         public func funcWithEscapingClosure(completionHandler: @escaping () -> Void)
-        public func funcWithAutoclosureEscapingClosure(_ customerProvider: @autoclosure @escaping () -> String)
+        public func funcWithAutoclosureEscapingClosure(_: @autoclosure @escaping () -> String)
     }
 }

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/GenericsExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/GenericsExpectFile.txt
@@ -2,82 +2,58 @@ Package parsed using Swift APIView (version 0.2.2)
 
 
 package GenericsTestFile.swifttxt {
-    public func swapTwoValues<T>(_ a: inout T, _ b: inout T)
-
-    public struct Stack<Element> {
-        public var items: [Element] = []
-        public mutating func push(_ item: Element)
-        public mutating func pop() -> Element
-    }
-
-    public extension Stack {
-        var topItem: Element?
-    }
-
-    public func findIndex<T: Equatable>(of valueToFind: T, in array:[T]) -> Int?
-
-    public struct ContainerStack<Element: Equatable>: Container
-
     public protocol Container {
         associatedtype Item: Equatable
-        mutating func append(_ item: Item)
+        mutating func append(_: Item)
         var count: Int { get }
         subscript(i: Int) -> Item { get }
     }
 
-    public struct IntContainerStack: Container {
-        var items: [Int] = []
-        mutating func push(_ item: Int)
-        mutating func pop() -> Int
-        public typealias Item = Int
-        public mutating func append(_ item: Int)
-        public var count: Int
-        public subscript(i: Int) -> Int
+    public extension Container {
+        func average() -> Double where Item == Int
+        func endsWith(_: Item) -> Bool where Item: Equatable
+        subscript<Indices: Sequence>(indices: Indices) -> [Item] where Indices.Iterator.Element == Int
     }
-
-    public protocol SuffixableContainer: Container {
-        associatedtype Suffix: SuffixableContainer where Suffix.Item == Item
-        func suffix(_ size: Int) -> Suffix
-    }
-
-    extension ContainerStack: SuffixableContainer {
-        public func suffix(_ size: Int) -> ContainerStack
-    }
-
-    extension IntContainerStack: SuffixableContainer {
-        public func suffix(_ size: Int) -> ContainerStack<Int>
-    }
-
-    public func allItemsMatch<C1: Container, C2: Container>
-        (_ someContainer: C1, _ anotherContainer: C2) -> Bool
-        where C1.Item == C2.Item, C1.Item: Equatable
 
     public extension Container where Item: Equatable {
-        func startsWith(_ item: Item) -> Bool
+        func startsWith(_: Item) -> Bool
     }
 
     public extension Container where Item == Double {
         func average() -> Double
     }
 
-    public extension Container {
-        func average() -> Double where Item == Int
-        func endsWith(_ item: Item) -> Bool where Item: Equatable
-    }
-
     public protocol ContainerAlt {
         associatedtype Item
-        mutating func append(_ item: Item)
+        mutating func append(_: Item)
         var count: Int { get }
         subscript(i: Int) -> Item { get }
-
         associatedtype Iterator: IteratorProtocol where Iterator.Element == Item
         func makeIterator() -> Iterator
     }
 
-    public extension Container {
-        subscript<Indices: Sequence>(indices: Indices) -> [Item]
-            where Indices.Iterator.Element == Int
+    public struct ContainerStack<Element: Equatable>: Container {
+        public var items: [Element] = []
+        public mutating func push(_: Element)
+        public mutating func pop() -> Element
+        public mutating func append(_: Element)
+        public var count: Int
+        public subscript(i: Int) -> Element
+    }
+
+    extension ContainerStack: SuffixableContainer {
+        public func suffix(_: Int) -> ContainerStack
+    }
+
+    public struct IntContainerStack: Container {
+        public typealias Item = Int
+        public mutating func append(_: Int)
+        public var count: Int
+        public subscript(i: Int) -> Int
+    }
+
+    extension IntContainerStack: SuffixableContainer {
+        public func suffix(_: Int) -> ContainerStack<Int>
     }
 
     public protocol Shape {
@@ -89,5 +65,26 @@ package GenericsTestFile.swifttxt {
         public func draw() -> String
     }
 
+    public struct Stack<Element> {
+        public var items: [Element] = []
+        public mutating func push(_: Element)
+        public mutating func pop() -> Element
+    }
+
+    public extension Stack {
+        var topItem: Element?
+    }
+
+    public protocol SuffixableContainer: Container {
+        associatedtype Suffix: SuffixableContainer where Suffix.Item == Item
+        func suffix(_: Int) -> Suffix
+    }
+
+    public func allItemsMatch<C1: Container, C2: Container>(_: C1, _: C2) -> Bool where C1.Item == C2.Item, C1.Item: Equatable
+
+    public func findIndex<T: Equatable>(of: T, in: [T]) -> Int?
+
     public func makeTrapezoid() -> some Shape
+
+    public func swapTwoValues<T>(_: inout T, _: inout T)
 }

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/GenericsExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/GenericsExpectFile.txt
@@ -1,0 +1,93 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package GenericsTestFile.swifttxt {
+    public func swapTwoValues<T>(_ a: inout T, _ b: inout T)
+
+    public struct Stack<Element> {
+        public var items: [Element] = []
+        public mutating func push(_ item: Element)
+        public mutating func pop() -> Element
+    }
+
+    public extension Stack {
+        var topItem: Element?
+    }
+
+    public func findIndex<T: Equatable>(of valueToFind: T, in array:[T]) -> Int?
+
+    public struct ContainerStack<Element: Equatable>: Container
+
+    public protocol Container {
+        associatedtype Item: Equatable
+        mutating func append(_ item: Item)
+        var count: Int { get }
+        subscript(i: Int) -> Item { get }
+    }
+
+    public struct IntContainerStack: Container {
+        var items: [Int] = []
+        mutating func push(_ item: Int)
+        mutating func pop() -> Int
+        public typealias Item = Int
+        public mutating func append(_ item: Int)
+        public var count: Int
+        public subscript(i: Int) -> Int
+    }
+
+    public protocol SuffixableContainer: Container {
+        associatedtype Suffix: SuffixableContainer where Suffix.Item == Item
+        func suffix(_ size: Int) -> Suffix
+    }
+
+    extension ContainerStack: SuffixableContainer {
+        public func suffix(_ size: Int) -> ContainerStack
+    }
+
+    extension IntContainerStack: SuffixableContainer {
+        public func suffix(_ size: Int) -> ContainerStack<Int>
+    }
+
+    public func allItemsMatch<C1: Container, C2: Container>
+        (_ someContainer: C1, _ anotherContainer: C2) -> Bool
+        where C1.Item == C2.Item, C1.Item: Equatable
+
+    public extension Container where Item: Equatable {
+        func startsWith(_ item: Item) -> Bool
+    }
+
+    public extension Container where Item == Double {
+        func average() -> Double
+    }
+
+    public extension Container {
+        func average() -> Double where Item == Int
+        func endsWith(_ item: Item) -> Bool where Item: Equatable
+    }
+
+    public protocol ContainerAlt {
+        associatedtype Item
+        mutating func append(_ item: Item)
+        var count: Int { get }
+        subscript(i: Int) -> Item { get }
+
+        associatedtype Iterator: IteratorProtocol where Iterator.Element == Item
+        func makeIterator() -> Iterator
+    }
+
+    public extension Container {
+        subscript<Indices: Sequence>(indices: Indices) -> [Item]
+            where Indices.Iterator.Element == Int
+    }
+
+    public protocol Shape {
+        func draw() -> String
+    }
+
+    public struct Square: Shape {
+        public var size: Int
+        public func draw() -> String
+    }
+
+    public func makeTrapezoid() -> some Shape
+}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/InitializersExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/InitializersExpectFile.txt
@@ -1,0 +1,9 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package InitializersTestFile.swifttxt {
+    public class InitializersTestClass {
+        public init(withThrowable: String) throws
+        public init?(withFailable: String)
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/OperatorExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/OperatorExpectFile.txt
@@ -1,0 +1,40 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package OperatorTestFile.swifttxt {
+    public struct Vector2D {
+        public var x = 0.0, y = 0.0
+    }
+
+    public extension Vector2D {
+        static func + (left: Vector2D, right: Vector2D) -> Vector2D
+    }
+
+    public extension Vector2D {
+        static prefix func - (vector: Vector2D) -> Vector2D
+    }
+
+    public extension Vector2D {
+        static func += (left: inout Vector2D, right: Vector2D)
+    }
+
+    extension Vector2D: Equatable {
+        public static func == (left: Vector2D, right: Vector2D) -> Bool
+    }
+
+    prefix operator +++
+    public extension Vector2D {
+        static prefix func +++ (vector: inout Vector2D) -> Vector2D
+    }
+
+    infix operator +-: AdditionPrecedence
+    public extension Vector2D {
+        static func +- (left: Vector2D, right: Vector2D) -> Vector2D
+    }
+
+    precedencegroup CongruentPrecedence {
+        lowerThan: MultiplicationPrecedence
+        higherThan: AdditionPrecedence
+        associativity: left
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/OperatorExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/OperatorExpectFile.txt
@@ -2,39 +2,29 @@ Package parsed using Swift APIView (version 0.2.2)
 
 
 package OperatorTestFile.swifttxt {
-    public struct Vector2D {
-        public var x = 0.0, y = 0.0
-    }
-
-    public extension Vector2D {
-        static func + (left: Vector2D, right: Vector2D) -> Vector2D
-    }
-
-    public extension Vector2D {
-        static prefix func - (vector: Vector2D) -> Vector2D
-    }
-
-    public extension Vector2D {
-        static func += (left: inout Vector2D, right: Vector2D)
-    }
-
-    extension Vector2D: Equatable {
-        public static func == (left: Vector2D, right: Vector2D) -> Bool
-    }
-
     prefix operator +++
-    public extension Vector2D {
-        static prefix func +++ (vector: inout Vector2D) -> Vector2D
-    }
 
     infix operator +-: AdditionPrecedence
-    public extension Vector2D {
-        static func +- (left: Vector2D, right: Vector2D) -> Vector2D
-    }
 
     precedencegroup CongruentPrecedence {
         lowerThan: MultiplicationPrecedence
         higherThan: AdditionPrecedence
         associativity: left
+    }
+
+    public struct Vector2D {
+        public var x = 0.0, y = 0.0
+    }
+
+    public extension Vector2D {
+        static func +(left: Vector2D, right: Vector2D) -> Vector2D
+        static prefix func -(vector: Vector2D) -> Vector2D
+        static func +=(left: inout Vector2D, right: Vector2D)
+        static prefix func +++(vector: inout Vector2D) -> Vector2D
+        static func +-(left: Vector2D, right: Vector2D) -> Vector2D
+    }
+
+    extension Vector2D: Equatable {
+        public static func ==(left: Vector2D, right: Vector2D) -> Bool
     }
 }

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/PrivateInternalExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/PrivateInternalExpectFile.txt
@@ -1,4 +1,5 @@
 Package parsed using Swift APIView (version 0.2.2)
 
 
-package PrivateInternalTestFile.swifttxt {}
+package PrivateInternalTestFile.swifttxt {
+}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/PrivateInternalExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/PrivateInternalExpectFile.txt
@@ -1,0 +1,4 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package PrivateInternalTestFile.swifttxt {}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/PropertiesExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/PropertiesExpectFile.txt
@@ -1,0 +1,20 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package PropertiesTestFile.swifttxt {
+    public class PropertiesTestClass {
+
+        public var totalSteps: Int = 0 {
+            willSet(newTotalSteps)
+            didSet
+        }
+
+        public var someReadOnly: String
+
+        private var _secretValue: String = ""
+        public var someReadWrite: String {
+            get
+            set
+        }
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/PropertiesExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/PropertiesExpectFile.txt
@@ -3,18 +3,8 @@ Package parsed using Swift APIView (version 0.2.2)
 
 package PropertiesTestFile.swifttxt {
     public class PropertiesTestClass {
-
-        public var totalSteps: Int = 0 {
-            willSet(newTotalSteps)
-            didSet
-        }
-
+        public var totalSteps: Int = 0 { willSet(newTotalSteps) didSet }
         public var someReadOnly: String
-
-        private var _secretValue: String = ""
-        public var someReadWrite: String {
-            get
-            set
-        }
+        public var someReadWrite: String { get set }
     }
 }

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/ProtocolExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/ProtocolExpectFile.txt
@@ -2,90 +2,6 @@ Package parsed using Swift APIView (version 0.2.2)
 
 
 package ProtocolTestFile.swifttxt {
-    public protocol SomeProtocol {
-        var mustBeSettable: Int { get set }
-        var doesNotNeedToBeSettable: Int { get }
-    }
-
-    public protocol FullyNamed {
-        var fullName: String { get }
-    }
-
-    public struct Person: FullyNamed {
-        public var fullName: String
-    }
-
-    public protocol RandomNumberGenerator {
-        func random() -> Double
-    }
-
-    public protocol Togglable {
-        mutating func toggle()
-    }
-
-    public enum OnOffSwitch: Togglable {
-        case off, on
-        public mutating func toggle()
-    }
-
-    public protocol SomeInitProtocol {
-        init(someParameter: Int)
-    }
-
-    public class SomeClass: SomeInitProtocol {
-        public required init(someParameter: Int)
-    }
-
-    public protocol SomeOtherInitProtocol {
-        init()
-    }
-
-    open class SomeSuperClass {
-        public init()
-    }
-
-    public class SomeSubClass: SomeSuperClass, SomeOtherInitProtocol {
-        public required override init()
-    }
-
-    public class Dice {
-        public let sides: Int
-        public let generator: RandomNumberGenerator
-        public init(sides: Int, generator: RandomNumberGenerator)
-        public func roll() -> Int
-    }
-
-    public protocol TextRepresentable {
-        var textualDescription: String { get }
-    }
-
-    extension Dice: TextRepresentable {
-        public var textualDescription: String
-    }
-
-    extension Array: TextRepresentable where Element: TextRepresentable {
-        public var textualDescription: String
-    }
-
-    public struct Hamster {
-        public var name: String
-        public var textualDescription: String
-    }
-
-    extension Hamster: TextRepresentable {}
-
-    public protocol PrettyTextRepresentable: TextRepresentable {
-        var prettyTextualDescription: String { get }
-    }
-
-    public protocol SomeClassOnlyProtocol: AnyObject, TextRepresentable {}
-
-    public protocol SomeOtherClassOnlyProtocol: class, TextRepresentable {}
-
-    public protocol Named {
-        var name: String { get }
-    }
-
     public protocol Aged {
         var age: Int { get }
     }
@@ -95,19 +11,107 @@ package ProtocolTestFile.swifttxt {
         public var age: Int
     }
 
-    public func wishHappyBirthday(to celebrator: Named & Aged)
-
-    @objc public protocol CounterDataSource {
-        @objc optional func increment(forCount count: Int) -> Int
+    @objc
+    public protocol CounterDataSource {
+        @objc
+        optional func increment(forCount: Int) -> Int
         @objc optional var fixedIncrement: Int { get }
+    }
+
+    public class Dice {
+        public let sides: Int
+        public let generator: RandomNumberGenerator
+        public init(sides: Int, generator: RandomNumberGenerator)
+        public func roll() -> Int
+    }
+
+    extension Dice: TextRepresentable {
+        public var textualDescription: String
+    }
+
+    public protocol FullyNamed {
+        var fullName: String { get }
+    }
+
+    public struct Hamster {
+        public var name: String
+        public var textualDescription: String
+    }
+
+    extension Hamster: TextRepresentable {
+    }
+
+    public protocol Named {
+        var name: String { get }
+    }
+
+    public enum OnOffSwitch: Togglable {
+        case off, on
+        public mutating func toggle()
+    }
+
+    public struct Person: FullyNamed {
+        public var fullName: String
+    }
+
+    public protocol PrettyTextRepresentable: TextRepresentable {
+        var prettyTextualDescription: String { get }
+    }
+
+    public extension PrettyTextRepresentable {
+        var prettyTextualDescription: String
+    }
+
+    public protocol RandomNumberGenerator {
+        func random() -> Double
     }
 
     public extension RandomNumberGenerator {
         func randomBool() -> Bool
     }
 
-    public extension PrettyTextRepresentable  {
-        var prettyTextualDescription: String
+    public class SomeClass: SomeInitProtocol {
+        public required init(someParameter: Int)
+    }
+
+    public protocol SomeClassOnlyProtocol: AnyObject, TextRepresentable {}
+
+    public protocol SomeInitProtocol {
+        init(someParameter: Int)
+    }
+
+    public protocol SomeOtherClassOnlyProtocol: class, TextRepresentable {}
+
+    public protocol SomeOtherInitProtocol {
+        init()
+    }
+
+    public protocol SomeProtocol {
+        var mustBeSettable: Int { get set }
+        var doesNotNeedToBeSettable: Int { get }
+    }
+
+    public class SomeSubClass: SomeSuperClass, SomeOtherInitProtocol {
+        public required override init()
+    }
+
+    open class SomeSuperClass {
+        public init()
+    }
+
+    public protocol TextRepresentable {
+        var textualDescription: String { get }
+    }
+
+    public protocol Togglable {
+        mutating func toggle()
+    }
+
+    public func wishHappyBirthday(to: Named & Aged)
+
+    \\ Non-package extensions
+    extension Array: TextRepresentable where Element: TextRepresentable {
+        public var textualDescription: String
     }
 
     public extension Collection where Element: Equatable {

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/ProtocolExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/ProtocolExpectFile.txt
@@ -1,0 +1,116 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package ProtocolTestFile.swifttxt {
+    public protocol SomeProtocol {
+        var mustBeSettable: Int { get set }
+        var doesNotNeedToBeSettable: Int { get }
+    }
+
+    public protocol FullyNamed {
+        var fullName: String { get }
+    }
+
+    public struct Person: FullyNamed {
+        public var fullName: String
+    }
+
+    public protocol RandomNumberGenerator {
+        func random() -> Double
+    }
+
+    public protocol Togglable {
+        mutating func toggle()
+    }
+
+    public enum OnOffSwitch: Togglable {
+        case off, on
+        public mutating func toggle()
+    }
+
+    public protocol SomeInitProtocol {
+        init(someParameter: Int)
+    }
+
+    public class SomeClass: SomeInitProtocol {
+        public required init(someParameter: Int)
+    }
+
+    public protocol SomeOtherInitProtocol {
+        init()
+    }
+
+    open class SomeSuperClass {
+        public init()
+    }
+
+    public class SomeSubClass: SomeSuperClass, SomeOtherInitProtocol {
+        public required override init()
+    }
+
+    public class Dice {
+        public let sides: Int
+        public let generator: RandomNumberGenerator
+        public init(sides: Int, generator: RandomNumberGenerator)
+        public func roll() -> Int
+    }
+
+    public protocol TextRepresentable {
+        var textualDescription: String { get }
+    }
+
+    extension Dice: TextRepresentable {
+        public var textualDescription: String
+    }
+
+    extension Array: TextRepresentable where Element: TextRepresentable {
+        public var textualDescription: String
+    }
+
+    public struct Hamster {
+        public var name: String
+        public var textualDescription: String
+    }
+
+    extension Hamster: TextRepresentable {}
+
+    public protocol PrettyTextRepresentable: TextRepresentable {
+        var prettyTextualDescription: String { get }
+    }
+
+    public protocol SomeClassOnlyProtocol: AnyObject, TextRepresentable {}
+
+    public protocol SomeOtherClassOnlyProtocol: class, TextRepresentable {}
+
+    public protocol Named {
+        var name: String { get }
+    }
+
+    public protocol Aged {
+        var age: Int { get }
+    }
+
+    public struct ComposedPerson: Named, Aged {
+        public var name: String
+        public var age: Int
+    }
+
+    public func wishHappyBirthday(to celebrator: Named & Aged)
+
+    @objc public protocol CounterDataSource {
+        @objc optional func increment(forCount count: Int) -> Int
+        @objc optional var fixedIncrement: Int { get }
+    }
+
+    public extension RandomNumberGenerator {
+        func randomBool() -> Bool
+    }
+
+    public extension PrettyTextRepresentable  {
+        var prettyTextualDescription: String
+    }
+
+    public extension Collection where Element: Equatable {
+        func allEqual() -> Bool
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/SwiftUIExpectFile.txt
+++ b/src/swift/SwiftAPIViewCore/Tests/ExpectFiles/SwiftUIExpectFile.txt
@@ -1,0 +1,10 @@
+Package parsed using Swift APIView (version 0.2.2)
+
+
+package SwiftUITestFile.swifttxt {
+    public class ViewBuilderExample {
+        public func testViewBuilder(@ViewBuilder content: () -> Content)
+        @ViewBuilder
+        public func createView() -> some View
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/SwiftAPIViewCoreTests.swift
+++ b/src/swift/SwiftAPIViewCore/Tests/SwiftAPIViewCoreTests.swift
@@ -30,37 +30,126 @@ import XCTest
 class SwiftAPIViewCoreTests: XCTestCase {
 
     override func setUpWithError() throws {
+        try super.setUpWithError()
+        continueAfterFailure = false
         SharedLogger.set(logger: NullLogger(), withLevel: .info)
     }
 
-    private func load(testFile filename: String) -> String {
-        let bundle = Bundle(for: Swift.type(of: self))
-        return bundle.path(forResource: filename, ofType: "swifttxt")!
+    private func pathFor(testFile filename: String) -> String {
+        let bundle = Bundle(for: APIViewManager.self)
+        if let filePath = bundle.path(forResource: filename, ofType: "swifttxt") {
+            return filePath
+        }
+        XCTFail("Could not find file \(filename).swifttxt")
+        return ""
     }
 
-    private func load(expectFile filename: String) -> String {
-        let bundle = Bundle(for: Swift.type(of: self))
+    private func contentsOf(expectFile filename: String) -> String {
+        let bundle = Bundle(for: APIViewManager.self)
         let path = bundle.path(forResource: filename, ofType: "txt")!
         return try! String(contentsOfFile: path)
     }
 
     private func compare(expected: String, actual: String) {
-        let actualLines = actual.split(separator: "\n").map { String($0) }
-        let expectedLines = expected.split(separator: "\n").map { String($0) }
-        print(actual)
-        XCTAssertEqual(actualLines.count, expectedLines.count)
+        let actualLines = actual.split(separator: "\n", omittingEmptySubsequences: false).map { String($0) }
+        let expectedLines = expected.split(separator: "\n", omittingEmptySubsequences: false).map { String($0) }
         for (i, expected) in expectedLines.enumerated() {
             let actual = actualLines[i]
-            XCTAssert(actual == expected, "Line \(i): (\(actual) is not equal to (\(expected)")
+            if (actual == expected) {
+                continue
+            }
+            XCTFail("Line \(i): (\(actual) is not equal to (\(expected)")
         }
+        XCTAssertEqual(actualLines.count, expectedLines.count, "Number of lines does not match")
     }
 
-    func testFile1() throws {
+    func testAttributes() throws {
         let manager = APIViewManager(mode: .testing)
-        manager.config.sourcePath = load(testFile: "TestFile1")
+        manager.config.sourcePath = pathFor(testFile: "AttributesTestFile")
         manager.config.packageVersion = "1.0.0"
-        let generated = try! manager.run()
-        let expected = load(expectFile: "ExpectFile1")
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "AttributesExpectFile")
+        compare(expected: expected, actual: generated)
+    }
+
+    func testEnumerations() throws {
+        let manager = APIViewManager(mode: .testing)
+        manager.config.sourcePath = pathFor(testFile: "EnumerationsTestFile")
+        manager.config.packageVersion = "1.0.0"
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "EnumerationsExpectFile")
+        compare(expected: expected, actual: generated)
+    }
+
+    func testExtensions() throws {
+        let manager = APIViewManager(mode: .testing)
+        manager.config.sourcePath = pathFor(testFile: "ExtensionTestFile")
+        manager.config.packageVersion = "1.0.0"
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "ExtensionExpectFile")
+        compare(expected: expected, actual: generated)
+    }
+
+    func testFunctions() throws {
+        let manager = APIViewManager(mode: .testing)
+        manager.config.sourcePath = pathFor(testFile: "FunctionsTestFile")
+        manager.config.packageVersion = "1.0.0"
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "FunctionsExpectFile")
+        compare(expected: expected, actual: generated)
+    }
+
+    func testGenerics() throws {
+        let manager = APIViewManager(mode: .testing)
+        manager.config.sourcePath = pathFor(testFile: "GenericsTestFile")
+        manager.config.packageVersion = "1.0.0"
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "GenericsExpectFile")
+        compare(expected: expected, actual: generated)
+    }
+
+    func testInitializers() throws {
+        let manager = APIViewManager(mode: .testing)
+        manager.config.sourcePath = pathFor(testFile: "InitializersTestFile")
+        manager.config.packageVersion = "1.0.0"
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "InitializersExpectFile")
+        compare(expected: expected, actual: generated)
+    }
+
+    func testOperators() throws {
+        let manager = APIViewManager(mode: .testing)
+        manager.config.sourcePath = pathFor(testFile: "OperatorTestFile")
+        manager.config.packageVersion = "1.0.0"
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "OperatorExpectFile")
+        compare(expected: expected, actual: generated)
+    }
+
+    func testPrivateInternal() throws {
+        let manager = APIViewManager(mode: .testing)
+        manager.config.sourcePath = pathFor(testFile: "PrivateInternalTestFile")
+        manager.config.packageVersion = "1.0.0"
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "PrivateInternalExpectFile")
+        compare(expected: expected, actual: generated)
+    }
+
+    func testProperties() throws {
+        let manager = APIViewManager(mode: .testing)
+        manager.config.sourcePath = pathFor(testFile: "PropertiesTestFile")
+        manager.config.packageVersion = "1.0.0"
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "PropertiesExpectFile")
+        compare(expected: expected, actual: generated)
+    }
+
+    func testProtocols() throws {
+        let manager = APIViewManager(mode: .testing)
+        manager.config.sourcePath = pathFor(testFile: "ProtocolTestFile")
+        manager.config.packageVersion = "1.0.0"
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "ProtocolExpectFile")
         compare(expected: expected, actual: generated)
     }
 }

--- a/src/swift/SwiftAPIViewCore/Tests/SwiftAPIViewCoreTests.swift
+++ b/src/swift/SwiftAPIViewCore/Tests/SwiftAPIViewCoreTests.swift
@@ -152,4 +152,13 @@ class SwiftAPIViewCoreTests: XCTestCase {
         let expected = contentsOf(expectFile: "ProtocolExpectFile")
         compare(expected: expected, actual: generated)
     }
+
+    func testSwiftUI() throws {
+        let manager = APIViewManager(mode: .testing)
+        manager.config.sourcePath = pathFor(testFile: "SwiftUITestFile")
+        manager.config.packageVersion = "1.0.0"
+        let generated = try manager.run()
+        let expected = contentsOf(expectFile: "SwiftUIExpectFile")
+        compare(expected: expected, actual: generated)
+    }
 }

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/AttributesTestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/AttributesTestFile.swifttxt
@@ -1,0 +1,69 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+// Using @available to rename a protocol
+
+public protocol MyRenamedProtocol {
+    // A protocol named MyProtocol was subsequent release renames MyProtocol
+}
+
+@available(*, unavailable, renamed: "MyRenamedProtocol")
+public typealias MyProtocol = MyRenamedProtocol
+
+// Using @available to specify OS versions
+
+@available(iOS 10.0, macOS 10.12, *)
+public class MyClass {
+    // class definition
+}
+
+// Using @available to specify swift version
+
+@available(swift 3.0.2)
+@available(macOS 10.12, *)
+public struct MyStruct {
+    // struct definition
+}
+
+// Using @objc
+
+public class ExampleClass: NSObject {
+    @objc public var enabled: Bool {
+        return true
+    }
+}
+
+// Use of @unchecked Sendable
+
+public class SomeSendable: @unchecked Sendable {
+    public let name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/EnumerationsTestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/EnumerationsTestFile.swifttxt
@@ -1,0 +1,65 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+// Basic enum
+
+public enum CompassPoint {
+    case north
+    case south
+    case east
+    case west
+}
+
+// Associated values
+
+public enum Barcode {
+    case upc(Int, Int, Int, Int)
+    case qrCode(String)
+}
+
+// RawValue enum
+
+public enum ASCIIControlCharacter: Character {
+    case tab = "\t"
+    case lineFeed = "\n"
+    case carriageReturn = "\r"
+}
+
+// Implicitly assigned value enum
+
+public enum Planet: Int {
+    case mercury = 1, venus, earth, mars, jupiter, saturn, uranus, neptune
+}
+
+// Recursive enumeration
+
+public enum ArithmeticExpression {
+    case number(Int)
+    indirect case addition(ArithmeticExpression, ArithmeticExpression)
+    indirect case multiplication(ArithmeticExpression, ArithmeticExpression)
+}

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/ExtensionTestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/ExtensionTestFile.swifttxt
@@ -1,0 +1,134 @@
+
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+// Computed properties on a package-defined type. Separate extensions--how to disambiguate?
+
+extension Stack {
+    public var count: Int {
+        return items.count
+    }
+}
+
+public extension Stack {
+    var underestimatedCount: Int {
+        return items.underestimatedCount
+    }
+}
+
+// An extension with a where clause
+
+extension Stack where Element: Equatable {
+    public func isTop(_ item: Element) -> Bool {
+        guard let topItem = items.last else {
+            return false
+        }
+        return topItem == item
+    }
+}
+
+// Computed property on a Foundation type
+
+public extension Double {
+    var km: Double { return self * 1_000.0 }
+    var m: Double { return self }
+    var cm: Double { return self / 100.0 }
+    var mm: Double { return self / 1_000.0 }
+    var ft: Double { return self / 3.28084 }
+}
+
+// Adding an initializer with an extension
+
+public struct Size {
+    public var width = 0.0, height = 0.0
+}
+
+public struct Point {
+    public var x = 0.0, y = 0.0
+}
+
+public struct Rect {
+    public var origin = Point()
+    public var size = Size()
+}
+
+public extension Rect {
+    init(center: Point, size: Size) {
+        let originX = center.x - (size.width / 2)
+        let originY = center.y - (size.height / 2)
+        self.init(origin: Point(x: originX, y: originY), size: size)
+    }
+}
+
+// Adding method to Foundation type
+
+public extension Int {
+    func repetitions(task: () -> Void) {
+        for _ in 0..<self {
+            task()
+        }
+    }
+}
+
+// Adding mutating method to Foundation type
+
+extension Int {
+    public mutating func square() {
+        self = self * self
+    }
+}
+
+// Adding subscript behavior to Foundation type
+
+extension Int {
+    public subscript(digitIndex: Int) -> Int {
+        var decimalBase = 1
+        for _ in 0..<digitIndex {
+            decimalBase *= 10
+        }
+        return (self / decimalBase) % 10
+    }
+}
+
+// Adding nested type to Foundation type
+
+public extension Int {
+    enum Kind {
+        case negative, zero, positive
+    }
+    var kind: Kind {
+        switch self {
+        case 0:
+            return .zero
+        case let x where x > 0:
+            return .positive
+        default:
+            return .negative
+        }
+    }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/FunctionsTestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/FunctionsTestFile.swifttxt
@@ -1,0 +1,67 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+
+public struct FunctionTestClass {
+
+    public func funcWithoutParams() -> String { "" }
+
+    public func funcWithMultipleParams(person: String, alreadyGreeted: Bool) -> String { "" }
+
+    public func funcWithoutReturnValue(person: String) { }
+
+    public func funcWithReturnValue(string: String) -> Int { 1 }
+
+    public func funcWithMultipleReturnValues(array: [Int]) -> (min: Int, max: Int)? { (0, 1) }
+
+    public func funcWithArgumentLabels(argumentLabel parameterName: Int) { }
+
+    public func funcWithoutArgumentLabels(_ firstParameterName: Int, _ secondParameterName: Int) { }
+
+    public func funcWithDefaultValue(parameterWithoutDefault: Int, parameterWithDefault: Int = 12) { }
+
+    public func funcWithVariadicParam(_ numbers: Double...) -> Double { 1.0 }
+
+    public func funcWithInOutParams(_ a: inout Int, _ b: inout Int) { }
+
+    public func addTwoInts(_ a: Int, _ b: Int) -> Int { a + b }
+
+    public var mathFunction: (Int, Int) -> Int
+
+    public func funcWithFuncTypeParam(_ mathFunction: (Int, Int) -> Int, _ a: Int, _ b: Int) { }
+
+    public func funcWithFuncReturnType(backward: Bool) -> (Int) -> Int {
+        func stepForward(input: Int) -> Int { return input + 1 }
+        func stepBackward(input: Int) -> Int { return input - 1 }
+        return backward ? stepBackward : stepForward
+    }
+
+    public func funcWithEscapingClosure(completionHandler: @escaping () -> Void) { }
+
+    public func funcWithAutoclosureEscapingClosure(_ customerProvider: @autoclosure @escaping () -> String) { }
+}

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/GenericsTestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/GenericsTestFile.swifttxt
@@ -1,0 +1,246 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+// Generic function
+
+public func swapTwoValues<T>(_ a: inout T, _ b: inout T) {
+    let temporaryA = a
+    a = b
+    b = temporaryA
+}
+
+// Generic object
+
+public struct Stack<Element> {
+    public var items: [Element] = []
+    public mutating func push(_ item: Element) {
+        items.append(item)
+    }
+    public mutating func pop() -> Element {
+        return items.removeLast()
+    }
+}
+
+// Extending generic
+
+public extension Stack {
+    var topItem: Element? {
+        return items.isEmpty ? nil : items[items.count - 1]
+    }
+}
+
+// Generic type constraints
+
+public func findIndex<T: Equatable>(of valueToFind: T, in array:[T]) -> Int? {
+    for (index, value) in array.enumerated() {
+        if value == valueToFind {
+            return index
+        }
+    }
+    return nil
+}
+
+// Associated type with constraint
+
+public struct ContainerStack<Element: Equatable>: Container {
+    public var items: [Element] = []
+    public mutating func push(_ item: Element) {
+        items.append(item)
+    }
+    public mutating func pop() -> Element {
+        return items.removeLast()
+    }
+    // conformance to the Container protocol
+    public mutating func append(_ item: Element) {
+        self.push(item)
+    }
+    public var count: Int {
+        return items.count
+    }
+    public subscript(i: Int) -> Element {
+        return items[i]
+    }
+}
+
+public protocol Container {
+    associatedtype Item: Equatable
+    mutating func append(_ item: Item)
+    var count: Int { get }
+    subscript(i: Int) -> Item { get }
+}
+
+public struct IntContainerStack: Container {
+    // original IntContainerStack implementation
+    var items: [Int] = []
+    mutating func push(_ item: Int) {
+        items.append(item)
+    }
+    mutating func pop() -> Int {
+        return items.removeLast()
+    }
+    // conformance to the Container protocol
+    public typealias Item = Int
+    public mutating func append(_ item: Int) {
+        self.push(item)
+    }
+    public var count: Int {
+        return items.count
+    }
+    public subscript(i: Int) -> Int {
+        return items[i]
+    }
+}
+
+// Using protocol in its associated type constraints
+
+public protocol SuffixableContainer: Container {
+    associatedtype Suffix: SuffixableContainer where Suffix.Item == Item
+    func suffix(_ size: Int) -> Suffix
+}
+
+extension ContainerStack: SuffixableContainer {
+    public func suffix(_ size: Int) -> ContainerStack {
+        var result = ContainerStack()
+        for index in (count-size)..<count {
+            result.append(self[index])
+        }
+        return result
+    }
+    // Inferred that Suffix is ContainerStack.
+}
+
+extension IntContainerStack: SuffixableContainer {
+    public func suffix(_ size: Int) -> ContainerStack<Int> {
+        var result = ContainerStack<Int>()
+        for index in (count-size)..<count {
+            result.append(self[index])
+        }
+        return result
+    }
+    // Inferred that Suffix is ContainerStack<Int>.
+}
+
+// Generic where clauses
+
+public func allItemsMatch<C1: Container, C2: Container>
+    (_ someContainer: C1, _ anotherContainer: C2) -> Bool
+    where C1.Item == C2.Item, C1.Item: Equatable {
+
+        // Check that both containers contain the same number of items.
+        if someContainer.count != anotherContainer.count {
+            return false
+        }
+
+        // Check each pair of items to see if they're equivalent.
+        for i in 0..<someContainer.count {
+            if someContainer[i] != anotherContainer[i] {
+                return false
+            }
+        }
+
+        // All items match, so return true.
+        return true
+}
+
+// Extension with generic where
+
+public extension Container where Item: Equatable {
+    func startsWith(_ item: Item) -> Bool {
+        return count >= 1 && self[0] == item
+    }
+}
+
+public extension Container where Item == Double {
+    func average() -> Double {
+        var sum = 0.0
+        for index in 0..<count {
+            sum += self[index]
+        }
+        return sum / Double(count)
+    }
+}
+
+// contextual where clauses
+
+public extension Container {
+    func average() -> Double where Item == Int {
+        var sum = 0.0
+        for index in 0..<count {
+            sum += Double(self[index])
+        }
+        return sum / Double(count)
+    }
+    func endsWith(_ item: Item) -> Bool where Item: Equatable {
+        return count >= 1 && self[count-1] == item
+    }
+}
+
+// Associated type with generic where clause
+
+public protocol ContainerAlt {
+    associatedtype Item
+    mutating func append(_ item: Item)
+    var count: Int { get }
+    subscript(i: Int) -> Item { get }
+
+    associatedtype Iterator: IteratorProtocol where Iterator.Element == Item
+    func makeIterator() -> Iterator
+}
+
+// Generic subscripts
+
+public extension Container {
+    subscript<Indices: Sequence>(indices: Indices) -> [Item]
+        where Indices.Iterator.Element == Int {
+            var result: [Item] = []
+            for index in indices {
+                result.append(self[index])
+            }
+            return result
+    }
+}
+
+// Opaque types
+
+public protocol Shape {
+    func draw() -> String
+}
+
+public struct Square: Shape {
+    public var size: Int
+    public func draw() -> String {
+        let line = String(repeating: "*", count: size)
+        let result = Array<String>(repeating: line, count: size)
+        return result.joined(separator: "\n")
+    }
+}
+
+public func makeTrapezoid() -> some Shape {
+    // Some more implementation stuff goes here
+    return Square(size: 2)
+}

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/InitializersTestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/InitializersTestFile.swifttxt
@@ -1,0 +1,38 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+public class InitializersTestClass {
+
+    // Throwing initializer
+
+    public init(withThrowable: String) throws {}
+
+    // Failable initializer
+
+    public init?(withFailable: String) {}
+}

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/OperatorTestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/OperatorTestFile.swifttxt
@@ -1,0 +1,90 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+// Custom Operator Methods
+
+public struct Vector2D {
+    public var x = 0.0, y = 0.0
+}
+
+public extension Vector2D {
+    static func + (left: Vector2D, right: Vector2D) -> Vector2D {
+        return Vector2D(x: left.x + right.x, y: left.y + right.y)
+    }
+}
+
+// Prefix operator extension
+
+public extension Vector2D {
+    static prefix func - (vector: Vector2D) -> Vector2D {
+        return Vector2D(x: -vector.x, y: -vector.y)
+    }
+}
+
+// Compound assignment operator
+
+public extension Vector2D {
+    static func += (left: inout Vector2D, right: Vector2D) {
+        left = left + right
+    }
+}
+
+// Equivalence operator
+
+extension Vector2D: Equatable {
+    public static func == (left: Vector2D, right: Vector2D) -> Bool {
+        return (left.x == right.x) && (left.y == right.y)
+    }
+}
+
+// Custom operator
+
+prefix operator +++
+public extension Vector2D {
+    static prefix func +++ (vector: inout Vector2D) -> Vector2D {
+        vector += vector
+        return vector
+    }
+}
+
+// Custom infix operator precedence
+
+infix operator +-: AdditionPrecedence
+public extension Vector2D {
+    static func +- (left: Vector2D, right: Vector2D) -> Vector2D {
+        return Vector2D(x: left.x + right.x, y: left.y - right.y)
+    }
+}
+
+// Custom precedence group
+
+precedencegroup CongruentPrecedence {
+    lowerThan: MultiplicationPrecedence
+    higherThan: AdditionPrecedence
+    associativity: left
+}

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/PrivateInternalTestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/PrivateInternalTestFile.swifttxt
@@ -1,0 +1,31 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+private struct _PrivateStruct {}
+internal struct _InternalStruct {}
+struct _ImplicitlyInternalStruct {}

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/PropertiesTestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/PropertiesTestFile.swifttxt
@@ -1,0 +1,59 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+public class PropertiesTestClass {
+
+    public var totalSteps: Int = 0 {
+        willSet(newTotalSteps) {
+            print("About to set totalSteps to \(newTotalSteps)")
+
+        }
+        didSet {
+            if totalSteps > oldValue  {
+                print("Added \(totalSteps - oldValue) steps")
+
+            }
+        }
+    }
+
+    public var someReadOnly: String {
+        return "test"
+    }
+
+    private var _secretValue: String = ""
+    public var someReadWrite: String {
+        get {
+            return "test"
+        }
+
+        set {
+            self._secretValue = newValue
+        }
+    }
+}
+

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/ProtocolTestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/ProtocolTestFile.swifttxt
@@ -1,0 +1,214 @@
+// --------------------------------------------------------------------------
+//
+// Copyright (c) Microsoft Corporation. All rights reserved.
+//
+// The MIT License (MIT)
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the ""Software""), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED *AS IS*, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+//
+// --------------------------------------------------------------------------
+
+import Foundation
+
+// Protocol with different get/set levels
+
+public protocol SomeProtocol {
+    var mustBeSettable: Int { get set }
+    var doesNotNeedToBeSettable: Int { get }
+}
+
+// Protocol with property requirements
+
+public protocol FullyNamed {
+    var fullName: String { get }
+}
+
+// Implementing protocol in declaration
+
+public struct Person: FullyNamed {
+    public var fullName: String
+}
+
+// Protocol with method requirements
+
+public protocol RandomNumberGenerator {
+    func random() -> Double
+}
+
+// Protocol with mutating function requirement
+
+public protocol Togglable {
+    mutating func toggle()
+}
+
+public enum OnOffSwitch: Togglable {
+    case off, on
+    public mutating func toggle() {
+        switch self {
+        case .off:
+            self = .on
+        case .on:
+            self = .off
+        }
+    }
+}
+
+// Protocol with initializer requirements
+
+public protocol SomeInitProtocol {
+    init(someParameter: Int)
+}
+
+// Class implementation of protocol requirement
+
+public class SomeClass: SomeInitProtocol {
+    public required init(someParameter: Int) {
+        // initializer implementation goes here
+    }
+}
+
+// Subclass overriding protocol and superclass initializer
+
+public protocol SomeOtherInitProtocol {
+    init()
+}
+
+open class SomeSuperClass {
+    public init() {
+        // initializer implementation goes here
+    }
+}
+
+public class SomeSubClass: SomeSuperClass, SomeOtherInitProtocol {
+    // "required" from SomeProtocol conformance; "override" from SomeSuperClass
+    public required override init() {
+        // initializer implementation goes here
+    }
+}
+
+// Protocol conformance with extension
+
+public class Dice {
+    public let sides: Int
+    public let generator: RandomNumberGenerator
+    public init(sides: Int, generator: RandomNumberGenerator) {
+        self.sides = sides
+        self.generator = generator
+    }
+    public func roll() -> Int {
+        return Int(generator.random() * Double(sides)) + 1
+    }
+}
+
+public protocol TextRepresentable {
+    var textualDescription: String { get }
+}
+
+extension Dice: TextRepresentable {
+    public var textualDescription: String {
+        return "A \(sides)-sided dice"
+    }
+}
+
+// Adding condition protocol conformance with extension
+
+extension Array: TextRepresentable where Element: TextRepresentable {
+    public var textualDescription: String {
+        let itemsAsText = self.map { $0.textualDescription }
+        return "[" + itemsAsText.joined(separator: ", ") + "]"
+    }
+}
+
+// Declaring protocol adoption with extension
+
+public struct Hamster {
+    public var name: String
+    public var textualDescription: String {
+        return "A hamster named \(name)"
+    }
+}
+extension Hamster: TextRepresentable {}
+
+// Protocol inheritance
+
+public protocol PrettyTextRepresentable: TextRepresentable {
+    var prettyTextualDescription: String { get }
+}
+
+// Class-only protocols
+
+public protocol SomeClassOnlyProtocol: AnyObject, TextRepresentable {
+    // class-only protocol definition goes here
+}
+
+public protocol SomeOtherClassOnlyProtocol: class, TextRepresentable {
+    // class-only protocol definition goes here
+}
+
+// Protocol composition
+
+public protocol Named {
+    var name: String { get }
+}
+public protocol Aged {
+    var age: Int { get }
+}
+public struct ComposedPerson: Named, Aged {
+    public var name: String
+    public var age: Int
+}
+public func wishHappyBirthday(to celebrator: Named & Aged) {
+    print("Happy birthday, \(celebrator.name), you're \(celebrator.age)!")
+}
+
+// Optional protocol requirements
+
+@objc public protocol CounterDataSource {
+    @objc optional func increment(forCount count: Int) -> Int
+    @objc optional var fixedIncrement: Int { get }
+}
+
+// Protocol extensions
+
+public extension RandomNumberGenerator {
+    func randomBool() -> Bool {
+        return random() > 0.5
+    }
+}
+
+// Providing default implementations of protocol with extension
+public extension PrettyTextRepresentable  {
+    var prettyTextualDescription: String {
+        return textualDescription
+    }
+}
+
+// Adding constraints to protocol extensions
+
+public extension Collection where Element: Equatable {
+    func allEqual() -> Bool {
+        for element in self {
+            if element != self.first {
+                return false
+            }
+        }
+        return true
+    }
+}
+

--- a/src/swift/SwiftAPIViewCore/Tests/TestFiles/SwiftUITestFile.swifttxt
+++ b/src/swift/SwiftAPIViewCore/Tests/TestFiles/SwiftUITestFile.swifttxt
@@ -25,45 +25,14 @@
 // --------------------------------------------------------------------------
 
 import Foundation
-import SwiftSyntax
+import SwiftUI
 
-enum SpacingKind {
-    /// Leading space
-    case Leading
-    /// Trailing space
-    case Trailing
-    /// Leading and trailing space
-    case Both
-    /// No spacing
-    case Neither
-    /// chomps any leading whitespace to the left
-    case TrimLeft
-}
+public class ViewBuilderExample {
+    public func testViewBuilder(@ViewBuilder content: () -> Content) {
+        self.content = content
+    }
 
-extension SwiftSyntax.TokenKind {
-    var spacing: SpacingKind {
-        switch self {
-        case .anyKeyword: return .Neither
-        case .nilKeyword: return .Neither
-        case .prefixPeriod: return .Leading
-        case .comma: return .Trailing
-        case .colon: return .Trailing
-        case .semicolon: return .Trailing
-        case .equal: return .Both
-        case .arrow: return .Both
-        case .postfixQuestionMark: return .TrimLeft
-        case .leftBrace: return .Leading
-        case .initKeyword: return .Leading
-        case .wildcardKeyword: return .Neither
-        case let .contextualKeyword(val):
-            switch val {
-            case "objc": return .TrimLeft
-            case "lowerThan", "higherThan", "associativity": return .Neither
-            case "available", "unavailable", "introduced", "deprecated", "obsoleted", "message", "renamed": return .Neither
-            default: return .Both
-            }
-        default:
-            return self.isKeyword ? .Both : .Neither
-        }
+    @ViewBuilder public func createView() -> some View {
+        return Button()
     }
 }


### PR DESCRIPTION
Previously these were only manual tests contained in a separate package. This organizes them as unit tests as a precursor to converting to the TreeToken model. 
