### PR TITLE
Add trivial comment to test sync propagation

### DIFF
--- a/eng/common/spelling/package-lock.json
+++ b/eng/common/spelling/package-lock.json
@@ -1,4 +1,5 @@
 {
+  "//comment": "edit package-lock.json to test edit propagations to other repos...",
   "name": "cspell-version-pin",
   "version": "0.1.1",
   "lockfileVersion": 2,


### PR DESCRIPTION
Testing propagation of a `.gitignore`'d file in the `azure-sdk-rest-api-specs` repo.. Creaiton doesn't seem to work but some local testing showed that updates DO work. 