### PR TITLE
eng, codeowner, weidxu to azure-rest-api-specs-examples-automation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,6 +34,7 @@
 # Eng Sys Tools
 ###########
 /tools/                                @azure/azure-sdk-eng
+/tools/azure-rest-api-specs-examples-automation/ @weidongxu-microsoft
 /tools/codeowners-utils/               @JimSuplizio
 /tools/github-event-processor/         @JimSuplizio @benbp @jsquire @ronniegeraghty
 /tools/github-team-user-store/         @JimSuplizio @weshaggard


### PR DESCRIPTION
Mostly because we are having stricter merge requirement soon.

Is it preferrable we try to have 2 (or more) persons in CODEOWNERS for the tool (so if owner raise a PR, the other owner can review and approve)?