### PR TITLE
Import Az powershell module in self contained post script task

### DIFF
--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -122,6 +122,7 @@ steps:
           scriptLocation: inlineScript
           scriptType: pscore
           inlineScript: |
+            eng/common/scripts/Import-AzModules.ps1  # Support post scripts using az powershell instead of az cli
             $env:ARM_OIDC_TOKEN = $env:idToken
             $scriptPath = '$(Agent.TempDirectory)/${{ parameters.SelfContainedPostScript }}'
             Write-Host "Executing self contained test resources post script '$scriptPath'"


### PR DESCRIPTION
Without this, existing post scripts can fail if they use az powershell cmdlets, similar to how we do this same thing for the above deploy task. The az import doesn't take any extra time since we've already done it there.

We still have to use the AzureCLI task because of its exclusive `addSpnToEnvironment` support.
