### PR TITLE
typespec-bump-deps, prepare release 0.9.7

### DIFF
--- a/tools/typespec-bump-deps/CHANGELOG.md
+++ b/tools/typespec-bump-deps/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @azure-tools/typespec-bump-deps
 
+## 0.9.7
+
+### Patch Changes
+
+- Include events, sse, streams in packages
+
 ## 0.9.6
 
 ### Patch Changes

--- a/tools/typespec-bump-deps/package-lock.json
+++ b/tools/typespec-bump-deps/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-bump-deps",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-bump-deps",
-      "version": "0.9.6",
+      "version": "0.9.7",
       "license": "MIT",
       "dependencies": {
         "pacote": "~21.0.0",

--- a/tools/typespec-bump-deps/package.json
+++ b/tools/typespec-bump-deps/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-bump-deps",
-  "version": "0.9.6",
+  "version": "0.9.7",
   "description": "Tool to grab latest @next version for all Typespec packages",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
I've (mistakenly) added the stream libs in the "move" PR https://github.com/Azure/azure-sdk-tools/pull/9967
https://github.com/weidongxu-microsoft/azure-sdk-tools/blob/811761c09eff43ec5f7738a4092e6615436221c3/tools/typespec-bump-deps/src/cli/typespec-bump-deps.ts#L13-L15

I've done a local test to package.json includes the 3 stream libs.