### PR TITLE
Add update-release-branch-in-specs pipeline

### DIFF
--- a/eng/pipelines/templates/steps/sync-repo-merge-branch.yml
+++ b/eng/pipelines/templates/steps/sync-repo-merge-branch.yml
@@ -21,6 +21,9 @@ parameters:
   - name: WorkingDirectory
     type: string
     default: $(System.DefaultWorkingDirectory)
+  - name: EnableAutoMerge
+    type: boolean
+    default: true
 
 steps:
 
@@ -74,11 +77,14 @@ steps:
         Write-Host "git push origin $mergeBranch -f"
         git push origin $mergeBranch -f
 
-        Write-Host "gh pr create --base ${{ target.key }} --head  --reviewer weshaggard --repo ${{ repo.key }} --body $commitMessage --title $commitMessage"
-        gh pr create --base ${{ target.key }} --head $mergeBranch --reviewer weshaggard --repo ${{ repo.key }} --body $commitMessage --title $commitMessage
+        Write-Host "gh pr create --base ${{ target.key }} --head  --repo ${{ repo.key }} --body $commitMessage --title $commitMessage"
+        gh pr create --base ${{ target.key }} --head $mergeBranch --repo ${{ repo.key }} --body $commitMessage --title $commitMessage
 
-        Write-Host "gh pr merge $mergeBranch --auto --merge --repo ${{ repo.key }}"
-        gh pr merge $mergeBranch --auto --merge --repo ${{ repo.key }}
+        if ("${{ parameters.EnableAutoMerge }}" -eq "true") {
+          Write-Host "gh pr merge $mergeBranch --auto --merge --repo ${{ repo.key }}"
+          gh pr merge $mergeBranch --auto --merge --repo ${{ repo.key }}
+        }
+
       displayName: Create Pull Request for merge
       continueOnError: true
       workingDirectory: ${{ parameters.WorkingDirectory }}/${{ repo.key }}

--- a/eng/pipelines/update-release-branch-in-specs.yml
+++ b/eng/pipelines/update-release-branch-in-specs.yml
@@ -1,0 +1,39 @@
+# Enable merging of main into release branches for easier updating of infrastructure without updating the specs themselves.
+
+trigger: none
+pr: none
+
+parameters:
+  - name: BranchToMergeTo
+    type: string
+    default: release-<name>
+  - name: Repo
+    type: string
+    default: Azure/azure-rest-api-specs
+  - name: BranchToMergeFrom
+    type: string
+    default: main
+
+pool:
+  name: azsdk-pool-mms-ubuntu-2204-general
+  vmImage: ubuntu-22.04
+
+jobs:
+  - job: MergeReleaseBranch
+    displayName: Merge '${{ parameters.BranchToMergeFrom }}' into '${{ parameters.BranchToMergeTo }}'
+
+    steps:
+    - template: ./templates/steps/sync-repo-merge-branch.yml
+      parameters:
+        GH_TOKEN: $(azuresdk-github-pat)
+        EnableAutoMerge: false
+        Repos:
+          ${{ parameters.Repo }}:
+            Branch: ${{ parameters.BranchToMergeFrom }}
+            TargetBranches:
+              ${{ parameters.BranchToMergeTo }}:
+                  Theirs: '@("**")'
+                  Ours: '@("specification")'
+                  Merge: '@("specification/common-types")'
+                  AcceptTheirsForFinalMerge: true
+


### PR DESCRIPTION
Created a helper [pipeline](https://dev.azure.com/azure-sdk/internal/_build?definitionId=7487) that will enable teams to generate a PR with a merge from the main in the specs repo that only includes things outside of the specification folder such as infrastructure.