### PR TITLE
Fix for overaggressive inclusion in `Get-PrPackageProperties`

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -173,7 +173,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
 
         foreach ($file in $targetedFiles) {
             $filePath = (Join-Path $RepoRoot $file)
-            $shouldInclude = $filePath -like "$pkgDirectory*"
+            $shouldInclude = $filePath -like (Join-Path "$pkgDirectory" "*")
             if ($shouldInclude) {
                 $packagesWithChanges += $pkg
 


### PR DESCRIPTION
The example I'll use. When we feed this as the file change:  `sdk/keyvault/azure-keyvault-keys/pyproject.toml`

We will match this to `azure-keyvault` AND `azure-keyvault-keys` packages. This change ensures a full match.