### PR TITLE
Filter out Exclude Paths for PR Pipelines

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -14,6 +14,9 @@ parameters:
   - name: ScriptDirectory
     type: string
     default: eng/common/scripts
+  - name: ExcludePaths
+    type: object
+    default: []
 
 steps:
   # There will be transitory period for every language repo where the <language> - pullrequest build definition will run
@@ -26,10 +29,12 @@ steps:
       - task: Powershell@2
         displayName: Generate PR Diff
         inputs:
-          filePath: ${{ parameters.ScriptDirectory }}/Generate-PR-Diff.ps1
-          arguments: >
+          targetType: inline
+          script: >
+            ${{ parameters.ScriptDirectory }}/Generate-PR-Diff.ps1
             -TargetPath '${{ parameters.TargetPath }}'
             -ArtifactPath '${{ parameters.DiffDirectory }}'
+            -ExcludePaths ('${{ convertToJson(parameters.ExcludePaths) }}' | convertFrom-Json)
           pwsh: true
 
       # When running in PR mode, we want the detected changed services to be attached to the build as tags.

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -34,7 +34,7 @@ steps:
             ${{ parameters.ScriptDirectory }}/Generate-PR-Diff.ps1
             -TargetPath '${{ parameters.TargetPath }}'
             -ArtifactPath '${{ parameters.DiffDirectory }}'
-            -ExcludePaths ('${{ convertToJson(parameters.ExcludePaths) }}' | convertFrom-Json)
+            -ExcludePaths ('${{ convertToJson(parameters.ExcludePaths) }}' | ConvertFrom-Json)
           pwsh: true
 
       # When running in PR mode, we want the detected changed services to be attached to the build as tags.

--- a/eng/common/scripts/Generate-PR-Diff.ps1
+++ b/eng/common/scripts/Generate-PR-Diff.ps1
@@ -16,7 +16,10 @@ Param (
   [Parameter(Mandatory = $True)]
   [string] $ArtifactPath,
   [Parameter(Mandatory = $True)]
-  [string] $TargetPath
+  [string] $TargetPath,
+  [Parameter(Mandatory=$false)]
+  [AllowEmptyCollection()]
+  [array] $ExcludePaths
 )
 
 . (Join-Path $PSScriptRoot "Helpers" "git-helpers.ps1")
@@ -45,13 +48,21 @@ $changedFiles = @()
 $changedServices = @()
 
 $changedFiles = Get-ChangedFiles -DiffPath $TargetPath
+
 if ($changedFiles) {
   $changedServices = Get-ChangedServices -ChangedFiles $changedFiles
 }
 
+# ExcludePaths is an object array with the default of [] which evaluates to null.
+# If the value is null, set it to empty list to ensure that the empty list is
+# stored in the json
+if (-not $ExcludePaths) {
+  $ExcludePaths = @()
+}
 $result = [PSCustomObject]@{
   "ChangedFiles"    = $changedFiles
   "ChangedServices" = $changedServices
+  "ExcludePaths"    = $ExcludePaths
   "PRNumber"        = if ($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER) { $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER } else { "-1" }
 }
 

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -167,8 +167,9 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     # slashes "/". The ExcludePaths need to have a trailing slash added in order
     # correctly test for string matches without overmatching. For example, if a pr
     # had files sdk/foo/file1 and sdk/foobar/file2 with the exclude of anything in
-    # sdk/foo, it should only exclude things under sdk/foo.
-    $excludePaths = $diff.ExcludePaths | ForEach-Object { $_ + "/" }
+    # sdk/foo, it should only exclude things under sdk/foo. The TrimEnd is just in
+    # case one of the paths ends with a slash, it doesn't add a second one.
+    $excludePaths = $diff.ExcludePaths | ForEach-Object { $_.TrimEnd("/") + "/" }
 
     $additionalValidationPackages = @()
     $lookup = @{}


### PR DESCRIPTION
@scbedd and @weshaggard 

These are the common changes required to filter out PackageInfo generation by what should be excluded from the pull request pipelines. This is the example in [Python](https://github.com/Azure/azure-sdk-for-python/blob/main/sdk/pullrequest.yml#L14), which excludes `sdk/cosmos`. The unfortunate thing here is that we can't access the pr->paths->exclude meaning this needs to be duplicated. Because of the default in the save-package-properties.yml nothing will break if the ExcludePaths aren't plumbed through. The only downside here is that wildcards aren't accepted but then again, most excludes in yml files aren't wildcarded.

I'd created a [draft PR in Python to test these changes](https://github.com/Azure/azure-sdk-for-python/pull/39185). Notice that the PR had changes in Cosmos and Template. This is the [test run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4476971&view=results) and if you notice, Cosmos no longer has a [PackageInfo](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4476971&view=artifacts&pathAsName=false&type=publishedArtifacts) file in the artifacts and it's [no longer running tests for azure-cosmos](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4476971&view=logs&j=418474da-bc95-5d2e-443a-6890a46f19ae&t=eb9aa47d-4807-5236-0326-10d69778a3ce&l=64) in the pullrequest pipeline. The diff.json for the PR is below which correctly has ExcludePaths.

```
{
  "ChangedFiles": [
    "eng/common/pipelines/templates/steps/save-package-properties.yml",
    "eng/common/scripts/Generate-PR-Diff.ps1",
    "eng/common/scripts/Package-Properties.ps1",
    "eng/pipelines/templates/jobs/ci.yml",
    "eng/pipelines/templates/stages/archetype-sdk-client.yml",
    "eng/pipelines/templates/steps/build-package-artifacts.yml",
    "sdk/cosmos/azure-cosmos/README.md",
    "sdk/pullrequest.yml",
    "sdk/template/azure-template/README.md"
  ],
  "ChangedServices": [
    "cosmos",
    "pullrequest.yml",
    "template"
  ],
  "ExcludePaths": [
    "sdk/cosmos"
  ],
  "PRNumber": "39185"
}
```
Last but not least, the test PR in Python also shows where ExcludePaths would have to be plumbed through. Once this gets reviewed and pushed out to the repositories, I'll end up making those changes in Python. For Java, we'll have more excludes, mostly for Track1 libraries, Cosmos, resourcemanagerhybrid and possibly Spring.

Fixes #9634
