### PR TITLE
[rust-api-parser] Enhance `use` item rendering

### DIFF
--- a/tools/apiview/parsers/rust-api-parser/CHANGELOG.md
+++ b/tools/apiview/parsers/rust-api-parser/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.0.2
+# 1.1.0 [Unreleased]
 
 Updated the parser
 

--- a/tools/apiview/parsers/rust-api-parser/CHANGELOG.md
+++ b/tools/apiview/parsers/rust-api-parser/CHANGELOG.md
@@ -1,4 +1,9 @@
+# 1.0.2
+
+Updated the parser
+
 # 1.0.1
+
 Updated the parser to handle multi-line doc comments and `ReviewLine`s to improve rendering in the API View tool, due to a breaking change in the API View tool's handling of multi-line `ReviewLine`.
 
 # 1.0.0

--- a/tools/apiview/parsers/rust-api-parser/CHANGELOG.md
+++ b/tools/apiview/parsers/rust-api-parser/CHANGELOG.md
@@ -1,6 +1,9 @@
-# 1.1.0 [Unreleased]
+# 1.1.0 
 
-Updated the parser
+Enhanced rendering of `use` items to more closely match the rustdoc (docs.rs) HTML view:
+- Improved handling of `use` items and module re-exports with better tracking to prevent duplication
+- Refactored module processing with enhanced sorting and organization of child items
+- Fixed bugs and improved utility functions for better code maintainability
 
 # 1.0.1
 

--- a/tools/apiview/parsers/rust-api-parser/package.json
+++ b/tools/apiview/parsers/rust-api-parser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/rust-genapi",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "",
   "main": "index.js",
   "publishConfig": {

--- a/tools/apiview/parsers/rust-api-parser/src/main.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/main.ts
@@ -94,7 +94,7 @@ function buildCodeFile(): CodeFile {
   const codeFile: CodeFile = {
     PackageName: apiJson.index[apiJson.root].name || "unknown",
     PackageVersion: apiJson["crate_version"] || "unknown",
-    ParserVersion: "1.0.0",
+    ParserVersion: "1.1.0",
     Language: "Rust",
     ReviewLines: [],
   };

--- a/tools/apiview/parsers/rust-api-parser/src/main.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/main.ts
@@ -1,11 +1,12 @@
 import * as fs from "fs";
 import { processItem } from "./process-items/processItem";
 import { CodeFile, ReviewLine, TokenKind } from "./models/apiview-models";
-import { Crate, FORMAT_VERSION, ItemKind } from "../rustdoc-types/output/rustdoc-types";
+import { Crate, FORMAT_VERSION } from "../rustdoc-types/output/rustdoc-types";
 import { reexportLines } from "./process-items/processUse";
-import { itemKindOrder, sortExternalItems } from "./process-items/utils/sorting";
+import { sortExternalItems } from "./process-items/utils/sorting";
 
 let apiJson: Crate;
+export let PACKAGE_NAME: string;
 export function getAPIJson(): Crate {
   return apiJson;
 }
@@ -141,6 +142,7 @@ function buildCodeFile(): CodeFile {
     Language: "Rust",
     ReviewLines: [],
   };
+  PACKAGE_NAME = codeFile.PackageName;
 
   processRootItem(codeFile);
   processInternalReexports(codeFile);

--- a/tools/apiview/parsers/rust-api-parser/src/main.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/main.ts
@@ -23,17 +23,6 @@ function processRootItem(codeFile: CodeFile): void {
 }
 
 /**
- * Processes internal reexport lines and adds them to the code file
- * @param codeFile The code file to add review lines to
- */
-function processInternalReexports(codeFile: CodeFile): void {
-  if (reexportLines.internal.length > 0) {
-    addSectionHeader(codeFile, "Internal module re-exports");
-    codeFile.ReviewLines.push(...reexportLines.internal);
-  }
-}
-
-/**
  * Adds a section header to the code file
  * @param codeFile The code file to add the header to
  * @param headerText The header text
@@ -145,7 +134,6 @@ function buildCodeFile(): CodeFile {
   PACKAGE_NAME = codeFile.PackageName;
 
   processRootItem(codeFile);
-  processInternalReexports(codeFile);
   processExternalModuleReexports(codeFile);
   processExternalItemReexports(codeFile);
   addSectionHeader(codeFile, "End");

--- a/tools/apiview/parsers/rust-api-parser/src/main.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/main.ts
@@ -2,7 +2,7 @@ import * as fs from "fs";
 import { processItem } from "./process-items/processItem";
 import { CodeFile, ReviewLine, TokenKind } from "./models/apiview-models";
 import { Crate, FORMAT_VERSION } from "../rustdoc-types/output/rustdoc-types";
-import { reexportLines } from "./process-items/processUse";
+import { reexportLines } from "./process-items/utils/externalReexports";
 import { sortExternalItems } from "./process-items/utils/sorting";
 
 let apiJson: Crate;
@@ -69,7 +69,7 @@ function isItemAlreadyIncludedInModules(reexportItem: ReviewLine): boolean {
  */
 function processExternalItemReexports(codeFile: CodeFile): void {
   if (reexportLines.external.items.length > 0) {
-    addSectionHeader(codeFile, "External items");
+    addSectionHeader(codeFile, "External references");
 
     // Sort the external items by kind (using itemKindOrder) and then by name
     sortExternalItems(reexportLines.external.items);

--- a/tools/apiview/parsers/rust-api-parser/src/main.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/main.ts
@@ -43,39 +43,6 @@ function addSectionHeader(codeFile: CodeFile, headerText: string): void {
 }
 
 /**
- * Processes external module reexports and adds them to the code file
- * @param codeFile The code file to add review lines to
- */
-function processExternalModuleReexports(codeFile: CodeFile): void {
-  if (reexportLines.external.items.length > 0) {
-    addSectionHeader(codeFile, "External module re-exports");
-
-    // Separate modules with and without RelatedToLine
-    const modulesWithRelatedToLine: { [LinedId: string]: ReviewLine } = {};
-    const modulesWithoutRelatedToLine = [];
-
-    for (const module of reexportLines.external.modules) {
-      if (!module.RelatedToLine) {
-        modulesWithoutRelatedToLine.push(module);
-      } else {
-        modulesWithRelatedToLine[module.RelatedToLine] = module;
-      }
-    }
-
-    // Sort only the modules without RelatedToLine
-    sortExternalItems(modulesWithoutRelatedToLine);
-
-    // Add to the code file
-    for (const module of modulesWithoutRelatedToLine) {
-      codeFile.ReviewLines.push(module);
-      if (module.LineId in modulesWithRelatedToLine) {
-        codeFile.ReviewLines.push(modulesWithRelatedToLine[module.LineId]);
-      }
-    }
-  }
-}
-
-/**
  * Checks if an item is already included in any of the external modules
  * @param reexportItem The item to check
  * @returns Whether the item is already included
@@ -134,10 +101,7 @@ function buildCodeFile(): CodeFile {
   PACKAGE_NAME = codeFile.PackageName;
 
   processRootItem(codeFile);
-  processExternalModuleReexports(codeFile);
   processExternalItemReexports(codeFile);
-  addSectionHeader(codeFile, "End");
-
   return codeFile;
 }
 

--- a/tools/apiview/parsers/rust-api-parser/src/main.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/main.ts
@@ -1,11 +1,12 @@
 import * as fs from "fs";
 import { processItem } from "./process-items/processItem";
 import { CodeFile, TokenKind } from "./models/apiview-models";
-import { Crate, FORMAT_VERSION } from "../rustdoc-types/output/rustdoc-types";
+import { Crate, FORMAT_VERSION, Id } from "../rustdoc-types/output/rustdoc-types";
 import { externalReferencesLines } from "./process-items/utils/externalReexports";
 import { sortExternalItems } from "./process-items/utils/sorting";
 
 let apiJson: Crate;
+export const processedItems = new Set<number>();
 export let PACKAGE_NAME: string;
 export function getAPIJson(): Crate {
   return apiJson;

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocConst.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocConst.ts
@@ -12,7 +12,7 @@ import { isAssocConstItem } from "./utils/typeGuards";
  */
 export function processAssocConst(item: Item): ReviewLine[] | null {
   if (!isAssocConstItem(item)) return null;
-  const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item): [];
+  const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
   // Create the ReviewLine object
   const reviewLine: ReviewLine = {

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processEnum.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processEnum.ts
@@ -43,6 +43,7 @@ export function processEnum(item: Item): ReviewLine[] {
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,
     RenderClasses: ["enum"],
+    HasSuffixSpace: false,
   });
 
   const genericsTokens = processGenerics(item.inner.enum.generics);
@@ -59,6 +60,7 @@ export function processEnum(item: Item): ReviewLine[] {
   enumLine.Tokens.push({
     Kind: TokenKind.Punctuation,
     Value: "{",
+    HasPrefixSpace: true,
   });
 
   // Process enum variants

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processItem.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processItem.ts
@@ -25,10 +25,13 @@ import { processAssocType } from "./processAssocType";
  * @param {Item} item - The item to process.
  * @returns {ReviewLine | null} The ReviewLine object or null if the item is not processed.
  */
-export function processItem(item: Item): ReviewLine[] | null {
+export function processItem(
+  item: Item,
+  parentModule?: { prefix: string; id: number },
+): ReviewLine[] | null {
   if (typeof item.inner === "object") {
     if ("module" in item.inner) {
-      return processModule(item);
+      return processModule(item, parentModule);
     } else if ("use" in item.inner) {
       return processUse(item);
     } else if ("union" in item.inner) {

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processItem.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processItem.ts
@@ -35,8 +35,6 @@ export function processItem(
   if (typeof item.inner === "object") {
     if ("module" in item.inner) {
       return processModule(item, parentModule);
-    } else if ("use" in item.inner) {
-      return processUse(item);
     } else if ("union" in item.inner) {
       return processUnion(item);
     } else if ("struct" in item.inner) {

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processItem.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processItem.ts
@@ -29,6 +29,9 @@ export function processItem(
   item: Item,
   parentModule?: { prefix: string; id: number },
 ): ReviewLine[] | null {
+  if (!item) {
+    return null;
+  }
   if (typeof item.inner === "object") {
     if ("module" in item.inner) {
       return processModule(item, parentModule);

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processMacro.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processMacro.ts
@@ -15,8 +15,8 @@ export function processMacro(item: Item): ReviewLine[] | null {
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
   // Split the macro value by newlines
-  const macroLines = item.inner.macro.split('\n');
-  
+  const macroLines = item.inner.macro.split("\n");
+
   // Create ReviewLines for each macro line
   macroLines.forEach((line, index) => {
     const reviewLine: ReviewLine = {

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processModule.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processModule.ts
@@ -185,7 +185,7 @@ function processModuleChildren(
         moduleReviewLine.Children.push(...childReviewLines.filter((line) => line != null));
         nonModuleChildrenExist = true;
       }
-    }// else-case handled at processUse
+    } // else-case handled at processUse
   }
 
   // Process module children (siblings)
@@ -206,10 +206,15 @@ function processModuleChildren(
       }
     } else if (moduleChildId in apiJson.paths) {
       // Handle external modules re-exported into this scope
-      const externalModules = processModuleReexport(moduleChildId, apiJson.paths[moduleChildId],apiJson, {
-        id: item.id,
-        prefix: modulePrefix,
-      });
+      const externalModules = processModuleReexport(
+        moduleChildId,
+        apiJson.paths[moduleChildId],
+        apiJson,
+        {
+          id: item.id,
+          prefix: modulePrefix,
+        },
+      );
       siblingModuleLines.push(...externalModules);
     }
   }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processStruct.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processStruct.ts
@@ -51,6 +51,7 @@ export function processStruct(item: Item): ReviewLine[] {
     RenderClasses: ["struct"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,
+    HasSuffixSpace: false,
   });
 
   const genericsTokens = processGenerics(item.inner.struct.generics);
@@ -74,6 +75,7 @@ export function processStruct(item: Item): ReviewLine[] {
       Kind: TokenKind.Punctuation,
       Value: "{",
       HasSuffixSpace: false,
+      HasPrefixSpace: true,
     });
     item.inner.struct.kind.plain.fields.forEach((fieldId: number) => {
       const fieldItem = apiJson.index[fieldId];

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUnion.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUnion.ts
@@ -50,6 +50,7 @@ export function processUnion(item: Item): ReviewLine[] {
     RenderClasses: ["struct"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,
+    HasSuffixSpace: false,
   });
 
   const genericsTokens = processGenerics(item.inner.union.generics);
@@ -66,6 +67,7 @@ export function processUnion(item: Item): ReviewLine[] {
   unionLine.Tokens.push({
     Kind: TokenKind.Punctuation,
     Value: "{",
+    HasPrefixSpace: true,
   });
 
   // Process fields

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -4,7 +4,7 @@ import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isModuleItem, isUseItem } from "./utils/typeGuards";
 import { processItem } from "./processItem";
 import { externalReexports } from "./utils/externalReexports";
-import { getAPIJson } from "../main";
+import { getAPIJson, PACKAGE_NAME } from "../main";
 
 export const reexportLines: {
   internal: ReviewLine[];
@@ -37,10 +37,22 @@ export function processUse(item: Item): ReviewLine[] | undefined {
 
   reviewLine.Tokens.push({
     Kind: TokenKind.TypeName,
-    Value: useValue,
+    Value: item.inner.use.name,
+  });
+
+  reviewLine.Tokens.push({
+    Kind: TokenKind.Punctuation,
+    Value: "=",
+  });
+
+  reviewLine.Tokens.push({
+    Kind: TokenKind.TypeName,
+    Value: useValue.startsWith("crate::")
+      ? useValue.replace("crate::", `${PACKAGE_NAME}::`) // replace "crate" with root mod name
+      : useValue,
     RenderClasses: ["dependencies"],
     NavigateToId: item.inner.use.id.toString(),
-    NavigationDisplayName: useValue,
+    NavigationDisplayName: item.inner.use.name,
   });
 
   reviewLines.push(reviewLine);

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -1,15 +1,15 @@
 import { ReviewLine, TokenKind } from "../models/apiview-models";
-import { Item, ItemKind, Crate, Id } from "../../rustdoc-types/output/rustdoc-types";
+import { Item, ItemKind } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isModuleItem, isUseItem } from "./utils/typeGuards";
-import { addExternalReexportIfNotExists } from "./utils/externalReexports";
+import { addExternalReferencesIfNotExists } from "./utils/externalReexports";
 import { getAPIJson } from "../main";
 import { replaceCratePath } from "./utils/cratePathUtils";
 
 export function processUse(item: Item): ReviewLine[] | undefined {
   if (!isUseItem(item)) return;
   const apiJson = getAPIJson();
-  // code path where use items are modules is handled in processModule
+  // code path where use items are "modules" is handled in processModule
   const useItemId = item.inner.use.id;
   if (
     (useItemId in apiJson.index && isModuleItem(apiJson.index[useItemId])) ||
@@ -53,7 +53,7 @@ export function processUse(item: Item): ReviewLine[] | undefined {
   });
 
   reviewLines.push(reviewLine);
-  addExternalReexportIfNotExists(useItemId);
+  addExternalReferencesIfNotExists(useItemId);
 
   return reviewLines;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -1,5 +1,5 @@
 import { ReviewLine, TokenKind } from "../models/apiview-models";
-import { Item } from "../../rustdoc-types/output/rustdoc-types";
+import { Item, ItemKind } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isModuleItem, isUseItem } from "./utils/typeGuards";
 import { processItem } from "./processItem";
@@ -18,6 +18,15 @@ export const reexportLines: {
 export function processUse(item: Item): ReviewLine[] | undefined {
   if (!isUseItem(item)) return;
   const apiJson = getAPIJson();
+  // code path where use items are modules is handled in processModule
+  const useItemId = item.inner.use.id;
+  if (
+    (useItemId in apiJson.index && isModuleItem(apiJson.index[useItemId])) ||
+    (useItemId in apiJson.paths && apiJson.paths[useItemId].kind == ItemKind.Module)
+  ) {
+    return;
+  }
+
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
   const reviewLine: ReviewLine = {
@@ -26,108 +35,39 @@ export function processUse(item: Item): ReviewLine[] | undefined {
     Children: [],
   };
 
+  let useValue = item.inner.use.source || "null";
+
+  // for all the non-module use items
   reviewLine.Tokens.push({
     Kind: TokenKind.Keyword,
     Value: "pub use",
   });
 
-  let useValue = item.inner.use.source || "null";
-  if (item.inner.use.is_glob) {
-    useValue += "::*";
-    reviewLine.Tokens.push({
-      Kind: TokenKind.TypeName,
-      Value: useValue,
-      RenderClasses: ["dependencies"],
-      NavigateToId: item.inner.use.id.toString(),
-      NavigationDisplayName: useValue,
-    });
-  } else {
-    reviewLine.Tokens.push({
-      Kind: TokenKind.TypeName,
-      Value: item.inner.use.name,
-    });
+  reviewLine.Tokens.push({
+    Kind: TokenKind.Text,
+    Value: item.inner.use.name,
+  });
 
-    reviewLine.Tokens.push({
-      Kind: TokenKind.Punctuation,
-      Value: "=",
-    });
+  reviewLine.Tokens.push({
+    Kind: TokenKind.Punctuation,
+    Value: "=",
+  });
 
-    reviewLine.Tokens.push({
-      Kind: TokenKind.TypeName,
-      Value: replaceCratePath(useValue),
-      RenderClasses: ["dependencies"],
-      NavigateToId: item.inner.use.id.toString(),
-      NavigationDisplayName: item.inner.use.name,
-    });
-  }
+  reviewLine.Tokens.push({
+    Kind: TokenKind.TypeName,
+    Value: replaceCratePath(useValue),
+    RenderClasses: ["dependencies"],
+    NavigateToId: useItemId.toString(),
+    NavigationDisplayName: item.inner.use.name,
+  });
 
   reviewLines.push(reviewLine);
-
-  if (item.inner.use.id in apiJson.index) {
-    // non external crates
-
-    // 1. Option 1 is to make them all children of "use" line
-    // reviewLine.Children = processItem(apiJson.index[item.inner.use.id], apiJson);
-
-    // 2. Option 2 is to dump them all globally to the parent module
-    // reexportLines.internal.push(...processItem(apiJson.index[item.inner.use.id], apiJson));
-
-    // 3. Option 3 is a revised version of option 2
-    // Dumps them all, but manages to keep the structure by encapsulating them in modules
-    // for the re-exports in the crate
-    if (isModuleItem(apiJson.index[item.inner.use.id])) {
-      reexportLines.internal.push(...processItem(apiJson.index[item.inner.use.id]));
-    } else {
-      // Extract the base path by removing the item name from the source
-      const useSource = replaceCratePath(item.inner.use.source);
-      const useName = apiJson.index[item.inner.use.id].name || "";
-      // Get the base path by removing the name from the end of the source
-      const basePath = useSource.endsWith(useName)
-        ? useSource.substring(0, useSource.length - useName.length - 2) // -2 for ::
-        : useSource;
-
-      const reviewLine: ReviewLine = {
-        LineId: apiJson.index[item.inner.use.id].id.toString() + "_reexport_parent",
-        Tokens: [
-          {
-            Kind: TokenKind.Keyword,
-            Value: "pub mod",
-          },
-          {
-            Kind: TokenKind.TypeName,
-            Value: basePath,
-            RenderClasses: ["namespace"],
-            NavigateToId: apiJson.index[item.inner.use.id].id.toString() + "_reexport_parent",
-            NavigationDisplayName: basePath,
-          },
-          {
-            Kind: TokenKind.Punctuation,
-            Value: "{",
-            HasSuffixSpace: false,
-          },
-        ],
-        Children: processItem(apiJson.index[item.inner.use.id]),
-      };
-      reexportLines.internal.push(reviewLine);
-      reexportLines.internal.push({
-        RelatedToLine: apiJson.index[item.inner.use.id].id.toString() + "_reexport_parent",
-        Tokens: [
-          {
-            Kind: TokenKind.Punctuation,
-            Value: "}",
-          },
-        ],
-      });
-    }
-  } else if (item.inner.use.id in apiJson.paths) {
+  if (useItemId in apiJson.paths) {
     // for the re-exports in the external crates
-    const lines = externalReexports(item.inner.use.id);
-    if (
-      !reexportLines.external.items.some((line) => line.LineId === item.inner.use.id.toString())
-    ) {
+    const lines = externalReexports(useItemId);
+    if (!reexportLines.external.items.some((line) => line.LineId === useItemId.toString())) {
       reexportLines.external.items.push(...lines.items);
     }
-    reexportLines.external.modules.push(...lines.modules);
   }
 
   return reviewLines;

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -2,7 +2,6 @@ import { ReviewLine, TokenKind } from "../models/apiview-models";
 import { Item, ItemKind } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isModuleItem, isUseItem } from "./utils/typeGuards";
-import { processItem } from "./processItem";
 import { externalReexports } from "./utils/externalReexports";
 import { getAPIJson } from "../main";
 import { replaceCratePath } from "./utils/cratePathUtils";
@@ -64,9 +63,9 @@ export function processUse(item: Item): ReviewLine[] | undefined {
   reviewLines.push(reviewLine);
   if (useItemId in apiJson.paths) {
     // for the re-exports in the external crates
-    const lines = externalReexports(useItemId);
+    const lines = externalReexports(useItemId, apiJson);
     if (!reexportLines.external.items.some((line) => line.LineId === useItemId.toString())) {
-      reexportLines.external.items.push(...lines.items);
+      reexportLines.external.items.push(...lines);
     }
   }
 

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -4,7 +4,8 @@ import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isModuleItem, isUseItem } from "./utils/typeGuards";
 import { processItem } from "./processItem";
 import { externalReexports } from "./utils/externalReexports";
-import { getAPIJson, PACKAGE_NAME } from "../main";
+import { getAPIJson } from "../main";
+import { replaceCratePath } from "./utils/cratePathUtils";
 
 export const reexportLines: {
   internal: ReviewLine[];
@@ -47,9 +48,7 @@ export function processUse(item: Item): ReviewLine[] | undefined {
 
   reviewLine.Tokens.push({
     Kind: TokenKind.TypeName,
-    Value: useValue.startsWith("crate::")
-      ? useValue.replace("crate::", `${PACKAGE_NAME}::`) // replace "crate" with root mod name
-      : useValue,
+    Value: replaceCratePath(useValue),
     RenderClasses: ["dependencies"],
     NavigateToId: item.inner.use.id.toString(),
     NavigationDisplayName: item.inner.use.name,
@@ -73,7 +72,7 @@ export function processUse(item: Item): ReviewLine[] | undefined {
       reexportLines.internal.push(...processItem(apiJson.index[item.inner.use.id]));
     } else {
       // Extract the base path by removing the item name from the source
-      const useSource = item.inner.use.source || "";
+      const useSource = replaceCratePath(item.inner.use.source);
       const useName = apiJson.index[item.inner.use.id].name || "";
       // Get the base path by removing the name from the end of the source
       const basePath = useSource.endsWith(useName)

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -1,23 +1,13 @@
 import { ReviewLine, TokenKind } from "../models/apiview-models";
-import { Item, ItemKind } from "../../rustdoc-types/output/rustdoc-types";
+import { Item } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
-import { isModuleItem, isUseItem } from "./utils/typeGuards";
+import { isUseItem } from "./utils/typeGuards";
 import { addExternalReferencesIfNotExists } from "./utils/externalReexports";
-import { getAPIJson } from "../main";
 import { replaceCratePath } from "./utils/cratePathUtils";
 
 export function processUse(item: Item): ReviewLine[] | undefined {
   if (!isUseItem(item)) return;
-  const apiJson = getAPIJson();
-  // code path where use items are "modules" is handled in processModule
   const useItemId = item.inner.use.id;
-  if (
-    (useItemId in apiJson.index && isModuleItem(apiJson.index[useItemId])) ||
-    (useItemId in apiJson.paths && apiJson.paths[useItemId].kind == ItemKind.Module)
-  ) {
-    return;
-  }
-
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
   const reviewLine: ReviewLine = {

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -8,7 +8,7 @@ import {
   getModuleChildIdsByPath,
   processModuleReexport,
 } from "./utils/externalReexports";
-import { replaceCratePath } from "./utils/cratePathUtils";
+import { replaceCratePath } from "./utils/pathUtils";
 import { AnnotatedReviewLines } from "./utils/models";
 import { getAPIJson, processedItems } from "../main";
 import { processItem } from "./processItem";

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -55,7 +55,7 @@ export function processUse(item: Item, parentModule: { prefix: string; id: numbe
   // case 5: [ glob = false; module = false; in index or paths ] - simple use item
   else if (dereferencedId in apiJson.index) {
     let useValue = item.inner.use.source || "null";
-    annotatedReviewLines.children[dereferencedId] = [{
+    annotatedReviewLines.children[item.id] = [{
       Tokens: [{
         Kind: TokenKind.Keyword,
         Value: "pub use",

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -1,49 +1,80 @@
 import { ReviewLine, TokenKind } from "../models/apiview-models";
-import { Item } from "../../rustdoc-types/output/rustdoc-types";
+import { Item, ItemKind } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
-import { isUseItem } from "./utils/typeGuards";
-import { addExternalReferencesIfNotExists } from "./utils/externalReexports";
+import { isModuleItem, isUseItem } from "./utils/typeGuards";
+import { addExternalReferencesIfNotExists, createItemLineFromPath, getModuleChildIdsByPath, processModuleReexport } from "./utils/externalReexports";
 import { replaceCratePath } from "./utils/cratePathUtils";
+import { AnnotatedReviewLines } from "./utils/models";
+import { getAPIJson } from "../main";
+import { processItem } from "./processItem";
+import { processModule } from "./processModule";
 
-export function processUse(item: Item): ReviewLine[] | undefined {
-  if (!isUseItem(item)) return;
-  const useItemId = item.inner.use.id;
-  const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
-
-  const reviewLine: ReviewLine = {
-    LineId: item.id.toString(),
-    Tokens: [],
-    Children: [],
+export function processUse(item: Item, parentModule: { prefix: string; id: number } | undefined): AnnotatedReviewLines {
+  const annotatedReviewLines: AnnotatedReviewLines = {
+    siblingModule: {},
+    children: {},
   };
 
-  let useValue = item.inner.use.source || "null";
-
-  // for all the non-module use items
-  reviewLine.Tokens.push({
-    Kind: TokenKind.Keyword,
-    Value: "pub use",
-  });
-
-  reviewLine.Tokens.push({
-    Kind: TokenKind.Text,
-    Value: item.inner.use.name,
-  });
-
-  reviewLine.Tokens.push({
-    Kind: TokenKind.Punctuation,
-    Value: "=",
-  });
-
-  reviewLine.Tokens.push({
-    Kind: TokenKind.TypeName,
-    Value: replaceCratePath(useValue),
-    RenderClasses: ["dependencies"],
-    NavigateToId: useItemId.toString(),
-    NavigationDisplayName: item.inner.use.name,
-  });
-
-  reviewLines.push(reviewLine);
-  addExternalReferencesIfNotExists(useItemId);
-
-  return reviewLines;
+  if (!isUseItem(item)) return annotatedReviewLines;
+  const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
+  const apiJson = getAPIJson()
+  const dereferencedId = item.inner.use.id;
+  if (item.inner.use.is_glob) {
+    // case 1: [ glob = true; module = true; in index ] - collapse all the children on to the parent
+    if ((dereferencedId in apiJson.index) && isModuleItem(apiJson.index[dereferencedId])) {
+      // isModuleItem check is not needed, being extra careful
+      const moduleItems = apiJson.index[dereferencedId].inner.module.items;
+      moduleItems.forEach((childId) => {
+        if (isModuleItem(apiJson.index[childId])) {
+          annotatedReviewLines.siblingModule[childId] = processModule(apiJson.index[childId], /* TODO: add parent info */);
+        } else if (!isUseItem(apiJson.index[childId])) {
+          annotatedReviewLines.children[childId] = processItem(apiJson.index[childId]);
+        } else {
+          const useReviewLines = processUse(apiJson.index[childId], parentModule);
+          annotatedReviewLines.siblingModule[childId] = useReviewLines.siblingModule[childId];
+          annotatedReviewLines.children[childId] = useReviewLines.children[childId];
+        }
+      });
+    }
+    // case 2: [ glob = true; module = true; in paths ] - collapse all the children on to the parent
+    else if (dereferencedId in apiJson.paths && (apiJson.paths[dereferencedId].kind === ItemKind.Module)) {
+      const moduleChildIds = getModuleChildIdsByPath(apiJson.paths[dereferencedId].path.join("::"), apiJson);
+      moduleChildIds.forEach((childId) => {
+        annotatedReviewLines.children[childId] = [createItemLineFromPath(childId, apiJson.paths[childId])];
+      });
+    }
+  }
+  // case 3: [ glob = false; module = true; in index ] - sibling module
+  else if ((dereferencedId in apiJson.index) && (isModuleItem(apiJson.index[dereferencedId]))) {
+    annotatedReviewLines.siblingModule[dereferencedId] = processModule(apiJson.index[dereferencedId], parentModule);
+  }
+  // case 4: [ glob = false; module = true; in paths ] - sibling module with a mention of re-export
+  else if ((dereferencedId in apiJson.paths) && (apiJson.paths[dereferencedId].kind === ItemKind.Module)) {
+    annotatedReviewLines.siblingModule[dereferencedId] = processModuleReexport(dereferencedId, apiJson.paths[dereferencedId], apiJson, parentModule);
+  }
+  // case 5: [ glob = false; module = false; in index or paths ] - simple use item
+  else if (dereferencedId in apiJson.index) {
+    let useValue = item.inner.use.source || "null";
+    annotatedReviewLines.children[dereferencedId] = [{
+      Tokens: [{
+        Kind: TokenKind.Keyword,
+        Value: "pub use",
+      }, {
+        Kind: TokenKind.Text,
+        Value: item.inner.use.name
+      },
+      {
+        Kind: TokenKind.Punctuation,
+        Value: "=",
+      }, {
+        Kind: TokenKind.TypeName,
+        Value: replaceCratePath(useValue),
+        RenderClasses: ["dependencies"],
+        NavigateToId: dereferencedId.toString(),
+        NavigationDisplayName: item.inner.use.name,
+      }]
+    }]
+  }
+  addExternalReferencesIfNotExists(dereferencedId);
+  return annotatedReviewLines;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -97,7 +97,7 @@ export function processUse(
     }
     // case 1: [ glob = true; module = true; in index ] - collapse all the children on to the parent
     else if (dereferencedId in apiJson.index && isModuleItem(apiJson.index[dereferencedId])) {
-      // isModuleItem check is not needed, being extra careful
+      // isModuleItem check is not needed, added for clarity
       const moduleItems = apiJson.index[dereferencedId].inner.module.items;
       moduleItems.forEach((childId) => {
         if (isModuleItem(apiJson.index[childId])) {
@@ -111,8 +111,12 @@ export function processUse(
           processedItems.add(childId);
         } else {
           const useReviewLines = processUse(apiJson.index[childId], parentModule);
-          annotatedReviewLines.siblingModule[childId] = useReviewLines.siblingModule[childId];
-          annotatedReviewLines.children[childId] = useReviewLines.children[childId];
+          for (const key in useReviewLines.siblingModule) {
+            annotatedReviewLines.siblingModule[key] = useReviewLines.siblingModule[key];
+          }
+          for (const key in useReviewLines.children) {
+            annotatedReviewLines.children[key] = useReviewLines.children[key];
+          }
         }
       });
     }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -102,7 +102,8 @@ export function processUse(
       moduleItems.forEach((childId) => {
         if (isModuleItem(apiJson.index[childId])) {
           annotatedReviewLines.siblingModule[childId] = processModule(
-            apiJson.index[childId] /* TODO: add parent info */,
+            apiJson.index[childId],
+            parentModule,
           );
           processedItems.add(childId);
         } else if (!isUseItem(apiJson.index[childId])) {

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -3,7 +3,7 @@ import { Item, ItemKind } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isModuleItem, isUseItem } from "./utils/typeGuards";
 import {
-  addExternalReferencesIfNotExists,
+  registerExternalItemReference,
   createItemLineFromPath,
   getModuleChildIdsByPath,
   processModuleReexport,
@@ -171,6 +171,6 @@ export function processUse(
   else if (dereferencedId in apiJson.paths) {
     annotatedReviewLines = processSimpleUseItem(item);
   }
-  addExternalReferencesIfNotExists(dereferencedId);
+  registerExternalItemReference(dereferencedId);
   return annotatedReviewLines;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -34,25 +34,32 @@ export function processUse(item: Item): ReviewLine[] | undefined {
   let useValue = item.inner.use.source || "null";
   if (item.inner.use.is_glob) {
     useValue += "::*";
+    reviewLine.Tokens.push({
+      Kind: TokenKind.TypeName,
+      Value: useValue,
+      RenderClasses: ["dependencies"],
+      NavigateToId: item.inner.use.id.toString(),
+      NavigationDisplayName: useValue,
+    });
+  } else {
+    reviewLine.Tokens.push({
+      Kind: TokenKind.TypeName,
+      Value: item.inner.use.name,
+    });
+
+    reviewLine.Tokens.push({
+      Kind: TokenKind.Punctuation,
+      Value: "=",
+    });
+
+    reviewLine.Tokens.push({
+      Kind: TokenKind.TypeName,
+      Value: replaceCratePath(useValue),
+      RenderClasses: ["dependencies"],
+      NavigateToId: item.inner.use.id.toString(),
+      NavigationDisplayName: item.inner.use.name,
+    });
   }
-
-  reviewLine.Tokens.push({
-    Kind: TokenKind.TypeName,
-    Value: item.inner.use.name,
-  });
-
-  reviewLine.Tokens.push({
-    Kind: TokenKind.Punctuation,
-    Value: "=",
-  });
-
-  reviewLine.Tokens.push({
-    Kind: TokenKind.TypeName,
-    Value: replaceCratePath(useValue),
-    RenderClasses: ["dependencies"],
-    NavigateToId: item.inner.use.id.toString(),
-    NavigationDisplayName: item.inner.use.name,
-  });
 
   reviewLines.push(reviewLine);
 

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -1,18 +1,10 @@
 import { ReviewLine, TokenKind } from "../models/apiview-models";
-import { Item, ItemKind } from "../../rustdoc-types/output/rustdoc-types";
+import { Item, ItemKind, Crate, Id } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isModuleItem, isUseItem } from "./utils/typeGuards";
-import { externalReexports } from "./utils/externalReexports";
+import { addExternalReexportIfNotExists } from "./utils/externalReexports";
 import { getAPIJson } from "../main";
 import { replaceCratePath } from "./utils/cratePathUtils";
-
-export const reexportLines: {
-  internal: ReviewLine[];
-  external: { items: ReviewLine[]; modules: ReviewLine[] };
-} = {
-  internal: [],
-  external: { items: [], modules: [] },
-};
 
 export function processUse(item: Item): ReviewLine[] | undefined {
   if (!isUseItem(item)) return;
@@ -61,13 +53,7 @@ export function processUse(item: Item): ReviewLine[] | undefined {
   });
 
   reviewLines.push(reviewLine);
-  if (useItemId in apiJson.paths) {
-    // for the re-exports in the external crates
-    const lines = externalReexports(useItemId, apiJson);
-    if (!reexportLines.external.items.some((line) => line.LineId === useItemId.toString())) {
-      reexportLines.external.items.push(...lines);
-    }
-  }
+  addExternalReexportIfNotExists(useItemId);
 
   return reviewLines;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -1,34 +1,113 @@
-import { ReviewLine, TokenKind } from "../models/apiview-models";
+import { ReviewLine, ReviewToken, TokenKind } from "../models/apiview-models";
 import { Item, ItemKind } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isModuleItem, isUseItem } from "./utils/typeGuards";
-import { addExternalReferencesIfNotExists, createItemLineFromPath, getModuleChildIdsByPath, processModuleReexport } from "./utils/externalReexports";
+import {
+  addExternalReferencesIfNotExists,
+  createItemLineFromPath,
+  getModuleChildIdsByPath,
+  processModuleReexport,
+} from "./utils/externalReexports";
 import { replaceCratePath } from "./utils/cratePathUtils";
 import { AnnotatedReviewLines } from "./utils/models";
-import { getAPIJson } from "../main";
+import { getAPIJson, processedItems } from "../main";
 import { processItem } from "./processItem";
 import { processModule } from "./processModule";
 
-export function processUse(item: Item, parentModule: { prefix: string; id: number } | undefined): AnnotatedReviewLines {
+function processSimpleUseItem(item: Item): AnnotatedReviewLines {
   const annotatedReviewLines: AnnotatedReviewLines = {
     siblingModule: {},
     children: {},
   };
 
   if (!isUseItem(item)) return annotatedReviewLines;
-  const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
-  const apiJson = getAPIJson()
+
+  const dereferencedId = item.inner.use.id;
+  const tokens: ReviewToken[] = [
+    {
+      Kind: TokenKind.Keyword,
+      Value: "pub use",
+    },
+  ];
+
+  if (item.inner.use.is_glob) {
+    tokens.push(
+      {
+        Kind: TokenKind.TypeName,
+        Value: item.inner.use.name,
+        RenderClasses: ["dependencies"],
+        NavigateToId: dereferencedId.toString(),
+        NavigationDisplayName: item.inner.use.name,
+        HasSuffixSpace: false,
+      },
+      {
+        Kind: TokenKind.Punctuation,
+        Value: "::*",
+      },
+    );
+  } else {
+    const useValue = item.inner.use.source || "null";
+    tokens.push(
+      {
+        Kind: TokenKind.Text,
+        Value: item.inner.use.name,
+      },
+      {
+        Kind: TokenKind.Punctuation,
+        Value: "=",
+      },
+      {
+        Kind: TokenKind.TypeName,
+        Value: replaceCratePath(useValue),
+        RenderClasses: ["dependencies"],
+        NavigateToId: dereferencedId.toString(),
+        NavigationDisplayName: item.inner.use.name,
+      },
+    );
+  }
+
+  annotatedReviewLines.children[item.id] = [{ Tokens: tokens }];
+  return annotatedReviewLines;
+}
+
+/**
+ * Processes a use item and returns the annotated review lines.
+ *
+ * @param {Item} item - The use item to process.
+ * @param {Object} parentModule - The parent module information.
+ * @returns {AnnotatedReviewLines} The annotated review lines for the use item.
+ */
+export function processUse(
+  item: Item,
+  parentModule: { prefix: string; id: number } | undefined,
+): AnnotatedReviewLines {
+  let annotatedReviewLines: AnnotatedReviewLines = {
+    siblingModule: {},
+    children: {},
+  };
+
+  if (!isUseItem(item)) return annotatedReviewLines;
+  const docsLines = item.docs ? createDocsReviewLines(item) : [];
+  const apiJson = getAPIJson();
   const dereferencedId = item.inner.use.id;
   if (item.inner.use.is_glob) {
+    if (processedItems.has(dereferencedId)) {
+      // This item has already been processed, so we only add a reference.
+      annotatedReviewLines = processSimpleUseItem(item);
+    }
     // case 1: [ glob = true; module = true; in index ] - collapse all the children on to the parent
-    if ((dereferencedId in apiJson.index) && isModuleItem(apiJson.index[dereferencedId])) {
+    else if (dereferencedId in apiJson.index && isModuleItem(apiJson.index[dereferencedId])) {
       // isModuleItem check is not needed, being extra careful
       const moduleItems = apiJson.index[dereferencedId].inner.module.items;
       moduleItems.forEach((childId) => {
         if (isModuleItem(apiJson.index[childId])) {
-          annotatedReviewLines.siblingModule[childId] = processModule(apiJson.index[childId], /* TODO: add parent info */);
+          annotatedReviewLines.siblingModule[childId] = processModule(
+            apiJson.index[childId] /* TODO: add parent info */,
+          );
+          processedItems.add(childId);
         } else if (!isUseItem(apiJson.index[childId])) {
           annotatedReviewLines.children[childId] = processItem(apiJson.index[childId]);
+          processedItems.add(childId);
         } else {
           const useReviewLines = processUse(apiJson.index[childId], parentModule);
           annotatedReviewLines.siblingModule[childId] = useReviewLines.siblingModule[childId];
@@ -37,43 +116,43 @@ export function processUse(item: Item, parentModule: { prefix: string; id: numbe
       });
     }
     // case 2: [ glob = true; module = true; in paths ] - collapse all the children on to the parent
-    else if (dereferencedId in apiJson.paths && (apiJson.paths[dereferencedId].kind === ItemKind.Module)) {
-      const moduleChildIds = getModuleChildIdsByPath(apiJson.paths[dereferencedId].path.join("::"), apiJson);
+    else if (
+      dereferencedId in apiJson.paths &&
+      apiJson.paths[dereferencedId].kind === ItemKind.Module
+    ) {
+      const moduleChildIds = getModuleChildIdsByPath(
+        apiJson.paths[dereferencedId].path.join("::"),
+        apiJson,
+      );
       moduleChildIds.forEach((childId) => {
-        annotatedReviewLines.children[childId] = [createItemLineFromPath(childId, apiJson.paths[childId])];
+        annotatedReviewLines.children[childId] = [
+          createItemLineFromPath(childId, apiJson.paths[childId]),
+        ];
       });
     }
   }
   // case 3: [ glob = false; module = true; in index ] - sibling module
-  else if ((dereferencedId in apiJson.index) && (isModuleItem(apiJson.index[dereferencedId]))) {
-    annotatedReviewLines.siblingModule[dereferencedId] = processModule(apiJson.index[dereferencedId], parentModule);
+  else if (dereferencedId in apiJson.index && isModuleItem(apiJson.index[dereferencedId])) {
+    annotatedReviewLines.siblingModule[dereferencedId] = processModule(
+      apiJson.index[dereferencedId],
+      parentModule,
+    );
   }
   // case 4: [ glob = false; module = true; in paths ] - sibling module with a mention of re-export
-  else if ((dereferencedId in apiJson.paths) && (apiJson.paths[dereferencedId].kind === ItemKind.Module)) {
-    annotatedReviewLines.siblingModule[dereferencedId] = processModuleReexport(dereferencedId, apiJson.paths[dereferencedId], apiJson, parentModule);
+  else if (
+    dereferencedId in apiJson.paths &&
+    apiJson.paths[dereferencedId].kind === ItemKind.Module
+  ) {
+    annotatedReviewLines.siblingModule[dereferencedId] = processModuleReexport(
+      dereferencedId,
+      apiJson.paths[dereferencedId],
+      apiJson,
+      parentModule,
+    );
   }
   // case 5: [ glob = false; module = false; in index or paths ] - simple use item
-  else if (dereferencedId in apiJson.index) {
-    let useValue = item.inner.use.source || "null";
-    annotatedReviewLines.children[item.id] = [{
-      Tokens: [{
-        Kind: TokenKind.Keyword,
-        Value: "pub use",
-      }, {
-        Kind: TokenKind.Text,
-        Value: item.inner.use.name
-      },
-      {
-        Kind: TokenKind.Punctuation,
-        Value: "=",
-      }, {
-        Kind: TokenKind.TypeName,
-        Value: replaceCratePath(useValue),
-        RenderClasses: ["dependencies"],
-        NavigateToId: dereferencedId.toString(),
-        NavigationDisplayName: item.inner.use.name,
-      }]
-    }]
+  else if (dereferencedId in apiJson.index || dereferencedId in apiJson.paths) {
+    annotatedReviewLines = processSimpleUseItem(item);
   }
   addExternalReferencesIfNotExists(dereferencedId);
   return annotatedReviewLines;

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -92,7 +92,7 @@ export function processUse(
   const dereferencedId = item.inner.use.id;
   if (item.inner.use.is_glob) {
     if (processedItems.has(dereferencedId)) {
-      // This item has already been processed, so we only add a reference.
+      // case 0: This item has already been processed, so we only add a reference.
       annotatedReviewLines = processSimpleUseItem(item);
     }
     // case 1: [ glob = true; module = true; in index ] - collapse all the children on to the parent
@@ -150,8 +150,20 @@ export function processUse(
       parentModule,
     );
   }
-  // case 5: [ glob = false; module = false; in index or paths ] - simple use item
-  else if (dereferencedId in apiJson.index || dereferencedId in apiJson.paths) {
+  // case 5: [ glob = false; module = false; in index ]
+  else if (dereferencedId in apiJson.index) {
+    // case 5.1: Has not been processed yet, so we process it.
+    if (!processedItems.has(dereferencedId)) {
+      annotatedReviewLines.children[dereferencedId] = processItem(apiJson.index[dereferencedId]);
+      processedItems.add(dereferencedId);
+    } 
+    // case 5.2: Already expanded, so we just add a reference.
+    else {
+      annotatedReviewLines = processSimpleUseItem(item);
+    }
+  }
+  // case 6: [ glob = false; module = false; in paths ] - simple use item
+  else if (dereferencedId in apiJson.paths) {
     annotatedReviewLines = processSimpleUseItem(item);
   }
   addExternalReferencesIfNotExists(dereferencedId);

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -157,7 +157,7 @@ export function processUse(
     if (!processedItems.has(dereferencedId)) {
       annotatedReviewLines.children[dereferencedId] = processItem(apiJson.index[dereferencedId]);
       processedItems.add(dereferencedId);
-    } 
+    }
     // case 5.2: Already expanded, so we just add a reference.
     else {
       annotatedReviewLines = processSimpleUseItem(item);

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/cratePathUtils.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/cratePathUtils.ts
@@ -1,7 +1,7 @@
 import { PACKAGE_NAME } from "../../main";
 
 export function replaceCratePath(path: string): string {
-    return path.startsWith("crate::") 
-        ? path.replace("crate::", `${PACKAGE_NAME}::`) // replace "crate" with root mod name
-        : path;
+  return path.startsWith("crate::")
+    ? path.replace("crate::", `${PACKAGE_NAME}::`) // replace "crate" with root mod name
+    : path;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/cratePathUtils.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/cratePathUtils.ts
@@ -1,0 +1,7 @@
+import { PACKAGE_NAME } from "../../main";
+
+export function replaceCratePath(path: string): string {
+    return path.startsWith("crate::") 
+        ? path.replace("crate::", `${PACKAGE_NAME}::`) // replace "crate" with root mod name
+        : path;
+}

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
@@ -5,10 +5,12 @@ import { ReviewLine, TokenKind } from "../../models/apiview-models";
 export const externalReferencesLines: ReviewLine[] = [];
 
 /**
- * Adds external references lines if the item exists in paths and is not already added.
+ * Registers external item references in the API view output.
+ * This function checks if an item exists in the external paths collection and 
+ * adds it to the references list if it hasn't been processed yet.
  * @param itemId The ID of the item being used/re-exported.
  */
-export function addExternalReferencesIfNotExists(itemId: Id): void {
+export function registerExternalItemReference(itemId: Id): void {
   const apiJson = getAPIJson();
   if (
     processedItems.has(itemId) ||

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
@@ -137,27 +137,31 @@ function createModuleHeaderLine(itemId: Id, itemSummary: ItemSummary): ReviewLin
 }
 
 /**
- * Finds all child items of a module based on path
+ * Returns all child item IDs of a module based on path
  */
-function findModuleChildren(currentPath: string, apiJson: Crate): ReviewLine[] {
-  const children: ReviewLine[] = [];
-
-  // Process all items in paths to find children
+export function getModuleChildIdsByPath(currentPath: string, apiJson: Crate): string[] {
+  const childIds: string[] = [];
   for (const childId in apiJson.paths) {
     const childItemSummary = apiJson.paths[childId];
-
-    // Skip if the child doesn't have a path
-    if (!hasValidPath(childItemSummary)) {
-      continue;
-    }
-
+    if (!hasValidPath(childItemSummary)) continue;
     const childPath = childItemSummary.path.join("::");
-
-    // Check if this is a child path (starts with the current path and is not the same path)
     if (childPath !== currentPath && childPath.startsWith(currentPath + "::")) {
-      // Add as a child
-      children.push(createItemLine(Number(childId), childItemSummary));
+      childIds.push(childId);
     }
+  }
+  return childIds;
+}
+
+/**
+ * Finds all child items of a module based on path and returns ReviewLines
+ */
+function findModuleChildren(currentPath: string, apiJson: Crate): ReviewLine[] {
+  const childIds = getModuleChildIdsByPath(currentPath, apiJson);
+  const children: ReviewLine[] = [];
+
+  for (const childId of childIds) {
+    const childItemSummary = apiJson.paths[childId];
+    children.push(createItemLine(Number(childId), childItemSummary));
   }
 
   // Sort children by kind and then by path

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
@@ -105,9 +105,7 @@ function createModuleHeaderLine(
         Value: parentModule.prefix,
         NavigateToId: parentModule.id.toString(),
         HasSuffixSpace: false,
-        RenderClasses: [
-          "namespace"
-        ],
+        RenderClasses: ["namespace"],
       },
       {
         Kind: TokenKind.Punctuation,
@@ -118,10 +116,9 @@ function createModuleHeaderLine(
         Kind: TokenKind.TypeName,
         Value: itemSummary.path[itemSummary.path.length - 1],
         NavigateToId: itemId.toString(),
-        NavigationDisplayName: parentModule.prefix + "::" + itemSummary.path[itemSummary.path.length - 1],
-        "RenderClasses": [
-          "namespace"
-        ],
+        NavigationDisplayName:
+          parentModule.prefix + "::" + itemSummary.path[itemSummary.path.length - 1],
+        RenderClasses: ["namespace"],
       },
       {
         Kind: TokenKind.Punctuation,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
@@ -1,5 +1,32 @@
 import { Crate, Id, ItemSummary } from "../../../rustdoc-types/output/rustdoc-types";
+import { getAPIJson } from "../../main";
 import { ReviewLine, TokenKind } from "../../models/apiview-models";
+
+export const reexportLines: {
+  internal: ReviewLine[];
+  external: { items: ReviewLine[]; modules: ReviewLine[] };
+} = {
+  internal: [],
+  external: { items: [], modules: [] },
+};
+
+/**
+ * Adds external re-export lines if the item exists in paths and is not already added.
+ * @param useItemId The ID of the item being used/re-exported.
+ */
+export function addExternalReexportIfNotExists(useItemId: Id): void {
+  const apiJson = getAPIJson();
+  if (
+    useItemId in apiJson.index ||
+    !(useItemId in apiJson.paths) ||
+    reexportLines.external.items.some((line) => line.LineId === useItemId.toString()) // Check if the re-export line already exists
+  ) {
+    return;
+  }
+
+  const lines = externalReexports(useItemId, apiJson);
+  reexportLines.external.items.push(...lines);
+}
 
 /**
  * Processes external non-module re-exports and creates a structured view

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/externalReexports.ts
@@ -18,7 +18,7 @@ export function addExternalReferencesIfNotExists(itemId: Id): void {
     return;
   }
 
-  externalReferencesLines.push(createItemLine(itemId, apiJson.paths[itemId]));
+  externalReferencesLines.push(createItemLineFromPath(itemId, apiJson.paths[itemId]));
 }
 
 /**
@@ -31,7 +31,7 @@ function hasValidPath(itemSummary: ItemSummary): boolean {
 /**
  * Creates a single ReviewLine representing a non-module item
  */
-function createItemLine(itemId: Id, itemSummary: ItemSummary): ReviewLine {
+export function createItemLineFromPath(itemId: Id, itemSummary: ItemSummary): ReviewLine {
   return {
     LineId: itemId.toString(),
     Tokens: [
@@ -63,7 +63,7 @@ export function processModuleReexport(
   parentModule?: { prefix: string; id: number },
 ): ReviewLine[] {
   const moduleHeaderLine = createModuleHeaderLine(itemId, itemSummary, parentModule);
-  const children = findModuleChildren(itemSummary.path.join("::"), apiJson);
+  const children = findModuleChildrenByPath(itemSummary.path.join("::"), apiJson);
 
   if (children.length === 0) {
     // Add closing brace to the header line for empty modules
@@ -153,13 +153,13 @@ export function getModuleChildIdsByPath(currentPath: string, apiJson: Crate): nu
 /**
  * Finds all child items of a module based on path and returns ReviewLines
  */
-function findModuleChildren(currentPath: string, apiJson: Crate): ReviewLine[] {
+function findModuleChildrenByPath(currentPath: string, apiJson: Crate): ReviewLine[] {
   const childIds = getModuleChildIdsByPath(currentPath, apiJson);
   const children: ReviewLine[] = [];
 
   for (const childId of childIds) {
     const childItemSummary = apiJson.paths[childId];
-    children.push(createItemLine(Number(childId), childItemSummary));
+    children.push(createItemLineFromPath(Number(childId), childItemSummary));
   }
 
   // Sort children by kind and then by path

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/generateDocReviewLine.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/generateDocReviewLine.ts
@@ -11,10 +11,10 @@ export function createDocsReviewLines(item: Item): ReviewLine[] {
   if (!item.docs) {
     return [];
   }
-  
+
   // Split the docs by newline character
-  const docLines = item.docs.split('\n');
-  
+  const docLines = item.docs.split("\n");
+
   // Create a ReviewLine for each doc line
   const reviewLines: ReviewLine[] = docLines.map((line, index) => ({
     Tokens: [

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/models.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/models.ts
@@ -1,0 +1,10 @@
+import { ReviewLine } from "../../models/apiview-models";
+ 
+export type AnnotatedReviewLines = {
+    siblingModule: {
+      [id: number]: ReviewLine[];
+    };
+    children: {
+      [id: number]: ReviewLine[];
+    };
+  } 

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/models.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/models.ts
@@ -1,10 +1,10 @@
 import { ReviewLine } from "../../models/apiview-models";
- 
+
 export type AnnotatedReviewLines = {
-    siblingModule: {
-      [id: number]: ReviewLine[];
-    };
-    children: {
-      [id: number]: ReviewLine[];
-    };
-  } 
+  siblingModule: {
+    [id: number]: ReviewLine[];
+  };
+  children: {
+    [id: number]: ReviewLine[];
+  };
+};

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/pathUtils.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/pathUtils.ts
@@ -5,3 +5,9 @@ export function replaceCratePath(path: string): string {
     ? path.replace("crate::", `${PACKAGE_NAME}::`) // replace "crate" with root mod name
     : path;
 }
+
+export function replaceSuperPrefix(path: string): string {
+  return path.startsWith("super::")
+    ? path.replace("super::", "") 
+    : path;
+}

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/sorting.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/sorting.ts
@@ -86,16 +86,28 @@ export function getSortedChildIds(childItems: number[]): { nonModule: number[]; 
 
   // First pass: categorize all items by their kind
   for (const childId of childItems) {
-    const child = apiJson.index[childId];
-    if (!child) continue;
+    if (childId in apiJson.index) {
+      const child = apiJson.index[childId];
+      if (!child) continue;
 
-    const kind = getItemKind(child);
-    if (!kind || !children[kind]) continue;
+      const kind = getItemKind(child);
+      if (!kind || !children[kind]) continue;
 
-    children[kind].push({
-      id: child.id,
-      name: getItemSortName(child, kind),
-    });
+      children[kind].push({
+        id: child.id,
+        name: getItemSortName(child, kind),
+      });
+    } else if (childId in apiJson.paths) {
+      const child = apiJson.paths[childId];
+      if (!child) continue;
+      const kind = child.kind;
+      if (!children[kind]) continue;
+
+      children[kind].push({
+        id: childId,
+        name: child.path[child.path.length - 1], // Use the last part of the path as the name
+      });
+    }
   }
 
   // Sort items within each kind by name (case-insensitive)

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
@@ -1,6 +1,6 @@
 import { Type } from "../../../rustdoc-types/output/rustdoc-types";
 import { ReviewToken, TokenKind } from "../../models/apiview-models";
-import { addExternalReexportIfNotExists } from "./externalReexports";
+import { addExternalReferencesIfNotExists } from "./externalReexports";
 import { processFunctionPointer } from "./processFunctionPointer";
 import { processGenericArgs } from "./processGenerics";
 import { shouldElideLifetime } from "./shouldElideLifeTime";
@@ -21,8 +21,8 @@ export function typeToReviewTokens(type: Type): ReviewToken[] {
       NavigateToId: type.resolved_path.id.toString(),
     };
 
-    // Add external re-export if it's an external type and not already added
-    addExternalReexportIfNotExists(type.resolved_path.id);
+    // Add references if it's an external type
+    addExternalReferencesIfNotExists(type.resolved_path.id);
     // If there are no generic arguments, just return the base token
     if (!type.resolved_path.args) {
       return [baseToken];

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
@@ -1,4 +1,5 @@
 import { Type } from "../../../rustdoc-types/output/rustdoc-types";
+import { getAPIJson } from "../../main";
 import { ReviewToken, TokenKind } from "../../models/apiview-models";
 import { reexportLines } from "../processUse";
 import { externalReexports } from "./externalReexports";
@@ -26,8 +27,8 @@ export function typeToReviewTokens(type: Type): ReviewToken[] {
     if (
       !reexportLines.external.items.some((line) => line.LineId === type.resolved_path.id.toString())
     ) {
-      const lines = externalReexports(type.resolved_path.id);
-      reexportLines.external.items.push(...lines.items);
+      const lines = externalReexports(type.resolved_path.id, getAPIJson());
+      reexportLines.external.items.push(...lines);
     }
     // If there are no generic arguments, just return the base token
     if (!type.resolved_path.args) {

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
@@ -101,7 +101,8 @@ export function typeToReviewTokens(type: Type): ReviewToken[] {
       ...type.impl_trait.flatMap((b, i) => {
         if ("trait_bound" in b) {
           return [
-            { Kind: TokenKind.TypeName, Value: b.trait_bound.trait.name },
+            { Kind: TokenKind.TypeName, Value: b.trait_bound.trait.name, HasSuffixSpace: false },
+            ...processGenericArgs(b.trait_bound.trait.args),
             i < type.impl_trait.length - 1
               ? { Kind: TokenKind.Punctuation, Value: "+", HasSuffixSpace: false }
               : { Kind: TokenKind.Text, Value: "", HasSuffixSpace: false },

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
@@ -1,6 +1,7 @@
 import { Type } from "../../../rustdoc-types/output/rustdoc-types";
 import { ReviewToken, TokenKind } from "../../models/apiview-models";
 import { registerExternalItemReference } from "./externalReexports";
+import { replaceSuperPrefix } from "./pathUtils";
 import { processFunctionPointer } from "./processFunctionPointer";
 import { processGenericArgs } from "./processGenerics";
 import { shouldElideLifetime } from "./shouldElideLifeTime";
@@ -16,7 +17,7 @@ export function typeToReviewTokens(type: Type): ReviewToken[] {
     // Create the base token for the type name
     const baseToken: ReviewToken = {
       Kind: TokenKind.TypeName,
-      Value: type.resolved_path.name || "unnamed",
+      Value: replaceSuperPrefix(type.resolved_path.name) || "unnamed",
       HasSuffixSpace: false,
       NavigateToId: type.resolved_path.id.toString(),
     };

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
@@ -1,6 +1,6 @@
 import { Type } from "../../../rustdoc-types/output/rustdoc-types";
 import { ReviewToken, TokenKind } from "../../models/apiview-models";
-import { addExternalReferencesIfNotExists } from "./externalReexports";
+import { registerExternalItemReference } from "./externalReexports";
 import { processFunctionPointer } from "./processFunctionPointer";
 import { processGenericArgs } from "./processGenerics";
 import { shouldElideLifetime } from "./shouldElideLifeTime";
@@ -22,7 +22,7 @@ export function typeToReviewTokens(type: Type): ReviewToken[] {
     };
 
     // Add references if it's an external type
-    addExternalReferencesIfNotExists(type.resolved_path.id);
+    registerExternalItemReference(type.resolved_path.id);
     // If there are no generic arguments, just return the base token
     if (!type.resolved_path.args) {
       return [baseToken];

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
@@ -1,8 +1,6 @@
 import { Type } from "../../../rustdoc-types/output/rustdoc-types";
-import { getAPIJson } from "../../main";
 import { ReviewToken, TokenKind } from "../../models/apiview-models";
-import { reexportLines } from "../processUse";
-import { externalReexports } from "./externalReexports";
+import { addExternalReexportIfNotExists } from "./externalReexports";
 import { processFunctionPointer } from "./processFunctionPointer";
 import { processGenericArgs } from "./processGenerics";
 import { shouldElideLifetime } from "./shouldElideLifeTime";
@@ -23,13 +21,8 @@ export function typeToReviewTokens(type: Type): ReviewToken[] {
       NavigateToId: type.resolved_path.id.toString(),
     };
 
-    // If the reexportLines.external.items does not already contain the line, add it
-    if (
-      !reexportLines.external.items.some((line) => line.LineId === type.resolved_path.id.toString())
-    ) {
-      const lines = externalReexports(type.resolved_path.id, getAPIJson());
-      reexportLines.external.items.push(...lines);
-    }
+    // Add external re-export if it's an external type and not already added
+    addExternalReexportIfNotExists(type.resolved_path.id);
     // If there are no generic arguments, just return the base token
     if (!type.resolved_path.args) {
       return [baseToken];


### PR DESCRIPTION
The primary objective is to enhance the rendering of `use` items, to keep it closer to the rustdoc (docs.rs) HTML view.

## Changes
1. **Refactor of `processUse` & Consolidation of Reexport Logic**:
   - The previous approach used `reexportLines` for managing internal and external reexports. 
   - The function `processUse` has been restructured to handle various complex cases of `use` items, including glob imports, module references, differentiating between items in `apiJson.index` and `apiJson.paths`, and external paths.
   - And a more streamlined structure for external references using `registerExternalItemReference`.

2. **Refactor of `processModule`**:
   - Enhanced logic to handle sibling modules and child items more effectively, with clearer separation of concerns.
   - Refactored `processModule` to split child items into `regularChildIds` and `useChildIds`.
   - Added logic to handle `useChildIds` and process them through `processUse`.
   - Replaced the `processModuleChildren` function with a new inline implementation for handling children and sibling modules.
   - Children and sibling modules are sorted using the new `getSortedChildIds`.
   - The `processItem` function now takes an optional `parentModule` parameter.
   - Modified the `processModule` and `processUse` calls within `processItem` to include the `parentModule`.
   - Collapsed items under rootModule into the top-level

3. **Tracking Processed Items**:
   - Introduced `processedItems` to prevent duplicate processing of items, to track linking for the `UseItem`s, to avoid duplication.

4. **Sorting**:
   - Enhanced `getSortedChildIds` to handle cases where `childId` exists in `apiJson.paths`.
   - Added `AnnotatedReviewLines` for efficient management w.r.t populating and sorting the review lines.

5. **General Code Cleanup**:
   - Removed functions and structures (`reexportLines`, `processInternalReexports`, etc.).
   - Consolidated logic for clarity and efficiency.
   - Introduced helper functions in `externalReexports` to handle external references and simplify logic.
   - `buildCodeFile` now uses `processExternalReferences` instead of the removed reexport functions.
   - Introduced `replaceCratePath` utility to handle crate path replacements.

6. **Miscellaneous**:
   - Updated `ParserVersion` to `1.1.0` in `buildCodeFile`.
   - Bug fix - with generics in the function signature workflow.
   - More formatting changes

### API View
Here's how the apiview for storage-blob would look like [APIView](https://spa.apiviewstagingtest.com/review/a413cb50d0fb4396a776c69b524ccc9e?activeApiRevisionId=f3926229089048aa9eeee5b34d077b64)

and for azure_core [APIView](https://spa.apiviewstagingtest.com/review/e18a70acf99a458ab00655a202ce0c25?activeApiRevisionId=9a0ff66afe2a4ec5b5868d7c51452d89)