### PR TITLE
Support Accessing a Specific `key` for ArtifactName value in `Create-PrJobMatrix`

### DIFF
--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -146,6 +146,7 @@ jobs:
               -PackagePropertiesFolder $(Build.ArtifactStagingDirectory)/PackageInfo `
               -PRMatrixFile matrix.json `
               -PRMatrixSetting ${{ parameters.PRMatrixSetting }} `
+              -PRMatrixKey ${{ parameters.PRMatrixKey }} `
               -DisplayNameFilter '$(displayNameFilter)' `
               -Filters '${{ join(''',''', parameters.MatrixFilters) }}', 'container=^$', 'SupportedClouds=^$|${{ parameters.CloudConfig.Cloud }}', 'Pool=${{ pool.filter }}' `
               -IndirectFilters '${{ join(''',''', parameters.PRMatrixIndirectFilters) }}' `

--- a/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
+++ b/eng/common/pipelines/templates/jobs/generate-job-matrix.yml
@@ -45,9 +45,14 @@ parameters:
 - name: EnablePRGeneration
   type: boolean
   default: false
+# name of the variable that will be added when creating batches for the PR Job Matrix
 - name: PRMatrixSetting
   type: string
   default: 'ArtifactPackageNames'
+# name of the key in PackageInfo that will be used to get the identifier when generating matrix batches
+- name: PRMatrixKey
+  type: string
+  default: 'ArtifactName'
 - name: PRJobBatchSize
   type: number
   default: 10

--- a/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
+++ b/eng/common/scripts/job-matrix/Create-PrJobMatrix.ps1
@@ -230,7 +230,7 @@ if (!(Test-Path $PRMatrixFile)) {
   exit 1
 }
 
-Write-Host "Generating PR job matrix for $PackagePropertiesFolder"
+Write-Host "Generating PR job matrix for $PackagePropertiesFolder using accesskey $PRMatrixKey to determine artifact batches."
 
 $configs = Get-Content -Raw $PRMatrixFile | ConvertFrom-Json
 


### PR DESCRIPTION
@JimSuplizio this should unblock you.

For everyone's benefit: I created a [draft PR](https://github.com/Azure/azure-sdk-for-java/pull/44813) with these changes in azure-sdk-for-java and I set the [PRMatrixKey to 'Name'](https://github.com/Azure/azure-sdk-for-java/pull/44813/files#diff-23849bb529451be6bf226bc895f60373a9181f673e6273d84474158a912d795bR457) with the expectation that since Name and ArtifactName are currently the same that the behavior would be the same. Looking at the generated [ArtifactPackageNames, it was](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4696989&view=logs&j=76992fd1-2312-5fae-7c45-7baba86b87ae&t=6c294a88-3151-521e-fcd8-a6c587ba9418&l=188).