### PR TITLE
Adding additional parameters to AI Triage Service

### DIFF
--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
@@ -470,7 +470,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests
         }
 
         // Override the AI Issue Triage Service call to return the values set in the test
-        public override Task<IssueTriageResponse> QueryAIIssueTriageService(IssueEventGitHubPayload issueEventPayload, bool disableLabels, bool disableAnswers)
+        public override Task<IssueTriageResponse> QueryAIIssueTriageService(IssueEventGitHubPayload issueEventPayload, bool predictLabels, bool predictAnswers)
         {
             return Task.FromResult(
                 new IssueTriageResponse { 

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/MockGitHubEventClient.cs
@@ -470,7 +470,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests
         }
 
         // Override the AI Issue Triage Service call to return the values set in the test
-        public override Task<IssueTriageResponse> QueryAIIssueTriageService(IssueEventGitHubPayload issueEventPayload)
+        public override Task<IssueTriageResponse> QueryAIIssueTriageService(IssueEventGitHubPayload issueEventPayload, bool disableLabels, bool disableAnswers)
         {
             return Task.FromResult(
                 new IssueTriageResponse { 

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Static/IssueProcessingTests.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor.Tests/Static/IssueProcessingTests.cs
@@ -92,6 +92,20 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.Tests.Static
                   false,
                   false,
                   false)]
+        // Scenario: Labels returned from AI Issue Triage Service
+        //           isMemberOfOrg and hasWriteOrAdmin both set to false.
+        // Expected: CustomerReported, Question, and only predicted labels added to the Issue
+        [TestCase(RulesConstants.InitialIssueTriage,
+                  "Tests.JsonEventPayloads/InitialIssueTriage_issue_opened_no_labels_no_assignee.json",
+                  RuleState.On,
+                  RuleState.On,
+                  "FakeLabel666", // labels returned from the AI Issue Triage Service
+                  null, // answer returned from the AI Issue Triage Service
+                  null, // answer type returned from the AI Issue Triage Service
+                  null, // owners with permission to be assigned to issues
+                  false,
+                  false,
+                  false)]
         // Scenario: No labels returned from AI Issue Triage Service
         //           isMemberOfOrg is true and hasWriteOrAdmin is false
         // Expected: Only NeedsTriage label added to the Issue

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/IssueProcessing.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/IssueProcessing.cs
@@ -119,8 +119,12 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                     if ((issueEventPayload.Issue.Labels.Count == 0) && (issueEventPayload.Issue.Assignee == null))
                     {
                         // Query AI Triage and disable Answers if this is not a customer reported issue.
-                        IssueTriageResponse triageOutput = await gitHubEventClient.QueryAIIssueTriageService(issueEventPayload, false, !isCustomerReported);
-                        if (triageOutput.Labels.Count() > 0)
+                        IssueTriageResponse triageOutput = await gitHubEventClient.QueryAIIssueTriageService(
+                            issueEventPayload, 
+                            true, 
+                            !isCustomerReported);
+
+                        if (triageOutput.Labels.Any())
                         {
                             // If labels were predicted, add them to the issue
                             foreach (string label in triageOutput.Labels)

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/IssueProcessing.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/EventProcessing/IssueProcessing.cs
@@ -49,7 +49,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
         /// Conditions: Issue has no labels
         ///             Issue has no assignee
         /// Resulting Actions:
-        ///    Query AI label service for label suggestions:
+        ///    Query AI Triage service:
         ///       IF labels were predicted:
         ///         - Assign returned labels to the issue
 
@@ -100,10 +100,26 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
             {
                 if (issueEventPayload.Action == ActionConstants.Opened)
                 {
+                    // If the user is not a member of the Azure Org AND the user does not have write or admin collaborator permission.
+                    // This piece is executed for every issue created that doesn't have labels or owners on it at the time of creation.
+                    bool isCustomerReported = false;
+                    bool isMemberOfOrg = await gitHubEventClient.IsUserMemberOfOrg(OrgConstants.Azure, issueEventPayload.Issue.User.Login);
+                    if (!isMemberOfOrg)
+                    {
+                        bool hasAdminOrWritePermission = await gitHubEventClient.DoesUserHaveAdminOrWritePermission(issueEventPayload.Repository.Id, issueEventPayload.Issue.User.Login);
+                        if (!hasAdminOrWritePermission)
+                        {
+                            gitHubEventClient.AddLabel(TriageLabelConstants.CustomerReported);
+                            gitHubEventClient.AddLabel(TriageLabelConstants.Question);
+                            isCustomerReported = true;
+                        }
+                    }
+
                     // If there are no labels and no assignees
                     if ((issueEventPayload.Issue.Labels.Count == 0) && (issueEventPayload.Issue.Assignee == null))
                     {
-                        IssueTriageResponse triageOutput = await gitHubEventClient.QueryAIIssueTriageService(issueEventPayload);
+                        // Query AI Triage and disable Answers if this is not a customer reported issue.
+                        IssueTriageResponse triageOutput = await gitHubEventClient.QueryAIIssueTriageService(issueEventPayload, false, !isCustomerReported);
                         if (triageOutput.Labels.Count() > 0)
                         {
                             // If labels were predicted, add them to the issue
@@ -221,8 +237,8 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                             }
 
                             // The needs-team-attention label is only added when it can be determined
-                            // who this issue belongs to.
-                            if (addNeedsTeamAttention)
+                            // who this issue belongs to and it is not customer reported. 
+                            if (addNeedsTeamAttention && !isCustomerReported)
                             {
                                 gitHubEventClient.AddLabel(TriageLabelConstants.NeedsTeamAttention);
                             }
@@ -253,19 +269,6 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor.EventProcessing
                         else
                         {
                             gitHubEventClient.AddLabel(TriageLabelConstants.NeedsTriage);
-                        }
-
-                        // If the user is not a member of the Azure Org AND the user does not have write or admin collaborator permission.
-                        // This piece is executed for every issue created that doesn't have labels or owners on it at the time of creation.
-                        bool isMemberOfOrg = await gitHubEventClient.IsUserMemberOfOrg(OrgConstants.Azure, issueEventPayload.Issue.User.Login);
-                        if (!isMemberOfOrg)
-                        {
-                            bool hasAdminOrWritePermission = await gitHubEventClient.DoesUserHaveAdminOrWritePermission(issueEventPayload.Repository.Id, issueEventPayload.Issue.User.Login);
-                            if (!hasAdminOrWritePermission)
-                            {
-                                gitHubEventClient.AddLabel(TriageLabelConstants.CustomerReported);
-                                gitHubEventClient.AddLabel(TriageLabelConstants.Question);
-                            }
                         }
                     }
                 }

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
@@ -1321,7 +1321,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
             return rulesConfiguration;
         }
 
-        public virtual async Task<IssueTriageResponse> QueryAIIssueTriageService(IssueEventGitHubPayload issueEventPayload, bool disableLabels, bool disableAnswers)
+        public virtual async Task<IssueTriageResponse> QueryAIIssueTriageService(IssueEventGitHubPayload issueEventPayload, bool predictLabels, bool predictAnswers)
         {
             // The LABEL_SERVICE_API_KEY is queried from Keyvault as part of the action and added to the
             // environment.
@@ -1341,8 +1341,8 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
                 IssueUserLogin = issueEventPayload.Issue.User.Login,
                 RepositoryName = issueEventPayload.Repository.Name,
                 RepositoryOwnerName = issueEventPayload.Repository.Owner.Login,
-                DisableAnswers = disableAnswers,
-                DisableLabels = disableLabels
+                DisableAnswers = predictAnswers,
+                DisableLabels = predictLabels
             };
             using var client = new HttpClient();
             IssueTriageResponse output;

--- a/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
+++ b/tools/github-event-processor/Azure.Sdk.Tools.GitHubEventProcessor/GitHubEventClient.cs
@@ -1321,7 +1321,7 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
             return rulesConfiguration;
         }
 
-        public virtual async Task<IssueTriageResponse> QueryAIIssueTriageService(IssueEventGitHubPayload issueEventPayload)
+        public virtual async Task<IssueTriageResponse> QueryAIIssueTriageService(IssueEventGitHubPayload issueEventPayload, bool disableLabels, bool disableAnswers)
         {
             // The LABEL_SERVICE_API_KEY is queried from Keyvault as part of the action and added to the
             // environment.
@@ -1340,7 +1340,9 @@ namespace Azure.Sdk.Tools.GitHubEventProcessor
                 issueEventPayload.Issue.Body,
                 IssueUserLogin = issueEventPayload.Issue.User.Login,
                 RepositoryName = issueEventPayload.Repository.Name,
-                RepositoryOwnerName = issueEventPayload.Repository.Owner.Login
+                RepositoryOwnerName = issueEventPayload.Repository.Owner.Login,
+                DisableAnswers = disableAnswers,
+                DisableLabels = disableLabels
             };
             using var client = new HttpClient();
             IssueTriageResponse output;


### PR DESCRIPTION
- Added in `DisableAnswers` and `DisableLabels` to turn off either service through here.
- When issue is not customer reported we will disable answers and not add `needs-team-attention`