### PR TITLE
Add `--update` option to `tsp-client compare`

### DIFF
--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@autorest/core": "^3.10.2",
         "@autorest/openapi-to-typespec": "0.10.5",
-        "@azure-tools/rest-api-diff": ">=0.1.0 <1.0.0",
+        "@azure-tools/rest-api-diff": "^0.1.8",
         "@azure-tools/typespec-autorest": ">=0.44.0 <1.0.0",
         "@azure/core-rest-pipeline": "^1.12.0",
         "@types/yargs": "^17.0.32",
@@ -395,12 +395,12 @@
       }
     },
     "node_modules/@azure-tools/rest-api-diff": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/rest-api-diff/-/rest-api-diff-0.1.0.tgz",
-      "integrity": "sha512-BWE31Q5mq6kMCR0VX5VVZ/99M4p63RO/GpLBs0FFpY3wG9asX9KOnRBBoT3dR64ceQK5pYI7trd8O5oWglRs7w==",
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/@azure-tools/rest-api-diff/-/rest-api-diff-0.1.8.tgz",
+      "integrity": "sha512-P44zSxUjmaz+/l9pWDDmHtTRga4mv+rG5TIFTqCuI39JwdLvPTDHZvcMgAhMMyE+fcL4MTTeRx0IJkZk8ovZlg==",
       "dependencies": {
-        "@azure-tools/typespec-autorest": "0.43.0",
-        "@azure-tools/typespec-azure-core": "0.43.0",
+        "@azure-tools/typespec-autorest": ">=0.44.0, <1.0.0",
+        "@azure-tools/typespec-azure-core": ">=0.44.0, <1.0.0",
         "acorn": "^8.12.0",
         "acorn-walk": "^8.3.3",
         "arg": "^4.1.3",
@@ -414,174 +414,11 @@
         "yargs": "^17.7.2",
         "yn": "^3.1.1"
       },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/@azure-tools/typespec-autorest": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-autorest/-/typespec-autorest-0.43.0.tgz",
-      "integrity": "sha512-tZ9uXXOdxu2y01W9n3mzXf+IEY2MQkP/JaQaKlcOx2+dbklHNQWSDU0Vm6Gmm6l//XiF9QiI8653BiuO97czyw==",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.43.0",
-        "@azure-tools/typespec-azure-resource-manager": "~0.43.0",
-        "@azure-tools/typespec-client-generator-core": "~0.43.0",
-        "@typespec/compiler": "~0.57.0",
-        "@typespec/http": "~0.57.0",
-        "@typespec/openapi": "~0.57.0",
-        "@typespec/rest": "~0.57.0",
-        "@typespec/versioning": "~0.57.0"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.43.0.tgz",
-      "integrity": "sha512-B1r0i3segJ7RuNXxcAMBy8H2t+jTkaf74dkyUWD0HIFPkhETN0uR59nuor+s+LoLU8yI4JypOFSNZt6e1rod8w==",
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@typespec/compiler": "~0.57.0",
-        "@typespec/http": "~0.57.0",
-        "@typespec/rest": "~0.57.0"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/@azure-tools/typespec-azure-resource-manager": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.43.0.tgz",
-      "integrity": "sha512-0GQL+/o1u+PAB63FpYz3sy3ZgZvCtk5T4sDAnICnV23v2YWIONDMUfxxd0x40xJbY6PkcwwHDpBLNMqajf2H6A==",
-      "peer": true,
-      "dependencies": {
-        "change-case": "~5.4.4",
-        "pluralize": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.43.0",
-        "@typespec/compiler": "~0.57.0",
-        "@typespec/http": "~0.57.0",
-        "@typespec/openapi": "~0.57.0",
-        "@typespec/rest": "~0.57.0",
-        "@typespec/versioning": "~0.57.0"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.43.2",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.43.2.tgz",
-      "integrity": "sha512-UAVV30BtTQBiXmBoQ3SyvmiuBDYoqWFIn7G96hjojpwXpE6D5ba0y5LascMuF1b65eAhGnnf974DElJE9DGepQ==",
-      "peer": true,
-      "dependencies": {
-        "change-case": "~5.4.4",
-        "pluralize": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "~0.43.0",
-        "@typespec/compiler": "~0.57.0",
-        "@typespec/http": "~0.57.0",
-        "@typespec/rest": "~0.57.0",
-        "@typespec/versioning": "~0.57.0"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/@typespec/compiler": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.57.0.tgz",
-      "integrity": "sha512-Z5L7J90Ol21IbzU+rBD2wzKy2vJ2Yg2FIzi+yB5rtb7/c4oBea/CgEByMVHBtT7uw45ZXJpHOiepuGSPVXw2EA==",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "~7.24.2",
-        "ajv": "~8.13.0",
-        "change-case": "~5.4.4",
-        "globby": "~14.0.1",
-        "mustache": "~4.2.0",
-        "picocolors": "~1.0.1",
-        "prettier": "~3.2.5",
-        "prompts": "~2.4.2",
-        "semver": "^7.6.2",
-        "vscode-languageserver": "~9.0.1",
-        "vscode-languageserver-textdocument": "~1.0.11",
-        "yaml": "~2.4.2",
-        "yargs": "~17.7.2"
-      },
       "bin": {
-        "tsp": "cmd/tsp.js",
-        "tsp-server": "cmd/tsp-server.js"
+        "rest-api-diff": "cmd/rest-api-diff.js"
       },
       "engines": {
         "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/@typespec/http": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.57.0.tgz",
-      "integrity": "sha512-k3bWOTPNqlRB3/TmrXVBtObmxj2J20l2FnhGXvs+tjdtbXLxCQWmvQz6xlne9nkLAtWVB/pQRUn+oMJfhWta3w==",
-      "peer": true,
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@typespec/compiler": "~0.57.0"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/@typespec/openapi": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.57.0.tgz",
-      "integrity": "sha512-35wK/BqjOXSlhWuGMwoYN3FSgIYFOKtw8ot4ErcgmxAGuKaS2GkUhZvtQJXUn2ByU0Fl4jqslPmTz8SEcz7rbw==",
-      "peer": true,
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@typespec/compiler": "~0.57.0",
-        "@typespec/http": "~0.57.0"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/@typespec/rest": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.57.0.tgz",
-      "integrity": "sha512-mZj76Kf+cmH38pYA6LT8Zz7QjuR3fdQo5bc8pXhKMwLq9vRqNLz6Z9InbOeo8zY+xP0GfUwEU9kXczmCc8gyRA==",
-      "peer": true,
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@typespec/compiler": "~0.57.0",
-        "@typespec/http": "~0.57.0"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/@typespec/versioning": {
-      "version": "0.57.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.57.0.tgz",
-      "integrity": "sha512-kk6zCNSwcqqYB9isNNagTy+Zv6wEIRA4NkcZ/X1riTj2zhJwKsIFNXQWm1yxpZn+BY4+1QtuaQHuBLo8HbgR/w==",
-      "peer": true,
-      "engines": {
-        "node": ">=18.0.0"
-      },
-      "peerDependencies": {
-        "@typespec/compiler": "~0.57.0"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/ajv": {
-      "version": "8.13.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
-      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
-      "peer": true,
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2",
-        "uri-js": "^4.4.1"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
       }
     },
     "node_modules/@azure-tools/rest-api-diff/node_modules/diff": {
@@ -590,33 +427,6 @@
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/prettier": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-      "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
-      "peer": true,
-      "bin": {
-        "prettier": "bin/prettier.cjs"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/@azure-tools/rest-api-diff/node_modules/yaml": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.4.5.tgz",
-      "integrity": "sha512-aBx2bnqDzVOyNKfsysjA2ms5ZlnjSAW2eG3/L5G/CSujfjLJTJsEw1bGw8kCf04KodQWk1pxlGnZ56CRxiawmg==",
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/@azure-tools/tasks": {
@@ -649,7 +459,6 @@
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.44.0.tgz",
       "integrity": "sha512-d11QK2v5fOZH8YUqf42FsqHEirKCHzeKFq4Uo/51BXCXmJJahsTaFMAG2M0GoJe8tmTHeMijStnVMfzcGNqCAA==",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       },

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@autorest/core": "^3.10.2",
     "@autorest/openapi-to-typespec": "0.10.5",
-    "@azure-tools/rest-api-diff": ">=0.1.0 <1.0.0",
+    "@azure-tools/rest-api-diff": "^0.1.8",
     "@azure-tools/typespec-autorest": ">=0.44.0 <1.0.0",
     "@azure/core-rest-pipeline": "^1.12.0",
     "@types/yargs": "^17.0.32",

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -237,7 +237,13 @@ const parser = yargs(hideBin(process.argv))
     "compare",
     "Compare two Swaggers for functional equivalency. This is typically used to compare a source Swagger with a TypeSpec project or TypeSpec generated Swagger to ensure that the TypeSpec project is functionally equivalent to the source Swagger.",
     (yargs: any) => {
-      return yargs.help(false);
+      return yargs
+        .option("update", {
+            type: "boolean",
+            description: "Update `@azure-tools/rest-api-diff` to the latest version.",
+            default: false,
+        })
+        .help(false);
     },
     async (argv: any) => {
       argv["output-dir"] = resolveOutputDir(argv);


### PR DESCRIPTION
Fixes #9498. 

This PR adds a hidden `--update` flag to `tsp-client compare` to allow for easily updating the wrapped version of `@azure-tools/rest-api-diff` in-place without having to uninstall and reinstall `tsp-client`. Because the option is hidden, the command will always end with a message describing the ability to update the command. 

This tool is under active development. If you experience issues or have questions, please contact Travis Prescott direct
ly (trpresco@microsoft.com). [Tool version: 0.1.8]
**Use `tsp-client compare --update` to update @azure-tools/rest-api-diff to the latest version**

**TODO**
- [ ] bump version
- [ ] verify this works when run in a non-dev setting