### PR TITLE
Update dotnet parser to skip RequiresUnreferencedCode attribute

### DIFF
--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParser/TreeToken/CodeFileBuilder.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis.SymbolDisplay;
 using System.Collections.Immutable;
 using System.ComponentModel;
 using ApiView;
+using System.Diagnostics.CodeAnalysis;
 
 namespace CSharpAPIParser.TreeToken
 {
@@ -540,6 +541,8 @@ namespace CSharpAPIParser.TreeToken
                 case "EditorBrowsableAttribute":
                 case "NullableAttribute":
                 case "NullableContextAttribute":
+                case "RequiresUnreferencedCodeAttribute":
+                case "RequiresDynamicCodeAttribute":
                     return true;
                 default:
                     return false;

--- a/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CSharpAPIParserTests.csproj
+++ b/tools/apiview/parsers/csharp-api-parser/CSharpAPIParserTests/CSharpAPIParserTests.csproj
@@ -10,8 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.42.0" />
+    <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Azure.Core.Expressions.DataFactory" Version="1.0.0" />
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.18.3" />
     <PackageReference Include="Azure.Security.Attestation" Version="1.0.0" />
     <PackageReference Include="Azure.Storage.Blobs" Version="12.21.2" />
     <PackageReference Include="Azure.Template" Version="1.0.3-beta.4055065" />


### PR DESCRIPTION
Update the list of attributes that are skipped from APIView for .NET