### PR TITLE
Disable SafeCRLF

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -622,7 +622,7 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                         var cloneUrl = GetCloneUrl(config.AssetsRepo, config.RepoRoot);
                         // The -c core.longpaths=true is basically for Windows and is a noop for other platforms
                         GitHandler.Run($"clone -c core.longpaths=true --no-checkout --filter=tree:0 {cloneUrl} .", config);
-                        GitHandler.Run("git config --local core.safecrlf false", config);
+                        GitHandler.Run("config --local core.safecrlf false", config);
                         GitHandler.Run($"sparse-checkout init", config);
 
                     }

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Store/GitStore.cs
@@ -622,7 +622,9 @@ namespace Azure.Sdk.Tools.TestProxy.Store
                         var cloneUrl = GetCloneUrl(config.AssetsRepo, config.RepoRoot);
                         // The -c core.longpaths=true is basically for Windows and is a noop for other platforms
                         GitHandler.Run($"clone -c core.longpaths=true --no-checkout --filter=tree:0 {cloneUrl} .", config);
+                        GitHandler.Run("git config --local core.safecrlf false", config);
                         GitHandler.Run($"sparse-checkout init", config);
+
                     }
                     catch (GitProcessException e)
                     {


### PR DESCRIPTION
@benbp @weshaggard I'm interested to get your opinion on this.

The storage team (and others merging recordings) sometimes get errors in their `git add` commands that pan out to something along the lines of:

```
Unhandled exception: Azure.Sdk.Tools.TestProxy.Common.Exceptions.HttpException: Invocation of "git add -A ." had a non-zero exit code -1.
fatal: LF would be replaced by CRLF in net/sdk/storage/Azure.Storage.Blobs/tests/SessionRecords/AppendBlobClientOpenReadTests/OpenReadAsync_AccessConditions.json
```

Best I can tell, this occurs when copying files from a tag on your machine, when the files were generated on an opposite platform. It's a fairly uncommon issue, but one that does happen.

The fix is to cd into the directory and add the file yourself, accepting the conversion to whatever line endings are in your base tag.

If the correct resolution is just to accept the conversion, I feel like we should just set this default so nobody hits the issue anymore. What do ya'll think?