### PR TITLE
Add keyboard event for saving comment

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/shared/comment-thread/comment-thread.component.html
@@ -20,7 +20,7 @@
                 <div *ngIf="comment.isInEditMode" class="mt-2 p-2 edit-editor-container">
                     <app-editor [content]="comment.commentText" [editorId]="comment.id" [style]="{ width: '100%'}"></app-editor>
                     <div class="btn-group mt-2" role="group" aria-label="Comment Action Buttons">
-                        <button type="button" class="btn btn-sm btn-outline-success editor-action-btn" [disabled]="getEditorContent(comment.id).length === 0" (click)="saveCommentAction($event)">Save</button>
+                        <button type="button" class="btn btn-sm btn-outline-success editor-action-btn submit" [disabled]="getEditorContent(comment.id).length === 0" (click)="saveCommentAction($event)">Save</button>
                         <button type="button" class="btn btn-sm btn-outline-danger editor-action-btn" (click)="cancelCommentAction($event)">Cancel</button>
                     </div>
                 </div>
@@ -53,7 +53,7 @@
     <div *ngIf="(codePanelRowData!.showReplyTextBox)" class="border-top border-bottom mt-2 p-2 reply-editor-container">
         <app-editor editorId="replyEditor" [style]="{ width: '100%'}"></app-editor>
         <div class="btn-group mt-2" role="group" aria-label="Comment Action Buttons">
-            <button type="button" class="btn btn-sm btn-outline-success editor-action-btn" [disabled]="getEditorContent('replyEditor').length === 0" (click)="saveCommentAction($event)">Add comment</button>
+            <button type="button" class="btn btn-sm btn-outline-success editor-action-btn submit" [disabled]="getEditorContent('replyEditor').length === 0" (click)="saveCommentAction($event)">Add comment</button>
             <button type="button" class="btn btn-sm btn-outline-danger editor-action-btn" (click)="cancelCommentAction($event)">Cancel</button>
             <button 
                 type="button" 


### PR DESCRIPTION
Resolves https://github.com/Azure/azure-sdk-tools/issues/9706
Allow `Ctrl + Enter` to save comment.