### PR TITLE
Early exit non-service changes, cache getchilditem results

### DIFF
--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -272,13 +272,14 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
                 $ciYml = Join-Path $RepoRoot $yml
                 # ensure we terminate the service directory with a /
                 $directory = [System.IO.Path]::GetDirectoryName($ciYml).Replace("`\", "/")
-                $soleCIYml = (Get-ChildItem -Path $directory -Filter "ci*.yml" -File).Count -eq 1
 
                 # we should only continue with this check if the file being changed is "in the service directory"
                 $serviceDirectoryChange = (Split-Path $filePath -Parent).Replace("`\", "/") -eq $directory
                 if (!$serviceDirectoryChange) {
                     break
                 }
+
+                $soleCIYml = (Get-ChildItem -Path $directory -Filter "ci*.yml" -File).Count -eq 1
 
                 if ($soleCIYml -and $filePath.Replace("`\", "/").StartsWith($directory)) {
                     if (-not $shouldInclude) {

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -207,9 +207,11 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     # To avoid this without wonky changes to the detection algorithm, we simply sort our files by their depth, so we will always
     # detect direct package changes first!
     $targetedFiles = $targetedFiles | Sort-Object { ($_.Split("/").Count) } -Descending
+    $pkgCounter = 1
 
     # this is the primary loop that identifies the packages that have changes
     foreach ($pkg in $allPackageProperties) {
+        Write-Host "Processing changed files against $($pkg.Name). $pkgCounter of $($allPackageProperties.Count)."
         $pkgDirectory = Resolve-Path "$($pkg.DirectoryPath)"
         $lookupKey = ($pkg.DirectoryPath).Replace($RepoRoot, "").TrimStart('\/')
         $lookup[$lookupKey] = $pkg
@@ -315,6 +317,8 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
                 break
             }
         }
+
+        $pkgCounter++
     }
 
     # add all of the packages that were added purely for validation purposes

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -205,8 +205,6 @@ function Get-PkgProperties {
 
 
 function Get-TriggerPaths([PSCustomObject]$AllPackageProperties) {
-    # todo: resolve the triggerPath to include the service directory instead of just having the relative path
-    # this should occur in the populating of package properties I'm thinking.
     $existingTriggeringPaths = @()
     $AllPackageProperties | ForEach-Object {
         if ($_.ArtifactDetails) {
@@ -260,7 +258,7 @@ function Update-TargetedFilesForTriggerPaths([string[]]$TargetedFiles, [string[]
         }
     }
 
-    return $processedFiles | Select-Object -Unique
+    return ($processedFiles | Select-Object -Unique)
 }
 
 function Update-TargetedFilesForExclude([string[]]$TargetedFiles, [string[]]$ExcludePaths) {
@@ -290,7 +288,6 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     $diff = Get-Content $InputDiffJson | ConvertFrom-Json
     $targetedFiles = $diff.ChangedFiles
 
-
     if ($diff.DeletedFiles) {
         if (-not $targetedFiles) {
             $targetedFiles = @()
@@ -301,8 +298,6 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
     $existingTriggeringPaths = Get-TriggerPaths $allPackageProperties
     $targetedFiles = Update-TargetedFilesForExclude $targetedFiles $diff.ExcludePaths
     $targetedFiles = Update-TargetedFilesForTriggerPaths $targetedFiles $existingTriggeringPaths
-
-    $targetedFiles = $processedFiles | Select-Object -Unique
 
     # Sort so that we very quickly find any directly changed packages before hitting service level changes.
     # This is important because due to the way we traverse the changed files, the instant we evaluate a pkg


### PR DESCRIPTION
We got a diff that had ~24k files. We have a lot to check, but still need to optimize best we can.

- [x] After further discussion with @benbp and @hallipr , going to update this logic to execute a pre-pass across the changed files. We will keep around any files that correlate to a `triggeringPath`, but otherwise we are going to simplify the changed files to changed directories. This reduces a prospective change of 24k files to ~1k. 