### PR TITLE
Parameterize test-pipeline version separator

### DIFF
--- a/eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
+++ b/eng/common/pipelines/templates/steps/set-test-pipeline-version.yml
@@ -2,6 +2,7 @@ parameters:
   PackageName: ''
   PackageNames: ''
   ServiceDirectory: ''
+  TagSeparator: '_'
   TestPipeline: false
 
 steps:
@@ -16,4 +17,5 @@ steps:
           -BuildID $(Build.BuildId)
           -PackageNames '${{ coalesce(parameters.PackageName, parameters.PackageNames) }}'
           -ServiceDirectory '${{ parameters.ServiceDirectory }}'
+          -TagSeparator '${{ parameters.TagSeparator }}'
         pwsh: true

--- a/eng/common/scripts/SetTestPipelineVersion.ps1
+++ b/eng/common/scripts/SetTestPipelineVersion.ps1
@@ -6,7 +6,9 @@ param (
   [Parameter(mandatory = $true)]
   [string]$PackageNames,
   [Parameter(mandatory = $true)]
-  [string]$ServiceDirectory
+  [string]$ServiceDirectory,
+  [Parameter(mandatory = $false)]
+  [string]$TagSeparator = "_"
 )
 
 . (Join-Path $PSScriptRoot common.ps1)
@@ -20,23 +22,23 @@ $packageNamesArray = @()
 if ([String]::IsNullOrWhiteSpace($PackageNames)) {
   LogError "PackageNames cannot be empty."
   exit 1
-} else {
+}
+else {
   $packageNamesArray = $PackageNames.Split(',')
 }
 
 foreach ($packageName in $packageNamesArray) {
   Write-Host "Processing $packageName"
   $newVersion = [AzureEngSemanticVersion]::new("1.0.0")
-  $latestTags = git tag -l "${packageName}_*"
+  $prefix = "$packageName$TagSeparator"
+  Write-Host "Get Latest Tag : git tag -l $prefix*"
+  $latestTags = git tag -l "$prefix*"
 
-  Write-Host "Get Latest Tag : git tag -l ${packageName}_*"
   $semVars = @()
 
-  if ($latestTags -and ($latestTags.Length -gt 0))
-  {
-    foreach ($tags in $latestTags)
-    {
-      $semVars += $tags.Replace("${packageName}_", "")
+  if ($latestTags -and ($latestTags.Length -gt 0)) {
+    foreach ($tag in $latestTags) {
+      $semVars += $tag.Substring($prefix.Length)
     }
 
     $semVarsSorted = [AzureEngSemanticVersion]::SortVersionStrings($semVars)


### PR DESCRIPTION
Rust crates use snake case for packages.  "Get-${Language}-PackageInfoFromPackageFile" in LanguageSettings.ps1 allows the language to choose its tag naming scheme.  When package names contain underscores, a dash is a better separator. 

It appears that SetTestPipelineVersion is the only script that cares about the structure of the repo tags.