### PR TITLE
Update typespec/compiler dep

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-05-01 - 0.21.0
+
+- Update `@typespec/compiler` dependency to `"1.0.0-rc.1 || >=1.0.0 <2.0.0"`.
+
 ## 2025-04-10 - 0.20.0
 
 - Support a `--trace` flag on the `init`, `update`, and `generate` commands to enable tracing when compiling.

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.20.0",
+      "version": "0.21.0",
       "license": "MIT",
       "dependencies": {
         "@autorest/core": "^3.10.2",

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -43,7 +43,7 @@
         "node": "^18.19.0 || >=20.6.0"
       },
       "peerDependencies": {
-        "@typespec/compiler": "^1.0.0-0"
+        "@typespec/compiler": "1.0.0-rc.1 || >=1.0.0 <2.0.0"
       }
     },
     "node_modules/@apidevtools/swagger-methods": {

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -65,6 +65,6 @@
     "yargs": "^17.2.1"
   },
   "peerDependencies": {
-    "@typespec/compiler": "^1.0.0-0"
+    "@typespec/compiler": "1.0.0-rc.1 || >=1.0.0 <2.0.0"
   }
 }

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.20.0",
+  "version": "0.21.0",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",


### PR DESCRIPTION
There are conflicts due to the rest-api-diff tool pulling in dev versions of certain packages when installing tsp-client. 