### PR TITLE
use the pull request head sha for APIView PR runs

### DIFF
--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -16,7 +16,7 @@ steps:
       filePath: ${{ parameters.RepoRoot }}/eng/common/scripts/Detect-Api-Changes.ps1
       arguments: >
         -ArtifactPath ${{parameters.ArtifactPath}}
-        -CommitSha '$(Build.SourceVersion)'
+        -CommitSha '$(System.PullRequest.SourceCommitId)'
         -BuildId $(Build.BuildId)
         -PullRequestNumber $(System.PullRequest.PullRequestNumber)
         -RepoFullName $(Build.Repository.Name)


### PR DESCRIPTION
- `$(Build.SourceVersion)` is a commit created during the DevOps pipeline run. `$(System.PullRequest.SourceCommitId)` is the actual HeadCommitSHA of the pull request.