### PR TITLE
[rust-api-parser] Update parser to have Stable Line IDs

### DIFF
--- a/tools/apiview/parsers/rust-api-parser/CHANGELOG.md
+++ b/tools/apiview/parsers/rust-api-parser/CHANGELOG.md
@@ -1,9 +1,10 @@
 # 1.1.0 
 
-Enhanced rendering of `use` items to more closely match the rustdoc (docs.rs) HTML view:
-- Improved handling of `use` items and module re-exports with better tracking to prevent duplication
-- Refactored module processing with enhanced sorting and organization of child items
-- Fixed bugs and improved utility functions for better code maintainability
+1. Enhanced rendering of `use` items to more closely match the rustdoc (docs.rs) HTML view:
+    - Improved handling of `use` items and module re-exports with better tracking to prevent duplication
+    - Refactored module processing with enhanced sorting and organization of child items
+    - Fixed bugs and improved utility functions for better code maintainability
+2. Updated IDs to stable, meaningful identifiers rather than relying on the dynamic rustdoc ids.
 
 # 1.0.1
 

--- a/tools/apiview/parsers/rust-api-parser/src/main.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/main.ts
@@ -68,8 +68,8 @@ function processExternalReferences(codeFile: CodeFile): void {
  */
 function buildCodeFile(): CodeFile {
   const codeFile: CodeFile = {
-    PackageName: apiJson.index[apiJson.root].name || "unknown",
-    PackageVersion: apiJson["crate_version"] || "unknown",
+    PackageName: apiJson.index[apiJson.root].name || "unknown_root_package_name",
+    PackageVersion: apiJson["crate_version"] || "unknown_crate_version",
     ParserVersion: "1.1.0",
     Language: "Rust",
     ReviewLines: [],

--- a/tools/apiview/parsers/rust-api-parser/src/main.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/main.ts
@@ -4,6 +4,7 @@ import { CodeFile, TokenKind } from "./models/apiview-models";
 import { Crate, FORMAT_VERSION, Id } from "../rustdoc-types/output/rustdoc-types";
 import { externalReferencesLines } from "./process-items/utils/externalReexports";
 import { sortExternalItems } from "./process-items/utils/sorting";
+import { updateReviewLinesWithStableLineIds } from "./utils/lineIdUtils";
 
 let apiJson: Crate;
 export const processedItems = new Set<number>();
@@ -77,6 +78,8 @@ function buildCodeFile(): CodeFile {
 
   processRootItem(codeFile);
   processExternalReferences(codeFile);
+
+  updateReviewLinesWithStableLineIds(codeFile.ReviewLines);
   return codeFile;
 }
 

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocConst.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocConst.ts
@@ -31,7 +31,7 @@ export function processAssocConst(item: Item): ReviewLine[] | null {
   // Add name
   reviewLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "unknown",
+    Value: item.name || "unknown_assoc_const",
     HasSuffixSpace: false,
     RenderClasses: ["interface"],
   });

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocConst.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocConst.ts
@@ -3,6 +3,7 @@ import { Item } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { typeToReviewTokens } from "./utils/typeToReviewTokens";
 import { isAssocConstItem } from "./utils/typeGuards";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes an associated constant item and returns ReviewLine objects.
@@ -62,5 +63,6 @@ export function processAssocConst(item: Item): ReviewLine[] | null {
   });
 
   reviewLines.push(reviewLine);
+  lineIdMap.set(item.id.toString(), `const_${item.name}`);
   return reviewLines;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocType.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocType.ts
@@ -33,7 +33,7 @@ export function processAssocType(item: Item): ReviewLine[] | null {
   // Add name
   reviewLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "unknown",
+    Value: item.name || "unknown_assoc_const",
     HasSuffixSpace: false,
     RenderClasses: ["interface"],
   });

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocType.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocType.ts
@@ -4,6 +4,7 @@ import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { typeToReviewTokens } from "./utils/typeToReviewTokens";
 import { isAssocTypeItem } from "./utils/typeGuards";
 import { createGenericBoundTokens, processGenerics } from "./utils/processGenerics";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes an associated type item and returns ReviewLine objects.
@@ -65,5 +66,6 @@ export function processAssocType(item: Item): ReviewLine[] | null {
   });
 
   reviewLines.push(reviewLine);
+  lineIdMap.set(item.id.toString(), `type_${item.name}`);
   return reviewLines;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocType.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processAssocType.ts
@@ -33,7 +33,7 @@ export function processAssocType(item: Item): ReviewLine[] | null {
   // Add name
   reviewLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "unknown_assoc_const",
+    Value: item.name || "unknown_assoc_type",
     HasSuffixSpace: false,
     RenderClasses: ["interface"],
   });

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processConstant.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processConstant.ts
@@ -22,7 +22,7 @@ export function processConstant(item: Item) {
   });
   reviewLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "null",
+    Value: item.name || "unknown_const",
     HasSuffixSpace: false,
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name,
@@ -39,7 +39,7 @@ export function processConstant(item: Item) {
   });
   reviewLine.Tokens.push({
     Kind: TokenKind.Text,
-    Value: item.inner.constant.const.expr || "null",
+    Value: item.inner.constant.const.expr || "unknown_const_expr",
     HasSuffixSpace: false,
   });
   reviewLine.Tokens.push({

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processConstant.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processConstant.ts
@@ -3,6 +3,7 @@ import { Item } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isConstantItem } from "./utils/typeGuards";
 import { typeToReviewTokens } from "./utils/typeToReviewTokens";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 export function processConstant(item: Item) {
   if (!isConstantItem(item)) return;
@@ -56,5 +57,6 @@ export function processConstant(item: Item) {
     });
   }
   reviewLines.push(reviewLine);
+  lineIdMap.set(item.id.toString(), `const_${item.name}`);
   return reviewLines;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processEnum.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processEnum.ts
@@ -40,7 +40,7 @@ export function processEnum(item: Item): ReviewLine[] {
 
   enumLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "null",
+    Value: item.name || "unknown_enum",
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,
     RenderClasses: ["enum"],
@@ -74,7 +74,7 @@ export function processEnum(item: Item): ReviewLine[] {
         Tokens: [
           {
             Kind: TokenKind.Text,
-            Value: variantItem.name || "null",
+            Value: variantItem.name || "unknown_variant",
             HasSuffixSpace: false,
           },
           {

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processEnum.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processEnum.ts
@@ -5,12 +5,14 @@ import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { processGenerics } from "./utils/processGenerics";
 import { isEnumItem } from "./utils/typeGuards";
 import { getAPIJson } from "../main";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 export function processEnum(item: Item): ReviewLine[] {
   if (!isEnumItem(item)) return [];
   const apiJson = getAPIJson();
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
+  lineIdMap.set(item.id.toString(), `enum_${item.name}`);
   // Process derives and impls
   let implResult: ImplProcessResult;
   if (item.inner.enum.impls) {
@@ -25,7 +27,6 @@ export function processEnum(item: Item): ReviewLine[] {
 
   if (implResult.deriveTokens.length > 0) {
     const deriveTokensLine: ReviewLine = {
-      LineId: item.id.toString() + "_derive",
       Tokens: implResult.deriveTokens,
       RelatedToLine: item.id.toString(),
     };
@@ -67,6 +68,7 @@ export function processEnum(item: Item): ReviewLine[] {
   if (item.inner.enum.variants) {
     enumLine.Children = item.inner.enum.variants.map((variant: number) => {
       const variantItem = apiJson.index[variant];
+      lineIdMap.set(variantItem.id.toString(), `variant_${variantItem.name}`);
       return {
         LineId: variantItem.id.toString(),
         Tokens: [
@@ -97,5 +99,6 @@ export function processEnum(item: Item): ReviewLine[] {
   if (implResult.traitImpls.length > 0) {
     reviewLines.push(...implResult.traitImpls);
   }
+  lineIdMap.set(item.id.toString(), `enum_${item.name}`);
   return reviewLines;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processExternType.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processExternType.ts
@@ -31,7 +31,7 @@ export function processExternType(item: Item): ReviewLine[] | null {
   // Add name
   reviewLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "unknown",
+    Value: item.name || "unknown_extern_type",
   });
 
   // Add semicolon

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processExternType.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processExternType.ts
@@ -2,6 +2,7 @@ import { ReviewLine, TokenKind } from "../models/apiview-models";
 import { Item } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isExternTypeItem } from "./utils/typeGuards";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes an extern type item and returns ReviewLine objects.
@@ -40,5 +41,6 @@ export function processExternType(item: Item): ReviewLine[] | null {
   });
 
   reviewLines.push(reviewLine);
+  lineIdMap.set(item.id.toString(), `extern_type_${item.name}`);
   return reviewLines;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processFunction.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processFunction.ts
@@ -84,7 +84,7 @@ export function processFunction(item: Item): ReviewLine[] {
 
   reviewLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "null",
+    Value: item.name || "unknown_fn",
     HasSuffixSpace: false,
     RenderClasses: ["method"],
     NavigateToId: item.id.toString(),

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processFunction.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processFunction.ts
@@ -4,6 +4,7 @@ import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { processGenerics } from "./utils/processGenerics";
 import { isFunctionItem } from "./utils/typeGuards";
 import { typeToReviewTokens } from "./utils/typeToReviewTokens";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes the function header and adds modifiers and ABI information to the tokens
@@ -175,5 +176,6 @@ export function processFunction(item: Item): ReviewLine[] {
     });
   }
   reviewLines.push(reviewLine);
+  lineIdMap.set(item.id.toString(), `function_${item.name}`);
   return reviewLines;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processImpl.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processImpl.ts
@@ -200,7 +200,7 @@ export function processImpl(
           { Kind: TokenKind.Keyword, Value: "impl" },
           {
             Kind: TokenKind.MemberName,
-            Value: item.name || "null",
+            Value: item.name || "unknown_impl",
             RenderClasses: ["interface"],
             NavigateToId: linedId,
             NavigationDisplayName: item.name || undefined,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processImpl.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processImpl.ts
@@ -12,6 +12,7 @@ import {
 import { typeToReviewTokens } from "./utils/typeToReviewTokens";
 import { processGenericArgs, processGenerics } from "./utils/processGenerics";
 import { getAPIJson } from "../main";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 // Interface for the result of processing implementations
 export interface ImplProcessResult {
@@ -60,7 +61,7 @@ export function processAutoTraitImpls(impls: number[]): ReviewToken[] {
 }
 
 // Process manually implemented trait implementations
-function processOtherTraitImpls(impls: number[]): ReviewLine[] {
+function processOtherTraitImpls(impls: number[], prefixId: string): ReviewLine[] {
   const apiJson = getAPIJson();
   const traitImpls = getFilteredImpls(impls, isManualTraitImpl);
   return traitImpls.flatMap((implItem) => {
@@ -69,33 +70,35 @@ function processOtherTraitImpls(impls: number[]): ReviewLine[] {
     // Get the type that the trait is implemented for
     const parentName = typeToReviewTokens(implItem.inner.impl.for);
 
-    const implId = implItem.id.toString();
+    const lineId = implItem.id.toString() + "_" + prefixId;
     // Process provided trait methods that are mentioned but not explicitly implemented
     const providedTraitMethods: ReviewLine[] = implItem.inner.impl.provided_trait_methods.map(
-      (method) => ({
-        LineId: implId + "_impl_" + method,
-        Tokens: [
-          { Kind: TokenKind.Keyword, Value: "pub" },
-          { Kind: TokenKind.Keyword, Value: "fn" },
-          {
-            Kind: TokenKind.MemberName,
-            Value: method,
-            RenderClasses: ["method"],
-            HasSuffixSpace: false,
-          },
-          { Kind: TokenKind.Punctuation, Value: ";" },
-          {
-            Kind: TokenKind.Comment,
-            Value: "// provided trait method",
-            HasSuffixSpace: false,
-          },
-        ],
-      }),
+      (method) => {
+        return {
+          Tokens: [
+            { Kind: TokenKind.Keyword, Value: "pub" },
+            { Kind: TokenKind.Keyword, Value: "fn" },
+            {
+              Kind: TokenKind.MemberName,
+              Value: method,
+              RenderClasses: ["method"],
+              HasSuffixSpace: false,
+            },
+            { Kind: TokenKind.Punctuation, Value: ";" },
+            {
+              Kind: TokenKind.Comment,
+              Value: "// provided trait method",
+              HasSuffixSpace: false,
+            },
+          ],
+          RelatedToLine: lineId,
+        };
+      },
     );
     const implGenerics = processGenerics(implItem.inner.impl.generics);
     // Create the main impl line with trait name and type
     const reviewLineForImpl: ReviewLine = {
-      LineId: implId + "_impl",
+      LineId: lineId,
       Tokens: [
         {
           Kind: TokenKind.Keyword,
@@ -108,7 +111,7 @@ function processOtherTraitImpls(impls: number[]): ReviewLine[] {
           Value: (implItem.inner.impl.is_negative ? "!" : "") + implItem.inner.impl.trait.name,
           HasPrefixSpace: true,
           HasSuffixSpace: false,
-          NavigateToId: implId + "_impl",
+          NavigateToId: lineId,
           // Create navigation display name by combining trait and type names
           NavigationDisplayName:
             implItem.inner.impl.trait.name + "_" + parentName.map((token) => token.Value).join(""),
@@ -132,8 +135,16 @@ function processOtherTraitImpls(impls: number[]): ReviewLine[] {
       ],
     };
 
+    lineIdMap.set(
+      lineId,
+      prefixId +
+        reviewLineForImpl.Tokens.map((token) => token.Value)
+          .join("_")
+          .replace(/[^a-zA-Z0-9]+/g, ""),
+    );
+
     const closingLine: ReviewLine = {
-      RelatedToLine: implItem.id.toString() + "_impl",
+      RelatedToLine: lineId,
       Tokens: [{ Kind: TokenKind.Punctuation, Value: "}" }],
     };
 
@@ -166,6 +177,8 @@ export function processImpl(
     | (Item & { inner: { enum: Enum } })
     | (Item & { inner: { union: Union } }),
 ): ImplProcessResult {
+  const linedId = item.id.toString() + "_impl";
+  lineIdMap.set(linedId, lineIdMap.get(item.id.toString()) + "_impl");
   // Get all implementations associated with this item
   const impls = getImplsFromItem(item);
 
@@ -176,35 +189,35 @@ export function processImpl(
   // Process children first to check if they're empty
   const children = processImpls(impls).filter((item) => item != null);
 
-  // Only create an implBlock if there are children
-  const implBlock: ReviewLine[] =
-    children.length === 0
-      ? [] // Empty implBlock if no children
-      : [
-          // Create the main implementation line with type name
+  let implBlock: ReviewLine[] = [];
+  if (children.length > 0) {
+    // Only create an implBlock if there are children
+    implBlock = [
+      // Create the main implementation line with type name
+      {
+        LineId: linedId,
+        Tokens: [
+          { Kind: TokenKind.Keyword, Value: "impl" },
           {
-            LineId: item.id.toString() + "_impl",
-            Tokens: [
-              { Kind: TokenKind.Keyword, Value: "impl" },
-              {
-                Kind: TokenKind.MemberName,
-                Value: item.name || "null",
-                RenderClasses: ["interface"],
-                NavigateToId: item.id.toString() + "_impl",
-                NavigationDisplayName: item.name || undefined,
-              },
-              { Kind: TokenKind.Punctuation, Value: "{" },
-            ],
-            Children: children,
+            Kind: TokenKind.MemberName,
+            Value: item.name || "null",
+            RenderClasses: ["interface"],
+            NavigateToId: linedId,
+            NavigationDisplayName: item.name || undefined,
           },
-          {
-            RelatedToLine: item.id.toString() + "_impl",
-            Tokens: [{ Kind: TokenKind.Punctuation, Value: "}" }],
-          },
-        ];
+          { Kind: TokenKind.Punctuation, Value: "{" },
+        ],
+        Children: children,
+      },
+      {
+        RelatedToLine: linedId,
+        Tokens: [{ Kind: TokenKind.Punctuation, Value: "}" }],
+      },
+    ];
+  }
 
   // Process manual trait implementations (like impl Trait for Type { ... })
-  const traitImpls = processOtherTraitImpls(impls);
+  const traitImpls = processOtherTraitImpls(impls, item.name);
 
   return { deriveTokens, implBlock, traitImpls };
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processMacro.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processMacro.ts
@@ -2,6 +2,7 @@ import { ReviewLine, TokenKind } from "../models/apiview-models";
 import { Item } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isMacroItem } from "./utils/typeGuards";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes a macro item and returns ReviewLine objects.
@@ -17,10 +18,12 @@ export function processMacro(item: Item): ReviewLine[] | null {
   // Split the macro value by newlines
   const macroLines = item.inner.macro.split("\n");
 
+  const linedId = item.id.toString();
+  lineIdMap.set(linedId, macroLines[0]);
   // Create ReviewLines for each macro line
   macroLines.forEach((line, index) => {
     const reviewLine: ReviewLine = {
-      LineId: index === 0 ? item.id.toString() : `${item.id.toString()}_macro_${index}`,
+      LineId: index === 0 ? linedId : undefined,
       Tokens: [
         {
           Kind: TokenKind.Text,
@@ -28,7 +31,7 @@ export function processMacro(item: Item): ReviewLine[] | null {
         },
       ],
       // Only additional lines are related to the first line
-      RelatedToLine: index === 0 ? undefined : item.id.toString(),
+      RelatedToLine: index === 0 ? undefined : linedId,
     };
     reviewLines.push(reviewLine);
   });

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processModule.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processModule.ts
@@ -7,6 +7,7 @@ import { getAPIJson, processedItems } from "../main";
 import { getSortedChildIds } from "./utils/sorting";
 import { processUse } from "./processUse";
 import { AnnotatedReviewLines } from "./utils/models";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes a module item and adds its documentation to the ReviewLine.
@@ -24,6 +25,7 @@ export function processModule(
   const apiJson = getAPIJson();
   const isRootModule = item.id === apiJson.root;
 
+  lineIdMap.set(item.id.toString(), item.name || "null");
   // Create the ReviewLine object
   const reviewLine: ReviewLine = {
     LineId: item.id.toString(),
@@ -54,6 +56,7 @@ export function processModule(
       });
     }
     fullName += item.name;
+    lineIdMap.set(item.id.toString(), fullName);
     // current module
     reviewLine.Tokens.push({
       Kind: TokenKind.TypeName,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processModule.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processModule.ts
@@ -25,7 +25,7 @@ export function processModule(
   const apiJson = getAPIJson();
   const isRootModule = item.id === apiJson.root;
 
-  lineIdMap.set(item.id.toString(), item.name || "null");
+  lineIdMap.set(item.id.toString(), item.name || "unknown_mod");
   // Create the ReviewLine object
   const reviewLine: ReviewLine = {
     LineId: item.id.toString(),
@@ -60,7 +60,7 @@ export function processModule(
     // current module
     reviewLine.Tokens.push({
       Kind: TokenKind.TypeName,
-      Value: item.name || "null",
+      Value: item.name || "unknown_mod",
       RenderClasses: ["namespace"],
       NavigateToId: item.id.toString(),
       NavigationDisplayName: fullName,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processProcMacro.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processProcMacro.ts
@@ -15,7 +15,7 @@ export function processProcMacro(item: Item): ReviewLine[] | null {
 
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
-  lineIdMap.set(item.id.toString(), item.name || "unknown");
+  lineIdMap.set(item.id.toString(), item.name || "unknown_proc_macro");
   // Create the ReviewLine object
   const reviewLine: ReviewLine = {
     LineId: item.id.toString(),

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processProcMacro.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processProcMacro.ts
@@ -2,6 +2,7 @@ import { ReviewLine, TokenKind } from "../models/apiview-models";
 import { Item } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isProcMacroItem } from "./utils/typeGuards";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes a procedural macro item and returns ReviewLine objects.
@@ -14,6 +15,7 @@ export function processProcMacro(item: Item): ReviewLine[] | null {
 
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
+  lineIdMap.set(item.id.toString(), item.name || "unknown");
   // Create the ReviewLine object
   const reviewLine: ReviewLine = {
     LineId: item.id.toString(),
@@ -57,8 +59,7 @@ export function processProcMacro(item: Item): ReviewLine[] | null {
   });
 
   // Add pub and fn keywords
-  const functionLine = {
-    LineId: `${item.id}_fn`,
+  const functionLine: ReviewLine = {
     Tokens: [
       {
         Kind: TokenKind.Keyword,
@@ -75,6 +76,7 @@ export function processProcMacro(item: Item): ReviewLine[] | null {
       },
     ],
     Children: [],
+    RelatedToLine: reviewLine.LineId,
   };
 
   reviewLines.push(reviewLine);

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processStatic.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processStatic.ts
@@ -29,7 +29,7 @@ export function processStatic(item: Item) {
   });
   reviewLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "null",
+    Value: item.name || "unknown_static",
     RenderClasses: ["interface"],
     NavigateToId: reviewLine.LineId,
     NavigationDisplayName: item.name || undefined,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processStatic.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processStatic.ts
@@ -3,6 +3,7 @@ import { Item } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isStaticItem } from "./utils/typeGuards";
 import { typeToReviewTokens } from "./utils/typeToReviewTokens";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes a static item and adds its documentation to the ReviewLine.
@@ -15,6 +16,7 @@ export function processStatic(item: Item) {
 
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
+  lineIdMap.set(item.id.toString(), `static_${item.name}`);
   // Create the ReviewLine object
   const reviewLine: ReviewLine = {
     LineId: item.id.toString(),
@@ -29,7 +31,7 @@ export function processStatic(item: Item) {
     Kind: TokenKind.MemberName,
     Value: item.name || "null",
     RenderClasses: ["interface"],
-    NavigateToId: item.id.toString(),
+    NavigateToId: reviewLine.LineId,
     NavigationDisplayName: item.name || undefined,
     HasSuffixSpace: false,
   });

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processStruct.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processStruct.ts
@@ -48,7 +48,7 @@ export function processStruct(item: Item): ReviewLine[] {
 
   structLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "null",
+    Value: item.name || "unknown_struct",
     RenderClasses: ["struct"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processStruct.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processStruct.ts
@@ -7,6 +7,7 @@ import { isStructItem } from "./utils/typeGuards";
 import { processStructField } from "./processStructField";
 import { typeToReviewTokens } from "./utils/typeToReviewTokens";
 import { getAPIJson } from "../main";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes a struct item and adds its documentation to the ReviewLine.
@@ -19,10 +20,11 @@ export function processStruct(item: Item): ReviewLine[] {
   const apiJson = getAPIJson();
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
+  lineIdMap.set(item.id.toString(), `struct_${item.name}`);
   // Process derives and impls
   let implResult: ImplProcessResult;
   if (item.inner.struct.impls) {
-    implResult = processImpl({ ...item, inner: { struct: item.inner.struct } });
+    implResult = processImpl(item);
   }
 
   const structLine: ReviewLine = {
@@ -33,7 +35,6 @@ export function processStruct(item: Item): ReviewLine[] {
 
   if (implResult.deriveTokens.length > 0) {
     const deriveTokensLine: ReviewLine = {
-      LineId: item.id.toString() + "_derive",
       Tokens: implResult.deriveTokens,
       RelatedToLine: item.id.toString(),
     };

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processStructField.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processStructField.ts
@@ -23,7 +23,7 @@ export function processStructField(fieldItem: Item): ReviewLine {
       },
       {
         Kind: TokenKind.MemberName,
-        Value: fieldItem.name || "null",
+        Value: fieldItem.name || "unknown_field_item",
         HasSuffixSpace: false,
         RenderClasses: ["interface"],
         NavigateToId: fieldItem.id.toString(),

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processStructField.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processStructField.ts
@@ -1,6 +1,7 @@
 import { ReviewLine, TokenKind } from "../models/apiview-models";
 import { Item } from "../../rustdoc-types/output/rustdoc-types";
 import { typeToReviewTokens } from "./utils/typeToReviewTokens";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes a struct field item and returns its ReviewLine.
@@ -12,6 +13,7 @@ export function processStructField(fieldItem: Item): ReviewLine {
   if (!(fieldItem && typeof fieldItem.inner === "object" && "struct_field" in fieldItem.inner))
     return null;
 
+  lineIdMap.set(fieldItem.id.toString(), `fieldItem_${fieldItem.name}`);
   return {
     LineId: fieldItem.id.toString(),
     Tokens: [

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processTrait.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processTrait.ts
@@ -5,6 +5,7 @@ import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isTraitItem } from "./utils/typeGuards";
 import { createGenericBoundTokens, processGenerics } from "./utils/processGenerics";
 import { getAPIJson } from "../main";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes a trait item and adds its documentation to the ReviewLine.
@@ -18,6 +19,7 @@ export function processTrait(item: Item): ReviewLine[] {
   const apiJson = getAPIJson();
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
+  lineIdMap.set(item.id.toString(), `trait_${item.name}`);
   // Create the ReviewLine object
   const reviewLine: ReviewLine = {
     LineId: item.id.toString(),

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processTrait.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processTrait.ts
@@ -45,7 +45,7 @@ export function processTrait(item: Item): ReviewLine[] {
   });
   reviewLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "null",
+    Value: item.name || "unknown_trait",
     RenderClasses: ["struct"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processTraitAlias.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processTraitAlias.ts
@@ -2,6 +2,7 @@ import { ReviewLine, TokenKind } from "../models/apiview-models";
 import { Item } from "../../rustdoc-types/output/rustdoc-types";
 import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { isTraitAliasItem } from "./utils/typeGuards";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes a trait alias item and returns ReviewLine objects.
@@ -15,6 +16,7 @@ export function processTraitAlias(item: Item): ReviewLine[] {
 
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
+  lineIdMap.set(item.id.toString(), `trait_alias_${item.name}`);
   // Create the ReviewLine object
   const reviewLine: ReviewLine = {
     LineId: item.id.toString(),

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processTypeAlias.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processTypeAlias.ts
@@ -4,6 +4,7 @@ import { createDocsReviewLines } from "./utils/generateDocReviewLine";
 import { typeToReviewTokens } from "./utils/typeToReviewTokens";
 import { isTypeAliasItem } from "./utils/typeGuards";
 import { processGenerics } from "./utils/processGenerics";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes a type alias item and returns ReviewLine objects.
@@ -15,6 +16,7 @@ export function processTypeAlias(item: Item): ReviewLine[] {
   if (!isTypeAliasItem(item)) return [];
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
+  lineIdMap.set(item.id.toString(), `type_alias_${item.name}`);
   // Create the ReviewLine object
   const reviewLine: ReviewLine = {
     LineId: item.id.toString(),

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUnion.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUnion.ts
@@ -47,7 +47,7 @@ export function processUnion(item: Item): ReviewLine[] {
 
   unionLine.Tokens.push({
     Kind: TokenKind.MemberName,
-    Value: item.name || "null",
+    Value: item.name || "unknown_union_name",
     RenderClasses: ["struct"],
     NavigateToId: item.id.toString(),
     NavigationDisplayName: item.name || undefined,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUnion.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUnion.ts
@@ -6,6 +6,7 @@ import { processGenerics } from "./utils/processGenerics";
 import { isUnionItem } from "./utils/typeGuards";
 import { processStructField } from "./processStructField";
 import { getAPIJson } from "../main";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 /**
  * Processes a union item and adds its documentation to the ReviewLine.
@@ -18,6 +19,7 @@ export function processUnion(item: Item): ReviewLine[] {
   const apiJson = getAPIJson();
   const reviewLines: ReviewLine[] = item.docs ? createDocsReviewLines(item) : [];
 
+  lineIdMap.set(item.id.toString(), `union_${item.name}`);
   // Process derives and impls
   let implResult: ImplProcessResult;
   if (item.inner.union && item.inner.union.impls) {
@@ -32,7 +34,6 @@ export function processUnion(item: Item): ReviewLine[] {
 
   if (implResult.deriveTokens.length > 0) {
     const deriveTokensLine: ReviewLine = {
-      LineId: item.id.toString() + "_derive",
       Tokens: implResult.deriveTokens,
       RelatedToLine: item.id.toString(),
     };

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -47,7 +47,7 @@ function processSimpleUseItem(item: Item): AnnotatedReviewLines {
       },
     );
   } else {
-    const useValue = item.inner.use.source || "null";
+    const useValue = item.inner.use.source || "unknown_use_source";
     tokens.push(
       {
         Kind: TokenKind.Text,

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/processUse.ts
@@ -13,6 +13,7 @@ import { AnnotatedReviewLines } from "./utils/models";
 import { getAPIJson, processedItems } from "../main";
 import { processItem } from "./processItem";
 import { processModule } from "./processModule";
+import { lineIdMap } from "../utils/lineIdUtils";
 
 function processSimpleUseItem(item: Item): AnnotatedReviewLines {
   const annotatedReviewLines: AnnotatedReviewLines = {
@@ -65,8 +66,8 @@ function processSimpleUseItem(item: Item): AnnotatedReviewLines {
       },
     );
   }
-
-  annotatedReviewLines.children[item.id] = [{ Tokens: tokens }];
+  lineIdMap.set(item.id.toString(), item.inner.use.name);
+  annotatedReviewLines.children[item.id] = [{ LineId: item.id.toString(), Tokens: tokens }];
   return annotatedReviewLines;
 }
 

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/generateDocReviewLine.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/generateDocReviewLine.ts
@@ -25,7 +25,6 @@ export function createDocsReviewLines(item: Item): ReviewLine[] {
       },
     ],
     RelatedToLine: item.id.toString(),
-    LineId: `${item.id.toString()}_docs_${index}`, // Add _docs_index to make each line unique
   }));
 
   return reviewLines;

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/pathUtils.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/pathUtils.ts
@@ -7,7 +7,5 @@ export function replaceCratePath(path: string): string {
 }
 
 export function replaceSuperPrefix(path: string): string {
-  return path.startsWith("super::")
-    ? path.replace("super::", "") 
-    : path;
+  return path.startsWith("super::") ? path.replace("super::", "") : path;
 }

--- a/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/process-items/utils/typeToReviewTokens.ts
@@ -17,7 +17,7 @@ export function typeToReviewTokens(type: Type): ReviewToken[] {
     // Create the base token for the type name
     const baseToken: ReviewToken = {
       Kind: TokenKind.TypeName,
-      Value: replaceSuperPrefix(type.resolved_path.name) || "unnamed",
+      Value: replaceSuperPrefix(type.resolved_path.name) || "unnamed_resolved_path",
       HasSuffixSpace: false,
       NavigateToId: type.resolved_path.id.toString(),
     };

--- a/tools/apiview/parsers/rust-api-parser/src/utils/lineIdUtils.ts
+++ b/tools/apiview/parsers/rust-api-parser/src/utils/lineIdUtils.ts
@@ -1,0 +1,50 @@
+import { PACKAGE_NAME } from "../main";
+import { ReviewLine } from "../models/apiview-models";
+
+export const lineIdMap = new Map<string, string>();
+
+function postProcessLineIdMap(reviewLines: ReviewLine[], updatedLineIdMap: Map<string, string>) {
+  function recurse(lines: ReviewLine[], prefix: string) {
+    for (const line of lines) {
+      if (line.LineId) {
+        let existingId = lineIdMap.has(line.LineId) ? lineIdMap.get(line.LineId) : line.LineId;
+        const newId = `${prefix}_${existingId}`;
+        updatedLineIdMap.set(line.LineId, newId);
+        if (line.Children && line.Children.length > 0) {
+          recurse(line.Children, newId);
+        }
+      }
+    }
+  }
+  if (reviewLines && Array.isArray(reviewLines)) {
+    recurse(reviewLines, `root_mod_${PACKAGE_NAME}`);
+  }
+}
+
+export function updateReviewLinesWithStableLineIds(reviewLines: ReviewLine[]) {
+  const updatedLineIdMap = new Map<string, string>();
+  postProcessLineIdMap(reviewLines, updatedLineIdMap);
+  function updateLineIdReferences(reviewLines: ReviewLine[]) {
+    if (reviewLines && Array.isArray(reviewLines)) {
+      for (const line of reviewLines) {
+        if (line.LineId) {
+          line.LineId = updatedLineIdMap.get(line.LineId) || line.LineId;
+        }
+        if (line.RelatedToLine) {
+          line.RelatedToLine = updatedLineIdMap.get(line.RelatedToLine) || line.RelatedToLine;
+        }
+        if (line.Tokens.length > 0) {
+          for (const token of line.Tokens) {
+            if (token.NavigateToId) {
+              token.NavigateToId = updatedLineIdMap.get(token.NavigateToId) || token.NavigateToId;
+            }
+          }
+        }
+        if (line.Children && Array.isArray(line.Children) && line.Children.length > 0) {
+          updateLineIdReferences(line.Children);
+        }
+      }
+    }
+  }
+  updateLineIdReferences(reviewLines);
+}


### PR DESCRIPTION
## Enhance Rust API Parser with Stable Line IDs
   - Introduced `lineIdMap` to map item IDs to stable, meaningful identifiers rather than relying on the dynamic rustdoc ids.
   - Updated `updateReviewLinesWithStableLineIds` to ensure consistent review line IDs across modules and external references.
   - Preserved the linking between items in the api view rendering
   - This is required to show meaningful diff between api views
   - Other changes include formatting and minor refactoring

New diff
- azure_identity
   ![image](https://github.com/user-attachments/assets/f141aadb-de8c-4609-9117-cd22d04c5b47)
- azure_core
   ![image](https://github.com/user-attachments/assets/12a52bf9-6ce1-4cca-b00e-0fa1355c8394)
- azure_messaging_eventhubs
   ![image](https://github.com/user-attachments/assets/70a90709-5e9b-46cc-bc45-1019f6f9430d)
- azure_security_keyvault_certificates
   ![image](https://github.com/user-attachments/assets/ad0e3b06-76f1-4471-87aa-5c7e4db3beca)