### PR TITLE
Update query count to fix automation

### DIFF
--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -55,7 +55,7 @@ function Invoke-Query($fields, $wiql, $output = $true)
   }
 
   $response = Invoke-RestMethod -Method POST `
-    -Uri "https://dev.azure.com/azure-sdk/Release/_apis/wit/wiql/?`$top=10000&api-version=6.0" `
+    -Uri "https://dev.azure.com/azure-sdk/Release/_apis/wit/wiql/?`$top=100000&api-version=6.0" `
     -Headers (Get-DevOpsRestHeaders) -Body $body -ContentType "application/json" | ConvertTo-Json -Depth 10 | ConvertFrom-Json -AsHashTable
 
   if ($response -isnot [HashTable] -or !$response.ContainsKey("workItems") -or $response.workItems.Count -eq 0) {

--- a/eng/common/scripts/Helpers/PSModule-Helpers.ps1
+++ b/eng/common/scripts/Helpers/PSModule-Helpers.ps1
@@ -79,7 +79,7 @@ function moduleIsInstalled([string]$moduleName, [string]$version) {
   if ($version -as [Version]) {
     $modules = $modules.Where({ [Version]$_.Version -ge [Version]$version })
     if ($modules.Count -gt 0) {
-      Write-Host "Using module $($modules[0].Name) with version $($modules[0].Version)."
+      Write-Verbose "Using module $($modules[0].Name) with version $($modules[0].Version)."
       return $modules[0]
     }
   }
@@ -100,7 +100,7 @@ function installModule([string]$moduleName, [string]$version, $repoUrl) {
     Set-PSRepository -Name $repo.Name -InstallationPolicy "Trusted" | Out-Null
   }
 
-  Write-Host "Installing module $moduleName with min version $version from $repoUrl"
+  Write-Verbose "Installing module $moduleName with min version $version from $repoUrl"
   # Install under CurrentUser scope so that the end up under $CurrentUserModulePath for caching
   Install-Module $moduleName -MinimumVersion $version -Repository $repo.Name -Scope CurrentUser -Force
   # Ensure module installed
@@ -171,7 +171,7 @@ function Install-ModuleIfNotInstalled() {
       break
     }
 
-    Write-Host "Using module '$($module.Name)' with version '$($module.Version)'."
+    Write-Verbose "Using module '$($module.Name)' with version '$($module.Version)'."
   }
   finally {
     $mutex.ReleaseMutex()


### PR DESCRIPTION
Fix issue where we are over 10000 work items so we aren't finding the newer ones. This updates to 100000, hopefully we don't hit that anytime soon.

Also made some of the common logging verbose to remove noise in steps like prepare-release where we don't need to see that once per yml file we parse.