### PR TITLE
[AI Triage] Utilizing Labels for Answer Service

### DIFF
--- a/tools/issue-labeler/src/IssueLabeler.Shared/TriageOutput.cs
+++ b/tools/issue-labeler/src/IssueLabeler.Shared/TriageOutput.cs
@@ -8,7 +8,7 @@ namespace IssueLabeler.Shared
 {
     public class TriageOutput
     {
-        public string[] Labels { get; set; }
+        public IEnumerable<string> Labels { get; set; }
         public string Answer { get; set; }
         public string AnswerType { get; set; }
     }

--- a/tools/issue-labeler/src/IssueLabelerService/Answers/IAnswerService.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/Answers/IAnswerService.cs
@@ -9,6 +9,6 @@ namespace IssueLabelerService
 {
     public interface IAnswerService
     {
-        public Task<AnswerOutput> AnswerQuery(IssuePayload issue);
+        public Task<AnswerOutput> AnswerQuery(IssuePayload issue, string[] labels);
     }
 }

--- a/tools/issue-labeler/src/IssueLabelerService/Answers/IAnswerService.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/Answers/IAnswerService.cs
@@ -9,6 +9,6 @@ namespace IssueLabelerService
 {
     public interface IAnswerService
     {
-        public Task<AnswerOutput> AnswerQuery(IssuePayload issue, string[] labels);
+        public Task<AnswerOutput> AnswerQuery(IssuePayload issue, Dictionary<string, string> labels);
     }
 }

--- a/tools/issue-labeler/src/IssueLabelerService/Answers/OpenAiAnswerService.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/Answers/OpenAiAnswerService.cs
@@ -19,7 +19,7 @@ namespace IssueLabelerService
             _ragService = ragService;
             _logger = logger;
         }
-        public async Task<AnswerOutput> AnswerQuery(IssuePayload issue)
+        public async Task<AnswerOutput> AnswerQuery(IssuePayload issue, string[] labels)
         {
             // Configuration for Azure services
             var modelName = _config.AnswerModelName;
@@ -40,13 +40,15 @@ namespace IssueLabelerService
             double scoreThreshold = double.Parse(_config.ScoreThreshold);
             double solutionThreshold = double.Parse(_config.SolutionThreshold);
 
-            var issues = await _ragService.SearchIssuesAsync(issueIndexName, issueSemanticName, issueFieldName, query, top, scoreThreshold);
+            var issues = await _ragService.SearchIssuesAsync(issueIndexName, issueSemanticName, issueFieldName, query, top, scoreThreshold, labels);
+
+            // TODO: Add labels once dotnet has Service and Category fields in Document Index
             var docs = await _ragService.SearchDocumentsAsync(documentIndexName, documentSemanticName, documentFieldName, query, top, scoreThreshold);
 
             // Filtered out all sources for either one then not enough information to answer the issue. 
-            if (docs.Count == 0 || issues.Count == 0)
+            if (docs.Count == 0 && issues.Count == 0)
             {
-                throw new Exception($"Not enough relevant sources found for {issue.RepositoryName} using the Complete Triage model for issue #{issue.IssueNumber}.");
+                throw new Exception($"Not enough relevant sources found for {issue.RepositoryName} using the Complete Triage model for issue #{issue.IssueNumber}. Documents: {docs.Count}, Issues: {issues.Count}.");
             }
 
             double highestScore = _ragService.GetHighestScore(issues, docs, issue.RepositoryName, issue.IssueNumber);

--- a/tools/issue-labeler/src/IssueLabelerService/Answers/OpenAiAnswerService.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/Answers/OpenAiAnswerService.cs
@@ -19,7 +19,7 @@ namespace IssueLabelerService
             _ragService = ragService;
             _logger = logger;
         }
-        public async Task<AnswerOutput> AnswerQuery(IssuePayload issue, string[] labels)
+        public async Task<AnswerOutput> AnswerQuery(IssuePayload issue, Dictionary<string, string> labels)
         {
             // Configuration for Azure services
             var modelName = _config.AnswerModelName;
@@ -41,9 +41,7 @@ namespace IssueLabelerService
             double solutionThreshold = double.Parse(_config.SolutionThreshold);
 
             var issues = await _ragService.SearchIssuesAsync(issueIndexName, issueSemanticName, issueFieldName, query, top, scoreThreshold, labels);
-
-            // TODO: Add labels once dotnet has Service and Category fields in Document Index
-            var docs = await _ragService.SearchDocumentsAsync(documentIndexName, documentSemanticName, documentFieldName, query, top, scoreThreshold);
+            var docs = await _ragService.SearchDocumentsAsync(documentIndexName, documentSemanticName, documentFieldName, query, top, scoreThreshold, labels);
 
             // Filtered out all sources for either one then not enough information to answer the issue. 
             if (docs.Count == 0 && issues.Count == 0)

--- a/tools/issue-labeler/src/IssueLabelerService/AzureSdkIssueLabelerService.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/AzureSdkIssueLabelerService.cs
@@ -9,10 +9,8 @@ using Microsoft.Azure.Functions.Worker;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Newtonsoft.Json;
-using System.Linq;
 using IssueLabeler.Shared;
 using System.Collections.Generic;
-using System.Text.RegularExpressions;
 
 namespace IssueLabelerService
 {
@@ -68,7 +66,7 @@ namespace IssueLabelerService
                 // Get the Qna model based on configuration
                 var qnaService = _answerServices.GetAnswerService(config);
 
-                var answer = await qnaService.AnswerQuery(issue);
+                var answer = await qnaService.AnswerQuery(issue, labels);
 
                 TriageOutput result = new TriageOutput
                 {

--- a/tools/issue-labeler/src/IssueLabelerService/AzureSdkIssueLabelerService.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/AzureSdkIssueLabelerService.cs
@@ -57,7 +57,7 @@ namespace IssueLabelerService
 
                 // If no labels are returned, do not generate an answer
                 // Fixing the issue by replacing 'Length' with 'Count' for Dictionary
-                if (labels == null || labels.Count == 0)
+                if (labels?.Count == 0)
                 {
                     _logger.LogInformation($"No labels predicted for issue #{issue.IssueNumber} in repository {issue.RepositoryName}.");
                     return EmptyResult;

--- a/tools/issue-labeler/src/IssueLabelerService/Configuration/RepositoryConfiguration.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/Configuration/RepositoryConfiguration.cs
@@ -56,6 +56,7 @@ namespace IssueLabelerService
         public string SuggestionUserPrompt => GetItem("SuggestionUserPrompt");
         public string LabelUserPrompt => GetItem("LabelUserPrompt");
         public string LabelInstructions => GetItem("LabelInstructions");
+        public string LabelNames => GetItem("LabelNames");
 
         public string GetItem(string name)
         {

--- a/tools/issue-labeler/src/IssueLabelerService/Labelers/ILabeler.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/Labelers/ILabeler.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using IssueLabeler.Shared;
 
@@ -5,6 +6,6 @@ namespace IssueLabelerService
 {
     public interface ILabeler
     {
-        public Task<string[]> PredictLabels(IssuePayload issue);
+        public Task<Dictionary<string, string>> PredictLabels(IssuePayload issue);
     }
 }

--- a/tools/issue-labeler/src/IssueLabelerService/Labelers/LegacyLabeler.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/Labelers/LegacyLabeler.cs
@@ -4,6 +4,7 @@ using Microsoft.Extensions.Logging;
 using IssueLabeler.Shared;
 using System.Threading.Tasks;
 using System;
+using System.Collections.Generic;
 
 
 namespace IssueLabelerService
@@ -32,7 +33,7 @@ namespace IssueLabelerService
             _config = config;
         }
 
-        public async Task<string[]> PredictLabels(IssuePayload issue)
+        public async Task<Dictionary<string, string>> PredictLabels(IssuePayload issue)
         {
             var predictionRepositoryName = TranslateRepoName(issue.RepositoryName);
 
@@ -84,7 +85,12 @@ namespace IssueLabelerService
                 }
 
                 _logger.LogInformation($"Labels were predicted for {issue.RepositoryName} using the `{predictionRepositoryName}` model for issue #{issue.IssueNumber}.  Using: [{predictions[0]}, {predictions[1]}].");
-                return [predictions[0], predictions[1]];
+                
+                return new Dictionary<string, string>
+                {
+                    { "Category", predictions[0] }, 
+                    { "Service", predictions[1] }
+                };
             }
             catch (Exception ex)
             {

--- a/tools/issue-labeler/src/IssueLabelerService/Labelers/OpenAiLabeler.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/Labelers/OpenAiLabeler.cs
@@ -90,7 +90,7 @@ namespace IssueLabelerService
 
             _logger.LogInformation($"Open AI Response for {issue.RepositoryName} using the Open AI Labeler for issue #{issue.IssueNumber} Service: {output.Service} Category: {output.Category}");
 
-            return [output.Service, output.Category];
+            return [output.Category, output.Service];
         }
 
         private class LabelOutput

--- a/tools/issue-labeler/src/IssueLabelerService/TraigeRag.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/TraigeRag.cs
@@ -133,7 +133,8 @@ namespace IssueLabelerService
                 semanticConfigName,
                 field,
                 query,
-                count);
+                count,
+                filter);
 
             List<Document> filteredDocuments = new List<Document>();
             foreach (var (document, score) in searchResults)

--- a/tools/issue-labeler/src/IssueLabelerService/TraigeRag.cs
+++ b/tools/issue-labeler/src/IssueLabelerService/TraigeRag.cs
@@ -217,7 +217,7 @@ namespace IssueLabelerService
 
         public string LabelsFilter(Dictionary<string, string> labels)
         {
-            if (labels != null && labels.Count > 0)
+            if (labels?.Take(2).Count() == 2)
             {
                 // Dynamically construct the filter string
                 var filters = labels.Select(label => $"{label.Key} eq '{label.Value}'");

--- a/tools/issue-labeler/src/SearchIndexCreator/IssueIndex.cs
+++ b/tools/issue-labeler/src/SearchIndexCreator/IssueIndex.cs
@@ -263,8 +263,14 @@ namespace SearchIndexCreator
                         IsSearchable = false
                     },
                     new SearchableField("Title"),
-                    new SearchableField("Service"),
-                    new SearchableField("Category"),
+                    new SearchableField("Service")
+                    {
+                        IsFilterable = true
+                    },
+                    new SearchableField("Category")
+                    {
+                        IsFilterable = true
+                    },
                     new SearchField("Author", SearchFieldDataType.String)
                     {
                         IsSearchable = false


### PR DESCRIPTION
- Filter through issues based on labels.
- Switched around the `OpenAiLabeler` output order since it was wrong.
- ~~Not filtering labels for Documents until dotnet documents have Service and Category labels.~~
- Added Filtering to Service and Category labels