### PR TITLE
EmitterPackageJsonPath fixes

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release
 
+## 2025-04-08 - 0.19.0
+
+- Use repo root for emitter-package path specified in `tsp-location.yaml`.
+- Fix issue in generate command where the package-lock naming did not respect the user config.
+- Update `generate-config-files` and `generate-lock-file` to support `emitter-package-json-path`.
+
 ## 2025-04-07 - 0.18.0
 
 - Specify tsp-client specific configurations under a `@azure-tools/typespec-client-generator-cli` entry in tspconfig.yaml options. This affects the `additionalDirectories` configuration. Example entry in tspconfig.yaml:

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.18.0",
+      "version": "0.19.0",
       "license": "MIT",
       "dependencies": {
         "@autorest/core": "^3.10.2",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.18.0",
+  "version": "0.19.0",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -41,7 +41,7 @@ export async function initCommand(argv: any) {
 
   const emitterPackageOverride = resolveEmitterPathFromArgs(argv);
 
-  const emitter = await getEmitterFromRepoConfig(emitterPackageOverride ?? defaultRelativeEmitterPackageJsonPath);
+  const emitter = await getEmitterFromRepoConfig(emitterPackageOverride ?? joinPaths(repoRoot, defaultRelativeEmitterPackageJsonPath));
   if (!emitter) {
     throw new Error("Couldn't find emitter-package.json in the repo");
   }
@@ -495,7 +495,7 @@ export async function generateConfigFilesCommand(argv: any) {
 export async function generateLockFileCommand(argv: any) {
   await generateLockFileCommandCore(
     argv["output-dir"],
-    resolveEmitterPathFromArgs(argv) ?? joinPaths(await getRepoRoot(argv["output-dir"]), "eng", "emitter-package.json"));
+    resolveEmitterPathFromArgs(argv) ?? joinPaths(await getRepoRoot(argv["output-dir"]), defaultRelativeEmitterPackageJsonPath));
 }
 
 export async function generateLockFileCommandCore(outputDir: string, emitterPackageJsonPath: string) {

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -481,7 +481,7 @@ export async function generateConfigFilesCommand(argv: any) {
     emitterPackageJson["overrides"] = overrideJson;
   }
   
-  const emitterPath = resolveEmitterPathFromArgs(argv) ?? defaultRelativeEmitterPackageJsonPath;
+  const emitterPath = resolveEmitterPathFromArgs(argv) ?? joinPaths(repoRoot, defaultRelativeEmitterPackageJsonPath);
   
   await writeFile(
     emitterPath,

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -24,7 +24,7 @@ import {
 } from "./utils.js";
 import { parse as parseYaml } from "yaml";
 import { config as dotenvConfig } from "dotenv";
-import path, { basename, dirname, resolve } from "node:path";
+import { basename, dirname, extname, relative, resolve } from "node:path";
 import { doesFileExist } from "./network.js";
 import { sortOpenAPIDocument } from "@azure-tools/typespec-autorest";
 
@@ -148,7 +148,7 @@ export async function initCommand(argv: any) {
     const emitterPackageOverride = resolveEmitterPathFromArgs(argv);
     if (emitterPackageOverride) {
       // store relative path to repo root
-      tspLocationData.emitterPackageJsonPath = path.relative(repoRoot, emitterPackageOverride);
+      tspLocationData.emitterPackageJsonPath = relative(repoRoot, emitterPackageOverride);
     }
     await writeTspLocationYaml(tspLocationData, newPackageDir);
     outputDir = newPackageDir;
@@ -578,7 +578,7 @@ function getEmitterPackageJsonPath(repoRoot: string, tspLocation: TspLocation): 
 }
 
 function getEmitterLockPath(emitterPackageJsonPath: string): string {
-  const emitterPackageJsonFileName = path.basename(emitterPackageJsonPath, path.extname(emitterPackageJsonPath));
+  const emitterPackageJsonFileName = basename(emitterPackageJsonPath, extname(emitterPackageJsonPath));
   return joinPaths(dirname(emitterPackageJsonPath), `${emitterPackageJsonFileName}-lock.json`);
 }
 

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -39,7 +39,7 @@ export async function initCommand(argv: any) {
 
   const repoRoot = await getRepoRoot(outputDir);
 
-  const emitterPackageOverride = resolveEmitterPathFromArgs(argv["emitter-package-json-path"]);
+  const emitterPackageOverride = resolveEmitterPathFromArgs(argv);
 
   const emitter = await getEmitterFromRepoConfig(emitterPackageOverride ?? defaultRelativeEmitterPackageJsonPath);
   if (!emitter) {
@@ -246,12 +246,7 @@ export async function syncCommand(argv: any) {
   }
 
   try {
-    let emitterLockPath = joinPaths(repoRoot, "eng", "emitter-package-lock.json");
-    if (tspLocation.emitterPackageJsonPath) {
-
-      // If the emitter package json path is provided, we need to check for the lock file in the same directory with the same name prefix.
-      emitterLockPath = getEmitterLockPath(emitterPackageJsonPath);
-    }
+    let emitterLockPath = getEmitterLockPath(getEmitterPackageJsonPath(repoRoot, tspLocation));
     
     // Copy the emitter lock file to the temp directory and rename it to package-lock.json so that npm can use it.
     await cp(emitterLockPath, joinPaths(tempRoot, "package-lock.json"), { recursive: true });

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -24,7 +24,7 @@ import {
 } from "./utils.js";
 import { parse as parseYaml } from "yaml";
 import { config as dotenvConfig } from "dotenv";
-import path, { basename, dirname, join, resolve } from "node:path";
+import path, { basename, dirname, resolve } from "node:path";
 import { doesFileExist } from "./network.js";
 import { sortOpenAPIDocument } from "@azure-tools/typespec-autorest";
 

--- a/tools/tsp-client/src/fs.ts
+++ b/tools/tsp-client/src/fs.ts
@@ -59,7 +59,7 @@ export async function getEmitterFromRepoConfig(emitterPath: string): Promise<str
   if (!obj || !obj.dependencies) {
     throw new Error("Invalid emitter-package.json");
   }
-  const languages: string[] = ["@azure-tools/typespec-", "@typespec/http-", "@typespec/openapi3"];
+  const languages: string[] = ["@azure-tools/typespec-", "@typespec/http-", "@typespec/openapi3", "@azure-typespec/"];
   for (const lang of languages) {
     const emitter = Object.keys(obj.dependencies).find((dep: string) => dep.startsWith(lang));
     if (emitter) {

--- a/tools/tsp-client/src/index.ts
+++ b/tools/tsp-client/src/index.ts
@@ -241,6 +241,10 @@ const parser = yargs(hideBin(process.argv))
         .option("overrides", {
           type: "string",
           description: "Path to an override config file for pinning specific dependencies",
+        })
+        .option("emitter-package-json-path", {
+          type: "string",
+          description: "Alternate path for emitter-package.json file",
         });
     },
     async (argv: any) => {
@@ -251,7 +255,13 @@ const parser = yargs(hideBin(process.argv))
   .command(
     "generate-lock-file",
     "Generate a lock file under the eng/ directory from an existing emitter-package.json",
-    {},
+    (yargs: any) => {
+      return yargs
+        .option("emitter-package-json-path", {
+          type: "string",
+          description: "Alternate path for emitter-package.json file",
+        });
+    },
     async (argv: any) => {
       argv["output-dir"] = resolveOutputDir(argv);
       await generateLockFileCommand(argv);

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -332,9 +332,9 @@ describe.sequential("Verify commands", () => {
       };
       repoRoot = await getRepoRoot(cwd());
       await generateConfigFilesCommand(args);
-      assert.isTrue(await doesFileExist(joinPaths(repoRoot, "eng", "emitter-package.json")));
+      assert.isTrue(await doesFileExist(joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json")));
       const emitterJson = JSON.parse(
-        await readFile(joinPaths(repoRoot, "eng", "emitter-package.json"), "utf8"),
+        await readFile(joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json"), "utf8"),
       );
       assert.equal(emitterJson["dependencies"]["@azure-tools/typespec-ts"], "0.38.4");
       assert.equal(emitterJson["devDependencies"]["@typespec/compiler"], "~0.67.0");

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -55,7 +55,7 @@ describe.sequential("Verify commands", () => {
 
   it("Generate lock file with altername package path", async () => {
     try {
-      await generateLockFileCommand({emitterPackageJsonPath: joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json")});
+      await generateLockFileCommand({"emitter-package-json-path": joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json")});
 
       assert.isTrue((await stat(joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json"))).isFile());
     } catch (error) {
@@ -308,6 +308,27 @@ describe.sequential("Verify commands", () => {
     try {
       const args = {
         "package-json": joinPaths(cwd(), "test", "examples", "package.json"),
+      };
+      repoRoot = await getRepoRoot(cwd());
+      await generateConfigFilesCommand(args);
+      assert.isTrue(await doesFileExist(joinPaths(repoRoot, "eng", "emitter-package.json")));
+      const emitterJson = JSON.parse(
+        await readFile(joinPaths(repoRoot, "eng", "emitter-package.json"), "utf8"),
+      );
+      assert.equal(emitterJson["dependencies"]["@azure-tools/typespec-ts"], "0.38.4");
+      assert.equal(emitterJson["devDependencies"]["@typespec/compiler"], "~0.67.0");
+      assert.isUndefined(emitterJson["overrides"]);
+      assert.isTrue(await doesFileExist(joinPaths(repoRoot, "eng", "emitter-package-lock.json")));
+    } catch (error: any) {
+      assert.fail("Failed to generate tsp-client config files. Error: " + error);
+    }
+  }, 360000);
+
+  it("Generate config files with alternate json path", async () => {
+    try {
+      const args = {
+        "package-json": joinPaths(cwd(), "test", "examples", "package.json"),
+        "emitter-package-json-path": joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json")
       };
       repoRoot = await getRepoRoot(cwd());
       await generateConfigFilesCommand(args);

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -55,9 +55,14 @@ describe.sequential("Verify commands", () => {
 
   it("Generate lock file with altername package path", async () => {
     try {
-      await generateLockFileCommand({"emitter-package-json-path": joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json")});
+      // delete the existing lock file if it exists
+      const lockFilePath = joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package-lock.json");
+      if (await doesFileExist(lockFilePath)) {
+        await rm(lockFilePath);
+      }
+      await generateLockFileCommand({"emitter-package-json-path":  joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json")});
 
-      assert.isTrue((await stat(joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json"))).isFile());
+      assert.isTrue((await stat(lockFilePath)).isFile());
     } catch (error) {
       assert.fail(`Failed to generate lock file. Error: ${error}`);
     }
@@ -326,20 +331,27 @@ describe.sequential("Verify commands", () => {
 
   it("Generate config files with alternate json path", async () => {
     try {
+
+      // delete the existing package JSON file if it exists
+      const packageJsonPath = joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json");
+      if (await doesFileExist(packageJsonPath)) {
+        await rm(packageJsonPath);
+      }
+
       const args = {
         "package-json": joinPaths(cwd(), "test", "examples", "package.json"),
-        "emitter-package-json-path": joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json")
+        "emitter-package-json-path": packageJsonPath
       };
       repoRoot = await getRepoRoot(cwd());
       await generateConfigFilesCommand(args);
-      assert.isTrue(await doesFileExist(joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json")));
+      assert.isTrue(await doesFileExist(packageJsonPath));
       const emitterJson = JSON.parse(
-        await readFile(joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json"), "utf8"),
+        await readFile(packageJsonPath, "utf8"),
       );
       assert.equal(emitterJson["dependencies"]["@azure-tools/typespec-ts"], "0.38.4");
       assert.equal(emitterJson["devDependencies"]["@typespec/compiler"], "~0.67.0");
       assert.isUndefined(emitterJson["overrides"]);
-      assert.isTrue(await doesFileExist(joinPaths(repoRoot, "eng", "emitter-package-lock.json")));
+      assert.isTrue(await doesFileExist(joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package-lock.json")));
     } catch (error: any) {
       assert.fail("Failed to generate tsp-client config files. Error: " + error);
     }

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -29,8 +29,13 @@ describe.sequential("Verify commands", () => {
 
   afterAll(async () => {
     await rm(joinPaths(repoRoot, "eng", "emitter-package.json"));
+    
     // This is generated in the first test using the command
-    await rm(joinPaths(repoRoot, "eng", "emitter-package-lock.json"));
+    const emitterPackageLock = joinPaths(repoRoot, "eng", "emitter-package-lock.json");
+    if (await doesFileExist(emitterPackageLock)){
+      await rm(emitterPackageLock);
+    }
+
     await rm(
       "./test/examples/sdk/contosowidgetmanager/contosowidgetmanager-rest/TempTypeSpecFiles/",
       { recursive: true },
@@ -137,7 +142,30 @@ describe.sequential("Verify commands", () => {
         commit: "45924e49834c4e01c0713e6b7ca21f94be17e396",
         repo: "Azure/azure-rest-api-specs",
         additionalDirectories: ["specification/contosowidgetmanager/Contoso.WidgetManager.Shared"],
-        emitterPackageJsonPath: joinPaths(cwd(), "test/utils/emitter-package.json"),
+        emitterPackageJsonPath: "tools/tsp-client/test/utils/emitter-package.json",
+      };
+      await writeTspLocationYaml(
+        tspLocationContent,
+        joinPaths(cwd(), "test/examples/sdk/alternate-emitter-package-json-path"),
+      );
+      const args = {
+        "output-dir": joinPaths(cwd(), "test/examples/sdk/alternate-emitter-package-json-path"),
+        "save-inputs": true,
+      };
+      await updateCommand(args);
+    } catch (error) {
+      assert.fail(`Failed to generate. Error: ${error}`);
+    }
+  });
+
+  it("Update example sdk with custom emitter-package.json path with alternate name", async () => {
+    try {
+      const tspLocationContent: TspLocation = {
+        directory: "specification/contosowidgetmanager/Contoso.WidgetManager",
+        commit: "45924e49834c4e01c0713e6b7ca21f94be17e396",
+        repo: "Azure/azure-rest-api-specs",
+        additionalDirectories: ["specification/contosowidgetmanager/Contoso.WidgetManager.Shared"],
+        emitterPackageJsonPath: "tools/tsp-client/test/utils/alternate-emitter-package.json",
       };
       await writeTspLocationYaml(
         tspLocationContent,

--- a/tools/tsp-client/test/commands.spec.ts
+++ b/tools/tsp-client/test/commands.spec.ts
@@ -53,6 +53,16 @@ describe.sequential("Verify commands", () => {
     }
   });
 
+  it("Generate lock file with altername package path", async () => {
+    try {
+      await generateLockFileCommand({emitterPackageJsonPath: joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json")});
+
+      assert.isTrue((await stat(joinPaths(repoRoot, "tools/tsp-client/test/utils/alternate-emitter-package.json"))).isFile());
+    } catch (error) {
+      assert.fail(`Failed to generate lock file. Error: ${error}`);
+    }
+  });
+
   it("Sync example sdk", async () => {
     try {
       const args = {

--- a/tools/tsp-client/test/utils/alternate-emitter-package-lock.json
+++ b/tools/tsp-client/test/utils/alternate-emitter-package-lock.json
@@ -6,21 +6,22 @@
     "": {
       "name": "typescript-emitter-package",
       "dependencies": {
-        "@azure-tools/typespec-ts": "0.38.6"
+        "@azure-tools/typespec-ts": "0.38.5"
       },
       "devDependencies": {
-        "@azure-tools/typespec-azure-core": ">=0.54.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.54.0 <1.0.0",
-        "@typespec/compiler": "^1.0.0-0",
-        "@typespec/http": "^1.0.0-0",
-        "@typespec/rest": ">=0.68.0 <1.0.0",
-        "@typespec/versioning": ">=0.68.0 <1.0.0"
+        "@azure-tools/typespec-azure-core": "0.53.0",
+        "@azure-tools/typespec-azure-rulesets": "0.53.0",
+        "@azure-tools/typespec-client-generator-core": "0.53.1",
+        "@typespec/compiler": "0.67.1",
+        "@typespec/http": "0.67.1",
+        "@typespec/rest": "0.67.1",
+        "@typespec/versioning": "0.67.1"
       }
     },
     "node_modules/@azure-tools/rlc-common": {
-      "version": "0.38.6",
-      "resolved": "https://registry.npmjs.org/@azure-tools/rlc-common/-/rlc-common-0.38.6.tgz",
-      "integrity": "sha512-rGg7ip1McdSQyaCZ2ZZKkuxcod5QLCSrAkhGZNcWb9sZhD7LHxIyFbPu2/nEItpkZIfmQY30ybWVd2WVLxagOw==",
+      "version": "0.38.5",
+      "resolved": "https://registry.npmjs.org/@azure-tools/rlc-common/-/rlc-common-0.38.5.tgz",
+      "integrity": "sha512-js6WRnG6Rrsdm1T2OhGRfjKWrfW8joyP/axPwIJKobuhLkXqxJhxBm9+q3jY8uSYpUKA0r5hd+ZohGeamqQ3Xg==",
       "license": "ISC",
       "dependencies": {
         "handlebars": "^4.7.7",
@@ -29,23 +30,62 @@
       }
     },
     "node_modules/@azure-tools/typespec-azure-core": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.54.0.tgz",
-      "integrity": "sha512-rlUK9j/1mHUHaNPzOibz1aeeUnROOrNlTPDmnHOfbo4WP0NwV4tDU3rnoUCZxwabVQGKb9U7VTsunb74AzAafg==",
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.53.0.tgz",
+      "integrity": "sha512-zG+DV58ApChmkIIoTZ+XMIRsYLm6DnysMofg0o1UEuY50mS71sjzavcwceT8pXekPHtcXkLyYfdd7FyxirCuUA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.0.0-rc.0",
-        "@typespec/http": "^1.0.0-rc.0",
-        "@typespec/rest": "^0.68.0"
+        "@typespec/compiler": "^0.67.0",
+        "@typespec/http": "^0.67.0",
+        "@typespec/rest": "^0.67.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-resource-manager": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-resource-manager/-/typespec-azure-resource-manager-0.53.0.tgz",
+      "integrity": "sha512-sHeB+HqETYiHoRgcUjr61rxzCn+ITnYrg2gFQ0ExIK/B26hQv50t+VHe1YdrprlqzSvElJD+CtoqQQZffridNw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "change-case": "~5.4.4",
+        "pluralize": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "^0.53.0",
+        "@typespec/compiler": "^0.67.0",
+        "@typespec/http": "^0.67.0",
+        "@typespec/openapi": "^0.67.0",
+        "@typespec/rest": "^0.67.0",
+        "@typespec/versioning": "^0.67.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-rulesets": {
+      "version": "0.53.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-rulesets/-/typespec-azure-rulesets-0.53.0.tgz",
+      "integrity": "sha512-TsQeFKNQEG0juFzf0dQt8iikPSXGHNyW9hbDrUNrbnjnFvpxUZlL+1aLyI2hBmhHvJQJpLzHViVgKhXTLLBvIQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "^0.53.0",
+        "@azure-tools/typespec-azure-resource-manager": "^0.53.0",
+        "@azure-tools/typespec-client-generator-core": "^0.53.0",
+        "@typespec/compiler": "^0.67.0"
       }
     },
     "node_modules/@azure-tools/typespec-client-generator-core": {
-      "version": "0.54.0",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.54.0.tgz",
-      "integrity": "sha512-qZR6FgB+wKfF5aRQtEwjUo6xgw1MomqyFwJf6WL+xstHDs7np3jBja43OCdJaooPzAknYWh2V+Hv77/fLFd9Aw==",
+      "version": "0.53.1",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.53.1.tgz",
+      "integrity": "sha512-BWHQQ9Kjsk23Rb0eZ6V6HI2Gr20n/LhxAKEuBChCFWLjrFMYyXrHtlUBK6j/9D2VqwjaurRQA2SVXx/wzGyvAg==",
       "license": "MIT",
       "dependencies": {
         "change-case": "~5.4.4",
@@ -56,25 +96,25 @@
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": "^0.54.0",
-        "@typespec/compiler": "^1.0.0-rc.0",
-        "@typespec/events": "^0.68.0",
-        "@typespec/http": "^1.0.0-rc.0",
-        "@typespec/openapi": "^1.0.0-rc.0",
-        "@typespec/rest": "^0.68.0",
-        "@typespec/sse": "^0.68.0",
-        "@typespec/streams": "^0.68.0",
-        "@typespec/versioning": "^0.68.0",
-        "@typespec/xml": "^0.68.0"
+        "@azure-tools/typespec-azure-core": "^0.53.0",
+        "@typespec/compiler": "^0.67.0",
+        "@typespec/events": "^0.67.0",
+        "@typespec/http": "^0.67.0",
+        "@typespec/openapi": "^0.67.0",
+        "@typespec/rest": "^0.67.0",
+        "@typespec/sse": "^0.67.0",
+        "@typespec/streams": "^0.67.0",
+        "@typespec/versioning": "^0.67.0",
+        "@typespec/xml": "^0.67.0"
       }
     },
     "node_modules/@azure-tools/typespec-ts": {
-      "version": "0.38.6",
-      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-ts/-/typespec-ts-0.38.6.tgz",
-      "integrity": "sha512-4jwcdGBFICC8rSbeV5DtIhpsaSht05mz15PGqmtHw7Xp7rrsHeuCYhYnjde/HZSSDPf3CO8j/RvEQ4wVoap8vw==",
+      "version": "0.38.5",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-ts/-/typespec-ts-0.38.5.tgz",
+      "integrity": "sha512-4EXOK7PLzKWqG6b5IW19pebcK8lLRBOwdNdrD+vZJeiFUE2Gu6OP9rBme4FITHY+YHvbCIpMqNHzU27Wen/MfA==",
       "license": "MIT",
       "dependencies": {
-        "@azure-tools/rlc-common": "^0.38.6",
+        "@azure-tools/rlc-common": "^0.38.5",
         "fs-extra": "^11.1.0",
         "lodash": "^4.17.21",
         "prettier": "^3.3.3",
@@ -82,12 +122,12 @@
         "tslib": "^2.3.1"
       },
       "peerDependencies": {
-        "@azure-tools/typespec-azure-core": ">=0.54.0 <1.0.0",
-        "@azure-tools/typespec-client-generator-core": ">=0.54.0 <1.0.0",
-        "@typespec/compiler": "^1.0.0-0",
-        "@typespec/http": "^1.0.0-0",
-        "@typespec/rest": ">=0.68.0 <1.0.0",
-        "@typespec/versioning": ">=0.68.0 <1.0.0"
+        "@azure-tools/typespec-azure-core": ">=0.53.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.53.1 <1.0.0",
+        "@typespec/compiler": ">=0.67.1 <1.0.0",
+        "@typespec/http": ">=0.67.1 <1.0.0",
+        "@typespec/rest": ">=0.67.1 <1.0.0",
+        "@typespec/versioning": ">=0.67.1 <1.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -114,14 +154,14 @@
       }
     },
     "node_modules/@inquirer/checkbox": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.5.tgz",
-      "integrity": "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.4.tgz",
+      "integrity": "sha512-d30576EZdApjAMceijXA5jDzRQHT/MygbC+J8I7EqA6f/FRpYxlRtRJbHF8gHeWYeSdOuTEJqonn7QLB1ELezA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
+        "@inquirer/core": "^10.1.9",
         "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -138,13 +178,13 @@
       }
     },
     "node_modules/@inquirer/confirm": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
-      "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
+      "version": "5.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.8.tgz",
+      "integrity": "sha512-dNLWCYZvXDjO3rnQfk2iuJNL4Ivwz/T2+C3+WnNfJKsNGSuOs3wAo2F6e0p946gtSAk31nZMfW+MRmYaplPKsg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -159,13 +199,13 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "10.1.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
-      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "version": "10.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.9.tgz",
+      "integrity": "sha512-sXhVB8n20NYkUBfDYgizGHlpRVaCRjtuzNZA6xpALIUbkgfd2Hjz+DfEN6+h1BRnuxw0/P4jCIMjMsEOAMwAJw==",
       "license": "MIT",
       "dependencies": {
         "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "cli-width": "^4.1.0",
         "mute-stream": "^2.0.0",
@@ -186,13 +226,13 @@
       }
     },
     "node_modules/@inquirer/editor": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
-      "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
+      "version": "4.2.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.9.tgz",
+      "integrity": "sha512-8HjOppAxO7O4wV1ETUlJFg6NDjp/W2NP5FB9ZPAcinAlNT4ZIWOLe2pUVwmmPRSV0NMdI5r/+lflN55AwZOKSw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "external-editor": "^3.1.0"
       },
       "engines": {
@@ -208,13 +248,13 @@
       }
     },
     "node_modules/@inquirer/expand": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.12.tgz",
-      "integrity": "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.11.tgz",
+      "integrity": "sha512-OZSUW4hFMW2TYvX/Sv+NnOZgO8CHT2TU1roUCUIF2T+wfw60XFRRp9MRUPCT06cRnKL+aemt2YmTWwt7rOrNEA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -239,13 +279,13 @@
       }
     },
     "node_modules/@inquirer/input": {
-      "version": "4.1.9",
-      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
-      "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
+      "version": "4.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.8.tgz",
+      "integrity": "sha512-WXJI16oOZ3/LiENCAxe8joniNp8MQxF6Wi5V+EBbVA0ZIOpFcL4I9e7f7cXse0HJeIPCWO8Lcgnk98juItCi7Q==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -260,13 +300,13 @@
       }
     },
     "node_modules/@inquirer/number": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.12.tgz",
-      "integrity": "sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.11.tgz",
+      "integrity": "sha512-pQK68CsKOgwvU2eA53AG/4npRTH2pvs/pZ2bFvzpBhrznh8Mcwt19c+nMO7LHRr3Vreu1KPhNBF3vQAKrjIulw==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6"
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5"
       },
       "engines": {
         "node": ">=18"
@@ -281,13 +321,13 @@
       }
     },
     "node_modules/@inquirer/password": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.12.tgz",
-      "integrity": "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.11.tgz",
+      "integrity": "sha512-dH6zLdv+HEv1nBs96Case6eppkRggMe8LoOTl30+Gq5Wf27AO/vHFgStTVz4aoevLdNXqwE23++IXGw4eiOXTg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2"
       },
       "engines": {
@@ -303,21 +343,21 @@
       }
     },
     "node_modules/@inquirer/prompts": {
-      "version": "7.4.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.1.tgz",
-      "integrity": "sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==",
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.0.tgz",
+      "integrity": "sha512-EZiJidQOT4O5PYtqnu1JbF0clv36oW2CviR66c7ma4LsupmmQlUwmdReGKRp456OWPWMz3PdrPiYg3aCk3op2w==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/checkbox": "^4.1.5",
-        "@inquirer/confirm": "^5.1.9",
-        "@inquirer/editor": "^4.2.10",
-        "@inquirer/expand": "^4.0.12",
-        "@inquirer/input": "^4.1.9",
-        "@inquirer/number": "^3.0.12",
-        "@inquirer/password": "^4.0.12",
-        "@inquirer/rawlist": "^4.0.12",
-        "@inquirer/search": "^3.0.12",
-        "@inquirer/select": "^4.1.1"
+        "@inquirer/checkbox": "^4.1.4",
+        "@inquirer/confirm": "^5.1.8",
+        "@inquirer/editor": "^4.2.9",
+        "@inquirer/expand": "^4.0.11",
+        "@inquirer/input": "^4.1.8",
+        "@inquirer/number": "^3.0.11",
+        "@inquirer/password": "^4.0.11",
+        "@inquirer/rawlist": "^4.0.11",
+        "@inquirer/search": "^3.0.11",
+        "@inquirer/select": "^4.1.0"
       },
       "engines": {
         "node": ">=18"
@@ -332,13 +372,13 @@
       }
     },
     "node_modules/@inquirer/rawlist": {
-      "version": "4.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.12.tgz",
-      "integrity": "sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==",
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.11.tgz",
+      "integrity": "sha512-uAYtTx0IF/PqUAvsRrF3xvnxJV516wmR6YVONOmCWJbbt87HcDHLfL9wmBQFbNJRv5kCjdYKrZcavDkH3sVJPg==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/core": "^10.1.9",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -354,14 +394,14 @@
       }
     },
     "node_modules/@inquirer/search": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.12.tgz",
-      "integrity": "sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==",
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.11.tgz",
+      "integrity": "sha512-9CWQT0ikYcg6Ls3TOa7jljsD7PgjcsYEM0bYE+Gkz+uoW9u8eaJCRHJKkucpRE5+xKtaaDbrND+nPDoxzjYyew==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
+        "@inquirer/core": "^10.1.9",
         "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/type": "^3.0.5",
         "yoctocolors-cjs": "^2.1.2"
       },
       "engines": {
@@ -377,14 +417,14 @@
       }
     },
     "node_modules/@inquirer/select": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.1.tgz",
-      "integrity": "sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.0.tgz",
+      "integrity": "sha512-z0a2fmgTSRN+YBuiK1ROfJ2Nvrpij5lVN3gPDkQGhavdvIVGHGW29LwYZfM/j42Ai2hUghTI/uoBuTbrJk42bA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/core": "^10.1.10",
+        "@inquirer/core": "^10.1.9",
         "@inquirer/figures": "^1.0.11",
-        "@inquirer/type": "^3.0.6",
+        "@inquirer/type": "^3.0.5",
         "ansi-escapes": "^4.3.2",
         "yoctocolors-cjs": "^2.1.2"
       },
@@ -401,9 +441,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
-      "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.5.tgz",
+      "integrity": "sha512-ZJpeIYYueOz/i/ONzrfof8g89kNdO2hjGuvULROo3O8rlB2CRtSseE5KeirnyE4t/thAn/EwvS/vuQeJCn+NZg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -489,13 +529,13 @@
       }
     },
     "node_modules/@typespec/compiler": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.0.0-rc.0.tgz",
-      "integrity": "sha512-2N5DCFzuPt5rPXReE4T1boZrG60sr3dTMgZOS/WX+Rosc6iFj2v1ULTI2ySXk/Abd3oxS5OR24l8veIWEi0lzw==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-0.67.1.tgz",
+      "integrity": "sha512-inaJUlbwvFBNiT8ViXZ4O2m0ECiLPkkp0Ek1wNquxpWNHxgvfFDH/JTv5SXXwL5FXY+uym9hNcyjmHQB7RJExw==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "~7.26.2",
-        "@inquirer/prompts": "^7.4.0",
+        "@inquirer/prompts": "^7.3.1",
         "ajv": "~8.17.1",
         "change-case": "~5.4.4",
         "env-paths": "^3.0.0",
@@ -521,29 +561,29 @@
       }
     },
     "node_modules/@typespec/events": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.68.0.tgz",
-      "integrity": "sha512-U2y9K8QJ6HsmNxEyHz2aG2bmD05FIsLkmIZgmNaHDwhN1oyI8EH1NkxvwZCnEkPAN7ReuLYK6blouWFWX3s5eg==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.67.1.tgz",
+      "integrity": "sha512-4pd/FEd+y72h2eUOlwGavK+nv3SDp7ZUJkGTcARyjLH5aSIAOl4uYW+WzQjGJylu/9t+xmoHy47siOvYBxONkQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.0.0-rc.0"
+        "@typespec/compiler": "^0.67.1"
       }
     },
     "node_modules/@typespec/http": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.0.0-rc.0.tgz",
-      "integrity": "sha512-Or2hhDXy8DZZoy3B/HudSrRHTFomiv6DI3vRpPKYT9ocIAxMGo1hQvqKye8uVk/QIMn/ouv6JUlP+pqjpfnPyw==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-0.67.1.tgz",
+      "integrity": "sha512-pkLFdKLA5ObCptUuwL8mhiy6EqVbqmtvHK89zqiTfYYGw2qm76+EUHaK0P/g2aAmjcwlrDGhJ0EhzbVp87H0mg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.0.0-rc.0",
-        "@typespec/streams": "^0.68.0"
+        "@typespec/compiler": "^0.67.1",
+        "@typespec/streams": "^0.67.1"
       },
       "peerDependenciesMeta": {
         "@typespec/streams": {
@@ -552,84 +592,84 @@
       }
     },
     "node_modules/@typespec/openapi": {
-      "version": "1.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.0.0-rc.0.tgz",
-      "integrity": "sha512-aswkRlzFI44CGe05qkzInA7jEhUKNxZYToYi5kXz05Jl5d4nh4VeEkCweb2pRL+4LKd2SZiOn09nXm+OKp5EoQ==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-0.67.1.tgz",
+      "integrity": "sha512-9/122dHw6ZA+laqHM1mqa0CWxg0lBhEqdVX74YoAOlE+NR2wIpUwwC4WIVTvIllDIl6hwV+zVgILtbvD8W5+1A==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.0.0-rc.0",
-        "@typespec/http": "^1.0.0-rc.0"
+        "@typespec/compiler": "^0.67.1",
+        "@typespec/http": "^0.67.1"
       }
     },
     "node_modules/@typespec/rest": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.68.0.tgz",
-      "integrity": "sha512-VJBEpC0MCFPPN6acc5o0fwQm4WMjMEl3aBHE+71XYkagsqb31rYSyfgfBMvHWaEMJV4dVk5T787/q6AWDzEE8g==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.67.1.tgz",
+      "integrity": "sha512-19IzFoaM0yFBSXpfrJgZEBVXtvEkMEprKc5B0kF4ylEPs32ShtZj05BXYrAkmMZbCsk0AC/VZdmVgcWP+AT6GQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.0.0-rc.0",
-        "@typespec/http": "^1.0.0-rc.0"
+        "@typespec/compiler": "^0.67.1",
+        "@typespec/http": "^0.67.1"
       }
     },
     "node_modules/@typespec/sse": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.68.0.tgz",
-      "integrity": "sha512-sePc+14iw8BZjBPwBaCL23y7lDWrUtmoYuPbfxJhRcIzbv2ww5d7mjvv5C2fjWyfRvG7tJ6wDk8YoHQJDoqtVA==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.67.1.tgz",
+      "integrity": "sha512-Y7O002u89nM55hc81/wadMG0+gnj9hr0i4icqOxjP7auWsYDwMoK7arxC+qM7tyyFGMgv/F0ZxNJmc2Ajq7kpQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.0.0-rc.0",
-        "@typespec/events": "^0.68.0",
-        "@typespec/http": "^1.0.0-rc.0",
-        "@typespec/streams": "^0.68.0"
+        "@typespec/compiler": "^0.67.1",
+        "@typespec/events": "^0.67.1",
+        "@typespec/http": "^0.67.1",
+        "@typespec/streams": "^0.67.1"
       }
     },
     "node_modules/@typespec/streams": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.68.0.tgz",
-      "integrity": "sha512-FsyPYOcPA6CDptdsAI0kiwR9tG6pngf5Bi4PiKTsXwseu93v5Y4keLNr4SR+bNQQK6uYIm0OkoK34Z6qn6uZEw==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.67.1.tgz",
+      "integrity": "sha512-it+WNzurrk+TEzLvqlbCreyATmSR/g61/YX/k1D+B/QThPv8bh2S1sQqKtUMeThCu4/MHhZL9xTtdxWcLww+lg==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.0.0-rc.0"
+        "@typespec/compiler": "^0.67.1"
       }
     },
     "node_modules/@typespec/versioning": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.68.0.tgz",
-      "integrity": "sha512-nsK0hbOeqfsNo1dsP64A4Ks0C/FEk5WJ5LEfgTwvFGdE48mHrj7UJdp58Ps5F6moiR9U20P1rHbo+mE0LDIRvA==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.67.1.tgz",
+      "integrity": "sha512-i1eZT8JlCthkRHJS3NH/nZTHUD7gJozP6pVy8wyHBx6TbnDOTfQ1P5YVlL2pF4ZdeRbGFhOKiUF/usEIOrkaVw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.0.0-rc.0"
+        "@typespec/compiler": "^0.67.1"
       }
     },
     "node_modules/@typespec/xml": {
-      "version": "0.68.0",
-      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.68.0.tgz",
-      "integrity": "sha512-uB904g9KMkuYKmGZnJsuozjPX+AKzZNStdXvMLq8+TkOitpJcb1dHtFH6KufG21xWuF0bmRUSkJvO4MOsuQNLA==",
+      "version": "0.67.1",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.67.1.tgz",
+      "integrity": "sha512-WDCxdtvlcUvD4AunpSje22Hb0BZzpluHATkx07/ru6HhdJsiwrc//IgGbV5eah9M6gK76sGXLicBLAFlxDfvDw==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.0.0-rc.0"
+        "@typespec/compiler": "^0.67.1"
       }
     },
     "node_modules/ajv": {

--- a/tools/tsp-client/test/utils/alternate-emitter-package-lock.json
+++ b/tools/tsp-client/test/utils/alternate-emitter-package-lock.json
@@ -1,0 +1,1660 @@
+{
+  "name": "typescript-emitter-package",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "typescript-emitter-package",
+      "dependencies": {
+        "@azure-tools/typespec-ts": "0.38.6"
+      },
+      "devDependencies": {
+        "@azure-tools/typespec-azure-core": ">=0.54.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.54.0 <1.0.0",
+        "@typespec/compiler": "^1.0.0-0",
+        "@typespec/http": "^1.0.0-0",
+        "@typespec/rest": ">=0.68.0 <1.0.0",
+        "@typespec/versioning": ">=0.68.0 <1.0.0"
+      }
+    },
+    "node_modules/@azure-tools/rlc-common": {
+      "version": "0.38.6",
+      "resolved": "https://registry.npmjs.org/@azure-tools/rlc-common/-/rlc-common-0.38.6.tgz",
+      "integrity": "sha512-rGg7ip1McdSQyaCZ2ZZKkuxcod5QLCSrAkhGZNcWb9sZhD7LHxIyFbPu2/nEItpkZIfmQY30ybWVd2WVLxagOw==",
+      "license": "ISC",
+      "dependencies": {
+        "handlebars": "^4.7.7",
+        "lodash": "^4.17.21",
+        "ts-morph": "^23.0.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-azure-core": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-azure-core/-/typespec-azure-core-0.54.0.tgz",
+      "integrity": "sha512-rlUK9j/1mHUHaNPzOibz1aeeUnROOrNlTPDmnHOfbo4WP0NwV4tDU3rnoUCZxwabVQGKb9U7VTsunb74AzAafg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/http": "^1.0.0-rc.0",
+        "@typespec/rest": "^0.68.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-client-generator-core": {
+      "version": "0.54.0",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-client-generator-core/-/typespec-client-generator-core-0.54.0.tgz",
+      "integrity": "sha512-qZR6FgB+wKfF5aRQtEwjUo6xgw1MomqyFwJf6WL+xstHDs7np3jBja43OCdJaooPzAknYWh2V+Hv77/fLFd9Aw==",
+      "license": "MIT",
+      "dependencies": {
+        "change-case": "~5.4.4",
+        "pluralize": "^8.0.0",
+        "yaml": "~2.7.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": "^0.54.0",
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/events": "^0.68.0",
+        "@typespec/http": "^1.0.0-rc.0",
+        "@typespec/openapi": "^1.0.0-rc.0",
+        "@typespec/rest": "^0.68.0",
+        "@typespec/sse": "^0.68.0",
+        "@typespec/streams": "^0.68.0",
+        "@typespec/versioning": "^0.68.0",
+        "@typespec/xml": "^0.68.0"
+      }
+    },
+    "node_modules/@azure-tools/typespec-ts": {
+      "version": "0.38.6",
+      "resolved": "https://registry.npmjs.org/@azure-tools/typespec-ts/-/typespec-ts-0.38.6.tgz",
+      "integrity": "sha512-4jwcdGBFICC8rSbeV5DtIhpsaSht05mz15PGqmtHw7Xp7rrsHeuCYhYnjde/HZSSDPf3CO8j/RvEQ4wVoap8vw==",
+      "license": "MIT",
+      "dependencies": {
+        "@azure-tools/rlc-common": "^0.38.6",
+        "fs-extra": "^11.1.0",
+        "lodash": "^4.17.21",
+        "prettier": "^3.3.3",
+        "ts-morph": "^23.0.0",
+        "tslib": "^2.3.1"
+      },
+      "peerDependencies": {
+        "@azure-tools/typespec-azure-core": ">=0.54.0 <1.0.0",
+        "@azure-tools/typespec-client-generator-core": ">=0.54.0 <1.0.0",
+        "@typespec/compiler": "^1.0.0-0",
+        "@typespec/http": "^1.0.0-0",
+        "@typespec/rest": ">=0.68.0 <1.0.0",
+        "@typespec/versioning": ">=0.68.0 <1.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.26.2",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
+      "integrity": "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
+      "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@inquirer/checkbox": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/checkbox/-/checkbox-4.1.5.tgz",
+      "integrity": "sha512-swPczVU+at65xa5uPfNP9u3qx/alNwiaykiI/ExpsmMSQW55trmZcwhYWzw/7fj+n6Q8z1eENvR7vFfq9oPSAQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.6",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/confirm": {
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/confirm/-/confirm-5.1.9.tgz",
+      "integrity": "sha512-NgQCnHqFTjF7Ys2fsqK2WtnA8X1kHyInyG+nMIuHowVTIgIuS10T4AznI/PvbqSpJqjCUqNBlKGh1v3bwLFL4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/core": {
+      "version": "10.1.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-10.1.10.tgz",
+      "integrity": "sha512-roDaKeY1PYY0aCqhRmXihrHjoSW2A00pV3Ke5fTpMCkzcGF64R8e0lw3dK+eLEHwS4vB5RnW1wuQmvzoRul8Mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.6",
+        "ansi-escapes": "^4.3.2",
+        "cli-width": "^4.1.0",
+        "mute-stream": "^2.0.0",
+        "signal-exit": "^4.1.0",
+        "wrap-ansi": "^6.2.0",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/editor": {
+      "version": "4.2.10",
+      "resolved": "https://registry.npmjs.org/@inquirer/editor/-/editor-4.2.10.tgz",
+      "integrity": "sha512-5GVWJ+qeI6BzR6TIInLP9SXhWCEcvgFQYmcRG6d6RIlhFjM5TyG18paTGBgRYyEouvCmzeco47x9zX9tQEofkw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6",
+        "external-editor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/expand": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/expand/-/expand-4.0.12.tgz",
+      "integrity": "sha512-jV8QoZE1fC0vPe6TnsOfig+qwu7Iza1pkXoUJ3SroRagrt2hxiL+RbM432YAihNR7m7XnU0HWl/WQ35RIGmXHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/figures": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-1.0.11.tgz",
+      "integrity": "sha512-eOg92lvrn/aRUqbxRyvpEWnrvRuTYRifixHkYVpJiygTgVSBIHDqLh0SrMQXkafvULg3ck11V7xvR+zcgvpHFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-4.1.9.tgz",
+      "integrity": "sha512-mshNG24Ij5KqsQtOZMgj5TwEjIf+F2HOESk6bjMwGWgcH5UBe8UoljwzNFHqdMbGYbgAf6v2wU/X9CAdKJzgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/number": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/number/-/number-3.0.12.tgz",
+      "integrity": "sha512-7HRFHxbPCA4e4jMxTQglHJwP+v/kpFsCf2szzfBHy98Wlc3L08HL76UDiA87TOdX5fwj2HMOLWqRWv9Pnn+Z5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/password": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/password/-/password-4.0.12.tgz",
+      "integrity": "sha512-FlOB0zvuELPEbnBYiPaOdJIaDzb2PmJ7ghi/SVwIHDDSQ2K4opGBkF+5kXOg6ucrtSUQdLhVVY5tycH0j0l+0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6",
+        "ansi-escapes": "^4.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/prompts": {
+      "version": "7.4.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.4.1.tgz",
+      "integrity": "sha512-UlmM5FVOZF0gpoe1PT/jN4vk8JmpIWBlMvTL8M+hlvPmzN89K6z03+IFmyeu/oFCenwdwHDr2gky7nIGSEVvlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/checkbox": "^4.1.5",
+        "@inquirer/confirm": "^5.1.9",
+        "@inquirer/editor": "^4.2.10",
+        "@inquirer/expand": "^4.0.12",
+        "@inquirer/input": "^4.1.9",
+        "@inquirer/number": "^3.0.12",
+        "@inquirer/password": "^4.0.12",
+        "@inquirer/rawlist": "^4.0.12",
+        "@inquirer/search": "^3.0.12",
+        "@inquirer/select": "^4.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/rawlist": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/rawlist/-/rawlist-4.0.12.tgz",
+      "integrity": "sha512-wNPJZy8Oc7RyGISPxp9/MpTOqX8lr0r+lCCWm7hQra+MDtYRgINv1hxw7R+vKP71Bu/3LszabxOodfV/uTfsaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/type": "^3.0.6",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/search": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@inquirer/search/-/search-3.0.12.tgz",
+      "integrity": "sha512-H/kDJA3kNlnNIjB8YsaXoQI0Qccgf0Na14K1h8ExWhNmUg2E941dyFPrZeugihEa9AZNW5NdsD/NcvUME83OPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.6",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/select": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@inquirer/select/-/select-4.1.1.tgz",
+      "integrity": "sha512-IUXzzTKVdiVNMA+2yUvPxWsSgOG4kfX93jOM4Zb5FgujeInotv5SPIJVeXQ+fO4xu7tW8VowFhdG5JRmmCyQ1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^10.1.10",
+        "@inquirer/figures": "^1.0.11",
+        "@inquirer/type": "^3.0.6",
+        "ansi-escapes": "^4.3.2",
+        "yoctocolors-cjs": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@inquirer/type": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-3.0.6.tgz",
+      "integrity": "sha512-/mKVCtVpyBu3IDarv0G+59KC4stsD5mDsGpYh+GKs1NZT88Jh52+cuoA1AtLk2Q0r/quNl+1cSUyLRHBFeD0XA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+      "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@ts-morph/common": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/@ts-morph/common/-/common-0.24.0.tgz",
+      "integrity": "sha512-c1xMmNHWpNselmpIqursHeOHHBTIsJLbB+NuovbTTRCNiTLEr/U9dbJ8qy0jd/O2x5pc3seWuOUN5R2IoOTp8A==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-glob": "^3.3.2",
+        "minimatch": "^9.0.4",
+        "mkdirp": "^3.0.1",
+        "path-browserify": "^1.0.1"
+      }
+    },
+    "node_modules/@typespec/compiler": {
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@typespec/compiler/-/compiler-1.0.0-rc.0.tgz",
+      "integrity": "sha512-2N5DCFzuPt5rPXReE4T1boZrG60sr3dTMgZOS/WX+Rosc6iFj2v1ULTI2ySXk/Abd3oxS5OR24l8veIWEi0lzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "~7.26.2",
+        "@inquirer/prompts": "^7.4.0",
+        "ajv": "~8.17.1",
+        "change-case": "~5.4.4",
+        "env-paths": "^3.0.0",
+        "globby": "~14.1.0",
+        "is-unicode-supported": "^2.1.0",
+        "mustache": "~4.2.0",
+        "picocolors": "~1.1.1",
+        "prettier": "~3.5.3",
+        "semver": "^7.7.1",
+        "tar": "^7.4.3",
+        "temporal-polyfill": "^0.2.5",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.12",
+        "yaml": "~2.7.0",
+        "yargs": "~17.7.2"
+      },
+      "bin": {
+        "tsp": "cmd/tsp.js",
+        "tsp-server": "cmd/tsp-server.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@typespec/events": {
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/events/-/events-0.68.0.tgz",
+      "integrity": "sha512-U2y9K8QJ6HsmNxEyHz2aG2bmD05FIsLkmIZgmNaHDwhN1oyI8EH1NkxvwZCnEkPAN7ReuLYK6blouWFWX3s5eg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@typespec/http": {
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@typespec/http/-/http-1.0.0-rc.0.tgz",
+      "integrity": "sha512-Or2hhDXy8DZZoy3B/HudSrRHTFomiv6DI3vRpPKYT9ocIAxMGo1hQvqKye8uVk/QIMn/ouv6JUlP+pqjpfnPyw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/streams": "^0.68.0"
+      },
+      "peerDependenciesMeta": {
+        "@typespec/streams": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typespec/openapi": {
+      "version": "1.0.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@typespec/openapi/-/openapi-1.0.0-rc.0.tgz",
+      "integrity": "sha512-aswkRlzFI44CGe05qkzInA7jEhUKNxZYToYi5kXz05Jl5d4nh4VeEkCweb2pRL+4LKd2SZiOn09nXm+OKp5EoQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/http": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@typespec/rest": {
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/rest/-/rest-0.68.0.tgz",
+      "integrity": "sha512-VJBEpC0MCFPPN6acc5o0fwQm4WMjMEl3aBHE+71XYkagsqb31rYSyfgfBMvHWaEMJV4dVk5T787/q6AWDzEE8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/http": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@typespec/sse": {
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/sse/-/sse-0.68.0.tgz",
+      "integrity": "sha512-sePc+14iw8BZjBPwBaCL23y7lDWrUtmoYuPbfxJhRcIzbv2ww5d7mjvv5C2fjWyfRvG7tJ6wDk8YoHQJDoqtVA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.0.0-rc.0",
+        "@typespec/events": "^0.68.0",
+        "@typespec/http": "^1.0.0-rc.0",
+        "@typespec/streams": "^0.68.0"
+      }
+    },
+    "node_modules/@typespec/streams": {
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/streams/-/streams-0.68.0.tgz",
+      "integrity": "sha512-FsyPYOcPA6CDptdsAI0kiwR9tG6pngf5Bi4PiKTsXwseu93v5Y4keLNr4SR+bNQQK6uYIm0OkoK34Z6qn6uZEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@typespec/versioning": {
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/versioning/-/versioning-0.68.0.tgz",
+      "integrity": "sha512-nsK0hbOeqfsNo1dsP64A4Ks0C/FEk5WJ5LEfgTwvFGdE48mHrj7UJdp58Ps5F6moiR9U20P1rHbo+mE0LDIRvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/@typespec/xml": {
+      "version": "0.68.0",
+      "resolved": "https://registry.npmjs.org/@typespec/xml/-/xml-0.68.0.tgz",
+      "integrity": "sha512-uB904g9KMkuYKmGZnJsuozjPX+AKzZNStdXvMLq8+TkOitpJcb1dHtFH6KufG21xWuF0bmRUSkJvO4MOsuQNLA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@typespec/compiler": "^1.0.0-rc.0"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-escapes": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.21.3"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "license": "MIT"
+    },
+    "node_modules/chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "license": "MIT"
+    },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+      "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cli-width": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-4.1.0.tgz",
+      "integrity": "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/code-block-writer": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-13.0.3.tgz",
+      "integrity": "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==",
+      "license": "MIT"
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/env-paths": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
+      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/external-editor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+      "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
+      "license": "MIT",
+      "dependencies": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
+      "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/fastq": {
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.14"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/handlebars": {
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.8.tgz",
+      "integrity": "sha512-vafaFqs8MZkRrSX7sFVUdo3ap/eNiLnb4IakshzvP56X5Nr1iGKAIqdX6tMlm6HcNRIkr6AxO5jFEoJzzpT8aQ==",
+      "license": "MIT",
+      "dependencies": {
+        "minimist": "^1.2.5",
+        "neo-async": "^2.6.2",
+        "source-map": "^0.6.1",
+        "wordwrap": "^1.0.0"
+      },
+      "bin": {
+        "handlebars": "bin/handlebars"
+      },
+      "engines": {
+        "node": ">=0.4.7"
+      },
+      "optionalDependencies": {
+        "uglify-js": "^3.1.4"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.3.tgz",
+      "integrity": "sha512-bAH5jbK/F3T3Jls4I0SO1hmPR0dKU0a7+SY6n1yzRtG54FLO8d6w/nxLFX2Nb7dBu6cCWXPaAME6cYqFUMmuCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
+      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "license": "MIT"
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
+      "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.0.2.tgz",
+      "integrity": "sha512-oG62iEk+CYt5Xj2YqI5Xi9xWUeZhDI8jjQmC5oThVH5JGCTgIjr7ciJDzC7MBzYd//WvR1OTmP5Q38Q8ShQtVA==",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-3.0.1.tgz",
+      "integrity": "sha512-+NsyUUAZDmo6YVHzL/stxSu3t9YS1iljliy3BSDrXJ/dkn1KYdmtZODGGjLcc9XLgVVpH4KshHB8XmZgMhaBXg==",
+      "license": "MIT",
+      "bin": {
+        "mkdirp": "dist/cjs/src/bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/mustache": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
+      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
+      "license": "MIT",
+      "bin": {
+        "mustache": "bin/mustache"
+      }
+    },
+    "node_modules/mute-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-2.0.0.tgz",
+      "integrity": "sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^18.17.0 || >=20.5.0"
+      }
+    },
+    "node_modules/neo-async": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
+      "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
+      "license": "MIT"
+    },
+    "node_modules/os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "license": "MIT"
+    },
+    "node_modules/path-type": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.3.tgz",
+      "integrity": "sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==",
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.4.3.tgz",
+      "integrity": "sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==",
+      "license": "ISC",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.0.1",
+        "mkdirp": "^3.0.1",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/temporal-polyfill": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.2.5.tgz",
+      "integrity": "sha512-ye47xp8Cb0nDguAhrrDS1JT1SzwEV9e26sSsrWzVu+yPZ7LzceEcH0i2gci9jWfOfSCCgM3Qv5nOYShVUUFUXA==",
+      "license": "MIT",
+      "dependencies": {
+        "temporal-spec": "^0.2.4"
+      }
+    },
+    "node_modules/temporal-spec": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.2.4.tgz",
+      "integrity": "sha512-lDMFv4nKQrSjlkHKAlHVqKrBG4DyFfa9F74cmBZ3Iy3ed8yvWnlWSIdi4IKfSqwmazAohBNwiN64qGx4y5Q3IQ==",
+      "license": "ISC"
+    },
+    "node_modules/tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-morph": {
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/ts-morph/-/ts-morph-23.0.0.tgz",
+      "integrity": "sha512-FcvFx7a9E8TUe6T3ShihXJLiJOiqyafzFKUO4aqIHDUCIvADdGNShcbc2W5PMr3LerXRv7mafvFZ9lRENxJmug==",
+      "license": "MIT",
+      "dependencies": {
+        "@ts-morph/common": "~0.24.0",
+        "code-block-writer": "^13.0.1"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "0.21.3",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/uglify-js": {
+      "version": "3.19.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
+      "integrity": "sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==",
+      "license": "BSD-2-Clause",
+      "optional": true,
+      "bin": {
+        "uglifyjs": "bin/uglifyjs"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/unicorn-magic": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
+      "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+      "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.1.tgz",
+      "integrity": "sha512-10ULxpnOCQXxJvBgxsn9ptjq6uviG/htZKk9veJGhlqn3w/DxQ631zFF+nlQXLwmImeS5amR2dl2U8sg6U9jsQ==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yoctocolors-cjs": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yoctocolors-cjs/-/yoctocolors-cjs-2.1.2.tgz",
+      "integrity": "sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    }
+  }
+}

--- a/tools/tsp-client/test/utils/alternate-emitter-package.json
+++ b/tools/tsp-client/test/utils/alternate-emitter-package.json
@@ -1,0 +1,15 @@
+{
+  "name": "typescript-emitter-package",
+  "main": "dist/src/index.js",
+  "dependencies": {
+    "@azure-tools/typespec-ts": "0.38.6"
+  },
+  "devDependencies": {
+    "@azure-tools/typespec-azure-core": ">=0.54.0 <1.0.0",
+    "@azure-tools/typespec-client-generator-core": ">=0.54.0 <1.0.0",
+    "@typespec/compiler": "^1.0.0-0",
+    "@typespec/http": "^1.0.0-0",
+    "@typespec/rest": ">=0.68.0 <1.0.0",
+    "@typespec/versioning": ">=0.68.0 <1.0.0"
+  }
+}

--- a/tools/tsp-client/test/utils/alternate-emitter-package.json
+++ b/tools/tsp-client/test/utils/alternate-emitter-package.json
@@ -2,14 +2,15 @@
   "name": "typescript-emitter-package",
   "main": "dist/src/index.js",
   "dependencies": {
-    "@azure-tools/typespec-ts": "0.38.6"
+    "@azure-tools/typespec-ts": "0.38.5"
   },
   "devDependencies": {
-    "@azure-tools/typespec-azure-core": ">=0.54.0 <1.0.0",
-    "@azure-tools/typespec-client-generator-core": ">=0.54.0 <1.0.0",
-    "@typespec/compiler": "^1.0.0-0",
-    "@typespec/http": "^1.0.0-0",
-    "@typespec/rest": ">=0.68.0 <1.0.0",
-    "@typespec/versioning": ">=0.68.0 <1.0.0"
+    "@azure-tools/typespec-azure-core": "0.53.0",
+    "@azure-tools/typespec-client-generator-core": "0.53.1",
+    "@azure-tools/typespec-azure-rulesets": "0.53.0",
+    "@typespec/compiler": "0.67.1",
+    "@typespec/http": "0.67.1",
+    "@typespec/rest": "0.67.1",
+    "@typespec/versioning": "0.67.1"
   }
 }


### PR DESCRIPTION
- Use repo root for emitter-package path and match package-lock naming with specified emitter path
- include azure-typespec scope in emitter list
- Update generate-config/generate-lockfile commands

Contributes to https://github.com/Azure/azure-sdk-for-net/issues/49240