### PR TITLE
Ensure that `TestRecordingMismatchException` doesn't exhaust default header size limits

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
@@ -408,7 +408,6 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             TestRecordingMismatchException exception = Assert.Throws<TestRecordingMismatchException>(() => matcher.FindMatch(requestEntry, entries));
             Assert.Equal(
                 "Unable to find a record for the request HEAD http://localhost/" + Environment.NewLine +
-                "Remaining entry: http://remote-host" + Environment.NewLine +
                 "Method doesn't match, request <HEAD> record <PUT>" + Environment.NewLine +
                 "Uri doesn't match:" + Environment.NewLine +
                 "    request <http://localhost/>" + Environment.NewLine +
@@ -420,7 +419,9 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
                 "Body differences:" + Environment.NewLine +
                 "Request and record bodies do not match at index 40:" + Environment.NewLine +
                 "     request: \"e and long.\"" + Environment.NewLine +
-                "     record:  \"e and long but it also doesn't\"" + Environment.NewLine,
+                "     record:  \"e and long but it also doesn't\"" + Environment.NewLine +
+                "Remaining Entries:" + Environment.NewLine +
+                "0: http://remote-host" + Environment.NewLine,
                 exception.Message);
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/HttpExceptionMiddleware.cs
@@ -44,17 +44,18 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                 response.StatusCode = statusCode;
                 response.ContentType = "application/json;";
 
-                var encodedException = Convert.ToBase64String(Encoding.UTF8.GetBytes(e.Message));
-
                 if (e is TestRecordingMismatchException)
                 {
                     response.Headers.Append("x-request-mismatch", "true");
-                    response.Headers.Append("x-request-mismatch-error", encodedException);
+
+                    // grab the exception up till Remaining Entries: which can potentially push the header size past the default limit of ~8k
+                    var onlyMisMatchMessage = e.Message.Split("Remaining Entries:")[0];
+                    response.Headers.Append("x-request-mismatch-error", Convert.ToBase64String(Encoding.UTF8.GetBytes(onlyMisMatchMessage)));
                 }
                 else
                 {
                     response.Headers.Append("x-request-known-exception", "true");
-                    response.Headers.Append("x-request-known-exception-error", encodedException);
+                    response.Headers.Append("x-request-known-exception-error", Convert.ToBase64String(Encoding.UTF8.GetBytes(e.Message.Substring(0, 5000))));
                 }
 
                 var bodyObj = new

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/RecordMatcher.cs
@@ -244,14 +244,6 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             StringBuilder builder = new StringBuilder();
             builder.AppendLine($"Unable to find a record for the request {request.RequestMethod} {request.RequestUri}");
 
-            if (entries != null)
-            {
-                foreach (var entry in entries)
-                {
-                    builder.AppendLine($"Remaining entry: {entry.RequestUri}");
-                }
-            }
-
             if (bestScoreEntry == null)
             {
                 builder.AppendLine("No records to match.");
@@ -279,6 +271,16 @@ namespace Azure.Sdk.Tools.TestProxy.Common
             request.Request.TryGetContentType(out var contentType);
             CompareBodies(request.Request.Body, bestScoreEntry.Request.Body, contentType, descriptionBuilder: builder);
 
+            builder.AppendLine("Remaining Entries:");
+
+            if (entries != null)
+            {
+                for (int i = 0; i < entries.Count; i++)
+                {
+                    var entry = entries[i];
+                    builder.AppendLine($"{i}: {entry.RequestUri}");
+                }
+            }
             return builder.ToString();
         }
 


### PR DESCRIPTION
Resolving an issue brought up in the [Test-Proxy Teams channel](https://teams.microsoft.com/l/message/19:b7c3eda7e0864d059721517174502bdb@thread.skype/1736982306937?tenantId=72f988bf-86f1-41af-91ab-2d7cd011db47&groupId=3e17dcb0-4257-4a30-b843-77f47f1d4121&parentMessageId=1736982306937&teamName=Azure%20SDK&channelName=Test-Proxy%20-%20Questions%2C%20Help%2C%20and%20Discussion&createdTime=1736982306937)

