### PR TITLE
[apiview][js parser] skip diff'ing for @Azure dependencies 

### DIFF
--- a/tools/apiview/parsers/js-api-parser/CHANGELOG.md
+++ b/tools/apiview/parsers/js-api-parser/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 2.0.5
+
+- skip diff for @azure\* and tslib dependencies
+- Support re-exported enums
+
 # 2.0.4
 
 - update models from latest CodeFile schemas

--- a/tools/apiview/parsers/js-api-parser/package.json
+++ b/tools/apiview/parsers/js-api-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/ts-genapi",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "",
   "main": "index.js",
   "publishConfig": {

--- a/tools/apiview/parsers/js-api-parser/src/export.ts
+++ b/tools/apiview/parsers/js-api-parser/src/export.ts
@@ -41,7 +41,7 @@ async function main() {
         Name,
         PackageName,
         PackageVersion,
-        ParserVersion: "2.0.0",
+        ParserVersion: "2.0.5",
         Language: "JavaScript",
       },
       dependencies,

--- a/tools/apiview/parsers/js-api-parser/src/generate.ts
+++ b/tools/apiview/parsers/js-api-parser/src/generate.ts
@@ -50,7 +50,7 @@ function shouldSkipDependency(dependency: string): boolean {
  * @param dependencies dependencies of name and version pairs
  * @returns
  */
-function buildDependencies(reviewLines: ReviewLine[], dependencies: Record<string, string>) {
+export function buildDependencies(reviewLines: ReviewLine[], dependencies: Record<string, string>) {
   if (!dependencies) {
     return;
   }

--- a/tools/apiview/parsers/js-api-parser/src/generate.ts
+++ b/tools/apiview/parsers/js-api-parser/src/generate.ts
@@ -35,6 +35,16 @@ function emptyLine(relatedToLine?: string): ReviewLine {
 }
 
 /**
+ * Whether to skip diffing a dependency or not
+ * @param dependency
+ * @returns
+ */
+function shouldSkipDependency(dependency: string): boolean {
+  const knownPackagesToSkip: string[] = ["tslib"];
+  return dependency.startsWith("@azure") || knownPackagesToSkip.includes(dependency);
+}
+
+/**
  * Builds review for the package's direct dependencies
  * @param reviewLines The result array to push {@link ReviewLine}s to
  * @param dependencies dependencies of name and version pairs
@@ -67,7 +77,7 @@ function buildDependencies(reviewLines: ReviewLine[], dependencies: Record<strin
     const nameToken: ReviewToken = buildToken({
       Kind: TokenKind.StringLiteral,
       Value: dependency,
-      SkipDiff: true,
+      SkipDiff: shouldSkipDependency(dependency),
     });
     const versionToken: ReviewToken = buildToken({
       Kind: TokenKind.StringLiteral,

--- a/tools/apiview/parsers/js-api-parser/test/generate.spec.ts
+++ b/tools/apiview/parsers/js-api-parser/test/generate.spec.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { generateApiview } from "../src/generate";
+import { buildDependencies, generateApiview } from "../src/generate";
 import { ApiModel } from "@microsoft/api-extractor-model";
 import path from "path";
+import { ReviewLine } from "../src/models";
 
 describe("generate", () => {
   describe("enums", () => {
@@ -27,6 +28,57 @@ describe("generate", () => {
       expect(enumReviewLine?.Tokens.map((t) => t.Value).join(" ")).toEqual(
         "export enum KnownFoo { }",
       );
+    });
+  });
+
+  describe("dependencies are skipped properly", () => {
+    it("skips azure dependencies", () => {
+      const dependencies = {
+        "@azure/package": "1.0.0",
+        "@azure-rest/package": "1.0.0-beta.1",
+      };
+      const reviewLines: ReviewLine[] = [];
+      buildDependencies(reviewLines, dependencies);
+      expect(reviewLines[0].LineId).toEqual("Dependencies");
+      const children = reviewLines[0].Children;
+
+      expect(children?.length).toEqual(2);
+      expect(children?.[0].Tokens?.[0].Value).toEqual("@azure/package");
+      expect(children?.[0].Tokens?.[0].SkipDiff).toEqual(true);
+      expect(children?.[0].Tokens?.[2].SkipDiff).toEqual(true);
+      expect(children?.[1].Tokens?.[0].Value).toEqual("@azure-rest/package");
+      expect(children?.[1].Tokens?.[0].SkipDiff).toEqual(true);
+      expect(children?.[1].Tokens?.[2].SkipDiff).toEqual(true);
+    });
+
+    it("skips tslib", () => {
+      const dependencies = {
+        tslib: "1.0.0",
+      };
+      const reviewLines: ReviewLine[] = [];
+      buildDependencies(reviewLines, dependencies);
+      expect(reviewLines[0].LineId).toEqual("Dependencies");
+      const children = reviewLines[0].Children;
+
+      expect(children?.length).toEqual(1);
+      expect(children?.[0].Tokens?.[0].Value).toEqual("tslib");
+      expect(children?.[0].Tokens?.[0].SkipDiff).toEqual(true);
+      expect(children?.[0].Tokens?.[2].SkipDiff).toEqual(true);
+    });
+
+    it("does not skip third-party dependencies", () => {
+      const dependencies = {
+        "fast-xml-parser": "5.0.7",
+      };
+      const reviewLines: ReviewLine[] = [];
+      buildDependencies(reviewLines, dependencies);
+      expect(reviewLines[0].LineId).toEqual("Dependencies");
+      const children = reviewLines[0].Children;
+
+      expect(children?.length).toEqual(1);
+      expect(children?.[0].Tokens?.[0].Value).toEqual("fast-xml-parser");
+      expect(children?.[0].Tokens?.[0].SkipDiff).toEqual(false);
+      expect(children?.[0].Tokens?.[2].SkipDiff).toEqual(true);
     });
   });
 });


### PR DESCRIPTION
and tslib.  This allows us to see third-party dependency changes.