### PR TITLE
Update JS API parser version

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Languages/JavaScriptLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JavaScriptLanguageService.cs
@@ -12,7 +12,7 @@ namespace APIViewWeb
         public override string Name { get; } = "JavaScript";
         public override string[] Extensions { get; } = { ".api.json" };
         public override string ProcessName { get; } = "node";
-        public override string VersionString { get; } = "2.0.3";
+        public override string VersionString { get; } = "2.0.5";
         private readonly string _jsParserToolPath;
 
         public JavaScriptLanguageService(IConfiguration configuration, TelemetryClient telemetryClient) : base(telemetryClient)

--- a/src/dotnet/APIView/apiview.yml
+++ b/src/dotnet/APIView/apiview.yml
@@ -4,10 +4,10 @@ parameters:
     default: 'https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-net/nuget/v3/index.json'
   - name: CSharpAPIParserVersion
     type: string
-    default: '1.0.0-dev.20250130.2'
+    default: '1.0.0-dev.20250301.1'
   - name: JavaScriptAPIParser
     type: string
-    default: '@azure-tools/ts-genapi@2.0.3'
+    default: '@azure-tools/ts-genapi@2.0.5'
   - name: RustAPIParser
     type: string
     default: '@azure-tools/rust-genapi@1.0.0-beta.1'


### PR DESCRIPTION
Update JS API parser version to 2.0.5 and update .NET parser version in the pipeline to latest released version.