### PR TITLE
Identify and Fix issue with non-pr-batched matrixResults in `Create-PRJobMatrix`

### DIFF
--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -144,7 +144,7 @@ function GeneratePRMatrixForBatch {
       }
     }
 
-    if ($matrixConfig.PSObject.Properties['PRBatching']) {
+    if ($matrixConfig.PSObject.Properties['PRBatching'] && $matrixResults) {
       # if we are doing a PR Batch, we need to just add the matrix items directly to the OverallResult
       # as the users have explicitly disabled PR batching for this matrix.
       if (!$matrixConfig.PRBatching) {

--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -144,7 +144,7 @@ function GeneratePRMatrixForBatch {
       }
     }
 
-    if ($matrixConfig.PSObject.Properties['PRBatching'] && $matrixResults) {
+    if ($matrixConfig.PSObject.Properties['PRBatching'] -and $matrixResults) {
       # if we are doing a PR Batch, we need to just add the matrix items directly to the OverallResult
       # as the users have explicitly disabled PR batching for this matrix.
       if (!$matrixConfig.PRBatching) {


### PR DESCRIPTION
The issue [occurring here](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4675062&view=logs&j=76992fd1-2312-5fae-7c45-7baba86b87ae&t=936713e1-120b-5cc3-5ba6-7d192d0ede9d&l=195) is resolved in this PR.

The issue was that in the case of PR batching, we don't want to blindly add the matrix results as due to additional filters we may _have no_ items to add.