### PR TITLE
[APIView Copilot] Ensure templates are populated with the "pretty" language name

### DIFF
--- a/packages/python-packages/apiview-copilot/scratch/output/ios/AzureCommunicationCalling.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/ios/AzureCommunicationCalling.json
@@ -3,77 +3,70 @@
         {
             "rule_ids": [],
             "line_no": 7,
-            "bad_code": "open func dealloc()",
-            "suggestion": "/* Remove explicit dealloc methods; rely on Swift’s automatic ARC and implement deinit if custom cleanup is needed. */",
-            "comment": "$Many classes include an explicit 'dealloc' method. In Swift, memory is managed automatically using ARC, so exposing dealloc is not idiomatic. Instead, use deinit for any necessary cleanup or remove these methods entirely. (general comment)",
+            "bad_code": "@available(*, deprecated, message: \"Use IncomingVideoOptions and OutgoingVideoOptions instead\") open var videoOptions: VideoOptions?",
+            "suggestion": "/* Consider removing this deprecated property in the next major release, and ensure that documentation clearly points to IncomingVideoOptions and OutgoingVideoOptions as replacements. */",
+            "comment": "While using @available for deprecation is good for guiding developers, maintaining deprecated API members increases clutter. A plan to phase them out in future major versions would improve maintainability.",
             "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 14,
+            "bad_code": "open class AddPhoneNumberOptions: NSObject {",
+            "suggestion": "/* Consider using a Swift struct or a plain class that does not inherit from NSObject if Objective-C interoperability isn’t required. */",
+            "comment": "The heavy reliance on NSObject throughout the API may indicate legacy design. Using value types or pure Swift classes can lead to more idiomatic, lightweight APIs.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [
+                "ios_design.html#ios-language-swift-idiomatic",
+                "ios_implementation.html#ios-implementation"
+            ],
+            "line_no": 16,
+            "bad_code": "open func dealloc()",
+            "suggestion": "Remove the public dealloc() method and implement cleanup in a deinit instead.",
+            "comment": "Publicly exposing dealloc() is not idiomatic in Swift. Memory management in Swift is handled automatically by ARC (using deinit), so dealloc methods should be hidden (made internal or removed) to avoid exposing implementation details as part of the public API.",
+            "source": "guideline"
         },
         {
             "rule_ids": [
                 "ios_design.html#ios-language-swift-idiomatic"
             ],
-            "line_no": 16,
-            "bad_code": "open func dealloc()",
-            "suggestion": "Remove the public dealloc() method and rely on Swift’s automatic reference counting (or implement deinit as needed, keeping such logic internal).",
-            "comment": "The API surface exposes numerous dealloc() methods (see line 16) which is not idiomatic in Swift 5. In Swift, resource cleanup is handled automatically through ARC and, if necessary, a deinit block. Exposing dealloc() as part of the public API violates the idiomatic Swift style expected in Azure SDKs.",
-            "source": "guideline"
-        },
-        {
-            "rule_ids": [
-                "ios_design.html#ios-client-options-types"
-            ],
             "line_no": 17,
             "bad_code": "open var alternateCallerId: UnsafeMutablePointer<Int32>",
-            "suggestion": "Use a safe Swift type (e.g. an optional Int32) instead of an UnsafeMutablePointer.",
-            "comment": "The property 'alternateCallerId' is declared as an UnsafeMutablePointer<Int32> (line 17). For improved safety and to be more idiomatic, a Swift value type (such as Int32? if appropriate) should be used instead of a low-level, mutable pointer.",
+            "suggestion": "Use a Swift native value type such as Int32 (or an Optional<Int32>) instead of an unsafe pointer.",
+            "comment": "Exposing an UnsafeMutablePointer in the public API is non‐idiomatic in Swift and undermines safety. Prefer using Swift’s native value types to ensure memory safety and to keep the API idiomatic.",
             "source": "guideline"
         },
         {
             "rule_ids": [],
-            "line_no": 152,
-            "bad_code": "open func mute() async throws",
-            "suggestion": "/* Maintain both async and callback variants if necessary, but consider unifying the API if possible. */",
-            "comment": "$Providing both completionHandler-based and async/await versions is useful for supporting different usage scenarios. However, it increases the surface area of the API. Consider if unification or clear guidance on which pattern to use can streamline the developer experience. (general comment)",
+            "line_no": 147,
+            "bad_code": "open func mute(completionHandler: @escaping (Error?) -> Void)",
+            "suggestion": "/* If supporting modern Swift, consider favoring the async/await variant and potentially deprecating the callback-based method. */",
+            "comment": "Offering both callback and async versions increases the API surface. While it improves compatibility, simplifying to a modern async interface can enhance clarity for Swift developers.",
             "source": "generic"
         },
         {
             "rule_ids": [],
             "line_no": 157,
             "bad_code": "open func add(participant: Any) throws -> RemoteParticipant?",
-            "suggestion": "open func add<T: CallParticipantProtocol>(participant: T) throws -> RemoteParticipant?",
-            "comment": "Accepting a parameter of type 'Any' reduces type safety and clarity. Replace 'Any' by defining a specific protocol or type (for example, CallParticipantProtocol) for participant objects so that developers get proper compile‐time checking and clearer intent.",
+            "suggestion": "/* Replace 'Any' with a more specific type (e.g., a protocol like CallParticipant or a concrete identifier type) to ensure type safety. */",
+            "comment": "Using Any lessens compile‐time checking and obscures API intent. A strongly typed parameter improves clarity and developer experience.",
             "source": "generic"
         },
         {
             "rule_ids": [],
-            "line_no": 223,
-            "bad_code": "open func createCallAgent(userCredential: Any!, options: CallAgentOptions?) async throws -> CallAgent",
-            "suggestion": "open func createCallAgent(userCredential: UserCredential, options: CallAgentOptions?) async throws -> CallAgent",
-            "comment": "Using 'Any!' for user credentials is too vague. Defining a specific type like 'UserCredential' increases clarity, enforces type safety, and improves the developer experience.",
+            "line_no": 158,
+            "bad_code": "open func add(participant: Any!, options: AddPhoneNumberOptions?) throws -> RemoteParticipant?",
+            "suggestion": "/* Avoid force-unwrapped parameters. Use a clearly defined, non-optional type instead of 'Any!'. */",
+            "comment": "Using an implicitly unwrapped 'Any!' risks runtime crashes and reduces type safety. It's better to design with explicit, meaningful types.",
             "source": "generic"
         },
         {
             "rule_ids": [],
-            "line_no": 224,
-            "bad_code": "optional func callAgent(_: CallAgent, didRecieveIncomingCall: IncomingCall)",
-            "suggestion": "extension CallAgentDelegate {\n    func callAgent(_ callAgent: CallAgent, didReceiveIncomingCall call: IncomingCall) {}\n}",
-            "comment": "$Having optional protocol methods via @objc is acceptable for Objective-C interop, but in pure Swift it’s more idiomatic to provide default implementations via protocol extensions. This improves discoverability and leverages Swift’s type safety. (general comment)",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 234,
-            "bad_code": "open var debugInfo: CallDebugInfo { get }",
-            "suggestion": "/* Ensure computed properties follow standard Swift naming. If this property involves computation, document its behavior clearly. */",
-            "comment": "While the naming is descriptive, it is important to ensure that computed properties that represent immutable values or diagnostic information maintain consistency with Swift conventions. Providing clear documentation on any non‐trivial computation or side effects can further enhance clarity.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 645,
-            "bad_code": "open func getServerCallId(completionHandler: @escaping (String?, Error?) -> Void)",
-            "suggestion": "Consider exposing the server call identifier as a read-only computed property if the operation is lightweight, e.g. 'var serverCallId: String { get }'.",
-            "comment": "Using a method prefixed with 'get' is less in line with Swift’s guidelines. If the value is available without side effects, consider using a computed read-only property.",
+            "line_no": 2144,
+            "bad_code": "open class TeamsCallAgentEvents: NSObject {",
+            "suggestion": "/* Consider unifying event types across similar modules (e.g., CallEvents, TeamsCallEvents) where possible or document the differences clearly. */",
+            "comment": "Even though naming is fairly consistent, the coexistence of very similarly named types (e.g. TeamsCall vs. Call) can confuse the API consumer. A clearer module or namespace strategy could enhance discoverability.",
             "source": "generic"
         }
     ]

--- a/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
@@ -221,7 +221,7 @@ class ApiViewReview:
             filter_prompt_path,
             inputs={
                 "comments": combined_results,
-                "language": self.language,
+                "language": self._get_language_pretty_name(),
                 "sample": filter_metadata["sample"],
                 "exceptions": filter_metadata["exceptions"],
             },
@@ -241,6 +241,22 @@ class ApiViewReview:
             print(f"{RED_TEXT}WARN: Semantic search failed for some chunks (see error.log).{RESET_COLOR}")
 
         return final_results
+
+    def _get_language_pretty_name(self) -> str:
+        """
+        Returns a pretty name for the language.
+        """
+        language_pretty_names = {
+            "android": "Android",
+            "cpp": "C++",
+            "dotnet": "C#",
+            "golang": "Go",
+            "ios": "Swift",
+            "java": "Java",
+            "python": "Python",
+            "typescript": "JavaScript",
+        }
+        return language_pretty_names.get(self.language, self.language.capitalize())
 
     def _retrieve_and_resolve_guidelines(self, query: str) -> List[object] | None:
         try:
@@ -464,7 +480,7 @@ class ApiViewReview:
                     prompty.execute,
                     os.path.join(_PROMPTS_FOLDER, guideline_prompt_file),
                     inputs={
-                        "language": self.language,
+                        "language": self._get_language_pretty_name(),
                         "context": context_string,
                         "apiview": chunk.numbered(),
                     },
@@ -476,7 +492,7 @@ class ApiViewReview:
                 prompty.execute,
                 os.path.join(_PROMPTS_FOLDER, generic_prompt_file),
                 inputs={
-                    "language": self.language,
+                    "language": self._get_language_pretty_name(),
                     "apiview": chunk.numbered(),
                     "custom_rules": generic_metadata["custom_rules"],
                 },


### PR DESCRIPTION
Without this, we would be populating the prompts with things like 

- "Be idiomatic for ios developers"
- "Be idiomatic for cpp developers"

Instead these SHOULD read:
- "Be idiomatic for Swift developers"
- "Be idiomatic for C++ developers"

Etc.