### PR TITLE
Return services as part of execution report

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-04-22 - 0.5.0
+
+- Output service names and artifact staging folder in execution report.
+
 ## 2025-04-17 - 0.4.2
 
 - Refactor sdk-suppressions.yaml link

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.4.2",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.4.2",
+  "version": "0.5.0",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -85,6 +85,7 @@ export const generateReport = (context: WorkflowContext) => {
 
   executionReport = {
     packages: packageReports,
+    services: context.services,
     executionResult: context.status,
     fullLogPath: context.fullLogFileName,
     filteredLogPath: context.filteredLogFileName,

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -41,6 +41,7 @@ export type WorkflowContext = SdkAutoContext & {
   sdkArtifactFolder?: string;
   sdkApiViewArtifactFolder?: string;
   specConfigPath?: string;
+  services: string[];
   pendingPackages: PackageData[];
   handledPackages: PackageData[];
   status: SDKAutomationState;
@@ -71,6 +72,7 @@ export const workflowInit = async (context: SdkAutoContext): Promise<WorkflowCon
 
   return {
     ...context,
+    services: [],
     pendingPackages: [],
     handledPackages: [],
     vsoLogs: new Map(),

--- a/tools/spec-gen-sdk/src/automation/workflowPackage.ts
+++ b/tools/spec-gen-sdk/src/automation/workflowPackage.ts
@@ -138,11 +138,11 @@ const workflowPkgSaveSDKArtifact = async (context: WorkflowContext, pkg: Package
   if (language.toLowerCase() === 'go') {
     serviceName = pkg.relativeFolderPath.replace(/^\/?sdk\//, ""); // go uses relative path as package name
   }
-  console.log(`##vso[task.setVariable variable=GeneratedSDK.ServiceName]${serviceName}`);
+  context.services?.push(serviceName);
   context.logger.info(`Save ${pkg.artifactPaths.length} artifact to Azure devOps.`);
   
   const stagedArtifactsFolder = path.join(context.config.workingFolder, 'out', 'stagedArtifacts');
-  console.log(`##vso[task.setVariable variable=GeneratedSDK.StagedArtifactsFolder]${stagedArtifactsFolder}`);
+  context.sdkArtifactFolder = stagedArtifactsFolder;
 
   // if no artifact generated or language is Go, skip
   if (pkg.artifactPaths.length === 0 || language.toLowerCase() === 'go') { 
@@ -154,7 +154,6 @@ const workflowPkgSaveSDKArtifact = async (context: WorkflowContext, pkg: Package
     fs.mkdirSync(destination, { recursive: true });
   }
   context.sdkArtifactFolder = destination;
-  console.log(`##vso[task.setVariable variable=GeneratedSDK.HasSDKArtifact]true`);
   for (const artifactPath of pkg.artifactPaths) {
     const fileName = path.basename(artifactPath);
     if (context.config.runEnv !== 'test') {
@@ -177,7 +176,6 @@ const workflowPkgSaveApiViewArtifact = async (context: WorkflowContext, pkg: Pac
     fs.mkdirSync(destination, { recursive: true });
   }
   context.sdkApiViewArtifactFolder = destination;
-  console.log(`##vso[task.setVariable variable=GeneratedSDK.HasApiViewArtifact]true`);
   const fileName = path.basename(pkg.apiViewArtifactPath);
   context.logger.info(`Copy apiView artifact from ${path.join(context.config.localSdkRepoPath, pkg.apiViewArtifactPath)} to ${path.join(destination, fileName)}`);
   copyFileSync(path.join(context.config.localSdkRepoPath, pkg.apiViewArtifactPath), path.join(destination, fileName));

--- a/tools/spec-gen-sdk/src/types/ExecutionReport.ts
+++ b/tools/spec-gen-sdk/src/types/ExecutionReport.ts
@@ -6,6 +6,7 @@ export const executionReportSchema = requireJsonc(__dirname + '/ExecutionReportS
 
 export type ExecutionReport = {
   packages: PackageReport[];
+  services?: string[];
   executionResult: SDKAutomationState;
   fullLogPath: string;
   filteredLogPath?: string;


### PR DESCRIPTION
Instead of writing a pipeline variable, return the services as part of the execution report.