### PR TITLE
Pass scenario type to downstream language scripts

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Release
 
+## 2025-04-10 - 0.4.0
+
+- Added run-mode input parameter
+- Deprecated is-triggered-by-pipeline parameter
+
 ## 2025-04-03 - 0.3.5
 
-- Exclude '-pr' in the language value when spec repo is private repo
+- Excluded '-pr' in the language value when spec repo is private repo
 
 ## 2025-04-02 - 0.3.4
 

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.3.4",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.3.4",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.3.5",
+  "version": "0.4.0",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/entrypoint.ts
+++ b/tools/spec-gen-sdk/src/automation/entrypoint.ts
@@ -32,11 +32,11 @@ interface SdkAutoOptions {
   readmePath?: string;  
   pullNumber?: string;
   apiVersion?: string;
+  runMode: string;
   sdkReleaseType: string;
   specCommitSha: string;
   specRepoHttpsUrl: string;
   workingFolder: string;
-  isTriggeredByPipeline: string;
   headRepoHttpsUrl?: string;
   headBranch?: string;
   runEnv: 'local' | 'azureDevOps' | 'test';
@@ -133,7 +133,7 @@ export const sdkAutoMain = async (options: SdkAutoOptions) => {
     await workflowMain(workflowContext);
   } catch (e) {
     if (workflowContext) {
-      const message = `FatalError: ${e.message}. Please refer to the inner logs for details or report this issue through https://aka.ms/azsdk/support/specreview-channel.`;
+      const message = `Refer to the inner logs for details or report this issue through https://aka.ms/azsdk/support/specreview-channel.`;
       sdkContext.logger.error(message);
       workflowContext.status = workflowContext.status === 'notEnabled' ? workflowContext.status : 'failed';
       setFailureType(workflowContext, FailureType.PipelineFrameworkFailed);

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -319,6 +319,7 @@ const workflowCallGenerateScript = async (
     repoHttpsUrl: context.config.specRepoHttpsUrl ?? "",
     changedFiles,
     apiVersion: context.config.apiVersion,
+    runMode: context.config.runMode,
     sdkReleaseType: context.config.sdkReleaseType,
     installInstructionInput: {
       isPublic: !context.isPrivateSpecRepo,

--- a/tools/spec-gen-sdk/src/cli/cli.ts
+++ b/tools/spec-gen-sdk/src/cli/cli.ts
@@ -14,7 +14,6 @@ This tool will generate the SDK code using the local specification repository an
 
 export type SpecGenSdkCliConfig = {
   workingFolder: string;
-  isTriggeredByPipeline: string;
   localSpecRepoPath: string;
   localSdkRepoPath: string;
   tspConfigPath?: string;
@@ -22,6 +21,7 @@ export type SpecGenSdkCliConfig = {
   sdkRepoName: string;
   apiVersion?: string;
   prNumber?: string;
+  runMode: string;
   sdkReleaseType: string;
   specCommitSha: string;
   specRepoHttpsUrl: string;
@@ -33,7 +33,6 @@ export type SpecGenSdkCliConfig = {
 const initCliConfig = (argv) : SpecGenSdkCliConfig => {
   return {
     workingFolder: argv.workingFolder,
-    isTriggeredByPipeline: argv.isTriggeredByPipeline,
     localSpecRepoPath: argv.localSpecRepoPath,
     localSdkRepoPath: argv.localSdkRepoPath,
     tspConfigPath: argv.tspConfigRelativePath,
@@ -41,6 +40,7 @@ const initCliConfig = (argv) : SpecGenSdkCliConfig => {
     sdkRepoName: argv.sdkRepoName,
     apiVersion: argv.apiVersion,
     prNumber: argv.prNumber,
+    runMode: argv.runMode,
     sdkReleaseType: argv.sdkReleaseType,
     specCommitSha: argv.specCommitSha,
     specRepoHttpsUrl: argv.specRepoHttpsUrl,
@@ -70,12 +70,12 @@ const generateSdk = async (config: SpecGenSdkCliConfig) => {
       pullNumber: config.prNumber,
       sdkName: config.sdkRepoName.replace('-pr', ''),
       apiVersion: config.apiVersion,
+      runMode: config.runMode,
       sdkReleaseType: config.sdkReleaseType,
       workingFolder: config.workingFolder,
       headRepoHttpsUrl: config.headRepoHttpsUrl,
       headBranch: config.headBranch,
-      isTriggeredByPipeline: config.isTriggeredByPipeline,
-      runEnv: config.isTriggeredByPipeline.toLowerCase() === "true" ? 'azureDevOps' : 'local',
+      runEnv: config.runMode !== "local" ? 'azureDevOps' : 'local',
       branchPrefix: 'sdkAuto',
       version: config.version
     });
@@ -124,12 +124,6 @@ yargs(hideBin(process.argv))
           type: "string",
           description: "The working folder to run this tool",
           default: path.join(homedir(), '.sdkauto')
-        },
-        'is-triggered-by-pipeline': {
-          alias: "t",
-          type: 'string',
-          description: 'Flag to indicate if triggered by pipeline',
-          default: "false",
         },
         'tsp-config-relative-path': {
           alias: "tcrp",
@@ -185,6 +179,13 @@ yargs(hideBin(process.argv))
           description: "The release type of SDK, either 'beta' or 'stable'",
           default: "beta",
           choices: ['beta', 'stable']
+        },
+        'run-mode': {
+          alias: "rm",
+          type: "string",
+          description: "The run mode of the tool, allowed values are 'local','spec-pull-request','release','batch'",
+          default: "local",
+          choices: ['local', 'spec-pull-request', 'release', 'batch'],
         }
     })},
     async (argv) => {

--- a/tools/spec-gen-sdk/src/types/GenerateInput.ts
+++ b/tools/spec-gen-sdk/src/types/GenerateInput.ts
@@ -8,6 +8,7 @@ export type GenerateInput = {
   headSha: string;
   repoHttpsUrl: string;
   apiVersion?: string;
+  runMode: string;
   sdkReleaseType: string;
   changedFiles: string[];
   relatedReadmeMdFiles?: string[];

--- a/tools/spec-gen-sdk/src/types/GenerateInputSchema.json
+++ b/tools/spec-gen-sdk/src/types/GenerateInputSchema.json
@@ -17,6 +17,14 @@
       // API version to be used to generate the SDK code.
       "type": "string"
     },
+    "runMode": {
+      // Run mode when call this tool.
+      "type": "string"
+    },
+    "sdkReleaseType": {
+      // SDK release type.
+      "type": "string"
+    },
     "changedFiles": {
       // Changed file list in spec PR.
       "type": "array",
@@ -47,5 +55,5 @@
       "type": "string"
     }
   },
-  "required": ["specFolder", "headSha", "repoHttpsUrl", "changedFiles"]
+  "required": ["specFolder", "headSha", "repoHttpsUrl", "changedFiles", "runMode", "sdkReleaseType"]
 }

--- a/tools/spec-gen-sdk/src/utils/utils.ts
+++ b/tools/spec-gen-sdk/src/utils/utils.ts
@@ -183,7 +183,7 @@ export function extractPathFromSpecConfig(tspConfigPath: string | undefined, rea
       prefix = segments.join('-').toLowerCase().replace(/\./g, '-');
     }
   }
-  return prefix;
+  return prefix ? prefix : `no-readme-tspconfig-${Math.floor(Math.random() * 1000)}`;
 }
 
 /**

--- a/tools/spec-gen-sdk/test/utils.test.ts
+++ b/tools/spec-gen-sdk/test/utils.test.ts
@@ -275,6 +275,6 @@ describe('extract and format the prefix from spec config path', () => {
       const tspConfigPath = undefined;
       const readmePath = undefined;
       const result = extractPathFromSpecConfig(tspConfigPath, readmePath);
-      expect(result).toEqual('');
+      expect(result).toMatch(/no-readme-tspconfig-\d+/);
     });
   });


### PR DESCRIPTION
* Added `runMode` input parameter and deprecated `isTriggeredByPipeline` parameter in various files, including `entrypoint.ts`, `cli.ts`, and `GenerateInput.ts`. This new parameter will be used by the downstream automation script to determine the right steps to run for different scenarios.

* Simplified the error message in `sdkAutoMain` function to remove redundant information.
