### PR TITLE
Don't try and sync .github/workflows to Rust yet

### DIFF
--- a/eng/pipelines/eng-workflows-sync.yml
+++ b/eng/pipelines/eng-workflows-sync.yml
@@ -22,7 +22,8 @@ parameters:
     - azure-sdk-for-js
     - azure-sdk-for-net
     - azure-sdk-for-python
-    - azure-sdk-for-rust
+# Add this back when Rust enables Check Enforcer and Actions and has .github/workflows directory
+#    - azure-sdk-for-rust
 
 trigger: none
 


### PR DESCRIPTION
The [azure-sdk-tools - sync - eng-workflows pipeline is failing](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4392109&view=logs&j=96791242-dbf3-587e-3a06-ae5af5c1a705&t=7d32c8b0-9463-5ee1-8584-402dd23c6c1c&l=63) because Rust was added to the list of repositories. At this time, Rust does not have a .github/workflows directory nor do they have CheckEnforcer or Actions enabled. Remove Rust from the list until they're ready to enable them both.