### PR TITLE
fix: bump node version in emitter pipeline

### DIFF
--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -241,6 +241,11 @@ extends:
               Paths:
               - "/*"
               - "!SessionRecords"
+          
+          - task: UseNode@1
+            displayName: 'Install Node.js'
+            inputs:
+              version: '22.x'
 
           - download: current
             displayName: Download pipeline artifacts
@@ -307,6 +312,10 @@ extends:
           variables:
             matrixArtifactsPath: $(Pipeline.Workspace)/matrix_artifacts
           steps:
+          - task: UseNode@1
+            displayName: 'Install Node.js'
+            inputs:
+              version: '22.x'
           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
             parameters:
               Paths:

--- a/eng/common/pipelines/templates/archetype-typespec-emitter.yml
+++ b/eng/common/pipelines/templates/archetype-typespec-emitter.yml
@@ -312,15 +312,16 @@ extends:
           variables:
             matrixArtifactsPath: $(Pipeline.Workspace)/matrix_artifacts
           steps:
-          - task: UseNode@1
-            displayName: 'Install Node.js'
-            inputs:
-              version: '22.x'
           - template: /eng/common/pipelines/templates/steps/sparse-checkout.yml
             parameters:
               Paths:
               - "/*"
               - "!SessionRecords"
+
+          - task: UseNode@1
+            displayName: 'Install Node.js'
+            inputs:
+              version: '22.x'
 
           - download: current
             displayName: Download pipeline artifacts


### PR DESCRIPTION
This PR fixes a dependency issue with installing & using the `tsp-client` with node v18.x.
Tested in : https://github.com/Azure/azure-sdk-for-net/pull/49789