### PR TITLE
Add path logging to sparse-checkout

### DIFF
--- a/eng/common/pipelines/templates/steps/sparse-checkout.yml
+++ b/eng/common/pipelines/templates/steps/sparse-checkout.yml
@@ -79,9 +79,9 @@ steps:
 
             if (Test-Path .git/info/sparse-checkout) {
               $hasInitialized = $true
-              Write-Host "Repository $($repository.Name) has already been initialized. Skipping this step."
+              Write-Host "Repository $($repository.Name) has already been initialized in $pwd. Skipping this step."
             } else {
-              Write-Host "Repository $($repository.Name) is being initialized."
+              Write-Host "Repository $($repository.Name) is being initialized in $pwd"
 
               if ($repository.Commitish -match '^refs/pull/\d+/merge$') {
                 Retry git clone --no-checkout --filter=tree:0 -c remote.origin.fetch=''+$($repository.Commitish):refs/remotes/origin/$($repository.Commitish)'' https://github.com/$($repository.Name) .


### PR DESCRIPTION
It's nice to see where the repos are being checked out.  The native `checkout:` step shows the target path in the step display name:
```
Starting: Checkout Azure/azure-sdk-for-net@users/pahallis/1es-deployment to s
```