### PR TITLE
[tsp-client] Fix additional directory implementation

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -8,8 +8,7 @@
 options:
   "@azure-tools/typespec-client-generator-cli":
     "additionalDirectories":
-      - "specification/ai/HealthInsights/HealthInsights.Common/"
-      - "specification/ai/HealthInsights/HealthInsights.OpenAPI/"
+      - "specification/contosowidgetmanager/Contoso.WidgetManager.Shared/"
 ```
 
 ## 2025-04-03 0.17.0

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Release
 
+## 2025-04-07 - 0.18.0
+
+- Specify tsp-client specific configurations under a `@azure-tools/typespec-client-generator-cli` entry in tspconfig.yaml options. This affects the `additionalDirectories` configuration. Example entry in tspconfig.yaml:
+
+```yaml
+options:
+  "@azure-tools/typespec-client-generator-cli":
+    "additionalDirectories":
+      - "specification/ai/HealthInsights/HealthInsights.Common/"
+      - "specification/ai/HealthInsights/HealthInsights.OpenAPI/"
+```
+
 ## 2025-04-03 0.17.0
 
 - Updated peerDependency support for `@typespec/compiler` to `^1.0.0-0`.

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.17.0",
+      "version": "0.18.0",
       "license": "MIT",
       "dependencies": {
         "@autorest/core": "^3.10.2",
         "@autorest/openapi-to-typespec": ">=0.10.6 <1.0.0",
         "@azure-tools/rest-api-diff": ">=0.1.0 <1.0.0",
-        "@azure-tools/typespec-autorest": ">=0.54.0 <1.0.0",
+        "@azure-tools/typespec-autorest": ">=0.53.0 <1.0.0",
         "@azure/core-rest-pipeline": "^1.12.0",
         "@types/yargs": "^17.0.32",
         "autorest": "^3.7.1",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.17.0",
+  "version": "0.18.0",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -90,7 +90,10 @@ export async function initCommand(argv: any) {
       directory: resolvedConfigUrl.path,
       commit: resolvedConfigUrl.commit,
       repo: resolvedConfigUrl.repo,
-      additionalDirectories: configYaml?.parameters?.dependencies?.additionalDirectories,
+      additionalDirectories:
+        configYaml?.options?.["@azure-tools/typespec-client-generator-cli"]?.[
+          "additionalDirectories"
+        ] ?? [],
     };
     if (argv["emitter-package-json-path"]) {
       tspLocationData.emitterPackageJsonPath = argv["emitter-package-json-path"];
@@ -136,7 +139,10 @@ export async function initCommand(argv: any) {
       directory: directory,
       commit: commit ?? "",
       repo: repo ?? "",
-      additionalDirectories: configYaml?.parameters?.dependencies?.additionalDirectories,
+      additionalDirectories:
+        configYaml?.options?.["@azure-tools/typespec-client-generator-cli"]?.[
+          "additionalDirectories"
+        ] ?? [],
     };
     if (argv["emitter-package-json-path"]) {
       tspLocationData.emitterPackageJsonPath = argv["emitter-package-json-path"];

--- a/tools/tsp-client/test/examples/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
+++ b/tools/tsp-client/test/examples/specification/contosowidgetmanager/Contoso.WidgetManager/tspconfig.yaml
@@ -1,10 +1,6 @@
 parameters:
   "service-dir":
     default: "sdk/contosowidgetmanager"
-  "dependencies":
-    "additionalDirectories":
-      - "tools/tsp-client/test/examples/specification/contosowidgetmanager/Contoso.WidgetManager.Shared/"
-    default: ""
 emit:
   - "@azure-tools/typespec-autorest"
 linter:
@@ -46,3 +42,6 @@ options:
     inject-spans: true
     single-client: true
     slice-elements-byval: true
+  "@azure-tools/typespec-client-generator-cli":
+    "additionalDirectories":
+      - "tools/tsp-client/test/examples/specification/contosowidgetmanager/Contoso.WidgetManager.Shared/"

--- a/tools/tsp-client/test/examples/tspconfig-custom-service-dir.yaml
+++ b/tools/tsp-client/test/examples/tspconfig-custom-service-dir.yaml
@@ -1,10 +1,6 @@
 parameters:
   "service-dir":
     default: "sdk/contosowidgetmanager"
-  "dependencies":
-    "additionalDirectories":
-      - "specification/contosowidgetmanager/Contoso.WidgetManager.Shared/"
-    default: ""
 emit:
   - "@azure-tools/typespec-autorest"
 linter:
@@ -37,3 +33,6 @@ options:
     package-dir: "azure-contoso-widgetmanager"
     namespace: com.azure.contoso.widgetmanager
     flavor: azure
+  "@azure-tools/typespec-client-generator-cli":
+    "additionalDirectories":
+      - "tools/tsp-client/test/examples/specification/contosowidgetmanager/Contoso.WidgetManager.Shared/"


### PR DESCRIPTION
Given the recent changes in typespec validation for the tspconfig.yaml file, move configuration options specific to tsp-client under an entry in the `options` property of tspconfig.yaml. This change affects the way additionalDirectories will be specified.