### PR TITLE
[Azure.ClientSdk.Analyzers] Refine AZC0030

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0030OptionsTest.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0030OptionsTest.cs
@@ -2,7 +2,7 @@ using System.Threading.Tasks;
 using Xunit;
 
 using VerifyCS = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<
-    Azure.ClientSdk.Analyzers.ModelName.GeneralSuffixAnalyzer>;
+    Azure.ClientSdk.Analyzers.ModelName.OptionsSuffixAnalyzer>;
 
 // Test cases for `Options` suffix. We allow `Options` suffix for property bags.
 // So need to skip property bags which do not have any serialization codes.
@@ -10,43 +10,18 @@ namespace Azure.ClientSdk.Analyzers.Tests.ModelName
 {
     public class AZC0030OptionsSuffixTests
     {
-        private const string diagnosticId = "AZC0030";
+        private const string DiagnosticId = "AZC0030";
 
-        [Fact]
-        public async Task WithoutAnySerialization()
+        // This test validates that the analyzer is triggered when the model is in the Azure.ResourceManager namespace
+        // and has serialization methods.
+        [Theory]
+        [InlineData("Azure.ResourceManager")]
+        [InlineData("Azure.ResourceManager.Models")]
+        [InlineData("Azure.ResourceManager.SomeOtherNs")]
+        public async Task WithAzureResourceManagerNamespaceAndSerialization(string ns)
         {
             var test = @"using System.Text.Json;
-namespace Azure.ResourceManager.Models;
-
-public class DiskOptions
-{
-}";
-            await VerifyCS.VerifyAnalyzerAsync(test);
-        }
-
-        [Fact]
-        public async Task WithDeserializationMethod()
-        {
-            var test = @"using System.Text.Json;
-namespace Azure.ResourceManager
-{
-    public class ResponseOptions
-    {
-        public static ResponseOptions DeserializeResponseOptions(JsonElement element)
-        {
-            return null;
-        }
-    }
-}";
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(4, 18, 4, 33).WithArguments("ResponseOptions", "Options", "'ResponseConfig'");
-            await VerifyCS.VerifyAnalyzerAsync(test, expected);
-        }
-
-        [Fact]
-        public async Task WithSerializationMethod()
-        {
-            var test = @"using System.Text.Json;
-namespace Azure.ResourceManager.Models
+namespace " + ns + @"
 {
     internal interface IUtf8JsonSerializable
     {
@@ -58,8 +33,214 @@ namespace Azure.ResourceManager.Models
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer) {}
     }
 }";
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(9, 18, 9, 29).WithArguments("DiskOptions", "Options", "'DiskConfig'");
+            var expectedMessage = GetDiagnosticMessage("DiskOptions");
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(9, 18, 9, 29).WithArguments("DiskOptions", "Options", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+
+        // This test validates that the analyzer is triggered when the model is in the Azure.ResourceManager namespace
+        // and has deserialization methods.
+        [Theory]
+        [InlineData("Azure.ResourceManager")]
+        [InlineData("Azure.ResourceManager.Models")]
+        [InlineData("Azure.ResourceManager.SomeOtherNs")]
+        public async Task WithAzureResourceManagerNamespaceAndDeserializationMethod(string ns)
+        {
+            var test = @"using System.Text.Json;
+namespace " + ns + @"
+{
+    public class ResponseOptions
+    {
+        public static ResponseOptions DeserializeResponseOptions(JsonElement element)
+        {
+            return null;
+        }
+    }
+}";
+            var expectedMessage = GetDiagnosticMessage("ResponseOptions");
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(4, 18, 4, 33).WithArguments("ResponseOptions", "Options", expectedMessage);
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [Theory]
+        [InlineData("Azure.ResourceManager")]
+        [InlineData("Azure.ResourceManager.Models")]
+        [InlineData("Azure.ResourceManager.SomeOtherNs")]
+        public async Task WithAzureResourceManagerNamespaceRoundTripModel(string ns)
+        {
+            var test = @"using System.Text.Json;
+namespace " + ns + @"
+{
+    internal interface IUtf8JsonSerializable
+    {
+        void Write(Utf8JsonWriter writer);
+    };
+
+
+    public class ResponseOptions : IUtf8JsonSerializable
+    {
+        void IUtf8JsonSerializable.Write(Utf8JsonWriter writer) {}
+        public static ResponseOptions DeserializeResponseOptions(JsonElement element)
+        {
+            return null;
+        }
+    }
+}";
+            var expectedMessage = GetDiagnosticMessage("ResponseOptions");
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(10, 18, 10, 33).WithArguments("ResponseOptions", "Options", expectedMessage);
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        [Theory]
+        [InlineData("Azure.ResourceManager")]
+        [InlineData("Azure.ResourceManager.Models")]
+        [InlineData("Azure.ResourceManager.SomeOtherNs")]
+        public async Task WithNestedNamespaceAndSerialization(string ns)
+        {
+            var test = @"using System.Text.Json;
+namespace " + ns + @"
+{
+    namespace SubTest
+    {
+         internal interface IUtf8JsonSerializable
+        {
+            void Write(Utf8JsonWriter writer);
+        };
+
+        public class DiskOptions: IUtf8JsonSerializable
+        {
+            void IUtf8JsonSerializable.Write(Utf8JsonWriter writer) {}
+        }
+    }
+}";
+            var expectedMessage = GetDiagnosticMessage("DiskOptions");
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(11, 22, 11, 33).WithArguments("DiskOptions", "Options", expectedMessage);
+            await VerifyCS.VerifyAnalyzerAsync(test, expected);
+        }
+
+        // This test validates that the analyzer is not triggered when the model is in the Azure.ResourceManager namespace
+        // and has no serialization methods.
+        [Theory]
+        [InlineData("Azure.ResourceManager")]
+        [InlineData("Azure.ResourceManager.Models")]
+        [InlineData("Azure.ResourceManager.SomeOtherNs")]
+        public async Task WithAzureResourceManagerNamespaceAndNoSerialization(string ns)
+        {
+            var test = @"using System.Text.Json;
+namespace " + ns + @"
+{
+    public class DiskOptions
+    {
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [Theory]
+        [InlineData("Azure.ResourceManager")]
+        [InlineData("Azure.ResourceManager.Models")]
+        [InlineData("Azure.ResourceManager.SomeOtherNs")]
+        public async Task WithAzureResourceManagerNamespaceAndOtherMethods(string ns)
+        {
+            var test = @"using System.Text.Json;
+namespace " + ns + @"
+{
+    public class DiskOptions
+    {
+        public void SomeMethod() {}
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        // This test validates that the analyzer does not trigger on a class that is not in the Azure.ResourceManager namespace
+        // despite it having serialization.
+        [Theory]
+        [InlineData("Azure.Foo.Models")]
+        [InlineData("Azure.Foo")]
+        public async Task NonManagementModelWithSerializationMethod(string ns)
+        {
+            var test = @"using System.Text.Json;
+namespace " + ns + @"
+{
+    internal interface IUtf8JsonSerializable
+    {
+        void Write(Utf8JsonWriter writer);
+    };
+
+    public class DiskOptions: IUtf8JsonSerializable
+    {
+        void IUtf8JsonSerializable.Write(Utf8JsonWriter writer) {}
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [Theory]
+        [InlineData("Azure.Foo.Models")]
+        [InlineData("Azure.Foo")]
+        public async Task NonManagementModelWithDeserializationMethod(string ns)
+        {
+            var test = @"using System.Text.Json;
+namespace " + ns + @"
+{
+    public class ResponseOptions
+    {
+        public static ResponseOptions DeserializeResponseOptions(JsonElement element)
+        {
+            return null;
+        }
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [Theory]
+        [InlineData("Azure.Foo.Models")]
+        [InlineData("Azure.Foo")]
+        public async Task NonManagementRoundTripModel(string ns)
+        {
+            var test = @"using System.Text.Json;
+namespace " + ns + @"
+{
+    internal interface IUtf8JsonSerializable
+    {
+        void Write(Utf8JsonWriter writer);
+    };
+
+
+    public class ResponseOptions : IUtf8JsonSerializable
+    {
+        void IUtf8JsonSerializable.Write(Utf8JsonWriter writer) {}
+        public static ResponseOptions DeserializeResponseOptions(JsonElement element)
+        {
+            return null;
+        }
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        [Theory]
+        [InlineData("Azure.Foo.Models")]
+        [InlineData("Azure.Foo")]
+        public async Task NonManagementModelWithNoMethods(string ns)
+        {
+            var test = @"using System.Text.Json;
+namespace " + ns + @"
+{
+    public class DiskOptions
+    {
+    }
+}";
+            await VerifyCS.VerifyAnalyzerAsync(test);
+        }
+
+        private static string GetDiagnosticMessage(string typeName)
+        {
+            return $"The `Options` suffix is reserved for input models described by https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-parameters. " +
+                $"Please rename `{typeName}` according to our guidelines at https://azure.github.io/azure-sdk/general_design.html#model-types for output or roundtrip models.";
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0030Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0030Tests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Azure.ClientSdk.Analyzers.ModelName;
 using Xunit;
 
 using VerifyCS = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<
@@ -9,7 +8,7 @@ namespace Azure.ClientSdk.Analyzers.Tests.ModelName
 {
     public class AZC0030Tests
     {
-        private const string diagnosticId = "AZC0030";
+        private const string DiagnosticId = "AZC0030";
 
         [Fact]
         public async Task GoodSuffix()
@@ -37,7 +36,8 @@ namespace Azure.ResourceManager
         }
     }
 }";
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(4, 18, 4, 36).WithArguments("ResponseParameters", "Parameters", "'ResponseContent' or 'ResponsePatch'");
+            var expectedMessage = $"Suggest to rename it to 'ResponseContent' or 'ResponsePatch' or any other appropriate name.";
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(4, 18, 4, 36).WithArguments("ResponseParameters", "Parameters", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -55,7 +55,8 @@ namespace Azure.ResourceManager.Models
         }
     }
 }";
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(4, 18, 4, 28).WithArguments("DiskOption", "Option", "'DiskConfig'");
+            var expectedMessage = $"Suggest to rename it to 'DiskConfig' or any other appropriate name.";
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(4, 18, 4, 28).WithArguments("DiskOption", "Option", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -72,7 +73,8 @@ namespace Azure.ResourceManager.Models
         }
     }
 }";
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(6, 22, 6, 32).WithArguments("DiskOption", "Option", "'DiskConfig'");
+            var expectedMessage = $"Suggest to rename it to 'DiskConfig' or any other appropriate name.";
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(6, 22, 6, 32).WithArguments("DiskOption", "Option", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -93,7 +95,8 @@ namespace Azure.ResourceManager.Models
         }
     }
 }";
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(6, 22, 6, 39).WithArguments("CreationResponses", "Responses", "'CreationResults'");
+            var expectedMessage = $"Suggest to rename it to 'CreationResults' or any other appropriate name.";
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(6, 22, 6, 39).WithArguments("CreationResponses", "Responses", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
     }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/SuffixAnalyzerBaseTests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/SuffixAnalyzerBaseTests.cs
@@ -1,5 +1,4 @@
 using System.Threading.Tasks;
-using Azure.ClientSdk.Analyzers.ModelName;
 using Xunit;
 
 using VerifyCS = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<
@@ -9,7 +8,7 @@ namespace Azure.ClientSdk.Analyzers.Tests.ModelName
 {
     public class SuffixAnalyzerBaseTests
     {
-        private const string diagnosticId = "AZC0030";
+        private const string DiagnosticId = "AZC0030";
 
         [Fact]
         public async Task NonPublicClassIsNotChecked()
@@ -38,9 +37,10 @@ public class MonitorParameter
 public class MonitorParameter
 {
 }")]
-        public async Task ClassWithoutSerliaizationMethodsButInModelsNamespaceIsChecked(string test)
+        public async Task ClassWithoutSerializationMethodsButInModelsNamespaceIsChecked(string test)
         {
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(3, 14, 3, 30).WithArguments("MonitorParameter", "Parameter", "'MonitorContent' or 'MonitorPatch'");
+            var expectedMessage = $"Suggest to rename it to 'MonitorContent' or 'MonitorPatch' or any other appropriate name.";
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(3, 14, 3, 30).WithArguments("MonitorParameter", "Parameter", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
@@ -57,12 +57,13 @@ public class MonitorParameter
         return null;
     }
 }";
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(4, 14, 4, 30).WithArguments("MonitorParameter", "Parameter", "'MonitorContent' or 'MonitorPatch'");
+            var expectedMessage = $"Suggest to rename it to 'MonitorContent' or 'MonitorPatch' or any other appropriate name.";
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(4, 14, 4, 30).WithArguments("MonitorParameter", "Parameter", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 
         [Fact]
-        public async Task ClassWithDeserliazationMethodIsChecked()
+        public async Task ClassWithDeserializationMethodIsChecked()
         {
             var test = @"using System.Text.Json;
 namespace Azure.NotModels;
@@ -79,7 +80,8 @@ public class MonitorParameter : IUtf8JsonSerializable
         return;
     }
 }";
-            var expected = VerifyCS.Diagnostic(diagnosticId).WithSpan(9, 14, 9, 30).WithArguments("MonitorParameter", "Parameter", "'MonitorContent' or 'MonitorPatch'");
+            var expectedMessage = $"Suggest to rename it to 'MonitorContent' or 'MonitorPatch' or any other appropriate name.";
+            var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(9, 14, 9, 30).WithArguments("MonitorParameter", "Parameter", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -134,7 +134,7 @@ namespace Azure.ClientSdk.Analyzers
         public static readonly DiagnosticDescriptor AZC0030 = new DiagnosticDescriptor(
             nameof(AZC0030),
             "Improper model name suffix",
-            "Model name '{0}' ends with '{1}'. Suggest to rename it to {2} or any other appropriate name.",
+            "Model name '{0}' ends with '{1}'. {2}",
             DiagnosticCategory.Naming,
             DiagnosticSeverity.Warning,
             true,

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/OptionsSuffixAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/OptionsSuffixAnalyzer.cs
@@ -1,0 +1,76 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.ClientSdk.Analyzers.ModelName
+{
+    /// <summary>
+    /// Analyzer that checks model names ending with "Options". This analyzer shares the diagnostic ID with <see cref="GeneralSuffixAnalyzer"/>.
+    /// </summary>
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class OptionsSuffixAnalyzer : SuffixAnalyzerBase
+    {
+        private const string AzureResourceManagerNamespaceName = "Azure.ResourceManager";
+        private const string OptionsSuffix = "Options";
+        private const string IUtf8JsonSerializable = "IUtf8JsonSerializable";
+        private const string JsonElement = "JsonElement";
+        private static readonly string[] suffixes = new string[] { OptionsSuffix };
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Descriptors.AZC0030); } }
+
+        protected override bool ShouldSkip(INamedTypeSymbol symbol, SymbolAnalysisContext context)
+        {
+            // skip property bag classes which have `Options` suffix and either:
+                // 1. not in Azure.ResourceManager namespace
+                // 2. don't have serialization
+            if (symbol.Name.EndsWith(OptionsSuffix) && (!IsInManagementNamespace(symbol) || !SupportSerialization(symbol)))
+                return true;
+
+            return false;
+        }
+
+        private bool SupportSerialization(INamedTypeSymbol symbol)
+        {
+            // if it has serialization method: `IUtf8JsonSerializable.Write`, e.g. ": IUtf8JsonSerializable"
+            if (symbol.Interfaces.Any(i => i.Name is IUtf8JsonSerializable))
+                return true;
+
+            // if it has deserialization method: static <T> Deserialize<T>(JsonElement element)
+            if (symbol.GetMembers($"Deserialize{symbol.Name}").Any(m => m is IMethodSymbol methodSymbol &&
+                methodSymbol is { IsStatic: true, ReturnType: INamedTypeSymbol symbol, Parameters.Length: 1 } &&
+                methodSymbol.Parameters[0].Type.Name is JsonElement))
+                return true;
+
+            return false;
+        }
+
+        private bool IsInManagementNamespace(INamedTypeSymbol symbol)
+        {
+            if (symbol.ContainingNamespace == null || symbol.ContainingNamespace.IsGlobalNamespace)
+                return false;
+
+            var fullNamespace = symbol.ContainingNamespace.GetFullNamespaceName();
+
+            if ($"{fullNamespace}".Equals(AzureResourceManagerNamespaceName)
+                || $"{fullNamespace}".StartsWith($"{AzureResourceManagerNamespaceName}."))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        protected override string[] SuffixesToCatch => suffixes;
+        protected override Diagnostic GetDiagnostic(INamedTypeSymbol typeSymbol, string suffix, SymbolAnalysisContext context)
+        {
+            var additionalMessage = $"The `{suffix}` suffix is reserved for input models described by " +
+                $"https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-parameters. Please rename `{typeSymbol.Name}` " +
+                $"according to our guidelines at https://azure.github.io/azure-sdk/general_design.html#model-types for output or roundtrip models.";
+            return Diagnostic.Create(Descriptors.AZC0030, context.Symbol.Locations[0], typeSymbol.Name, suffix, additionalMessage);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/OptionsSuffixAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/OptionsSuffixAnalyzer.cs
@@ -20,7 +20,7 @@ namespace Azure.ClientSdk.Analyzers.ModelName
         private const string JsonElement = "JsonElement";
         private static readonly string[] suffixes = new string[] { OptionsSuffix };
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Descriptors.AZC0030); } }
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptors.AZC0030);
 
         protected override bool ShouldSkip(INamedTypeSymbol symbol, SymbolAnalysisContext context)
         {
@@ -54,14 +54,8 @@ namespace Azure.ClientSdk.Analyzers.ModelName
                 return false;
 
             var fullNamespace = symbol.ContainingNamespace.GetFullNamespaceName();
-
-            if ($"{fullNamespace}".Equals(AzureResourceManagerNamespaceName)
-                || $"{fullNamespace}".StartsWith($"{AzureResourceManagerNamespaceName}."))
-            {
-                return true;
-            }
-
-            return false;
+            return $"{fullNamespace}".Equals(AzureResourceManagerNamespaceName)
+                || $"{fullNamespace}".StartsWith($"{AzureResourceManagerNamespaceName}.");
         }
 
         protected override string[] SuffixesToCatch => suffixes;


### PR DESCRIPTION
This PR introduces fixes for these items:
- [Refine AZC0030 Error Message Regarding Options Suffix](https://github.com/Azure/azure-sdk-tools/issues/9469)
   - The analyzer that was validating models with the Options suffix was updated to include a general diagnostic message which links to our guidelines regarding naming models. It will no longer suggest a name to use as a replacement.
- [Update AZC0030 so that it doesn't prevent clients from having serializable models with the Options suffix](https://github.com/Azure/azure-sdk-tools/issues/9335).
  - The analyzer that was validating models with the Options suffix was scoped down to management plane models.

sdk-for-net test pr: https://github.com/Azure/azure-sdk-for-net/pull/48597