### PR TITLE
[APIView Copilot] Move all configuration to ApiViewReviewer constructor

### DIFF
--- a/packages/python-packages/apiview-copilot/cli.py
+++ b/packages/python-packages/apiview-copilot/cli.py
@@ -55,12 +55,14 @@ def local_review(
     """
     from src._apiview_reviewer import ApiViewReview
 
-    rg = ApiViewReview(language=language, model=model)
+    rg = ApiViewReview(
+        language=language, model=model, chunk_input=chunk_input, use_rag=use_rag
+    )
     filename = os.path.splitext(os.path.basename(path))[0]
 
     with open(path, "r") as f:
         apiview = f.read()
-    review = rg.get_response(apiview, chunk_input=chunk_input, use_rag=use_rag)
+    review = rg.get_response(apiview)
     output_path = os.path.join("scratch", "output", language)
     os.makedirs(output_path, exist_ok=True)
     output_file = os.path.join(output_path, f"{filename}.json")

--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -15,7 +15,6 @@ from azure.ai.evaluation import evaluate, SimilarityEvaluator, GroundednessEvalu
 
 dotenv.load_dotenv()
 
-MODEL = "o3-mini"
 NUM_RUNS: int = 3
 
 
@@ -101,8 +100,8 @@ def review_apiview(query: str, language: str):
         ApiViewReview,
     )
 
-    ai_review = ApiViewReview(language=language, model=MODEL)
-    review = ai_review.get_response(query, chunk_input=False, use_rag=False)
+    ai_review = ApiViewReview(language=language)
+    review = ai_review.get_response(query)
     return {"response": review.model_dump_json()}
 
 


### PR DESCRIPTION
Previously configuration was split between the ApiViewReviewer constructor and the get_response method. This PR moves all of that configuration to the constructor, making it easier to understand and maintain.

Also `evals\run.py` adjusted to use the defaults, the same as the app-service.