### PR TITLE
Avoid unnecessary repo root look up

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-04-09 - 0.19.1
+
+- Avoid looking up the repo root when an `emitter-package-json-path` is specified in `generate-config-files` command.
+
 ## 2025-04-08 - 0.19.0
 
 - Use repo root for emitter-package path specified in `tsp-location.yaml`.

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.19.0",
+      "version": "0.19.1",
       "license": "MIT",
       "dependencies": {
         "@autorest/core": "^3.10.2",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.19.0",
+  "version": "0.19.1",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -436,7 +436,6 @@ export async function convertCommand(argv: any): Promise<void> {
 
 export async function generateConfigFilesCommand(argv: any) {
   const outputDir = argv["output-dir"];
-  const repoRoot = await getRepoRoot(outputDir);
   const packageJsonPath = normalizePath(resolve(argv["package-json"]));
   const overridePath = argv["overrides"] ?? undefined;
 
@@ -481,7 +480,7 @@ export async function generateConfigFilesCommand(argv: any) {
     emitterPackageJson["overrides"] = overrideJson;
   }
   
-  const emitterPath = resolveEmitterPathFromArgs(argv) ?? joinPaths(repoRoot, defaultRelativeEmitterPackageJsonPath);
+  const emitterPath = resolveEmitterPathFromArgs(argv) ?? joinPaths(await getRepoRoot(outputDir), defaultRelativeEmitterPackageJsonPath);
   
   await writeFile(
     emitterPath,


### PR DESCRIPTION
This lookup is causing issues in the emitter publish CI context