### PR TITLE
Set the resource group prefix after we get the tenantId

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -199,18 +199,6 @@ try {
         -serviceDirectoryName $serviceName `
         -CI $CI
 
-    if ($wellKnownTMETenants.Contains($TenantId)) {
-        # Add a prefix to the resource group name to avoid flagging the usages of local auth
-        # See details at https://eng.ms/docs/products/onecert-certificates-key-vault-and-dsms/key-vault-dsms/certandsecretmngmt/credfreefaqs#how-can-i-disable-s360-reporting-when-testing-customer-facing-3p-features-that-depend-on-use-of-unsafe-local-auth
-        $ResourceGroupName = "SSS3PT_" + $ResourceGroupName
-    }
-
-    if ($ResourceGroupName.Length -gt 90) {
-        # See limits at https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
-        Write-Warning -Message "Resource group name '$ResourceGroupName' is too long. So pruning it to be the first 90 characters."
-        $ResourceGroupName = $ResourceGroupName.Substring(0, 90)
-    }
-
     # Make sure pre- and post-scripts are passed formerly required arguments.
     $PSBoundParameters['BaseName'] = $BaseName
 
@@ -302,6 +290,19 @@ try {
         if (!$TenantId) {
             $TenantId = $context.Subscription.TenantId
         }
+    }
+
+    # This needs to happen after we set the TenantId but before we use the ResourceGroupName
+    if ($wellKnownTMETenants.Contains($TenantId)) {
+        # Add a prefix to the resource group name to avoid flagging the usages of local auth
+        # See details at https://eng.ms/docs/products/onecert-certificates-key-vault-and-dsms/key-vault-dsms/certandsecretmngmt/credfreefaqs#how-can-i-disable-s360-reporting-when-testing-customer-facing-3p-features-that-depend-on-use-of-unsafe-local-auth
+        $ResourceGroupName = "SSS3PT_" + $ResourceGroupName
+    }
+
+    if ($ResourceGroupName.Length -gt 90) {
+        # See limits at https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
+        Write-Warning -Message "Resource group name '$ResourceGroupName' is too long. So pruning it to be the first 90 characters."
+        $ResourceGroupName = $ResourceGroupName.Substring(0, 90)
     }
 
     # If a provisioner service principal was provided log into it to perform the pre- and post-scripts and deployments.


### PR DESCRIPTION
Given we are using the tenantId to determine to add the prefix or not we need to make sure we have it set before we check it. For the pipelines it is set at the script calling time, so it was working there but for some local scenarios it is not set yet, so we need to do it a little later in the script.