### PR TITLE
Enable conversion of existing Swift reviews and disable conversion of…

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/SwiftLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/SwiftLanguageService.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using Microsoft.Extensions.Configuration;
@@ -8,7 +8,7 @@ namespace APIViewWeb
     public class SwiftLanguageService : JsonLanguageService
     {
         public override string Name { get; } = "Swift";
-        public override string VersionString { get; } = "0.3.0";
+        public string VersionString { get; } = "0.3.0";
 
         //Swift doesn't have any parser for now
         //It will upload a json file with name Swift so Swift reviews are listed under that filter type
@@ -20,7 +20,7 @@ namespace APIViewWeb
         public override bool IsSupportedFile(string name)
         {
             // Skip initial processing so this service won't be selected for LLC when json is uploaded
-            // This is only a temporary solution for POC and will be remvoed once autorest yaml is uploaded instead of json for LLC
+            // This is only a temporary solution for POC and will be removed once autorest yaml is uploaded instead of json for LLC
             return false;
         }
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/SwiftLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/SwiftLanguageService.cs
@@ -8,6 +8,7 @@ namespace APIViewWeb
     public class SwiftLanguageService : JsonLanguageService
     {
         public override string Name { get; } = "Swift";
+        public override string VersionString { get; } = "0.3.0";
 
         //Swift doesn't have any parser for now
         //It will upload a json file with name Swift so Swift reviews are listed under that filter type
@@ -21,6 +22,16 @@ namespace APIViewWeb
             // Skip initial processing so this service won't be selected for LLC when json is uploaded
             // This is only a temporary solution for POC and will be remvoed once autorest yaml is uploaded instead of json for LLC
             return false;
+        }
+
+        public override bool CanUpdate(string versionString)
+        {
+            return false;
+        }
+
+        public override bool CanConvert(string versionString)
+        {
+            return versionString != VersionString;
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Languages/TypeSpecLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/TypeSpecLanguageService.cs
@@ -46,7 +46,7 @@ namespace APIViewWeb
 
         public override bool CanConvert(string versionString)
         {
-            return versionString != VersionString;
+            return false
         }
 
         public override bool GeneratePipelineRunParams(APIRevisionGenerationPipelineParamModel param)

--- a/src/dotnet/APIView/APIViewWeb/Languages/TypeSpecLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/TypeSpecLanguageService.cs
@@ -46,7 +46,7 @@ namespace APIViewWeb
 
         public override bool CanConvert(string versionString)
         {
-            return false
+            return false;
         }
 
         public override bool GeneratePipelineRunParams(APIRevisionGenerationPipelineParamModel param)


### PR DESCRIPTION
Enable conversion of existing Swift reviews to new tree model and disable the conversion for TypeSpec  since all TypeSpec reviews have been converted to tree model. APIView will attempt to convert reviews again for TypeSpec when a new version of TypeSpec parser is released if we don't disable the conversion.