### PR TITLE
Log warning when SDK configuration is not enabled in the configuration

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-02-21 - 0.1.9
+
+- Fixed some warnings output
+
 ## 2025-02-18 - 0.1.8
 
 - Formated error log which has ANSI codes to prevent garbled characters are displayed

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.1.8",
+  "version": "0.1.9",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -67,7 +67,7 @@ export const generateReport = (context: WorkflowContext) => {
     context.logger.info(`package [${pkg.name}] hasBreakingChange [${pkg.hasBreakingChange}] isBetaMgmtSdk [${pkg.isBetaMgmtSdk}] hasSuppressions [${hasSuppressions}] hasAbsentSuppressions [${hasAbsentSuppressions}]`);
   }
 
-  if (context.config.pullNumber) {
+  if (context.config.pullNumber && markdownContent) {
     try {
       // Write a markdown file to be rendered by the Azure DevOps pipeline
       const fileNamePrefix = extractPathFromSpecConfig(context.config.tspConfigPath, context.config.readmePath);
@@ -78,9 +78,9 @@ export const generateReport = (context: WorkflowContext) => {
       }
       writeFileSync(markdownFilePath, markdownContent);
       vsoAddAttachment(`Generation Summary for ${specConfigPath}`, markdownFilePath);
-      } catch (e) {
-        context.logger.error(`IOError: Fails to write markdown file. Details: ${e}`);
-      }
+    } catch (e) {
+      context.logger.error(`IOError: Fails to write markdown file. Details: ${e}`);
+    }
   }
 
   executionReport = {

--- a/tools/spec-gen-sdk/src/automation/workflowPackage.ts
+++ b/tools/spec-gen-sdk/src/automation/workflowPackage.ts
@@ -204,4 +204,3 @@ const workflowPkgCallInstallInstructionScript = async (
 
   context.logger.log('section', 'Call InstallInstructionScript');
 };
-

--- a/tools/spec-gen-sdk/src/utils/utils.ts
+++ b/tools/spec-gen-sdk/src/utils/utils.ts
@@ -177,7 +177,7 @@ export function extractPathFromSpecConfig(tspConfigPath: string | undefined, rea
       prefix = segments.join('-').toLowerCase().replace(/\./g, '-');
     }
   } else if (readmePath) {
-    const match = readmePath.match(/specification\/(.+)\/(?:resource-manager|data-plane)\/readme\.md$/i);
+    const match = readmePath.match(/specification\/(.+?)\/readme\.md$/i);
     if (match) {
       const segments = match[1].split('/');
       prefix = segments.join('-').toLowerCase().replace(/\./g, '-');

--- a/tools/spec-gen-sdk/test/utils.test.ts
+++ b/tools/spec-gen-sdk/test/utils.test.ts
@@ -309,14 +309,14 @@ describe('extract and format the prefix from spec config path', () => {
       const tspConfigPath = undefined;
       const readmePath = 'specification/myService/resource-manager/readme.md';
       const result = extractPathFromSpecConfig(tspConfigPath, readmePath);
-      expect(result).toEqual('myservice');
+      expect(result).toEqual('myservice-resource-manager');
     });
 
     it('should extract and format the prefix from readmePath', () => {
       const tspConfigPath = undefined;
       const readmePath = 'specification/myService/subservice/data-plane/readme.md';
       const result = extractPathFromSpecConfig(tspConfigPath, readmePath);
-      expect(result).toEqual('myservice-subservice');
+      expect(result).toEqual('myservice-subservice-data-plane');
     });
 
     it('should return an empty string if paths are not provided', () => {


### PR DESCRIPTION
- Changed the message from error level to warning level when SDK configuration is not enabled in the configuration file.
- Updated the regex to get the prefix of spec folder path