### PR TITLE
Fix `test-proxy` integration tests for .NET

### DIFF
--- a/tools/test-proxy/tests.yml
+++ b/tools/test-proxy/tests.yml
@@ -174,6 +174,12 @@ stages:
           inputs:
             version: "7.x"
 
+        - task: UseDotNet@2
+          displayName: "Install .NET 6"
+          retryCountOnTaskFailure: 3
+          inputs:
+            version: "6.x"
+
         - template: /eng/pipelines/templates/steps/install-dotnet.yml
 
         - pwsh: |

--- a/tools/test-proxy/tests.yml
+++ b/tools/test-proxy/tests.yml
@@ -5,6 +5,7 @@ variables:
 
 stages:
   - stage: IntegrationTests
+    condition: false
     displayName: "Asset Sync Integration Tests"
     jobs:
     - job: Solution_Integration_Test
@@ -84,6 +85,7 @@ stages:
     jobs:
     - job: Test_JS_Utils
 
+      condition: false
       displayName: Invoke JS Utils CI Tests
 
       strategy:
@@ -204,6 +206,7 @@ stages:
       displayName: Run Python Tables CI Tests
 
 
+      condition: false
       strategy:
         matrix:
           Windows:

--- a/tools/test-proxy/tests.yml
+++ b/tools/test-proxy/tests.yml
@@ -5,7 +5,6 @@ variables:
 
 stages:
   - stage: IntegrationTests
-    condition: false
     displayName: "Asset Sync Integration Tests"
     jobs:
     - job: Solution_Integration_Test
@@ -85,7 +84,6 @@ stages:
     jobs:
     - job: Test_JS_Utils
 
-      condition: false
       displayName: Invoke JS Utils CI Tests
 
       strategy:
@@ -206,7 +204,6 @@ stages:
       displayName: Run Python Tables CI Tests
 
 
-      condition: false
       strategy:
         matrix:
           Windows:


### PR DESCRIPTION
.NET 6.0 isn't on the machines (this change occurred early/mid December), so this should get it off the floor. I want clean nightly livetests if possible 👍 

[Proving Build](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4461356&view=logs&j=bf74e942-6840-5835-1ce0-37a6d60262e3) (ignore skipped jobs I deliberately `condition: false`-d working steps to avoid agent wastage.)