### PR TITLE
fix: use full type name when checking for ClientOptions type

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0007Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0007Tests.cs
@@ -73,5 +73,35 @@ namespace RandomNamespace
 }";
             await Verifier.VerifyAnalyzerAsync(code);
         }
+
+        // This test validates that the analyzer does not produce a diagnostic for clients with multiple constructors
+        // which end with a ClientOptions parameter.
+        [Fact]
+        public async Task AZC0007NotProducedForClientWithMultipleCtors()
+        {
+            const string code = @"
+using System;
+using Azure;
+using Azure.Core;
+
+namespace RandomNamespace.Foo
+{
+
+    public partial class RoomsClientOptions : ClientOptions {} 
+
+    public partial class RoomsClient
+    {
+        protected RoomsClient() {}
+        public RoomsClient(string connectionString) {}
+        public RoomsClient(string connectionString, RoomsClientOptions options) {}
+        public RoomsClient(Uri endpoint, AzureKeyCredential credential, RoomsClientOptions options = null) {}
+        public RoomsClient(Uri endpoint, TokenCredential credential, RoomsClientOptions options = null) {}
+    }
+
+
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
     }
 }
+

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0007Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0007Tests.cs
@@ -97,8 +97,6 @@ namespace RandomNamespace.Foo
         public RoomsClient(Uri endpoint, AzureKeyCredential credential, RoomsClientOptions options = null) {}
         public RoomsClient(Uri endpoint, TokenCredential credential, RoomsClientOptions options = null) {}
     }
-
-
 }";
             await Verifier.VerifyAnalyzerAsync(code);
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0008Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0008Tests.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
@@ -22,6 +22,46 @@ namespace RandomNamespace
             await Verifier.VerifyAnalyzerAsync(code);
         }
 
+        // This test validates that AZC0008 is produced for nested client options types
+        // when both types do not have a service version enum.
+        [Fact]
+        public async Task AZC0008ProducedForAllNestedClientOptionsTypeWithoutServiceVersionEnum()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class {|AZC0008:SomeBaseClientOptions|} : Azure.Core.ClientOptions
+    {
+    }
+    public class {|AZC0008:SomeClientOptions|} : SomeBaseClientOptions { 
+
+    }
+}";
+            await Verifier.VerifyAnalyzerAsync(code);
+        }
+
+
+        [Fact]
+        public async Task AZC0008ProducedForNestedClientOptionsTypeWithoutServiceVersionEnum()
+        {
+            const string code = @"
+namespace RandomNamespace
+{
+    public class {|AZC0008:SomeBaseClientOptions|} : Azure.Core.ClientOptions
+    {
+    }
+    public class SomeClientOptions : SomeBaseClientOptions { 
+        public enum ServiceVersion
+        {
+            V2018_11_09 = 0
+        }
+    }
+}";
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0009")
+                .RunAsync();
+        }
+
         [Fact]
         public async Task AZC0008NotProducedForClientOptionsWithServiceVersionEnum()
         {
@@ -31,6 +71,36 @@ namespace RandomNamespace
     public class SomeClientOptions { 
 
         public enum ServiceVersion
+        {
+            V2018_11_09 = 0
+        }
+    }
+}";
+            await Verifier.CreateAnalyzer(code)
+                .WithDisabledDiagnostics("AZC0009")
+                .RunAsync();
+        }
+
+        // This test validates that AZC0008 is not produced for nested client options types
+        // when both types define a service version enum.
+        [Fact]
+        public async Task AZC0008NotProducedForAllNestedClientOptionsTypeWithoutServiceVersionEnum()
+        {
+            const string code = @"
+using Azure;
+using Azure.Core;
+
+namespace RandomNamespace
+{
+    public class SomeBaseClientOptions : ClientOptions
+    {
+        public enum ServiceVersion
+        {
+            V2018_11_09 = 0
+        }
+    }
+    public class SomeClientOptions : SomeBaseClientOptions { 
+        public new enum ServiceVersion
         {
             V2018_11_09 = 0
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/SymbolAnalyzerBase.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/SymbolAnalyzerBase.cs
@@ -10,6 +10,7 @@ namespace Azure.ClientSdk.Analyzers
     {
         private const string ClientOptionsSuffix = "ClientOptions";
         private const string ClientsOptionsSuffix = "ClientsOptions";
+        private const string AzureCoreClientOptions = "Azure.Core.ClientOptions";
 
         public abstract SymbolKind[] SymbolKinds { get; }
         public abstract void Analyze(ISymbolAnalysisContext context);
@@ -20,16 +21,8 @@ namespace Azure.ClientSdk.Analyzers
         {
             context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze | GeneratedCodeAnalysisFlags.ReportDiagnostics);
             context.EnableConcurrentExecution();
-            context.RegisterCompilationStartAction(CompilationStart);
             context.RegisterSymbolAction(c => Analyze(new RoslynSymbolAnalysisContext(c)), SymbolKinds);
         }
-
-#pragma warning disable RS1012 // Start action has no registered actions.
-        protected virtual void CompilationStart(CompilationStartAnalysisContext context)
-        {
-            ClientOptionsType = context.Compilation.GetTypeByMetadataName("Azure.Core.ClientOptions");
-        }
-#pragma warning restore RS1012 // Start action has no registered actions.
 
         protected bool IsPublicApi(ISymbol symbol)
         {
@@ -53,7 +46,12 @@ namespace Azure.ClientSdk.Analyzers
             ITypeSymbol baseType = typeSymbol.BaseType;
             while (baseType != null) 
             {
-                if (SymbolEqualityComparer.Default.Equals(baseType, ClientOptionsType))
+                // validate if the base type is Azure.Core.ClientOptions
+                var fullName = baseType.ContainingNamespace.GetFullNamespaceName()
+                    .Append(".")
+                    .Append(baseType.Name);
+
+                if ($"{fullName}".Equals(AzureCoreClientOptions))
                 {
                     return typeSymbol.Name.EndsWith(ClientOptionsSuffix) || typeSymbol.Name.EndsWith(ClientsOptionsSuffix);
                 }


### PR DESCRIPTION
This PR introduces a fix for AZC0007, where this analyzer was incorrectly firing for clients even when the expected constructors were present. Rather than trying to load the `Azure.Core.ClientOption` type during compilation start, and using this loaded type to validate if a constructor's last parameter matches it, we now simply just check the parameter's base type's name to see if it matches `Azure.Core.ClientOption`.

![image](https://github.com/user-attachments/assets/034df7c7-016f-454b-8db2-42e7d7eac2ae)


sdk-for-net pr:  https://github.com/Azure/azure-sdk-for-net/pull/48474