### PR TITLE
[TestProxy] Add auto-shutdown to the proxy

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/OptionsGenerator.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/OptionsGenerator.cs
@@ -56,7 +56,7 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
             universalOption.AddAlias("-u");
 
             var autoShutdownOption = new Option<int>(
-                name: "--shutdownInSeconds",
+                name: "--auto-shutdown-in-seconds",
                 description: "Integer argument; When provided, the proxy will auto-shutdown after not being contacted over any HTTP route for this number of seconds.",
                 getDefaultValue: () => -1);
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/OptionsGenerator.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/OptionsGenerator.cs
@@ -55,6 +55,11 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
                 getDefaultValue: () => false);
             universalOption.AddAlias("-u");
 
+            var autoShutdownOption = new Option<int>(
+                name: "--shutdownInSeconds",
+                description: "Integer argument; When provided, the proxy will auto-shutdown after not being contacted over any HTTP route for this number of seconds.",
+                getDefaultValue: () => -1);
+
             var breakGlassOption = new Option<bool>(
                 name: "--break-glass",
                 description: "Flag; Ignore secret push protection results when pushing.",
@@ -88,10 +93,11 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
             startCommand.AddOption(insecureOption);
             startCommand.AddOption(dumpOption);
             startCommand.AddOption(universalOption);
+            startCommand.AddOption(autoShutdownOption);
             startCommand.AddArgument(collectedArgs);
 
             startCommand.SetHandler(async (startOpts) => await callback(startOpts),
-                new StartOptionsBinder(storageLocationOption, storagePluginOption, insecureOption, dumpOption, universalOption, collectedArgs)
+                new StartOptionsBinder(storageLocationOption, storagePluginOption, insecureOption, dumpOption, universalOption, autoShutdownOption, collectedArgs)
             );
             root.Add(startCommand);
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/StartOptions.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/CommandOptions/StartOptions.cs
@@ -10,6 +10,8 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
         public bool Dump { get; set; }
         public bool UniversalOutput { get; set; }
 
+        public int AutoShutdownTime { get; set; }
+
         // On the command line, use -- and everything after that becomes arguments to Host.CreateDefaultBuilder
         // For example Test-Proxy start -i -d -- --urls https://localhost:8002 would set AdditionaArgs to a list containing
         // --urls and https://localhost:8002 as individual entries. This is converted to a string[] before being
@@ -23,15 +25,17 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
         private readonly Option<bool> _insecureOption;
         private readonly Option<bool> _dumpOption;
         private readonly Option<bool> _univeralOutputOption;
+        private readonly Option<int> _autoShutdownTime;
         private readonly Argument<string[]> _additionalArgs;
 
-        public StartOptionsBinder(Option<string> storageLocationOption, Option<string> storagePluginOption, Option<bool> insecureOption, Option<bool> dumpOption, Option<bool> universalOutput, Argument<string[]> additionalArgs)
+        public StartOptionsBinder(Option<string> storageLocationOption, Option<string> storagePluginOption, Option<bool> insecureOption, Option<bool> dumpOption, Option<bool> universalOutput, Option<int> autoShutdownTime, Argument<string[]> additionalArgs)
         {
             _storageLocationOption = storageLocationOption;
             _storagePluginOption = storagePluginOption;
             _insecureOption = insecureOption;
             _dumpOption = dumpOption;
             _univeralOutputOption = universalOutput;
+            _autoShutdownTime = autoShutdownTime;
             _additionalArgs = additionalArgs;
         }
 
@@ -43,6 +47,7 @@ namespace Azure.Sdk.Tools.TestProxy.CommandOptions
                 Insecure = bindingContext.ParseResult.GetValueForOption(_insecureOption),
                 Dump = bindingContext.ParseResult.GetValueForOption(_dumpOption),
                 UniversalOutput = bindingContext.ParseResult.GetValueForOption(_univeralOutputOption),
+                AutoShutdownTime = bindingContext.ParseResult.GetValueForOption(_autoShutdownTime),
                 AdditionalArgs = bindingContext.ParseResult.GetValueForArgument(_additionalArgs)
             };
     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AutoShutdown/ShutdownConfiguration.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AutoShutdown/ShutdownConfiguration.cs
@@ -1,0 +1,7 @@
+namespace Azure.Sdk.Tools.TestProxy.Common.AutoShutdown
+{
+    public class ShutdownConfiguration
+    {
+        public bool EnableAutoShutdown { get; set; } = false;
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AutoShutdown/ShutdownConfiguration.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AutoShutdown/ShutdownConfiguration.cs
@@ -3,5 +3,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common.AutoShutdown
     public class ShutdownConfiguration
     {
         public bool EnableAutoShutdown { get; set; } = false;
+        public int TimeoutInSeconds { get; set; } = 300;
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AutoShutdown/ShutdownTimer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AutoShutdown/ShutdownTimer.cs
@@ -6,13 +6,13 @@ namespace Azure.Sdk.Tools.TestProxy.Common.AutoShutdown
 {
     public class ShutdownTimer
     {
-        private readonly int _timeoutSeconds;
+        private readonly ShutdownConfiguration _shutdownConfig;
         private CancellationTokenSource _cts;
         private Task _shutdownTask;
 
-        public ShutdownTimer(int timeoutSeconds = 300)
+        public ShutdownTimer(ShutdownConfiguration shutdownConfiguration)
         {
-            _timeoutSeconds = timeoutSeconds;
+            _shutdownConfig = shutdownConfiguration;
         }
 
         public void ResetTimer()
@@ -24,21 +24,19 @@ namespace Azure.Sdk.Tools.TestProxy.Common.AutoShutdown
             {
                 try
                 {
-                    await Task.Delay(_timeoutSeconds * 1000, _cts.Token);
+                    await Task.Delay(_shutdownConfig.TimeoutInSeconds * 1000, _cts.Token);
 
-                    System.Console.WriteLine("Server idle timeout reached. Shutting down...");
-                    Environment.Exit(0);
+                    if (_shutdownConfig.EnableAutoShutdown)
+                    {
+                        System.Console.WriteLine("Server idle timeout reached. Shutting down...");
+                        Environment.Exit(0);
+                    }
                 }
                 catch (TaskCanceledException)
                 {
                     // Timer was reset or canceled
                 }
             });
-        }
-
-        public void StopTimer()
-        {
-            _cts?.Cancel();
         }
     }
 }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AutoShutdown/ShutdownTimer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AutoShutdown/ShutdownTimer.cs
@@ -1,0 +1,44 @@
+using System.Threading.Tasks;
+using System.Threading;
+using System;
+
+namespace Azure.Sdk.Tools.TestProxy.Common.AutoShutdown
+{
+    public class ShutdownTimer
+    {
+        private readonly int _timeoutSeconds;
+        private CancellationTokenSource _cts;
+        private Task _shutdownTask;
+
+        public ShutdownTimer(int timeoutSeconds = 300)
+        {
+            _timeoutSeconds = timeoutSeconds;
+        }
+
+        public void ResetTimer()
+        {
+            _cts?.Cancel();
+            _cts = new CancellationTokenSource();
+
+            _shutdownTask = Task.Run(async () =>
+            {
+                try
+                {
+                    await Task.Delay(_timeoutSeconds * 1000, _cts.Token);
+
+                    System.Console.WriteLine("Server idle timeout reached. Shutting down...");
+                    Environment.Exit(0);
+                }
+                catch (TaskCanceledException)
+                {
+                    // Timer was reset or canceled
+                }
+            });
+        }
+
+        public void StopTimer()
+        {
+            _cts?.Cancel();
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AutoShutdown/ShutdownTimerMiddleware.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/AutoShutdown/ShutdownTimerMiddleware.cs
@@ -1,0 +1,28 @@
+using Microsoft.AspNetCore.Http;
+using System.Threading.Tasks;
+
+namespace Azure.Sdk.Tools.TestProxy.Common.AutoShutdown
+{
+    public class ShutdownTimerMiddleware
+    {
+        private readonly RequestDelegate _next;
+        private readonly ShutdownTimer _shutdownTimer;
+        private readonly ShutdownConfiguration _shutdownConfig;
+
+        public ShutdownTimerMiddleware(RequestDelegate next, ShutdownTimer shutdownTimer, ShutdownConfiguration shutdownConfig)
+        {
+            _next = next;
+            _shutdownTimer = shutdownTimer;
+            _shutdownConfig = shutdownConfig;
+        }
+
+        public async Task InvokeAsync(HttpContext context)
+        {
+            if (_shutdownConfig.EnableAutoShutdown)
+            {
+                _shutdownTimer.ResetTimer();
+            }
+            await _next(context);
+        }
+    }
+}

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Startup.cs
@@ -150,7 +150,6 @@ namespace Azure.Sdk.Tools.TestProxy
 
             var host = Host.CreateDefaultBuilder((startOptions.AdditionalArgs??new string[] { }).ToArray());
             
-
             host.ConfigureWebHostDefaults(
                 builder =>
                     builder.UseStartup<Startup>()
@@ -187,6 +186,7 @@ namespace Azure.Sdk.Tools.TestProxy
             if (startOptions.AutoShutdownTime > -1)
             {
                 shutdownService.EnableAutoShutdown = true;
+                shutdownService.TimeoutInSeconds = startOptions.AutoShutdownTime;
                 // start the first iteration of the shutdown timer
                 app.Services.GetRequiredService<ShutdownTimer>().ResetTimer();
             }


### PR DESCRIPTION
Resolves #9467 

If a user provides `--auto-shutdown-in-seconds` to the proxy, the proxy will automatically shut down after the specified number of seconds if any route isn't contacted. We reset this on _any_ handled request via middleware, so we should have 100% coverage.
