### PR TITLE
Replace `CIMatrixConfigs` with generalized `CIParameters` within `Package-Properties`

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -61,7 +61,7 @@ class PackageProps {
             $this.ChangeLogPath = $null
         }
 
-        $this.CIParameters = @{}
+        $this.CIParameters = @{"CIMatrixConfigs" = @()}
         $this.InitializeCIArtifacts()
     }
 
@@ -131,13 +131,13 @@ class PackageProps {
                 $matrixConfigList = GetValueSafelyFrom-Yaml $ciArtifactResult.ParsedYml @("extends", "parameters", "MatrixConfigs")
 
                 if ($matrixConfigList) {
-                    $this.CIMatrixConfigs += $matrixConfigList
+                    $this.CIParameters["CIMatrixConfigs"] += $matrixConfigList
                 }
 
                 $additionalMatrixConfigList = GetValueSafelyFrom-Yaml $ciArtifactResult.ParsedYml @("extends", "parameters", "AdditionalMatrixConfigs")
 
                 if ($additionalMatrixConfigList) {
-                    $this.CIMatrixConfigs += $additionalMatrixConfigList
+                    $this.CIParameters["CIMatrixConfigs"] += $additionalMatrixConfigList
                 }
             }
         }

--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -219,6 +219,7 @@ $configs = Get-Content -Raw $PRMatrixFile | ConvertFrom-Json
 # get all the package property objects loaded
 $packageProperties = Get-ChildItem -Recurse "$PackagePropertiesFolder" *.json `
 | ForEach-Object { Get-Content -Path $_.FullName | ConvertFrom-Json }
+| ForEach-Object { Add-Member -InputObject $_ -MemberType NoteProperty -Name CIMatrixConfigs -Value $_.CIParameters.CIMatrixConfigs -PassThru }
 
 # enhance the package props with a default matrix config if one isn't present
 $packageProperties | ForEach-Object {


### PR DESCRIPTION
We need a way to make a few `ci.yml` parameters available to the `package-properties` class. We need to do this for a couple of the .NET parameterized checks. Specifically:

- `AOTCompat: boolean`
- `CheckSnippets: boolean`

These are opt-in, so anyone forwarding `CheckSnippets: false` _aren't_ expecting check snippets to run. We can't currently honor this scenario in `net - pullrequest`.

This PR does two things:

- [x] Adds `CIParameters` hashtable to `PackageProps` class.
- [x] Removes `CIMatrixConfigs` as a direct prop of `PkgProp` and instead adds it as key `CIMatrixConfigs` _within_ `CIParameters`
- [x] Externalizes the "give me the ci.yml parameters for this package" in `Package-Properties.ps1`

My intent is to utilize `GetCIYmlForArtifact` within the `Get-AllPackageInformationFromRepo` function in `.NET`. From there, I'll add key-value pairs representing these values to the `CIParameters` hashtable.

The reason I'm offering it this way, is that `Save-Package-Properties.ps1` doesn't currently offer customizations as an argument, we rely on each individual repo to implement the "give me all the metadata" functions. We will get each generated PkgProps, then before returning it we'll parse the CIYml and add these two parameters if necessary.

The `analyze` steps will then be able to check these parameter values to see which packages need these optional checks run.
