### PR TITLE
Fix the expression used for AddDevVersion param in save package properties

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -61,10 +61,11 @@ steps:
   - ${{ else }}:
       - task: Powershell@2
         displayName: Save package properties
+        condition: succeeded()
         inputs:
           filePath: ${{ parameters.ScriptDirectory }}/Save-Package-Properties.ps1
           arguments: >
             -ServiceDirectory '${{parameters.ServiceDirectory}}'
             -OutDirectory '${{ parameters.PackageInfoDirectory }}'
-            -AddDevVersion:$${{ eq(variables['SetDevVersion'],'true') }}
+            -AddDevVersion $$(SetDevVersion)
           pwsh: true

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -61,11 +61,10 @@ steps:
   - ${{ else }}:
       - task: Powershell@2
         displayName: Save package properties
-        condition: succeeded()
         inputs:
           filePath: ${{ parameters.ScriptDirectory }}/Save-Package-Properties.ps1
           arguments: >
             -ServiceDirectory '${{parameters.ServiceDirectory}}'
             -OutDirectory '${{ parameters.PackageInfoDirectory }}'
-            -AddDevVersion $$(SetDevVersion)
+            -AddDevVersion $${{ eq(variables['SetDevVersion'],'true') }}
           pwsh: true

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -66,5 +66,5 @@ steps:
           arguments: >
             -ServiceDirectory '${{parameters.ServiceDirectory}}'
             -OutDirectory '${{ parameters.PackageInfoDirectory }}'
-            -AddDevVersion $${{ eq(variables['SetDevVersion'],'true') }}
+            -AddDevVersion:($env:SetDevVersion -eq 'true')
           pwsh: true

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -39,10 +39,15 @@ Param (
   [Parameter(Mandatory = $True)]
   [string] $outDirectory,
   [string] $prDiff,
-  [switch] $addDevVersion
+  [bool] $addDevVersion = $false
 )
 
 . (Join-Path $PSScriptRoot common.ps1)
+
+Write-Host "Service directory: $serviceDirectory"
+Write-Host "Output directory: $outDirectory"
+Write-Host "PR diff file: $prDiff"
+Write-Host "Add dev version: $addDevVersion"
 
 function SetOutput($outputPath, $incomingPackageSpec)
 {

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -39,15 +39,10 @@ Param (
   [Parameter(Mandatory = $True)]
   [string] $outDirectory,
   [string] $prDiff,
-  [bool] $addDevVersion = $false
+  [switch] $addDevVersion
 )
 
 . (Join-Path $PSScriptRoot common.ps1)
-
-Write-Host "Service directory: $serviceDirectory"
-Write-Host "Output directory: $outDirectory"
-Write-Host "PR diff file: $prDiff"
-Write-Host "Add dev version: $addDevVersion"
 
 function SetOutput($outputPath, $incomingPackageSpec)
 {


### PR DESCRIPTION
Save package properties add DEV version only if `AddDevVersion` switch is passed and currently this is incorrectly set in yaml. Script also needs a change since this is wrapped in a yaml to pass `AddDevVersion` a bool to avoid duplicate step in the pipeline yaml.