### PR TITLE
fix: replace `import.meta.resolve` with `require.resolve` for Node 18+ compatibility

### DIFF
--- a/tools/tsp-client/src/utils.ts
+++ b/tools/tsp-client/src/utils.ts
@@ -2,7 +2,6 @@ import { joinPaths, normalizeSlashes } from "@typespec/compiler";
 import { randomUUID } from "node:crypto";
 import { access, constants, mkdir, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import { Logger } from "./log.js";
 import { TspLocation } from "./typespec.js";
 import { normalizeDirectory } from "./fs.js";

--- a/tools/tsp-client/src/utils.ts
+++ b/tools/tsp-client/src/utils.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { Logger } from "./log.js";
 import { TspLocation } from "./typespec.js";
 import { normalizeDirectory } from "./fs.js";
+import { createRequire } from "module";
 
 export function formatAdditionalDirectories(additionalDirectories?: string[]): string {
   let additionalDirOutput = "\n";
@@ -61,7 +62,8 @@ export function getServiceDir(configYaml: any, emitter: string): string {
  */
 export async function getPathToDependency(dependency: string): Promise<string> {
   // Example: /home/user/foo/node_modules/@autorest/bar/dist/index.js
-  const entrypoint = fileURLToPath(import.meta.resolve(dependency));
+  const require = createRequire(import.meta.url);
+  const entrypoint = require.resolve(dependency);
 
   // Walk up directory tree to first folder containing "package.json"
   let currentDir = dirname(entrypoint);


### PR DESCRIPTION
Under Node 18+, the `tsp-client convert` tool met this issue:

```
TypeError: (intermediate value).resolve is not a function
    at getPathToDependency (file:///C:/nvm/v18.15.0/node_modules/@azure-tools/typespec-client-generator-cli/dist/utils.js:55:50)
    at convertCommand (file:///C:/nvm/v18.15.0/node_modules/@azure-tools/typespec-client-generator-cli/dist/commands.js:321:32)
    at async Object.handler (file:///C:/nvm/v18.15.0/node_modules/@azure-tools/typespec-client-generator-cli/dist/index.js:170:5)
```

In Node.js, there is no built-in `import.meta.resolve()` API. That function is a browser feature and isn’t implemented in Node 18 (nor in later versions at time of writing). If you need to resolve a module path in an ES module, the simplest solution is to use createRequire from the module package. 

After I patched this commit in my local module, the issue is fixed.