### PR TITLE
Add condition parameter to detect-api-changes template

### DIFF
--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -2,13 +2,14 @@ parameters:
   ArtifactPath: $(Build.ArtifactStagingDirectory)
   ArtifactName: 'packages'
   RepoRoot: $(Build.SourcesDirectory)
+  Condition: true
 
 steps:
   - pwsh: |
       $apiChangeDetectRequestUrl = "https://apiview.dev/PullRequest/DetectApiChanges"
       echo "##vso[task.setvariable variable=ApiChangeDetectRequestUrl]$apiChangeDetectRequestUrl"
     displayName: "Set API change detect request URL"
-    condition: eq(variables['ApiChangeDetectRequestUrl'], '')
+    condition: and(${{ parameters.Condition}}, eq(variables['ApiChangeDetectRequestUrl'], ''))
 
   - task: Powershell@2
     inputs:
@@ -24,4 +25,4 @@ steps:
         -DevopsProject $(System.TeamProject)
       pwsh: true
     displayName: Detect API changes
-    condition: and(succeededOrFailed(), eq(variables['Build.Reason'],'PullRequest'))
+    condition: and(${{ parameters.Condition }}, succeededOrFailed(), eq(variables['Build.Reason'],'PullRequest'))


### PR DESCRIPTION
This solves a problem in the go repo where we have tools in `eng/` that run pipelines with no artifacts generated. Paired with https://github.com/Azure/azure-sdk-for-go/pull/24166