### PR TITLE
[rust-api-parser] bin folder for installation

### DIFF
--- a/tools/apiview/parsers/rust-api-parser/bin/rust-genapi.cjs
+++ b/tools/apiview/parsers/rust-api-parser/bin/rust-genapi.cjs
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const path = require("path");
+
+require(path.join(__dirname, "../", "dist", "src", "main.js"));


### PR DESCRIPTION
`bin` folder was ignored by .gitignore, adding the file to get the installation working