### PR TITLE
Pass non sparse parameters through to PR job matrix generator

### DIFF
--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -100,6 +100,7 @@ function GeneratePRMatrixForBatch {
     $matrixResults = @()
     foreach ($matrixConfig in $matrixConfigs) {
       Write-Host "Generating config for $($matrixConfig.Path)"
+      $nonSparse = $matrixConfig.PSObject.Properties['NonSparseParameters'] ? $matrixConfig.NonSparseParameters : @()
 
       $matrixResults = @()
       if ($directBatch) {
@@ -108,7 +109,8 @@ function GeneratePRMatrixForBatch {
           -Selection $matrixConfig.Selection `
           -DisplayNameFilter $DisplayNameFilter `
           -Filters $Filters `
-          -Replace $Replace
+          -Replace $Replace `
+          -NonSparseParameters $nonSparse
 
         if ($matrixResults) {
           Write-Host "We have the following direct matrix results: "
@@ -121,7 +123,8 @@ function GeneratePRMatrixForBatch {
           -Selection $matrixConfig.Selection `
           -DisplayNameFilter $DisplayNameFilter `
           -Filters ($Filters + $IndirectFilters) `
-          -Replace $Replace
+          -Replace $Replace `
+          -NonSparseParameters $nonSparse
 
         if ($matrixResults) {
           Write-Host "We have the following indirect matrix results: "

--- a/eng/common/scripts/job-matrix/job-matrix-functions.ps1
+++ b/eng/common/scripts/job-matrix/job-matrix-functions.ps1
@@ -743,10 +743,11 @@ function Get4dMatrixIndex([int]$index, [Array]$dimensions) {
 function GenerateMatrixForConfig {
     param (
       [Parameter(Mandatory = $true)][string] $ConfigPath,
-      [Parameter(Mandatory = $True)][string] $Selection,
+      [Parameter(Mandatory = $true)][string] $Selection,
       [Parameter(Mandatory = $false)][string] $DisplayNameFilter,
       [Parameter(Mandatory = $false)][array] $Filters,
-      [Parameter(Mandatory = $false)][array] $Replace
+      [Parameter(Mandatory = $false)][array] $Replace,
+      [Parameter(Mandatory = $false)][Array] $NonSparseParameters = @()
     )
     $matrixFile = Join-Path $PSScriptRoot ".." ".." ".." ".." $ConfigPath
 
@@ -761,7 +762,8 @@ function GenerateMatrixForConfig {
       -selectFromMatrixType $Selection `
       -displayNameFilter $DisplayNameFilter `
       -filters $Filters `
-      -replace $Replace
+      -replace $Replace `
+      -nonSparseParameters $NonSparseParameters
 
     return , $matrix
 }


### PR DESCRIPTION
@JimSuplizio and I were trying to figure out why the new `java - pullrequest` matrix generation was short a couple jobs from the `java - core - ci` matrix. I found that we aren't plumbing through `NonSparseParameters` from the matrix config.

@scbedd I wasn't sure if this was intended to be skipped or not. If it should be skipped I can change this PR to just add a comment explaining why.