### PR TITLE
Properly handle error for case where no issue (pr) is found for specified commit

### DIFF
--- a/eng/common/scripts/Helpers/ApiView-Helpers.ps1
+++ b/eng/common/scripts/Helpers/ApiView-Helpers.ps1
@@ -132,7 +132,7 @@ function Set-ApiViewCommentForRelatedIssues {
   try {
     $issuesForCommit = Search-GitHubIssues -CommitHash $HeadCommitish
     if ($issuesForCommit.items.Count -eq 0) {
-      LogWarning "No issues found for commit: $HeadCommitish"
+      LogInfo "No issues found for commit: $HeadCommitish"
       Write-Host "##vso[task.complete result=SucceededWithIssues;]DONE"
       exit 0
     }
@@ -170,7 +170,7 @@ function Set-ApiViewCommentForPR {
   $commentText += "## API Change Check"
   try {
     $response = Invoke-WebRequest -Uri $apiviewEndpoint -Method Get -MaximumRetryCount 3
-    LogDebug "OperationId: $($response.Headers['X-Operation-Id'])"
+    LogInfo "OperationId: $($response.Headers['X-Operation-Id'])"
     if ($response.StatusCode -ne 200) {
       LogWarning "API changes are not detected in this pull request."
       exit 0

--- a/eng/common/scripts/Helpers/ApiView-Helpers.ps1
+++ b/eng/common/scripts/Helpers/ApiView-Helpers.ps1
@@ -132,8 +132,9 @@ function Set-ApiViewCommentForRelatedIssues {
   try {
     $issuesForCommit = Search-GitHubIssues -CommitHash $HeadCommitish
     if ($issuesForCommit.items.Count -eq 0) {
-      LogError "No issues found for commit: $HeadCommitish"
-      exit 1
+      LogWarning "No issues found for commit: $HeadCommitish"
+      Write-Host "##vso[task.complete result=SucceededWithIssues;]DONE"
+      exit 0
     }
   } catch {
     LogError "No issues found for commit: $HeadCommitish"
@@ -169,6 +170,7 @@ function Set-ApiViewCommentForPR {
   $commentText += "## API Change Check"
   try {
     $response = Invoke-WebRequest -Uri $apiviewEndpoint -Method Get -MaximumRetryCount 3
+    LogDebug "OperationId: $($response.Headers['X-Operation-Id'])"
     if ($response.StatusCode -ne 200) {
       LogWarning "API changes are not detected in this pull request."
       exit 0

--- a/eng/common/scripts/Helpers/ApiView-Helpers.ps1
+++ b/eng/common/scripts/Helpers/ApiView-Helpers.ps1
@@ -172,7 +172,7 @@ function Set-ApiViewCommentForPR {
     $response = Invoke-WebRequest -Uri $apiviewEndpoint -Method Get -MaximumRetryCount 3
     LogInfo "OperationId: $($response.Headers['X-Operation-Id'])"
     if ($response.StatusCode -ne 200) {
-      LogWarning "API changes are not detected in this pull request."
+      LogInfo "API changes are not detected in this pull request."
       exit 0
     }
     else {


### PR DESCRIPTION
- Properly handle error for case where no issue (pr) is found for specified commit.
- Log `OperationId` to enable location of trace data in App Insights