### PR TITLE
MicrosoftDocs/AzureRestPreview's default branch is now main

### DIFF
--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -175,12 +175,9 @@ jobs:
             pwsh: true
             workingDirectory: $(System.DefaultWorkingDirectory)
             filePath: $(System.DefaultWorkingDirectory)/eng/common/scripts/Delete-RemoteBranches.ps1
-            # TODO: 00a0dc86-3419-4dd5-b119-e83edaf17e7e needs to be skipped because it's the default
-            # branch for the repository. This will be removed once the default branch has been changed
-            # to main
             arguments: >
               -RepoId "${{ repo }}"
-              -BranchRegex "^(result_)?(?!00a0dc86-3419-4dd5-b119-e83edaf17e7e)([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-)|(openapiHub_production_)|(openapiHub_preproduction_)[0-9a-z]{12}$"
+              -BranchRegex "^(result_)?([0-9a-z]{8}-[0-9a-z]{4}-[0-9a-z]{4}-[0-9a-z]{4}-)|(openapiHub_production_)|(openapiHub_preproduction_)[0-9a-z]{12}$"
               -LastCommitOlderThan ((Get-Date).AddDays(-14))
               -AuthToken $(azuresdk-github-pat)
               -WhatIf:$${{parameters.WhatIfPreference}}


### PR DESCRIPTION
The default branch of [MicrosoftDocs/AzureRestPreview](https://github.com/MicrosoftDocs/AzureRestPreview) used to be 00a0dc86-3419-4dd5-b119-e83edaf17e7e but was set to main on 12/11/2024. This removes regex exclusion for 00a0dc86-3419-4dd5-b119-e83edaf17e7e. The query was tested locally with WhatIf:$true and everything behaved as expected. When the branch cleanup runs next, it'll cleanup the 00a0dc86-3419-4dd5-b119-e83edaf17e7e branch.