### PR TITLE
Fix pipeline generation for private repos

### DIFF
--- a/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
+++ b/eng/common/pipelines/templates/jobs/prepare-pipelines.yml
@@ -50,17 +50,21 @@ jobs:
           - '!sdk/**/recordings/*'
           - '!sdk/**/SessionRecords/*'
           - '!sdk/**/session-records/*'
+        ${{ if endsWith(parameters.Repository, '-pr') }}:
+          TokenToUseForAuth: $(azuresdk-github-pat)
+
     - template: /eng/common/pipelines/templates/steps/install-pipeline-generation.yml
     - template: /eng/common/pipelines/templates/steps/set-default-branch.yml
 
     - pwsh: |
         Write-Host "Setting up pipeline variables"
-        if ("${{ parameters.Repository }}" -match "Azure/azure-sdk-for-(?<prefix>[^-]*)(?<pr>-pr)?") {
-          $prefix = $matches['prefix']
-          $devOpsPath = "\$prefix"
+        if ("${{ parameters.Repository }}" -match "Azure/azure-sdk-for-(?<lang>[^-]*)(?<pr>-pr)?") {
+          $lang = $matches['lang']
+          $devOpsPath = "\$lang"
+          $prefix = $lang
           if ($matches['pr']) {
             $devOpsPath = "${devOpsPath}\pr"
-            $prefix = "${prefix}-pr"
+            $prefix += "-pr"
             Write-Host "##vso[task.setvariable variable=ProjectForPRValidation]internal"
           }
           Write-Host "Prefix = $prefix"
@@ -79,8 +83,8 @@ jobs:
         $testServiceConnections = '"Azure" "azure-sdk-tests" "azure-sdk-tests-preview" "azure-sdk-tests-public" "Azure SDK Test Resources - LiveTestSecrets"'
         $internalServiceConnections = '"Azure" "Azure SDK Artifacts" "Azure SDK Engineering System" "opensource-api-connection" "AzureSDKEngKeyVault Secrets"'
 
-        # Map the language prefix to the appropriate variable groups
-        switch ($prefix)
+        # Map the language to the appropriate variable groups
+        switch ($lang)
         {
           "java" {
             $internalVariableGroups = '$(AzureSDK_Maven_Release_Pipeline_Secrets) $(Release_Secrets_for_GitHub) $(APIReview_AutoCreate_Configurations)'
@@ -115,7 +119,7 @@ jobs:
             $generateUnifiedWeekly = 'true'
           }
           default {
-            Write-Error "Prefix '$prefix' is not recognized."
+            Write-Error "Language '$lang' is not recognized."
             exit 1
           }
         }

--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -11,10 +11,19 @@ parameters:
   - name: SkipCheckoutNone
     type: boolean
     default: false
+  - name: TokenToUseForAuth
+    type: string
+    default: ''
 
 steps:
   - ${{ if not(parameters.SkipCheckoutNone) }}:
       - checkout: none
+
+  - ${{ if ne(parameters.TokenToUseForAuth, '') }}:
+    - pwsh: |
+        $base64Token = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("nobody:${{ parameters.TokenToUseForAuth }}"))
+        git config set --global "http.extraheader" "AUTHORIZATION: basic $base64Token"
+      displayName: Setup git config auth header
 
   - task: PowerShell@2
     ${{ if eq(length(parameters.Repositories), 1) }}:
@@ -126,3 +135,9 @@ steps:
         }
       pwsh: true
       workingDirectory: $(System.DefaultWorkingDirectory)
+
+  - ${{ if ne(parameters.TokenToUseForAuth, '') }}:
+    - pwsh: |
+        git config unset --global "http.extraheader"
+      displayName: Removing git config auth header
+      condition: always()

--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -22,6 +22,7 @@ steps:
   - ${{ if ne(parameters.TokenToUseForAuth, '') }}:
     - pwsh: |
         $base64Token = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes("nobody:${{ parameters.TokenToUseForAuth }}"))
+        Write-Host "##vso[task.setvariable variable=_base64AuthToken;issecret=true;]$base64Token"
         git config set --global "http.extraheader" "AUTHORIZATION: basic $base64Token"
       displayName: Setup git config auth header
 

--- a/eng/common/pipelines/templates/steps/validate-all-packages.yml
+++ b/eng/common/pipelines/templates/steps/validate-all-packages.yml
@@ -4,7 +4,7 @@ parameters:
   ConfigFileDir: $(Build.ArtifactStagingDirectory)/PackageInfo
 
 steps:
- - ${{ if and(ne(variables['Skip.PackageValidation'], 'true'), eq(variables['System.TeamProject'], 'internal')) }}:
+ - ${{ if and(ne(variables['Skip.PackageValidation'], 'true'), and(ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))) }}:
     - pwsh: |
         echo "##vso[task.setvariable variable=SetAsReleaseBuild]false"
       displayName: "Set as release build"


### PR DESCRIPTION
Pipeline generation for the private repos no longer works after my recent refactoring. The reason is because sparse-checkout doesn't support cloning them without a key. I've hacked together a proof of concept to unblock folks but I'm not sure how I like this implementation. 

I'm curious of your thoughts @benbp 