### PR TITLE
Remove requirement of only modifying 1 folder

### DIFF
--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.7.19",
+  "version": "2.7.20",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -7,7 +7,7 @@ import { modifyOrGenerateCiYml } from "../../utils/changeCiYaml";
 import { changeConfigOfTestAndSample, ChangeModel, SdkType } from "../../utils/changeConfigOfTestAndSample";
 import { changeRushJson } from "../../utils/changeRushJson";
 import { getOutputPackageInfo } from "../../utils/getOutputPackageInfo";
-import { getChangedCiYmlFilesInSpecificFolder, getChangedPackageDirectory } from "../../utils/git";
+import { getChangedCiYmlFilesInSpecificFolder } from "../../utils/git";
 import { logger } from "../../utils/logger";
 import { RunningEnvironment } from "../../utils/runningEnvironment";
 import { prepareCommandToInstallDependenciesForTypeSpecProject } from '../utils/prepareCommandToInstallDependenciesForTypeSpecProject';
@@ -194,19 +194,6 @@ export async function generateRLCInPipeline(options: {
     const outputPackageInfo = getOutputPackageInfo(options.runningEnvironment, options.readmeMd, options.typespecProject);
 
     try {
-        // TODO: need to refactor
-        // too tricky here, when relativePackagePath === undefined,
-        // the project should be typespec,
-        // and the changedPackageDirectories should be join(service-dir, package-dir)
-        if (!packagePath || !relativePackagePath) {
-            const changedPackageDirectories: Set<string> = await getChangedPackageDirectory(!options.skipGeneration);
-            if (changedPackageDirectories.size !== 1) {
-                throw new Error(`Find unexpected changed package directory. Length: ${changedPackageDirectories.size}. Value: ${[...changedPackageDirectories].join(', ')}. Please only change files in one directory`)
-            }
-            for (const d of changedPackageDirectories) relativePackagePath = d;
-            packagePath = path.join(options.sdkRepo, relativePackagePath!);
-        }
-
         if (!packagePath || !relativePackagePath) {
             throw new Error(`Failed to get package path`);
         }


### PR DESCRIPTION
Fix: https://github.com/Azure/azure-sdk-tools/issues/9829

Solution: remove the check to limit the number of changed folders more than one (while the the old tool pass only one `readmeMd` already, no need to check the number)