### PR TITLE
[APIView] parse module level function overloads

### DIFF
--- a/packages/python-packages/apistubgentest/apistubgentest/__init__.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/__init__.py
@@ -14,6 +14,8 @@ from ._client import (
     Python2TypeHintClient,
     Python3TypeHintClient,
     SpecialArgsClient,
+    module_func,
+    another_func,
 )
 
 __version__ = VERSION

--- a/packages/python-packages/apistubgentest/apistubgentest/_client.py
+++ b/packages/python-packages/apistubgentest/apistubgentest/_client.py
@@ -5,8 +5,31 @@ from typing import Optional, Union, List, Any, overload
 from .models import FakeObject, FakeError, PetEnumPy3Metaclass
 
 from azure.core import PipelineClient
-from typing import Optional, Union
+from typing import Optional, Union, overload
 
+
+
+@overload
+def module_func(a: int, *, b: str, **kwargs) -> bool:
+    ...
+
+@overload
+def module_func(a: int, *, b: int, **kwargs) -> bool:
+    ...
+
+def module_func(*args, **kwargs) -> bool:
+    pass
+
+@overload
+def another_func(*, b: str) -> bool:
+    ...
+
+@overload
+def another_func(*, b: int) -> bool:
+    ...
+
+def another_func(*, b: Union[int, str]) -> bool:
+    pass
 
 # pylint:disable=docstring-missing-return,docstring-missing-rtype
 class DefaultValuesClient:

--- a/packages/python-packages/apiview-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/apiview-stub-generator/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
-## Version 0.3.14 (Unreleased)
+## Version 0.3.15 (Unreleased)
+Fixed issue where module-level overloads were not being parsed.
+
+## Version 0.3.14 (2025-02-22)
 Update for tree token style parser.
 
 ## Version 0.3.13 (2025-01-13)

--- a/packages/python-packages/apiview-stub-generator/apistub/_parsing_helpers.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_parsing_helpers.py
@@ -1,0 +1,41 @@
+from typing import List, Union, TYPE_CHECKING
+import astroid
+from .nodes._function_node import FunctionNode
+
+if TYPE_CHECKING:
+    from .nodes._module_node import ModuleNode
+    from .nodes._class_node import ClassNode   
+
+
+def parse_overloads(
+    node: Union["ModuleNode", "ClassNode"],
+    functions: List[astroid.FunctionDef],
+    *,
+    is_module_level: bool = False
+) -> List[FunctionNode]:
+    """ Uses AST parsing to look for @overload decorated functions
+        because inspect cannot see these. Returns a list of overloads given class or module node and function nodes to look through.
+    """
+    overload_nodes = []
+    for func in functions:
+        if not func.decorators:
+            continue
+        for ast_dec in func.decorators.nodes:
+            try:
+                if ast_dec.name == "overload":
+                    overload_node = FunctionNode(node.namespace, node, node=func, is_module_level=is_module_level, apiview=node.apiview)
+                    overload_nodes.append(overload_node)
+            except AttributeError:
+                continue
+    return overload_nodes
+
+def add_overload_nodes(node: Union["ModuleNode", "ClassNode"], func_node: FunctionNode, overloads: List[FunctionNode]) -> None:
+    """Gets overloads of the function node and appends them to the child nodes, then appends the function node."""
+    func_overloads = [x for x in overloads if x.name == func_node.name]
+
+    # Append a numeric tag to overloads to distinguish them from one another.
+    # This will break down if overloads are moved around in the source file.
+    for x, overload in enumerate(func_overloads):
+        overload.namespace_id = overload.namespace_id + f"_{x+1}"
+        node.child_nodes.append(overload)
+    node.child_nodes.append(func_node)

--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -321,7 +321,7 @@ class StubGenerator:
 
     def _install_package(self, pkg_name):
         commands = [sys.executable, "-m", "pip", "install", self.pkg_path, "-q"]
-        check_call(commands, timeout=60)
+        check_call(commands, timeout=120)
 
 
 def parse_setup_py(setup_path):

--- a/packages/python-packages/apiview-stub-generator/apistub/_version.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.3.14"
+VERSION = "0.3.15"

--- a/packages/python-packages/apiview-stub-generator/tests/module_parsing_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/module_parsing_test.py
@@ -1,0 +1,111 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+
+import importlib
+
+from apistub.nodes import ModuleNode
+
+from pytest import fail
+
+from ._test_util import _check, _tokenize, _render_lines, MockApiView, _count_review_line_metadata
+
+
+class TestModuleParsing:
+
+    pkg_namespace = "apistubgentest"
+
+    # Validates that there are no repeat defintion IDs and that each line has only one definition ID.
+    def _validate_line_ids(self, review_lines):
+        line_ids = set()
+
+        def collect_line_ids(review_lines, index=0):
+            for line in review_lines:
+                # Ensure that each line has either 0 or 1 definition ID.
+                if line.line_id and not isinstance(line.line_id, str):
+                    fail(f"Some lines have more than one definition ID. {line.line_id}")
+                # Ensure that there are no repeated definition IDs.
+                if line.line_id and line.line_id in line_ids:
+                    fail(f"Duplicate definition ID {line.line_id}.")
+                    line_ids.add(line.line_id)
+                # Recursively collect definition IDs from child lines
+                if line.children:
+                    collect_line_ids(line.children, index)
+
+        collect_line_ids(review_lines)
+    def test_overloads(self):
+        obj = importlib.import_module(TestModuleParsing.pkg_namespace)
+        module_node = ModuleNode(
+            namespace=obj.__name__,
+            module=obj,
+            pkg_root_namespace=self.pkg_namespace,
+            apiview=MockApiView,
+        )
+        tokens = _tokenize(module_node)
+        lines = _render_lines(tokens)
+        assert lines[2].lstrip() == "@overload"
+        actual1 = lines[3]
+        expected1 = "def apistubgentest.another_func(*, b: str) -> bool"
+        _check(actual1, expected1, obj)
+
+        assert lines[6].lstrip() == "@overload"
+        actual2 = lines[7]
+        expected2 = "def apistubgentest.another_func(*, b: int) -> bool"
+
+        _check(actual2, expected2, obj)
+
+        actual3 = lines[10]
+        expected3 = "def apistubgentest.another_func(*, b: Union[int, str]) -> bool"
+
+        _check(actual3, expected3, obj)
+
+        assert lines[13].lstrip() == "@overload"
+        actual4 = lines[14:20]
+        expected4 = [
+            "def apistubgentest.module_func(",
+            "    a: int, ",
+            "    *, ",
+            "    b: str, ",
+            "    **kwargs",
+            ") -> bool"
+        ]
+        _check(actual4, expected4, obj)
+
+        assert lines[22].lstrip() == "@overload"
+        actual5 = lines[23:29]
+        expected5 = [
+            "def apistubgentest.module_func(",
+            "    a: int, ",
+            "    *, ",
+            "    b: int, ",
+            "    **kwargs",
+            ") -> bool"
+        ]
+        _check(actual5, expected5, obj)
+
+        actual6 = lines[31]
+        expected6 = "def apistubgentest.module_func(*args, **kwargs) -> bool"
+        _check(actual6, expected6, obj)
+
+        self._validate_line_ids(tokens)
+
+    #def test_review_line_metadata(self):
+    #    # TODO: empty lines should have RelatedToLine set
+    #    obj = importlib.import_module(TestModuleParsing.pkg_namespace)
+    #    module_node = ModuleNode(
+    #        namespace=obj.__name__,
+    #        module=obj,
+    #        pkg_root_namespace=self.pkg_namespace,
+    #        apiview=MockApiView,
+    #    )
+    #    tokens = _tokenize(module_node)
+    #    metadata = {"RelatedToLine": 0, "IsContextEndLine": 0}
+    #    metadata = _count_review_line_metadata(tokens[:31], metadata)
+
+    #    # methods empty line after related to method
+    #    # module level objects empty line before and after inside "stuff"
+    #    # namespace empty line at beginning and end
+    #    assert metadata["RelatedToLine"] == 4
+    #    assert metadata["IsContextEndLine"] == 1

--- a/packages/python-packages/apiview-stub-generator/tests/module_parsing_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/module_parsing_test.py
@@ -90,22 +90,3 @@ class TestModuleParsing:
         _check(actual6, expected6, obj)
 
         self._validate_line_ids(tokens)
-
-    #def test_review_line_metadata(self):
-    #    # TODO: empty lines should have RelatedToLine set
-    #    obj = importlib.import_module(TestModuleParsing.pkg_namespace)
-    #    module_node = ModuleNode(
-    #        namespace=obj.__name__,
-    #        module=obj,
-    #        pkg_root_namespace=self.pkg_namespace,
-    #        apiview=MockApiView,
-    #    )
-    #    tokens = _tokenize(module_node)
-    #    metadata = {"RelatedToLine": 0, "IsContextEndLine": 0}
-    #    metadata = _count_review_line_metadata(tokens[:31], metadata)
-
-    #    # methods empty line after related to method
-    #    # module level objects empty line before and after inside "stuff"
-    #    # namespace empty line at beginning and end
-    #    assert metadata["RelatedToLine"] == 4
-    #    assert metadata["IsContextEndLine"] == 1


### PR DESCRIPTION
fixes: #9587

* Also updated timeout value during package installation step, for Windows.
* Remove unused get_navigation method