### PR TITLE
Update original file path value in detect change request to APIView

### DIFF
--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -40,9 +40,18 @@ function Submit-Request($filePath, $packageName)
     $query.Add('language', $LanguageShort)
     $query.Add('project', $DevopsProject)
     $reviewFileFullName = Join-Path -Path $ArtifactPath $packageName $reviewFileName
+    # If CI generates token file then it passes both token file name and original file (filePath) to APIView
+    # If both files are passed then APIView downloads the parent directory as a zip
+    # If code file is not passed(for e.g. .NET or Java) then APIView needs full path to original file to download only that file.
     if (Test-Path $reviewFileFullName)
     {
         $query.Add('codeFile', $reviewFileName)
+        # Pass only relative path in package artifact directory when code file is also present
+        $query.Add('filePath', (Split-Path -Leaf $filePath))
+    }
+    else
+    {
+        $query.Add('filePath', $filePath)
     }
     $uri = [System.UriBuilder]$APIViewUri
     $uri.query = $query.toString()


### PR DESCRIPTION
Some languages generate API review token file in CI side and some languages passes source only to APIView. When both code file and original source file are passed to APIView then it downloads package directory as zip and iterate over the zip to identify the files. But if original file only is passed to APIview then it downloads just that file. 

Script was sending full path for original file along with code file and APIView ignores the original file when it does not match the file name in zip.