### PR TITLE
Make MVC controllers API Controllers

### DIFF
--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -6,7 +6,7 @@ parameters:
 
 steps:
   - pwsh: |
-      $apiChangeDetectRequestUrl = "https://apiviewstagingtest.com/api/PullRequests/CreateAPIRevisionIfAPIHasChanges"
+      $apiChangeDetectRequestUrl = "https://apiview.dev/PullRequest/DetectApiChanges"
       echo "##vso[task.setvariable variable=ApiChangeDetectRequestUrl]$apiChangeDetectRequestUrl"
     displayName: "Set API change detect request URL"
     condition: and(${{ parameters.Condition}}, eq(variables['ApiChangeDetectRequestUrl'], ''))

--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -6,7 +6,7 @@ parameters:
 
 steps:
   - pwsh: |
-      $apiChangeDetectRequestUrl = "https://apiview.dev/api/PullRequests/CreateAPIRevisionIfAPIHasChanges"
+      $apiChangeDetectRequestUrl = "https://apiviewstagingtest.com/api/PullRequests/CreateAPIRevisionIfAPIHasChanges"
       echo "##vso[task.setvariable variable=ApiChangeDetectRequestUrl]$apiChangeDetectRequestUrl"
     displayName: "Set API change detect request URL"
     condition: and(${{ parameters.Condition}}, eq(variables['ApiChangeDetectRequestUrl'], ''))

--- a/eng/common/pipelines/templates/steps/detect-api-changes.yml
+++ b/eng/common/pipelines/templates/steps/detect-api-changes.yml
@@ -6,7 +6,7 @@ parameters:
 
 steps:
   - pwsh: |
-      $apiChangeDetectRequestUrl = "https://apiview.dev/PullRequest/DetectApiChanges"
+      $apiChangeDetectRequestUrl = "https://apiview.dev/api/PullRequests/CreateAPIRevisionIfAPIHasChanges"
       echo "##vso[task.setvariable variable=ApiChangeDetectRequestUrl]$apiChangeDetectRequestUrl"
     displayName: "Set API change detect request URL"
     condition: and(${{ parameters.Condition}}, eq(variables['ApiChangeDetectRequestUrl'], ''))
@@ -24,5 +24,5 @@ steps:
         -ArtifactName ${{ parameters.ArtifactName }}
         -DevopsProject $(System.TeamProject)
       pwsh: true
-    displayName: Detect API changes
+    displayName: Create APIView if API has changes
     condition: and(${{ parameters.Condition }}, succeededOrFailed(), eq(variables['Build.Reason'],'PullRequest'))

--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -55,11 +55,19 @@ function Submit-Request($filePath, $packageName)
     }
     $uri = [System.UriBuilder]$APIViewUri
     $uri.query = $query.toString()
+
+    $correlationId = [System.Guid]::NewGuid().ToString()
+    $headers = @{
+      "Content-Type"  = "application/json"
+      "x-correlation-id" = $correlationId
+    }
     LogInfo "Request URI: $($uri.Uri.OriginalString)"
+    LogInfo "Correlation ID: $correlationId"
     try
     {
-        $Response = Invoke-WebRequest -Method 'GET' -Uri $uri.Uri -MaximumRetryCount 3
+        $Response = Invoke-WebRequest -Method 'GET' -Uri $uri.Uri -Headers $headers -MaximumRetryCount 3
         $StatusCode = $Response.StatusCode
+        LogSuccess $Response.Content
     }
     catch
     {

--- a/eng/common/scripts/Detect-Api-Changes.ps1
+++ b/eng/common/scripts/Detect-Api-Changes.ps1
@@ -67,7 +67,8 @@ function Submit-Request($filePath, $packageName)
     {
         $Response = Invoke-WebRequest -Method 'GET' -Uri $uri.Uri -Headers $headers -MaximumRetryCount 3
         $StatusCode = $Response.StatusCode
-        LogSuccess $Response.Content
+        $responseContent = $Response.Content | ConvertFrom-Json | ConvertTo-Json -Depth 10
+        LogSuccess $responseContent
     }
     catch
     {

--- a/eng/common/scripts/Helpers/ApiView-Helpers.ps1
+++ b/eng/common/scripts/Helpers/ApiView-Helpers.ps1
@@ -241,7 +241,7 @@ function Set-ApiViewCommentForPR {
 # Helper function used to create API review requests for Spec generation SDKs pipelines
 function Create-API-Review {
   param (
-    [string]$apiviewEndpoint = "https://apiviewstagingtest.com/api/PullRequests/CreateAPIRevisionIfAPIHasChanges",
+    [string]$apiviewEndpoint = "https://apiview.dev/PullRequest/DetectAPIChanges",
     [string]$specGenSDKArtifactPath,
     [string]$apiviewArtifactName,
     [string]$buildId,

--- a/eng/common/scripts/Helpers/ApiView-Helpers.ps1
+++ b/eng/common/scripts/Helpers/ApiView-Helpers.ps1
@@ -241,7 +241,7 @@ function Set-ApiViewCommentForPR {
 # Helper function used to create API review requests for Spec generation SDKs pipelines
 function Create-API-Review {
   param (
-    [string]$apiviewEndpoint = "https://apiview.dev/api/PullRequests/CreateAPIRevisionIfAPIHasChanges",
+    [string]$apiviewEndpoint = "https://apiviewstagingtest.com/api/PullRequests/CreateAPIRevisionIfAPIHasChanges",
     [string]$specGenSDKArtifactPath,
     [string]$apiviewArtifactName,
     [string]$buildId,
@@ -278,10 +278,12 @@ function Create-API-Review {
     {
       $response = Invoke-WebRequest -Method 'GET' -Uri $requestUri.Uri -Headers $headers -MaximumRetryCount 3
       if ($response.StatusCode -eq 201) {
-        LogSuccess "Status Code: $($response.StatusCode)`nAPI review request created successfully.`n$($response.Content)"
+        $responseContent = $Response.Content | ConvertFrom-Json | ConvertTo-Json -Depth 10
+        LogSuccess "Status Code: $($response.StatusCode)`nAPI review request created successfully.`n$($responseContent)"
       }
       elseif ($response.StatusCode -eq 208) {
-        LogSuccess "Status Code: $($response.StatusCode)`nThere is no API change compared with the previous version.`n$($response.Content)"
+        $responseContent = $Response.Content | ConvertFrom-Json | ConvertTo-Json -Depth 10
+        LogSuccess "Status Code: $($response.StatusCode)`nThere is no API change compared with the previous version.`n$($responseContent)"
       }
       else {
         LogError "Failed to create API review request. $($response)"

--- a/src/dotnet/APIView/APIViewWeb/Helpers/APIHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/APIHelpers.cs
@@ -81,6 +81,12 @@ namespace APIViewWeb.Helpers
 
     }
 
+    public class CreateAPIRevisionAPIResponse
+    {
+        public string APIRevisionUrl { get; set; }
+        public IEnumerable<string> CompletedActions { get; set; } = new List<string>();
+    }
+
     public class LeanJsonResult : JsonResult
     {
         private readonly int _statusCode;

--- a/src/dotnet/APIView/APIViewWeb/Helpers/APIHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/APIHelpers.cs
@@ -84,7 +84,7 @@ namespace APIViewWeb.Helpers
     public class CreateAPIRevisionAPIResponse
     {
         public string APIRevisionUrl { get; set; }
-        public IEnumerable<string> CompletedActions { get; set; } = new List<string>();
+        public IEnumerable<string> ActionsOnAPIRevison { get; set; } = new List<string>();
     }
 
     public class LeanJsonResult : JsonResult

--- a/src/dotnet/APIView/APIViewWeb/Helpers/APIHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/APIHelpers.cs
@@ -84,7 +84,7 @@ namespace APIViewWeb.Helpers
     public class CreateAPIRevisionAPIResponse
     {
         public string APIRevisionUrl { get; set; }
-        public IEnumerable<string> ActionsOnAPIRevison { get; set; } = new List<string>();
+        public List<string> ActionsTaken { get; set; } = new List<string>();
     }
 
     public class LeanJsonResult : JsonResult

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/PullRequestsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/PullRequestsController.cs
@@ -137,15 +137,8 @@ namespace APIViewWeb.LeanControllers
             int pullRequestNumber = 0, string codeFile = null, string baselineCodeFile = null, bool commentOnPR = true,
             string language = null, string project = "internal")
         {
-            var correlationId = HttpContext.Items["CorrelationId"]?.ToString();
-            _logger.LogInformation("Processing request with Correlation ID: {CorrelationId}", correlationId);
-            _telemetryClient.TrackEvent("CreateAPIRevisionIfAPIHasChanges", new Dictionary<string, string>
-            {
-                { "CorrelationId", correlationId }
-            });
-
             var responseContent = new CreateAPIRevisionAPIResponse();
-            if (!ValidateInputParams(correlationId))
+            if (!ValidateInputParams())
             {
                 return new LeanJsonResult(responseContent, StatusCodes.Status400BadRequest);
             }
@@ -158,7 +151,7 @@ namespace APIViewWeb.LeanControllers
                     artifactName: artifactName, originalFileName: filePath, commitSha: commitSha, repoName: repoName,
                     packageName: packageName, prNumber: pullRequestNumber, hostName: this.Request.Host.ToUriComponent(),
                     responseContent: responseContent, codeFileName: codeFile, baselineCodeFileName: baselineCodeFile,
-                    commentOnPR: commentOnPR, language: language, project: project, correlationId: correlationId);
+                    commentOnPR: commentOnPR, language: language, project: project);
 
                 responseContent.APIRevisionUrl = apiRevisionUrl;
 
@@ -170,7 +163,7 @@ namespace APIViewWeb.LeanControllers
             }
         }
 
-        private bool ValidateInputParams(string correlationId)
+        private bool ValidateInputParams()
         {
             foreach (var queryParam in this.Request.Query)
             {
@@ -179,7 +172,7 @@ namespace APIViewWeb.LeanControllers
                 {
                     if (!VALID_EXTENSIONS.Any(e => value.EndsWith(e))) 
                     {
-                        _logger.LogWarning($"QueryParam 'filePath' has an invalid extension. Correlation ID: {correlationId}");
+                        _logger.LogWarning($"QueryParam 'filePath' has an invalid extension.");
                         return false;
                     }
                        
@@ -189,7 +182,7 @@ namespace APIViewWeb.LeanControllers
                 {
                     if (!value.Contains("/"))
                     {
-                        _logger.LogWarning($"QueryParam 'repoName' should not contain '/'. Correlation ID: {correlationId}");
+                        _logger.LogWarning($"QueryParam 'repoName' should contain '/'.");
                         return false;
                     }
                 }

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/PullRequestsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/PullRequestsController.cs
@@ -2,6 +2,8 @@ using APIViewWeb.DTOs;
 using APIViewWeb.Helpers;
 using APIViewWeb.Managers;
 using APIViewWeb.Models;
+using APIViewWeb.Repositories;
+using Microsoft.ApplicationInsights;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -10,21 +12,26 @@ using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
+using static MongoDB.Libmongocrypt.CryptContext;
 
 namespace APIViewWeb.LeanControllers
 {
     public class PullRequestsController  : BaseApiController
     {
+        private readonly TelemetryClient _telemetryClient;
         private readonly ILogger<PullRequestsController> _logger;
         private readonly IPullRequestManager _pullRequestManager;
         private readonly IConfiguration _configuration;
         private readonly IEnumerable<LanguageService> _languageServices;
 
+        string[] VALID_EXTENSIONS = new string[] { ".whl", ".api.json", ".json", ".nupkg", "-sources.jar", ".gosource" };
+
         public PullRequestsController(
-            ILogger<PullRequestsController> logger,
+            ILogger<PullRequestsController> logger, TelemetryClient telemetryClient,
             IPullRequestManager pullRequestManager, IConfiguration configuration, IEnumerable<LanguageService> languageServices)
         {
             _logger = logger;
+            _telemetryClient = telemetryClient;
             _pullRequestManager = pullRequestManager;
             _configuration = configuration;
             _languageServices = languageServices;
@@ -108,7 +115,7 @@ namespace APIViewWeb.LeanControllers
         }
 
         /// <summary>
-        /// Check if ther are changes in API surface between new and existing API revisions
+        /// Check if there are changes in API surface between new and existing API revisions
         /// Create new API revision bases presence of API changes
         /// </summary>
         /// <param name="buildId"></param>
@@ -120,15 +127,74 @@ namespace APIViewWeb.LeanControllers
         /// <param name="pullRequestNumber"></param>
         /// <param name="codeFile"></param>
         /// <param name="baselineCodeFile"></param>
+        /// <param name="commentOnPR"></param>
         /// <param name="language"></param>
         /// <param name="project"></param>
         /// <returns></returns>
-        [HttpGet("CreateAPIRevisionIfAPIHasChanges", Name = "DetectAPIChanges")]
-        public async Task<ActionResult<IEnumerable<PullRequestModel>>> CreateAPIRevisionIfAPIHasChanges(
-            string buildId, string artifactName, string filePath, string commitSha,
-            string repoName, string packageName, int pullRequestNumber = 0, string codeFile = null,
-            string baselineCodeFile = null, string language = null, string project = "internal")
+        [HttpGet("CreateAPIRevisionIfAPIHasChanges", Name = "CreateAPIRevisionIfAPIHasChanges")]
+        public async Task<ActionResult<IEnumerable<CreateAPIRevisionAPIResponse>>> CreateAPIRevisionIfAPIHasChanges(
+            string buildId, string artifactName, string filePath, string commitSha,string repoName, string packageName,
+            int pullRequestNumber = 0, string codeFile = null, string baselineCodeFile = null, bool commentOnPR = true,
+            string language = null, string project = "internal")
         {
+            var correlationId = HttpContext.Items["CorrelationId"]?.ToString();
+            _logger.LogInformation("Processing request with Correlation ID: {CorrelationId}", correlationId);
+            _telemetryClient.TrackEvent("CreateAPIRevisionIfAPIHasChanges", new Dictionary<string, string>
+            {
+                { "CorrelationId", correlationId }
+            });
+
+            var responseContent = new CreateAPIRevisionAPIResponse();
+            if (!ValidateInputParams(correlationId))
+            {
+                return new LeanJsonResult(responseContent, StatusCodes.Status400BadRequest);
+            }
+
+            //Handle only authorization exception and send 401 as status code.
+            //All other exception should not be handled so we will have required info in app insights.
+            try
+            {
+                var apiRevisionUrl = await _pullRequestManager.CreateAPIRevisionIfAPIHasChanges(buildId: buildId,
+                    artifactName: artifactName, originalFileName: filePath, commitSha: commitSha, repoName: repoName,
+                    packageName: packageName, prNumber: pullRequestNumber, hostName: this.Request.Host.ToUriComponent(),
+                    responseContent: responseContent, codeFileName: codeFile, baselineCodeFileName: baselineCodeFile,
+                    commentOnPR: commentOnPR, language: language, project: project, correlationId: correlationId);
+
+                responseContent.APIRevisionUrl = apiRevisionUrl;
+
+                return !string.IsNullOrEmpty(apiRevisionUrl) ? new LeanJsonResult(responseContent, StatusCodes.Status201Created) : new LeanJsonResult(responseContent, StatusCodes.Status208AlreadyReported);
+            }
+            catch (AuthorizationFailedException)
+            {
+                return new LeanJsonResult(responseContent, StatusCodes.Status401Unauthorized);
+            }
+        }
+
+        private bool ValidateInputParams(string correlationId)
+        {
+            foreach (var queryParam in this.Request.Query)
+            {
+                var value = queryParam.Value.ToString();
+                if (queryParam.Key == "filePath")
+                {
+                    if (!VALID_EXTENSIONS.Any(e => value.EndsWith(e))) 
+                    {
+                        _logger.LogWarning($"QueryParam 'filePath' has an invalid extension. Correlation ID: {correlationId}");
+                        return false;
+                    }
+                       
+                }
+
+                if (queryParam.Key == "repoName")
+                {
+                    if (!value.Contains("/"))
+                    {
+                        _logger.LogWarning($"QueryParam 'repoName' should not contain '/'. Correlation ID: {correlationId}");
+                        return false;
+                    }
+                }
+            }
+            return true;
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/PullRequestsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/PullRequestsController.cs
@@ -18,7 +18,6 @@ namespace APIViewWeb.LeanControllers
 {
     public class PullRequestsController  : BaseApiController
     {
-        private readonly TelemetryClient _telemetryClient;
         private readonly ILogger<PullRequestsController> _logger;
         private readonly IPullRequestManager _pullRequestManager;
         private readonly IConfiguration _configuration;
@@ -27,11 +26,10 @@ namespace APIViewWeb.LeanControllers
         string[] VALID_EXTENSIONS = new string[] { ".whl", ".api.json", ".json", ".nupkg", "-sources.jar", ".gosource" };
 
         public PullRequestsController(
-            ILogger<PullRequestsController> logger, TelemetryClient telemetryClient,
-            IPullRequestManager pullRequestManager, IConfiguration configuration, IEnumerable<LanguageService> languageServices)
+            ILogger<PullRequestsController> logger, IPullRequestManager pullRequestManager,
+            IConfiguration configuration, IEnumerable<LanguageService> languageServices)
         {
             _logger = logger;
-            _telemetryClient = telemetryClient;
             _pullRequestManager = pullRequestManager;
             _configuration = configuration;
             _languageServices = languageServices;
@@ -116,7 +114,7 @@ namespace APIViewWeb.LeanControllers
 
         /// <summary>
         /// Check if there are changes in API surface between new and existing API revisions
-        /// Create new API revision bases presence of API changes
+        /// Create new API revision based on presence of API changes
         /// </summary>
         /// <param name="buildId"></param>
         /// <param name="artifactName"></param>
@@ -127,15 +125,15 @@ namespace APIViewWeb.LeanControllers
         /// <param name="pullRequestNumber"></param>
         /// <param name="codeFile"></param>
         /// <param name="baselineCodeFile"></param>
-        /// <param name="commentOnPR"></param>
         /// <param name="language"></param>
         /// <param name="project"></param>
         /// <returns></returns>
+        [AllowAnonymous]
         [HttpGet("CreateAPIRevisionIfAPIHasChanges", Name = "CreateAPIRevisionIfAPIHasChanges")]
         public async Task<ActionResult<IEnumerable<CreateAPIRevisionAPIResponse>>> CreateAPIRevisionIfAPIHasChanges(
             string buildId, string artifactName, string filePath, string commitSha,string repoName, string packageName,
-            int pullRequestNumber = 0, string codeFile = null, string baselineCodeFile = null, bool commentOnPR = true,
-            string language = null, string project = "internal")
+            int pullRequestNumber = 0, string codeFile = null, string baselineCodeFile = null, string language = null,
+            string project = "internal")
         {
             var responseContent = new CreateAPIRevisionAPIResponse();
             if (!ValidateInputParams())
@@ -151,7 +149,7 @@ namespace APIViewWeb.LeanControllers
                     artifactName: artifactName, originalFileName: filePath, commitSha: commitSha, repoName: repoName,
                     packageName: packageName, prNumber: pullRequestNumber, hostName: this.Request.Host.ToUriComponent(),
                     responseContent: responseContent, codeFileName: codeFile, baselineCodeFileName: baselineCodeFile,
-                    commentOnPR: commentOnPR, language: language, project: project);
+                    language: language, project: project);
 
                 responseContent.APIRevisionUrl = apiRevisionUrl;
 

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/PullRequestsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/PullRequestsController.cs
@@ -106,5 +106,29 @@ namespace APIViewWeb.LeanControllers
             }
             return new LeanJsonResult(pullRequestReviewDtos, statusCode);
         }
+
+        /// <summary>
+        /// Check if ther are changes in API surface between new and existing API revisions
+        /// Create new API revision bases presence of API changes
+        /// </summary>
+        /// <param name="buildId"></param>
+        /// <param name="artifactName"></param>
+        /// <param name="filePath"></param>
+        /// <param name="commitSha"></param>
+        /// <param name="repoName"></param>
+        /// <param name="packageName"></param>
+        /// <param name="pullRequestNumber"></param>
+        /// <param name="codeFile"></param>
+        /// <param name="baselineCodeFile"></param>
+        /// <param name="language"></param>
+        /// <param name="project"></param>
+        /// <returns></returns>
+        [HttpGet("CreateAPIRevisionIfAPIHasChanges", Name = "DetectAPIChanges")]
+        public async Task<ActionResult<IEnumerable<PullRequestModel>>> CreateAPIRevisionIfAPIHasChanges(
+            string buildId, string artifactName, string filePath, string commitSha,
+            string repoName, string packageName, int pullRequestNumber = 0, string codeFile = null,
+            string baselineCodeFile = null, string language = null, string project = "internal")
+        {
+        }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IPullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IPullRequestManager.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using APIViewWeb.Helpers;
 using APIViewWeb.Models;
 
 namespace APIViewWeb.Managers
@@ -11,5 +12,10 @@ namespace APIViewWeb.Managers
         public Task<IEnumerable<PullRequestModel>> GetPullRequestsModelAsync(int pullRequestNumber, string repoName);
         public Task<PullRequestModel> GetPullRequestModelAsync(int prNumber, string repoName, string packageName, string originalFile, string language);
         public Task CleanupPullRequestData();
+        public Task<string> CreateAPIRevisionIfAPIHasChanges(
+            string buildId, string artifactName, string originalFileName, string commitSha, string repoName,
+            string packageName, int prNumber, string hostName, CreateAPIRevisionAPIResponse responseContent,
+            string codeFileName = null, string baselineCodeFileName = null, bool commentOnPR = true,
+            string language = null, string project = "internal", string correlationId = null);
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IPullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IPullRequestManager.cs
@@ -15,7 +15,6 @@ namespace APIViewWeb.Managers
         public Task<string> CreateAPIRevisionIfAPIHasChanges(
             string buildId, string artifactName, string originalFileName, string commitSha, string repoName,
             string packageName, int prNumber, string hostName, CreateAPIRevisionAPIResponse responseContent,
-            string codeFileName = null, string baselineCodeFileName = null, bool commentOnPR = true,
-            string language = null, string project = "internal");
+            string codeFileName = null, string baselineCodeFileName = null, string language = null, string project = "internal");
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IPullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IPullRequestManager.cs
@@ -16,6 +16,6 @@ namespace APIViewWeb.Managers
             string buildId, string artifactName, string originalFileName, string commitSha, string repoName,
             string packageName, int prNumber, string hostName, CreateAPIRevisionAPIResponse responseContent,
             string codeFileName = null, string baselineCodeFileName = null, bool commentOnPR = true,
-            string language = null, string project = "internal", string correlationId = null);
+            string language = null, string project = "internal");
     }
 }


### PR DESCRIPTION
- Converts PullRequestController to API controller
- Return object that include actions taken in APIView data to give user better insight on how APIView was created or updated.
- Use correlation Id in API call headers to allow for easier location of telemetry
- Update calls to PullRequestController API
- Deploy these changes before merging

Sample response
```json
{
  "apiRevisionUrl": "https://localhost:5000/Assemblies/Review/2b6aa77e83404f5fa60cf9aa5a8f771c?revisionId=dc3807c473ed4ed9bed34193283d7015",
  "actionsTaken": [
    "Pull Request data for PR updated with new CommitSha '61c3ba9a94bc54df2593189af7153b947f82af00'",
    "Pull Request has changes in the API surface when compared to the last updated existing APIRevision.",
    "Created New APIRevision with id 'dc3807c473ed4ed9bed34193283d7015'."
  ]
}
```

Test Run https://dev.azure.com/azure-sdk/public/_build/results?buildId=4868527&view=logs&j=011e1ec8-6569-5e69-4f06-baf193d1351e&t=486c0909-f67d-5748-80b3-bb1d531e7b43

https://dev.azure.com/azure-sdk/public/_build/results?buildId=4868581&view=logs&j=3dc8fd7e-4368-5a92-293e-d53cefc8c4b3&t=00913ed3-6224-599f-5780-70386e2dd22d