### PR TITLE
Use subscription name to assign supportsSafeSecretStandard

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -121,6 +121,8 @@ param (
 . $PSScriptRoot/TestResources-Helpers.ps1
 . $PSScriptRoot/SubConfig-Helpers.ps1
 
+$wellKnownTMETenants = @('70a036f6-8e4d-4615-bad6-149c02e7720d')
+
 if (!$ServicePrincipalAuth) {
     # Clear secrets if not using Service Principal auth. This prevents secrets
     # from being passed to pre- and post-scripts.
@@ -527,8 +529,11 @@ try {
     if ($CI -and $Environment -eq 'AzureCloud' -and $env:PoolSubnet) {
         $templateParameters.Add('azsdkPipelineSubnetList', @($env:PoolSubnet))
     }
-    # Some arm/bicep templates may want to change deployment settings (e.g. local auth) in sandboxed TME tenants
-    $templateParameters.Add('supportsSafeSecretStandard', ($context.Tenant.Name -notlike '*TME*'))
+    # The TME tenants are our place for local auth testing so we do not support safe secret standard there.
+    # Some arm/bicep templates may want to change deployment settings like local auth in sandboxed TME tenants.
+    # The pipeline account context does not have the .Tenant.Name property, so check against subscription via
+    # naming convention instead.
+    $templateParameters.Add('supportsSafeSecretStandard', ($wellKnownTMETenants.Contains($TenantId)))
 
     $defaultCloudParameters = LoadCloudConfig $Environment
     MergeHashes $defaultCloudParameters $(Get-Variable templateParameters)


### PR DESCRIPTION
The `.Tenant.Name` property is null in the pipeline's login context.

I'm not a fan of this approach, but it's either subscription name checking or hardcoded tenant id checking.