### PR TITLE
Relying on `CIParameters` for storage of trigger information

### DIFF
--- a/eng/common-tests/helpers/Package-Helpers.tests.ps1
+++ b/eng/common-tests/helpers/Package-Helpers.tests.ps1
@@ -68,7 +68,6 @@ Describe "Yaml Parsing" {
 
     It "It should handle early escapes due to no data" {
         $yaml = @"
-# NOTE: Please refer to https://aka.ms/azsdk/engsys/ci-yaml before editing this file.
 trigger: none
 pr: none
 

--- a/eng/common/scripts/Helpers/Package-Helpers.ps1
+++ b/eng/common/scripts/Helpers/Package-Helpers.ps1
@@ -155,7 +155,7 @@ function GetValueSafelyFrom-Yaml {
   )
   $current = $YamlContentAsHashtable
   foreach ($key in $Keys) {
-    if ($current.ContainsKey($key) -or $current[$key]) {
+    if ($current -is [HashTable] -and ($current.ContainsKey($key) -or $current[$key])) {
       $current = $current[$key]
     }
     else {

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -126,14 +126,7 @@ class PackageProps {
 
             if ($ciArtifactResult) {
                 $this.ArtifactDetails = [Hashtable]$ciArtifactResult.ArtifactConfig
-                $this.CIParameters["CITriggerPaths"] = @()
                 $this.CIParameters["CIMatrixConfigs"] = @()
-
-                $triggers = GetValueSafelyFrom-Yaml $ciArtifactResult.ParsedYml @("trigger", "paths", "include")
-
-                if ($triggers) {
-                    $this.CIParameters["CITriggerPaths"] += $triggers
-                }
 
                 # if we know this is the matrix for our file, we should now see if there is a custom matrix config for the package
                 $matrixConfigList = GetValueSafelyFrom-Yaml $ciArtifactResult.ParsedYml @("extends", "parameters", "MatrixConfigs")

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -230,6 +230,11 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
             }
             $filePath = (Join-Path $RepoRoot $file)
 
+            # but I believe that we have to include the exclude paths as well
+            # otherwise we will not handle when the trigger path has exclude. like for java/core/ci.yml
+            # in that instance, the trigger path is sdk/core but we want to exclude sdk/core/azure-core-v2
+            # so we need to ensure that we are including the exclude paths when we evaluate the additional trigger paths
+            # this is still todo though, a follow-up commit will add this
             foreach($triggerPath in $triggerPaths) {
                 # utilize the various trigger paths against the targeted file here
             }

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -244,6 +244,9 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
 
                 if ($resolvedRelativePath) {
                     $shouldInclude = $shouldInclude -or ($filePath -like (Join-Path "$resolvedRelativePath" "*"))
+                    # if we reached here, this package wasn't directly changed, but instead
+                    # should be validated because it was indirectly changed
+                    $pkg.IncludedForValidation = $true
                 }
             }
 

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -210,6 +210,13 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
         $lookupKey = ($pkg.DirectoryPath).Replace($RepoRoot, "").TrimStart('\/')
         $lookup[$lookupKey] = $pkg
 
+        # resolve the trigger paths for the package, either from individual artifact config OR by falling back to associated ci.yml file trigger paths
+        $triggerPaths = $pkg.CIParameters["CITriggerPaths"]
+        if ($pkg.ArtifactDetails -and $pkg.ArtifactDetails["TriggerPaths"]) {
+            $triggerPaths = $pkg.ArtifactDetails["TriggerPaths"]
+        }
+        $triggerPaths = $triggerPaths | ForEach-Object { $_.TrimEnd("/") + "/" }
+
         foreach ($file in $targetedFiles) {
             $shouldExclude = $false
             foreach ($exclude in $excludePaths) {
@@ -222,6 +229,11 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
                 continue
             }
             $filePath = (Join-Path $RepoRoot $file)
+
+            foreach($triggerPath in $triggerPaths) {
+                # utilize the various trigger paths against the targeted file here
+            }
+
             $shouldInclude = $filePath -like (Join-Path "$pkgDirectory" "*")
             if ($shouldInclude) {
                 $packagesWithChanges += $pkg

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -237,7 +237,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     }
 
     # add all of the packages that were added purely for validation purposes
-    # this is executed seperately because we need to identify packages added this way as only included for validation
+    # this is executed separately because we need to identify packages added this way as only included for validation
     # we don't actually need to build or analyze them. only test them.
     $existingPackageNames = @($packagesWithChanges | ForEach-Object { $_.Name })
     foreach ($addition in $additionalValidationPackages) {

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -215,6 +215,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
         # end up in a situation where any change to a service would
         # still trigger every package in that service. individual package triggers
         # must be added to handle this.
+        $triggeringPaths = @()
         if ($pkg.ArtifactDetails -and $pkg.ArtifactDetails["triggeringPaths"]) {
             $triggeringPaths = $pkg.ArtifactDetails["triggeringPaths"]
         }

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -243,11 +243,14 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
                     $resolvedRelativePath = (Join-Path $RepoRoot "sdk" "$($pkg.ServiceDirectory)" $triggerPath)
                 }
 
+                # if we are including this package due to one of its additional trigger paths, we need
+                # to ensure we're counting it as included for validation, not as an actual package change
                 if ($resolvedRelativePath) {
-                    $shouldInclude = $shouldInclude -or ($filePath -like (Join-Path "$resolvedRelativePath" "*"))
-                    # if we reached here, this package wasn't directly changed, but instead
-                    # should be validated because it was indirectly changed
-                    $pkg.IncludedForValidation = $true
+                    $includedForValidation = $filePath -like (Join-Path "$resolvedRelativePath" "*")
+                    $shouldInclude = $shouldInclude -or $includedForValidation
+                    if ($includedForValidation) {
+                        $pkg.IncludedForValidation = $true
+                    }
                 }
             }
 


### PR DESCRIPTION
FYI @benbp @JimSuplizio 

This PR:

- [x] Adds support for saving trigger paths from the `ci.yml` for each pkg into the `pkgprops` under `CITriggerPaths`.
- [x] ~~Honor the `CITriggerPaths` with fallback to artifact `triggerPaths` to implement non-sdk path triggers in `Get-PrPkgProperties`~~

This covers the "if eng/ changes add this package purely for validation".

The issue I discovered is that if we honor the default `trigger` from each `ci.yml`, we would end up causing `pullrequest` builds to just target the entire `servicedirectory` again. We need the inclusion to be at the _artifact_ level.

So for instances like `eventhub` for .NET. Where a given service directory contains multiple `ci.yml` that all target different artifact lists. This enables specific coverage of packages that depend on a specific directory path that might not even be a valid package. So for eventhub, that looks like this:

```
     - name: Azure.Messaging.EventHubs.Processor
       safeName: AzureMessagingEventHubsProcessor
       triggeringPaths:
         - sdk/eventhub/Azure.Messaging.EventHubs.Shared
```