### PR TITLE
[spec-gen] bugfix for missing closing brace

### DIFF
--- a/tools/spec-gen-sdk/src/templates/commentDetailNew.handlebars
+++ b/tools/spec-gen-sdk/src/templates/commentDetailNew.handlebars
@@ -3,7 +3,7 @@
   <li>
     <div>
 {{renderStatus status}}{{#if failureType}}{{failureType}}{{else}}{{renderStatusName status}}{{/if}}
- in generating from {{renderCommitLink config.specRepoHttpsUrl config.specCommitSha}}. spec-gen-sdk {config.version}}
+ in generating from {{renderCommitLink config.specRepoHttpsUrl config.specCommitSha}}. spec-gen-sdk {{config.version}}
     {{#if config.pullNumber}}
       Related Pull Request {{renderPullRequestLink config.specRepoHttpsUrl config.pullNumber}}
     {{/if}}


### PR DESCRIPTION
This pull request includes a minor fix to the `tools/spec-gen-sdk/src/templates/commentDetailNew.handlebars` file. The change corrects a misplaced closing brace in the template syntax to properly reference `config.version`.