### PR TITLE
[APIView Copilot] Ensure that suggestions are ONLY code

### DIFF
--- a/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
@@ -42,8 +42,7 @@ sample: |
           {
             "line_no": 2,
             "bad_code": "def method1(self, arg1: str) -> None",
-            "code_fix": "",
-            "general_suggestion": "Add docstring explaining method purpose",
+            "suggestion": "Add docstring explaining method purpose",
             "comment": "Methods should have descriptive docstrings"
             "status": "REMOVE",
             "status_reason": "Comment on docstring suggestion violates exceptions"
@@ -51,8 +50,7 @@ sample: |
           {
             "line_no": 2,
             "bad_code": "def method1(self, arg1: str) -> None",
-            "code_fix": "def get_something(self, name: str) -> None",
-            "general_suggestion": "Improve the method name",
+            "suggestion": "def get_something(self, name: str) -> None",
             "comment": "Method name should be more descriptive"
             "status": "KEEP",
             "status_reason": "Comment enhances API design"

--- a/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
@@ -42,7 +42,8 @@ sample: |
           {
             "line_no": 2,
             "bad_code": "def method1(self, arg1: str) -> None",
-            "suggestion": "Add docstring explaining method purpose",
+            "code_fix": "",
+            "general_suggestion": "Add docstring explaining method purpose",
             "comment": "Methods should have descriptive docstrings"
             "status": "REMOVE",
             "status_reason": "Comment on docstring suggestion violates exceptions"
@@ -50,7 +51,8 @@ sample: |
           {
             "line_no": 2,
             "bad_code": "def method1(self, arg1: str) -> None",
-            "suggestion": "def get_something(self, name: str) -> None",
+            "code_fix": "def get_something(self, name: str) -> None",
+            "general_suggestion": "Improve the method name",
             "comment": "Method name should be more descriptive"
             "status": "KEEP",
             "status_reason": "Comment enhances API design"

--- a/packages/python-packages/apiview-copilot/prompts/filtered_result_schema.json
+++ b/packages/python-packages/apiview-copilot/prompts/filtered_result_schema.json
@@ -27,13 +27,9 @@
                 "type": "string",
                 "description": "the original code that was bad. MUST be identical to the input."
               },
-              "code_fix": {
-                "type": "string",
-                "description": "valid code which fixes the bad_code. MUST be code (but NOT just a code comment)."
-              },
-              "general_suggestion": {
-                "type": "string",
-                "description": "a natural language suggestion for fixing the bad_code. MUST NOT be code."
+              "suggestion": {
+                "type": ["string", "null"],
+                "description": "the suggested code which fixes the bad code. MUST be identical to the input."
               },
               "comment": {
                 "type": "string",
@@ -56,8 +52,7 @@
               "rule_ids",
               "line_no",
               "bad_code",
-              "code_fix",
-              "general_suggestion",
+              "suggestion",
               "comment",
               "source",
               "status",

--- a/packages/python-packages/apiview-copilot/prompts/filtered_result_schema.json
+++ b/packages/python-packages/apiview-copilot/prompts/filtered_result_schema.json
@@ -27,9 +27,13 @@
                 "type": "string",
                 "description": "the original code that was bad. MUST be identical to the input."
               },
-              "suggestion": {
+              "code_fix": {
                 "type": "string",
-                "description": "the suggested code which fixes the bad code. MUST be identical to the input."
+                "description": "valid code which fixes the bad_code. MUST be code (but NOT just a code comment)."
+              },
+              "general_suggestion": {
+                "type": "string",
+                "description": "a natural language suggestion for fixing the bad_code. MUST NOT be code."
               },
               "comment": {
                 "type": "string",
@@ -52,7 +56,8 @@
               "rule_ids",
               "line_no",
               "bad_code",
-              "suggestion",
+              "code_fix",
+              "general_suggestion",
               "comment",
               "source",
               "status",

--- a/packages/python-packages/apiview-copilot/prompts/final_comments_filter.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/final_comments_filter.prompty
@@ -81,7 +81,7 @@ system: |
   - Flag any comments' `status` field as "REMOVE" that violate the exceptions
   - Flag any comments' `status` field as "KEEP" that enhance API design
   - All comments MUST be flagged with a `status` field, and a `status_reason`.
-  - Maintain the same output schema as the proposed comments, except for the addition of `status` and `status_reason` fields.
+  - For properties that are in the input schema AND the output schema, the value in the output must be the same as the input.
 
 user: |
   Please validate the following review against the exceptions:
@@ -97,7 +97,7 @@ assistant: |
   1. Check if it violates any of the validation rules by focusing on the content in the `comment` field, not other fields.
   2. Flag any comments' `status` field as "REMOVE" that violate the exceptions
   3. Flag any comments' `status` field as "KEEP" that enhance API design
-  4. Return a filtered set of comments in the same schema, with the addition of `status` and `status_reason` fields.
+  4. For properties that are in the input schema AND the output schema, the value in the output must be the same as the input.
 
   For each comment I will:
   - Verify it doesn't comment on excluded aspects
@@ -107,7 +107,8 @@ assistant: |
 
   The response will maintain the schema structure with:
   - A list of comments
-  - Each comment containing line_no, bad_code, suggestion, and comment identical to the original
-  - Each comments will include new fields `status` and `status_reason` to indicate whether it was kept or removed and the reason for that decision.
+  - Each comment containing line_no, bad_code, and comment identical to the original
+  - Each comment will include new fields `status` and `status_reason` to indicate whether it was kept or removed and the reason for that decision.
+  - Each comment will include new fields `code_fix` and `general_suggestion` to ensure distinction between code and general suggestions.
 
 {{sample}}

--- a/packages/python-packages/apiview-copilot/prompts/final_comments_filter.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/final_comments_filter.prompty
@@ -46,20 +46,23 @@ sample:
         {
           "line_no": 2,
           "bad_code": "def method1(self, arg1: str) -> None",
-          "suggestion": "Add docstring explaining method purpose",
-          "comment": "Methods should have descriptive docstrings"
+          "suggestion": "",
+          "comment": "Methods should have descriptive docstrings",
+          "source": "generic"
         },
         {
           "line_no": 2,
           "bad_code": "def method1(self, arg1: str) -> None",
           "suggestion": "`def method1(self, arg1: str) -> None:`",
-          "comment": "Methods should end with a colon"
+          "comment": "Methods should end with a colon",
+          "source": "generic"
         },
         {
           "line_no": 2,
           "bad_code": "def method1(self, arg1: str) -> None",
           "suggestion": "def get_something(self, name: str) -> None",
           "comment": "Method name should be more descriptive"
+          "source": "generic"
         }
       ]
     }

--- a/packages/python-packages/apiview-copilot/prompts/final_comments_filter.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/final_comments_filter.prompty
@@ -65,7 +65,7 @@ sample:
     }
   sample: ""
 ---
-system: |
+system:
   You are a helpful AI that reviews {{language}} API design comments from another AI. Your role is to filter out any comments that violate a set of known exceptions. You will receive:
   1. The proposed comments to review
   2. The exceptions that must be followed
@@ -83,7 +83,7 @@ system: |
   - All comments MUST be flagged with a `status` field, and a `status_reason`.
   - For properties that are in the input schema AND the output schema, the value in the output must be the same as the input.
 
-user: |
+user:
   Please validate the following review against the exceptions:
 
   Proposed Review Comments:
@@ -107,8 +107,7 @@ assistant: |
 
   The response will maintain the schema structure with:
   - A list of comments
-  - Each comment containing line_no, bad_code, and comment identical to the original
+  - Each comment containing line_no, bad_code, suggestion, and comment identical to the original
   - Each comment will include new fields `status` and `status_reason` to indicate whether it was kept or removed and the reason for that decision.
-  - Each comment will include new fields `code_fix` and `general_suggestion` to ensure distinction between code and general suggestions.
 
 {{sample}}

--- a/packages/python-packages/apiview-copilot/prompts/generic_result_schema.json
+++ b/packages/python-packages/apiview-copilot/prompts/generic_result_schema.json
@@ -21,7 +21,7 @@
                 "description": "the original code that was bad, cited verbatim. MUST BE a single line of code."
               },
               "suggestion": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "a suggested fix for the bad code. MUST be code, or null."
               },
               "comment": {

--- a/packages/python-packages/apiview-copilot/prompts/generic_result_schema.json
+++ b/packages/python-packages/apiview-copilot/prompts/generic_result_schema.json
@@ -18,15 +18,15 @@
               },
               "bad_code": {
                 "type": "string",
-                "description": "the original code that was bad, cited verbatim. MUST BE a single line of code."
+                "description": "must always cite the SINGLE matching APIView line, stopping at newlines. OMIT the line number. NEVER concatenate multiple lines."
               },
               "suggestion": {
                 "type": ["string", "null"],
-                "description": "a suggested fix for the bad code. MUST be code, or null."
+                "description": "only the single replacement code line exactly as it should appear (no markdown fencing, no prose), or the literal JSON null if there’s no fix."
               },
               "comment": {
                 "type": "string",
-                "description": "description of the violation."
+                "description": "concise, human-readable description of the issue. DO NOT use code snippets. DO NOT cite line numbers or guideline IDs."
               }
             },
             "required": ["line_no", "bad_code", "suggestion", "comment"]

--- a/packages/python-packages/apiview-copilot/prompts/generic_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/generic_review.prompty
@@ -73,6 +73,7 @@ system: |
   - Consider both experienced and novice {{language}} developers
   - APIView shows a high-level {{language}} pseudocode summary, not implementations
   - Only comment on improvements that can be made, not just general observations
+  - `suggestion` must either be a code snippet or the literal JSON null (no quotes)
 
 user:
 Evaluate the following APIView for developer experience and {{language}} design.

--- a/packages/python-packages/apiview-copilot/prompts/generic_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/generic_review.prompty
@@ -84,6 +84,7 @@ system:
   - **bad_code** must always cite the SINGLE matching APIView line, stopping at newlines. NEVER concatenate multiple lines.
     - GOOD: `def __init__(`
     - BAD: `def __init__(self, *, ...)`
+    - BAD: `10: def __init__(self, *, ...)`
   - **suggestion** only the single replacement code line exactly as it should appear (no markdown fencing, no prose), or the literal JSON null if there’s no fix.
     - GOOD: "  VALUE = 'value'"
     - BAD: "Suggest: '  VALUE = "value"'"
@@ -92,6 +93,7 @@ system:
     - GOOD: "Enum values should always be capitalized."
     - GOOD: "This class has too many methods. I suggest breaking it up into smaller classes."
     - BAD: "Per guideline python_implementation.html#python-enum-capitalization, enum value on line 25 should be capitalized. Suggest: `   VALUE = 'value'`"
+    - BAD: "Some comment.. Suggest: `   VALUE = 'value'`"
 
 user:
   Evaluate the following APIView for developer experience and {{language}} design.

--- a/packages/python-packages/apiview-copilot/prompts/generic_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/generic_review.prompty
@@ -15,7 +15,7 @@ model:
   parameters:
     frequency_penalty: 0
     presence_penalty: 0
-    max_completion_tokens: 20000
+    max_completion_tokens: 80000
     reasoning_effort: "high"
     response_format: ${file:generic_result_schema.json}
 sample:
@@ -30,12 +30,17 @@ sample:
     - Does the API use proper type hints and follow best static typing practices for Python?
   apiview: |
     ```python
-    1: class azure.contoso.ClassName:
-    2:     def __init__(self, param1: str, param2: int)
-    3:     def method1(self, arg1: str) -> None
+    500: class azure.ai.vision.imageanalysis.models.VisualFeatures(str, Enum):
+    501:     CAPTION = 'caption'
+    502:     DENSE_CAPTIONS = 'denseCaptions'
+    503:     OBJECTS = 'objects'
+    504:     PEOPLE = 'people'
+    505:     READ = 'read'
+    506:     SMART_CROPS = 'smartCrops'
+    507:     tags = 'tags'
     ```
 ---
-system: |
+system:
   You are an expert API designer with deep knowledge of {{language}} and its ecosystem. You will analyze client library API surfaces to evaluate the developer experience and design qualities. Your goal is to ensure APIs are delightful to use, appropriately complex, and follow {{language}}'s philosophy of being explicit, simple and beautiful.
 
   # EVALUATION CRITERIA
@@ -62,9 +67,7 @@ system: |
   - Are standard {{language}} naming conventions followed?
   - Are names of reasonable length?
 
-  {{custom_rules}}
-
-  # RULES
+  # GENERAL RULES
   - Focus on qualitative aspects rather than strict guidelines
   - Each line of the APIView is prepended with a line number and colon
   - Make concrete suggestions for improvements
@@ -73,13 +76,28 @@ system: |
   - Consider both experienced and novice {{language}} developers
   - APIView shows a high-level {{language}} pseudocode summary, not implementations
   - Only comment on improvements that can be made, not just general observations
-  - `suggestion` must either be a code snippet or the literal JSON null (no quotes)
+
+  {{custom_rules}}
+
+
+  # OUTPUT RULES
+  - **bad_code** must always cite the SINGLE matching APIView line, stopping at newlines. NEVER concatenate multiple lines.
+    - GOOD: `def __init__(`
+    - BAD: `def __init__(self, *, ...)`
+  - **suggestion** only the single replacement code line exactly as it should appear (no markdown fencing, no prose), or the literal JSON null if there’s no fix.
+    - GOOD: "  VALUE = 'value'"
+    - BAD: "Suggest: '  VALUE = "value"'"
+    - BAD: "/* Capitalize value to be VALUE */"
+  - **comment** concise, human-readable description of the issue. DO NOT use code snippets. DO NOT cite line numbers or guideline IDs.
+    - GOOD: "Enum values should always be capitalized."
+    - GOOD: "This class has too many methods. I suggest breaking it up into smaller classes."
+    - BAD: "Per guideline python_implementation.html#python-enum-capitalization, enum value on line 25 should be capitalized. Suggest: `   VALUE = 'value'`"
 
 user:
-Evaluate the following APIView for developer experience and {{language}} design.
-```{{language}}
-{{apiview}}
-```
+  Evaluate the following APIView for developer experience and {{language}} design.
+  ```{{language}}
+  {{apiview}}
+  ```
 assistant: |
   Based on the evaluation criteria, analyze how delightful this API is and how well it adheres to {{language}} best practices. Consider:
 

--- a/packages/python-packages/apiview-copilot/prompts/guideline_result_schema.json
+++ b/packages/python-packages/apiview-copilot/prompts/guideline_result_schema.json
@@ -25,15 +25,15 @@
               },
               "bad_code": {
                 "type": "string",
-                "description": "the original code that was bad, cited verbatim. MUST BE a single line of code."
+                "description": "must always cite the SINGLE matching APIView line, stopping at newlines. OMIT the line number. NEVER concatenate multiple lines."
               },
               "suggestion": {
                 "type": ["string", "null"],
-                "description": "a suggested fix for the bad code. MUST be code, or null."
+                "description": "only the single replacement code line exactly as it should appear (no markdown fencing, no prose), or the literal JSON null if there’s no fix."
               },
               "comment": {
                 "type": "string",
-                "description": "description of the violation."
+                "description": "concise, human-readable description of the issue. DO NOT use code snippets. DO NOT cite line numbers or guideline IDs."
               }
             },
             "required": [

--- a/packages/python-packages/apiview-copilot/prompts/guideline_result_schema.json
+++ b/packages/python-packages/apiview-copilot/prompts/guideline_result_schema.json
@@ -28,7 +28,7 @@
                 "description": "the original code that was bad, cited verbatim. MUST BE a single line of code."
               },
               "suggestion": {
-                "type": "string",
+                "type": ["string", "null"],
                 "description": "a suggested fix for the bad code. MUST be code, or null."
               },
               "comment": {

--- a/packages/python-packages/apiview-copilot/prompts/guidelines_review_reasoning.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/guidelines_review_reasoning.prompty
@@ -96,6 +96,7 @@ system:
   - **bad_code** must always cite the SINGLE matching APIView line, stopping at newlines. NEVER concatenate multiple lines.
     - GOOD: `def __init__(`
     - BAD: `def __init__(self, *, ...)`
+    - BAD: `10: def __init__(self, *, ...)`
   - **suggestion** only the single replacement code line exactly as it should appear (no markdown fencing, no prose), or the literal JSON null if there’s no fix.
     - GOOD: "  VALUE = 'value'"
     - BAD: "Suggest: '  VALUE = "value"'"
@@ -104,6 +105,7 @@ system:
     - GOOD: "Enum values should always be capitalized."
     - GOOD: "This class has too many methods. I suggest breaking it up into smaller classes."
     - BAD: "Per guideline python_implementation.html#python-enum-capitalization, enum value on line 25 should be capitalized. Suggest: `   VALUE = 'value'`"
+    - BAD: "Some comment.. Suggest: `   VALUE = 'value'`"
 
   # CONTEXT
   These are deemed the most relevant guidelines for this review. Ground your responses solely within this context.

--- a/packages/python-packages/apiview-copilot/prompts/guidelines_review_reasoning.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/guidelines_review_reasoning.prompty
@@ -89,6 +89,8 @@ followed.
 
 - `bad_code` should always cite the SINGLE match APIView line, stopping at newlines. NEVER concatenate multiple lines. (GOOD: `def __init__(` BAD: `def __init__(self, *, ...)`
 
+- `suggestion` must either be a code snippet or the literal JSON null (no quotes)
+
 # CONTEXT
 These are deemed the most relevant guidelines for this review. Ground your responses solely within this context.
 {{context}}

--- a/packages/python-packages/apiview-copilot/prompts/guidelines_review_reasoning.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/guidelines_review_reasoning.prompty
@@ -15,19 +15,17 @@ model:
   parameters:
     frequency_penalty: 0
     presence_penalty: 0
-    max_completion_tokens: 20000
+    max_completion_tokens: 80000
     reasoning_effort: "high"
     response_format: ${file:guideline_result_schema.json}
 sample:
   language: python
   context: |
-    [
-      {
+    [{
       "id": "python_implementation=html=python-codestyle-kwargs",
       "title": "Use Keyword-Only Arguments for No Obvious Ordering",
       "content": "DO use keyword-only arguments for arguments that have no obvious ordering.\n\n",
       "language": "python",
-      "category": "Coding Style",
       "related_guidelines": [],
       "related_examples": [
         "python_implementation=html=python-codestyle-kwargs-example-1",
@@ -39,7 +37,6 @@ sample:
       "title": "Specify Parameter Names for Positional Parameters",
       "content": "DO specify the parameter name when calling methods with more than two required positional parameters.\n\n",
       "language": "python",
-      "category": "Coding Style",
       "related_guidelines": [],
       "related_examples": [
         "python_implementation=html=python-codestyle-positional-params-example-1",
@@ -51,52 +48,69 @@ sample:
       "title": "Specify Parameter Names for Optional Parameters",
       "content": "DO specify the parameter name for optional parameters when calling functions.\n\n",
       "language": "python",
-      "category": "Coding Style",
       "related_guidelines": [],
       "related_examples": [
         "python_implementation=html=python-codestyle-optional-param-calling-example-1",
         "python_implementation=html=python-codestyle-optional-param-calling-example-2"
       ]
-    }
-    ]
+    },
+    {
+      "id": "python_design.html#python-models-enum-name-uppercase",
+      "category": "Enumerations",
+      "text": "DO use UPPERCASE for enum member names.\n\n```python\n\n# Yes\nclass MyGoodEnum(str, Enum):\n    ONE = 'one'\n    TWO = 'two'\n\n# No\nclass MyBadEnum(str, Enum):\n    One = 'one' # No - using PascalCased name.\n    two = 'two' # No - using all lower case name.\n\n```"
+    }]
   apiview: |
     ```python
-    1: class azure.contoso.ClassName:
-    2:     def __init__(self, param1: str, param2: int)
-    3:     def method1(self, arg1: str) -> None
+    500: class azure.ai.vision.imageanalysis.models.VisualFeatures(str, Enum):
+    501:     CAPTION = 'caption'
+    502:     DENSE_CAPTIONS = 'denseCaptions'
+    503:     OBJECTS = 'objects'
+    504:     PEOPLE = 'people'
+    505:     READ = 'read'
+    506:     SMART_CROPS = 'smartCrops'
+    507:     tags = 'tags'
     ```
 ---
 system:
-You are an expert code reviewer of SDKs. You will analyze an entire client library APIView surface for {{language}} to determine whether it meets the SDK guidelines. 
+  You are an expert code reviewer of SDKs. You will analyze an entire client library APIView surface for {{language}} to determine whether it meets the SDK guidelines. 
 
-# RULES
-- ONLY mention if the library is clearly and visibly violating a guideline.
+  # RULES
+  - ONLY mention if the library is clearly and visibly violating a guideline.
 
-- Each line of the APIView is prepended with a line number a colon.
+  - Each line of the APIView is prepended with a line number a colon.
 
-- Be conservative - DO NOT make assumptions that a guideline is being violated because it is possible that all guidelines are being
-followed.
+  - Be conservative - DO NOT make assumptions that a guideline is being violated because it is possible that all guidelines are being
+  followed.
 
-- Evaluate each piece of code against all guidelines.
+  - Evaluate each piece of code against all guidelines.
 
-- Code may violate multiple guidelines.
+  - Code may violate multiple guidelines.
 
-- Each class will contain its namespace, like `class azure.contoso.ClassName` where 'azure.contoso' is the namespace and `ClassName` is the name of the class. 
+  - Each class will contain its namespace, like `class azure.contoso.ClassName` where 'azure.contoso' is the namespace and `ClassName` is the name of the class. 
 
-- APIView does not contain runnable code or implementations. It is a high-level {{language}} pseudocode summary of the client library surface. 
+  - APIView does not contain runnable code or implementations. It is a high-level {{language}} pseudocode summary of the client library surface. 
 
-- Always cite guideline IDs VERBATIM. Examples (GOOD: `python_implementation.html#python-codestyle-kwargs`, BAD: `python-codestyle-kwargs`).
+  - Always cite guideline IDs VERBATIM. Examples (GOOD: `python_implementation.html#python-codestyle-kwargs`, BAD: `python-codestyle-kwargs`).
 
-- `bad_code` should always cite the SINGLE match APIView line, stopping at newlines. NEVER concatenate multiple lines. (GOOD: `def __init__(` BAD: `def __init__(self, *, ...)`
+  # OUTPUT RULES
+  - **bad_code** must always cite the SINGLE matching APIView line, stopping at newlines. NEVER concatenate multiple lines.
+    - GOOD: `def __init__(`
+    - BAD: `def __init__(self, *, ...)`
+  - **suggestion** only the single replacement code line exactly as it should appear (no markdown fencing, no prose), or the literal JSON null if there’s no fix.
+    - GOOD: "  VALUE = 'value'"
+    - BAD: "Suggest: '  VALUE = "value"'"
+    - BAD: "/* Capitalize value to be VALUE */"
+  - **comment** concise, human-readable description of the issue. DO NOT use code snippets. DO NOT cite line numbers or guideline IDs.
+    - GOOD: "Enum values should always be capitalized."
+    - GOOD: "This class has too many methods. I suggest breaking it up into smaller classes."
+    - BAD: "Per guideline python_implementation.html#python-enum-capitalization, enum value on line 25 should be capitalized. Suggest: `   VALUE = 'value'`"
 
-- `suggestion` must either be a code snippet or the literal JSON null (no quotes)
-
-# CONTEXT
-These are deemed the most relevant guidelines for this review. Ground your responses solely within this context.
-{{context}}
+  # CONTEXT
+  These are deemed the most relevant guidelines for this review. Ground your responses solely within this context.
+  {{context}}
 
 user:
-Evaluate the following APIView and make comments.
-```{{language}}
-{{apiview}}
-```
+  Evaluate the following APIView and make comments.
+  ```{{language}}
+  {{apiview}}
+  ```

--- a/packages/python-packages/apiview-copilot/prompts/guidelines_review_regular.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/guidelines_review_regular.prompty
@@ -91,6 +91,8 @@ followed.
 
 - `bad_code` should always cite the SINGLE match APIView line, stopping at newlines. NEVER concatenate multiple lines. (GOOD: `def __init__(` BAD: `def __init__(self, *, ...)`
 
+- `suggestion` must either be a code snippet or the literal JSON null (no quotes)
+
 # CONTEXT
 These are deemed the most relevant guidelines for this review. Ground your responses solely within this context.
 {{context}}

--- a/packages/python-packages/apiview-copilot/prompts/guidelines_review_regular.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/guidelines_review_regular.prompty
@@ -109,6 +109,7 @@ system:
     - GOOD: "Enum values should always be capitalized."
     - GOOD: "This class has too many methods. I suggest breaking it up into smaller classes."
     - BAD: "Per guideline python_implementation.html#python-enum-capitalization, enum value on line 25 should be capitalized. Suggest: `   VALUE = 'value'`"
+    - BAD: "Some comment.. Suggest: `   VALUE = 'value'`"
 
   # CONTEXT
   These are deemed the most relevant guidelines for this review. Ground your responses solely within this context.

--- a/packages/python-packages/apiview-copilot/prompts/guidelines_review_regular.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/guidelines_review_regular.prompty
@@ -19,12 +19,11 @@ model:
     frequency_penalty: 0
     presence_penalty: 0
     max_tokens: 16384
-    response_format: ${file:guideline_violation_schema.json}
+    response_format: ${file:guideline_result_schema.json}
 sample:
   language: python
   context: |
-    [
-      {
+    [{
       "id": "python_implementation=html=python-codestyle-kwargs",
       "title": "Use Keyword-Only Arguments for No Obvious Ordering",
       "content": "DO use keyword-only arguments for arguments that have no obvious ordering.\n\n",
@@ -59,47 +58,64 @@ sample:
         "python_implementation=html=python-codestyle-optional-param-calling-example-1",
         "python_implementation=html=python-codestyle-optional-param-calling-example-2"
       ]
-    }
-    ]
+    },
+    {
+      "id": "python_design.html#python-models-enum-name-uppercase",
+      "category": "Enumerations",
+      "text": "DO use UPPERCASE for enum member names.\n\n```python\n\n# Yes\nclass MyGoodEnum(str, Enum):\n    ONE = 'one'\n    TWO = 'two'\n\n# No\nclass MyBadEnum(str, Enum):\n    One = 'one' # No - using PascalCased name.\n    two = 'two' # No - using all lower case name.\n\n```"
+    }]
   apiview: |
     ```python
-    1: class azure.contoso.ClassName:
-    2:     def __init__(self, param1: str, param2: int)
-    3:     def method1(self, arg1: str) -> None
+    500: class azure.ai.vision.imageanalysis.models.VisualFeatures(str, Enum):
+    501:     CAPTION = 'caption'
+    502:     DENSE_CAPTIONS = 'denseCaptions'
+    503:     OBJECTS = 'objects'
+    504:     PEOPLE = 'people'
+    505:     READ = 'read'
+    506:     SMART_CROPS = 'smartCrops'
+    507:     tags = 'tags'
     ```
 ---
 system:
-You are an expert code reviewer of SDKs. You will analyze an entire client library APIView surface for {{language}} to determine whether it meets the SDK guidelines. 
+  You are an expert code reviewer of SDKs. You will analyze an entire client library APIView surface for {{language}} to determine whether it meets the SDK guidelines. 
 
-# RULES
-- ONLY mention if the library is clearly and visibly violating a guideline.
+  # RULES
+  - ONLY mention if the library is clearly and visibly violating a guideline.
 
-- Each line of the APIView is prepended with a line number a colon.
+  - Each line of the APIView is prepended with a line number a colon.
 
-- Be conservative - DO NOT make assumptions that a guideline is being violated because it is possible that all guidelines are being
-followed.
+  - Be conservative - DO NOT make assumptions that a guideline is being violated because it is possible that all guidelines are being
+  followed.
 
-- Evaluate each piece of code against all guidelines.
+  - Evaluate each piece of code against all guidelines.
 
-- Code may violate multiple guidelines.
+  - Code may violate multiple guidelines.
 
-- Each class will contain its namespace, like `class azure.contoso.ClassName` where 'azure.contoso' is the namespace and `ClassName` is the name of the class. 
+  - Each class will contain its namespace, like `class azure.contoso.ClassName` where 'azure.contoso' is the namespace and `ClassName` is the name of the class. 
 
-- APIView does not contain runnable code or implementations. It is a high-level {{language}} pseudocode summary of the client library surface. 
+  - APIView does not contain runnable code or implementations. It is a high-level {{language}} pseudocode summary of the client library surface. 
 
-- Always cite guideline IDs VERBATIM. Examples (GOOD: `python_implementation.html#python-codestyle-kwargs`, BAD: `python-codestyle-kwargs`).
+  - Always cite guideline IDs VERBATIM. Examples (GOOD: `python_implementation.html#python-codestyle-kwargs`, BAD: `python-codestyle-kwargs`).
 
-- `bad_code` should always cite the SINGLE match APIView line, stopping at newlines. NEVER concatenate multiple lines. (GOOD: `def __init__(` BAD: `def __init__(self, *, ...)`
+  # OUTPUT RULES
+  - **bad_code** must always cite the SINGLE matching APIView line, stopping at newlines. NEVER concatenate multiple lines.
+    - GOOD: `def __init__(`
+    - BAD: `def __init__(self, *, ...)`
+  - **suggestion** only the single replacement code line exactly as it should appear (no markdown fencing, no prose), or the literal JSON null if there’s no fix.
+    - GOOD: "  VALUE = 'value'"
+    - BAD: "Suggest: '  VALUE = "value"'"
+    - BAD: "/* Capitalize value to be VALUE */"
+  - **comment** concise, human-readable description of the issue. DO NOT use code snippets. DO NOT cite line numbers or guideline IDs.
+    - GOOD: "Enum values should always be capitalized."
+    - GOOD: "This class has too many methods. I suggest breaking it up into smaller classes."
+    - BAD: "Per guideline python_implementation.html#python-enum-capitalization, enum value on line 25 should be capitalized. Suggest: `   VALUE = 'value'`"
 
-- `suggestion` must either be a code snippet or the literal JSON null (no quotes)
-
-# CONTEXT
-These are deemed the most relevant guidelines for this review. Ground your responses solely within this context.
-{{context}}
-
+  # CONTEXT
+  These are deemed the most relevant guidelines for this review. Ground your responses solely within this context.
+  {{context}}
 
 user:
-Evaluate the following APIView and make comments.
-```{{language}}
-{{apiview}}
-```
+  Evaluate the following APIView and make comments.
+  ```{{language}}
+  {{apiview}}
+  ```

--- a/packages/python-packages/apiview-copilot/prompts/merge_comments.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/merge_comments.prompty
@@ -1,0 +1,65 @@
+---
+name: Merge Comments
+description: A prompt to merge multiple comments into a single comment.
+authors:
+  - tjprescott
+version: 1.0.0
+model:
+  api: chat
+  configuration:
+    type: azure_openai
+    azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
+    azure_deployment: gpt-4o
+    api_version: 2025-01-01-preview
+  parameters:
+    temperature: 0.7
+    top_p: 0.95
+    stop: []
+    frequency_penalty: 0
+    presence_penalty: 0
+    max_tokens: 16384
+    response_format: ${file:guideline_result_schema.json}
+sample:
+  comments: |
+    [{
+      "rule_ids": [
+        "python_design.html#python-models-enum-name-uppercase"
+      ],
+      "line_no": 517, 
+      "bad_code": "    tags = 'tags'",
+      "suggestion": "    TAGS = 'tags'",
+      "comment": "Enum member names must be uppercase for consistency.", 
+      "source": "guideline"
+    },
+    {
+      "rule_ids": [],
+      "line_no": 517, 
+      "bad_code": "    tags = 'tags'", 
+      "suggestion": "    TAGS = 'tags'", 
+      "comment": "Enum members should be consistently capitalized. Use 'TAGS' to align with other members.", 
+      "source": "generic"
+    }]
+  context: |
+    [{
+      "id": "python_design.html#python-models-enum-name-uppercase",
+      "category": "Enumerations",
+      "text": "DO use UPPERCASE for enum member names.\n\n```python\n\n# Yes\nclass MyGoodEnum(str, Enum):\n    ONE = 'one'\n    TWO = 'two'\n\n# No\nclass MyBadEnum(str, Enum):\n    One = 'one' # No - using PascalCased name.\n    two = 'two' # No - using all lower case name.\n\n```"
+    }]
+---
+system:
+  You are a code review assistant. Your task is to merge multiple comments into a single comment. 
+  The merged comment should be concise and clear, summarizing the key points from all the comments.
+  Ensure that the merged comment maintains the context and intent of the original comments.
+  If there are conflicting suggestions, prioritize the one based on the guidelines.
+  Use the provided context to enhance the understanding of the comments.
+  Ensure the output maintains all of the rule_ids and line numbers from the original comments.
+  Regardless of the number of input comments, the output should always be an array of one comment.
+
+user:
+  Given this context:
+  {{context}}
+
+  And these comments:
+  {{comments}}
+
+  Generate a single merged comment that summarizes the key points from all the comments.

--- a/packages/python-packages/apiview-copilot/scratch/output/python/content_understanding.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/python/content_understanding.json
@@ -1,11 +1,29 @@
 {
     "comments": [
         {
+            "rule_ids": [
+                "python_design.html#python-client-sync-async-separate-clients"
+            ],
+            "line_no": 7,
+            "bad_code": "ivar analyzers: AnalyzersOperations",
+            "suggestion": "Use a synchronous operations type (for example, azure.ai.contentunderstanding.operations.AnalyzersOperations)",
+            "comment": "The synchronous ContentUnderstandingClient exposes an 'analyzers' property typed as AnalyzersOperations, but the only provided definition of AnalyzersOperations (in namespace azure.ai.contentunderstanding.aio.operations) defines asynchronous methods. Synchronous clients should use a corresponding synchronous operations type so that sync and async APIs remain clearly separated.. Suggest: Use a synchronous operations type (for example, azure.ai.contentunderstanding.operations.AnalyzersOperations) that provides synchronous method signatures in the synchronous client.",
+            "source": "guideline"
+        },
+        {
             "rule_ids": [],
             "line_no": 110,
-            "bad_code": "input: bytes,",
-            "suggestion": "data: bytes,",
-            "comment": "Avoid using 'input' as a parameter name since it shadows Python's built-in function. A more descriptive name such as 'data' or 'binary_data' is recommended.",
+            "bad_code": "input: bytes",
+            "suggestion": "binary_data: bytes",
+            "comment": "The parameter name 'input' shadows the built-in function. Renaming it to something like 'binary_data' avoids this shadowing and improves clarity.. Suggest: binary_data: bytes",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 167,
+            "bad_code": "def get_operation_status(...): -> ResourceOperationStatusContentAnalyzerContentAnalyzerError",
+            "suggestion": "/* Consider defining a type alias (e.g., OperationStatusError) to simplify the long return type name */ (general comment)",
+            "comment": "$The verbose return type name reduces readability. Using a type alias to encapsulate 'ResourceOperationStatusContentAnalyzerContentAnalyzerError' would make the signature cleaner and more approachable.. Suggest: /* Consider defining a type alias (e.g., OperationStatusError) to simplify the long return type name */ (general comment)",
             "source": "generic"
         },
         {
@@ -13,23 +31,39 @@
             "line_no": 266,
             "bad_code": "ivar spans: list[ContentSpan]",
             "suggestion": "ivar spans: List[ContentSpan]",
-            "comment": "There is an inconsistency in generic type annotation style. Standardize on either the built-in generics (e.g. 'list[...]' if targeting Python 3.9+) or on the typing counterparts (e.g. 'List[...]') to maintain consistency throughout the API.",
+            "comment": "The API inconsistently uses built-in generics (list[...]) and typing generics (List[...]). For consistency and clarity, choose one style across the API.. Suggest: ivar spans: List[ContentSpan]",
             "source": "generic"
         },
         {
             "rule_ids": [],
-            "line_no": 1041,
-            "bad_code": "ivar type: Optional[Union[str, FieldType]]",
-            "suggestion": "ivar field_type: Optional[Union[str, FieldType]]",
-            "comment": "Avoid shadowing Python built-ins such as 'type'. Renaming this attribute (for example, to 'field_type') makes the intent clearer and prevents potential conflicts.",
+            "line_no": 284,
+            "bad_code": "def __init__(self, *, confidence: Optional[float] = ..., source: Optional[str] = ..., spans: Optional[List[ContentSpan]] = ..., type: str) -> None",
+            "suggestion": "def __init__(self, *, confidence: Optional[float] = None, source: Optional[str] = None, spans: Optional[List[ContentSpan]] = None, field_type: str) -> None",
+            "comment": "Using 'type' as a parameter name can overshadow the built-in type() function. Renaming it to 'field_type' (or similar) avoids this conflict and improves code clarity.. Suggest: def __init__(self, *, confidence: Optional[float] = None, source: Optional[str] = None, spans: Optional[List[ContentSpan]] = None, field_type: str) -> None",
             "source": "generic"
         },
         {
             "rule_ids": [],
-            "line_no": 1138,
+            "line_no": 736,
+            "bad_code": "ivar footnotes: Optional[List[ForwardRef('DocumentFootnote')]]",
+            "suggestion": "ivar footnotes: Optional[List['DocumentFootnote']]",
+            "comment": "Prefer using string literals for forward references in type annotations. This approach is more idiomatic and improves readability.. Suggest: ivar footnotes: Optional[List['DocumentFootnote']]",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1139,
+            "bad_code": "ivar type: Literal[INTEGER]",
+            "suggestion": "ivar type: Literal['INTEGER']",
+            "comment": "When using Literal with string values, enclose the literal value in quotes to correctly indicate it is a string.. Suggest: ivar type: Literal['INTEGER']",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1212,
             "bad_code": "ivar spans: list[ContentSpan]",
             "suggestion": "ivar spans: List[ContentSpan]",
-            "comment": "For consistency and clarity, use the standard generic type from the typing module (List) rather than the built-in list when annotating types.",
+            "comment": "There is an inconsistency in type annotations for list types (using both 'list' and 'List'). Choose one style (preferably using the typing import for broader compatibility) to maintain consistency.. Suggest: ivar spans: List[ContentSpan]",
             "source": "generic"
         },
         {
@@ -37,55 +71,59 @@
             "line_no": 1213,
             "bad_code": "ivar type: Literal[NUMBER]",
             "suggestion": "ivar field_type: Literal[NUMBER]",
-            "comment": "Naming an attribute 'type' shadows Python’s built-in. Renaming it (for example, to 'field_type') prevents potential conflicts and clarifies intent.",
+            "comment": "Using the attribute name 'type' shadows the built-in type() function. Renaming it to something like 'field_type' will prevent potential confusion and improve clarity.. Suggest: ivar field_type: Literal[NUMBER]",
             "source": "generic"
         },
         {
-            "rule_ids": [],
-            "line_no": 1254,
-            "bad_code": "ivar value_object: Optional[Dict[str, ForwardRef('ContentField')]]",
-            "suggestion": "from __future__ import annotations  // then use: value_object: Optional[Dict[str, ContentField]]",
-            "comment": "Leveraging 'from __future__ import annotations' can simplify forward references, making the type hints clearer and more maintainable.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
+            "rule_ids": [
+                "python_design.html#python-client-constructor-form"
+            ],
             "line_no": 1510,
-            "bad_code": "def __init__(\n\t    self, \n\t    *args, \n\t    **kwargs\n\t)",
-            "suggestion": "def __init__(self, client: HttpClient, config: Config) -> None:",
-            "comment": "Using *args and **kwargs in the public constructor reduces discoverability of required parameters. Consider defining them explicitly to make the API more self‐documenting.",
+            "bad_code": "def __init__(",
+            "suggestion": "def __init__(self, client: Any, endpoint: str, **kwargs) -> None:",
+            "comment": "The constructor is defined using generic *args and **kwargs rather than explicitly declaring the required binding parameters (for example, a service client or endpoint). For a public operations class, the constructor should clearly list its required positional parameters per python_design.html#python-client-constructor-form.. Suggest: def __init__(self, client: Any, endpoint: str, **kwargs) -> None:",
+            "source": "guideline"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1547,
+            "bad_code": "def begin_analyze(self, analyzer_id: str, body: Union[JSON, IO[bytes]] = _Unset, *, url: Optional[str] = ..., **kwargs: Any) -> LROPoller[AnalyzeResult]",
+            "suggestion": "def begin_analyze(self, analyzer_id: str, *, body: Optional[Union[JSON, IO[bytes]]] = None, url: Optional[str] = None, **kwargs: Any) -> LROPoller[AnalyzeResult]:",
+            "comment": "The begin_analyze method accepts both 'body' and 'url', which may confuse developers about their mutual exclusivity. Making them keyword-only with a default of None clarifies usage and improves the API's intuitiveness.. Suggest: def begin_analyze(self, analyzer_id: str, *, body: Optional[Union[JSON, IO[bytes]]] = None, url: Optional[str] = None, **kwargs: Any) -> LROPoller[AnalyzeResult]:",
             "source": "generic"
         },
         {
             "rule_ids": [],
-            "line_no": 1517,
-            "bad_code": "def begin_analyze(",
-            "suggestion": "def begin_analyze_from_url(self, analyzer_id: str, url: str, *, content_type: str = 'application/json', **kwargs: Any) -> LROPoller[AnalyzeResult]:",
-            "comment": "The multiple overloads for begin_analyze (handling URL, JSON body, and binary IO) may be confusing. Splitting these into clearly named methods (e.g. begin_analyze_from_url) can improve clarity.",
+            "line_no": 1557,
+            "bad_code": "def begin_analyze_binary(self, analyzer_id: str, input: bytes, **kwargs: Any) -> LROPoller[AnalyzeResult]",
+            "suggestion": "def begin_analyze_binary(self, analyzer_id: str, data: bytes, **kwargs: Any) -> LROPoller[AnalyzeResult]",
+            "comment": "Avoid using 'input' as a parameter name since it shadows the built-in Python function. Renaming it to 'data' (or 'content') will prevent potential confusion.. Suggest: def begin_analyze_binary(self, analyzer_id: str, data: bytes, **kwargs: Any) -> LROPoller[AnalyzeResult]",
             "source": "generic"
         },
         {
             "rule_ids": [],
-            "line_no": 1550,
-            "bad_code": "body: Union[JSON, IO[bytes]] = _Unset,",
-            "suggestion": "body: Optional[Union[JSON, IO[bytes]]] = None,",
-            "comment": "Relying on an internal sentinel (_Unset) can be confusing. Using None as the default (or ensuring the sentinel is clearly documented) improves clarity.",
+            "line_no": 1617,
+            "bad_code": "def get_operation_status(self, analyzer_id: str, operation_id: str, **kwargs: Any) -> ResourceOperationStatusContentAnalyzerContentAnalyzerError",
+            "suggestion": "/* Consider using a type alias or simplifying the return type name if possible */",
+            "comment": "The return type is very verbose. Simplifying or aliasing complex type names can make the API more approachable and reduce friction for developers.. Suggest: /* Consider using a type alias or simplifying the return type name if possible */",
             "source": "generic"
         },
         {
-            "rule_ids": [],
-            "line_no": 1560,
-            "bad_code": "input: bytes,",
-            "suggestion": "data: bytes,",
-            "comment": "The parameter name 'input' shadows the built-in input() function. Renaming it to something like 'data' avoids this conflict and follows best practices.",
-            "source": "generic"
+            "rule_ids": [
+                "python_design.html#python-paged-prefix"
+            ],
+            "line_no": 1642,
+            "bad_code": "def list(self, **kwargs: Any) -> Iterable[ContentAnalyzer]",
+            "suggestion": "def list_analyzers(self, **kwargs: Any) -> Iterable[ContentAnalyzer]",
+            "comment": "Methods that enumerate resources should be prefixed with 'list_'. Renaming the 'list' method to something like 'list_analyzers' would better align with python_design.html#python-paged-prefix.. Suggest: def list_analyzers(self, **kwargs: Any) -> Iterable[ContentAnalyzer]",
+            "source": "guideline"
         },
         {
             "rule_ids": [],
-            "line_no": 1645,
-            "bad_code": "def update(",
-            "suggestion": "def update_from_json(self, analyzer_id: str, resource: JSON, *, content_type: str = 'application/merge-patch+json', **kwargs: Any) -> ContentAnalyzer:",
-            "comment": "Similar to begin_analyze, the update method has several overloads for different resource types. Consider splitting these into separate methods to reduce complexity and help users understand the API.",
+            "line_no": 1675,
+            "bad_code": "def update(self, analyzer_id: str, resource: Union[ContentAnalyzer, JSON, IO[bytes]], **kwargs: Any) -> ContentAnalyzer",
+            "suggestion": "def update(self, analyzer_id: str, resource: Union[ContentAnalyzer, JSON, IO[bytes]], *, content_type: str = 'application/merge-patch+json', **kwargs: Any) -> ContentAnalyzer",
+            "comment": "The overloads for update include an explicit content_type parameter, but the final implementation defers it into **kwargs. Including it explicitly aligns the implementation with its overloads and improves clarity for users.. Suggest: def update(self, analyzer_id: str, resource: Union[ContentAnalyzer, JSON, IO[bytes]], *, content_type: str = 'application/merge-patch+json', **kwargs: Any) -> ContentAnalyzer",
             "source": "generic"
         }
     ]

--- a/packages/python-packages/apiview-copilot/scratch/output/python/image_analysis.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/python/image_analysis.json
@@ -6,24 +6,16 @@
             ],
             "line_no": 10,
             "bad_code": "connection_string: Optional[str] = None,",
-            "suggestion": "null",
-            "comment": "The constructor should not accept a connection string; instead provide a from_connection_string factory method.",
+            "suggestion": null,
+            "comment": "The constructor should not accept a connection_string parameter; use a separate factory method (from_connection_string) instead.",
             "source": "guideline"
         },
         {
             "rule_ids": [],
-            "line_no": 33,
-            "bad_code": "    visual_features: List[VisualFeatures],",
-            "suggestion": "    visual_features: List[VisualFeatures], *,",
-            "comment": "Insert '*' after required parameters to enforce keyword-only optional arguments, ensuring consistency with the 'analyze' method.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
             "line_no": 168,
-            "bad_code": "    ivar list: List[DenseCaption]",
-            "suggestion": "    ivar captions: List[DenseCaption]",
-            "comment": "Avoid using the built-in name 'list' as an attribute; use a more descriptive name like 'captions'.",
+            "bad_code": "ivar list: List[DenseCaption]",
+            "suggestion": "ivar captions: List[DenseCaption]",
+            "comment": "Avoid using 'list' as an attribute name since it shadows the built-in; use a more descriptive name.",
             "source": "generic"
         },
         {
@@ -33,15 +25,15 @@
             "line_no": 209,
             "bad_code": "class azure.ai.vision.imageanalysis.models.detectedPerson(MutableMapping[str, Any]):",
             "suggestion": "class azure.ai.vision.imageanalysis.models.DetectedPerson(MutableMapping[str, Any]):",
-            "comment": "Type names must use PascalCase. Rename 'detectedPerson' to 'DetectedPerson' for consistency.",
+            "comment": "Class names should use PascalCase according to naming conventions.",
             "source": "merged"
         },
         {
             "rule_ids": [],
             "line_no": 409,
-            "bad_code": "    ivar list: List[DetectedObject]",
-            "suggestion": "    ivar objects: List[DetectedObject]",
-            "comment": "Avoid shadowing the built-in 'list'; rename the attribute to something more descriptive such as 'objects'.",
+            "bad_code": "ivar list: List[DetectedObject]",
+            "suggestion": "ivar objects: List[DetectedObject]",
+            "comment": "Rename the 'list' attribute to avoid shadowing the built-in type and to better reflect its contents.",
             "source": "generic"
         },
         {
@@ -50,8 +42,8 @@
             ],
             "line_no": 411,
             "bad_code": "def get_result(self) -> ObjectsResult",
-            "suggestion": "null",
-            "comment": "Simple getter methods should be implemented as properties to follow Pythonic conventions and provide a more idiomatic API.",
+            "suggestion": null,
+            "comment": "Replace simple getter methods with properties to adhere to Python's codestyle guidelines. Additionally, since accessor methods like get_result may be redundant with existing interfaces such as MutableMapping, consider removing them to streamline the API.",
             "source": "merged"
         },
         {
@@ -60,9 +52,9 @@
             ],
             "line_no": 413,
             "bad_code": "def set_result(self, obj) -> None",
-            "suggestion": "null",
-            "comment": "The set_result method should be replaced with a property setter to adhere to Pythonic design principles and avoid simple setter methods.",
-            "source": "merged"
+            "suggestion": null,
+            "comment": "Avoid simple setter methods; use a property with a setter instead.",
+            "source": "guideline"
         },
         {
             "rule_ids": [
@@ -70,24 +62,16 @@
             ],
             "line_no": 432,
             "bad_code": "class azure.ai.vision.imageanalysis.models.aio.PeopleResult(MutableMapping[str, Any]):",
-            "suggestion": "null",
-            "comment": "Models should not be duplicated in the aio namespace; shared models must exist in a single location.",
+            "suggestion": null,
+            "comment": "Models should not be duplicated in the aio namespace; reuse the model from the root namespace.",
             "source": "guideline"
         },
         {
             "rule_ids": [],
             "line_no": 433,
-            "bad_code": "    ivar list: List[detectedPerson]",
-            "suggestion": "    ivar people: List[DetectedPerson]",
-            "comment": "Avoid using built-in names for attributes and ensure type names use PascalCase; consider 'people' instead of 'list' with 'DetectedPerson'.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 473,
-            "bad_code": "    ivar list: List[CropRegion]",
-            "suggestion": "    ivar crop_regions: List[CropRegion]",
-            "comment": "Avoid using the built-in 'list' as an attribute name; choose a descriptive name such as 'crop_regions'.",
+            "bad_code": "ivar list: List[detectedPerson]",
+            "suggestion": "ivar people: List[DetectedPerson]",
+            "comment": "Avoid using 'list' as an attribute name and ensure that type names follow CamelCase.",
             "source": "generic"
         },
         {
@@ -95,7 +79,15 @@
             "line_no": 492,
             "bad_code": "ivar list: List[DetectedTag]",
             "suggestion": "ivar tags: List[DetectedTag]",
-            "comment": "Using a built‐in name like 'list' can be confusing. Rename it (e.g. to 'tags') for clarity and consistency.",
+            "comment": "Avoid using the built-in name 'list' for an instance variable; renaming it to 'tags' clarifies intent and prevents shadowing.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 498,
+            "bad_code": "list: List[DetectedTag]",
+            "suggestion": "tags: List[DetectedTag]",
+            "comment": "Rename the parameter 'list' to 'tags' to avoid conflict with Python's built-in and to clearly convey its purpose.",
             "source": "generic"
         },
         {
@@ -105,7 +97,7 @@
             "line_no": 517,
             "bad_code": "tags = 'tags'",
             "suggestion": "TAGS = 'tags'",
-            "comment": "Enum member names should be uppercase for consistency. Change 'tags' to 'TAGS' to adhere to the guideline.",
+            "comment": "Enum member names should be uppercase for consistency. Rename 'tags' to 'TAGS'.",
             "source": "merged"
         }
     ]

--- a/packages/python-packages/apiview-copilot/scratch/output/python/image_analysis.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/python/image_analysis.json
@@ -1,66 +1,42 @@
 {
     "comments": [
         {
-            "rule_ids": [],
-            "line_no": 3,
-            "bad_code": "namespace azure.ai.vision.imageanalysis",
-            "suggestion": "Remove the 'namespace' declaration and rely on Python’s package structure (i.e. directories with __init__.py files) to organize modules.",
-            "comment": "Namespaces are not a standard Python construct and may confuse developers who expect a directory‐based module organization.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 5,
-            "bad_code": "class azure.ai.vision.imageanalysis.ImageAnalysisClient(ImageAnalysisClient): implements ContextManager",
-            "suggestion": "Remove the non‐Python 'implements' keyword. Instead, either inherit from contextlib.AbstractContextManager or implement the __enter__ and __exit__ methods directly. Also, verify that inheriting from ImageAnalysisClient (i.e. itself) is correct.",
-            "comment": "Using 'implements' and self‐inheritance is non‐idiomatic and could be misleading. Python prefers explicit dunder methods or inheritance from standard base classes for context management.",
-            "source": "generic"
-        },
-        {
             "rule_ids": [
                 "python_design.html#python-client-connection-string"
             ],
             "line_no": 10,
-            "bad_code": "connection_string: Optional[str] = None,",
-            "suggestion": "Remove the connection_string parameter from the __init__ method and instead provide a separate factory method (e.g. from_connection_string) that accepts a connection string.",
-            "comment": "The constructor for ImageAnalysisClient includes a 'connection_string' parameter, which violates the guideline that the constructor must not take a connection string.",
-            "source": "guideline"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 12,
-            "bad_code": "api_version: str = ...",
-            "suggestion": "Replace the ellipsis (...) with an explicit default value (such as None or an actual API version string) to make the API more explicit.",
-            "comment": "Using an ellipsis as a default is unusual in Python and can lead to ambiguity. An explicit default improves clarity.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 22,
-            "bad_code": "gender_neutral_caption: Optional[bool] = ...",
-            "suggestion": "Use a concrete default (e.g. None or a Boolean value) instead of ellipsis for optional parameters.",
-            "comment": "Ellipsis as a default value is non‐idiomatic. Explicit defaults (or None) help users understand the intended behavior without guessing.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [
-                "python_design.html#python-client-same-name-sync-async"
-            ],
-            "line_no": 53,
-            "bad_code": "class azure.ai.vision.imageanalysis.aio.AsyncImageAnalysisClient(ImageAnalysisClient): implements AsyncContextManager",
-            "suggestion": "Rename the async client to ImageAnalysisClient (in the azure.ai.vision.imageanalysis.aio namespace) so that it matches the synchronous client name.",
-            "comment": "The async client should have the same client name as the synchronous client as per the guidelines; using 'AsyncImageAnalysisClient' is a violation.",
+            "bad_code": "         connection_string: Optional[str] = None,",
+            "suggestion": "",
+            "comment": "The constructor must not accept a connection string. Instead, implement a separate from_connection_string factory method.",
             "source": "guideline"
         },
         {
             "rule_ids": [
-                "python_implementation.html#python-codestyle-static-methods"
+                "python_design.html#python-client-optional-arguments-keyword-only"
             ],
-            "line_no": 88,
-            "bad_code": "@staticmethod",
-            "suggestion": "Remove the @staticmethod decorator and define send_request as an instance method (or as a module-level function if appropriate).",
-            "comment": "Static methods are discouraged. The async send_request should be an instance method instead of a static method.",
+            "line_no": 30,
+            "bad_code": "def analyze_from_url(",
+            "suggestion": "def analyze_from_url(self, image_url: str, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
+            "comment": "Optional parameters must be keyword-only; add '*' after the required positional parameters.",
             "source": "guideline"
+        },
+        {
+            "rule_ids": [
+                "python_design.html#python-client-optional-arguments-keyword-only"
+            ],
+            "line_no": 74,
+            "bad_code": "async def analyze_from_url(",
+            "suggestion": "async def analyze_from_url(self, image_url: str, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
+            "comment": "Optional parameters must be keyword-only; insert '*' to separate them from required positional arguments.",
+            "source": "guideline"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 168,
+            "bad_code": "    ivar list: List[DenseCaption]",
+            "suggestion": "    ivar captions: List[DenseCaption]",
+            "comment": "Avoid using built-in names like 'list' for attributes; use a more descriptive name such as 'captions'.",
+            "source": "generic"
         },
         {
             "rule_ids": [
@@ -68,45 +44,47 @@
             ],
             "line_no": 209,
             "bad_code": "class azure.ai.vision.imageanalysis.models.detectedPerson(MutableMapping[str, Any]):",
-            "suggestion": "Rename the class to 'DetectedPerson' using PascalCase.",
-            "comment": "Class names must use PascalCase. The identifier 'detectedPerson' should be renamed to 'DetectedPerson'.",
-            "source": "guideline"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 407,
-            "bad_code": "ivar list: List[DetectedObject]",
-            "suggestion": "Rename the attribute to something more descriptive like 'objects' or 'object_list' to avoid shadowing the built-in type 'list'.",
-            "comment": "Using 'list' as an attribute name can lead to confusion with Python's built-in list type and is best avoided.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 411,
-            "bad_code": "def get_result(self) -> ObjectsResult",
-            "suggestion": "Consider replacing explicit getter and setter methods with a property, for example using the @property decorator for 'result'.",
-            "comment": "Python idioms favor properties over get/set methods, which can lead to a cleaner and more natural API interface.",
-            "source": "generic"
+            "suggestion": "class azure.ai.vision.imageanalysis.models.DetectedPerson(MutableMapping[str, Any]):",
+            "comment": "Type names must be in PascalCase. Rename 'detectedPerson' to 'DetectedPerson' to adhere to naming conventions.",
+            "source": "merged"
         },
         {
             "rule_ids": [
-                "python_design.html#python-models-async"
+                "python_implementation.html#python-codestyle-properties"
             ],
-            "line_no": 432,
-            "bad_code": "class azure.ai.vision.imageanalysis.models.aio.PeopleResult(MutableMapping[str, Any]):",
-            "suggestion": "Remove the duplicate PeopleResult model from the aio namespace and use the one defined in the root models package.",
-            "comment": "Models should not be duplicated between the root and aio namespaces. Having a separate PeopleResult in the aio namespace goes against this guideline.",
+            "line_no": 411,
+            "bad_code": "    def get_result(self) -> ObjectsResult",
+            "suggestion": null,
+            "comment": "Avoid using simple getter methods; implement a property instead.",
             "source": "guideline"
+        },
+        {
+            "rule_ids": [
+                "python_implementation.html#python-codestyle-properties"
+            ],
+            "line_no": 412,
+            "bad_code": "    def set_result(self, obj) -> None",
+            "suggestion": null,
+            "comment": "Avoid using simple setter methods; implement a property with a setter instead.",
+            "source": "guideline"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 498,
+            "bad_code": "list: List[DetectedTag]",
+            "suggestion": "detected_tags: List[DetectedTag]",
+            "comment": "Avoid using a built‐in name as a parameter; rename 'list' to something more descriptive like 'detected_tags'.",
+            "source": "generic"
         },
         {
             "rule_ids": [
                 "python_design.html#python-models-enum-name-uppercase"
             ],
             "line_no": 517,
-            "bad_code": "    tags = 'tags'",
-            "suggestion": "Rename the enum member to 'TAGS' in order to comply with the uppercase naming convention.",
-            "comment": "Enum members should be in ALL CAPS; 'tags' violates this guideline.",
-            "source": "guideline"
+            "bad_code": "tags = 'tags'",
+            "suggestion": "TAGS = 'tags'",
+            "comment": "Enum member names must be uppercase to conform to Python conventions. Change 'tags' to 'TAGS' for consistency.",
+            "source": "merged"
         }
     ]
 }

--- a/packages/python-packages/apiview-copilot/scratch/output/python/image_analysis.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/python/image_analysis.json
@@ -5,37 +5,25 @@
                 "python_design.html#python-client-connection-string"
             ],
             "line_no": 10,
-            "bad_code": "         connection_string: Optional[str] = None,",
-            "suggestion": "",
-            "comment": "The constructor must not accept a connection string. Instead, implement a separate from_connection_string factory method.",
+            "bad_code": "connection_string: Optional[str] = None,",
+            "suggestion": "null",
+            "comment": "The constructor should not accept a connection string; instead provide a from_connection_string factory method.",
             "source": "guideline"
         },
         {
-            "rule_ids": [
-                "python_design.html#python-client-optional-arguments-keyword-only"
-            ],
-            "line_no": 30,
-            "bad_code": "def analyze_from_url(",
-            "suggestion": "def analyze_from_url(self, image_url: str, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
-            "comment": "Optional parameters must be keyword-only; add '*' after the required positional parameters.",
-            "source": "guideline"
-        },
-        {
-            "rule_ids": [
-                "python_design.html#python-client-optional-arguments-keyword-only"
-            ],
-            "line_no": 74,
-            "bad_code": "async def analyze_from_url(",
-            "suggestion": "async def analyze_from_url(self, image_url: str, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
-            "comment": "Optional parameters must be keyword-only; insert '*' to separate them from required positional arguments.",
-            "source": "guideline"
+            "rule_ids": [],
+            "line_no": 33,
+            "bad_code": "    visual_features: List[VisualFeatures],",
+            "suggestion": "    visual_features: List[VisualFeatures], *,",
+            "comment": "Insert '*' after required parameters to enforce keyword-only optional arguments, ensuring consistency with the 'analyze' method.",
+            "source": "generic"
         },
         {
             "rule_ids": [],
             "line_no": 168,
             "bad_code": "    ivar list: List[DenseCaption]",
             "suggestion": "    ivar captions: List[DenseCaption]",
-            "comment": "Avoid using built-in names like 'list' for attributes; use a more descriptive name such as 'captions'.",
+            "comment": "Avoid using the built-in name 'list' as an attribute; use a more descriptive name like 'captions'.",
             "source": "generic"
         },
         {
@@ -45,35 +33,69 @@
             "line_no": 209,
             "bad_code": "class azure.ai.vision.imageanalysis.models.detectedPerson(MutableMapping[str, Any]):",
             "suggestion": "class azure.ai.vision.imageanalysis.models.DetectedPerson(MutableMapping[str, Any]):",
-            "comment": "Type names must be in PascalCase. Rename 'detectedPerson' to 'DetectedPerson' to adhere to naming conventions.",
+            "comment": "Type names must use PascalCase. Rename 'detectedPerson' to 'DetectedPerson' for consistency.",
             "source": "merged"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 409,
+            "bad_code": "    ivar list: List[DetectedObject]",
+            "suggestion": "    ivar objects: List[DetectedObject]",
+            "comment": "Avoid shadowing the built-in 'list'; rename the attribute to something more descriptive such as 'objects'.",
+            "source": "generic"
         },
         {
             "rule_ids": [
                 "python_implementation.html#python-codestyle-properties"
             ],
             "line_no": 411,
-            "bad_code": "    def get_result(self) -> ObjectsResult",
-            "suggestion": null,
-            "comment": "Avoid using simple getter methods; implement a property instead.",
-            "source": "guideline"
+            "bad_code": "def get_result(self) -> ObjectsResult",
+            "suggestion": "null",
+            "comment": "Simple getter methods should be implemented as properties to follow Pythonic conventions and provide a more idiomatic API.",
+            "source": "merged"
         },
         {
             "rule_ids": [
                 "python_implementation.html#python-codestyle-properties"
             ],
-            "line_no": 412,
-            "bad_code": "    def set_result(self, obj) -> None",
-            "suggestion": null,
-            "comment": "Avoid using simple setter methods; implement a property with a setter instead.",
+            "line_no": 413,
+            "bad_code": "def set_result(self, obj) -> None",
+            "suggestion": "null",
+            "comment": "The set_result method should be replaced with a property setter to adhere to Pythonic design principles and avoid simple setter methods.",
+            "source": "merged"
+        },
+        {
+            "rule_ids": [
+                "python_design.html#python-models-async"
+            ],
+            "line_no": 432,
+            "bad_code": "class azure.ai.vision.imageanalysis.models.aio.PeopleResult(MutableMapping[str, Any]):",
+            "suggestion": "null",
+            "comment": "Models should not be duplicated in the aio namespace; shared models must exist in a single location.",
             "source": "guideline"
         },
         {
             "rule_ids": [],
-            "line_no": 498,
-            "bad_code": "list: List[DetectedTag]",
-            "suggestion": "detected_tags: List[DetectedTag]",
-            "comment": "Avoid using a built‐in name as a parameter; rename 'list' to something more descriptive like 'detected_tags'.",
+            "line_no": 433,
+            "bad_code": "    ivar list: List[detectedPerson]",
+            "suggestion": "    ivar people: List[DetectedPerson]",
+            "comment": "Avoid using built-in names for attributes and ensure type names use PascalCase; consider 'people' instead of 'list' with 'DetectedPerson'.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 473,
+            "bad_code": "    ivar list: List[CropRegion]",
+            "suggestion": "    ivar crop_regions: List[CropRegion]",
+            "comment": "Avoid using the built-in 'list' as an attribute name; choose a descriptive name such as 'crop_regions'.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 492,
+            "bad_code": "ivar list: List[DetectedTag]",
+            "suggestion": "ivar tags: List[DetectedTag]",
+            "comment": "Using a built‐in name like 'list' can be confusing. Rename it (e.g. to 'tags') for clarity and consistency.",
             "source": "generic"
         },
         {
@@ -83,7 +105,7 @@
             "line_no": 517,
             "bad_code": "tags = 'tags'",
             "suggestion": "TAGS = 'tags'",
-            "comment": "Enum member names must be uppercase to conform to Python conventions. Change 'tags' to 'TAGS' for consistency.",
+            "comment": "Enum member names should be uppercase for consistency. Change 'tags' to 'TAGS' to adhere to the guideline.",
             "source": "merged"
         }
     ]

--- a/packages/python-packages/apiview-copilot/src/_models.py
+++ b/packages/python-packages/apiview-copilot/src/_models.py
@@ -21,6 +21,11 @@ class Comment(BaseModel):
     comment: str = Field(description="the contents of the comment.")
     source: str = Field(description="unique tag for the prompt that produced the comment.")
 
+    def __init__(self, **data):
+        super().__init__(**data)
+        if self.suggestion == "" or self.suggestion == "null":
+            self.suggestion = None
+
 
 class Guideline(BaseModel):
     """

--- a/packages/python-packages/apiview-copilot/src/_models.py
+++ b/packages/python-packages/apiview-copilot/src/_models.py
@@ -105,10 +105,17 @@ class ReviewResult(BaseModel):
         default_line_no = 0
         for comment in comments:
             raw_line_no = str(comment.get("line_no", "0")).replace(" ", "").strip()
+            bad_code = comment.get("bad_code", None)
+            code_fix = comment.get("code_fix", None)
+            if code_fix == bad_code:
+                code_fix = None
+            general_suggestion = comment.get("suggestion", None)
+            comment_val = comment.get("comment", None)
 
             # Ensure all required fields exist
-            if "suggestion" not in comment:
-                comment["suggestion"] = ""
+            comment["suggestion"] = code_fix or ""
+            if general_suggestion and general_suggestion != comment_val:
+                comment["comment"] = f"{comment_val}. Suggest: {general_suggestion}"
             if "rule_ids" not in comment:
                 comment["rule_ids"] = []
             if "source" not in comment:


### PR DESCRIPTION
Closes #10444.
Closes #10429.

This pull request does work to better ensure that suggestions are only code, not prose. It also uses a gpt-4o prompt to intelligently (I hope) merge multiple comments on the same line instead of programmatically doing so. 