### PR TITLE
Spec-Gen-SDK for Suppressions File Link

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-04-17 - 0.4.2
+
+- Directly using sdk-suppressions.yaml link
+
 ## 2025-04-17 - 0.4.1
 
 - Added pull request link to the generated html report

--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## 2025-04-17 - 0.4.2
 
-- Directly using sdk-suppressions.yaml link
+- Refactor sdk-suppressions.yaml link
+- Remove render template's sdk-suppressions context and sdk-suppressions link
 
 ## 2025-04-17 - 0.4.1
 

--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 2025-04-17 - 0.4.2
 
 - Refactor sdk-suppressions.yaml link
-- Remove render template's sdk-suppressions context and sdk-suppressions link
+- Remove render template's sdk-suppressions link only
 
 ## 2025-04-17 - 0.4.1
 

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -239,15 +239,14 @@ export const workflowInitGetSdkSuppressionsYml = async (
     // Use file parsing to obtain yaml content and check if the suppression file has any grammar errors
     const sdkSuppressionFilesParseErrorTotal: string[] = [];
     let suppressionFileData: string = '';
-    const filePath = path.join(context.config.localSpecRepoPath, sdkSuppressionFilePath);
     try {
-      suppressionFileData = fs.readFileSync(filePath).toString();
+      suppressionFileData = fs.readFileSync(sdkSuppressionFilePath).toString();
     } catch (error) {
       context.logger.error(`IOError: Fails to read SDK suppressions file with path of '${sdkSuppressionFilePath}'. Assuming no suppressions are present. Please ensure the suppression file exists in the right path in order to load the suppressions for the SDK breaking changes. Error: ${error.message}`);
       continue;
     }
     // parse file both to get yaml content and validate the suppression file has grammar error
-    const suppressionFileParseResult = parseYamlContent(suppressionFileData, filePath);
+    const suppressionFileParseResult = parseYamlContent(suppressionFileData, sdkSuppressionFilePath);
     if (!suppressionFileParseResult.result) {
       sdkSuppressionFilesParseErrorTotal.push(suppressionFileParseResult.message);
       continue;

--- a/tools/spec-gen-sdk/src/templates/commentDetailNew.handlebars
+++ b/tools/spec-gen-sdk/src/templates/commentDetailNew.handlebars
@@ -29,6 +29,20 @@
     {{#if (shouldRender messages isBetaMgmtSdk)}}
       {{renderMessagesUnifiedPipeline messages status}}
     {{/if}}
+    {{#if (shouldRender presentSuppressionLines isBetaMgmtSdk hasBreakingChange)}}
+      {{renderPresentSuppressionLines presentSuppressionLines}}
+    {{/if}}
+    {{#if (shouldRender absentSuppressionLines isBetaMgmtSdk hasBreakingChange)}}
+      {{renderAbsentSuppressionLines absentSuppressionLines}}
+    {{/if}}
+    {{#if (shouldRender parseSuppressionLinesErrors isBetaMgmtSdk hasBreakingChange)}}
+      {{renderParseSuppressionLinesErrors parseSuppressionLinesErrors}}
+    {{/if}}
+    {{#if (shouldRender messages isBetaMgmtSdk hasBreakingChange)}}
+    <div>
+      Please refer to the <a target="_blank" href="https://aka.ms/azsdk/sdk-suppression">guidance</a> for suppressing SDK breaking changes.
+    </div>
+    {{/if}}
   </li>
   {{/each}}
 </ul>

--- a/tools/spec-gen-sdk/src/templates/commentDetailNew.handlebars
+++ b/tools/spec-gen-sdk/src/templates/commentDetailNew.handlebars
@@ -23,28 +23,11 @@
         {{/if}}
         {{#if (shouldRender hasBreakingChange isBetaMgmtSdk)}}
         <b>Breaking Change Detected</b> 
-          {{#if sdkSuppressionFilePath}}
-            [<a href="{{sdkSuppressionFilePath}}">Suppression File</a>]
-          {{/if}}
         {{/if}}
       </span>
     </div>
     {{#if (shouldRender messages isBetaMgmtSdk)}}
       {{renderMessagesUnifiedPipeline messages status}}
-    {{/if}}
-    {{#if (shouldRender presentSuppressionLines isBetaMgmtSdk hasBreakingChange)}}
-      {{renderPresentSuppressionLines presentSuppressionLines}}
-    {{/if}}
-    {{#if (shouldRender absentSuppressionLines isBetaMgmtSdk hasBreakingChange)}}
-      {{renderAbsentSuppressionLines absentSuppressionLines}}
-    {{/if}}
-    {{#if (shouldRender parseSuppressionLinesErrors isBetaMgmtSdk hasBreakingChange)}}
-      {{renderParseSuppressionLinesErrors parseSuppressionLinesErrors}}
-    {{/if}}
-    {{#if (shouldRender messages isBetaMgmtSdk hasBreakingChange)}}
-    <div>
-      Please refer to the <a target="_blank" href="https://aka.ms/azsdk/sdk-suppression">guidance</a> for suppressing SDK breaking changes.
-    </div>
     {{/if}}
   </li>
   {{/each}}


### PR DESCRIPTION
This pull request updates the `spec-gen-sdk` tool to version 0.4.2 and removes references to the SDK suppressions file from the codebase. Key changes include refactoring file handling logic, removing suppression-related templates, and updating versioning metadata.

### Version Updates:
* Updated the version of the `spec-gen-sdk` tool from 0.4.1 to 0.4.2 in `package.json` and `package-lock.json` to reflect the new release. 

### Removal of SDK Suppressions Context:
* Removed the `sdkSuppressionFilePath` variable from file parsing logic in `workflow.ts` to simplify file handling by directly referencing the file path.
* Deleted all suppression-related rendering logic from the `commentDetailNew.handlebars` template, including links to suppression files and associated error messages.

### Documentation Updates:
* Added a changelog entry for version 0.4.2, documenting the removal of SDK suppressions context and related refactoring.