### PR TITLE
[Python APIView] fix manual upload command

### DIFF
--- a/eng/scripts/Create-Apiview-Token-Python.ps1
+++ b/eng/scripts/Create-Apiview-Token-Python.ps1
@@ -8,4 +8,4 @@ param (
 
 python -m pip freeze
 Write-Host "Generating API review token file: $($SourcePath)"
-python -m apistubgen --pkg-path $SourcePath --out-path $OutPath
+python -m apistub --pkg-path $SourcePath --out-path $OutPath


### PR DESCRIPTION
Reverting this PR for now: https://github.com/Azure/azure-sdk-tools/pull/10357/files

Originally changed "apistub" to "apistubgen" since that's the command used everywhere else, and thought it might account for discrepancy we're seeing between local generation and CI. However, the "apistubgen" command seems to not even be recognized in the pipeline. Need to investigate + test more.