### PR TITLE
Fix broken link to Learn docs

### DIFF
--- a/eng/common/scripts/Test-SampleMetadata.ps1
+++ b/eng/common/scripts/Test-SampleMetadata.ps1
@@ -73,7 +73,7 @@ process {
 
                 Write-Error "File '$($file.FullName)' contains invalid product slug: $product" -TargetObject $file `
                     -Category InvalidData -CategoryTargetName $product -CategoryTargetType string `
-                    -RecommendedAction 'Use only product slugs listed at https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=main#product'
+                    -RecommendedAction 'Use only product slugs listed at https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main#product'
             }
         }
 
@@ -95,7 +95,7 @@ end {
 }
 
 begin {
-    # https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=main#product
+    # https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main#product
     $productSlugs = @(
         "ai-builder",
         "aspnet",
@@ -509,7 +509,7 @@ Checks sample markdown files' frontmatter for invalid information.
 .DESCRIPTION
 Given a collection of markdown files, their frontmatter - if present - is checked for invalid information, including:
 
-Invalid product slugs, i.e. those not listed in https://review.docs.microsoft.com/help/contribute/metadata-taxonomies?branch=main#product.
+Invalid product slugs, i.e. those not listed in https://review.learn.microsoft.com/help/platform/metadata-taxonomies?branch=main#product.
 
 .PARAMETER Path
 Specifies the path to an item to search. Wildcards are permitted.


### PR DESCRIPTION
Resolves broken link references that were discovered in Python's nightly link checker: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4466891&view=logs&j=09cf8b18-32ff-5ace-942c-480825d4e4bd&t=038ef773-2c87-526e-5636-46093602ba59