### PR TITLE
Add AdditionalMatrixConfigs the CIMatrixConfigs

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -90,13 +90,20 @@ class PackageProps {
                 $result = [PSCustomObject]@{
                     ArtifactConfig = [HashTable]$artifactForCurrentPackage
                     MatrixConfigs  = @()
+                    AdditionalMatrixConfigs = @()
                 }
 
                 # if we know this is the matrix for our file, we should now see if there is a custom matrix config for the package
                 $matrixConfigList = GetValueSafelyFrom-Yaml $content @("extends", "parameters", "MatrixConfigs")
 
                 if ($matrixConfigList) {
-                    $result.MatrixConfigs = $matrixConfigList
+                    $result.MatrixConfigs += $matrixConfigList
+                }
+
+                $additionalMatrixConfigList = GetValueSafelyFrom-Yaml $content @("extends", "parameters", "AdditionalMatrixConfigs")
+
+                if ($additionalMatrixConfigList) {
+                    $result.AdditionalMatrixConfigs += $additionalMatrixConfigList
                 }
 
                 return $result
@@ -123,6 +130,9 @@ class PackageProps {
                     $this.CIMatrixConfigs = $ciArtifactResult.MatrixConfigs
                     # if this package appeared in this ci file, then we should
                     # treat this CI file as the source of the Matrix for this package
+                    if ($ciArtifactResult.PSObject.Properties.Name -contains "AdditionalMatrixConfigs" -and $ciArtifactResult.AdditionalMatrixConfigs) {
+                        $this.CIMatrixConfigs += $ciArtifactResult.AdditionalMatrixConfigs
+                    }
                     break
                 }
             }


### PR DESCRIPTION
Credit where credit is due, @scbedd made and tested these changes in Java in a [PR](https://github.com/Azure/azure-sdk-for-java/pull/44046) against my pull request testing branch.

GetValueSafelyFrom-Yaml is victim to array unrolling, so our previous use case was accidentally changing type, and adding the additionalMatrix config to it was causing issues.

For Java this PR fixes that + optionally parses the AdditionalMatrixConfigs param. We are now seeing version_override generate correctly for azure-core in the [pull request pipeline run](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4537995&view=results) against the test PR.