### PR TITLE
Don't invoke `prepare-pipelines` for `CI` convention for `js`, `python`

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/Program.cs
@@ -17,6 +17,7 @@ namespace PipelineGenerator
 {
     public class Program
     {
+        public static string[] DisallowedCIRepositories = ["azure/azure-sdk-for-python", "azure/azure-sdk-for-js"];
         public static async Task Main(string[] args)
         {
             var cancellationTokenSource = new CancellationTokenSource();
@@ -168,6 +169,12 @@ namespace PipelineGenerator
                     setManagedVariables,
                     overwriteTriggers
                     );
+
+                if (convention.ToLower() == "ci" && DisallowedCIRepositories.Contains(repository.ToLower()))
+                {
+                    logger.LogWarning($"The pullrequest convention has been disabled for the repository '{repository}'.");
+                    return ExitCondition.Success;
+                }
 
                 var pipelineConvention = GetPipelineConvention(convention, context);
                 var components = ScanForComponents(path, pipelineConvention.SearchPattern);


### PR DESCRIPTION
An alternative to implementing it this way is to make the `disallowed` repositories arguments to the tool. EG:

`--disallowed "azure/azure-sdk-for-js,azure/azure-sdk-for-python"`

And then we split this input, and use it the same way that we're using the hardcoded values. Figured I'd do the extremely easy first, and prompt opinions from @weshaggard  and @benbp based on this simple version.