### PR TITLE
Get-ObjectKey converts boolean values

### DIFF
--- a/eng/common-tests/helpers/Package-Helpers.tests.ps1
+++ b/eng/common-tests/helpers/Package-Helpers.tests.ps1
@@ -1,5 +1,65 @@
 Import-Module Pester
 
+
+Describe "ObjectKey Discovery" {
+    BeforeAll {
+        . $PSScriptRoot/../../common/scripts/Helpers/Package-Helpers.ps1
+
+        $ClientCoreMatrixConfig = @{
+            Name = "clientcore_ci_test_base"
+            Path = "sdk/clientcore/platform-matrix.json"
+            Selection = "sparse"
+            NonSparseParameters = "Agent"
+            GenerateVMJobs = $true
+        }
+
+        $CoreMatrixConfig = @{
+            Name = "Java_ci_test_base"
+            Path = "eng/pipelines/templates/stages/platform-matrix.json"
+            Selection = "sparse"
+            NonSparseParameters = "Agent"
+            GenerateVMJobs = $true
+        }
+
+        $CoreMatrixConfigWithWeirdBoolean = @{
+            Name = "Java_ci_test_base"
+            Path = "eng/pipelines/templates/stages/platform-matrix.json"
+            Selection = "sparse"
+            NonSparseParameters = "Agent"
+            GenerateVMJobs = "True"
+        }
+    }
+
+    It "Should evaluate the same object to the same hashcode" {
+        $value1 = Get-ObjectKey -Object $CoreMatrixConfig
+        $value2 = Get-ObjectKey -Object $CoreMatrixConfig
+
+        $value1 | Should -BeLikeExactly $value2
+    }
+
+    It "Should evaluate different objects with the same value to the same hashcode" {
+        $CopiedCoreMatrixConfig = @{
+            Name = "Java_ci_test_base"
+            Path = "eng/pipelines/templates/stages/platform-matrix.json"
+            Selection = "sparse"
+            NonSparseParameters = "Agent"
+            GenerateVMJobs = $true
+        }
+
+        $value1 = Get-ObjectKey -Object $CoreMatrixConfig
+        $value2 = Get-ObjectKey -Object $CopiedCoreMatrixConfig
+
+        $value1 | Should -BeLikeExactly $value2
+    }
+
+    It "Should properly evaluate different objects with similar values, but convert booleans" {
+        $value1 = Get-ObjectKey -Object $CoreMatrixConfig
+        $value2 = Get-ObjectKey -Object $CoreMatrixConfigWithWeirdBoolean
+
+        $value1 | Should -BeLikeExactly $value2
+    }
+}
+
 Describe "Matrix-Collation" {
     BeforeAll {
         . $PSScriptRoot/../../common/scripts/Helpers/Package-Helpers.ps1

--- a/eng/common-tests/helpers/Package-Helpers.tests.ps1
+++ b/eng/common-tests/helpers/Package-Helpers.tests.ps1
@@ -81,7 +81,7 @@ Describe "Matrix-Collation" {
         }
     }
 
-    It -Skip "Should properly group identical matrix inputs" {
+    It "Should properly group identical matrix inputs" {
         $Pkgs = @(
             @{
                 Name = "package1"
@@ -113,7 +113,7 @@ Describe "Matrix-Collation" {
         $groupingResults[$group2][1].Name | Should -Be "package3"
     }
 
-    It -Skip "Should properly group items with no setting" {
+    It "Should properly group items with no setting" {
         $Pkgs = @(
             @{
                 Name = "package1"

--- a/eng/common-tests/helpers/Package-Helpers.tests.ps1
+++ b/eng/common-tests/helpers/Package-Helpers.tests.ps1
@@ -159,7 +159,7 @@ Describe "Matrix-Collation" {
             },
             @{
                 ArtifactName = "azure-identity"
-                CIMatrixConfigs = @({
+                CIMatrixConfigs = @(@{
                     Name = "Java_ci_test_base"
                     Path = "eng/pipelines/templates/stages/platform-matrix.json"
                     Selection = "sparse"

--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -178,7 +178,7 @@ function Get-ObjectKey {
 
   if ($Object -is [hashtable] -or $Object -is [System.Collections.Specialized.OrderedDictionary]) {
     $sortedEntries = $Object.GetEnumerator() | Sort-Object Name
-    $hashString = ($sortedEntries | ForEach-Object { "$($_.Key)=$($_.Value)" }) -join ";"
+    $hashString = ($sortedEntries | ForEach-Object { "$($_.Key)=$(Get-ObjectKey $_.Value)" }) -join ";"
     return $hashString.GetHashCode()
   }
 

--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -184,7 +184,7 @@ function Get-ObjectKey {
 
   elseif ($Object -is [PSCustomObject]) {
     $sortedProperties = $Object.PSObject.Properties | Sort-Object Name
-    $propertyString = ($sortedProperties | ForEach-Object { "$($_.Name)=$($_.Value)" }) -join ";"
+    $propertyString = ($sortedProperties | ForEach-Object { "$($_.Name)=$(Get-ObjectKey $_.Value)" }) -join ";"
     return $propertyString.GetHashCode()
   }
 

--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -194,7 +194,12 @@ function Get-ObjectKey {
   }
 
   else {
-    return $Object.GetHashCode()
+    $parsedBool = $null
+    if ([bool]::TryParse($Object, [ref]$parsedBool)) {
+      return $parsedBool.GetHashCode()
+    } else {
+      return $Object.GetHashCode()
+    }
   }
 }
 


### PR DESCRIPTION
This PR enhances the `Group-ByObjectKey` function to coalesce boolean-like values to their true boolean representation before getting a hashcode for them.

We use this grouping function to group a list of packages by which matrix config they belong to. The issue is that due to devops shenanigans, these matrix configs are getting their booleans a bit changed. The "default" matrix that is fed into `Create-PrJobMatrix` is a result of a devops json conversion of the static yaml parameter. Due to this, the booleans are getting messed up.


```yml
MatrixConfigs:
      - Name: NET_ci_test_base
        Path: eng/pipelines/templates/stages/platform-matrix.json
        Selection: sparse
        GenerateVMJobs: true
```

But devops _converts_ this to:

```json
{
  "Name": "NET_ci_test_base",
  "Path": "eng/pipelines/templates/stages/platform-matrix.json",
  "Selection": "sparse",
  "GenerateVMJobs": "True"
}
```

Notice that `GenerateVMJobs` value is different and not really a boolean anymore? This was causing matrix coalesce to treat these as _different matrices_ when they were NOT intended to be. This PR addresses this possible issue.