### PR TITLE
Disallow absolute recording file paths when an assets.json is provided

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -325,9 +325,11 @@ final path = C:/repo/sdk-for-net/sdk/anomalydetector/Azure.AI.AnomalyDetector/te
 
 When the user POSTS to `/Record/Stop` the recording will be written to the file as described directly above.
 
+> ⚠️ **Note!** If passing the body key `x-recording-assets-file`, DO NOT pass a fully qualified absolute path. The test-proxy must be able to combine your assets repo location with the file path.
+
 During a `playback` start, the value for `x-recording-file` is used to _load an existing recording into memory_ and serve requests from it!
 
-Please note that if a **absolute** path is presented in header `x-recording-file`. The test-proxy will write directly to that file, wherever it is. If the parent folders do not exist, they will be created at run-time during the write operation.
+Please note that if a **absolute** path is presented in the `x-recording-file` key. The test-proxy will write directly to that file, wherever it is. If the parent folders do not exist, they will be created at run-time during the write operation.
 
 ### Start the test run
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/README.md
@@ -329,7 +329,7 @@ When the user POSTS to `/Record/Stop` the recording will be written to the file 
 
 During a `playback` start, the value for `x-recording-file` is used to _load an existing recording into memory_ and serve requests from it!
 
-Please note that if a **absolute** path is presented in the `x-recording-file` key. The test-proxy will write directly to that file, wherever it is. If the parent folders do not exist, they will be created at run-time during the write operation.
+Please note that if an **absolute** path is presented in the `x-recording-file` key. The test-proxy will write directly to that file, wherever it is. If the parent folders do not exist, they will be created at run-time during the write operation.
 
 ### Start the test run
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -532,7 +532,7 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 throw new HttpException(HttpStatusCode.BadRequest, $"There is no active playback session under recording id {recordingId}.");
             }
-            
+
             RecordEntry noBodyEntry = RecordingHandler.CreateNoBodyRecordEntry(incomingRequest);
             session.AuditLog.Enqueue(new AuditLogItem(recordingId, noBodyEntry.RequestUri, noBodyEntry.RequestMethod.ToString()));
 
@@ -1049,7 +1049,7 @@ namespace Azure.Sdk.Tools.TestProxy
             else
             {
                 await SanitizerRegistry.SessionSanitizerLock.WaitAsync();
-                try { 
+                try {
                     foreach (var sanitizer in sanitizers)
                     {
                         registrations.Add(await SanitizerRegistry.Register(sanitizer, shouldLock: false));
@@ -1202,6 +1202,12 @@ namespace Azure.Sdk.Tools.TestProxy
             {
                 var contextDirectory = await Store.GetPath(assetsPath);
 
+                if (Path.IsPathFullyQualified(file)) {
+                    throw new HttpException(
+                        HttpStatusCode.BadRequest,
+                        $"The path provided in the recording file value {file} is fully qualified. This is not allowed when an assets.json is provided."
+                    );
+                }
                 path = Path.Join(contextDirectory, file);
             }
             // otherwise, it's a basic restore like we're used to
@@ -1250,14 +1256,14 @@ namespace Azure.Sdk.Tools.TestProxy
             //    https://portal.azure.com/
             //    http://localhost:8080
             //    http://user:pass@localhost:8080/ <-- this should be EXTREMELY rare given it's extremely insecure
-            // 
+            //
             // The value from rawTarget is the _exact_ "rest of the URI" WITHOUT auto-decoding (as specified above) and could look like:
             //    ///request
             //    /hello/world?query=blah
             //    ""
             //    //hello/world
             //
-            // We cannot use a URIBuilder to combine the hostValue and the rawTarget, as doing so results in auto-decoding of escaped 
+            // We cannot use a URIBuilder to combine the hostValue and the rawTarget, as doing so results in auto-decoding of escaped
             // characters that will BREAK the request that we actually wish to make.
             //
             // Given these limitations, and safe in the knowledge of both sides of this operation. We trim the trailing / off of the host,


### PR DESCRIPTION
During restore, make this an explicit error.

@heaths was getting badrequests due to improperly joining paths. Let's make it explicit so he isn't surprised.