### PR TITLE
Fix the issue in adding dev version in package info

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -66,5 +66,5 @@ steps:
           arguments: >
             -ServiceDirectory '${{parameters.ServiceDirectory}}'
             -OutDirectory '${{ parameters.PackageInfoDirectory }}'
-            -AddDevVersion:($env:SetDevVersion -eq 'true')
+            -AddDevVersion:($env:SETDEVVERSION -eq 'true')
           pwsh: true

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -44,11 +44,6 @@ Param (
 
 . (Join-Path $PSScriptRoot common.ps1)
 
-Write-Host "Service directory: $serviceDirectory"
-Write-Host "Output directory: $outDirectory"
-Write-Host "PR diff: $prDiff"
-Write-Host "Add dev version: $addDevVersion"
-
 function SetOutput($outputPath, $incomingPackageSpec)
 {
 
@@ -68,7 +63,6 @@ function SetOutput($outputPath, $incomingPackageSpec)
   {
     # Use the "Version" property which was provided by the incoming package spec
     # as the DevVersion. This may be overridden later.
-    Write-Host "Adding DevVersion property to package info json. Dev version: $($incomingPackageSpec.Version)"
     $outputObject.DevVersion = $incomingPackageSpec.Version
   }
 

--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -44,6 +44,11 @@ Param (
 
 . (Join-Path $PSScriptRoot common.ps1)
 
+Write-Host "Service directory: $serviceDirectory"
+Write-Host "Output directory: $outDirectory"
+Write-Host "PR diff: $prDiff"
+Write-Host "Add dev version: $addDevVersion"
+
 function SetOutput($outputPath, $incomingPackageSpec)
 {
 
@@ -63,6 +68,7 @@ function SetOutput($outputPath, $incomingPackageSpec)
   {
     # Use the "Version" property which was provided by the incoming package spec
     # as the DevVersion. This may be overridden later.
+    Write-Host "Adding DevVersion property to package info json. Dev version: $($incomingPackageSpec.Version)"
     $outputObject.DevVersion = $incomingPackageSpec.Version
   }
 


### PR DESCRIPTION
Environment variable SETDEVVERSION is not accessed correctly so it is empty on Unix machines.