### PR TITLE
Fix Migration Command Failure

### DIFF
--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.7.17",
+  "version": "2.7.18",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/src/common/migration.ts
+++ b/tools/js-sdk-release-tools/src/common/migration.ts
@@ -11,7 +11,7 @@ export async function migratePackage(packageDirectory: string): Promise<void> {
     await ensureDir(posix.join(packageDirectory, 'review'));
     await runCommand(
         "npm",
-        `exec dev-tool admin migrate-package --package-name=${info.name}`.split(
+        `exec dev-tool admin migrate-package --package-name="${info.name}"`.split(
             " "
         ),
         {

--- a/tools/js-sdk-release-tools/src/common/migration.ts
+++ b/tools/js-sdk-release-tools/src/common/migration.ts
@@ -10,7 +10,7 @@ export async function migratePackage(packageDirectory: string): Promise<void> {
     // Note: bug in migration tool: failed to create review directory
     await ensureDir(posix.join(packageDirectory, 'review'));
     await runCommand(
-        "pnpm",
+        "npm",
         `exec dev-tool admin migrate-package --package-name=${info.name}`.split(
             " "
         ),

--- a/tools/js-sdk-release-tools/src/common/migration.ts
+++ b/tools/js-sdk-release-tools/src/common/migration.ts
@@ -11,7 +11,7 @@ export async function migratePackage(packageDirectory: string): Promise<void> {
     await ensureDir(posix.join(packageDirectory, 'review'));
     await runCommand(
         "npm",
-        `exec dev-tool admin migrate-package --package-name="${info.name}"`.split(
+        `exec -- dev-tool admin migrate-package --package-name=${info.name}`.split(
             " "
         ),
         {


### PR DESCRIPTION
Root Cause: use `pnpm` which is not available in pipeline
Solution: Use `npm` instead
Test: (Migration Success) https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4455904&view=logs&j=47092895-c7c8-567a-c7a6-8c88f3ec178e&t=d293a8e8-c6af-5091-cdf7-4c66482dd6f2&l=2020