### PR TITLE
Allow override of the AddDevVersion setting

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -17,6 +17,9 @@ parameters:
   - name: ExcludePaths
     type: object
     default: []
+  - name: SetDevVersion
+    type: boolean
+    default: true
 
 steps:
   # There will be transitory period for every language repo where the <language> - pullrequest build definition will run
@@ -66,5 +69,5 @@ steps:
           arguments: >
             -ServiceDirectory '${{parameters.ServiceDirectory}}'
             -OutDirectory '${{ parameters.PackageInfoDirectory }}'
-            -AddDevVersion:$${{ eq(variables['SetDevVersion'],'true') }}
+            -AddDevVersion:$${{ and(eq(variables['SetDevVersion'],'true'), eq(parameters.BuildVersion, true)) }}
           pwsh: true


### PR DESCRIPTION
In `azure-sdk-for-net`, before the `net - pullrequest` PR, we call [daily-dev-build-variable](https://github.com/Azure/azure-sdk-tools/blob/6ecd9b21b50d76bc57add2a13b3a145069234f93/eng/common/pipelines/templates/steps/daily-dev-build-variable.yml#L7) which gets package properties for non-dev, then sets the daily dev variable. Later after the `build and package` step, we call save-package-properties again with AddDevVersion set to the result of `daily-dev-build-variable` execution.

In the new world, we have changed to call `daily-dev-build-variable` without a service directory, so it doesn't call that save-package props. We are using `save-package-properties.yml` now, to handle diff generation etc. To keep it simple, I'd like to override the `AddDevVersion` in `save-package-properties.yml`, so that we can SetDevVersion to true, but still evaluate the production set of packages.

I can do without this PR, but I think I would kludge together a `- ${{ if` condition to only include `save-package-properties.yml` if not in a pullrequest pipeline, and then I could call save-package-properties with AddDevVersion set to false manually.

Thoughts?
