### PR TITLE
Support `input-file` in autorest config to recognize RP

### DIFF
--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.7.20",
+  "version": "2.7.19",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.7.19",
+  "version": "2.7.21",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -164,6 +164,11 @@ export async function generateRLCInPipeline(options: {
                             const InputFilePattern = new RegExp(`input-file:.*${specPath}.*`);
                             const containsInputFile = InputFilePattern.test(autoRestConfigContent);
                             
+                            // DEBUG:
+                            logger.info(`specPath: ${specPath}`);
+                            logger.info(`options.swaggerRepo: ${options.swaggerRepo}`);
+                            logger.info(`path.dirname(options.readmeMd!): ${path.dirname(options.readmeMd!)}`);
+
                             if (containsInputFile || requireFoundOnlyOne) {
                                 // NOTE: it can be overrided from other RPs
                                 if (requireFoundOnlyOne) replaceRequireInAutorestConfigurationFile(currentAutorestConfigFilePath, regexExecResult![1], path.join(options.swaggerRepo, options.readmeMd!));

--- a/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -140,7 +140,7 @@ export async function generateRLCInPipeline(options: {
                             if (!!autorestConfigFilePath) break;
                             if (!packageFolder.endsWith('-rest')) 
                             {
-                                logger.info(`Skip due to the folder name '${packageFolder}' does not end with '-rest'.`);
+                                logger.warn(`Skip due to the folder name '${packageFolder}' does not end with '-rest'.`);
                                 continue;
                             }
                             const packageFolderPath = path.join(rpFolderPath, packageFolder);

--- a/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -138,7 +138,11 @@ export async function generateRLCInPipeline(options: {
                     if (fs.lstatSync(rpFolderPath).isDirectory()) {
                         for (const packageFolder of fs.readdirSync(rpFolderPath)) {
                             if (!!autorestConfigFilePath) break;
-                            if (!packageFolder.endsWith('-rest')) continue;
+                            if (!packageFolder.endsWith('-rest')) 
+                            {
+                                logger.info(`Skip due to the folder name '${packageFolder}' does not end with '-rest'.`);
+                                continue;
+                            }
                             const packageFolderPath = path.join(rpFolderPath, packageFolder);
                             logger.info(`Start to find autorest configuration in '${packageFolderPath}'.`);
                             if (!fs.lstatSync(packageFolderPath).isDirectory()) {
@@ -153,7 +157,8 @@ export async function generateRLCInPipeline(options: {
                             const autorestConfigFilterRegex = new RegExp(`require:[\\s]*-?[\\s]*(.*${options.readmeMd!.replace(/\//g, '\\/').replace(/\./, '\\.')})`);
                             const regexExecResult = autorestConfigFilterRegex.exec(fs.readFileSync(currentAutorestConfigFilePath, 'utf-8'));
                             if (!regexExecResult || regexExecResult.length < 2) {
-                                logger.warn(`Failed to find AutoRest config in ${currentAutorestConfigFilePath}.`);
+                                const pattern = `require:[\\s]*-?[\\s]*(.*${options.readmeMd!.replace(/\//g, '\\/').replace(/\./, '\\.')})`;
+                                logger.warn(`Failed to find AutoRest config in ${currentAutorestConfigFilePath} due to the content unmatches to pattern: ${pattern}`);
                                 continue;
                             }
                             if (regexExecResult.length !== 2) {

--- a/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -7,7 +7,7 @@ import { modifyOrGenerateCiYml } from "../../utils/changeCiYaml";
 import { changeConfigOfTestAndSample, ChangeModel, SdkType } from "../../utils/changeConfigOfTestAndSample";
 import { changeRushJson } from "../../utils/changeRushJson";
 import { getOutputPackageInfo } from "../../utils/getOutputPackageInfo";
-import { getChangedCiYmlFilesInSpecificFolder, getChangedPackageDirectory } from "../../utils/git";
+import { getChangedCiYmlFilesInSpecificFolder } from "../../utils/git";
 import { logger } from "../../utils/logger";
 import { RunningEnvironment } from "../../utils/runningEnvironment";
 import { prepareCommandToInstallDependenciesForTypeSpecProject } from '../utils/prepareCommandToInstallDependenciesForTypeSpecProject';
@@ -197,7 +197,7 @@ export async function generateRLCInPipeline(options: {
 
     try {
         if (!packagePath || !relativePackagePath) {
-            throw new Error(`Failed to get package path.`);
+            throw new Error(`Failed to get package path`);
         }
         const packageJson = JSON.parse(fs.readFileSync(path.join(packagePath, 'package.json'), {encoding: 'utf-8'}));
         const packageName = packageJson.name;


### PR DESCRIPTION
Bugs:
- Failed to update package path and relative path which are used to generate some other files for the package for TSP
- Failed to get autorest config in sdk repo
- Get the first autorest config even if the swagger file is NOT the one in generating.
Test: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4578488&view=logs&j=47092895-c7c8-567a-c7a6-8c88f3ec178e&t=d293a8e8-c6af-5091-cdf7-4c66482dd6f2 (Type `Read temp file azure-sdk-for-js_tmp/generateOutput.json` to check result summay)
Issue Fix: https://github.com/Azure/azure-sdk-tools/issues/9829