### PR TITLE
[sdk-gen] clears the file content before writing new content

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-02-11 - 0.1.9
+
+- The writeTmpJsonFile function now clears the file content using fs.truncateSync before writing new content to ensure no residual data remains.
+
 ## 2025-02-11 - 0.1.7
 
 - Excluded general messages containing 'error' from being displayed in the Azure pipeline results

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.1.7",
+  "version": "0.1.9",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/utils/fsUtils.ts
+++ b/tools/spec-gen-sdk/src/utils/fsUtils.ts
@@ -146,6 +146,13 @@ const getFilesInFolder = async (searchPath: string, opts: FsSearchOptions): Prom
 export const writeTmpJsonFile = (context: WorkflowContext, fileName: string, content: unknown) => {
   const filePath = path.join(context.tmpFolder, fileName);
   const contentString = JSON.stringify(content, undefined, 2);
+
+  try {
+    fs.truncateSync(filePath, 0);
+  } catch (err) {
+    context.logger.error(`Failed to truncate file ${filePath}: ${err.message}`);
+  }
+
   context.logger.info(`Write temp file ${filePath} with content:`);
   context.logger.info(JSON.stringify(content, undefined, 2));
   fs.writeFileSync(filePath, contentString);


### PR DESCRIPTION
Ensure that the new content does not mix with the old content in sdk-gen for java