### PR TITLE
handle only deleted files in a <language> - pullrequest build

### DIFF
--- a/eng/common/scripts/Generate-PR-Diff.ps1
+++ b/eng/common/scripts/Generate-PR-Diff.ps1
@@ -48,6 +48,7 @@ $changedFiles = @()
 $changedServices = @()
 
 $changedFiles = Get-ChangedFiles -DiffPath $TargetPath
+$deletedFiles = Get-ChangedFiles -DiffPath $TargetPath -DiffFilterType "D"
 
 if ($changedFiles) {
   $changedServices = Get-ChangedServices -ChangedFiles $changedFiles
@@ -63,6 +64,7 @@ $result = [PSCustomObject]@{
   "ChangedFiles"    = $changedFiles
   "ChangedServices" = $changedServices
   "ExcludePaths"    = $ExcludePaths
+  "DeletedFiles"    = $deletedFiles
   "PRNumber"        = if ($env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER) { $env:SYSTEM_PULLREQUEST_PULLREQUESTNUMBER } else { "-1" }
 }
 

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -162,6 +162,14 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     $allPackageProperties = Get-AllPkgProperties
     $diff = Get-Content $InputDiffJson | ConvertFrom-Json
     $targetedFiles = $diff.ChangedFiles
+
+    if ($diff.DeletedFiles) {
+        if (-not $targetedFiles) {
+            $targetedFiles = @()
+        }
+        $targetedFiles += $diff.DeletedFiles
+    }
+
     # The exclude paths and the targeted files paths aren't full OS paths, they're
     # GitHub paths meaning they're relative to the repo root and slashes are forward
     # slashes "/". The ExcludePaths need to have a trailing slash added in order


### PR DESCRIPTION
[In action](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4488546&view=results)

I think the only real discussion item here is whether to fold the deleted files directly under `ChangedFiles`. I prefer it to be separate, as we can rely on `ChangedFiles` actually resolving to a reference on disk. However for this usage it doesn't actually matter, as we don't rely on them existing on disk to check which package they belong to in `Get-PrPackageProperties`.

Pending feedback from @weshaggard or @benbp , I have an opinion but I know ya'll will have one as well 👍 

@kristapratico when I merge this (regardless of implementation detail) this PR will resolve the issue you saw over [here.](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4484095&view=logs&jobId=22aa3ba4-644c-509d-acec-db6f6514dcba)