### PR TITLE
Exit early if no API changes are found

### DIFF
--- a/eng/common/scripts/Helpers/ApiView-Helpers.ps1
+++ b/eng/common/scripts/Helpers/ApiView-Helpers.ps1
@@ -171,8 +171,7 @@ function Set-ApiViewCommentForPR {
     $response = Invoke-WebRequest -Uri $apiviewEndpoint -Method Get -MaximumRetryCount 3
     if ($response.StatusCode -ne 200) {
       LogWarning "API changes are not detected in this pull request."
-      $commentText += ""
-      $commentText += "API changes are not detected in this pull request."
+      exit 0
     }
     else {
       LogSuccess "APIView identified API level changes in this PR and created $($response.Count) API reviews"


### PR DESCRIPTION
- Don't add comment to the pull request if no API change is found.
- The helps address the problem of adding comments even when the API check change did not actually occur even though its pipeline was run