### PR TITLE
Package Properties processing updates

### DIFF
--- a/eng/common/scripts/Save-Package-Properties.ps1
+++ b/eng/common/scripts/Save-Package-Properties.ps1
@@ -141,12 +141,17 @@ foreach ($pkg in $allPackageProperties)
     Write-Host "Package Version: $($pkg.Version)"
     Write-Host "Package SDK Type: $($pkg.SdkType)"
     Write-Host "Artifact Name: $($pkg.ArtifactName)"
+    if (-not [System.String]::IsNullOrEmpty($pkg.Group)) {
+      Write-Host "GroupId: $($pkg.Group)"
+    }
     Write-Host "Release date: $($pkg.ReleaseStatus)"
     $configFilePrefix = $pkg.Name
 
-    if ($pkg.ArtifactName)
-    {
-      $configFilePrefix = $pkg.ArtifactName
+    # Any languages (like JS) which need to override the the packageInfo file name to be something
+    # other than the name just need to declare this function in their Language-Settings.ps1 return
+    # the desired string from there.
+    if (Test-Path "Function:Get-PackageInfoNameOverride") {
+      $configFilePrefix = Get-PackageInfoNameOverride $pkg
     }
 
     $outputPath = Join-Path -Path $outDirectory "$configFilePrefix.json"


### PR DESCRIPTION
There are a few changes in here
1. Save-Package-Properties.ps1 - The $configFilePrefix is actually what will become the package properties json name for a given artifact however this was always being set to the ArtifactName. This was done because was JS which has Names that start with "@azure/". The problem with this is that it effectively eliminated the ability to change the package properties json name. The solution for JS (and any future language that might need to do this) is to declare a Get-PackageInfoNameOverride in the respective Language-Settings file to override this.
2. Package-Properties.ps1 - Change the PackageProps that takes in the Group to also take in the ArtifactName and set the Group and ArtifactName on the object _before_ calling Initialize. The reason for this is that Initialize, through a call chain, ultimately calls ParseYmlForArtifact which tries to match the "name" in the yml file to the name or ArtifactName on the object which wouldn't work for ArtifactName in the constructor since it wasn't set before calling Initialize. With this fix, if ArtifactName and/or Group is set, use those to match. Only try and match the PackageProps Name to the name in the yml file if ArtifactName isn't set.

This PR is going to require me to update sync eng/common PRs in the following repositories:

- [x] azure-sdk-for-android and azure-sdk-for-java - These are the only two languages that use the PackageProps constructor that takes in a GroupId which also now needs to take in an ArtifactName. _Both languages had their sync PRs updated._
- [x] azure-sdk-for-js - The Language-Settings.ps1 will need to have Get-PackageInfoNameOverride implemented that returns the ArtifactName. _Note: Since this was an additional function, I was able to check this into azure-sdk-for-js prior to creating the sync eng/common PRs. This was the [PR](https://github.com/Azure/azure-sdk-for-js/pull/33478)._


**Testing**
It's worth mentioning that I've tested this in every azure-sdk-for-<language> repository except for Android, C and Rust. Full repo PackageInfo files were generated with and without my changes and diffed using BeyondCompare. There were no differences. Android and Rust required a build environment (gradle and concord) that I don't have setup. Android is like Java, using the Group and Artifact so I'm not worried. Rust's PackageInfo name and ArtifactName are the same, so this won't affect it. C doesn't use Package-Properties.ps1 to save the singular package info which, for C, is always package-info.json