### PR TITLE
Refine error messages and specConfigPath

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2025-03-21 - 0.3.1
 
 - Added 'sdk-release-type' to input parameters and 'generateInput' type
+- Removed setting pipeline variables of SDK pull request
 
 ## 2025-03-14 - 0.3.0
 

--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2025-03-21 - 0.3.1
 
-- Added 'sdk-release-type' to input parameters and 'generateInput' type.
+- Added 'sdk-release-type' to input parameters and 'generateInput' type
 
 ## 2025-03-14 - 0.3.0
 

--- a/tools/spec-gen-sdk/src/automation/entrypoint.ts
+++ b/tools/spec-gen-sdk/src/automation/entrypoint.ts
@@ -203,7 +203,7 @@ export const getSdkRepoConfig = async (options: SdkAutoOptions, specRepoConfig: 
   };
   let sdkRepoConfig = specRepoConfig.sdkRepositoryMappings[sdkName];
   if (sdkRepoConfig === undefined) {
-    throw new Error(`ConfigError: SDK ${sdkName} is not defined in SpecConfig. Please add the related config at the 'specificationRepositoryConfiguration.json' file under the root folder of the azure-rest-api-specs(-pr) repository.`);
+    throw new Error(`ConfigError: SDK ${sdkName} is not defined in SpecConfig. Please add the related config at the 'specificationRepositoryConfiguration.json' file under the root folder of the azure-rest-api-specs(-pr) repository`);
   }
 
   if (typeof sdkRepoConfig === 'string') {

--- a/tools/spec-gen-sdk/src/automation/logging.ts
+++ b/tools/spec-gen-sdk/src/automation/logging.ts
@@ -78,11 +78,6 @@ export const loggerDevOpsTransport = () => {
       winston.format.printf((info: WinstonInfo) => {
         const { level } = info;
         const msg = formatLog(info);
-
-        // Log issue if it's an error'
-        if (level === "error" && msg.includes("Error")) {
-          return `##vso[task.logissue type=error]${msg}`;
-        }
         switch (level) {
           case 'error':
           case 'debug':

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -1,4 +1,4 @@
-import { MessageRecord, sendSuccess, sendFailure, sendPipelineVariable } from '../types/Message';
+import { MessageRecord } from '../types/Message';
 import { existsSync, readFileSync, rmSync, writeFileSync} from 'fs';
 import * as path from 'path';
 import * as prettier from 'prettier';
@@ -11,7 +11,6 @@ import { extractPathFromSpecConfig, mapToObject, removeAnsiEscapeCodes } from '.
 import { vsoAddAttachment } from './logging';
 import { ExecutionReport, PackageReport } from '../types/ExecutionReport';
 import { deleteTmpJsonFile, writeTmpJsonFile } from '../utils/fsUtils';
-import { getGenerationBranchName } from '../types/PackageData';
 import { marked } from "marked";
 import { vsoLogError, vsoLogWarning } from './entrypoint';
 
@@ -108,17 +107,6 @@ export const generateReport = (context: WorkflowContext) => {
     vsoLogWarning(context, message);
   } else {
     context.logger.info(`Main status [${context.status}]`);
-  }
-  if (context.config.runEnv === 'azureDevOps') {
-    context.logger.info("Set pipeline variables.");
-    setPipelineVariables(context, executionReport);
-  }
-
-  if (context.status === 'failed') {
-    console.log(`##vso[task.complete result=Failed;]`);
-    sendFailure();
-  } else {
-    sendSuccess();
   }
 
   context.logger.log('endsection', 'Generate report');
@@ -413,28 +401,4 @@ const renderHandlebarTemplate = (
 
 function unifiedRenderingMessages(message: string[], title?: string): string {
   return `<pre>${title ? `<strong>${title}</strong><BR>` : ''}${message.map(trimNewLine).join('<BR>')}</pre>`;
-}
-
-const setPipelineVariables = async (context: WorkflowContext, executionReport: ExecutionReport) => {
-  let packageName = "";
-  let prBranch = "";
-  let prTitle = "";
-  let prBody = "";
-
-  if (executionReport && executionReport.packages && executionReport.packages.length > 0) {
-    const pkg = executionReport.packages[0];
-    packageName = pkg.packageName ?? "";
-    if (context.config.pullNumber) {    
-      prBody = `Create to sync ${context.config.specRepoHttpsUrl}/pull/${context.config.pullNumber}\n\n`;
-    }
-    prBranch = getGenerationBranchName(context, packageName);
-    prBody = `${prBody}${pkg.installInstructions ?? ''}`;
-  }
-  
-  prBody = `${prBody}\n This pull request has been automatically generated for preview purposes.`;
-  prTitle = `[AutoPR ${packageName}]`;
-  sendPipelineVariable("BreakingChangeLabel", context.swaggerToSdkConfig.packageOptions.breakingChangesLabel ?? "")
-  sendPipelineVariable("PrBranch", prBranch);
-  sendPipelineVariable("PrTitle", prTitle);
-  sendPipelineVariable("PrBody", prBody);
 }

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -21,7 +21,7 @@ export const generateReport = (context: WorkflowContext) => {
   context.logger.log('section', 'Generate report');
   let executionReport: ExecutionReport;
   const packageReports: PackageReport[] = [];
-  const specConfigPath = (context.config.tspConfigPath ?? context.config.readmePath)?.replace(/\//g, '-');
+  const specConfigPath = (context.specConfigPath)?.replace(/\//g, '-');
 
   let hasSuppressions = false
   let hasAbsentSuppressions = false;

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -129,7 +129,7 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
       if (!twoConfigProvided) {
         context.status = 'notEnabled';
         let sampleTspConfigUrl = "https://aka.ms/azsdk/tspconfig-sample-dpg";
-        if (tspConfigPath.includes(".Management/")) {
+        if (tspConfigPath.includes(".Management")) {
           sampleTspConfigUrl = "https://aka.ms/azsdk/tspconfig-sample-mpg"
         }
         context.logger.warn(`Warning: cannot find supported emitter in tspconfig.yaml for typespec project ${tspConfigPath}. This typespec project will be skipped from SDK generation. Refer to ${sampleTspConfigUrl} to add the right emitter config in the 'tspconfig.yaml' file`);

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -40,6 +40,7 @@ export enum FailureType {
 export type WorkflowContext = SdkAutoContext & {
   sdkArtifactFolder?: string;
   sdkApiViewArtifactFolder?: string;
+  specConfigPath?: string;
   pendingPackages: PackageData[];
   handledPackages: PackageData[];
   status: SDKAutomationState;
@@ -74,6 +75,7 @@ export const workflowInit = async (context: SdkAutoContext): Promise<WorkflowCon
     pendingPackages: [],
     handledPackages: [],
     vsoLogs: new Map(),
+    specConfigPath: context.config.tspConfigPath ?? context.config.readmePath,
     status: 'inProgress',
     messages,
     messageCaptureTransport: captureTransport,
@@ -117,7 +119,7 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
   }
   
   if (!tspConfigPath && !readmeMdPath) {
-    throw new Error(`ConfigError: 'tspConfigPath' and 'readmePath' are not provided. Please provide at least one of them.`);
+    throw new Error(`ConfigError: 'tspConfigPath' and 'readmePath' are not provided. Please provide at least one of them`);
   }
   
   if (tspConfigPath) {
@@ -126,7 +128,11 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
     if (!config || config.length === 0 || !config.includes(context.config.sdkName)) {
       if (!twoConfigProvided) {
         context.status = 'notEnabled';
-        context.logger.warn(`Warning: cannot find supported emitter in tspconfig.yaml for typespec project ${tspConfigPath}. This typespec project will be skipped from SDK generation. Please add the right emitter config in the 'tspconfig.yaml' file. The example project can be found at https://aka.ms/azsdk/sample-arm-tsproject-tspconfig`);
+        let sampleTspConfigUrl = "https://aka.ms/azsdk/tspconfig-sample-dpg";
+        if (tspConfigPath.includes(".Management/")) {
+          sampleTspConfigUrl = "https://aka.ms/azsdk/tspconfig-sample-mpg"
+        }
+        context.logger.warn(`Warning: cannot find supported emitter in tspconfig.yaml for typespec project ${tspConfigPath}. This typespec project will be skipped from SDK generation. Refer to ${sampleTspConfigUrl} to add the right emitter config in the 'tspconfig.yaml' file`);
         return;
       }
     } else {
@@ -149,12 +155,13 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
   // only needs to check the two config provided case when both config enable the sdk generation or both config disable the sdk generation
   // the last case is the normal case, only one config enabled the sdk generation
   if (enabledSdkForTspConfig && enabledSdkForReadme) {
-    throw new Error(`SDK generation configuration is enabled for both ${context.config.tspConfigPath} and ${context.config.readmePath}. Refer to https://aka.ms/azsdk/spec-gen-sdk-config to disable sdk configuration from one of them.`);
+    throw new Error(`SDK generation configuration is enabled for both ${context.config.tspConfigPath} and ${context.config.readmePath}. Refer to https://aka.ms/azsdk/spec-gen-sdk-config to disable sdk configuration from one of them`);
   } else if (!enabledSdkForTspConfig && !enabledSdkForReadme) {
     context.status = 'notEnabled';
     context.logger.warn(`No SDKs are enabled for generation. Please enable them in either the corresponding tspconfig.yaml or readme.md file.`);
   } else {
     context.logger.info(`SDK to generate:${context.config.sdkName}, configPath: ${enabledSdkForTspConfig ? context.config.tspConfigPath : context.config.readmePath}`);
+    context.specConfigPath = enabledSdkForTspConfig ? context.config.tspConfigPath : context.config.readmePath;
   }
   context.logger.log('endsection', 'Validate SDK configuration');
 };
@@ -165,24 +172,24 @@ const workflowGenerateSdk = async (context: WorkflowContext) => {
   let suppressionFile;
   const filterSuppressionFileMap: Map<string, string|undefined> = new Map();
   context.logger.add(context.messageCaptureTransport);
-  if (context.config.tspConfigPath) {
-    context.logger.log('info', `Handle the following typespec project: ${context.config.tspConfigPath}`);
-	typespecProjectList.push(context.config.tspConfigPath.replace('/tspconfig.yaml', ''));
-    suppressionFile = path.join(context.config.localSpecRepoPath, context.config.tspConfigPath.replace('tspconfig.yaml', sdkSuppressionsFileName));
-    if (fs.existsSync(suppressionFile)) {
-      filterSuppressionFileMap.set(context.config.tspConfigPath, suppressionFile);
-    }
-  } else if (context.config.readmePath) {
-    context.logger.log('info', `Handle the following readme.md: ${context.config.readmePath}`);
-	readmeMdList.push(context.config.readmePath);
-    suppressionFile = path.join(context.config.localSpecRepoPath, context.config.readmePath.replace('readme.md', sdkSuppressionsFileName));
-    if (fs.existsSync(suppressionFile)) {
-      filterSuppressionFileMap.set(context.config.readmePath, suppressionFile);
+
+  if (context.specConfigPath) {
+    if (context.specConfigPath.endsWith('tspconfig.yaml')) {
+      typespecProjectList.push(context.specConfigPath.replace('/tspconfig.yaml', ''));
+      suppressionFile = path.join(context.config.localSpecRepoPath, context.specConfigPath.replace('tspconfig.yaml', sdkSuppressionsFileName));
+    } else {
+      readmeMdList.push(context.specConfigPath);
+      suppressionFile = path.join(context.config.localSpecRepoPath, context.specConfigPath.replace('readme.md', sdkSuppressionsFileName));
     }
   }
   else {
     context.logger.error(`ConfigError: 'tspConfigPath' and 'readmePath' are not provided. Please provide at least one of them.`);
     return;
+  }
+
+  context.logger.log('info', `Handle the following typespec project: ${context.specConfigPath}`);
+  if (fs.existsSync(suppressionFile)) {
+    filterSuppressionFileMap.set(context.specConfigPath, suppressionFile);
   }
 
   const { status, generateOutput } = await workflowCallGenerateScript(
@@ -273,7 +280,7 @@ const workflowCallInitScript = async (context: WorkflowContext) => {
   if (initScriptConfig === undefined) {
     context.logger.error('ConfigError: initScript is not configured in the swagger-to-sdk config. Please refer to the schema.');
     setFailureType(context, FailureType.PipelineFrameworkFailed);
-    throw new Error('The initScript is not configured in the swagger-to-sdk config. Please refer to the schema.');
+    throw new Error('The initScript is not configured in the swagger-to-sdk config. Please refer to the schema');
   }
 
   writeTmpJsonFile(context, fileInitInput, {});
@@ -323,7 +330,7 @@ const workflowCallGenerateScript = async (
   if (context.swaggerToSdkConfig.generateOptions.generateScript === undefined) {
     context.logger.error('ConfigError: generateScript is not configured in the swagger-to-sdk config. Please refer to the schema.');
     setFailureType(context, FailureType.PipelineFrameworkFailed);
-    throw new Error('The generateScript is not configured in the swagger-to-sdk config. Please refer to the schema.');
+    throw new Error('The generateScript is not configured in the swagger-to-sdk config. Please refer to the schema');
   }
 
   context.logger.log('section', 'Call generateScript');
@@ -352,7 +359,7 @@ const workflowCallGenerateScript = async (
   if (generateOutputJson !== undefined) {
     generateOutput = getGenerateOutput(generateOutputJson);
   } else {
-    return { ...statusContext, generateInput, generateOutput };
+    throw new Error("Failed to read generateOutput.json. Refer to the detail logs to check if this is a configuration issue");
   }
 
   /**

--- a/tools/spec-gen-sdk/src/cli/cli.ts
+++ b/tools/spec-gen-sdk/src/cli/cli.ts
@@ -88,10 +88,10 @@ const generateSdk = async (config: SpecGenSdkCliConfig) => {
   const elapsed = process.hrtime(start);
   console.log(`spec-gen-sdk execution time: ${elapsed[0]}s`);
   console.log(`spec-gen-sdk exit with status ${status}`);
-  if (status !== undefined && !['warning', 'succeeded', 'notEnabled'].includes(status)) {
-    process.exit(-1);
-  } else {
+  if (status !== undefined && ['warning', 'succeeded', 'notEnabled'].includes(status)) {
     process.exit(0);
+  } else {
+    process.exit(-1);
   }
 };
 

--- a/tools/spec-gen-sdk/src/types/Message.ts
+++ b/tools/spec-gen-sdk/src/types/Message.ts
@@ -81,15 +81,3 @@ export type MessageRecord = ResultMessageRecord | RawMessageRecord | MarkdownMes
  * See type MessageRecord
  */
 export type MessageLine = MessageRecord | MessageRecord[];
-
-
-export const sendPipelineVariable = (variable: string, value: string,isOutput=false) => {
-  console.log(`##vso[task.setVariable variable=${variable}${isOutput?';isoutput=true':''}]${value}`);
-};
-export const sendSuccess = () => {
-  sendPipelineVariable("ValidationResult", "success");
-};
-
-export const sendFailure = () => {
-  sendPipelineVariable("ValidationResult", "failure");
-};

--- a/tools/spec-gen-sdk/src/types/validator.ts
+++ b/tools/spec-gen-sdk/src/types/validator.ts
@@ -9,7 +9,7 @@ export const getTypeTransformer = <T>(schema: object, name: string) => {
     }
     if (!validator(obj)) {
       const error = validator.errors![0];
-      throw new Error(`ConfigError: Invalid ${name}: ${error.dataPath} ${error.message}. If the SDK artifacts haven't been successfully generated, please fix the errors to ensure they are generated correctly. Refer to the schema definitions at https://github.com/Azure/azure-rest-api-specs/tree/main/documentation/sdkautomation for guidance.`);
+      throw new Error(`ConfigError: Invalid ${name}: ${error.dataPath} ${error.message}. If the SDK artifacts haven't been successfully generated, please fix the errors to ensure they are generated correctly. Refer to the schema definitions at https://github.com/Azure/azure-rest-api-specs/tree/main/documentation/sdkautomation for guidance`);
     }
 
     return obj as T;

--- a/tools/spec-gen-sdk/src/utils/fsUtils.ts
+++ b/tools/spec-gen-sdk/src/utils/fsUtils.ts
@@ -15,7 +15,7 @@ export const readTmpJsonFile = (context: WorkflowContext, fileName: string): unk
   const filePath = path.join(context.tmpFolder, fileName);
 
   if (!fs.existsSync(filePath)) {
-    context.logger.warn(`Warning: File ${filePath} not found to read. Please re-run the pipeline if the error is transitient error or report this issue through https://aka.ms/azsdk/support/specreview-channel.`);
+    context.logger.warn(`Warning: File ${filePath} not found to read. Re-run if the error is transitient or report this issue through https://aka.ms/azsdk/support/specreview-channel.`);
     return undefined;
   }
 
@@ -26,7 +26,7 @@ export const readTmpJsonFile = (context: WorkflowContext, fileName: string): unk
     context.logger.info(JSON.stringify(content, undefined, 2));
     return content;
   } catch (e) {
-    context.logger.error(`IOError: Failed to read ${fileName}: ${e.message}. Please re-run the pipeline if the error is retryable or report this issue through https://aka.ms/azsdk/support/specreview-channel.`);
+    context.logger.error(`IOError: Failed to read ${fileName}: ${e.message}. Re-run if the error is retryable or report this issue through https://aka.ms/azsdk/support/specreview-channel.`);
     return undefined;
   }
 };

--- a/tools/spec-gen-sdk/src/utils/fsUtils.ts
+++ b/tools/spec-gen-sdk/src/utils/fsUtils.ts
@@ -15,7 +15,7 @@ export const readTmpJsonFile = (context: WorkflowContext, fileName: string): unk
   const filePath = path.join(context.tmpFolder, fileName);
 
   if (!fs.existsSync(filePath)) {
-    context.logger.warn(`Warning: File ${filePath} not found to read. Re-run if the error is transitient or report this issue through https://aka.ms/azsdk/support/specreview-channel.`);
+    context.logger.warn(`Warning: File ${filePath} not found to read. Re-run if the error is transient or report this issue through https://aka.ms/azsdk/support/specreview-channel.`);
     return undefined;
   }
 

--- a/tools/spec-gen-sdk/src/utils/runScript.ts
+++ b/tools/spec-gen-sdk/src/utils/runScript.ts
@@ -101,7 +101,7 @@ export const runSdkAutoCustomScript = async (
   } catch (e) {
     cmdRet.code = -1;
     const scriptName = scriptPath.split("/").pop();
-    message = `RuntimeError: exception is thrown while running customized language ${scriptName} script. Stack: ${e.stack}. Please refer to the detail log in pipeline run or local console for more information.`;
+    message = `RuntimeError: exception is thrown while running customized language ${scriptName} script. Stack: ${e.stack}. Please refer to the detail log in pipeline run or local console for more information`;
     context.logger.error(message);
     if (context.config.runEnv === 'azureDevOps') {
       vsoLogErrorsArray.push(message);


### PR DESCRIPTION
* Added `specConfigPath` property to `WorkflowContext` and used it to record the configuration path used for sdk generation
* Updated various error messages to remove trailing periods for consistency
* Removed setting pipeline variables of SDK pull request, and they will be set in the runner tool