### PR TITLE
Fix failing `test-proxy` .NET integration tests

### DIFF
--- a/tools/test-proxy/tests.yml
+++ b/tools/test-proxy/tests.yml
@@ -192,8 +192,16 @@ stages:
             rootFolder: $(CLONE_LOCATION)
 
         - pwsh: |
-            dotnet test
-          displayName: 'Invoke Tests'
+            dotnet test --framework 9.0
+          displayName: 'Invoke Tests .NET 9'
+          workingDirectory: $(CLONE_LOCATION)/sdk/core/Azure.Core.TestFramework
+          env:
+            PROXY_MANUAL_START: "true"
+            PROXY_DEBUG_MODE: "true"
+
+        - pwsh: |
+            dotnet test --framework 8.0
+          displayName: 'Invoke Tests .NET 8'
           workingDirectory: $(CLONE_LOCATION)/sdk/core/Azure.Core.TestFramework
           env:
             PROXY_MANUAL_START: "true"

--- a/tools/test-proxy/tests.yml
+++ b/tools/test-proxy/tests.yml
@@ -192,7 +192,7 @@ stages:
             rootFolder: $(CLONE_LOCATION)
 
         - pwsh: |
-            dotnet test --framework 9.0
+            dotnet test --framework net9.0
           displayName: 'Invoke Tests .NET 9'
           workingDirectory: $(CLONE_LOCATION)/sdk/core/Azure.Core.TestFramework
           env:
@@ -200,17 +200,15 @@ stages:
             PROXY_DEBUG_MODE: "true"
 
         - pwsh: |
-            dotnet test --framework 8.0
+            dotnet test --framework net8.0
           displayName: 'Invoke Tests .NET 8'
           workingDirectory: $(CLONE_LOCATION)/sdk/core/Azure.Core.TestFramework
           env:
             PROXY_MANUAL_START: "true"
             PROXY_DEBUG_MODE: "true"
 
-
     - job: Test_Python_Tables
       displayName: Run Python Tables CI Tests
-
 
       strategy:
         matrix:


### PR DESCRIPTION
Elsewhere, dotnet tests run one at a time for a specific framework. In the test-proxy integration tests, we ran them in _parallel_. I'm just splitting this up so that this [error](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4719358&view=logs&j=fab08167-d63b-51ff-cd93-7068dc91610b&t=07c6419c-06a1-542d-26b6-b036293b8068) doesn't occur anymore.