### PR TITLE
Update emitter template

### DIFF
--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -448,10 +448,10 @@ extends:
               artifactName: test_artifacts_$(System.JobName)
               artifactPath: $(Build.ArtifactStagingDirectory)
 
-          - ${{ and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
+          - ${{ if and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
               - task: AzureCLI@2
                 displayName: "Upload Spector Standard Coverage Report"
-                condition: and(ne('$(SpectorName)', ''), succeeded())
+                condition: and(ne(variables['SpectorName'], ''), succeeded())
                 inputs:
                   azureSubscription: "TypeSpec Storage"
                   scriptType: "bash"

--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -447,3 +447,14 @@ extends:
             parameters:
               artifactName: test_artifacts_$(System.JobName)
               artifactPath: $(Build.ArtifactStagingDirectory)
+
+          - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+              - task: AzureCLI@2
+                displayName: "Upload Spector Standard Coverage Report"
+                condition: and(ne(variables['Build.Reason'], 'PullRequest'), ne('$(SpectorName)', ''))
+                inputs:
+                  azureSubscription: "TypeSpec Storage"
+                  scriptType: "bash"
+                  scriptLocation: "inlineScript"
+                  inlineScript: npx tsp-spector upload-coverage --coverageFile $(Build.ArtifactStagingDirectory)/tsp-spector-coverage-azure.json --generatorName @azure-typespec/$(SpectorName) --storageAccountName typespec --containerName coverages --generatorVersion $(node -p -e "require('./package.json').version") --generatorMode azure
+                  workingDirectory: $(Build.SourcesDirectory)/eng/packages/$(SpectorName)

--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -448,10 +448,10 @@ extends:
               artifactName: test_artifacts_$(System.JobName)
               artifactPath: $(Build.ArtifactStagingDirectory)
 
-          - ${{ if eq(variables['System.TeamProject'], 'internal') }}:
+          - ${{ and(eq(variables['System.TeamProject'], 'internal'), ne(variables['Build.Reason'], 'PullRequest')) }}:
               - task: AzureCLI@2
                 displayName: "Upload Spector Standard Coverage Report"
-                condition: and(ne(variables['Build.Reason'], 'PullRequest'), ne('$(SpectorName)', ''))
+                condition: and(ne('$(SpectorName)', ''), succeeded())
                 inputs:
                   azureSubscription: "TypeSpec Storage"
                   scriptType: "bash"


### PR DESCRIPTION
Adding a common step to upload spector coverage from azure-sdk-for-[lang] repos.

Supports https://github.com/Azure/azure-sdk-for-net/issues/47071

Tested with a temp change in this pr https://github.com/Azure/azure-sdk-for-net/pull/48006