### PR TITLE
[APIView Copilot] Disable use of general guidelines by default.

### DIFF
--- a/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
@@ -101,7 +101,7 @@ class ApiViewReview:
         start_time = time()
         apiview = self.unescape(apiview)
         static_guidelines = self.search.retrieve_static_guidelines(
-            self.language, include_general_guidelines=True
+            self.language, include_general_guidelines=False
         )
         static_guideline_ids = [x["id"] for x in static_guidelines]
 

--- a/packages/python-packages/apiview-copilot/src/_search_manager.py
+++ b/packages/python-packages/apiview-copilot/src/_search_manager.py
@@ -205,9 +205,11 @@ class ContextItem:
 
 class SearchManager:
 
-    def __init__(self, *, language: str):
+    def __init__(self, *, language: str, include_general_guidelines: bool = False):
         self.language = language
-        self.filter_expression = f"lang eq '{language}' or lang eq '' or lang eq null"
+        self.filter_expression = f"lang eq '{language}'"
+        if include_general_guidelines:
+            self.filter_expression += " or lang eq '' or lang eq null"
 
     def _ensure_env_vars(self, vars: List[str]):
         """


### PR DESCRIPTION
Ensures that, by default, general guidelines aren't used either in RAG or static mode.