### PR TITLE
Fixing an issue with `ExcludePaths`, Adding Acceptance Tests for PRMatrix Generation

### DIFF
--- a/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
@@ -34,8 +34,8 @@
                     "/sdk/eventhub/Azure.Messaging.EventHubs.Shared",
                     "/sdk/eventhub/ci.yml"
                   ],
-                  "safeName": "AzureMessagingEventHubs",
-                  "name": "Azure.Messaging.EventHubs"
+                  "name": "Azure.Messaging.EventHubs",
+                  "safeName": "AzureMessagingEventHubs"
                 },
                 "CIParameters": {
                   "CIMatrixConfigs": []

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
@@ -13,8 +13,6 @@
             "DeletedFiles": [],
             "PRNumber": "48379"
         },
-        "repo": "Azure/azure-sdk-for-net",
-        "commit": "",
         "expected_package_output": [
             {
                 "Name": "Azure.Messaging.EventHubs",

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
@@ -1,0 +1,48 @@
+[
+    {
+        "name": "core-change-net-scenario",
+        "diff": {
+            "ChangedFiles": [
+              "sdk/eventhub/Azure.Messaging.EventHubs/README.md"
+            ],
+            "ChangedServices": [
+              "eventhub",
+              "template"
+            ],
+            "ExcludePaths": [],
+            "DeletedFiles": [],
+            "PRNumber": "48379"
+        },
+        "repo": "Azure/azure-sdk-for-net",
+        "commit": "",
+        "expected_package_output": [
+            {
+                "Name": "Azure.Messaging.EventHubs",
+                "Version": "5.12.0-beta.3",
+                "DevVersion": null,
+                "DirectoryPath": "sdk/eventhub/Azure.Messaging.EventHubs",
+                "ServiceDirectory": "eventhub",
+                "ReadMePath": "sdk/eventhub/Azure.Messaging.EventHubs/README.md",
+                "ChangeLogPath": "sdk/eventhub/Azure.Messaging.EventHubs/CHANGELOG.md",
+                "Group": null,
+                "SdkType": "client",
+                "IsNewSdk": true,
+                "ArtifactName": "Azure.Messaging.EventHubs",
+                "ReleaseStatus": "Unreleased",
+                "IncludedForValidation": false,
+                "AdditionalValidationPackages": null,
+                "ArtifactDetails": {
+                  "triggeringPaths": [
+                    "/sdk/eventhub/Azure.Messaging.EventHubs.Shared",
+                    "/sdk/eventhub/ci.yml"
+                  ],
+                  "safeName": "AzureMessagingEventHubs",
+                  "name": "Azure.Messaging.EventHubs"
+                },
+                "CIParameters": {
+                  "CIMatrixConfigs": []
+                }
+            }
+        ]
+    }
+]

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.helpers.ps1
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.helpers.ps1
@@ -1,0 +1,51 @@
+$PackagePropertiesPath = Join-Path "eng" "common" "scripts" "Save-Package-Properties.ps1"
+
+Function Get-Repo {
+    param (
+        [string]$Repo,
+        [string]$Reference
+    )
+
+    $tempDir = [System.IO.Path]::GetTempPath()
+    $repoPath = Join-Path $tempDir $Repo.Replace("/", "-")
+
+    if (!(Test-Path $repoPath)) {
+        New-Item -ItemType Directory -Path $repoPath | Out-Null
+
+        try {
+            Push-Location $repoPath
+            git clone --no-checkout "https://github.com/$Repo.git" .
+            git fetch origin $Reference
+            git checkout $Reference
+        }
+        finally {
+            Pop-Location | Out-Null
+        }
+    }
+
+    return $repoPath
+}
+
+Function Invoke-PackageProps {
+    param (
+        [PSCustomObject]$InputDiff,
+        [string]$Repo
+    )
+
+    $env:GITHUB_ACTIONS="true"
+    $uniqueTempDir = Join-Path -Path ([System.IO.Path]::GetTempPath()) -ChildPath ([System.IO.Path]::GetRandomFileName())
+    New-Item -Path $uniqueTempDir -ItemType Directory | Out-Null
+
+    $prDiffFile = Join-Path $uniqueTempDir "pr-diff.json"
+    $InputDiff | ConvertTo-Json -Depth 100 | Set-Content -Path $prDiffFile -Force
+
+    try {
+        Push-Location $Repo
+        &"$PackagePropertiesPath" -outDirectory "$uniqueTempDir" -prDiff "$prDiffFile"
+    }
+    finally {
+        Pop-Location | Out-Null
+    }
+
+    return $uniqueTempDir
+}

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.tests.ps1
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.tests.ps1
@@ -1,7 +1,8 @@
 Import-Module Pester
 
 # Load scenarios before we enter the Describe block so they're available for -ForEach
-$scenarios = Get-Content (Join-Path $PSScriptRoot net_scenarios.json) | ConvertFrom-Json
+$netScenarios = Get-Content (Join-Path $PSScriptRoot net_scenarios.json) | ConvertFrom-Json
+$pythonScenarios = Get-Content (Join-Path $PSScriptRoot python_scenarios.json) | ConvertFrom-Json
 
 Describe "Acceptance tests for .NET PR Matrix Generation" {
     BeforeAll {
@@ -9,7 +10,25 @@ Describe "Acceptance tests for .NET PR Matrix Generation" {
         $RepoRoot = Get-Repo -Repo "Azure/azure-sdk-for-net" -Reference "331c07a1ab59ed0042972ca6d0df830df235280f"
     }
 
-    It "Should evaluate .NET core diffs correctly - <name>" -ForEach $scenarios {
+    It "Should evaluate .NET core diffs correctly - <name>" -ForEach $netScenarios {
+        $scenario = $_
+        $outputProps = Invoke-PackageProps -InputDiff $scenario.diff -Repo "$RepoRoot"
+        $expectedOutputs = $scenario.expected_package_output | Sort-Object -Property Name
+        $detectedOutputs = Get-ChildItem -Path $outputProps -Recurse -Filter "*.json" -Exclude "pr-diff.json" `
+            | ForEach-Object { Get-Content -Raw $_ | ConvertFrom-Json }
+            | Sort-Object -Property Name
+
+        ($detectedOutputs | ConvertTo-Json -Depth 100) | Should -Be ($expectedOutputs | ConvertTo-Json -Depth 100)
+    }
+}
+
+Describe "Acceptance tests for Python PR Matrix Generation" {
+    BeforeAll {
+        . $PSScriptRoot/pr-matrix-generation-acceptance.helpers.ps1
+        $RepoRoot = Get-Repo -Repo "Azure/azure-sdk-for-python" -Reference "516977e3a0f9ba22d5611608f64b836fefffc37e"
+    }
+
+    It "Should evaluate python diffs correctly - <name>" -ForEach $pythonScenarios {
         $scenario = $_
         $outputProps = Invoke-PackageProps -InputDiff $scenario.diff -Repo "$RepoRoot"
         $expectedOutputs = $scenario.expected_package_output | Sort-Object -Property Name

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.tests.ps1
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.tests.ps1
@@ -1,6 +1,7 @@
 Import-Module Pester
 
-
+# Load scenarios before we enter the Describe block so they're available for -ForEach
+$scenarios = Get-Content (Join-Path $PSScriptRoot net_scenarios.json) | ConvertFrom-Json
 
 Describe "Acceptance tests for .NET PR Matrix Generation" {
     BeforeAll {
@@ -8,16 +9,14 @@ Describe "Acceptance tests for .NET PR Matrix Generation" {
         $RepoRoot = Get-Repo -Repo "Azure/azure-sdk-for-net" -Reference "331c07a1ab59ed0042972ca6d0df830df235280f"
     }
 
-    # todo: parametrize this test to via file
-    It "Should evaluate .NET core diffs correctly" {
-        # todo actually parameterize this instead of going after the first one specifically only
-        $scenarios = Get-Content (Join-Path $PSScriptRoot net_scenarios.json) -Raw | ConvertFrom-Json
-        $scenario = $scenarios[0]
-
+    It "Should evaluate .NET core diffs correctly - <name>" -ForEach $scenarios {
+        $scenario = $_
         $outputProps = Invoke-PackageProps -InputDiff $scenario.diff -Repo "$RepoRoot"
-
+        $expectedOutputs = $scenario.expected_package_output | Sort-Object -Property Name
         $detectedOutputs = Get-ChildItem -Path $outputProps -Recurse -Filter "*.json" -Exclude "pr-diff.json" `
             | ForEach-Object { Get-Content -Raw $_ | ConvertFrom-Json }
+            | Sort-Object -Property Name
 
+        $detectedOutputs | Should -Be $expectedOutputs
     }
 }

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.tests.ps1
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.tests.ps1
@@ -1,0 +1,21 @@
+Import-Module Pester
+
+
+
+Describe "Acceptance tests for .NET PR Matrix Generation" {
+    BeforeAll {
+        . $PSScriptRoot/pr-matrix-generation-acceptance.helpers.ps1
+        $RepoRoot = Get-Repo -Repo "Azure/azure-sdk-for-net" -Reference "331c07a1ab59ed0042972ca6d0df830df235280f"
+    }
+
+    # todo: parametrize this test to via file
+    It "Should evaluate a basic package diff correctly" {
+        # todo actually parameterize this instead of going after the first one specifically only
+        $scenarios = Get-Content (Join-Path $PSScriptRoot net_scenarios.json) -Raw | ConvertFrom-Json
+        $scenario = $scenarios[0]
+
+        $outputProps = Invoke-PackageProps -InputDiff $scenario.diff -Repo "$RepoRoot"
+
+        Write-Host $outputProps
+    }
+}

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.tests.ps1
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.tests.ps1
@@ -17,6 +17,6 @@ Describe "Acceptance tests for .NET PR Matrix Generation" {
             | ForEach-Object { Get-Content -Raw $_ | ConvertFrom-Json }
             | Sort-Object -Property Name
 
-        $detectedOutputs | Should -Be $expectedOutputs
+        ($detectedOutputs | ConvertTo-Json -Depth 100) | Should -Be ($expectedOutputs | ConvertTo-Json -Depth 100)
     }
 }

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.tests.ps1
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/pr-matrix-generation-acceptance.tests.ps1
@@ -9,13 +9,15 @@ Describe "Acceptance tests for .NET PR Matrix Generation" {
     }
 
     # todo: parametrize this test to via file
-    It "Should evaluate a basic package diff correctly" {
+    It "Should evaluate .NET core diffs correctly" {
         # todo actually parameterize this instead of going after the first one specifically only
         $scenarios = Get-Content (Join-Path $PSScriptRoot net_scenarios.json) -Raw | ConvertFrom-Json
         $scenario = $scenarios[0]
 
         $outputProps = Invoke-PackageProps -InputDiff $scenario.diff -Repo "$RepoRoot"
 
-        Write-Host $outputProps
+        $detectedOutputs = Get-ChildItem -Path $outputProps -Recurse -Filter "*.json" -Exclude "pr-diff.json" `
+            | ForEach-Object { Get-Content -Raw $_ | ConvertFrom-Json }
+
     }
 }

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/python_scenarios.json
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/python_scenarios.json
@@ -1,0 +1,106 @@
+[
+    {
+        "name": "core-change-net-scenario",
+        "diff": {
+          "ChangedFiles": [
+            "eng/tox/run_coverage.py",
+            "scripts/devops_tasks/create_coverage.py",
+            "sdk/ml/azure-ai-ml/pyproject.toml"
+          ],
+          "ChangedServices": [
+            "ml"
+          ],
+          "ExcludePaths": [
+            "sdk/cosmos/"
+          ],
+          "DeletedFiles": [],
+          "PRNumber": "40035"
+        },
+        "expected_package_output": [
+          {
+            "Name": "azure-template",
+            "Version": "0.0.18b3",
+            "DevVersion": null,
+            "DirectoryPath": "sdk/template/azure-template",
+            "ServiceDirectory": "template",
+            "ReadMePath": "sdk/template/azure-template/README.md",
+            "ChangeLogPath": "sdk/template/azure-template/CHANGELOG.md",
+            "Group": null,
+            "SdkType": "client",
+            "IsNewSdk": true,
+            "ArtifactName": "azure-template",
+            "ReleaseStatus": "Unreleased",
+            "IncludedForValidation": true,
+            "AdditionalValidationPackages": [
+              ""
+            ],
+            "ArtifactDetails": null,
+            "CIParameters": {
+              "CIMatrixConfigs": []
+            }
+          },
+          {
+            "Name": "azure-ai-ml",
+            "Version": "1.27.0",
+            "DevVersion": null,
+            "DirectoryPath": "sdk/ml/azure-ai-ml",
+            "ServiceDirectory": "ml",
+            "ReadMePath": "sdk/ml/azure-ai-ml/README.md",
+            "ChangeLogPath": "sdk/ml/azure-ai-ml/CHANGELOG.md",
+            "Group": null,
+            "SdkType": "client",
+            "IsNewSdk": true,
+            "ArtifactName": "azure-ai-ml",
+            "ReleaseStatus": "unreleased",
+            "IncludedForValidation": false,
+            "AdditionalValidationPackages": [
+              ""
+            ],
+            "ArtifactDetails": null,
+            "CIParameters": {
+              "CIMatrixConfigs": []
+            }
+          },
+          {
+            "Name": "azure-core",
+            "Version": "1.33.0",
+            "DevVersion": null,
+            "DirectoryPath": "sdk/core/azure-core",
+            "ServiceDirectory": "core",
+            "ReadMePath": "sdk/core/azure-core/README.md",
+            "ChangeLogPath": "sdk/core/azure-core/CHANGELOG.md",
+            "Group": null,
+            "SdkType": "client",
+            "IsNewSdk": true,
+            "ArtifactName": "azure-core",
+            "ReleaseStatus": "2025-03-10",
+            "IncludedForValidation": true,
+            "AdditionalValidationPackages": [
+              "/sdk\\servicebus\\azure-servicebus",
+              "/sdk\\eventhub\\azure-eventhub",
+              "/sdk\\tables\\azure-data-tables",
+              "/sdk\\appconfiguration\\azure-appconfiguration",
+              "/sdk\\keyvault\\azure-keyvault-keys",
+              "/sdk\\identity\\azure-identity",
+              "/sdk\\core\\azure-mgmt-core",
+              "/sdk\\core\\azure-core-experimental",
+              "/sdk\\core\\azure-core-tracing-opentelemetry",
+              "/sdk\\core\\azure-core-tracing-opencensus",
+              "/sdk\\ml\\azure-ai-ml",
+              "/sdk\\documentintelligence\\azure-ai-documentintelligence",
+              "/sdk\\ai\\azure-ai-inference",
+              "/sdk\\textanalytics\\azure-ai-textanalytics",
+              "/sdk\\translation\\azure-ai-translation-document",
+              "/sdk\\compute\\azure-mgmt-compute",
+              "/sdk\\communication\\azure-communication-chat",
+              "/sdk\\communication\\azure-communication-identity",
+              "/sdk\\storage\\azure-storage-blob"
+            ],
+            "ArtifactDetails": null,
+            "CIParameters": {
+              "CIMatrixConfigs": []
+            }
+          }
+        ]
+    }
+]

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -266,7 +266,7 @@ function Update-TargetedFilesForExclude([string[]]$TargetedFiles, [string[]]$Exc
     foreach ($file in $TargetedFiles) {
         $shouldExclude = $false
         foreach ($exclude in $ExcludePaths) {
-            if (!$file.StartsWith($exclude,'CurrentCultureIgnoreCase')) {
+            if ($file.StartsWith($exclude,'CurrentCultureIgnoreCase')) {
                 $shouldExclude = $true
                 break
             }


### PR DESCRIPTION
Unfortunately I needed them to work because that PR yesterday did have an impact on python.

On a follow-up where I more samples for js and java, I will add the tests to the `eng-common` tests that are run. For now I need to get this through.