### PR TITLE
deprecate track2 and refine code for PR scenario

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release
 
+## 2025-01-22 - 0.1.4
+
+- Deprecated 'azure-sdk-for-net-track2' and repurposed 'azure-sdk-for-net' for the .NET track2 SDK
+- Added functionality to generate an HTML file for the filtered log
+
 ## 2025-01-14 - 0.1.3
 
 - Ensure the PrBranch variable is consistently set in all scenarios

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/entrypoint.ts
+++ b/tools/spec-gen-sdk/src/automation/entrypoint.ts
@@ -77,6 +77,9 @@ export const getSdkAutoContext = async (options: SdkAutoOptions): Promise<SdkAut
   if (fs.existsSync(filteredLogFileName)) {
     fs.rmSync(filteredLogFileName);
   }
+  if (fs.existsSync(htmlLogFileName)) {
+    fs.rmSync(htmlLogFileName);
+  }
   logger.add(loggerFileTransport(fullLogFileName));
   logger.info(`Log to ${fullLogFileName}`);
   const localSpecConfigPath = path.join(options.localSpecRepoPath, specConfigPath);
@@ -121,8 +124,8 @@ export const sdkAutoMain = async (options: SdkAutoOptions) => {
   }
   if (workflowContext) {
     generateReport(workflowContext);
-    await saveFilteredLog(workflowContext);
-    await generateHtmlFromFilteredLog(workflowContext);
+    saveFilteredLog(workflowContext);
+    generateHtmlFromFilteredLog(workflowContext);
   }
   await loggerWaitToFinish(sdkContext.logger);
   return workflowContext?.status;

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -93,7 +93,7 @@ export const generateReport = (context: WorkflowContext) => {
   context.logger.log('endsection', 'Generate report');
 }
 
-export const saveFilteredLog = async (context: WorkflowContext) => {
+export const saveFilteredLog = (context: WorkflowContext) => {
   context.logger.log('section', 'Save filtered log');
   let hasBreakingChange = false;
   let isBetaMgmtSdk = true;
@@ -147,7 +147,7 @@ export const saveFilteredLog = async (context: WorkflowContext) => {
   context.logger.log('endsection', 'Save filtered log status');
 };
 
-export const generateHtmlFromFilteredLog = async (context: WorkflowContext) => {
+export const generateHtmlFromFilteredLog = (context: WorkflowContext) => {
     context.logger.log('section', 'Generate HTML from filtered log');
     const RegexMarkdownSplit = /^(.*?)(<ul>.*)$/s;
     const RegexNoteBlock = /> \[!NOTE\]\s*>\s*(.*)/;

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -170,7 +170,7 @@ export const workflowValidateSdkConfigForSpecPr = async (context: WorkflowContex
   }
 
   if (changedSpecs.length === 0) {
-    throw new Error(`No changed specs are detected and SDK generation is skipped.`);
+    throw new Error(`No changes detected in the API specs; SDK generation skipped.`);
   }
   if (sdkToGenerate.size === 0) {
     throw new Error(`No SDKs are enabled for generation. Please check the configuration in the realted tspconfig.yaml or readme.md`);

--- a/tools/spec-gen-sdk/src/types/sdks.ts
+++ b/tools/spec-gen-sdk/src/types/sdks.ts
@@ -12,7 +12,6 @@ export type SdkName =
   | "azure-sdk-for-java"
   | "azure-sdk-for-js"
   | "azure-sdk-for-net"
-  | "azure-sdk-for-net-track2"
   | "azure-sdk-for-python";
 
 export const sdkLabels: {
@@ -50,12 +49,6 @@ export const sdkLabels: {
     breakingChangeSuppression: undefined,
     breakingChangeSuppressionApproved: undefined,
   },
-  "azure-sdk-for-net-track2": {
-    breakingChange: undefined,
-    breakingChangeApproved: undefined,
-    breakingChangeSuppression: undefined,
-    breakingChangeSuppressionApproved: undefined
-  },  
   "azure-sdk-for-python": {
     breakingChange: "BreakingChange-Python-Sdk",
     breakingChangeApproved: "BreakingChange-Python-Sdk-Approved",


### PR DESCRIPTION
- Deprecated 'azure-sdk-for-net-track2' and repurposed 'azure-sdk-for-net' for the .NET track2 SDK
- Added functionality to generate an HTML file for the filtered log
- Refined code for PR scenario