### PR TITLE
Revert global.json to net8

### DIFF
--- a/global.json
+++ b/global.json
@@ -3,7 +3,7 @@
     "Microsoft.Build.Traversal": "3.2.0"
   },
   "sdk": {
-    "version": "9.0.101",
+    "version": "8.0.302",
     "rollForward": "feature"
   }
 }

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Azure.Sdk.Tools.PerfAutomation.csproj
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Azure.Sdk.Tools.PerfAutomation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
 
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>

--- a/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Azure.Sdk.Tools.PerfAutomation.csproj
+++ b/tools/perf-automation/Azure.Sdk.Tools.PerfAutomation/Azure.Sdk.Tools.PerfAutomation.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
 
     <OutputType>Exe</OutputType>
     <PackAsTool>true</PackAsTool>


### PR DESCRIPTION
Fixes failures we're seeing in the perf pipelines, e.g. https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4420526&view=logs&j=42ded549-05ee-5cdb-7ba7-7a948a0cc056&t=b938c548-640d-5101-7a83-c666c2d131df