### PR TITLE
Move tsp-client to regenerate stage

### DIFF
--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -150,10 +150,7 @@ extends:
             artifactPath: $(Build.ArtifactStagingDirectory)
 
     # Publish stage
-    # Responsible for publishing the packages in `build_artifacts/packages` and producing `emitter-package-lock.json`
-    # Produces the artifact `publish_artifacts` which contains the following:
-    #   emitter-package.json: Created using the package json from the build step.
-    #   emitter-package-lock.json: Created by calling `npm install` using `emitter-package.json`
+    # Responsible for publishing the packages in `build_artifacts/packages`
     - ${{ if parameters.ShouldPublish }}:
       - stage: Publish
         dependsOn:
@@ -207,36 +204,6 @@ extends:
                 ServiceEndpointUrl: https://api.esrp.microsoft.com
                 MainPublisher: ESRPRELPACMANTEST
 
-          - pwsh: |
-              npm install -g @azure-tools/typespec-client-generator-cli@latest
-            displayName: Install tsp-client
-
-          - pwsh: |
-              Write-Host "Overrides location: $(buildArtifactsPath)/packages/overrides.json"
-
-              if (Test-Path -Path '$(buildArtifactsPath)/packages/overrides.json') {
-                Write-Host "Using overrides.json to generate emitter-package.json"
-                tsp-client generate-config-files `
-                --package-json '$(buildArtifactsPath)/lock-files/package.json' `
-                --output-dir '$(Build.SourcesDirectory)' `
-                --emitter-package-json-path '${{ parameters.EmitterPackageJsonOutputPath }}' `
-                --overrides '$(buildArtifactsPath)/packages/overrides.json'
-              } else {
-                Write-Host "No overrides.json found. Running tsp-client without overrides."
-                
-                tsp-client generate-config-files `
-                --package-json '$(buildArtifactsPath)/lock-files/package.json' `
-                --output-dir '$(Build.SourcesDirectory)' `
-                --emitter-package-json-path '${{ parameters.EmitterPackageJsonOutputPath }}'
-              }
-            displayName: Generate emitter-package.json and emitter-package-lock files
-            workingDirectory: $(Build.SourcesDirectory)
-
-          - template: /eng/common/pipelines/templates/steps/publish-1es-artifact.yml
-            parameters:
-              artifactName: publish_artifacts
-              artifactPath: $(Build.ArtifactStagingDirectory)
-
     # Regenerate stage
     # Responsible for regenerating the SDK code using the emitter package and the generation matrix.
     - ${{ if and(parameters.ShouldPublish, parameters.ShouldRegenerate) }}:
@@ -246,7 +213,7 @@ extends:
         - Publish
         variables:
           pullRequestTargetBranch: 'main'
-          publishArtifactsPath: $(Pipeline.Workspace)/publish_artifacts
+          buildArtifactsPath: $(Pipeline.Workspace)/build_artifacts
           branchName: $[stageDependencies.Build.Build.outputs['set_branch_name.branchName']]
         pool: ${{ parameters.Pool }}
         jobs:
@@ -262,9 +229,27 @@ extends:
             displayName: Download pipeline artifacts
 
           - pwsh: |
-              Write-Host "Copying *emitter-package*.json to $(Build.SourcesDirectory)/eng"
-              Copy-Item $(publishArtifactsPath)/*emitter-package*.json $(Build.SourcesDirectory)/eng/ -Force
-            displayName: Copy emitter-package json files
+              npm install -g @azure-tools/typespec-client-generator-cli@latest
+            displayName: Install tsp-client
+
+          - pwsh: |
+              Write-Host "Overrides location: $(buildArtifactsPath)/packages/overrides.json"
+
+              if (Test-Path -Path '$(buildArtifactsPath)/packages/overrides.json') {
+                Write-Host "Using overrides.json to generate emitter-package.json"
+                tsp-client generate-config-files `
+                --package-json '$(buildArtifactsPath)/lock-files/package.json' `
+                --emitter-package-json-path '${{ parameters.EmitterPackageJsonOutputPath }}' `
+                --overrides '$(buildArtifactsPath)/packages/overrides.json'
+              } else {
+                Write-Host "No overrides.json found. Running tsp-client without overrides."
+                
+                tsp-client generate-config-files `
+                --package-json '$(buildArtifactsPath)/lock-files/package.json' `
+                --emitter-package-json-path '${{ parameters.EmitterPackageJsonOutputPath }}'
+              }
+            displayName: Generate emitter-package.json and emitter-package-lock files
+            workingDirectory: $(Build.SourcesDirectory)
 
           - ${{ parameters.InitializationSteps }}
 

--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -206,6 +206,7 @@ extends:
 
     # Regenerate stage
     # Responsible for regenerating the SDK code using the emitter package and the generation matrix.
+    # Creates a pull request to the `main` branch with the regened changes and updated emitter-package and emitter-package-lock files.
     - ${{ if and(parameters.ShouldPublish, parameters.ShouldRegenerate) }}:
       - stage: Regenerate
         dependsOn:

--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -98,6 +98,7 @@ extends:
 
         - ${{ parameters.InitializationSteps }}
 
+        # Initialize-WorkingDirectory.ps1 is responsible for setting the emitterVersion output variable.
         - task: PowerShell@2
           displayName: 'Run initialize script'
           name: initialize

--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -100,6 +100,7 @@ extends:
 
         - task: PowerShell@2
           displayName: 'Run initialize script'
+          name: initialize
           inputs:
             pwsh: true
             filePath: $(Build.SourcesDirectory)/eng/scripts/typespec/Initialize-WorkingDirectory.ps1
@@ -117,7 +118,6 @@ extends:
 
         - task: PowerShell@2
           displayName: 'Run build script'
-          name: ci_build
           inputs:
             pwsh: true
             filePath: $(Build.SourcesDirectory)/eng/scripts/typespec/Build-Emitter.ps1
@@ -206,7 +206,6 @@ extends:
 
     # Regenerate stage
     # Responsible for regenerating the SDK code using the emitter package and the generation matrix.
-    # Creates a pull request to the `main` branch with the regened changes and updated emitter-package and emitter-package-lock files.
     - ${{ if and(parameters.ShouldPublish, parameters.ShouldRegenerate) }}:
       - stage: Regenerate
         dependsOn:
@@ -327,7 +326,7 @@ extends:
           - Generate
           variables:
             generateJobResult: $[dependencies.Generate.result]
-            emitterVersion: $[stageDependencies.Build.Build.outputs['ci_build.emitterVersion']]
+            emitterVersion: $[stageDependencies.Build.Build.outputs['initialize.emitterVersion']]
           steps:
           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
 
@@ -387,6 +386,16 @@ extends:
               } else {
                 Write-Error "Build.Repository.Name not in the expected {Owner}/{Name} format"
               }
+
+              $openAsDraft = -not ($reason -eq 'IndividualCI' -and $sourceBranch -eq 'refs/heads/main')
+              Write-Host "Setting OpenAsDraftBool = $openAsDraft"
+              Write-Host "##vso[task.setvariable variable=OpenAsDraft]$openAsDraft"
+              if ($openAsDraft) {
+                Write-Host "##vso[task.setvariable variable=PRLabels]Do Not Merge"
+              } else {
+                Write-Host "##vso[task.setvariable variable=PRLabels]"
+              }
+              
             displayName: Get PR title and body
 
           - task: PowerShell@2
@@ -403,8 +412,8 @@ extends:
                 -AuthToken '$(azuresdk-github-pat)'
                 -PRTitle '$(PullRequestTitle)'
                 -PRBody '$(PullRequestBody)'
-                -OpenAsDraft $true
-                -PRLabels 'Do Not Merge'
+                -OpenAsDraft $$(OpenAsDraft)
+                -PRLabels '$(PRLabels)'
               workingDirectory: $(Build.SourcesDirectory)
 
     # Test stage


### PR DESCRIPTION
- tsp-client generation of the config files needs to happen when regenerating, not when publishing. 
- get the emitterVersion output from the correct stage
- Add Do Not Merge label to PR only when triggered manually or not against main.

Tested in https://github.com/Azure/azure-sdk-for-net/pull/49409