### PR TITLE
[sdk-gen] add new state & format script line code

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release
 
+## 2025-02-18 - 0.1.8
+
+- Format error log which has ANSI code that garbled characters are displayed on github checks
+- Add new state `NotEnabled` when missing language config in readme.md or tspconfig.yaml
+
 ## 2025-02-11 - 0.1.7
 
 - Excluded general messages containing 'error' from being displayed in the Azure pipeline results

--- a/tools/spec-gen-sdk/src/automation/entrypoint.ts
+++ b/tools/spec-gen-sdk/src/automation/entrypoint.ts
@@ -120,7 +120,7 @@ export const sdkAutoMain = async (options: SdkAutoOptions) => {
   } catch (e) {
     if (workflowContext) {
       sdkContext.logger.error(`FatalError: ${e.message}. Please refer to the inner logs for details or report this issue through https://aka.ms/azsdk/support/specreview-channel.`);
-      workflowContext.status = 'failed';
+      workflowContext.status = workflowContext.status === 'notEnabled' ? workflowContext.status : 'failed';
       setFailureType(workflowContext, FailureType.PipelineFrameworkFailed);
       workflowContext.messages.push(e.message);
     }

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -95,6 +95,9 @@ export const generateReport = (context: WorkflowContext) => {
   writeTmpJsonFile(context, 'execution-report.json', executionReport);
   if (context.status === 'failed') {
     vsoLogIssue(`The generation process failed for ${specConfigPath}. Refer to the full log for details.`);
+  } 
+  else if (context.status === 'notEnabled') {
+    vsoLogIssue(`The generation process failed for missing language configuration in ${specConfigPath}. Refer to the full log for details.`);
   } else {
     context.logger.info(`Main status [${context.status}]`);
   }
@@ -103,7 +106,7 @@ export const generateReport = (context: WorkflowContext) => {
     setPipelineVariables(context, executionReport);
   }
 
-  if (context.status === 'failed') {
+  if (['notEnabled', 'failed'].includes(context.status)) {
     console.log(`##vso[task.complete result=Failed;]`);
     sendFailure();
   } else {
@@ -148,7 +151,8 @@ export const saveFilteredLog = (context: WorkflowContext) => {
     inProgress: 'Error',
     failed: 'Error',
     warning: 'Warning',
-    succeeded: 'Info'
+    succeeded: 'Info',
+    notEnabled: 'Warning'
   } as const;
   const type = statusMap[context.status];
   const filteredResultData = [
@@ -340,7 +344,7 @@ export const sdkAutoReportStatus = async (context: WorkflowContext) => {
   }
 
   context.logger.info(`Main status [${context.status}] hasBreakingChange [${hasBreakingChange}] isBetaMgmtSdk [${isBetaMgmtSdk}] hasSuppressions [${hasSuppressions}] hasAbsentSuppressions [${hasAbsentSuppressions}]`);
-  if (context.status === 'failed') {
+  if (['failed','notEnabled'].includes(context.status)) {
     console.log(`##vso[task.complete result=Failed;]`);
     sendFailure();
   } else {
@@ -366,7 +370,8 @@ export const sdkAutoReportStatus = async (context: WorkflowContext) => {
     inProgress: 'Error',
     failed: 'Error',
     warning: 'Warning',
-    succeeded: 'Info'
+    succeeded: 'Info',
+    notEnabled: 'Warning'
   } as const;
   const type = statusMap[context.status];
   const pipelineResultData = [
@@ -408,7 +413,8 @@ const githubStateEmoji: { [key in SDKAutomationState]: string } = {
   failed: '❌',
   inProgress: '🔄',
   succeeded: '️✔️',
-  warning: '⚠️'
+  warning: '⚠️',
+  notEnabled: '🚫'
 };
 const trimNewLine = (line: string) => htmlEscape(line.trimEnd());
 const handleBarHelpers = {

--- a/tools/spec-gen-sdk/src/automation/sdkAutomationState.ts
+++ b/tools/spec-gen-sdk/src/automation/sdkAutomationState.ts
@@ -22,7 +22,11 @@ const SDKAutomationStateStrings = {
   /**
    * The generation process has warnings.
    */
-  warning: `Warning`
+  warning: `Warning`,
+  /**
+   * The generation process exited due to missing language configuration in tspconfig.yaml or reamd.md .
+   */
+  notEnabled: `NotEnabled`
 };
 
 /**

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -173,6 +173,7 @@ export const workflowValidateSdkConfigForSpecPr = async (context: WorkflowContex
     throw new Error(`No changes detected in the API specs; SDK generation skipped.`);
   }
   if (sdkToGenerate.size === 0) {
+    context.status = 'notEnabled';
     throw new Error(`No SDKs are enabled for generation. Please check the configuration in the realted tspconfig.yaml or readme.md`);
   }
   context.logger.info(`SDK to generate:`);
@@ -188,7 +189,7 @@ export const workflowValidateSdkConfigForSpecPr = async (context: WorkflowContex
   context.logger.log('endsection', 'Validate SDK config for spec PR scenario');
 };
 
-export const workflowValidateSdkConfig = async (context: SdkAutoContext) => {
+export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
   context.logger.log('section', 'Validate SDK configuration');
   let sdkToGenerate = "";
 
@@ -231,6 +232,7 @@ export const workflowValidateSdkConfig = async (context: SdkAutoContext) => {
     context.logger.info(`SDK to generate:${context.config.sdkName}`);
   }
   else {
+    context.status = 'notEnabled';
     throw new Error(`No SDKs are enabled for generation. Please check the configuration in the related tspconfig.yaml or readme.md`);
   }
   context.logger.log('endsection', 'Validate SDK configuration');
@@ -291,6 +293,7 @@ const workflowHandleReadmeMdOrTypeSpecProject = async (context: WorkflowContext,
   }
 
   if (typespecProjectList.length === 0 && readmeMdList.length === 0) {
+    context.status = 'notEnabled';
     context.logger.remove(context.messageCaptureTransport);
     return;
   }

--- a/tools/spec-gen-sdk/src/utils/runScript.ts
+++ b/tools/spec-gen-sdk/src/utils/runScript.ts
@@ -5,15 +5,17 @@ import { RunLogFilterOptions, RunLogOptions, RunOptions } from '../types/Swagger
 import { Readable } from 'stream';
 import { SDKAutomationState } from '../automation/sdkAutomationState';
 import { vsoLogIssue } from '../automation/logging';
+import { removeAnsiEscapeCodes } from './utils';
 
-export type RunResult = Exclude<SDKAutomationState, 'inProgress' | 'pending'>;
+export type RunResult = Exclude<SDKAutomationState, 'inProgress' | 'pending' | 'notEnabled'>;
 export type StatusContainer = { status: SDKAutomationState };
 const resultLevelMap: { [result in SDKAutomationState]: number } = {
   pending: -2,
   inProgress: -1,
   succeeded: 0,
   warning: 1,
-  failed: 2
+  notEnabled: 2,
+  failed: 3
 };
 const resultLogLevelMap: { [result in RunResult]: string } = {
   succeeded: 'info',
@@ -147,7 +149,7 @@ const listenOnStream = (
     }
     setSdkAutoStatus(result, lineResult);
     if (context.config.runEnv === 'azureDevOps' && line.toLowerCase().includes("[error]")) {
-      vsoLogIssue(line);
+      vsoLogIssue(removeAnsiEscapeCodes(line));
     } else {
       context.logger.log(logType, `${prefix} ${line}`, { showInComment: _showInComment, lineResult });
     }

--- a/tools/spec-gen-sdk/src/utils/utils.ts
+++ b/tools/spec-gen-sdk/src/utils/utils.ts
@@ -31,15 +31,13 @@ export function getValueByKey<T>(
     return foundObject ? foundObject[targetKey] : undefined;
 }
 
-export function removeAnsiEscapeCodes(
-    messages: string[] | string
-): string[] | string {
+export function removeAnsiEscapeCodes<T extends string | string[]>(messages: T): T {
     // eslint-disable-next-line no-control-regex
     const ansiEscapeCodeRegex = /\x1b\[(\d{1,2}(;\d{0,2})*)?[A-HJKSTfimnsu]/g;
     if (typeof messages === "string") {
-        return messages.replace(ansiEscapeCodeRegex, "");
+        return messages.replace(ansiEscapeCodeRegex, "") as T;
     }
-    return messages.map((item) => item.replace(ansiEscapeCodeRegex, ""));
+    return messages.map((item) => item.replace(ansiEscapeCodeRegex, "")) as T;
 }
 
 export function extractServiceName(path: string): string {

--- a/tools/spec-gen-sdk/test/utils.test.ts
+++ b/tools/spec-gen-sdk/test/utils.test.ts
@@ -142,6 +142,11 @@ describe('Remove AnsiEscape Codes', () => {
 
     expect(removeAnsiEscapeCodes(ansiArr)).toEqual(expect.arrayContaining(resArr));
   })
+  
+  it('test ansi code error in net generate script', () => {
+    const ansiError = '\x1b[31;1mWrite-Error: \x1b[31;1m[ERROR] The service service is not onboarded yet. We will not support onboard a new service from swagger. Please contact the DotNet language support channel at https://aka.ms/azsdk/donet-teams-channel and include this spec pull request.\x1b[0m';
+    expect(removeAnsiEscapeCodes(ansiError)).toEqual('Write-Error: [ERROR] The service service is not onboarded yet. We will not support onboard a new service from swagger. Please contact the DotNet language support channel at https://aka.ms/azsdk/donet-teams-channel and include this spec pull request.');
+  })
 })
 
 describe('getTypeSpecProjectServiceName', () => {


### PR DESCRIPTION
- Format error log which has ANSI code that garbled characters are displayed on github checks
- Add new state `NotEnabled` when missing language config in readme.md or tspconfig.yaml