### PR TITLE
Update Approval Button tooltip

### DIFF
--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.html
@@ -10,10 +10,9 @@
                     </div>
                 </ng-container>
                 <ng-template #cantToggleApproveAPIRevision>
-                    <div class="d-grid gap-2">
+                    <div class="d-grid gap-2" pTooltip="API Revision cannot be approved when comparing against unapproved revision. Or when the diffApiRevision is older than the activeApiRevision." 
+                        tooltipPosition="bottom">
                         <button class="{{apiRevisionApprovalBtnClass}}" type="button"
-                            pTooltip="API Revision cannot be approved when comparing against unapproved revision. Or when the diffApiRevision is older than the activeApiRevision." 
-                            tooltipPosition="bottom"
                             disabled>
                             {{apiRevisionApprovalBtnLabel}}
                         </button>

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.html
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.html
@@ -10,7 +10,7 @@
                     </div>
                 </ng-container>
                 <ng-template #cantToggleApproveAPIRevision>
-                    <div class="d-grid gap-2" pTooltip="API Revision cannot be approved when comparing against unapproved revision. Or when the diffApiRevision is older than the activeApiRevision." 
+                    <div class="d-grid gap-2" pTooltip="API Revision cannot be approved when comparing against unapproved revision." 
                         tooltipPosition="bottom">
                         <button class="{{apiRevisionApprovalBtnClass}}" type="button"
                             disabled>

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.spec.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.spec.ts
@@ -105,4 +105,14 @@ describe('ReviewPageOptionsComponent', () => {
       expect(component.disableCodeLinesLazyLoading).toEqual(false);
     })
   });
+
+  describe('Toggle APIRevision Approval', () => {
+    it('should close APIRevision Approval Modal', () => {
+      component.showAPIRevisionApprovalModal = true;
+      component.loadingStatus = "completed";
+      fixture.detectChanges();
+      component.toggleAPIRevisionApproval();
+      expect(component.showAPIRevisionApprovalModal).not.toBeTruthy();
+    });
+  });
 });

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
@@ -144,7 +144,7 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges {
       this.setPullRequestsInfo();
     }
 
-    if (changes['diffAPIRevision'] && changes['diffAPIRevision'].currentValue != undefined) {
+    if (changes['diffAPIRevision']) {
       this.setAPIRevisionApprovalStates();
     }
 
@@ -294,8 +294,7 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges {
 
   setAPIRevisionApprovalStates() {
     this.activeAPIRevisionIsApprovedByCurrentUser = this.activeAPIRevision?.approvers.includes(this.userProfile?.userName!)!;
-    const isActiveAPIRevisionAhead = (!this.diffAPIRevision) ? true : ((new Date(this.activeAPIRevision?.createdOn!)) > (new Date(this.diffAPIRevision?.createdOn!)));
-    this.canToggleApproveAPIRevision = (!this.diffAPIRevision || this.diffAPIRevision.approvers.length > 0) && isActiveAPIRevisionAhead;
+    this.canToggleApproveAPIRevision = (!this.diffAPIRevision || this.diffAPIRevision.approvers.length > 0);
 
     if (this.canToggleApproveAPIRevision) {
       this.apiRevisionApprovalBtnClass = (this.activeAPIRevisionIsApprovedByCurrentUser) ? "btn btn-outline-secondary" : "btn btn-success";

--- a/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
+++ b/src/dotnet/APIView/ClientSPA/src/app/_components/review-page-options/review-page-options.component.ts
@@ -399,6 +399,7 @@ export class ReviewPageOptionsComponent implements OnInit, OnChanges {
 
   toggleAPIRevisionApproval() {
     this.apiRevisionApprovalEmitter.emit(true);
+    this.showAPIRevisionApprovalModal = false;
   }
 
   getPullRequestsOfAssociatedAPIRevisionsUrl(pr: PullRequestModel) {


### PR DESCRIPTION
- Allow approval regardless of age of diff revision.
- Properly manage diff revision state