### PR TITLE
Update parser version in Cosmos when converting code file to tree model

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CLanguageService.cs
@@ -72,6 +72,7 @@ namespace APIViewWeb
         public override string Name { get; } = "C";
 
         public override string [] Extensions { get; } = { ".zip" };
+        public override string VersionString => CurrentVersion;
 
         public override bool CanUpdate(string versionString) => versionString != CurrentVersion;
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/CppLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/CppLanguageService.cs
@@ -114,6 +114,8 @@ namespace APIViewWeb
 
         public override string Name { get; } = "C++";
 
+        public override string VersionString => CurrentVersion;
+
         public override string [] Extensions { get; } = { ".cppast" };
 
         public override bool CanUpdate(string versionString) => versionString != CurrentVersion;

--- a/src/dotnet/APIView/APIViewWeb/Languages/JsonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JsonLanguageService.cs
@@ -12,6 +12,7 @@ namespace APIViewWeb
     {
         public override string Name { get; } = "Json";
         public override string[] Extensions { get; } = { ".json" };
+        public override string VersionString { get; } = "1.0";
 
         public override bool CanUpdate(string versionString) => false;
 

--- a/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
@@ -18,7 +18,6 @@ namespace APIViewWeb
         }
 
         public abstract string ProcessName { get; }
-        public abstract string VersionString { get; }
         public abstract string GetProcessorArguments(string originalName, string tempDirectory, string jsonPath);
 
         public override bool CanUpdate(string versionString)

--- a/src/dotnet/APIView/APIViewWeb/Languages/LanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/LanguageService.cs
@@ -13,6 +13,7 @@ namespace APIViewWeb
     {
         public abstract string Name { get; }
         public abstract string [] Extensions { get; }
+        public abstract string VersionString { get; }
         public virtual bool IsSupportedFile(string name) => Extensions.Any(x => name.EndsWith(x, StringComparison.OrdinalIgnoreCase));
         public abstract bool CanUpdate(string versionString);
         public abstract Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis);

--- a/src/dotnet/APIView/APIViewWeb/Languages/SwiftLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/SwiftLanguageService.cs
@@ -8,7 +8,7 @@ namespace APIViewWeb
     public class SwiftLanguageService : JsonLanguageService
     {
         public override string Name { get; } = "Swift";
-        public string VersionString { get; } = "0.3.0";
+        public override string VersionString { get; } = "0.3.0";
 
         //Swift doesn't have any parser for now
         //It will upload a json file with name Swift so Swift reviews are listed under that filter type

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -1014,7 +1014,7 @@ namespace APIViewWeb.Managers
             }
             else if (languageService != null && languageService.CanConvert(codeFileDetails.VersionString) &&  codeFileDetails.ParserStyle == ParserStyle.Flat)
             {
-                // Convert to tree model only iof current token file is in flat token model
+                // Convert to tree model only if current token file is in flat token model
                 var codeFile = await _codeFileRepository.GetCodeFileFromStorageAsync(revisionModel.Id, codeFileDetails.FileId);
                 if (codeFile != null && codeFile.ReviewLines.Count == 0)
                 {

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -67,7 +67,7 @@ namespace APIViewWeb.Managers
         /// Retrieve Revisions from the Revisions container in CosmosDb after applying filter to the query.
         /// </summary>
         /// <param name="user"></param>
-        /// <param name="pageParams"></param> Contains paginationinfo
+        /// <param name="pageParams"></param> Contains pagination info
         /// <param name="filterAndSortParams"></param> Contains filter and sort parameters
         /// <returns></returns>
         public async Task<PagedList<APIRevisionListItemModel>> GetAPIRevisionsAsync(ClaimsPrincipal user, PageParams pageParams, FilterAndSortParams filterAndSortParams)
@@ -1012,20 +1012,21 @@ namespace APIViewWeb.Managers
                 await UpdateAPIRevisionAsync(revisionModel, languageService, false);
                 revisionModel = await _apiRevisionsRepository.GetAPIRevisionAsync(revisionModel.Id);
             }
-            else if (languageService != null && languageService.CanConvert(codeFileDetails.VersionString))
+            else if (languageService != null && languageService.CanConvert(codeFileDetails.VersionString) &&  codeFileDetails.ParserStyle == ParserStyle.Flat)
             {
+                // Convert to tree model only iof current token file is in flat token model
                 var codeFile = await _codeFileRepository.GetCodeFileFromStorageAsync(revisionModel.Id, codeFileDetails.FileId);
                 if (codeFile != null && codeFile.ReviewLines.Count == 0)
                 {
-                    codeFile.ConvertToTreeTokenModel();
-                    await _codeFileRepository.UpsertCodeFileAsync(revisionModel.Id, codeFileDetails.FileId, codeFile);
-                    // update only version string
-                    codeFileDetails.VersionString = codeFile.VersionString;
+                    codeFile.ConvertToTreeTokenModel();                    
                     if (codeFile.ReviewLines.Count > 0)
                     {
+                        await _codeFileRepository.UpsertCodeFileAsync(revisionModel.Id, codeFileDetails.FileId, codeFile);
+                        codeFileDetails.VersionString = languageService.VersionString;
                         codeFileDetails.ParserStyle = ParserStyle.Tree;
-                    }
-                    await _apiRevisionsRepository.UpsertAPIRevisionAsync(revisionModel);
+                        codeFileDetails.IsConvertedTokenModel = true;
+                        await _apiRevisionsRepository.UpsertAPIRevisionAsync(revisionModel);
+                    }                    
                 }
             }
             return revisionModel;

--- a/src/dotnet/APIView/APIViewWeb/Models/APICodeFileModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/APICodeFileModel.cs
@@ -41,5 +41,6 @@ namespace APIViewWeb
         public string FileName { get; set; }
         public string PackageVersion { get; set; }
         public string CrossLanguagePackageId { get; set; }
+        public bool IsConvertedTokenModel { get; set; } = false;
     }
 }


### PR DESCRIPTION
Update version string property in Cosmos DB to current parser version when converting to tree token model. Also mark  revision as converted when converting from flat model.