### PR TITLE
[API View] Extending rust-api-parser support 

### DIFF
--- a/tools/apiview/parsers/rust-api-parser/src/main.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/main.ts
@@ -46,6 +46,7 @@ function addSectionHeader(codeFile: CodeFile, headerText: string): void {
         Value: `/* ${headerText} */`,
         NavigateToId: `header-${headerText}`,
         NavigationDisplayName: `/* ${headerText} */`,
+        RenderClasses: ["namespace"],
       },
     ],
   });

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocConst.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocConst.ts
@@ -46,15 +46,18 @@ export function processAssocConst(item: Item): ReviewLine[] | null {
 
   reviewLine.Tokens.push(...typeToReviewTokens(item.inner.assoc_const.type));
 
-  reviewLine.Tokens.push({
-    Kind: TokenKind.Punctuation,
-    Value: " =",
-  });
+  if (item.inner.assoc_const.value) {
+    reviewLine.Tokens.push({
+      Kind: TokenKind.Punctuation,
+      Value: " =",
+    });
 
-  reviewLine.Tokens.push({
-    Kind: TokenKind.Text,
-    Value: item.inner.assoc_const.value || "unknown",
-  });
+    reviewLine.Tokens.push({
+      Kind: TokenKind.Text,
+      Value: item.inner.assoc_const.value,
+      HasSuffixSpace: false,
+    });
+  }
 
   reviewLine.Tokens.push({
     Kind: TokenKind.Punctuation,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocConst.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocConst.ts
@@ -33,9 +33,10 @@ export function processAssocConst(item: Item): ReviewLine[] | null {
 
   // Add name
   reviewLine.Tokens.push({
-    Kind: TokenKind.Text,
+    Kind: TokenKind.MemberName,
     Value: item.name || "unknown",
     HasSuffixSpace: false,
+    RenderClasses: ["interface"],
   });
 
   // Add colon

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocType.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocType.ts
@@ -3,7 +3,7 @@ import { Item } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLine } from "./utils/generateDocReviewLine";
 import { typeToReviewTokens } from "./utils/typeToReviewTokens";
 import { isAssocTypeItem } from "./utils/typeGuards";
-import { createGenericBoundTokens } from "./utils/processGenerics";
+import { createGenericBoundTokens, processGenerics } from "./utils/processGenerics";
 
 /**
  * Processes an associated type item and returns ReviewLine objects.
@@ -39,6 +39,8 @@ export function processAssocType(item: Item): ReviewLine[] | null {
     HasSuffixSpace: false,
   });
 
+  const generics = processGenerics(item.inner.assoc_type.generics)
+  reviewLine.Tokens.push(...generics.params);
   // Add bounds if available
   const assocType = item.inner.assoc_type;
   if (assocType && assocType.bounds && assocType.bounds.length > 0) {
@@ -58,6 +60,7 @@ export function processAssocType(item: Item): ReviewLine[] | null {
     reviewLine.Tokens.push(...typeToReviewTokens(assocType.type));
   }
 
+  reviewLine.Tokens.push(...generics.wherePredicates);
   reviewLine.Tokens.push({
     Kind: TokenKind.Punctuation,
     Value: ";",

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocType.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocType.ts
@@ -34,12 +34,13 @@ export function processAssocType(item: Item): ReviewLine[] | null {
 
   // Add name
   reviewLine.Tokens.push({
-    Kind: TokenKind.Text,
+    Kind: TokenKind.MemberName,
     Value: item.name || "unknown",
     HasSuffixSpace: false,
+    RenderClasses: ["interface"],
   });
 
-  const generics = processGenerics(item.inner.assoc_type.generics)
+  const generics = processGenerics(item.inner.assoc_type.generics);
   reviewLine.Tokens.push(...generics.params);
   // Add bounds if available
   const assocType = item.inner.assoc_type;

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processConstant.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processConstant.ts
@@ -21,11 +21,12 @@ export function processConstant(item: Item) {
     Value: "pub const",
   });
   reviewLine.Tokens.push({
-    Kind: TokenKind.Text,
+    Kind: TokenKind.MemberName,
     Value: item.name || "null",
     HasSuffixSpace: false,
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name,
+    RenderClasses: ["interface"],
   });
   reviewLine.Tokens.push({
     Kind: TokenKind.Punctuation,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processEnum.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processEnum.ts
@@ -42,10 +42,11 @@ export function processEnum(item: Item): ReviewLine[] {
   });
 
   enumLine.Tokens.push({
-    Kind: TokenKind.TypeName,
+    Kind: TokenKind.MemberName,
     Value: item.name || "null",
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,
+    RenderClasses: ["enum"],
   });
 
   const genericsTokens = processGenerics(item.inner.enum.generics);
@@ -72,10 +73,8 @@ export function processEnum(item: Item): ReviewLine[] {
         LineId: variantItem.id.toString(),
         Tokens: [
           {
-            Kind: TokenKind.TypeName,
+            Kind: TokenKind.Text,
             Value: variantItem.name || "null",
-            NavigateToId: variantItem.id.toString(),
-            NavigationDisplayName: variantItem.name || undefined,
             HasSuffixSpace: false,
           },
           {

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processExternType.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processExternType.ts
@@ -32,7 +32,7 @@ export function processExternType(item: Item): ReviewLine[] | null {
 
   // Add name
   reviewLine.Tokens.push({
-    Kind: TokenKind.Text,
+    Kind: TokenKind.MemberName,
     Value: item.name || "unknown",
   });
 

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processFunction.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processFunction.ts
@@ -143,6 +143,7 @@ export function processFunction(item: Item) {
     Kind: TokenKind.Punctuation,
     Value: ")",
     HasPrefixSpace: false,
+    HasSuffixSpace: false,
   });
 
   // Add return type if present
@@ -150,6 +151,7 @@ export function processFunction(item: Item) {
     reviewLine.Tokens.push({
       Kind: TokenKind.Punctuation,
       Value: "->",
+      HasPrefixSpace: true,
     });
     reviewLine.Tokens.push(...typeToReviewTokens(item.inner.function.sig.output));
   }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processFunction.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processFunction.ts
@@ -7,7 +7,7 @@ import { typeToReviewTokens } from "./utils/typeToReviewTokens";
 
 /**
  * Processes the function header and adds modifiers and ABI information to the tokens
- * 
+ *
  * @param {FunctionHeader} header - The function header containing const, unsafe, async and ABI information
  * @param {ReviewLine} reviewLine - The review line to add tokens to
  */

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processFunction.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processFunction.ts
@@ -86,7 +86,7 @@ export function processFunction(item: Item) {
     Kind: TokenKind.MemberName,
     Value: item.name || "null",
     HasSuffixSpace: false,
-    RenderClasses: ["tname", "method"],
+    RenderClasses: ["method"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,
   });

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processImpl.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processImpl.ts
@@ -36,9 +36,8 @@ export function processAutoTraitImpls(impls: number[]): ReviewToken[] {
   const traitItems = getFilteredImpls(impls, isAutoDerivedImpl);
   // Get all traits that have been derived
   const traits = traitItems.map<ReviewToken>((item) => ({
-    Kind: TokenKind.TypeName,
+    Kind: TokenKind.MemberName,
     Value: item.inner.impl.trait!.name,
-    RenderClasses: ["tname", "trait"],
     HasSuffixSpace: false,
   }));
   if (!traits.length) return [];
@@ -81,7 +80,7 @@ function processOtherTraitImpls(impls: number[]): ReviewLine[] {
           {
             Kind: TokenKind.MemberName,
             Value: method,
-            RenderClasses: ["tname", "method"],
+            RenderClasses: ["method"],
             HasSuffixSpace: false,
           },
           { Kind: TokenKind.Punctuation, Value: ";" },
@@ -93,7 +92,7 @@ function processOtherTraitImpls(impls: number[]): ReviewLine[] {
         ],
       }),
     );
-    const implGenerics = processGenerics(implItem.inner.impl.generics)
+    const implGenerics = processGenerics(implItem.inner.impl.generics);
     // Create the main impl line with trait name and type
     const reviewLineForImpl: ReviewLine = {
       LineId: implId + "_impl",
@@ -105,7 +104,7 @@ function processOtherTraitImpls(impls: number[]): ReviewLine[] {
         },
         ...implGenerics.params,
         {
-          Kind: TokenKind.TypeName,
+          Kind: TokenKind.MemberName,
           Value: (implItem.inner.impl.is_negative ? "!" : "") + implItem.inner.impl.trait.name,
           HasPrefixSpace: true,
           HasSuffixSpace: false,
@@ -181,27 +180,27 @@ export function processImpl(
     children.length === 0
       ? [] // Empty implBlock if no children
       : [
-        // Create the main implementation line with type name
-        {
-          LineId: item.id.toString() + "_impl",
-          Tokens: [
-            { Kind: TokenKind.Keyword, Value: "impl" },
-            {
-              Kind: TokenKind.TypeName,
-              Value: item.name || "null",
-              RenderClasses: ["tname"],
-              NavigateToId: item.id.toString() + "_impl",
-              NavigationDisplayName: item.name || undefined,
-            },
-            { Kind: TokenKind.Punctuation, Value: "{" },
-          ],
-          Children: children,
-        },
-        {
-          RelatedToLine: item.id.toString() + "_impl",
-          Tokens: [{ Kind: TokenKind.Punctuation, Value: "}" }],
-        },
-      ];
+          // Create the main implementation line with type name
+          {
+            LineId: item.id.toString() + "_impl",
+            Tokens: [
+              { Kind: TokenKind.Keyword, Value: "impl" },
+              {
+                Kind: TokenKind.MemberName,
+                Value: item.name || "null",
+                RenderClasses: ["tname"],
+                NavigateToId: item.id.toString() + "_impl",
+                NavigationDisplayName: item.name || undefined,
+              },
+              { Kind: TokenKind.Punctuation, Value: "{" },
+            ],
+            Children: children,
+          },
+          {
+            RelatedToLine: item.id.toString() + "_impl",
+            Tokens: [{ Kind: TokenKind.Punctuation, Value: "}" }],
+          },
+        ];
 
   // Process manual trait implementations (like impl Trait for Type { ... })
   const traitImpls = processOtherTraitImpls(impls);

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processImpl.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processImpl.ts
@@ -13,27 +13,27 @@ import { typeToReviewTokens } from "./utils/typeToReviewTokens";
 import { processGenericArgs } from "./utils/processGenerics";
 import { getAPIJson } from "../main";
 
+// Helper function to map impl IDs to their items and filter by type
+function getFilteredImpls<T extends ImplItem>(
+  impls: number[],
+  filterFn: (item: ImplItem) => boolean,
+): T[] {
+  const apiJson = getAPIJson();
+  return impls
+    .map((implId) => apiJson.index[implId] as ImplItem)
+    .filter((item) => isImplItem(item) && filterFn(item)) as T[];
+}
+
 // Process automatically derived trait implementations
 export function processAutoTraitImpls(impls: number[]): ReviewToken[] {
-  const apiJson = getAPIJson();
-
-  // Helper function that transforms impl IDs to ReviewTokens
-  const traitImpls = (impls: number[]) =>
-    impls
-      // each impl ID to its corresponding item
-      .map((implId) => apiJson.index[implId] as ImplItem)
-      // Filter for only auto-derived trait implementations
-      .filter((implItem) => isImplItem(implItem) && isAutoDerivedImpl(implItem))
-      // Create a token for each trait that's been derived
-      .map<ReviewToken>((implItem) => ({
-        Kind: TokenKind.TypeName,
-        Value: implItem.inner.impl.trait!.name,
-        RenderClasses: ["tname", "trait"],
-        HasSuffixSpace: false,
-      }));
-
+  const traitItems = getFilteredImpls(impls, isAutoDerivedImpl);
   // Get all traits that have been derived
-  const traits = traitImpls(impls);
+  const traits = traitItems.map<ReviewToken>((item) => ({
+    Kind: TokenKind.TypeName,
+    Value: item.inner.impl.trait!.name,
+    RenderClasses: ["tname", "trait"],
+    HasSuffixSpace: false,
+  }));
   if (!traits.length) return [];
 
   // Build the complete derive attribute with all derived traits
@@ -56,97 +56,85 @@ export function processAutoTraitImpls(impls: number[]): ReviewToken[] {
 // Process manually implemented trait implementations
 function processOtherTraitImpls(impls: number[]): ReviewLine[] {
   const apiJson = getAPIJson();
+  const traitImpls = getFilteredImpls(impls, isManualTraitImpl);
+  return traitImpls.flatMap((implItem) => {
+    if (!implItem.inner.impl.trait) return [];
 
-  return (
-    impls
-      // impl IDs to corresponding items
-      .map((implId) => apiJson.index[implId] as ImplItem)
-      // Filter for only manual trait implementations
-      .filter((implItem) => isImplItem(implItem) && isManualTraitImpl(implItem))
-      .flatMap((implItem) => {
-        if (!implItem.inner.impl.trait) return [];
+    // Get the type that the trait is implemented for
+    const parentName = typeToReviewTokens(implItem.inner.impl.for);
 
-        // Get the type that the trait is implemented for
-        const parentName = typeToReviewTokens(implItem.inner.impl.for);
-
-        // Process provided trait methods that are mentioned but not explicitly implemented
-        const providedTraitMethods: ReviewLine[] = implItem.inner.impl.provided_trait_methods.map(
-          (method) => {
-            return {
-              LineId: implItem.id.toString() + "_impl_" + method,
-              Tokens: [
-                { Kind: TokenKind.Keyword, Value: "pub" },
-                { Kind: TokenKind.Keyword, Value: "fn" },
-                {
-                  Kind: TokenKind.MemberName,
-                  Value: method,
-                  RenderClasses: ["tname", "method"],
-                  HasSuffixSpace: false,
-                },
-                { Kind: TokenKind.Punctuation, Value: ";" },
-                {
-                  Kind: TokenKind.Comment,
-                  Value: "// provided trait method",
-                  HasSuffixSpace: false,
-                },
-              ],
-            };
+    const implId = implItem.id.toString();
+    // Process provided trait methods that are mentioned but not explicitly implemented
+    const providedTraitMethods: ReviewLine[] = implItem.inner.impl.provided_trait_methods.map(
+      (method) => ({
+        LineId: implId + "_impl_" + method,
+        Tokens: [
+          { Kind: TokenKind.Keyword, Value: "pub" },
+          { Kind: TokenKind.Keyword, Value: "fn" },
+          {
+            Kind: TokenKind.MemberName,
+            Value: method,
+            RenderClasses: ["tname", "method"],
+            HasSuffixSpace: false,
           },
-        );
+          { Kind: TokenKind.Punctuation, Value: ";" },
+          {
+            Kind: TokenKind.Comment,
+            Value: "// provided trait method",
+            HasSuffixSpace: false,
+          },
+        ],
+      }),
+    );
+    // Create the main impl line with trait name and type
+    const reviewLineForImpl: ReviewLine = {
+      LineId: implId + "_impl",
+      Tokens: [
+        {
+          Kind: TokenKind.Keyword,
+          Value: (implItem.inner.impl.is_unsafe ? "unsafe " : "") + "impl",
+        },
+        {
+          Kind: TokenKind.TypeName,
+          Value: (implItem.inner.impl.is_negative ? "!" : "") + implItem.inner.impl.trait.name,
+          HasSuffixSpace: false,
+          NavigateToId: implId + "_impl",
+          // Create navigation display name by combining trait and type names
+          NavigationDisplayName:
+            implItem.inner.impl.trait.name + "_" + parentName.map((token) => token.Value).join(""),
+        },
+        // Add any generic arguments the trait might have
+        ...processGenericArgs(implItem.inner.impl.trait.args),
+        { Kind: TokenKind.Punctuation, Value: "for", HasPrefixSpace: true },
+        // Add the type the trait is implemented for
+        ...parentName,
+        { Kind: TokenKind.Punctuation, Value: "{", HasPrefixSpace: true },
+      ],
+      // Add both implemented methods and provided methods as children
+      Children: [
+        ...implItem.inner.impl.items
+          .map((item) => processItem(apiJson.index[item]))
+          .filter((item) => item != null)
+          .flat(),
+        ...providedTraitMethods,
+      ],
+    };
 
-        // Create the main impl line with trait name and type
-        const reviewLineForImpl: ReviewLine = {
-          LineId: implItem.id.toString() + "_impl",
-          Tokens: [
-            { Kind: TokenKind.Keyword, Value: "impl" },
-            {
-              Kind: TokenKind.TypeName,
-              Value: implItem.inner.impl.trait.name,
-              HasSuffixSpace: false,
-              NavigateToId: implItem.id.toString() + "_impl",
-              // Create navigation display name by combining trait and type names
-              NavigationDisplayName:
-                implItem.inner.impl.trait.name +
-                "_" +
-                parentName.map((token) => token.Value).join(""),
-            },
-            // Add any generic arguments the trait might have
-            ...processGenericArgs(implItem.inner.impl.trait.args),
-            { Kind: TokenKind.Punctuation, Value: "for", HasPrefixSpace: true },
-            // Add the type the trait is implemented for
-            ...parentName,
-            { Kind: TokenKind.Punctuation, Value: "{", HasPrefixSpace: true },
-          ],
-          // Add both implemented methods and provided methods as children
-          Children: [
-            ...implItem.inner.impl.items
-              .map((item) => processItem(apiJson.index[item]))
-              .filter((item) => item != null)
-              .flat(),
-            ...providedTraitMethods,
-          ],
-        };
+    const closingLine: ReviewLine = {
+      RelatedToLine: implItem.id.toString() + "_impl",
+      Tokens: [{ Kind: TokenKind.Punctuation, Value: "}" }],
+    };
 
-        const closingLine: ReviewLine = {
-          RelatedToLine: implItem.id.toString() + "_impl",
-          Tokens: [{ Kind: TokenKind.Punctuation, Value: "}" }],
-        };
-
-        return [reviewLineForImpl, closingLine];
-      })
-  );
+    return [reviewLineForImpl, closingLine];
+  });
 }
-
 // Process inherent implementations
 function processImpls(impls: number[]): ReviewLine[] {
   const apiJson = getAPIJson();
+  const inherentImpls = getFilteredImpls(impls, isInherentImpl);
 
   return (
-    impls
-      // impl IDs to corresponding items
-      .map((implId) => apiJson.index[implId] as ImplItem)
-      // Filter for only inherent implementations (not trait implementations)
-      .filter((implItem) => isImplItem(implItem) && isInherentImpl(implItem))
+    inherentImpls
       // Process each implementation's items and flatten the results
       .flatMap((implItem) =>
         implItem.inner.impl.items

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processImpl.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processImpl.ts
@@ -112,6 +112,7 @@ function processOtherTraitImpls(impls: number[]): ReviewLine[] {
           // Create navigation display name by combining trait and type names
           NavigationDisplayName:
             implItem.inner.impl.trait.name + "_" + parentName.map((token) => token.Value).join(""),
+          RenderClasses: ["interface"],
         },
         // Add any generic arguments the trait might have
         ...processGenericArgs(implItem.inner.impl.trait.args),
@@ -188,7 +189,7 @@ export function processImpl(
               {
                 Kind: TokenKind.MemberName,
                 Value: item.name || "null",
-                RenderClasses: ["tname"],
+                RenderClasses: ["interface"],
                 NavigateToId: item.id.toString() + "_impl",
                 NavigationDisplayName: item.name || undefined,
               },

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processModule.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processModule.ts
@@ -39,7 +39,7 @@ export function processModule(
     reviewLine.Tokens.push({
       Kind: TokenKind.TypeName,
       Value: parentModule.prefix,
-      RenderClasses: ["mname", "module"],
+      RenderClasses: ["namespace"],
       NavigateToId: parentModule.id.toString(),
       HasSuffixSpace: false,
     });
@@ -55,7 +55,7 @@ export function processModule(
   reviewLine.Tokens.push({
     Kind: TokenKind.TypeName,
     Value: item.name || "null",
-    RenderClasses: ["mname", "module"],
+    RenderClasses: ["namespace"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: fullName,
   });

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processStatic.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processStatic.ts
@@ -29,7 +29,7 @@ export function processStatic(item: Item) {
   reviewLine.Tokens.push({
     Kind: TokenKind.MemberName,
     Value: item.name || "null",
-    RenderClasses: ["sliteral", "static"],
+    RenderClasses: ["interface"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,
     HasSuffixSpace: false,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processStruct.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processStruct.ts
@@ -50,9 +50,9 @@ export function processStruct(item: Item): ReviewLine[] {
   });
 
   structLine.Tokens.push({
-    Kind: TokenKind.TypeName,
+    Kind: TokenKind.MemberName,
     Value: item.name || "null",
-    RenderClasses: ["tname", "struct"],
+    RenderClasses: ["struct"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,
   });

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processStructField.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processStructField.ts
@@ -23,6 +23,9 @@ export function processStructField(fieldItem: Item): ReviewLine {
         Kind: TokenKind.MemberName,
         Value: fieldItem.name || "null",
         HasSuffixSpace: false,
+        RenderClasses: ["interface"],
+        NavigateToId: fieldItem.id.toString(),
+        NavigationDisplayName: fieldItem.name,
       },
       {
         Kind: TokenKind.Punctuation,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processTrait.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processTrait.ts
@@ -43,9 +43,9 @@ export function processTrait(item: Item) {
     Value: "trait",
   });
   reviewLine.Tokens.push({
-    Kind: TokenKind.TypeName,
+    Kind: TokenKind.MemberName,
     Value: item.name || "null",
-    RenderClasses: ["tname", "trait"],
+    RenderClasses: ["struct"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,
     HasSuffixSpace: false,
@@ -58,7 +58,7 @@ export function processTrait(item: Item) {
   }
 
   if (item.inner.trait.bounds) {
-    const boundTokens = createGenericBoundTokens(item.inner.trait.bounds)
+    const boundTokens = createGenericBoundTokens(item.inner.trait.bounds);
     if (boundTokens.length > 0) {
       reviewLine.Tokens.push({ Kind: TokenKind.Text, Value: ":", HasPrefixSpace: false });
       reviewLine.Tokens.push(...boundTokens);

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processTrait.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processTrait.ts
@@ -28,7 +28,19 @@ export function processTrait(item: Item) {
 
   reviewLine.Tokens.push({
     Kind: TokenKind.Keyword,
-    Value: "pub trait",
+    Value: "pub",
+  });
+
+  if (item.inner.trait.is_unsafe) {
+    reviewLine.Tokens.push({
+      Kind: TokenKind.Keyword,
+      Value: "unsafe",
+    });
+  }
+
+  reviewLine.Tokens.push({
+    Kind: TokenKind.Keyword,
+    Value: "trait",
   });
   reviewLine.Tokens.push({
     Kind: TokenKind.TypeName,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processTrait.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processTrait.ts
@@ -58,8 +58,11 @@ export function processTrait(item: Item) {
   }
 
   if (item.inner.trait.bounds) {
-    reviewLine.Tokens.push({ Kind: TokenKind.Text, Value: ":", HasPrefixSpace: false });
-    reviewLine.Tokens.push(...createGenericBoundTokens(item.inner.trait.bounds));
+    const boundTokens = createGenericBoundTokens(item.inner.trait.bounds)
+    if (boundTokens.length > 0) {
+      reviewLine.Tokens.push({ Kind: TokenKind.Text, Value: ":", HasPrefixSpace: false });
+      reviewLine.Tokens.push(...boundTokens);
+    }
   }
 
   // Add generics where clauses if present

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processTraitAlias.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processTraitAlias.ts
@@ -33,9 +33,12 @@ export function processTraitAlias(item: Item): ReviewLine[] {
 
   // Add name
   reviewLine.Tokens.push({
-    Kind: TokenKind.Text,
+    Kind: TokenKind.MemberName,
     Value: item.name || "unknown",
     HasSuffixSpace: false,
+    RenderClasses: ["interface"],
+    NavigateToId: item.id.toString(),
+    NavigationDisplayName: item.name || undefined,
   });
 
   // Add equals sign

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processTypeAlias.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processTypeAlias.ts
@@ -34,10 +34,11 @@ export function processTypeAlias(item: Item): ReviewLine[] {
 
   // Add name
   reviewLine.Tokens.push({
-    Kind: TokenKind.Text,
+    Kind: TokenKind.MemberName,
     Value: item.name || "unknown",
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || "unknown",
+    RenderClasses: ["interface"],
   });
 
   // Add equals sign

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUnion.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUnion.ts
@@ -49,9 +49,9 @@ export function processUnion(item: Item): ReviewLine[] {
   });
 
   unionLine.Tokens.push({
-    Kind: TokenKind.TypeName,
+    Kind: TokenKind.MemberName,
     Value: item.name || "null",
-    RenderClasses: ["tname", "union"],
+    RenderClasses: ["struct"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,
   });

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -39,8 +39,9 @@ export function processUse(item: Item): ReviewLine[] | undefined {
   reviewLine.Tokens.push({
     Kind: TokenKind.TypeName,
     Value: useValue,
-    RenderClasses: ["mname", "use"],
+    RenderClasses: ["dependencies"],
     NavigateToId: item.inner.use.id.toString(),
+    NavigationDisplayName: useValue,
   });
 
   reviewLines.push(reviewLine);
@@ -78,7 +79,7 @@ export function processUse(item: Item): ReviewLine[] | undefined {
           {
             Kind: TokenKind.TypeName,
             Value: basePath,
-            RenderClasses: ["mname"],
+            RenderClasses: ["namespace"],
             NavigateToId: apiJson.index[item.inner.use.id].id.toString() + "_reexport_parent",
             NavigationDisplayName: basePath,
           },

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
@@ -63,7 +63,7 @@ function createItemLine(itemId: Id, itemSummary: ItemSummary): ReviewLine {
       {
         Kind: TokenKind.TypeName,
         Value: itemSummary.path.concat().join("::"),
-        RenderClasses: ["mname", "reexport"],
+        RenderClasses: ["dependencies"],
         NavigateToId: itemId.toString(),
       },
     ],
@@ -125,7 +125,6 @@ function createModuleHeaderLine(itemId: Id, itemSummary: ItemSummary): ReviewLin
       {
         Kind: TokenKind.TypeName,
         Value: itemSummary.path.concat().join("::"),
-        RenderClasses: ["mname", "module", "reexport"],
         NavigateToId: itemId.toString(),
       },
       {

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/processGenerics.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/processGenerics.ts
@@ -139,6 +139,8 @@ export function createGenericBoundTokens(bounds: GenericBound[]): ReviewToken[] 
 
 export function processGenericArgs(args: GenericArgs): ReviewToken[] {
   let result: ReviewToken[] = [];
+  // Check if args is empty
+  if (!args) return result;
   // Process generic arguments based on their type
   if ("angle_bracketed" in args) {
     // Filter valid args that have a type property

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
@@ -157,6 +157,7 @@ export function typeToReviewTokens(type: Type): ReviewToken[] {
         HasSuffixSpace: false,
       },
       { Kind: TokenKind.TypeName, Value: type.qualified_path.name, HasSuffixSpace: false },
+      ...processGenericArgs(type.qualified_path.args),
     ];
   } else {
     return [{ Kind: TokenKind.Text, Value: "unknown" }];

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
@@ -156,6 +156,7 @@ export function typeToReviewTokens(type: Type): ReviewToken[] {
         Value: type.qualified_path.trait ? type.qualified_path.trait.name + "::" : "",
         HasSuffixSpace: false,
       },
+      ...processGenericArgs(type.qualified_path.trait.args),
       { Kind: TokenKind.TypeName, Value: type.qualified_path.name, HasSuffixSpace: false },
       ...processGenericArgs(type.qualified_path.args),
     ];


### PR DESCRIPTION
Follow up of https://github.com/Azure/azure-sdk-tools/pull/9592
## Improves/adds support for the following features
1. assoc_const aesthetics
2. func spaces
3. trait - remove extra punctuation
4. null check in processGenerics
5. "unsafe" traits
6. Negative implementations 
7. impl generics and where predicates
8. generics for assoc_type
9. qualified_path#generics_args
10. processGenericArgs for type.qualified_path.trait.args
11. Update RenderClasses with existing classes for now

And refactoring