### PR TITLE
Moving more discovery into `Get-PrPkgProperties`

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -256,29 +256,27 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
             # for this task. This is because we can resolve a service directory from the ci.yml, and if
             # there is a single ci.yml in that directory, we can assume that any file change in that directory
             # will apply to all packages that exist in that directory.
-            if ($pathComponents.Length -eq 3 -and $pathComponents[0] -eq "sdk") {
-                $triggeringCIYmls = $triggeringPaths | Where-Object { $_ -like "*ci*.yml" }
+            $triggeringCIYmls = $triggeringPaths | Where-Object { $_ -like "*ci*.yml" }
 
-                foreach($yml in $triggeringCIYmls) {
-                    # given that this path is coming from the populated triggering paths in the artifact,
-                    # we can assume that the path to the ci.yml will successfully resolve.
-                    $ciYml = Join-Path $RepoRoot $yml
-                    # ensure we terminate the service directory with a /
-                    $directory = [System.IO.Path]::GetDirectoryName($ciYml).Replace("`\", "/") + "/"
-                    $soleCIYml = (Get-ChildItem -Path $directory -Filter "ci*.yml" -File).Count -eq 1
+            foreach($yml in $triggeringCIYmls) {
+                # given that this path is coming from the populated triggering paths in the artifact,
+                # we can assume that the path to the ci.yml will successfully resolve.
+                $ciYml = Join-Path $RepoRoot $yml
+                # ensure we terminate the service directory with a /
+                $directory = [System.IO.Path]::GetDirectoryName($ciYml).Replace("`\", "/") + "/"
+                $soleCIYml = (Get-ChildItem -Path $directory -Filter "ci*.yml" -File).Count -eq 1
 
-                    if ($soleCIYml -and $filePath.Replace("`\", "/").StartsWith($directory)) {
-                        if (-not $shouldInclude) {
-                            $pkg.IncludedForValidation = $true
-                            $shouldInclude = $true
-                        }
-                        break
+                if ($soleCIYml -and $filePath.Replace("`\", "/").StartsWith($directory)) {
+                    if (-not $shouldInclude) {
+                        $pkg.IncludedForValidation = $true
+                        $shouldInclude = $true
                     }
-                    else {
-                        # if the ci.yml is not the only file in the directory, we cannot assume that any file changed within the directory that isn't the ci.yml
-                        # should trigger this package
-                        Write-Host "Skipping adding package for file `"$file`" because the ci yml `"$yml`" is not the only file in the service directory `"$directory`""
-                    }
+                    break
+                }
+                else {
+                    # if the ci.yml is not the only file in the directory, we cannot assume that any file changed within the directory that isn't the ci.yml
+                    # should trigger this package
+                    Write-Host "Skipping adding package for file `"$file`" because the ci yml `"$yml`" is not the only file in the service directory `"$directory`""
                 }
             }
 

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -268,8 +268,10 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
                     $soleCIYml = (Get-ChildItem -Path $directory -Filter "ci*.yml" -File).Count -eq 1
 
                     if ($soleCIYml -and $filePath.Replace("`\", "/").StartsWith($directory)) {
-                        $shouldInclude = $true
-                        $pkg.IncludedForValidation = $true
+                        if (-not $shouldInclude) {
+                            $pkg.IncludedForValidation = $true
+                            $shouldInclude = $true
+                        }
                         break
                     }
                     else {

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -263,10 +263,11 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
                     # given that this path is coming from the populated triggering paths in the artifact,
                     # we can assume that the path to the ci.yml will successfully resolve.
                     $ciYml = Join-Path $RepoRoot $yml
+                    # ensure we terminate the service directory with a /
                     $directory = [System.IO.Path]::GetDirectoryName($ciYml).Replace("`\", "/") + "/"
                     $soleCIYml = (Get-ChildItem -Path $directory -Filter "ci*.yml" -File).Count -eq 1
 
-                    if ($soleCIYml -and $filePath.StartsWith($directory)) {
+                    if ($soleCIYml -and $filePath.Replace("`\", "/").StartsWith($directory)) {
                         $shouldInclude = $true
                         $pkg.IncludedForValidation = $true
                         break

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -233,10 +233,8 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
 
             # handle changes to files that are RELATED to each package
             foreach($triggerPath in $triggeringPaths) {
-                # each relative path will be resolved relative to the repo root
                 $resolvedRelativePath = (Join-Path $RepoRoot $triggerPath)
 
-                # or if the path doesn't start with a slash, it will be resolved relative to directory containing our ci.yml
                 if (!$triggerPath.StartsWith("/")){
                     $resolvedRelativePath = (Join-Path $RepoRoot "sdk" "$($pkg.ServiceDirectory)" $triggerPath)
                 }
@@ -253,10 +251,11 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
             }
 
             # handle changes to files under the service directory, but not a ci.yml file
+               # changes to ci.yml files that are owned by artifacts will be handled by the default inclusion of the owning ci.yml to each packages' triggeringPaths
                # so what we are dealing with here is the singular instance where a service-level file has changed,
                # but we CAN'T tell which ci.yml is associated with it.
-               # if there is an instance where there is a single ci.yml file, but we SHOULD NOT include all the packages within
-               # the service directory, we can't handle it currently.
+               # need to run down whether there are any instances of service directories that contain a single ci.yml file but CANNOT include
+               # all packages that exist therein.
 
             if ($shouldInclude) {
                 $packagesWithChanges += $pkg


### PR DESCRIPTION
This PR handles service-level changes without language-specific settings.

- [x] Add owning `ci.yml` to `triggeringPaths` by default. 
- [x] Handle service-level changes where there is a single `ci.yml` present in the service directory for the package.
  - Just add the artifacts within the `ci.yml` to the set of artifacts for testing
- [x] When there are multiple ci.yml files in service directory, and a file that is NOT a ci.yml is changed, emit a warning


This approach is working the way I expect in: Azure/azure-sdk-for-net#48379