### PR TITLE
Update Test-Proxy install instructions

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -86,18 +86,18 @@ For a more detailed explanation of how the test proxy works, along with links to
 
 ### Via Local Compile or .NET
 
-1. [Install .NET 5.0 or 6.0](https://dotnet.microsoft.com/download)
-2. Install test-proxy
+1. [Install .NET 8.0 (LTS) or 9.0](https://dotnet.microsoft.com/download)
+2. Install or update test-proxy
 
 ```powershell
-dotnet tool update azure.sdk.tools.testproxy --global --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json --version "1.0.0-dev*" --ignore-failed-sources
+dotnet tool update azure.sdk.tools.testproxy --global --prerelease --add-source https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json --ignore-failed-sources
 ```
 
 The test-proxy is also available from the [azure-sdk-for-net public feed](https://dev.azure.com/azure-sdk/public/_artifacts/feed/azure-sdk-for-net)
 
 _Note: if you're not authorized to access these feeds, make sure you have [Azure Artifacts Credential Provider](https://github.com/microsoft/artifacts-credprovider) installed. You can also [download executable](#via-standalone-executable)._
 
-To uninstall an existing test-proxy
+To uninstall an existing test-proxy:
 
 ```powershell
 dotnet tool uninstall --global azure.sdk.tools.testproxy


### PR DESCRIPTION
Update to modern .NET recommendation, and simplify instructions with the `--prerelease` switch I asked for and was implemented a couple years ago.