### PR TITLE
Allow for empty serviceDirectory in deploy-test-resources

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -162,7 +162,7 @@ try {
     $root = $repositoryRoot = "$PSScriptRoot/../../.." | Resolve-Path
 
     if($ServiceDirectory) {
-        $root = [System.IO.Path]::Combine($repositoryRoot, "sdk", $ServiceDirectory) | Resolve-Path
+        $root = "$repositoryRoot/sdk/$ServiceDirectory" | Resolve-Path
     }
 
     if ($TestResourcesDirectory) {
@@ -197,7 +197,7 @@ try {
 
     # returns empty string if $ServiceDirectory is not set
     $serviceName = GetServiceLeafDirectoryName $ServiceDirectory
-
+    
     # in ci, random names are used
     # in non-ci, without BaseName, ResourceGroupName or ServiceDirectory, all invocations will
     # generate the same resource group name and base name for a given user
@@ -207,18 +207,6 @@ try {
         -user (GetUserName) `
         -serviceDirectoryName $serviceName `
         -CI $CI
-
-    if ($wellKnownTMETenants.Contains($TenantId)) {
-        # Add a prefix to the resource group name to avoid flagging the usages of local auth
-        # See details at https://eng.ms/docs/products/onecert-certificates-key-vault-and-dsms/key-vault-dsms/certandsecretmngmt/credfreefaqs#how-can-i-disable-s360-reporting-when-testing-customer-facing-3p-features-that-depend-on-use-of-unsafe-local-auth
-        $ResourceGroupName = "SSS3PT_" + $ResourceGroupName
-    }
-
-    if ($ResourceGroupName.Length -gt 90) {
-        # See limits at https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
-        Write-Warning -Message "Resource group name '$ResourceGroupName' is too long. So pruning it to be the first 90 characters."
-        $ResourceGroupName = $ResourceGroupName.Substring(0, 90)
-    }
 
     # Make sure pre- and post-scripts are passed formerly required arguments.
     $PSBoundParameters['BaseName'] = $BaseName
@@ -311,6 +299,18 @@ try {
         if (!$TenantId) {
             $TenantId = $context.Subscription.TenantId
         }
+    }
+
+    if ($wellKnownTMETenants.Contains($TenantId)) {
+        # Add a prefix to the resource group name to avoid flagging the usages of local auth
+        # See details at https://eng.ms/docs/products/onecert-certificates-key-vault-and-dsms/key-vault-dsms/certandsecretmngmt/credfreefaqs#how-can-i-disable-s360-reporting-when-testing-customer-facing-3p-features-that-depend-on-use-of-unsafe-local-auth
+        $ResourceGroupName = "SSS3PT_" + $ResourceGroupName
+    }
+
+    if ($ResourceGroupName.Length -gt 90) {
+        # See limits at https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
+        Write-Warning -Message "Resource group name '$ResourceGroupName' is too long. So pruning it to be the first 90 characters."
+        $ResourceGroupName = $ResourceGroupName.Substring(0, 90)
     }
 
     # If a provisioner service principal was provided log into it to perform the pre- and post-scripts and deployments.
@@ -667,6 +667,7 @@ $serialized
 '`@ | ConvertFrom-Json -AsHashtable
 # Set global variables that aren't always passed as parameters
 `$ResourceGroupName = `$parameters.ResourceGroupName
+`$AdditionalParameters = `$parameters.AdditionalParameters
 `$DeploymentOutputs = `$parameters.DeploymentOutputs
 $postDeploymentScript `@parameters
 "@

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -18,7 +18,7 @@ param (
     [ValidatePattern('^[-\w\._\(\)]+$')]
     [string] $ResourceGroupName,
 
-    [Parameter(Mandatory = $true, Position = 0)]
+    [Parameter(Position = 0)]
     [string] $ServiceDirectory,
 
     [Parameter()]
@@ -158,10 +158,13 @@ if ($initialContext) {
 
 # try..finally will also trap Ctrl+C.
 try {
-
     # Enumerate test resources to deploy. Fail if none found.
-    $repositoryRoot = "$PSScriptRoot/../../.." | Resolve-Path
-    $root = [System.IO.Path]::Combine($repositoryRoot, "sdk", $ServiceDirectory) | Resolve-Path
+    $root = $repositoryRoot = "$PSScriptRoot/../../.." | Resolve-Path
+
+    if($ServiceDirectory) {
+        $root = [System.IO.Path]::Combine($repositoryRoot, "sdk", $ServiceDirectory) | Resolve-Path
+    }
+
     if ($TestResourcesDirectory) {
         $root = $TestResourcesDirectory | Resolve-Path
         # Add an explicit check below in case ErrorActionPreference is overridden and Resolve-Path doesn't stop execution
@@ -170,6 +173,7 @@ try {
         }
         Write-Verbose "Overriding test resources search directory to '$root'"
     }
+    
     $templateFiles = @()
 
     "$ResourceType-resources.json", "$ResourceType-resources.bicep" | ForEach-Object {
@@ -191,13 +195,30 @@ try {
         exit
     }
 
+    # returns empty string if $ServiceDirectory is not set
     $serviceName = GetServiceLeafDirectoryName $ServiceDirectory
+
+    # in ci, random names are used
+    # in non-ci, without BaseName, ResourceGroupName or ServiceDirectory, all invocations will
+    # generate the same resource group name and base name for a given user
     $BaseName, $ResourceGroupName = GetBaseAndResourceGroupNames `
         -baseNameDefault $BaseName `
         -resourceGroupNameDefault $ResourceGroupName `
         -user (GetUserName) `
         -serviceDirectoryName $serviceName `
         -CI $CI
+
+    if ($wellKnownTMETenants.Contains($TenantId)) {
+        # Add a prefix to the resource group name to avoid flagging the usages of local auth
+        # See details at https://eng.ms/docs/products/onecert-certificates-key-vault-and-dsms/key-vault-dsms/certandsecretmngmt/credfreefaqs#how-can-i-disable-s360-reporting-when-testing-customer-facing-3p-features-that-depend-on-use-of-unsafe-local-auth
+        $ResourceGroupName = "SSS3PT_" + $ResourceGroupName
+    }
+
+    if ($ResourceGroupName.Length -gt 90) {
+        # See limits at https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
+        Write-Warning -Message "Resource group name '$ResourceGroupName' is too long. So pruning it to be the first 90 characters."
+        $ResourceGroupName = $ResourceGroupName.Substring(0, 90)
+    }
 
     # Make sure pre- and post-scripts are passed formerly required arguments.
     $PSBoundParameters['BaseName'] = $BaseName
@@ -292,19 +313,6 @@ try {
         }
     }
 
-    # This needs to happen after we set the TenantId but before we use the ResourceGroupName
-    if ($wellKnownTMETenants.Contains($TenantId)) {
-        # Add a prefix to the resource group name to avoid flagging the usages of local auth
-        # See details at https://eng.ms/docs/products/onecert-certificates-key-vault-and-dsms/key-vault-dsms/certandsecretmngmt/credfreefaqs#how-can-i-disable-s360-reporting-when-testing-customer-facing-3p-features-that-depend-on-use-of-unsafe-local-auth
-        $ResourceGroupName = "SSS3PT_" + $ResourceGroupName
-    }
-
-    if ($ResourceGroupName.Length -gt 90) {
-        # See limits at https://docs.microsoft.com/azure/architecture/best-practices/resource-naming
-        Write-Warning -Message "Resource group name '$ResourceGroupName' is too long. So pruning it to be the first 90 characters."
-        $ResourceGroupName = $ResourceGroupName.Substring(0, 90)
-    }
-
     # If a provisioner service principal was provided log into it to perform the pre- and post-scripts and deployments.
     if ($ProvisionerApplicationId -and $ServicePrincipalAuth) {
         $null = Disable-AzContextAutosave -Scope Process
@@ -360,9 +368,10 @@ try {
         $ProvisionerApplicationOid = $sp.Id
     }
 
-    $tags = @{
-        Owners = (GetUserName)
-        ServiceDirectory = $ServiceDirectory
+    $tags = @{ Owners = (GetUserName) }
+
+    if ($ServiceDirectory) {
+        $tags['ServiceDirectory'] = $ServiceDirectory
     }
 
     # Tag the resource group to be deleted after a certain number of hours.
@@ -658,7 +667,6 @@ $serialized
 '`@ | ConvertFrom-Json -AsHashtable
 # Set global variables that aren't always passed as parameters
 `$ResourceGroupName = `$parameters.ResourceGroupName
-`$AdditionalParameters = `$parameters.AdditionalParameters
 `$DeploymentOutputs = `$parameters.DeploymentOutputs
 $postDeploymentScript `@parameters
 "@

--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -301,6 +301,7 @@ try {
         }
     }
 
+    # This needs to happen after we set the TenantId but before we use the ResourceGroupName	
     if ($wellKnownTMETenants.Contains($TenantId)) {
         # Add a prefix to the resource group name to avoid flagging the usages of local auth
         # See details at https://eng.ms/docs/products/onecert-certificates-key-vault-and-dsms/key-vault-dsms/certandsecretmngmt/credfreefaqs#how-can-i-disable-s360-reporting-when-testing-customer-facing-3p-features-that-depend-on-use-of-unsafe-local-auth

--- a/eng/common/TestResources/Remove-TestResources.ps1
+++ b/eng/common/TestResources/Remove-TestResources.ps1
@@ -157,10 +157,6 @@ $context = Get-AzContext
 
 if (!$ResourceGroupName) {
     if ($CI) {
-        if (!$ServiceDirectory) {
-            Write-Warning "ServiceDirectory parameter is empty, nothing to remove"
-            exit 0
-        }
         $envVarName = (BuildServiceDirectoryPrefix (GetServiceLeafDirectoryName $ServiceDirectory)) + "RESOURCE_GROUP"
         $ResourceGroupName = [Environment]::GetEnvironmentVariable($envVarName)
         if (!$ResourceGroupName) {
@@ -221,7 +217,12 @@ if ($wellKnownSubscriptions.ContainsKey($subscriptionName)) {
 Log "Selected subscription '$subscriptionName'"
 
 if ($ServiceDirectory) {
-    $root = [System.IO.Path]::Combine("$PSScriptRoot/../../../sdk", $ServiceDirectory) | Resolve-Path
+    $root = "$PSScriptRoot/../../.."
+    if($ServiceDirectory) {
+      $root = "$root/sdk/$ServiceDirectory"
+    }
+    $root = $root | Resolve-Path
+    
     $preRemovalScript = Join-Path -Path $root -ChildPath "remove-$ResourceType-resources-pre.ps1"
     if (Test-Path $preRemovalScript) {
         Log "Invoking pre resource removal script '$preRemovalScript'"

--- a/eng/common/TestResources/SubConfig-Helpers.ps1
+++ b/eng/common/TestResources/SubConfig-Helpers.ps1
@@ -1,4 +1,7 @@
 function BuildServiceDirectoryPrefix([string]$serviceName) {
+    if(!$serviceName) {
+        return ""
+    }
     $serviceName = $serviceName -replace '[\./\\]', '_'
     return $serviceName.ToUpperInvariant() + "_"
 }
@@ -32,10 +35,15 @@ function GetBaseAndResourceGroupNames(
     if ($CI) {
         $base = 't' + (New-Guid).ToString('n').Substring(0, 16)
         # Format the resource group name based on resource group naming recommendations and limitations.
-        $generatedGroup = "rg-{0}-$base" -f ($serviceName -replace '[\.\\\/:]', '-').
-                            Substring(0, [Math]::Min($serviceDirectoryName.Length, 90 - $base.Length - 4)).
-                            Trim('-').
-                            ToLowerInvariant()
+        if ($serviceDirectoryName) {
+            $generatedGroup = "rg-{0}-$base" -f ($serviceName -replace '[\.\\\/:]', '-').
+              Substring(0, [Math]::Min($serviceDirectoryName.Length, 90 - $base.Length - 4)).
+              Trim('-').
+              ToLowerInvariant()
+        } else {
+            $generatedGroup = "rg-$base"
+        }
+
         $group = $resourceGroupNameDefault ? $resourceGroupNameDefault : $generatedGroup
 
         Log "Generated resource base name '$base' and resource group name '$group' for CI build"

--- a/eng/common/TestResources/deploy-test-resources.yml
+++ b/eng/common/TestResources/deploy-test-resources.yml
@@ -1,5 +1,5 @@
 parameters:
-  ServiceDirectory: not-set
+  ServiceDirectory: ''
   ArmTemplateParameters: '@{}'
   DeleteAfterHours: 8
   Location: ''


### PR DESCRIPTION
azure-mcp needs to deploy test resource and doesn't use the `sdk/<ServiceDirectory>` repo structure