### PR TITLE
Read sdk repo config for private repo case

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release
 
-## 2025-04-01 - 0.3.4
+## 2025-04-02 - 0.3.4
 
 - Read the corresponding sdk repository configuration for private repository
 

--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-04-01 - 0.3.4
+
+- Read the corresponding sdk repository configuration for private repository
+
 ## 2025-04-01 - 0.3.3
 
 - Use relative directory paths from 'sdk' as go service name

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.3.3",
+      "version": "0.3.4",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/entrypoint.ts
+++ b/tools/spec-gen-sdk/src/automation/entrypoint.ts
@@ -201,7 +201,14 @@ export const getSdkRepoConfig = async (options: SdkAutoOptions, specRepoConfig: 
     }
     return repoKey;
   };
-  let sdkRepoConfig = specRepoConfig.sdkRepositoryMappings[sdkName];
+  let sdkRepositoryMappings = specRepoConfig.sdkRepositoryMappings;
+  if (specRepo.name.endsWith("-pr")) {
+    sdkRepositoryMappings = specRepoConfig.overrides[`${specRepo.owner}/${specRepo.name}`]?.sdkRepositoryMappings ?? specRepoConfig.overrides[`Azure/${specRepo.name}`]?.sdkRepositoryMappings;
+  }
+  if (!sdkRepositoryMappings) {
+    throw new Error(`ConfigError: SDK repository mappings cannot be found in SpecConfig for ${specRepo.owner}/${specRepo.name}. Please add the related config at the 'specificationRepositoryConfiguration.json' file under the root folder of the azure-rest-api-specs(-pr) repository`);
+  }
+  let sdkRepoConfig = sdkRepositoryMappings[sdkName];
   if (sdkRepoConfig === undefined) {
     throw new Error(`ConfigError: SDK ${sdkName} is not defined in SpecConfig. Please add the related config at the 'specificationRepositoryConfiguration.json' file under the root folder of the azure-rest-api-specs(-pr) repository`);
   }


### PR DESCRIPTION
* [`tools/spec-gen-sdk/src/automation/entrypoint.ts`]: Modified the configuration logic to read the corresponding SDK repository configuration for private repositories. Added error handling for missing SDK repository mappings.
