### PR TITLE
Fix Windows Path Issue in js-sdk-release-tool

### DIFF
--- a/tools/js-sdk-release-tools/src/autoGenerateInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/autoGenerateInPipeline.ts
@@ -74,7 +74,7 @@ async function automationGenerateInPipeline(
 
             case SDKType.ModularClient: {
                 const typeSpecDirectory = path.posix.join(specFolder, typespecProject!);
-                const sdkRepoRoot = String(shell.pwd());
+                const sdkRepoRoot = String(shell.pwd()).replaceAll('\\', '/');
                 const skip = skipGeneration ?? false;
                 const repoUrl = repoHttpsUrl;
                 const options: ModularClientPackageOptions = {

--- a/tools/js-sdk-release-tools/src/common/ciYamlUtils.ts
+++ b/tools/js-sdk-release-tools/src/common/ciYamlUtils.ts
@@ -1,5 +1,5 @@
 import { NpmPackageInfo, VersionPolicyName } from './types';
-import { basename, join, posix, resolve } from 'path';
+import { posix } from 'path';
 import { getNpmPackageName, getNpmPackageSafeName } from './npmUtils';
 import { parse, stringify } from 'yaml';
 import { readFile, writeFile } from 'fs/promises';
@@ -98,7 +98,7 @@ async function createManagementPlaneCiYaml(
     npmPackageInfo: NpmPackageInfo
 ): Promise<void> {
     const artifact = getArtifact(npmPackageInfo);
-    const templatePath = join(__dirname, 'ciYamlTemplates/ci.mgmt.template.yml');
+    const templatePath = posix.join(__dirname, 'ciYamlTemplates/ci.mgmt.template.yml');
     const template = await readFile(templatePath, { encoding: 'utf-8' });
     const parsed = parse(template.toString());
     parsed.trigger.paths.include = [packageDirToSdkRoot, ciMgmtPath];
@@ -112,7 +112,7 @@ async function createManagementPlaneCiYaml(
 async function writeCiYaml(ciMgmtPath: string, config: any) {
     const content = comment + stringify(config);
     await writeFile(ciMgmtPath, content, { encoding: 'utf-8', flush: true });
-    logger.info(`Created Management CI file '${resolve(ciMgmtPath)}' with content: \n${content}`);
+    logger.info(`Created Management CI file '${posix.resolve(ciMgmtPath)}' with content: \n${content}`);
 }
 
 async function createOrUpdateDataPlaneCiYaml(

--- a/tools/js-sdk-release-tools/src/common/ciYamlUtils.ts
+++ b/tools/js-sdk-release-tools/src/common/ciYamlUtils.ts
@@ -82,7 +82,7 @@ async function updateManagementPlaneCiYaml(
     needUpdate = tryAddItemInArray(parsed.pr.paths.include, ciMgmtPath) || needUpdate;
     needUpdate = tryAddItemInArray(parsed.extends.parameters.Artifacts, artifact, artifactInclude) || needUpdate;
 
-    writeCiYaml(ciMgmtPath, parsed);
+    await writeCiYaml(ciMgmtPath, parsed);
 }
 
 function getArtifact(npmPackageInfo: NpmPackageInfo): ArtifactInfo {

--- a/tools/js-sdk-release-tools/src/mlc/clientGenerator/modularClientPackageGenerator.ts
+++ b/tools/js-sdk-release-tools/src/mlc/clientGenerator/modularClientPackageGenerator.ts
@@ -1,7 +1,7 @@
 import { ModularClientPackageOptions, NpmPackageInfo, PackageResult } from '../../common/types';
 import { buildPackage, createArtifact } from '../../common/rushUtils';
 import { initPackageResult, updateChangelogResult, updateNpmPackageResult } from '../../common/packageResultUtils';
-import { join, normalize, posix, relative } from 'node:path';
+import { posix } from 'node:path';
 
 import { createOrUpdateCiYaml } from '../../common/ciYamlUtils';
 import { generateChangelogAndBumpVersion } from '../../common/changlog/automaticGenerateChangeLogAndBumpVersion';
@@ -21,19 +21,19 @@ import unixify from 'unixify';
 export async function generateAzureSDKPackage(options: ModularClientPackageOptions): Promise<PackageResult> {
     logger.info(`Start to generate modular client package for azure-sdk-for-js.`);
     const packageResult = initPackageResult();
-    const rushScript = join(options.sdkRepoRoot, 'common/scripts/install-run-rush.js');
-    const rushxScript = join(options.sdkRepoRoot, 'common/scripts/install-run-rushx.js');
+    const rushScript = posix.join(options.sdkRepoRoot, 'common/scripts/install-run-rush.js');
+    const rushxScript = posix.join(options.sdkRepoRoot, 'common/scripts/install-run-rushx.js');
 
     try {
         const packageDirectory = await getGeneratedPackageDirectory(options.typeSpecDirectory, options.sdkRepoRoot);
-        const packageJsonPath = join(packageDirectory, 'package.json');
+        const packageJsonPath = posix.join(packageDirectory, 'package.json');
         let originalNpmPackageInfo: undefined | NpmPackageInfo;
         if (await exists(packageJsonPath)) originalNpmPackageInfo = await getNpmPackageInfo(packageDirectory);
 
         await remove(packageDirectory);
 
         await generateTypeScriptCodeFromTypeSpec(options, originalNpmPackageInfo?.version, packageDirectory);
-        const relativePackageDirToSdkRoot = relative(normalize(options.sdkRepoRoot), normalize(packageDirectory));
+        const relativePackageDirToSdkRoot = posix.relative(posix.normalize(options.sdkRepoRoot), posix.normalize(packageDirectory));
 
         await buildPackage(packageDirectory, options, packageResult, rushScript, rushxScript);
 


### PR DESCRIPTION
Bug: Falied to resolve correct path in windows
Fix: Use posix path as it is supported in all platforms