### PR TITLE
[CODEOWNERS] Fixing codeowners for issue-labeler and github tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,8 +30,8 @@
 /tools/                                 @azure/azure-sdk-eng
 /tools/azure-rest-api-specs-examples-automation/ @weidongxu-microsoft
 /tools/codeowners-utils/                @JimSuplizio
-/tools/github-event-processor/          @JimSuplizio @benbp @jsquire @ronniegeraghty
 /tools/github/                          @jsquire @ronniegeraghty
+/tools/github-event-processor/          @JimSuplizio @benbp @jsquire @ronniegeraghty
 /tools/github-team-user-store/          @JimSuplizio @weshaggard
 /tools/issue-labeler/                   @jsquire @jeo02
 /tools/js-sdk-release-tools/            @qiaozha @MaryGao @wanlwanl

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,19 +25,15 @@
 /eng/common/pipelines/codeowners-linter.yml @kurtzeborn @JimSuplizio @weshaggard
 
 ###########
-# GitHub Tools
-###########
-/tools/github/                         @jsquire @ronniegeraghty
-/tools/issue-labeler/                  @jsquire @jeo02
-
-###########
 # Eng Sys Tools
 ###########
 /tools/                                 @azure/azure-sdk-eng
 /tools/azure-rest-api-specs-examples-automation/ @weidongxu-microsoft
 /tools/codeowners-utils/                @JimSuplizio
 /tools/github-event-processor/          @JimSuplizio @benbp @jsquire @ronniegeraghty
+/tools/github/                          @jsquire @ronniegeraghty
 /tools/github-team-user-store/          @JimSuplizio @weshaggard
+/tools/issue-labeler/                   @jsquire @jeo02
 /tools/js-sdk-release-tools/            @qiaozha @MaryGao @wanlwanl
 /tools/mock-service-host/               @raych1 @tadelesh
 /tools/perf-automation/                 @mikeharder @benbp


### PR DESCRIPTION
- CODEOWNERS is read bottom to top, /tools/issue-labeler/ and /tools/github/ entries were above the /tools/ catch all and were setting the owners to engsys instead of @jeo02 and @jsquire