### PR TITLE
Resolve identified issue with crossplat get-prpackageproperties

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -188,7 +188,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     }
 
     foreach ($addition in $additionalValidationPackages) {
-        $key = $addition.Replace($RepoRoot, "").TrimStart('\/')
+        $key = $addition.Replace($RepoRoot, "").TrimStart('\/').Replace("\", "/")
 
         if ($lookup[$key]) {
             $lookup[$key].IncludedForValidation = $true


### PR DESCRIPTION
Within `Get-PrPkgProperties`, as we walk the list of discovered package properties, we grab the PkgDirectory path and save the pkgprop as an item in a hashmap.

During processing of `AdditionalPackagesForValidation` array, we check each item to see if it exists as a package in the lookup hashmap. If it is found, we add it to the set of packages to validate, with `IncludedForValidation` set to **true**.

I absolutely can handle this on the .NET side, but I'm adding this trim so that I don't get gotcha-ed on the next repo that adds this. (This was a dumb debug session)