### PR TITLE
[tsp-client] Allow an alternate path for emitter-package.json

### DIFF
--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -38,7 +38,7 @@ export async function initCommand(argv: any) {
   const repoRoot = await getRepoRoot(outputDir);
 
   const emitterPackageJsonPath =
-    argv["emitter-package-json"] ?? joinPaths(repoRoot, "eng", "emitter-package.json");
+    argv["emitter-package-json-path"] ?? joinPaths(repoRoot, "eng", "emitter-package.json");
 
   const emitter = await getEmitterFromRepoConfig(emitterPackageJsonPath);
   if (!emitter) {

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -24,7 +24,7 @@ import {
 } from "./utils.js";
 import { parse as parseYaml } from "yaml";
 import { config as dotenvConfig } from "dotenv";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
 import { doesFileExist } from "./network.js";
 import { sortOpenAPIDocument } from "@azure-tools/typespec-autorest";
 
@@ -169,6 +169,8 @@ export async function syncCommand(argv: any) {
     throw new Error("Could not find repo root");
   }
   const tspLocation: TspLocation = await readTspLocation(outputDir);
+  const emitterPackageJsonPath =
+    tspLocation.emitterPackageJsonPath ?? joinPaths(repoRoot, "eng", "emitter-package.json");
   const dirSplit = tspLocation.directory.split("/");
   let projectName = dirSplit[dirSplit.length - 1];
   Logger.debug(`Using project name: ${projectName}`);
@@ -234,15 +236,24 @@ export async function syncCommand(argv: any) {
   }
 
   try {
-    const emitterLockPath = joinPaths(repoRoot, "eng", "emitter-package-lock.json");
+    let emitterLockPath = joinPaths(repoRoot, "eng", "emitter-package-lock.json");
+    if (tspLocation.emitterPackageJsonPath) {
+      // If the emitter package json path is provided, we need to check for the lock file in the same directory
+      const emitterPackageJsonDir = dirname(tspLocation.emitterPackageJsonPath);
+      const lockFileExists = await stat(
+        joinPaths(emitterPackageJsonDir, "emitter-package-lock.json"),
+      );
+      if (lockFileExists.isFile()) {
+        emitterLockPath = joinPaths(emitterPackageJsonDir, "emitter-package-lock.json");
+      }
+    }
     await cp(emitterLockPath, joinPaths(tempRoot, "package-lock.json"), { recursive: true });
   } catch (err) {
     Logger.debug(`Ran into the following error when looking for emitter-package-lock.json: ${err}`);
     Logger.debug("Will attempt look for emitter-package.json...");
   }
   try {
-    const emitterPath = joinPaths(repoRoot, "eng", "emitter-package.json");
-    await cp(emitterPath, joinPaths(tempRoot, "package.json"), { recursive: true });
+    await cp(emitterPackageJsonPath, joinPaths(tempRoot, "package.json"), { recursive: true });
   } catch (err) {
     throw new Error(
       `Ran into the following error: ${err}\nTo continue using tsp-client, please provide a valid emitter-package.json file in the eng/ directory of the repository.`,
@@ -265,7 +276,8 @@ export async function generateCommand(argv: any) {
   }
   const srcDir = joinPaths(tempRoot, projectName);
   const emitter = await getEmitterFromRepoConfig(
-    joinPaths(await getRepoRoot(outputDir), "eng", "emitter-package.json"),
+    tspLocation.emitterPackageJsonPath ??
+      joinPaths(await getRepoRoot(outputDir), "eng", "emitter-package.json"),
   );
   if (!emitter) {
     throw new Error("emitter is undefined");

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -37,9 +37,10 @@ export async function initCommand(argv: any) {
 
   const repoRoot = await getRepoRoot(outputDir);
 
-  const emitter = await getEmitterFromRepoConfig(
-    joinPaths(repoRoot, "eng", "emitter-package.json"),
-  );
+  const emitterPackageJsonPath =
+    argv["emitter-package-json"] ?? joinPaths(repoRoot, "eng", "emitter-package.json");
+
+  const emitter = await getEmitterFromRepoConfig(emitterPackageJsonPath);
   if (!emitter) {
     throw new Error("Couldn't find emitter-package.json in the repo");
   }
@@ -91,6 +92,9 @@ export async function initCommand(argv: any) {
       repo: resolvedConfigUrl.repo,
       additionalDirectories: configYaml?.parameters?.dependencies?.additionalDirectories,
     };
+    if (argv["emitter-package-json-path"]) {
+      tspLocationData.emitterPackageJsonPath = argv["emitter-package-json-path"];
+    }
     await writeTspLocationYaml(tspLocationData, newPackageDir);
     Logger.debug(`Removing sparse-checkout directory ${cloneDir}`);
     await removeDirectory(cloneDir);
@@ -134,6 +138,9 @@ export async function initCommand(argv: any) {
       repo: repo ?? "",
       additionalDirectories: configYaml?.parameters?.dependencies?.additionalDirectories,
     };
+    if (argv["emitter-package-json-path"]) {
+      tspLocationData.emitterPackageJsonPath = argv["emitter-package-json-path"];
+    }
     await writeTspLocationYaml(tspLocationData, newPackageDir);
     outputDir = newPackageDir;
   }

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -117,6 +117,10 @@ const parser = yargs(hideBin(process.argv))
         .option("skip-install", {
           type: "boolean",
           description: "Skip installing dependencies",
+        })
+        .option("emitter-package-json-path", {
+          type: "string",
+          description: "Alternate path for emitter-package.json file",
         });
     },
     async (argv: any) => {

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -14,6 +14,7 @@ export interface TspLocation {
   repo: string;
   additionalDirectories?: string[];
   entrypointFile?: string;
+  emitterPackageJsonPath?: string;
 }
 
 export function resolveTspConfigUrl(configUrl: string): {

--- a/tools/tsp-client/src/utils.ts
+++ b/tools/tsp-client/src/utils.ts
@@ -93,8 +93,12 @@ export async function writeTspLocationYaml(
   tspLocation: TspLocation,
   projectPath: string,
 ): Promise<void> {
-  await writeFile(
-    joinPaths(projectPath, "tsp-location.yaml"),
-    `directory: ${tspLocation.directory}\ncommit: ${tspLocation.commit}\nrepo: ${tspLocation.repo}\nadditionalDirectories: ${formatAdditionalDirectories(tspLocation.additionalDirectories)}`,
-  );
+  let tspLocationContent = `directory: ${tspLocation.directory}\ncommit: ${tspLocation.commit}\nrepo: ${tspLocation.repo}\nadditionalDirectories: ${formatAdditionalDirectories(tspLocation.additionalDirectories)}`;
+  if (tspLocation.entrypointFile) {
+    tspLocationContent += `\nentrypointFile: ${tspLocation.entrypointFile}`;
+  }
+  if (tspLocation.emitterPackageJsonPath) {
+    tspLocationContent += `\nemitterPackageJsonPath: ${tspLocation.emitterPackageJsonPath}`;
+  }
+  await writeFile(joinPaths(projectPath, "tsp-location.yaml"), tspLocationContent);
 }

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -14,6 +14,8 @@ import { cwd } from "node:process";
 import { joinPaths } from "@typespec/compiler";
 import { readTspLocation, removeDirectory } from "../src/fs.js";
 import { doesFileExist } from "../src/network.js";
+import { TspLocation } from "../src/typespec.js";
+import { writeTspLocationYaml } from "../src/utils.js";
 
 describe.sequential("Verify commands", () => {
   let repoRoot;
@@ -120,6 +122,29 @@ describe.sequential("Verify commands", () => {
           cwd(),
           "./test/examples/sdk/contosowidgetmanager/contosowidgetmanager-rest",
         ),
+        "save-inputs": true,
+      };
+      await updateCommand(args);
+    } catch (error) {
+      assert.fail(`Failed to generate. Error: ${error}`);
+    }
+  });
+
+  it("Update example sdk with custom emitter-package.json path", async () => {
+    try {
+      const tspLocationContent: TspLocation = {
+        directory: "specification/contosowidgetmanager/Contoso.WidgetManager",
+        commit: "45924e49834c4e01c0713e6b7ca21f94be17e396",
+        repo: "Azure/azure-rest-api-specs",
+        additionalDirectories: ["specification/contosowidgetmanager/Contoso.WidgetManager.Shared"],
+        emitterPackageJsonPath: joinPaths(cwd(), "test/utils/emitter-package.json"),
+      };
+      await writeTspLocationYaml(
+        tspLocationContent,
+        joinPaths(cwd(), "test/examples/sdk/alternate-emitter-package-json-path"),
+      );
+      const args = {
+        "output-dir": joinPaths(cwd(), "test/examples/sdk/alternate-emitter-package-json-path"),
         "save-inputs": true,
       };
       await updateCommand(args);


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-tools/issues/10173