### PR TITLE
Ensure that packages that are both changed AND part of the AdditionalValidationPackages set are handled properly

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -187,7 +187,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
         }
     }
 
-    $existingPackageNames = $packagesWithChanges | ForEach-Object { $_.Name }
+    $existingPackageNames = @($packagesWithChanges | ForEach-Object { $_.Name })
     foreach ($addition in $additionalValidationPackages) {
         $key = $addition.Replace($RepoRoot, "").TrimStart('\/')
 

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -187,12 +187,17 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
         }
     }
 
+    $existingPackageNames = $packagesWithChanges | ForEach-Object { $_.Name }
     foreach ($addition in $additionalValidationPackages) {
         $key = $addition.Replace($RepoRoot, "").TrimStart('\/')
 
         if ($lookup[$key]) {
-            $lookup[$key].IncludedForValidation = $true
-            $packagesWithChanges += $lookup[$key]
+            $pkg = $lookup[$key]
+
+            if ($pkg.Name -notin $existingPackageNames) {
+                $pkg.IncludedForValidation = $true
+                $packagesWithChanges += $pkg
+            }
         }
     }
 


### PR DESCRIPTION
The issue this PR is resolving is highlighted [in this pr step](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4473778&view=logs&j=b70e5e73-bbb6-5567-0939-8415943fadb9&t=2102385d-609d-5572-64d2-932661c7902f&l=91)

Note that we're saying

> for this stage, only look at the `indirect` included packages

However, due to the order of operations, we resolve the set of `direct` changed packages _first_, then we walk each of them checking to see if there are additional packages that they should also include if they are changed. In the example PR above, we directly changed `azure-core-opencensus`, but because it was _also_ an `additionalValidationPackage` for `azure-core`, it was getting marked as an `indirect` package. This PR fixes our logic so that if a package is directly changed, we always count is as such, instead of accidentally overriding and claiming it is an `includedForValidation` package.