### PR TITLE
Python API review is not generated using correct package name

### DIFF
--- a/packages/python-packages/apiview-stub-generator/CHANGELOG.md
+++ b/packages/python-packages/apiview-stub-generator/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Release History
 
-## Version 0.3.15 (Unreleased)
+## Version 0.3.16 (2025-03-03)
+Fixed emty package name issue when running parser against pacakge source path instead of wheel. PKG_INFO is not available in this case.
+
+## Version 0.3.15 (2025-02-28)
 Fixed issue where module-level overloads were not being parsed.
 Added support for parsing pyproject.toml-managed packages.
 Updated RelatedToLine for empty lines to show in the diff.

--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -181,7 +181,6 @@ class StubGenerator:
             pkg_name = os.path.split(self.pkg_path)[-1]
             version = importlib.metadata.version(pkg_name)
             pkg_root_path = self.pkg_path
-            self.namespace = self.namespace or pkg_name.replace("-", ".")
 
         logging.info(
             "package name: {0}, version:{1}, namespace:{2}".format(

--- a/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_stub_generator.py
@@ -174,13 +174,14 @@ class StubGenerator:
     def generate_tokens(self):
         # TODO: We should install to a virtualenv
         logging.debug("Installing package from {}".format(self.pkg_path))
+        pkg_root_path, pkg_name, version = self._get_pkg_metadata()
         self._install_package()
-        if self.pkg_path.endswith((".whl", ".zip", ".tar.gz")):
-            pkg_root_path, pkg_name, version = self._get_pkg_metadata()
-        else:
+        # pkginfo does not get package metadata in 3.10 when running against package root path
+        if not self.pkg_path.endswith((".whl", ".zip", ".tar.gz")):
             pkg_name = os.path.split(self.pkg_path)[-1]
             version = importlib.metadata.version(pkg_name)
-            pkg_root_path = self.pkg_path
+            dist = importlib.metadata.distribution(pkg_name)
+            self.extras_require = self.extras_require or dist.metadata.get_all('Provides-Extra')
 
         logging.info(
             "package name: {0}, version:{1}, namespace:{2}".format(

--- a/packages/python-packages/apiview-stub-generator/apistub/_version.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/_version.py
@@ -1,4 +1,4 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-VERSION = "0.3.15"
+VERSION = "0.3.16"

--- a/packages/python-packages/apiview-stub-generator/tests/apiview_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/apiview_test.py
@@ -104,6 +104,12 @@ class TestApiView:
             self._uninstall_dep(dep)
         # uninstall apistubgentest if installed, so new install will be from pkg_path
         self._uninstall_dep("apistubgentest")
+        # if pkg is src, rm *.egg-info from path to check that pkg metadata parsing works
+        if os.path.isdir(pkg_path):
+            for f in os.listdir(pkg_path):
+                if f == "apistubgentest.egg-info":
+                    shutil.rmtree(os.path.join(pkg_path, f))
+                    break
         temp_path = tempfile.gettempdir()
         stub_gen = StubGenerator(pkg_path=pkg_path, temp_path=temp_path)
         apiview = stub_gen.generate_tokens()
@@ -113,6 +119,7 @@ class TestApiView:
         assert not self._dependency_installed("qsharp")
         # assert package name is correct
         assert apiview.package_name == "apistubgentest"
+        assert False
     
     @mark.parametrize("pkg_path", PYPROJECT_PATHS, ids=PYPROJECT_IDS)
     def test_pyproject_toml_line_ids(self, pkg_path):

--- a/packages/python-packages/apiview-stub-generator/tests/apiview_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/apiview_test.py
@@ -119,7 +119,6 @@ class TestApiView:
         assert not self._dependency_installed("qsharp")
         # assert package name is correct
         assert apiview.package_name == "apistubgentest"
-        assert False
     
     @mark.parametrize("pkg_path", PYPROJECT_PATHS, ids=PYPROJECT_IDS)
     def test_pyproject_toml_line_ids(self, pkg_path):

--- a/packages/python-packages/apiview-stub-generator/tests/apiview_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/apiview_test.py
@@ -111,6 +111,8 @@ class TestApiView:
             assert self._dependency_installed(dep)
         # skip conditional optional dependencies
         assert not self._dependency_installed("qsharp")
+        # assert package name is correct
+        assert apiview.package_name == "apistubgentest"
     
     @mark.parametrize("pkg_path", PYPROJECT_PATHS, ids=PYPROJECT_IDS)
     def test_pyproject_toml_line_ids(self, pkg_path):


### PR DESCRIPTION
API parser has a new change to get package name and version using pkginfo and this only works when gnerating review file from wheel or sdist. But python CI generates token from package source hence pkginfo is not available and as a result review token file is generated with wrong version and wrong token file name.

Parser also iterates all directories including tests and build and include those paths in package modules.