### PR TITLE
Accidental Early-Exit on additional `triggeringPaths` in `Get-PrPkgProperties`

### DIFF
--- a/eng/common-tests/matrix-generator/pr-matrix-samples/js_scenarios.json
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/js_scenarios.json
@@ -527,6 +527,140 @@
         "CIParameters": {
           "CIMatrixConfigs": []
         }
+      },
+      {
+        "Name": "@azure/arm-resources",
+        "Version": "6.0.1",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/resources/arm-resources",
+        "ServiceDirectory": "resources",
+        "ReadMePath": "sdk/resources/arm-resources/README.md",
+        "ChangeLogPath": "sdk/resources/arm-resources/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "mgmt",
+        "IsNewSdk": true,
+        "ArtifactName": "azure-arm-resources",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": true,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "name": "azure-arm-resources",
+          "triggeringPaths": [
+            "/sdk/identity",
+            "config",
+            "devcontainer",
+            "github",
+            "scripts",
+            "/common",
+            "/eng",
+            "/sdk/resources/ci.mgmt.yml"
+          ],
+          "safeName": "azurearmresources"
+        },
+        "CIParameters": {
+          "CIMatrixConfigs": []
+        }
+      },
+      {
+        "Name": "@azure/identity",
+        "Version": "4.8.1",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/identity/identity",
+        "ServiceDirectory": "identity",
+        "ReadMePath": "sdk/identity/identity/README.md",
+        "ChangeLogPath": "sdk/identity/identity/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "azure-identity",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": true,
+        "AdditionalValidationPackages": [
+          "@azure-tests/perf-storage-blob"
+        ],
+        "ArtifactDetails": {
+          "name": "azure-identity",
+          "triggeringPaths": [
+            "/sdk/test-utils",
+            "config",
+            "devcontainer",
+            "github",
+            "scripts",
+            "/common",
+            "/eng",
+            "/sdk/identity/ci.yml"
+          ],
+          "safeName": "azureidentity"
+        },
+        "CIParameters": {
+          "CIMatrixConfigs": []
+        }
+      },
+      {
+        "Name": "@azure/service-bus",
+        "Version": "7.10.0",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/servicebus/service-bus",
+        "ServiceDirectory": "servicebus",
+        "ReadMePath": "sdk/servicebus/service-bus/README.md",
+        "ChangeLogPath": "sdk/servicebus/service-bus/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "azure-service-bus",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": true,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "name": "azure-service-bus",
+          "triggeringPaths": [
+            "config",
+            "devcontainer",
+            "github",
+            "scripts",
+            "/common",
+            "/eng",
+            "/sdk/servicebus/ci.yml"
+          ],
+          "safeName": "azureservicebus"
+        },
+        "CIParameters": {
+          "CIMatrixConfigs": []
+        }
+      },
+      {
+        "Name": "@azure/template",
+        "Version": "1.0.13-beta.2",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/template/template",
+        "ServiceDirectory": "template",
+        "ReadMePath": "sdk/template/template/README.md",
+        "ChangeLogPath": "sdk/template/template/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "azure-template",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": true,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "name": "azure-template",
+          "triggeringPaths": [
+            "/sdk/test-utils",
+            "/sdk/identity",
+            "config",
+            "devcontainer",
+            "github",
+            "scripts",
+            "/common",
+            "/eng",
+            "/sdk/template/ci.yml"
+          ],
+          "safeName": "azuretemplate"
+        },
+        "CIParameters": {
+          "CIMatrixConfigs": []
+        }
       }
     ]
   },

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
@@ -205,7 +205,7 @@
         "IsNewSdk": true,
         "ArtifactName": "Azure.Core.Amqp",
         "ReleaseStatus": "Unreleased",
-        "IncludedForValidation": false,
+        "IncludedForValidation": true,
         "AdditionalValidationPackages": null,
         "ArtifactDetails": {
           "triggeringPaths": [
@@ -234,7 +234,7 @@
         "IsNewSdk": true,
         "ArtifactName": "Azure.Core.Experimental",
         "ReleaseStatus": "Unreleased",
-        "IncludedForValidation": false,
+        "IncludedForValidation": true,
         "AdditionalValidationPackages": null,
         "ArtifactDetails": {
           "triggeringPaths": [
@@ -263,7 +263,7 @@
         "IsNewSdk": true,
         "ArtifactName": "Azure.Core.Expressions.DataFactory",
         "ReleaseStatus": "Unreleased",
-        "IncludedForValidation": false,
+        "IncludedForValidation": true,
         "AdditionalValidationPackages": null,
         "ArtifactDetails": {
           "triggeringPaths": [
@@ -292,7 +292,7 @@
         "IsNewSdk": true,
         "ArtifactName": "Microsoft.Azure.Core.NewtonsoftJson",
         "ReleaseStatus": "Unreleased",
-        "IncludedForValidation": false,
+        "IncludedForValidation": true,
         "AdditionalValidationPackages": null,
         "ArtifactDetails": {
           "triggeringPaths": [
@@ -321,7 +321,7 @@
         "IsNewSdk": true,
         "ArtifactName": "Microsoft.Azure.Core.Spatial",
         "ReleaseStatus": "Unreleased",
-        "IncludedForValidation": false,
+        "IncludedForValidation": true,
         "AdditionalValidationPackages": null,
         "ArtifactDetails": {
           "triggeringPaths": [
@@ -350,7 +350,7 @@
         "IsNewSdk": true,
         "ArtifactName": "Microsoft.Azure.Core.Spatial.NewtonsoftJson",
         "ReleaseStatus": "Unreleased",
-        "IncludedForValidation": false,
+        "IncludedForValidation": true,
         "AdditionalValidationPackages": null,
         "ArtifactDetails": {
           "triggeringPaths": [
@@ -379,7 +379,7 @@
         "IsNewSdk": true,
         "ArtifactName": "System.ClientModel",
         "ReleaseStatus": "Unreleased",
-        "IncludedForValidation": false,
+        "IncludedForValidation": true,
         "AdditionalValidationPackages": null,
         "ArtifactDetails": {
           "triggeringPaths": [

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
@@ -146,7 +146,7 @@
     ]
   },
   {
-    "name": "Core ci.yml change (should walk all triggering paths and indirect include core)",
+    "name": "Core ci.yml change (triggeringPaths should completely walk and include Azure.Core)",
     "diff": {
       "ChangedFiles": [
         "sdk/core/ci.yml"
@@ -190,6 +190,212 @@
           },
           "CheckAOTCompat": true,
           "BuildSnippets": false
+        }
+      },
+      {
+        "Name": "Azure.Core.Amqp",
+        "Version": "1.4.0-beta.1",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/core/Azure.Core.Amqp",
+        "ServiceDirectory": "core",
+        "ReadMePath": "sdk/core/Azure.Core.Amqp/README.md",
+        "ChangeLogPath": "sdk/core/Azure.Core.Amqp/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "Azure.Core.Amqp",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": false,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "triggeringPaths": [
+            "/sdk/core/ci.yml"
+          ],
+          "safeName": "AzureCoreAmqp",
+          "name": "Azure.Core.Amqp"
+        },
+        "CIParameters": {
+          "BuildSnippets": false,
+          "AOTTestInputs": null,
+          "CIMatrixConfigs": [],
+          "CheckAOTCompat": true
+        }
+      },
+      {
+        "Name": "Azure.Core.Experimental",
+        "Version": "0.1.0-preview.37",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/core/Azure.Core.Experimental",
+        "ServiceDirectory": "core",
+        "ReadMePath": "sdk/core/Azure.Core.Experimental/README.md",
+        "ChangeLogPath": "sdk/core/Azure.Core.Experimental/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "Azure.Core.Experimental",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": false,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "triggeringPaths": [
+            "/sdk/core/ci.yml"
+          ],
+          "safeName": "AzureCoreExperimental",
+          "name": "Azure.Core.Experimental"
+        },
+        "CIParameters": {
+          "BuildSnippets": false,
+          "AOTTestInputs": null,
+          "CIMatrixConfigs": [],
+          "CheckAOTCompat": true
+        }
+      },
+      {
+        "Name": "Azure.Core.Expressions.DataFactory",
+        "Version": "1.1.0-beta.1",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/core/Azure.Core.Expressions.DataFactory",
+        "ServiceDirectory": "core",
+        "ReadMePath": "sdk/core/Azure.Core.Expressions.DataFactory/README.md",
+        "ChangeLogPath": "sdk/core/Azure.Core.Expressions.DataFactory/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "Azure.Core.Expressions.DataFactory",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": false,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "triggeringPaths": [
+            "/sdk/core/ci.yml"
+          ],
+          "safeName": "AzureCoreExpressionsDataFactory",
+          "name": "Azure.Core.Expressions.DataFactory"
+        },
+        "CIParameters": {
+          "BuildSnippets": false,
+          "AOTTestInputs": null,
+          "CIMatrixConfigs": [],
+          "CheckAOTCompat": true
+        }
+      },
+      {
+        "Name": "Microsoft.Azure.Core.NewtonsoftJson",
+        "Version": "2.1.0-beta.1",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/core/Microsoft.Azure.Core.NewtonsoftJson",
+        "ServiceDirectory": "core",
+        "ReadMePath": "sdk/core/Microsoft.Azure.Core.NewtonsoftJson/README.md",
+        "ChangeLogPath": "sdk/core/Microsoft.Azure.Core.NewtonsoftJson/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "Microsoft.Azure.Core.NewtonsoftJson",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": false,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "triggeringPaths": [
+            "/sdk/core/ci.yml"
+          ],
+          "safeName": "MicrosoftAzureCoreNewtonsoftJson",
+          "name": "Microsoft.Azure.Core.NewtonsoftJson"
+        },
+        "CIParameters": {
+          "BuildSnippets": false,
+          "AOTTestInputs": null,
+          "CIMatrixConfigs": [],
+          "CheckAOTCompat": true
+        }
+      },
+      {
+        "Name": "Microsoft.Azure.Core.Spatial",
+        "Version": "1.2.0-beta.2",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/core/Microsoft.Azure.Core.Spatial",
+        "ServiceDirectory": "core",
+        "ReadMePath": "sdk/core/Microsoft.Azure.Core.Spatial/README.md",
+        "ChangeLogPath": "sdk/core/Microsoft.Azure.Core.Spatial/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "Microsoft.Azure.Core.Spatial",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": false,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "triggeringPaths": [
+            "/sdk/core/ci.yml"
+          ],
+          "safeName": "MicrosoftAzureCoreSpatial",
+          "name": "Microsoft.Azure.Core.Spatial"
+        },
+        "CIParameters": {
+          "BuildSnippets": false,
+          "AOTTestInputs": null,
+          "CIMatrixConfigs": [],
+          "CheckAOTCompat": true
+        }
+      },
+      {
+        "Name": "Microsoft.Azure.Core.Spatial.NewtonsoftJson",
+        "Version": "1.1.0-beta.2",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/core/Microsoft.Azure.Core.Spatial.NewtonsoftJson",
+        "ServiceDirectory": "core",
+        "ReadMePath": "sdk/core/Microsoft.Azure.Core.Spatial.NewtonsoftJson/README.md",
+        "ChangeLogPath": "sdk/core/Microsoft.Azure.Core.Spatial.NewtonsoftJson/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "Microsoft.Azure.Core.Spatial.NewtonsoftJson",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": false,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "triggeringPaths": [
+            "/sdk/core/ci.yml"
+          ],
+          "safeName": "MicrosoftAzureCoreSpatialNewtonsoftJson",
+          "name": "Microsoft.Azure.Core.Spatial.NewtonsoftJson"
+        },
+        "CIParameters": {
+          "BuildSnippets": false,
+          "AOTTestInputs": null,
+          "CIMatrixConfigs": [],
+          "CheckAOTCompat": true
+        }
+      },
+      {
+        "Name": "System.ClientModel",
+        "Version": "1.4.0-beta.2",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/core/System.ClientModel",
+        "ServiceDirectory": "core",
+        "ReadMePath": "sdk/core/System.ClientModel/README.md",
+        "ChangeLogPath": "sdk/core/System.ClientModel/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "System.ClientModel",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": false,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "triggeringPaths": [
+            "/sdk/core/ci.yml"
+          ],
+          "safeName": "SystemClientModel",
+          "name": "System.ClientModel"
+        },
+        "CIParameters": {
+          "BuildSnippets": false,
+          "AOTTestInputs": {
+            "ArtifactName": "System.ClientModel",
+            "ExpectedWarningsFilepath": "None"
+          },
+          "CIMatrixConfigs": [],
+          "CheckAOTCompat": true
         }
       }
     ]

--- a/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
+++ b/eng/common-tests/matrix-generator/pr-matrix-samples/net_scenarios.json
@@ -146,6 +146,55 @@
     ]
   },
   {
+    "name": "Core ci.yml change (should walk all triggering paths and indirect include core)",
+    "diff": {
+      "ChangedFiles": [
+        "sdk/core/ci.yml"
+      ],
+      "ChangedServices": [
+        "core"
+      ],
+      "ExcludePaths": [],
+      "DeletedFiles": [],
+      "PRNumber": "48379"
+    },
+    "expected_package_output": [
+      {
+        "Name": "Azure.Core",
+        "Version": "1.46.0-beta.1",
+        "DevVersion": null,
+        "DirectoryPath": "sdk/core/Azure.Core",
+        "ServiceDirectory": "core",
+        "ReadMePath": "sdk/core/Azure.Core/README.md",
+        "ChangeLogPath": "sdk/core/Azure.Core/CHANGELOG.md",
+        "Group": null,
+        "SdkType": "client",
+        "IsNewSdk": true,
+        "ArtifactName": "Azure.Core",
+        "ReleaseStatus": "Unreleased",
+        "IncludedForValidation": true,
+        "AdditionalValidationPackages": null,
+        "ArtifactDetails": {
+          "name": "Azure.Core",
+          "safeName": "AzureCore",
+          "triggeringPaths": [
+            "/sdk/resourcemanager",
+            "/sdk/core/ci.yml"
+          ]
+        },
+        "CIParameters": {
+          "CIMatrixConfigs": [],
+          "AOTTestInputs": {
+            "ExpectedWarningsFilepath": "/Azure.Core/tests/compatibility/ExpectedAotWarnings.txt",
+            "ArtifactName": "Azure.Core"
+          },
+          "CheckAOTCompat": true,
+          "BuildSnippets": false
+        }
+      }
+    ]
+  },
+  {
     "name": "Resource Manager Change (should indirect include core)",
     "diff": {
       "ChangedFiles": [

--- a/eng/common/scripts/Package-Properties.ps1
+++ b/eng/common/scripts/Package-Properties.ps1
@@ -396,8 +396,8 @@ function Get-PrPkgProperties([string]$InputDiffJson) {
                     $shouldInclude = $shouldInclude -or $includedForValidation
                     if ($includedForValidation) {
                         $pkg.IncludedForValidation = $true
+                        break
                     }
-                    break
                 }
 
                 # handle service-level changes to the ci.yml files


### PR DESCRIPTION
Badly placed break. This will jump out at you when you see the change. This came up because I added `eng/` to the `triggeringPaths` for `Azure.Core` in the .NET repo and the nothing changed as far as generated package props.

- [x] Added a test case to confirm the additional triggeringPath
- [x] Found an existing test case that was affected by this exact scenario unbeknownst to me, updated that too. 