### PR TITLE
Like variants in pipeline files to be any word char

### DIFF
--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/SdkComponentScanner.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/SdkComponentScanner.cs
@@ -20,7 +20,7 @@ namespace PipelineGenerator
 
         public IEnumerable<SdkComponent> Scan(DirectoryInfo path, string searchPattern)
         {
-            string variantPattern = searchPattern.Replace(".yml", "\\.(?<variant>([a-z]+))\\.yml");
+            string variantPattern = searchPattern.Replace(".yml", "\\.(?<variant>(\w+))\\.yml");
             Regex variantExtractionExpression = new Regex($"^{variantPattern}$");
             Logger.LogDebug($"Scanning directory '{path.FullName}' for components with search pattern '{searchPattern}' variant pattern '{variantPattern}'");
 

--- a/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/SdkComponentScanner.cs
+++ b/tools/pipeline-generator/Azure.Sdk.Tools.PipelineGenerator/SdkComponentScanner.cs
@@ -20,7 +20,7 @@ namespace PipelineGenerator
 
         public IEnumerable<SdkComponent> Scan(DirectoryInfo path, string searchPattern)
         {
-            string variantPattern = searchPattern.Replace(".yml", "\\.(?<variant>(\w+))\\.yml");
+            string variantPattern = searchPattern.Replace(".yml", "\\.(?<variant>(\\w+))\\.yml");
             Regex variantExtractionExpression = new Regex($"^{variantPattern}$");
             Logger.LogDebug($"Scanning directory '{path.FullName}' for components with search pattern '{searchPattern}' variant pattern '{variantPattern}'");
 


### PR DESCRIPTION
Fixing https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4537511&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=f627a99b-3dfd-52f6-3228-32c29542eb4a

![image](https://github.com/user-attachments/assets/0f7fe708-aa4b-40c7-85ff-c707c22b1afb)

Apparently our pipeline generator currently restricts to lower case chars for variants in the pipeline names. This enables it to be all word characters and thus enables the java "v2" variants.

fyi @JimSuplizio @alzimmermsft 