### PR TITLE
Fix: failed to get package path

### DIFF
--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.7.20",
+  "version": "2.7.21",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -77,7 +77,9 @@ export async function generateRLCInPipeline(options: {
                 logger.info(`Start to run command: '${scriptCommand}'`);
                 execSync(scriptCommand, {stdio: 'inherit'});
                 logger.info("Generated code by tsp-client successfully.");
-            } 
+            }
+            packagePath = generatedPackageDir;
+            relativePackagePath = path.relative(options.sdkRepo, packagePath);
         }
     } else {
         logger.info(`Start to generate SDK from '${options.readmeMd}'.`);


### PR DESCRIPTION
Root cause: forget to set package path (declared in line 42, 43) after code generation
Test: https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4578488&view=logs&j=47092895-c7c8-567a-c7a6-8c88f3ec178e&t=d293a8e8-c6af-5091-cdf7-4c66482dd6f2&l=6927