### PR TITLE
Make eng/common sync PR approve script runnable from bash

### DIFF
--- a/eng/scripts/Approve-Eng-Common-Sync-PRs.ps1
+++ b/eng/scripts/Approve-Eng-Common-Sync-PRs.ps1
@@ -1,3 +1,5 @@
+#!/usr/bin/env pwsh
+
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
   [Parameter(Mandatory = $true)]


### PR DESCRIPTION
Make eng/common sync PR approve script runnable from bash