### PR TITLE
Fix filename parser to support digits in artifact name

### DIFF
--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
@@ -41,7 +41,7 @@ public class Main {
     private static final String PACKAGE_VERSION = "version";
 
     // Expected format <artifact-id>-<majorversion>.<minorversion>.<patchversion>(-beta.<betaversion>)-sources.jar
-    private static final Pattern SOURCES_JAR_PATTERN = Pattern.compile("(.+)-(\\d+\\.\\d+.\\d+(-beta\\.\\d+)?)-sources\\.jar");
+    private static final Pattern SOURCES_JAR_PATTERN = Pattern.compile("(.+)-(\\d+\\.\\d+.\\d+(-.+)?)-sources\\.jar");
 
     // expected argument order:
     // [inputFiles] <outputDirectory>

--- a/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/FilenameParserTest.java
+++ b/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/FilenameParserTest.java
@@ -36,7 +36,9 @@ public class FilenameParserTest {
                 Arguments.of("azure-core-1.0.0-beta.1-sources.jar", "azure-core", "1.0.0-beta.1"),
                 Arguments.of("azure-storage-blob-1.0.0-sources.jar", "azure-storage-blob", "1.0.0"),
                 Arguments.of("azure-c1o1r1e-1.0.0-sources.jar", "azure-c1o1r1e", "1.0.0"),
-                Arguments.of("azure-core-123.456.789-sources.jar", "azure-core", "123.456.789")
+                Arguments.of("azure-core-1.0.0-preview.1-sources.jar", "azure-core", "1.0.0-preview.1"),
+                Arguments.of("azure-core-1.0.0-SNAPSHOT-sources.jar", "azure-core", "1.0.0-SNAPSHOT"),
+                Arguments.of("azure-core-1.0.0-rc1-sources.jar", "azure-core", "1.0.0-rc1")
         );
     }
 
@@ -45,8 +47,6 @@ public class FilenameParserTest {
                 "azure-core-v2-1.0-sources.jar",
                 "1.0-sources.jar",
                 "azure-core-v2-sources.jar",
-                "azure-core-1.0.0.jar",
-                "azure-1.0.0-beta.1-core-sources.jar",
-                "azure-core-1.0.0-preview.1-sources.jar");
+                "azure-core-1.0.0.jar");
     }
 }

--- a/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/FilenameParserTest.java
+++ b/src/java/apiview-java-processor/src/test/java/com/azure/tools/apiview/processor/FilenameParserTest.java
@@ -1,0 +1,52 @@
+package com.azure.tools.apiview.processor;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class FilenameParserTest {
+
+    @ParameterizedTest
+    @MethodSource("getValidFilenames")
+    public void testValidFilenames(String filename, String artifactId, String packageVersion) {
+        Map<String, String> filenameParts = Main.parseFilename(filename);
+        assertEquals(filenameParts.get("artifactId"), artifactId);
+        assertEquals(filenameParts.get("version"), packageVersion);
+    }
+
+    @ParameterizedTest
+    @MethodSource("getInvalidFilenames")
+    public void testInvalidFilenames(String filename) {
+        assertThrows(IllegalArgumentException.class, () -> Main.parseFilename(filename));
+    }
+
+    private static Stream<Arguments> getValidFilenames() {
+        return Stream.of(
+                Arguments.of("azure-core-v2-1.0.0-sources.jar", "azure-core-v2", "1.0.0"),
+                Arguments.of("azure-core-v2-1.0.0-beta.1-sources.jar", "azure-core-v2", "1.0.0-beta.1"),
+                Arguments.of("azure-core-1.0.0-sources.jar", "azure-core", "1.0.0"),
+                Arguments.of("azure-core-v500-1.0.0-sources.jar", "azure-core-v500", "1.0.0"),
+                Arguments.of("azure-core-v2-1232-1.0.0-sources.jar", "azure-core-v2-1232", "1.0.0"),
+                Arguments.of("azure-core-1.0.0-beta.1-sources.jar", "azure-core", "1.0.0-beta.1"),
+                Arguments.of("azure-storage-blob-1.0.0-sources.jar", "azure-storage-blob", "1.0.0"),
+                Arguments.of("azure-c1o1r1e-1.0.0-sources.jar", "azure-c1o1r1e", "1.0.0"),
+                Arguments.of("azure-core-123.456.789-sources.jar", "azure-core", "123.456.789")
+        );
+    }
+
+    private static Stream<String> getInvalidFilenames() {
+        return Stream.of(
+                "azure-core-v2-1.0-sources.jar",
+                "1.0-sources.jar",
+                "azure-core-v2-sources.jar",
+                "azure-core-1.0.0.jar",
+                "azure-1.0.0-beta.1-core-sources.jar",
+                "azure-core-1.0.0-preview.1-sources.jar");
+    }
+}


### PR DESCRIPTION
This PR fixes the filename parser to support digits in the artifact name. The previous parser assumed the first digit in the filename was the start of the version number, which caused issues when the artifact name contained digits. The change uses regex pattern matcher to identify the artifact ID and package version in the filename.