### PR TITLE
Remove ansi code from generate string

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-02-18 - 0.1.8
+
+- Format error log which has ANSI code that garbled characters are displayed on github checks
+- 
 ## 2025-02-11 - 0.1.7
 
 - Excluded general messages containing 'error' from being displayed in the Azure pipeline results

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/logging.ts
+++ b/tools/spec-gen-sdk/src/automation/logging.ts
@@ -2,6 +2,7 @@ import * as winston from 'winston';
 import { default as Transport } from 'winston-transport';
 import { SDKAutomationState } from './sdkAutomationState';
 import { setTimeout } from 'timers/promises';
+import { removeAnsiEscapeCodes } from '../utils/utils';
 
 export const sdkAutoLogLevels = {
   levels: {
@@ -151,5 +152,5 @@ export function vsoAddAttachment(name: string, path: string): void {
 }
 
 export function vsoLogIssue(message: string, type = "error"): void {
-  console.log(`##vso[task.logissue type=${type}]${message}`);
+  console.log(`##vso[task.logissue type=${type}]${removeAnsiEscapeCodes(message)}`);
 }

--- a/tools/spec-gen-sdk/test/utils.test.ts
+++ b/tools/spec-gen-sdk/test/utils.test.ts
@@ -142,6 +142,10 @@ describe('Remove AnsiEscape Codes', () => {
 
     expect(removeAnsiEscapeCodes(ansiArr)).toEqual(expect.arrayContaining(resArr));
   })
+  it('test ansi code error in net generate script', () => {
+    const ansiError = '\x1b[31;1mWrite-Error: \x1b[31;1m[ERROR] The service service is not onboarded yet. We will not support onboard a new service from swagger. Please contact the DotNet language support channel at https://aka.ms/azsdk/donet-teams-channel and include this spec pull request.\x1b[0m';
+    expect(removeAnsiEscapeCodes(ansiError)).toEqual('Write-Error: [ERROR] The service service is not onboarded yet. We will not support onboard a new service from swagger. Please contact the DotNet language support channel at https://aka.ms/azsdk/donet-teams-channel and include this spec pull request.');
+  })
 })
 
 describe('getTypeSpecProjectServiceName', () => {


### PR DESCRIPTION
Error logs which from .net error log in Github checks will render like this 
![image](https://github.com/user-attachments/assets/39878c38-38b7-4b22-bee5-141665ec8717)

E.g.
https://github.com/Azure/azure-rest-api-specs/pull/32652/checks?check_run_id=37331082298