### PR TITLE
Properly support Rust language

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/PullRequestController.cs
@@ -116,7 +116,7 @@ namespace APIViewWeb.Controllers
                 packageName: packageName, originalFileName: originalFileName,
                 codeFileName: codeFileName, originalFileStream: memoryStream,
                 baselineCodeFileName: baselineCodeFileName, baselineStream: baselineStream,
-                project: project);
+                project: project, language: language);
 
             if (codeFile.PackageName != null && (packageName ==  null || packageName != codeFile.PackageName))
             {

--- a/src/dotnet/APIView/APIViewWeb/Helpers/LanguageServiceHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/LanguageServiceHelpers.cs
@@ -70,7 +70,7 @@ namespace APIViewWeb.Helpers
 
         public static LanguageService GetLanguageService(string language, IEnumerable<LanguageService> languageServices)
         {
-            return languageServices.FirstOrDefault(service => service.Name == language);
+            return languageServices.FirstOrDefault(service => service.Name.Equals(language, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Languages/JsonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/JsonLanguageService.cs
@@ -20,7 +20,7 @@ namespace APIViewWeb
         public override bool IsSupportedFile(string name)
         {
             // Skip JS uploads
-            return base.IsSupportedFile(name) && !name.EndsWith(".api.json", StringComparison.OrdinalIgnoreCase);
+            return base.IsSupportedFile(name) && !name.EndsWith(".api.json", StringComparison.OrdinalIgnoreCase) && !name.EndsWith(".rust.json", StringComparison.OrdinalIgnoreCase);
         }
 
         public override async Task<CodeFile> GetCodeFileAsync(string originalName, Stream stream, bool runAnalysis)

--- a/src/dotnet/APIView/APIViewWeb/Managers/CodeFileManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/CodeFileManager.cs
@@ -41,6 +41,7 @@ namespace APIViewWeb.Managers
         /// <param name="baselineCodeFileName"></param>
         /// <param name="baselineStream"></param>
         /// <param name="project"></param>
+        /// <param name="language"></param>
         /// <returns></returns>
         public async Task<CodeFile> GetCodeFileAsync(string repoName,
             string buildId,
@@ -51,7 +52,8 @@ namespace APIViewWeb.Managers
             MemoryStream originalFileStream,
             string baselineCodeFileName = "",
             MemoryStream baselineStream = null,
-            string project = "public"
+            string project = "public",
+            string language = null
             )
         {
             CodeFile codeFile = null;
@@ -59,7 +61,7 @@ namespace APIViewWeb.Managers
             {
                 // backward compatibility until all languages moved to sandboxing of codefile to pipeline
                 using var stream = await _devopsArtifactRepository.DownloadPackageArtifact(repoName, buildId, artifactName, originalFileName, format: "file", project: project);
-                codeFile = await CreateCodeFileAsync(originalName: Path.GetFileName(originalFileName), fileStream: stream, runAnalysis: false, memoryStream: originalFileStream);
+                codeFile = await CreateCodeFileAsync(originalName: Path.GetFileName(originalFileName), fileStream: stream, runAnalysis: false, memoryStream: originalFileStream, language: language);
             }
             else
             {
@@ -141,7 +143,7 @@ namespace APIViewWeb.Managers
             Stream fileStream = null,
             string language = null)
         {
-            var languageService = _languageServices.FirstOrDefault(s => (language != null ? s.Name == language : s.IsSupportedFile(originalName)));
+            var languageService = LanguageServiceHelpers.GetLanguageService(language, _languageServices) ?? _languageServices.FirstOrDefault(s => s.IsSupportedFile(originalName));
             if (fileStream != null)
             {
                 await fileStream.CopyToAsync(memoryStream);

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/ICodeFileManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/ICodeFileManager.cs
@@ -8,7 +8,7 @@ namespace APIViewWeb.Managers.Interfaces
     public interface ICodeFileManager
     {
         public Task<CodeFile> GetCodeFileAsync(string repoName, string buildId, string artifactName, string packageName, string originalFileName, string codeFileName,
-            MemoryStream originalFileStream, string baselineCodeFileName = "", MemoryStream baselineStream = null, string project = "public");
+            MemoryStream originalFileStream, string baselineCodeFileName = "", MemoryStream baselineStream = null, string project = "public", string language = null);
         public Task<APICodeFileModel> CreateCodeFileAsync(string apiRevisionId, string originalName, bool runAnalysis, Stream fileStream = null, string language = null);
         public Task<CodeFile> CreateCodeFileAsync(string originalName, bool runAnalysis, MemoryStream memoryStream, Stream fileStream = null, string language = null);
         public Task<APICodeFileModel> CreateReviewCodeFileModel(string apiRevisionId, MemoryStream memoryStream, CodeFile codeFile);


### PR DESCRIPTION
- Enusre language variable is passed down to GetCodeFileAsync
- Ensure JsonLanguage service is not selected in place of RustLanguageService