### PR TITLE
[APIView Copilit] Reimplement and refactor id validation

### DIFF
--- a/packages/python-packages/apiview-copilot/.gitignore
+++ b/packages/python-packages/apiview-copilot/.gitignore
@@ -1,3 +1,4 @@
 scratch/prompts
 raw_requests
 build
+error.log

--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -7,7 +7,7 @@ import sys
 import pathlib
 
 from src._search_manager import SearchManager
-from src._apiview_reviewer import supported_models
+from src._apiview_reviewer import supported_models, DEFAULT_MODEL
 
 from knack import CLI, ArgumentsContext, CLICommandsLoader
 from knack.commands import CommandGroup
@@ -46,7 +46,7 @@ helps[
 def local_review(
     language: str,
     path: str,
-    model: str,
+    model: str = DEFAULT_MODEL,
     chunk_input: bool = False,
     use_rag: bool = False,
 ):

--- a/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
@@ -14,35 +14,29 @@ from ._sectioned_document import SectionedDocument
 from ._search_manager import SearchManager
 from ._models import ReviewResult
 
-# Set up the logger at the module level
+# Set up paths
 _PACKAGE_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 _PROMPTS_FOLDER = os.path.join(_PACKAGE_ROOT, "prompts")
 
-# Create output folder for logs
-output_folder = os.path.join(_PACKAGE_ROOT, "scratch", "output")
-os.makedirs(output_folder, exist_ok=True)
-log_file = os.path.join(output_folder, "error.log")
+# Configure logger to write to project root error.log
+log_file = os.path.join(_PACKAGE_ROOT, "error.log")
 
-# Configure logger for immediate outputs (no buffering)
 logging.basicConfig(
     filename=log_file,
-    filemode="w",  # 'w' means write mode (overwrites existing file)
+    filemode="w",  # overwrite on each run
     level=logging.ERROR,
     format="%(asctime)s - %(levelname)s - %(message)s",
-    force=True,  # Override any existing logger configuration
+    force=True,
 )
 
 for handler in logging.root.handlers:
     if isinstance(handler, logging.FileHandler):
         handler.setLevel(logging.ERROR)
-
-        # Instead, call flush() after each log message if needed
-        # Or use this approach to make writes unbuffered:
         handler.formatter = logging.Formatter(
             "%(asctime)s - %(levelname)s - %(message)s"
         )
 
-# Create a module-level logger that can be used anywhere in the file
+# Create module-level logger
 logger = logging.getLogger(__name__)
 
 if "APPSETTING_WEBSITE_SITE_NAME" not in os.environ:
@@ -106,14 +100,16 @@ class ApiViewReview:
 
         start_time = time()
         apiview = self.unescape(apiview)
-        if not use_rag:
-            guidelines = self.search.retrieve_static_guidelines(
-                self.language, include_general_guidelines=True
-            )
+        static_guidelines = self.search.retrieve_static_guidelines(
+            self.language, include_general_guidelines=True
+        )
+        static_guideline_ids = [x["id"] for x in static_guidelines]
 
         # Prepare the document
         chunked_apiview = SectionedDocument(apiview.splitlines(), chunk=chunk_input)
-        final_results = ReviewResult(status="Success", violations=[])
+        final_results = ReviewResult(
+            guideline_ids=static_guideline_ids, status="Success", violations=[]
+        )
 
         # Skip header if multiple sections
         chunks_to_process = []
@@ -182,22 +178,20 @@ class ApiViewReview:
                     )
 
                     try:
+                        # build the context string
                         if use_rag:
                             context = self._retrieve_and_resolve_guidelines(str(chunk))
-                            if context is None:
+                            if context:
+                                context_string = context.to_markdown()
+                            else:
+                                # Use static guidelines as fallback if semantic search fails
                                 logger.warning(
                                     f"Failed to retrieve guidelines for chunk {i}, using static guidelines instead."
                                 )
                                 self.semantic_search_failed = True
-                                context = self.search.retrieve_static_guidelines(
-                                    self.language, include_general_guidelines=True
-                                )
-                                context_string = json.dumps(context)
-                            else:
-                                context_string = context.to_markdown()
+                                context_string = json.dumps(static_guidelines)
                         else:
-                            context = guidelines
-                            context_string = json.dumps(context)
+                            context_string = json.dumps(static_guidelines)
 
                         response = prompty.execute(
                             prompt_path,

--- a/packages/python-packages/apiview-copilot/src/_models.py
+++ b/packages/python-packages/apiview-copilot/src/_models.py
@@ -1,6 +1,6 @@
 from enum import Enum
-from pydantic import BaseModel, Field
-from typing import List, Optional, Union, Dict
+from pydantic import BaseModel, Field, PrivateAttr
+from typing import List, Optional, Dict, Set
 
 from ._sectioned_document import Section
 
@@ -79,12 +79,26 @@ class ReviewResult(BaseModel):
     status: str = Field(
         description="Succeeded if the request has no violations. Error if there are violations."
     )
-    violations: List[Violation] = Field(description="list of violations if any")
+    violations: List[Violation] = Field(description="List of violations if any")
 
-    def __init__(self, **data):
+    # truly private, never part of Pydantic’s schema or serialization
+    _guideline_ids: Set[str] = PrivateAttr(default_factory=set)
+
+    def __init__(
+        self,
+        *,
+        guideline_ids: Optional[List[str]] = None,
+        **data,
+    ):
         actual_violations = data.pop("violations", [])
         data["violations"] = []
         super().__init__(**data)
+        # initialize private attr outside of Pydantic’s field system
+        object.__setattr__(
+            self,
+            "_guideline_ids",
+            set(guideline_ids) if guideline_ids else set(),
+        )
         self._process_violations(actual_violations)
 
     def _process_violations(self, violations: List[Dict]):
@@ -102,6 +116,8 @@ class ReviewResult(BaseModel):
             # if violation doesn't have suggestion, set it to empty string
             if "suggestion" not in violation:
                 violation["suggestion"] = ""
+
+            # handle common line number issues from the LLM
             for item in raw_line_no.split(","):
                 item = item.strip()
                 violation_copy = (
@@ -130,64 +146,54 @@ class ReviewResult(BaseModel):
         """
         Merge two ReviewResult objects.
         """
-        self.violations.extend(self._merge_violations(other.violations, section))
+        self._guideline_ids.update(other._guideline_ids)
+        self._merge_violations(other.violations, section)
         if len(self.violations) > 0:
             self.status = "Error"
 
-    def validate(self, *, guideline_ids: List[str]):
+    def _validate(self, item: Violation) -> bool:
         """
-        Runs validations on the ReviewResult collection.
-        For now this is just ensure rule IDs are valid.
+        Validates the Violation object.
+        If the result of validation is that the violation is invalid, return False.
+        Even if the violation is changed during validation, if it is still valid, return True.
         """
-        # TODO: Disable for now. See: https://github.com/Azure/azure-sdk-tools/issues/10303
-        # self._process_rule_ids(guideline_ids)
+        # Validate and sanitize rule IDs
+        resolved_rule_ids = set()
+        for rule_id in item.rule_ids:
+            resolved_rule_id = self._resolve_rule_id(rule_id)
+            if resolved_rule_id:
+                resolved_rule_ids.add(resolved_rule_id)
+        if not resolved_rule_ids:
+            return False
+        else:
+            item.rule_ids = list(resolved_rule_ids)
+        return True
 
-    def _process_rule_ids(self, guideline_ids: List[str]):
+    def _resolve_rule_id(self, rid: str) -> str | None:
         """
-        Ensure that each rule ID matches with an actual guideline ID.
+        Ensure that the rule ID matches with an actual guideline ID.
         This ensures that the links that appear in APIView should never be broken (404).
+        Allows for specific partial matches.
         """
-        return
-        # FIXME: Fix up this logic...
-        # create an index for easy lookup
-        # index = set(guideline_ids)
-        # for violation in self.violations:
-        #     to_remove = []
-        #     to_add = []
-        #     for rule_id in violation.rule_ids:
-        #         if rule_id in index:
-        #             # see if any guideline ID ends with the rule_id. If so, update it and preserve in the index
-        #             matched = False
-        #             for gid in guideline_ids:
-        #                 if gid.endswith(rule_id):
-        #                     to_remove.append(rule_id)
-        #                     to_add.append(gid)
-        #                     index[rule_id] = gid
-        #                     matched = True
-        #                     break
-        #             if matched:
-        #                 continue
-        #             # no match or partial match found, so remove the rule_id
-        #             to_remove.append(rule_id)
-        #             print(
-        #                 f"WARNING: Rule ID {rule_id} not found. Possible hallucination."
-        #             )
-        #     # update the rule_ids arrays with the new values. Don't modify the array while iterating over it!
-        #     for rule_id in to_remove:
-        #         violation.rule_ids.remove(rule_id)
-        #     for rule_id in to_add:
-        #         violation.rule_ids.append(rule_id)
+        if rid in self._guideline_ids:
+            return rid
 
-    def _merge_violations(
-        self, violations: List[Violation], section: Section
-    ) -> List[Violation]:
+        # check if the part of the guideline_id after the # matches the rule_id
+        for gid in self._guideline_ids:
+            gid_end = gid.split("#")[-1]
+            if rid == gid_end:
+                return gid
+        print(f"WARNING: Rule ID {rid} not found. Possible hallucination.")
+        return None
+
+    def _merge_violations(self, violations: List[Violation], section: Section):
         """
         Process and combine batches of violations as needed. Attempts to
         determine line numbers and ignores violations that can't be mapped to a line.
         If multiple of the same violation are found on the same line, they are combined.
         """
         if not violations:
-            return violations
+            return
 
         combined_violations = {}
         for violation in violations:
@@ -206,10 +212,14 @@ class ReviewResult(BaseModel):
                         existing.comment = existing.comment + " " + violation.comment
             else:
                 combined_violations[line_no] = violation
-        # this logic tosses out violations that can't be mapped to an actual line
-        return [x for x in combined_violations.values() if x.line_no != 1]
 
-    def _find_line_number(self, chunk: Section, bad_code: str) -> Union[int, None]:
+        # remove any violations that don't pass validation and then add them to the list
+        filtered_violations = [
+            x for x in combined_violations.values() if self._validate(x)
+        ]
+        self.violations.extend(filtered_violations)
+
+    def _find_line_number(self, chunk: Section, bad_code: str) -> Optional[int]:
         """
         Find the line number of the bad code in the chunk.
         This is a bit of a hack, but it works for now.


### PR DESCRIPTION
Allows shortened ids that miss the part prior to the # and ignores violations that have completely fabricated ids. 