### PR TITLE
Non-Sparse Indirect Packages

### DIFF
--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -54,6 +54,9 @@ parameters:
 - name: PRMatrixIndirectFilters
   type: object
   default: []
+- name: PRMatrixSparseIndirect
+  type: boolean
+  default: true
 # Mappings to OS name required at template compile time by 1es pipeline templates
 - name: Pools
   type: object
@@ -142,7 +145,8 @@ jobs:
               -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}' `
               -IndirectFilters '${{ join(''',''', parameters.PRMatrixIndirectFilters) }}' `
               -Replace '${{ join(''',''', parameters.MatrixReplace) }}' `
-              -PackagesPerPRJob ${{ parameters.PRJobBatchSize }}
+              -PackagesPerPRJob ${{ parameters.PRJobBatchSize }} `
+              -SparseIndirect $${{ parameters.PRMatrixSparseIndirect }}
           displayName: Create ${{ pool.name }} PR Matrix
           name: vm_job_matrix_pr_${{ pool.name }}
 

--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -74,7 +74,7 @@ function QueuePop([ref]$queue) {
 function GeneratePRMatrixForBatch {
   param (
     [Parameter(Mandatory = $true)][array] $Packages,
-    [Parameter(Mandatory = $true)][bool] $FullSparseMatrix
+    [Parameter(Mandatory = $false)][bool] $FullSparseMatrix = $false
   )
 
   $OverallResult = @()
@@ -159,7 +159,7 @@ function GeneratePRMatrixForBatch {
             }
 
             if ($batchSuffixNecessary) {
-              $outputItem["name"] = $outputItem["name"] + "$batchPrefix$batchCounter"
+              $outputItem["name"] = $outputItem["name"] + "$batchNamePrefix$batchCounter"
             }
 
             $OverallResult += $outputItem
@@ -184,7 +184,7 @@ function GeneratePRMatrixForBatch {
           }
 
           if ($batchSuffixNecessary) {
-            $outputItem["name"] = $outputItem["name"] + "_ib$batchCounter"
+            $outputItem["name"] = $outputItem["name"]  + "_$batchNamePrefix$batchCounter"
           }
           # now we need to take an item from the front of the matrix results, clone it, and add it to the back of the matrix results
           # we will add the cloned version to OverallResult

--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -240,7 +240,7 @@ if ($indirectPackages) {
   foreach($artifact in $indirectPackages) {
     Write-Host "-> $($artifact.ArtifactName)"
   }
-  $OverallResult += GeneratePRMatrixForBatch -Packages $indirectPackages -FullSparseMatrix !$SparseIndirect
+  $OverallResult += GeneratePRMatrixForBatch -Packages $indirectPackages -FullSparseMatrix (-not $SparseIndirect)
 }
 $serialized = SerializePipelineMatrix $OverallResult
 


### PR DESCRIPTION
js team needs the full (or at least MORE full) matrix as they want the indirectly changed packages to run both `node` and `browser` tests.

This code change, alone, would return them to the full matrix for indirect changes. However, I'm going to pair it with setting arguments to `IndirectFilters` to filter the full matrix down a bit to only `Ubuntu` platforms.

This is in response to feedback from @jeremymeng WRT [this pipeline](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4504825&view=logs&j=69104f8e-b88e-5d11-595c-90fd5e8e65ca&t=4ba20f2a-6568-5c82-27d3-3f34c36a0661). We need common changes to also run against browser (which it's not as evidenced by the linked PR).