### PR TITLE
Remove trailing slash addition to ExcludePaths

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -192,7 +192,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     # had files sdk/foo/file1 and sdk/foobar/file2 with the exclude of anything in
     # sdk/foo, it should only exclude things under sdk/foo. The TrimEnd is just in
     # case one of the paths ends with a slash, it doesn't add a second one.
-    $excludePaths = $diff.ExcludePaths | ForEach-Object { $_.TrimEnd("/") + "/" }
+    $excludePaths = $diff.ExcludePaths | ForEach-Object { $_ }
 
     $additionalValidationPackages = @()
     $lookup = @{}

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -185,14 +185,7 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
         $targetedFiles += $diff.DeletedFiles
     }
 
-    # The exclude paths and the targeted files paths aren't full OS paths, they're
-    # GitHub paths meaning they're relative to the repo root and slashes are forward
-    # slashes "/". The ExcludePaths need to have a trailing slash added in order
-    # correctly test for string matches without overmatching. For example, if a pr
-    # had files sdk/foo/file1 and sdk/foobar/file2 with the exclude of anything in
-    # sdk/foo, it should only exclude things under sdk/foo. The TrimEnd is just in
-    # case one of the paths ends with a slash, it doesn't add a second one.
-    $excludePaths = $diff.ExcludePaths | ForEach-Object { $_ }
+    $excludePaths = $diff.ExcludePaths
 
     $additionalValidationPackages = @()
     $lookup = @{}


### PR DESCRIPTION
We were adding a trailing slash to ExcludePaths. The problem with doing this it that it only allowed paths to be excluded and disallowed excluding specific files. For Java, this was a problem because we need to exclude the centralized versioning files from the PR pipeline, otherwise, anything changing these would get azure-core added as an indirect package which would cause the PR pipeline to run when it shouldn't. For example, Java Cosmos had [PR](https://github.com/Azure/azure-sdk-for-java/pull/44306) yesterday to prepare for their release which changed version_client.txt but every other change was in sdk/cosmos.

This change will allow the ExcludePaths to include specific files. PRs in [Java](https://github.com/Azure/azure-sdk-for-java/pull/44330), [JS](https://github.com/Azure/azure-sdk-for-js/pull/33156), [Net](https://github.com/Azure/azure-sdk-for-net/pull/48391) and [Python ](https://github.com/Azure/azure-sdk-for-python/pull/39825) have already been made to add trailing slashes to their ExcludePaths and remove the other place in their specific Language-Settings.ps1 files where this was also being done. Note: Rust didn't require a PR like the other languages, as it has no exclude paths and its Language-Settings doesn't have the trailing slash addition.

I won't create the merge PRs from this change until the other ones are in.