### PR TITLE
Update API revision metadata when processing update requests from sandboxing pipeline

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -691,7 +691,10 @@ namespace APIViewWeb.Managers
                         var file = apiRevision.Files.FirstOrDefault();
                         file.VersionString = codeFile.VersionString;
                         file.PackageName = codeFile.PackageName;
+                        file.PackageVersion = codeFile.PackageVersion;
+                        file.ParserStyle = codeFile.ReviewLines.Count > 0 ? ParserStyle.Tree : ParserStyle.Flat;
                         await _reviewsRepository.UpsertReviewAsync(review);
+                        await _apiRevisionsRepository.UpsertAPIRevisionAsync(apiRevision);
 
                         if (!String.IsNullOrEmpty(review.Language) && review.Language == "Swagger")
                         {


### PR DESCRIPTION
APIView updates review metadata but it's not updating revision metadata when processing successful upgrade of revisions using new parser. This will prompt APIView to reprocess those revisions again unnecessarily when restarting the server.