### PR TITLE
Encode `RollForward` behavior for test-proxy

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Azure.Sdk.Tools.TestProxy.csproj
@@ -10,6 +10,7 @@
     <InformationalVersion>$(OfficialBuildId)</InformationalVersion>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <IncludeSourceRevisionInInformationalVersion>false</IncludeSourceRevisionInInformationalVersion>
+    <RollForward>Major</RollForward>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
So that users don't need to set `DOTNET_ROLL_FORWARD=Major` if they have a NEWER version of dotnet other than what the project was compiled upon. 

CC @alzimmermsft 