### PR TITLE
[APIView Copilot] Run de-duplication and filtering with multiple, parallel prompts

### DIFF
--- a/packages/python-packages/apiview-copilot/prompts/filtered_result_schema_single.json
+++ b/packages/python-packages/apiview-copilot/prompts/filtered_result_schema_single.json
@@ -1,0 +1,58 @@
+{
+  "type": "json_schema",
+  "json_schema": {
+    "name": "filtered_result",
+    "strict": true,
+    "schema": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "rule_ids": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Unique guideline ID or IDs that were violated."
+        },
+        "line_no": {
+          "type": "integer",
+          "description": "Line number of the violation. MUST be identical to the input."
+        },
+        "bad_code": {
+          "type": "string",
+          "description": "the original code that was bad. MUST be identical to the input."
+        },
+        "suggestion": {
+          "type": ["string", "null"],
+          "description": "the suggested code which fixes the bad code. MUST be identical to the input."
+        },
+        "comment": {
+          "type": "string",
+          "description": "a comment about the violation. MUST be identical to the input."
+        },
+        "source": {
+          "type": "string",
+          "description": "the source of the comment. MUST be identical to the input."
+        },
+        "status": {
+          "type": "string",
+          "description": "status of the comment, can be 'KEEP' or 'REMOVE'"
+        },
+        "status_reason": {
+          "type": "string",
+          "description": "the reasoning used to determine the status of the comment. This should be a short sentence explaining why the comment was kept or removed."
+        }
+      },
+      "required": [
+        "rule_ids",
+        "line_no",
+        "bad_code",
+        "suggestion",
+        "comment",
+        "source",
+        "status",
+        "status_reason"
+      ]
+    }
+  }
+}

--- a/packages/python-packages/apiview-copilot/prompts/final_comment_filter_single.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/final_comment_filter_single.prompty
@@ -10,17 +10,18 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
-    azure_deployment: o3-mini
+    azure_deployment: gpt-4.1
     api_version: 2025-01-01-preview
   parameters:
+    temperature: 0.7
+    top_p: 0.95
     stop: []
     frequency_penalty: 0
     presence_penalty: 0
-    max_completion_tokens: 80000
-    reasoning_effort: "high"
-    response_format: ${file:filtered_result_schema.json}
+    max_tokens: 16384
+    response_format: ${file:filtered_result_schema_single.json}
 sample:
-  language: python
+  language: Python
   exceptions: |
     1. Comment on the `send_request` method
     2. Suggest changes to class inheritance patterns
@@ -40,42 +41,23 @@ sample:
     16. Comments about not using the non-standard namespace declaration
     17. Comment on the overuse of **kwargs
     18. Comment on class names being prefixed by the full module name
-  comments: |
+  content: |
     {
-      "comments": [
-        {
-          "line_no": 2,
-          "bad_code": "def method1(self, arg1: str) -> None",
-          "suggestion": "",
-          "comment": "Methods should have descriptive docstrings",
-          "source": "generic"
-        },
-        {
-          "line_no": 2,
-          "bad_code": "def method1(self, arg1: str) -> None",
-          "suggestion": "`def method1(self, arg1: str) -> None:`",
-          "comment": "Methods should end with a colon",
-          "source": "generic"
-        },
-        {
-          "line_no": 2,
-          "bad_code": "def method1(self, arg1: str) -> None",
-          "suggestion": "def get_something(self, name: str) -> None",
-          "comment": "Method name should be more descriptive"
-          "source": "generic"
-        }
-      ]
+      "line_no": 2,
+      "bad_code": "def method1(self, arg1: str) -> None",
+      "suggestion": "",
+      "comment": "Methods should have descriptive docstrings",
+      "source": "generic"
     }
-  sample: ""
 ---
 system:
   You are a helpful AI that reviews {{language}} API design comments from another AI. Your role is to filter out any comments that violate a set of known exceptions. You will receive:
-  1. The proposed comments to review
+  1. A proposed comment to review
   2. The exceptions that must be followed
 
   # EXCEPTIONS
   
-  You MUST remove any comments that:
+  You MUST remove any comment that:
   {{exceptions}}
 
   # OUTPUT REQUIREMENTS
@@ -87,30 +69,27 @@ system:
   - For properties that are in the input schema AND the output schema, the value in the output must be the same as the input.
 
 user:
-  Please validate the following review against the exceptions:
+  Please validate the following comment against the exceptions:
 
-  Proposed Review Comments:
+  Proposed Comment:
   ```json
-  {{comments}}
+  {{content}}
   ```
 
 assistant: |
-  I will analyze each comment in the review results and:
+  I will analyze this comment and:
 
   1. Check if it violates any of the validation rules by focusing on the content in the `comment` field, not other fields.
-  2. Flag any comments' `status` field as "REMOVE" that violate the exceptions
-  3. Flag any comments' `status` field as "KEEP" that enhance API design
+  2. Flag the comment's `status` field as "REMOVE" if it violates the exceptions
+  3. Flag the comment's `status` field as "KEEP" if it enhances API design
   4. For properties that are in the input schema AND the output schema, the value in the output must be the same as the input.
 
-  For each comment I will:
+  For this comment I will:
   - Verify it doesn't comment on excluded aspects
   - Ensure it focuses on API design quality
   - Validate it improves developer experience
   - Confirm it aligns with {{language}} best practices
 
   The response will maintain the schema structure with:
-  - A list of comments
-  - Each comment containing line_no, bad_code, suggestion, and comment identical to the original
-  - Each comment will include new fields `status` and `status_reason` to indicate whether it was kept or removed and the reason for that decision.
-
-{{sample}}
+  - The comment will contain `line_no`, `bad_code`, `suggestion`, and `comment` identical to the original
+  - The comment will include new fields `status` and `status_reason` to indicate whether it was kept or removed and the reason for that decision.

--- a/packages/python-packages/apiview-copilot/prompts/merge_comments.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/merge_comments.prompty
@@ -9,7 +9,7 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
-    azure_deployment: gpt-4o
+    azure_deployment: gpt-4.1
     api_version: 2025-01-01-preview
   parameters:
     temperature: 0.7

--- a/packages/python-packages/apiview-copilot/scratch/output/python/clinical_matching.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/python/clinical_matching.json
@@ -1,24 +1,12 @@
 {
-    "status": "Error",
-    "violations": [
+    "comments": [
         {
-            "rule_ids": [
-                "python_design.html#python-client-naming",
-                "python_design.html#python-client-same-name-sync-async"
-            ],
-            "line_no": 6,
-            "bad_code": "class azure.healthinsights.clinicalmatching.ClinicalMatching(ClinicalMatchingClientOperationsMixin): implements ContextManager",
-            "suggestion": "Rename the sync client to 'ClinicalMatchingClient' so that it ends with 'Client' and matches the async client naming.",
-            "comment": "Service client types should have a 'Client' suffix and the sync and async clients should share the same name (see guidelines python_design.html#python-client-naming and python_design.html#python-client-same-name-sync-async)."
-        },
-        {
-            "rule_ids": [
-                "python_design.html#python-client-options-naming"
-            ],
-            "line_no": 70,
-            "bad_code": "options: Optional[CreateTrialsOptions] = None,",
-            "suggestion": "Remove the options bag parameter and expose the individual optional keyword arguments instead.",
-            "comment": "Using an options bag to group optional parameters violates the guideline (python_design.html#python-client-options-naming)."
+            "rule_ids": [],
+            "line_no": 1,
+            "bad_code": "",
+            "suggestion": null,
+            "comment": "Here is a summary of the service described by this APIView:\n\nOverview:\nThis API provides a clinical matching service intended for processing patient clinical data and matching it against clinical trial criteria. It facilitates the submission, evaluation, and management of trial matching requests and results, supporting both synchronous and asynchronous workflows via long-running operations and context management.\n\nAPI Version:\nClients accept an `api_version` parameter during initialization; however, no separate API Version object or explicit latest version is defined in this view.\n\nClient Classes:\nThe primary client classes are `ClinicalMatching` (synchronous) and `ClinicalMatchingClient` (asynchronous). Both expose methods including `__init__`, `begin_match_trials`, `create_trials`, `trials`, `erase_trials`, `close`, and `send_request`.\n\nModels and Support Classes:\nA comprehensive set of models is provided under the `azure.healthinsights.clinicalmatching.models` namespace. These models represent structures for trial matching data and clinical information, including types such as `TrialMatcherData`, `TrialMatcherResult`, and `TrialMatcherPatientResult`, as well as configuration types like `TrialMatcherModelConfiguration`. Additionally, several enums (for example, `AgeUnit`, `ClinicalDocumentType`, `JobStatus`, and others) and additional data classes cover clinical trial details, patient records and documents, geographic data, and other related clinical properties.\n\nStructure and Functionality:\nThe API is structured to support long-running operations using pollers (`LROPoller` and `AsyncLROPoller`) and integrates distributed tracing via the `distributed_trace` and `distributed_trace_async` decorators. It manages various input types (e.g., structured objects, JSON, and IO streams) through method overloads, providing flexibility for different client use cases while maintaining robust context management in both synchronous and asynchronous environments.",
+            "source": "summary"
         },
         {
             "rule_ids": [
@@ -26,35 +14,19 @@
             ],
             "line_no": 102,
             "bad_code": "def trials(",
-            "suggestion": "Rename the method to 'list_trials' and consider returning an ItemPaged type for consistency with listing operations.",
-            "comment": "Methods that enumerate resources should be prefixed with 'list_' (python_design.html#python-paged-prefix)."
-        },
-        {
-            "rule_ids": [
-                "python_design.html#python-client-service-verbs"
-            ],
-            "line_no": 108,
-            "bad_code": "def erase_trials(",
-            "suggestion": "Rename the method to 'delete_trials' to adhere to the preferred service verb usage.",
-            "comment": "Deletion operations should use the 'delete_' prefix rather than non-standard verbs like 'erase_' (python_design.html#python-client-service-verbs)."
+            "suggestion": "def list_trials(",
+            "comment": "Methods that enumerate resources should be prefixed with 'list_'.",
+            "source": "guideline"
         },
         {
             "rule_ids": [
                 "python_design.html#python-client-options-naming"
             ],
-            "line_no": 191,
-            "bad_code": "options: Optional[CreateTrialsOptions] = None,",
-            "suggestion": "Remove the options bag parameter and expose the individual optional keyword arguments instead.",
-            "comment": "Using an options bag to group optional parameters violates the guideline (python_design.html#python-client-options-naming)."
-        },
-        {
-            "rule_ids": [
-                "python_design.html#python-paged-prefix"
-            ],
-            "line_no": 223,
-            "bad_code": "def trials(",
-            "suggestion": "Rename the method to 'list_trials' and consider returning an ItemPaged type for consistency with listing operations.",
-            "comment": "Methods that enumerate resources should be prefixed with 'list_' (python_design.html#python-paged-prefix)."
+            "line_no": 187,
+            "bad_code": "async def create_trials(",
+            "suggestion": "async def create_trials(self, body: Union[TrialMatcherData, JSON, IO], *, unit: Optional[Union[str, AgeUnit]] = None, value: Optional[float] = None, language: Optional[str] = None, date: Optional[datetime] = None, **kwargs: Any) -> AsyncLROPoller[TrialMatcherResult]",
+            "comment": "Operation-specific options should be provided as individual keyword-only arguments instead of using an options bag in the async client.",
+            "source": "guideline"
         },
         {
             "rule_ids": [
@@ -62,8 +34,39 @@
             ],
             "line_no": 229,
             "bad_code": "async def erase_trials(",
-            "suggestion": "Rename the method to 'delete_trials' to adhere to the preferred service verb usage.",
-            "comment": "Deletion operations should use the 'delete_' prefix rather than non-standard verbs like 'erase_' (python_design.html#python-client-service-verbs)."
+            "suggestion": "async def delete_trials(",
+            "comment": "Deletion operations should use the 'delete_' verb rather than 'erase_' in the async client.",
+            "source": "guideline"
+        },
+        {
+            "rule_ids": [
+                "python_implementation.html#python-codestyle-vars-naming"
+            ],
+            "line_no": 998,
+            "bad_code": "ivar eligibilityCriteriaEvidence: Optional[str]",
+            "suggestion": "ivar eligibility_criteria_evidence: Optional[str]",
+            "comment": "The attribute name should use snake_case instead of camelCase to follow Python naming conventions and to match the __init__ parameter style.",
+            "source": "merged"
+        },
+        {
+            "rule_ids": [
+                "python_implementation.html#python-codestyle-vars-naming"
+            ],
+            "line_no": 1000,
+            "bad_code": "ivar patientDataEvidence: Optional[ClinicalNoteEvidence]",
+            "suggestion": "ivar patient_data_evidence: Optional[ClinicalNoteEvidence]",
+            "comment": "Attribute names should use snake_case to maintain consistency and follow naming conventions.",
+            "source": "merged"
+        },
+        {
+            "rule_ids": [
+                "python_implementation.html#python-codestyle-vars-naming"
+            ],
+            "line_no": 1001,
+            "bad_code": "ivar patientInfoEvidence: Optional[ClinicalCodedElement]",
+            "suggestion": "ivar patient_info_evidence: Optional[ClinicalCodedElement]",
+            "comment": "Property names should use snake_case for consistency with Python naming conventions.",
+            "source": "merged"
         }
     ]
 }

--- a/packages/python-packages/apiview-copilot/scratch/output/python/image_analysis.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/python/image_analysis.json
@@ -1,104 +1,22 @@
 {
     "comments": [
         {
-            "rule_ids": [
-                "python_design.html#python-client-connection-string"
-            ],
-            "line_no": 10,
-            "bad_code": "connection_string: Optional[str] = None,",
+            "rule_ids": [],
+            "line_no": 1,
+            "bad_code": "",
             "suggestion": null,
-            "comment": "The constructor should not accept a connection_string parameter; use a separate factory method (from_connection_string) instead.",
+            "comment": "Here is a summary of the service described by this APIView:\n\nOverview  \nThis API provides image analysis capabilities that enable the extraction and interpretation of various visual features from images provided as byte streams or via URLs. The service supports a range of analysis types including caption generation, dense captioning, object and person detection, optical character recognition, smart cropping, and tagging. It is designed with distributed tracing support and leverages context management for resource handling.\n\nAPI Version  \nThe API clients accept an `api_version` parameter during initialization. Although no dedicated API version object is defined in this view, the version is configurable through the client.\n\nPrimary Client Classes  \nThe API exposes a synchronous client class, `ImageAnalysisClient`, and an asynchronous client class, `AsyncImageAnalysisClient`. The `ImageAnalysisClient` offers the following methods: `__init__`, `analyze`, `analyze_from_url`, `close`, and `send_request`. The `AsyncImageAnalysisClient` provides analogous methods: `__init__`, `analyze`, `analyze_from_url`, `close`, and a static `send_request`.\n\nOther Classes and Models  \nSupporting models are organized under the `models` namespace and represent the structure of analysis results and image components. These include classes such as `CaptionResult`, `CropRegion`, `DenseCaption`, `DenseCaptionsResult`, `DetectedObject`, `detectedPerson`, `DetectedTag`, `DetectedTextBlock`, `DetectedTextLine`, `DetectedTextWord`, `ImageAnalysisResult`, `ImageBoundingBox`, `ImageMetadata`, `ImagePoint`, `ObjectsResult`, `PeopleResult`, `ReadResult`, `SmartCropsResult`, and `TagsResult`. Additionally, the `VisualFeatures` enumeration lists available visual feature types including `CAPTION`, `DENSE_CAPTIONS`, `OBJECTS`, `PEOPLE`, `READ`, `SMART_CROPS`, and `tags`.\n\nAdditional Details  \nThe clients implement context management protocols (with `ImageAnalysisClient` as a `ContextManager` and `AsyncImageAnalysisClient` as an `AsyncContextManager`) to manage resource lifecycles. Decorators for distributed tracing (`@distributed_trace` and `@distributed_trace_async`) are used to support observability within distributed environments. The model classes inherit from `MutableMapping`, offering flexible access to their properties, and support multiple construction patterns either via explicit parameters or mappings.",
+            "source": "summary"
+        },
+        {
+            "rule_ids": [
+                "python_implementation.html#python-codestyle-kwargs"
+            ],
+            "line_no": 34,
+            "bad_code": "         gender_neutral_caption: Optional[bool] = ...,",
+            "suggestion": "         *, gender_neutral_caption: Optional[bool] = ...,",
+            "comment": "Optional parameters should be keyword-only; insert a '*' to separate positional from keyword-only arguments.",
             "source": "guideline"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 168,
-            "bad_code": "ivar list: List[DenseCaption]",
-            "suggestion": "ivar captions: List[DenseCaption]",
-            "comment": "Avoid using 'list' as an attribute name since it shadows the built-in; use a more descriptive name.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [
-                "python_implementation.html#python-codestyle-type-naming"
-            ],
-            "line_no": 209,
-            "bad_code": "class azure.ai.vision.imageanalysis.models.detectedPerson(MutableMapping[str, Any]):",
-            "suggestion": "class azure.ai.vision.imageanalysis.models.DetectedPerson(MutableMapping[str, Any]):",
-            "comment": "Class names should use PascalCase according to naming conventions.",
-            "source": "merged"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 409,
-            "bad_code": "ivar list: List[DetectedObject]",
-            "suggestion": "ivar objects: List[DetectedObject]",
-            "comment": "Rename the 'list' attribute to avoid shadowing the built-in type and to better reflect its contents.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [
-                "python_implementation.html#python-codestyle-properties"
-            ],
-            "line_no": 411,
-            "bad_code": "def get_result(self) -> ObjectsResult",
-            "suggestion": null,
-            "comment": "Replace simple getter methods with properties to adhere to Python's codestyle guidelines. Additionally, since accessor methods like get_result may be redundant with existing interfaces such as MutableMapping, consider removing them to streamline the API.",
-            "source": "merged"
-        },
-        {
-            "rule_ids": [
-                "python_implementation.html#python-codestyle-properties"
-            ],
-            "line_no": 413,
-            "bad_code": "def set_result(self, obj) -> None",
-            "suggestion": null,
-            "comment": "Avoid simple setter methods; use a property with a setter instead.",
-            "source": "guideline"
-        },
-        {
-            "rule_ids": [
-                "python_design.html#python-models-async"
-            ],
-            "line_no": 432,
-            "bad_code": "class azure.ai.vision.imageanalysis.models.aio.PeopleResult(MutableMapping[str, Any]):",
-            "suggestion": null,
-            "comment": "Models should not be duplicated in the aio namespace; reuse the model from the root namespace.",
-            "source": "guideline"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 433,
-            "bad_code": "ivar list: List[detectedPerson]",
-            "suggestion": "ivar people: List[DetectedPerson]",
-            "comment": "Avoid using 'list' as an attribute name and ensure that type names follow CamelCase.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 492,
-            "bad_code": "ivar list: List[DetectedTag]",
-            "suggestion": "ivar tags: List[DetectedTag]",
-            "comment": "Avoid using the built-in name 'list' for an instance variable; renaming it to 'tags' clarifies intent and prevents shadowing.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 498,
-            "bad_code": "list: List[DetectedTag]",
-            "suggestion": "tags: List[DetectedTag]",
-            "comment": "Rename the parameter 'list' to 'tags' to avoid conflict with Python's built-in and to clearly convey its purpose.",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [
-                "python_design.html#python-models-enum-name-uppercase"
-            ],
-            "line_no": 517,
-            "bad_code": "tags = 'tags'",
-            "suggestion": "TAGS = 'tags'",
-            "comment": "Enum member names should be uppercase for consistency. Rename 'tags' to 'TAGS'.",
-            "source": "merged"
         }
     ]
 }

--- a/packages/python-packages/apiview-copilot/scratch/output/python/keyvault_secrets_4.10.0b1.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/python/keyvault_secrets_4.10.0b1.json
@@ -5,23 +5,31 @@
             "line_no": 1,
             "bad_code": "",
             "suggestion": null,
-            "comment": "Here is a summary of the service described by this APIView:\n\nOverview  \nThis API provides a service for managing secrets within an Azure Key Vault. It supports operations for creating, retrieving, updating, deleting, backing up, restoring, and listing secrets as well as their properties and versions.\n\nAPI Version  \nThe API includes an `ApiVersion` enumeration with multiple values; the latest version is `V7_6_PREVIEW_2`.\n\nKey Client Classes  \nThe synchronous `SecretClient` class exposes methods such as `backup_secret`, `begin_delete_secret`, `begin_recover_deleted_secret`, `close`, `get_deleted_secret`, `get_secret`, `list_deleted_secrets`, `list_properties_of_secret_versions`, `list_properties_of_secrets`, `purge_deleted_secret`, `restore_secret_backup`, `send_request`, `set_secret`, and `update_secret_properties`. Its asynchronous counterpart, `SecretClient` in the `azure.keyvault.secrets.aio` namespace, provides methods including `backup_secret`, `close`, `delete_secret`, `get_deleted_secret`, `get_secret`, `list_deleted_secrets`, `list_properties_of_secret_versions`, `list_properties_of_secrets`, `purge_deleted_secret`, `recover_deleted_secret`, `restore_secret_backup`, `send_request`, `set_secret`, and `update_secret_properties`.\n\nAdditional Classes  \nOther classes include `DeletedSecret`, which represents a deleted secret and offers initialization and representation methods; `KeyVaultSecret`, which models a secret along with its value and metadata; `KeyVaultSecretIdentifier`, used for identifying secrets within the vault; and `SecretProperties`, which encapsulates the metadata associated with a secret.\n\nFunctionality and Structure  \nThe API is structured to support both synchronous and asynchronous operations with context management and is instrumented with distributed tracing decorators. It also incorporates mechanisms for handling long-running operations and direct HTTP request handling, providing flexibility in managing the lifecycle of secrets in a cloud environment.",
+            "comment": "Here is a summary of the service described by this APIView:\n\nPurpose  \nThis API provides functionality for managing secrets in an Azure KeyVault context. It supports operations such as setting, retrieving, backing up, deleting, recovering, purging, and updating secrets. It also includes capabilities for listing secret properties and versions as well as sending custom HTTP requests. Both synchronous and asynchronous interactions are supported.\n\nAPI Version  \nThe API version is defined by an enum named `ApiVersion`. The latest version listed is `7.6-preview.2`.\n\nClient Classes  \nThe synchronous client class, `SecretClient`, includes the following methods: `backup_secret`, `begin_delete_secret`, `begin_recover_deleted_secret`, `close`, `get_deleted_secret`, `get_secret`, `list_deleted_secrets`, `list_properties_of_secret_versions`, `list_properties_of_secrets`, `purge_deleted_secret`, `restore_secret_backup`, `send_request`, `set_secret`, and `update_secret_properties`. The asynchronous client class, also named `SecretClient` within the `azure.keyvault.secrets.aio` namespace, offers these methods: `backup_secret`, `close`, `delete_secret`, `get_deleted_secret`, `get_secret`, `list_deleted_secrets`, `list_properties_of_secret_versions`, `list_properties_of_secrets`, `purge_deleted_secret`, `recover_deleted_secret`, `restore_secret_backup`, `send_request`, `set_secret`, and `update_secret_properties`.\n\nOther Classes  \nAdditional classes in this API include `DeletedSecret`, `KeyVaultSecret`, `KeyVaultSecretIdentifier`, and `SecretProperties`. These classes define the data models for handling secret information and their associated metadata within the service.",
             "source": "summary"
         },
         {
             "rule_ids": [],
-            "line_no": 4,
-            "bad_code": "namespace azure.keyvault.secrets",
+            "line_no": 18,
+            "bad_code": "property deleted_date: Optional[datetime]    # Read-only",
             "suggestion": null,
-            "comment": "Remove the non‐Python 'namespace' syntax; organize the code using standard package/module structures (e.g. with __init__.py files).",
+            "comment": "Replace non-standard property declarations with @property decorators to adhere to Python conventions.",
             "source": "generic"
         },
         {
             "rule_ids": [],
-            "line_no": 202,
-            "bad_code": "namespace azure.keyvault.secrets.aio",
-            "suggestion": null,
-            "comment": "Remove the non‐Python 'namespace' syntax; use standard Python packaging instead.",
+            "line_no": 115,
+            "bad_code": "def list_properties_of_secret_versions(",
+            "suggestion": "def list_secret_versions(",
+            "comment": "Simplify the method name to improve readability by removing redundant wording.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 122,
+            "bad_code": "def list_properties_of_secrets(self, **kwargs: Any) -> ItemPaged[SecretProperties]",
+            "suggestion": "def list_secrets(self, **kwargs: Any) -> ItemPaged[SecretProperties]",
+            "comment": "Simplify the method name to improve readability by removing redundant wording.",
             "source": "generic"
         },
         {
@@ -30,9 +38,9 @@
             ],
             "line_no": 227,
             "bad_code": "async def delete_secret(",
-            "suggestion": "async def begin_delete_secret(self, name: str, **kwargs: Any) -> DeletedSecret",
-            "comment": "Rename the async delete method to use the 'begin_' prefix for consistency with long running operations and to align with the sync client's naming convention.",
-            "source": "merged"
+            "suggestion": "async def begin_delete_secret(",
+            "comment": "Long running operations must use a begin_ prefix. The async method for deleting a secret should be renamed to begin_delete_secret.",
+            "source": "guideline"
         },
         {
             "rule_ids": [
@@ -40,8 +48,8 @@
             ],
             "line_no": 269,
             "bad_code": "async def recover_deleted_secret(",
-            "suggestion": "async def begin_recover_deleted_secret(self, name: str, **kwargs: Any) -> SecretProperties",
-            "comment": "Long running operations must use the 'begin_' prefix; rename the async recover method accordingly.",
+            "suggestion": "async def begin_recover_deleted_secret(",
+            "comment": "Long running operations must use a begin_ prefix. The async method for recovering a deleted secret should be renamed to begin_recover_deleted_secret.",
             "source": "guideline"
         }
     ]

--- a/packages/python-packages/apiview-copilot/scratch/output/python/keyvault_secrets_4._2.0_10.0b1.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/python/keyvault_secrets_4._2.0_10.0b1.json
@@ -5,15 +5,39 @@
             "line_no": 1,
             "bad_code": "",
             "suggestion": null,
-            "comment": "Here is a summary of the changes in this APIView:\n\n• The `azure.keyvault.secrets.ApiVersion` enum now includes additional values, with the newest API version being `7.6-preview.2`.\n\n• In the `DeletedSecret` class, the properties `deleted_date`, `id`, `name`, `recovery_id`, and `scheduled_purge_date` have been updated to use `Optional` types.\n\n• In the `KeyVaultSecret` class, the `id`, `name`, and `value` properties are now marked as `Optional`, and the initializer has been updated with explicit type hints for `properties` (of type `SecretProperties`) and `value` (of type `Optional[str]`).\n\n• A new class, `KeyVaultSecretIdentifier`, has been introduced. It includes read-only properties `name`, `source_id`, `vault_url`, and an optional `version`, and provides an initializer that accepts a `source_id` parameter.\n\n• The `SecretClient` class has several updates:\n – Its constructor now requires `credential` to be of type `TokenCredential` and accepts an `api_version` parameter that can be either an `ApiVersion` or a `str`. A new parameter, `verify_challenge_resource`, has also been added.\n – Methods such as `backup_secret`, `get_deleted_secret`, `get_secret`, `list_deleted_secrets`, `list_properties_of_secret_versions`, `list_properties_of_secrets`, `purge_deleted_secret`, `restore_secret_backup`, `set_secret`, and `update_secret_properties` now include explicit type hints for `**kwargs` (typed as `Any`) and other parameters. Notably, `begin_delete_secret` and `begin_recover_deleted_secret` now return `LROPoller` types, wrapping their respective result types.\n – A new method, `send_request`, has been added. It accepts an `HttpRequest`, a `stream` flag, and additional keyword arguments, and returns an `HttpResponse`.\n\n• The `SecretProperties` class now marks most of its properties (including `content_type`, `created_on`, `enabled`, `expires_on`, `id`, `key_id`, `name`, `not_before`, `recovery_level`, `tags`, `updated_on`, `vault_url`, and `version`) as `Optional`. A new property, `managed`, is also added, and the initializer has been modified to accept variadic arguments with proper type hints.\n\n• In the asynchronous namespace (`azure.keyvault.secrets.aio`), the `SecretClient` class mirrors many of these updates:\n – The constructor now also accepts an `api_version` of type `Union[ApiVersion, str]` along with the additional `verify_challenge_resource` parameter.\n – Listing methods (`list_deleted_secrets`, `list_properties_of_secret_versions`, and `list_properties_of_secrets`) now return `AsyncItemPaged` types instead of `AsyncIterable`.\n – A new asynchronous method, `send_request`, has been added, which takes an `HttpRequest` (with similar parameters as its synchronous counterpart) and returns an `Awaitable[AsyncHttpResponse]`.\n – Other methods such as `set_secret` and `update_secret_properties` have updated their parameter type hints (for example, changing `tags` to an `Optional[Dict[str, str]]`).\n\nOverall, the diff significantly enhances type annotations (emphasizing the use of `Optional` and precise types for keyword arguments) and introduces new functionality for sending custom requests in both synchronous and asynchronous clients.",
+            "comment": "Here is a summary of the changes in this APIView:\n\n• The `ApiVersion` enumeration has been expanded with several new members. The newest API Version is now “7.6-preview.2”.\n\n• In the `DeletedSecret` class the types for the properties `deleted_date`, `id`, `name`, `recovery_id`, and `scheduled_purge_date` have been changed to use `Optional` types.\n\n• In the `KeyVaultSecret` class the types for the properties `id`, `name`, and `value` have been updated to be `Optional`, and its initializer now includes explicit type hints for its parameters.\n\n• A new class, `KeyVaultSecretIdentifier`, has been added. This class defines read-only properties for `name`, `source_id`, `vault_url`, and an optional `version`, and defines an initializer that accepts a `source_id`.\n\n• Within the `SecretClient` class (synchronous version):\n  - The initializer now requires a `credential` of type `TokenCredential` and changes the `api_version` parameter to accept a union of `ApiVersion` and `str`. A new parameter, `verify_challenge_resource`, has also been introduced.\n  - Many methods such as `backup_secret`, `get_deleted_secret`, and `get_secret` now include explicit type hints for `**kwargs`.\n  - The `begin_delete_secret` and `begin_recover_deleted_secret` methods have updated return types, now returning `LROPoller[DeletedSecret]` and `LROPoller[SecretProperties]`, respectively.\n  - In both the `set_secret` and `update_secret_properties` methods, the type for the `tags` parameter has been changed from `dict[str, str]` to `Optional[Dict[str, str]]`.\n  - A new method `send_request` has been added, which takes an `HttpRequest`, an optional boolean `stream` parameter, and `**kwargs`, and it returns an `HttpResponse`.\n\n• In the `SecretProperties` class the property types for `content_type`, `created_on`, `enabled`, `expires_on`, `id`, `key_id`, `name`, `not_before`, `recovery_level`, `tags`, `updated_on`, `vault_url`, and `version` have been updated to be `Optional`. Additionally, a new property `managed` has been added with an `Optional[bool]` type.\n\n• In the asynchronous client (`azure.keyvault.secrets.aio.SecretClient`):\n  - The initializer now also uses an `api_version` parameter of type `Union[ApiVersion, str]` and the additional `verify_challenge_resource` parameter.\n  - The return types of the listing methods have been changed from `AsyncIterable` to `AsyncItemPaged`.\n  - The `set_secret` and `update_secret_properties` methods have been updated similarly with the `tags` parameter now of type `Optional[Dict[str, str]]`.\n  - A new asynchronous `send_request` method has been introduced. This method takes an `HttpRequest`, an optional `stream` flag, and `**kwargs`, and returns an `Awaitable[AsyncHttpResponse]`.",
             "source": "summary"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 171,
+            "bad_code": "tags: Optional[Dict[str, str]] = ...,",
+            "suggestion": "tags: Optional[dict[str, str]] = ...,",
+            "comment": "Ensure a consistent dict type hint style across secret update methods.",
+            "source": "generic"
         },
         {
             "rule_ids": [],
             "line_no": 195,
             "bad_code": "*args: Any,",
-            "suggestion": null,
-            "comment": "Using *args in __init__ can obscure expected arguments; consider replacing with explicit parameters or ensure accepted positional arguments are well documented.",
+            "suggestion": "attributes: Any,",
+            "comment": "Replace variadic *args with explicit parameter names to improve clarity and discoverability.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 301,
+            "bad_code": "tags: Optional[Dict[str, str]] = ...,",
+            "suggestion": "tags: Optional[dict[str, str]] = ...,",
+            "comment": "Adopt built‐in dict annotations for consistency in async client method signatures.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 315,
+            "bad_code": "tags: Optional[Dict[str, str]] = ...,",
+            "suggestion": "tags: Optional[dict[str, str]] = ...,",
+            "comment": "Ensure consistent dictionary type hints in async update_secret_properties.",
             "source": "generic"
         }
     ]

--- a/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
@@ -392,29 +392,42 @@ class ApiViewReview:
 
     def _filter_comments(self):
         """
-        Run the filter prompt on the comments.
+        Run the filter prompt on the comments, processing each comment in parallel.
         """
-        # Pass combined results through the filter function with retry logic
-        filter_prompt_file = "final_comments_filter.prompty"
+        filter_prompt_file = "final_comment_filter_single.prompty"
         filter_prompt_path = os.path.join(_PROMPTS_FOLDER, filter_prompt_file)
 
-        # load the language-specific yaml file for the filter
-        filter_metadata = self._load_filter_metadata()
-        print(f"Filtering results...")
-        response = self._run_prompt(
-            filter_prompt_path,
-            inputs={
-                "comments": self.results.comments,
-                "language": self._get_language_pretty_name(),
-                "sample": filter_metadata["sample"],
-                "exceptions": filter_metadata["exceptions"],
-            },
-        )
-        response_json = json.loads(response)
-        keep_json = [x for x in response_json["comments"] if x["status"] == "KEEP"]
-        discard_json = [x for x in response_json["comments"] if x["status"] == "REMOVE"]
-        logger.info(f"Kept {len(keep_json)} comments and discarded {len(discard_json)} comments.")
-        self.results = ReviewResult(**{"comments": keep_json})
+        print(f"Filtering comments...")
+
+        # Submit each comment to the executor for parallel processing
+        futures = {}
+        for idx, comment in enumerate(self.results.comments):
+            futures[idx] = self.executor.submit(
+                self._run_prompt,
+                filter_prompt_path,
+                inputs={
+                    "content": comment.model_dump(),
+                    "language": self._get_language_pretty_name(),
+                },
+            )
+
+        # Collect results as they complete
+        keep_comments = []
+        discard_comments = []
+        for idx, future in futures.items():
+            try:
+                response = future.result()
+                response_json = json.loads(response)
+                if response_json.get("status") == "KEEP":
+                    keep_comments.append(response_json)
+                else:
+                    discard_comments.append(response_json)
+            except Exception as e:
+                logger.error(f"Error filtering comment at index {idx}: {str(e)}")
+
+        # Update the results with the filtered comments
+        print(f"Filtering completed. Kept {len(keep_comments)} comments. Discarded {len(discard_comments)} comments.")
+        self.results.comments = [Comment(**comment) for comment in keep_comments]
 
     def _run_prompt(self, prompt_path: str, inputs: dict, max_retries: int = 5) -> str:
         """
@@ -461,21 +474,34 @@ class ApiViewReview:
     def run(self) -> ReviewResult:
         try:
             print(f"Generating {self._get_language_pretty_name()} review...")
-            start_time = time()
+            overall_start_time = time()
 
+            # Track time for _generate_comments
+            generate_start_time = time()
             self._generate_comments()
+            generate_end_time = time()
+            print(f"  Generated comments in {generate_end_time - generate_start_time:.2f} seconds.")
 
-            # 4. Post-processing
+            # Track time for _deduplicate_comments
+            deduplicate_start_time = time()
             self._deduplicate_comments()
+            deduplicate_end_time = time()
+            print(f"  Deduplication completed in {deduplicate_end_time - deduplicate_start_time:.2f} seconds.")
+
+            # Track time for _filter_comments
+            filter_start_time = time()
             self._filter_comments()
+            filter_end_time = time()
+            print(f"  Filtering completed in {filter_end_time - filter_start_time:.2f} seconds.")
 
             # Add the summary to the results
             if self.summary:
                 self.results.comments.append(self.summary)
             results = self.results.sorted()
-            end_time = time()
 
-            print(f"Review generated in {end_time - start_time:.2f} seconds.")
+            overall_end_time = time()
+            print(f"Review generated in {overall_end_time - overall_start_time:.2f} seconds.")
+
             if self.semantic_search_failed:
                 print(f"{self.RED_TEXT}WARN: Semantic search failed for some chunks (see error.log).{self.RESET_COLOR}")
 


### PR DESCRIPTION
- Runs the de-duplication prompts in parallel
- Coverts the filtering stage to use one prompt per comment with a gpt-4.1 model, running in parallel, to significantly reduce the runtime of this stage
- Adds more logging to show how long each of the three stages takes