### PR TITLE
Sparse checkout 1espt auto-baselining file by default

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -86,7 +86,10 @@ steps:
 
               # Set non-cone mode otherwise path filters will not work in git >= 2.37.0
               # See https://github.blog/2022-06-27-highlights-from-git-2-37/#tidbits
-              git sparse-checkout set --no-cone '/*' '!/*/' '/eng'
+              # '/*' '!/*/' -> only checkout files in top level directory
+              # '/eng' -> checkout required eng/ scripts/configs
+              # '.config' -> required for files like .config/1espt/PipelineAutobaseliningConfig.yml and .config/guardian/.gdnbaselines used by 1es PT scripts
+              git sparse-checkout set --no-cone '/*' '!/*/' '/eng' '/.config'
             }
 
             # Prevent wildcard expansion in Invoke-Expression (e.g. for checkout path '/*')


### PR DESCRIPTION
1es pt scripts normally try to download this file remotely using the pipeline gh token, but they will also honor the file on the machine. In some cases the remote fetch will fail or be unauthorized, so we should always check out 1espt config files for consistency/reliability.