### PR TITLE
Support incrementing semver prereleases with 'zero' versions

### DIFF
--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -78,13 +78,10 @@ class AzureEngSemanticVersion : IComparable {
 
       if ($null -eq $matches['prelabel'])
       {
-        # artifically provide these values for non-prereleases to enable easy sorting of them later than prereleases.
-        $this.PrereleaseLabel = "zzz"
-        $this.PrereleaseNumber = 99999999
         $this.IsPrerelease = $false
         $this.VersionType = "GA"
         if ($this.Major -eq 0) {
-           # Treat initial 0 versions as a prerelease beta's
+          # Treat initial 0 versions as a prerelease beta's
           $this.VersionType = "Beta"
           $this.IsPrerelease = $true
         }
@@ -116,7 +113,7 @@ class AzureEngSemanticVersion : IComparable {
   # See https://azure.github.io/azure-sdk/policies_releases.html#package-versioning
   [bool] HasValidPrereleaseLabel()
   {
-    if ($this.IsPrerelease -eq $true) {
+    if ($this.PrereleaseLabel) {
       if ($this.PrereleaseLabel -ne $this.DefaultPrereleaseLabel -and $this.PrereleaseLabel -ne $this.DefaultAlphaReleaseLabel) {
         Write-Host "Unexpected pre-release identifier '$($this.PrereleaseLabel)', "`
                    "should be '$($this.DefaultPrereleaseLabel)' or '$($this.DefaultAlphaReleaseLabel)'"
@@ -136,7 +133,7 @@ class AzureEngSemanticVersion : IComparable {
   {
     $versionString = "{0}.{1}.{2}" -F $this.Major, $this.Minor, $this.Patch
 
-    if ($this.IsPrerelease -and $this.PrereleaseLabel -ne "zzz")
+    if ($this.PrereleaseLabel)
     {
       $versionString += $this.PrereleaseLabelSeparator + $this.PrereleaseLabel + `
                         $this.PrereleaseNumberSeparator + $this.PrereleaseNumber
@@ -147,22 +144,40 @@ class AzureEngSemanticVersion : IComparable {
     return $versionString;
   }
 
-  [void] IncrementAndSetToPrerelease() {
-    if ($this.IsPrerelease -eq $false)
+  [void] IncrementAndSetToPrerelease($Segment) {
+    if ($this.BuildNumber)
     {
-      $this.PrereleaseLabel = $this.DefaultPrereleaseLabel
-      $this.PrereleaseNumber = 1
-      $this.Minor++
-      $this.Patch = 0
-      $this.IsPrerelease = $true
+      throw "Cannot increment releases tagged with azure pipelines build numbers"
+    }
+
+    if ($this.PrereleaseLabel)
+    {
+      $this.PrereleaseNumber++
     }
     else
     {
-      if ($this.BuildNumber) {
-        throw "Cannot increment releases tagged with azure pipelines build numbers"
+      $this.$Segment++
+      if($Segment -eq "Major") {
+        $this.Minor = 0
+        $this.Patch = 0
       }
-      $this.PrereleaseNumber++
+      if($Segment -eq "Minor") {
+        $this.Patch = 0
+      }
+
+      # If the major version is 0, we don't need a prerelease label
+      if ($this.Major -ne 0)
+      {
+        $this.PrereleaseLabel = $this.DefaultPrereleaseLabel
+        $this.PrereleaseNumber = 1
+      }
+
+      $this.IsPrerelease = $true
     }
+  }
+
+  [void] IncrementAndSetToPrerelease() {
+    $this.IncrementAndSetToPrerelease("Minor")
   }
 
   [void] SetupPythonConventions()
@@ -198,11 +213,30 @@ class AzureEngSemanticVersion : IComparable {
     $ret = $this.Patch.CompareTo($other.Patch)
     if ($ret) { return $ret }
 
+    # provide artificial prerelease values for non-prereleases to sort them later than prereleases.
+    if ($this.PrereleaseLabel) {
+      $thisPrereleaseLabel = $this.PrereleaseLabel
+      $thisPrereleaseNumber = $this.PrereleaseNumber
+    }
+    else {
+      $thisPrereleaseLabel = "zzz"
+      $thisPrereleaseNumber = 99999999
+    }
+
+    if ($other.PrereleaseLabel) {
+      $otherPrereleaseLabel = $other.PrereleaseLabel
+      $otherPrereleaseNumber = $other.PrereleaseNumber
+    }
+    else {
+      $otherPrereleaseLabel = "zzz"
+      $otherPrereleaseNumber = 99999999
+    }
+
     # Mimic PowerShell that uses case-insensitive comparisons by default.
-    $ret = [string]::Compare($this.PrereleaseLabel, $other.PrereleaseLabel, $true)
+    $ret = [string]::Compare($thisPrereleaseLabel, $otherPrereleaseLabel, $true)
     if ($ret) { return $ret }
 
-    $ret = $this.PrereleaseNumber.CompareTo($other.PrereleaseNumber)
+    $ret = $thisPrereleaseNumber.CompareTo($otherPrereleaseNumber)
     if ($ret) { return $ret }
 
     return ([int] $this.BuildNumber).CompareTo([int] $other.BuildNumber)
@@ -358,6 +392,38 @@ class AzureEngSemanticVersion : IComparable {
     $pbetaVer.IncrementAndSetToPrerelease()
     if ("1.2.3b5" -ne $pbetaVer.ToString()) {
       Write-Host "Error: Python beta string did not correctly increment"
+    }
+
+    $versionString = "0.1.2"
+    $version = [AzureEngSemanticVersion]::ParseVersionString($versionString)
+    $version.IncrementAndSetToPrerelease()
+    $expected = "0.2.0"
+    if ($expected -ne $version.ToString()) {
+      Write-Host "Error: version string did not correctly increment. Expected: $expected, Actual: $version"
+    }
+
+    $version.IncrementAndSetToPrerelease("patch")
+    $expected = "0.2.1"
+    if ($expected -ne $version.ToString()) {
+      Write-Host "Error: version string did not correctly increment. Expected: $expected, Actual: $version"
+    }
+
+    $version.IncrementAndSetToPrerelease("minor")
+    $expected = "0.3.0"
+    if ($expected -ne $version.ToString()) {
+      Write-Host "Error: version string did not correctly increment. Expected: $expected, Actual: $version"
+    }
+
+    $version.IncrementAndSetToPrerelease("major")
+    $expected = "1.0.0-beta.1"
+    if ($expected -ne $version.ToString()) {
+      Write-Host "Error: version string did not correctly increment. Expected: $expected, Actual: $version"
+    }
+
+    $version.IncrementAndSetToPrerelease()
+    $expected = "1.0.0-beta.2"
+    if ($expected -ne $version.ToString()) {
+      Write-Host "Error: version string did not correctly increment. Expected: $expected, Actual: $version"
     }
 
     Write-Host "QuickTests done"

--- a/eng/common/scripts/SemVer.ps1
+++ b/eng/common/scripts/SemVer.ps1
@@ -394,32 +394,35 @@ class AzureEngSemanticVersion : IComparable {
       Write-Host "Error: Python beta string did not correctly increment"
     }
 
-    $versionString = "0.1.2"
-    $version = [AzureEngSemanticVersion]::ParseVersionString($versionString)
+    $version = [AzureEngSemanticVersion]::ParseVersionString("0.1.2")
     $version.IncrementAndSetToPrerelease()
     $expected = "0.2.0"
     if ($expected -ne $version.ToString()) {
       Write-Host "Error: version string did not correctly increment. Expected: $expected, Actual: $version"
     }
 
+    $version = [AzureEngSemanticVersion]::ParseVersionString("0.1.2")
     $version.IncrementAndSetToPrerelease("patch")
-    $expected = "0.2.1"
+    $expected = "0.1.3"
     if ($expected -ne $version.ToString()) {
       Write-Host "Error: version string did not correctly increment. Expected: $expected, Actual: $version"
     }
 
+    $version = [AzureEngSemanticVersion]::ParseVersionString("0.1.2")
     $version.IncrementAndSetToPrerelease("minor")
-    $expected = "0.3.0"
+    $expected = "0.2.0"
     if ($expected -ne $version.ToString()) {
       Write-Host "Error: version string did not correctly increment. Expected: $expected, Actual: $version"
     }
 
+    $version = [AzureEngSemanticVersion]::ParseVersionString("0.1.2")
     $version.IncrementAndSetToPrerelease("major")
     $expected = "1.0.0-beta.1"
     if ($expected -ne $version.ToString()) {
       Write-Host "Error: version string did not correctly increment. Expected: $expected, Actual: $version"
     }
 
+    $version = [AzureEngSemanticVersion]::ParseVersionString("1.0.0-beta.1")
     $version.IncrementAndSetToPrerelease()
     $expected = "1.0.0-beta.2"
     if ($expected -ne $version.ToString()) {


### PR DESCRIPTION
- Remove the artificial `PrereleaseLabel` and `PrereleaseNumber` values from non-prerelease versions
- Add support for bumping Major, Minor or Patch versions using `IncrementAndSetToPrerelease($segment)`
  - The default segment is still `minor`
- Fix support for "zero" versions in `HasValidPrereleaseLabel`
  - previously, `[AzureEngSemanticVersion]::new("0.1.2").HasValidPrereleaseLabel()` would return
     ```
     Unexpected pre-release identifier 'zzz',  should be 'beta' or 'alpha'
     False
     ```



Parse results before:
| Property         | `0.1.2`  | `1.2.3`  | `1.2.3-alpha.1` | `1.2.3-alpha.20250121.10` |
| ---------------- | -------- | -------- | --------------- | ------------------------- |
| Major            | 0        | 1        | 1               | 1                         |
| Minor            | 1        | 2        | 2               | 2                         |
| Patch            | 2        | 3        | 3               | 3                         |
| PrereleaseLabel  | zzz      | zzz      | alpha           | alpha                     |
| BuildNumber      |          |          |                 | 10                        |
| PrereleaseNumber | 99999999 | 99999999 | 1               | 20250121                  |
| IsPrerelease     | True     | False    | True            | True                      |
| VersionType      | Beta     | Patch    | Beta            | Beta                      |

Parse results after change:
| Property         | `0.1.2` | `1.2.3` | `1.2.3-alpha.1` | `1.2.3-alpha.20250121.10` |
| ---------------- | ------- | ------- | --------------- | ------------------------- |
| Major            | 0       | 1       | 1               | 1                         |
| Minor            | 1       | 2       | 2               | 2                         |
| Patch            | 2       | 3       | 3               | 3                         |
| PrereleaseLabel  |         |         | alpha           | alpha                     |
| BuildNumber      |         |         |                 | 10                        |
| PrereleaseNumber | 0       | 0       | 1               | 20250121                  |
| IsPrerelease     | True    | False   | True            | True                      |
| VersionType      | Beta    | Patch   | Beta            | Beta                      |