### PR TITLE
[js-parser] Support re-exported enums

### DIFF
--- a/tools/apiview/parsers/js-api-parser/package.json
+++ b/tools/apiview/parsers/js-api-parser/package.json
@@ -25,14 +25,16 @@
     "rimraf": "^6.0.1",
     "ts-node": "^10.0.0",
     "typescript": "~5.6.2",
-    "typescript-eslint": "^8.11.0"
+    "typescript-eslint": "^8.11.0",
+    "vitest": "3.0.5"
   },
   "scripts": {
     "build": "npm run clean && tsc -p .",
     "watch": "tsc -p . -watch",
     "clean": "rimraf dist/",
     "format": "prettier --write ./src ./*.{js,mjs,json}",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "test": "vitest"
   },
   "keywords": [],
   "author": "azure-sdk",

--- a/tools/apiview/parsers/js-api-parser/src/generate.ts
+++ b/tools/apiview/parsers/js-api-parser/src/generate.ts
@@ -300,6 +300,8 @@ function buildMemberLineTokens(line: ReviewLine, item: ApiItem) {
               Value: excerpt.text,
             });
             line.Tokens.push(token);
+          } else if (item.kind === ApiItemKind.Enum) {
+            splitAndBuild(line.Tokens, `export enum ${item.displayName}`, item);
           } else {
             splitAndBuild(line.Tokens, excerpt.text, item);
           }

--- a/tools/apiview/parsers/js-api-parser/src/jstokens.ts
+++ b/tools/apiview/parsers/js-api-parser/src/jstokens.ts
@@ -212,10 +212,7 @@ function getRenderClass(kind: ApiItemKind) {
 export function splitAndBuild(reviewTokens: ReviewToken[], s: string, item: ApiItem) {
   // Not sure why api.json uses "export declare function", while api.md uses "export function".
   // Use the latter because that's how we normally define it in the TypeScript source code.
-  const lines = s
-    .replace(/export declare function/g, "export function")
-    .replace(/export declare enum/g, "export enum")
-    .split("\n");
+  const lines = s.replace(/export declare function/g, "export function").split("\n");
   const { kind: memberKind, displayName: currentTypeName } = item;
   const currentTypeid = item.canonicalReference.toString();
   for (const l of lines) {

--- a/tools/apiview/parsers/js-api-parser/test/data/renamedEnum.json
+++ b/tools/apiview/parsers/js-api-parser/test/data/renamedEnum.json
@@ -1,0 +1,41 @@
+{
+  "metadata": {
+    "toolPackage": "@microsoft/api-extractor",
+    "toolVersion": "7.49.1",
+    "schemaVersion": 1011,
+    "oldestForwardsCompatibleVersion": 1001,
+    "tsdocConfig": {
+      "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json"
+    }
+  },
+  "kind": "Package",
+  "canonicalReference": "@azure/test-package",
+  "name": "@azure/test-package",
+  "preserveMemberOrder": false,
+  "members": [
+    {
+      "kind": "EntryPoint",
+      "canonicalReference": "@azure/test-package!",
+      "name": "",
+      "preserveMemberOrder": false,
+      "members": [
+        {
+          "kind": "Enum",
+          "canonicalReference": "@azure/test-package!KnownFoo:enum",
+          "docComment": "/**\n * doc comment for KnownFoo.\n */\n",
+          "excerptTokens": [
+            {
+              "kind": "Content",
+              "text": "export declare enum GeneratedKnownFoo "
+            }
+          ],
+          "fileUrlPath": "src/generated/models/models.ts",
+          "releaseTag": "Public",
+          "name": "KnownFoo",
+          "preserveMemberOrder": false,
+          "members": []
+        }
+      ]
+    }
+  ]
+}

--- a/tools/apiview/parsers/js-api-parser/test/generate.spec.ts
+++ b/tools/apiview/parsers/js-api-parser/test/generate.spec.ts
@@ -24,7 +24,7 @@ describe("generate", () => {
         (c) => c.LineId === "@azure/test-package!KnownFoo:enum",
       );
       expect(enumReviewLine).toBeDefined();
-      expect(enumReviewLine!.Tokens.map((t) => t.Value).join(" ")).toEqual(
+      expect(enumReviewLine?.Tokens.map((t) => t.Value).join(" ")).toEqual(
         "export enum KnownFoo { }",
       );
     });

--- a/tools/apiview/parsers/js-api-parser/test/generate.spec.ts
+++ b/tools/apiview/parsers/js-api-parser/test/generate.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { generateApiview } from "../src/generate";
+import {
+  ApiEntryPoint,
+  ApiEnum,
+  ApiModel,
+  ApiPackage,
+  ExcerptTokenKind,
+  ReleaseTag,
+} from "@microsoft/api-extractor-model";
+import { DocComment, TSDocConfiguration } from "@microsoft/tsdoc";
+
+describe("generate", () => {
+  describe("enums", () => {
+    it("generates correct models for renamed exports", () => {
+      // TODO: work with Jeremy on better testing approaches for this
+      const model: ApiModel = new ApiModel();
+      const apiPackage = new ApiPackage({
+        docComment: new DocComment({ configuration: new TSDocConfiguration() }),
+        name: "test",
+        tsdocConfiguration: new TSDocConfiguration(),
+      });
+      const entryPoint = new ApiEntryPoint({ name: "test" });
+      const apiEnum = new ApiEnum({
+        docComment: new DocComment({ configuration: new TSDocConfiguration() }),
+        excerptTokens: [
+          {
+            kind: ExcerptTokenKind.Content,
+            text: "export declare enum KnownJsonWebKeyEncryptionAlgorithm ",
+          },
+        ],
+        isExported: true,
+        name: "KnownEncryptionAlgorithms",
+        releaseTag: ReleaseTag.Public,
+      });
+      entryPoint.addMember(apiEnum);
+      apiPackage.addMember(entryPoint);
+      model.addMember(apiPackage);
+      const result = generateApiview({
+        apiModel: model,
+        dependencies: {},
+        meta: {
+          Name: "",
+          PackageName: "",
+          PackageVersion: "",
+          ParserVersion: "",
+          Language: "JavaScript",
+        },
+      });
+      const enumReviewLine = result.ReviewLines[0].Children?.[0];
+      expect(enumReviewLine).toBeDefined();
+      expect(enumReviewLine!.Tokens.map((t) => t.Value).join(" ")).toEqual(
+        "export enum KnownEncryptionAlgorithms { }",
+      );
+    });
+  });
+});

--- a/tools/apiview/parsers/js-api-parser/test/generate.spec.ts
+++ b/tools/apiview/parsers/js-api-parser/test/generate.spec.ts
@@ -1,41 +1,14 @@
 import { describe, expect, it } from "vitest";
 import { generateApiview } from "../src/generate";
-import {
-  ApiEntryPoint,
-  ApiEnum,
-  ApiModel,
-  ApiPackage,
-  ExcerptTokenKind,
-  ReleaseTag,
-} from "@microsoft/api-extractor-model";
-import { DocComment, TSDocConfiguration } from "@microsoft/tsdoc";
+import { ApiModel } from "@microsoft/api-extractor-model";
+import path from "path";
 
 describe("generate", () => {
   describe("enums", () => {
     it("generates correct models for renamed exports", () => {
-      // TODO: work with Jeremy on better testing approaches for this
       const model: ApiModel = new ApiModel();
-      const apiPackage = new ApiPackage({
-        docComment: new DocComment({ configuration: new TSDocConfiguration() }),
-        name: "test",
-        tsdocConfiguration: new TSDocConfiguration(),
-      });
-      const entryPoint = new ApiEntryPoint({ name: "test" });
-      const apiEnum = new ApiEnum({
-        docComment: new DocComment({ configuration: new TSDocConfiguration() }),
-        excerptTokens: [
-          {
-            kind: ExcerptTokenKind.Content,
-            text: "export declare enum KnownJsonWebKeyEncryptionAlgorithm ",
-          },
-        ],
-        isExported: true,
-        name: "KnownEncryptionAlgorithms",
-        releaseTag: ReleaseTag.Public,
-      });
-      entryPoint.addMember(apiEnum);
-      apiPackage.addMember(entryPoint);
-      model.addMember(apiPackage);
+      model.loadPackage(path.join(__dirname, "./data/renamedEnum.json"));
+
       const result = generateApiview({
         apiModel: model,
         dependencies: {},
@@ -47,10 +20,12 @@ describe("generate", () => {
           Language: "JavaScript",
         },
       });
-      const enumReviewLine = result.ReviewLines[0].Children?.[0];
+      const enumReviewLine = result.ReviewLines[0].Children?.find(
+        (c) => c.LineId === "@azure/test-package!KnownFoo:enum",
+      );
       expect(enumReviewLine).toBeDefined();
       expect(enumReviewLine!.Tokens.map((t) => t.Value).join(" ")).toEqual(
-        "export enum KnownEncryptionAlgorithms { }",
+        "export enum KnownFoo { }",
       );
     });
   });

--- a/tools/apiview/parsers/js-api-parser/vitest.config.ts
+++ b/tools/apiview/parsers/js-api-parser/vitest.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "vitest/config";
 export default defineConfig({
   test: {
-    include: ["**/*.spec.ts"],
+    include: ["test/**/*.spec.ts"],
     watch: false,
   },
 });

--- a/tools/apiview/parsers/js-api-parser/vitest.config.ts
+++ b/tools/apiview/parsers/js-api-parser/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+export default defineConfig({
+  test: {
+    include: ["**/*.spec.ts"],
+    watch: false,
+  },
+});


### PR DESCRIPTION
Adds support for re-exported enums, ensuring APIView shows the correct (i.e. exported and customer-visible) name for an enum.

I scoped this just to enums for now, but we can expand if we find other usages.

I also went ahead and added a basic test with a basic test fixture. Future PR will work with @praveenkuttappan to ideally add this to CI builds for the parser.

Resolves #9768