### PR TITLE
Hotfix `test-proxy` Error Response

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
@@ -56,11 +56,11 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                     response.Headers.Append("x-request-known-exception", "true");
                     response.Headers.Append("x-request-known-exception-error", encodedException);
                 }
-                
+
                 var bodyObj = new
                 {
                     Message = e.Message,
-                    Status = e.StatusCode
+                    Status = e.StatusCode.ToString()
                 };
 
                 DebugLogger.LogError(e.Message);
@@ -85,7 +85,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 var bodyObj = new
                 {
                     Message = e.Message,
-                    Status = unexpectedStatusCode,
+                    Status = unexpectedStatusCode.ToString(),
                     StackTrace = e.StackTrace,
                 };
 

--- a/tools/test-proxy/typespec/main.tsp
+++ b/tools/test-proxy/typespec/main.tsp
@@ -16,7 +16,7 @@ model StartPayload {
 
 model CommonErrorResponse {
     Message: string;
-    Status: int32;
+    Status: string;
     StackTrace?: string;
     @header("x-request-exception") requestException: boolean;
     @header("x-request-exception-error") requestExceptionError: string;


### PR DESCRIPTION
This is actually a revert of the tiny change in #9451 

I don't want to deal with the API change for this release, as there are some `git exception` fixes that I want to get out into the wild in this version.

There are some unified breaking changes that I want to make to the test-proxy API that I'll work through later this month. Nothing _huge_, but some QoL and design fixes to make the API a bit more model driven, versus the organic growth that it's experienced so far.