### PR TITLE
Code needs to handle more than one template library

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -320,7 +320,9 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     # packages. We should never return NO validation.
     if ($packagesWithChanges.Count -eq 0) {
         $packagesWithChanges += ($allPackageProperties | Where-Object { $_.ServiceDirectory -eq "template" })
-        $packagesWithChanges[0].IncludedForValidation = $true
+        foreach ($package in $packagesWithChanges) {
+            $package.IncludedForValidation = $true
+        }
     }
 
     return $packagesWithChanges


### PR DESCRIPTION
If there are no packages with changes detected we add the template libraries for validation. The problem here is that the code incorrectly assumed that there's only one template library but, because of batch release in Java, we have more than one. If IncludedForValidation isn't set to true for all of them then it'll end up with multiple test matrices, one for the indirect packages and one for the direct packages.