### PR TITLE
Update publish-1es-artifact.yml

### DIFF
--- a/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -12,10 +12,11 @@ parameters:
   ArtifactPath: ''
   CustomCondition: true
   SbomEnabled: true
+  SkipRenamingArtifact: false
 
 steps:
   - pwsh: |
-      if ($env:AGENT_JOBSTATUS -eq "Failed") {
+      if (($env:AGENT_JOBSTATUS -eq "Failed") -and ('${{ parameters.SkipRenamingArtifact }}' -eq 'false')) {
         Write-Host "Setting artifact name to ${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt) because there were failures." 
         Write-Host "##vso[task.setvariable variable=PublishArtifactName;]${{ parameters.ArtifactName }}-FailedAttempt$(System.JobAttempt)"
       } else {


### PR DESCRIPTION
Added a flag to skip renaming the artifact when a job is failed. `spec-gen-sdk` pipelines needs to publish an artifact with a fixed name all the time. 

Refer to this [spec-gen-sdk PR](https://github.com/Azure/azure-rest-api-specs/pull/34179#issue-3015302076) for details.