### PR TITLE
[APIView Copilot] Add outline generation and filtration

### DIFF
--- a/packages/python-packages/apiview-copilot/evals/results/python/small.json
+++ b/packages/python-packages/apiview-copilot/evals/results/python/small.json
@@ -36,21 +36,37 @@
         "actual": {
             "comments": [
                 {
+                    "rule_ids": [],
+                    "line_no": 1,
+                    "bad_code": "",
+                    "suggestion": null,
+                    "comment": "Here is a summary of the service described by this APIView:\n\nPurpose and Functionality  \nThis API provides image analysis capabilities by exposing operations that process images either from raw byte data or via URL. It is designed to extract visual features\u2014such as captions, dense captions, objects, people, text, smart crops, and tags\u2014from images. Both synchronous and asynchronous workflows are supported, which facilitates integration into varied application designs.\n\nAPI Version  \nThe client constructors accept an `api_version` parameter to determine the image analysis API version in use. No explicit version object or default latest version is detailed in the provided APIView.\n\nPrimary Client Classes  \nThe API exposes a `ImageAnalysisClient` class in the synchronous namespace and a corresponding `ImageAnalysisClient` in the asynchronous (`aio`) namespace. The synchronous client includes the methods `__init__`, `analyze`, `analyze_from_url`, `close`, and `send_request`. The asynchronous client similarly provides `__init__`, `analyze`, `analyze_from_url`, `close`, and `send_request`.\n\nSupporting Model Classes and Methods  \nA range of data models under the models namespace encapsulate the results and parameters related to the image analysis process. These models include `CaptionResult`, `CropRegion`, `DenseCaption`, `DenseCaptionsResult`, `DetectedTextBlock`, `DetectedTextLine`, `DetectedTextWord`, `ImageAnalysisResult`, `ImageBoundingBox`, `ImageMetadata`, `ImagePoint`, `ObjectsResult`, a `PeopleResult` (in the asynchronous models namespace), `ReadResult`, `SmartCropsResult`, and `TagsResult`. In addition, the `VisualFeatures` enumeration defines the various analysis features available.\n\nOverall Service Structure  \nThe API is structured around client classes that implement context management and distributed tracing, enabling better integration with monitoring solutions. The split between synchronous and asynchronous clients allows for flexible application design, while the extensive model classes provide strong typing for the diverse outputs generated during image analysis.\n\n",
+                    "source": "summary"
+                },
+                {
                     "rule_ids": [
                         "python_design.html#python-client-connection-string"
                     ],
                     "line_no": 10,
                     "bad_code": "connection_string: Optional[str] = None,",
-                    "suggestion": "Remove the connection_string parameter from __init__ and instead provide a separate factory classmethod (e.g. from_connection_string) that accepts a connection string.",
-                    "comment": "According to the SDK guidelines, the constructor must not accept a connection string. Use a factory method to create a client from a connection string (python_design.html#python-client-connection-string).",
+                    "suggestion": "def __init__(self, endpoint: str, credential: Union[AzureKeyCredential, TokenCredential], *, api_version: str = ..., **kwargs: Any) -> None",
+                    "comment": "The client constructor should not include a connection_string parameter. Instead, provide a from_connection_string factory method.",
                     "source": "guideline"
                 },
                 {
                     "rule_ids": [],
                     "line_no": 171,
                     "bad_code": "ivar list: List[DenseCaption]",
-                    "suggestion": "ivar items: List[DenseCaption]",
-                    "comment": "Avoid using built-in names such as 'list' for attribute identifiers. Renaming to 'items' (or a similar descriptive term) prevents shadowing the Python built-in and enhances readability.",
+                    "suggestion": "ivar captions: List[DenseCaption]",
+                    "comment": "Avoid using the built\u2010in name 'list' as an attribute; use a more descriptive name such as 'captions'.",
+                    "source": "generic"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 363,
+                    "bad_code": "ivar list: List[DetectedObject]",
+                    "suggestion": "ivar objects: List[DetectedObject]",
+                    "comment": "Rename 'list' to a descriptive name like 'objects' to prevent shadowing the built\u2010in and improve clarity.",
                     "source": "generic"
                 },
                 {
@@ -59,25 +75,41 @@
                     ],
                     "line_no": 382,
                     "bad_code": "class azure.ai.vision.imageanalysis.models.aio.PeopleResult(MutableMapping[str, Any]):",
-                    "suggestion": "Remove the PeopleResult model from the aio sub-namespace and define it only once in the main models namespace.",
-                    "comment": "Models should not be duplicated between the sync and aio namespaces. PeopleResult is defined under the aio namespace, which violates the guideline (python_design.html#python-models-async).",
+                    "suggestion": null,
+                    "comment": "Model types should not be duplicated in the aio namespace; remove the PeopleResult class from the async models.",
                     "source": "guideline"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 383,
+                    "bad_code": "ivar list: List[DetectedPerson]",
+                    "suggestion": "ivar people: List[DetectedPerson]",
+                    "comment": "Rename 'list' to 'people' to avoid overshadowing the built\u2010in and to better describe its content.",
+                    "source": "generic"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 442,
+                    "bad_code": "ivar list: List[DetectedTag]",
+                    "suggestion": "ivar tags: List[DetectedTag]",
+                    "comment": "Replace the generic name 'list' with 'tags' to avoid collision with the built\u2010in and enhance descriptiveness.",
+                    "source": "generic"
                 }
             ]
         },
         "expected_comments": 2,
-        "comments_found": 3,
-        "valid_generic_comments": 1,
+        "comments_found": 6,
+        "valid_generic_comments": 4,
         "true_positives": 2,
         "false_positives": 0,
         "false_negatives": 0,
         "percent_coverage": 100,
         "rule_matches_wrong_line": 0,
         "wrong_line_details": [],
-        "similarity": 5,
+        "similarity": 4,
         "groundedness": 5,
-        "groundedness_reason": "The RESPONSE accurately reflects the guidelines provided in the CONTEXT without adding unsupported information or omitting any critical details. It addresses both guidelines thoroughly and correctly.",
-        "overall_score": 100
+        "groundedness_reason": "The response is fully grounded, accurately and completely reflecting all essential information from the context without adding or omitting anything.",
+        "overall_score": 97
     },
     {
         "testcase": "many_violations",
@@ -196,52 +228,78 @@
         "actual": {
             "comments": [
                 {
+                    "rule_ids": [],
+                    "line_no": 1,
+                    "bad_code": "",
+                    "suggestion": null,
+                    "comment": "Here is a summary of the service described by this APIView:\n\nPurpose  \nThis API provides image analysis capabilities for processing images supplied either as raw byte data or via a URL. It enables extraction of various visual features such as captions, dense captions, objects, people, written text, smart crops, and tags. The service incorporates distributed tracing and supports context management for seamless resource handling.\n\nAPI Version  \nThe clients accept an `api_version` parameter at initialization, allowing users to specify the service version. Though no standalone API Version object is defined, the configurable `api_version` parameter represents the version being used, with the latest version determined by the service deployment.\n\nPrimary Client Classes  \nThe API exposes a synchronous `ImageAnalysisClient` and an asynchronous `AsyncImageAnalysisClient`. The synchronous client includes methods `analyze`, `analyze_from_url`, `close`, and `send_request`. The asynchronous client includes methods `analyze`, `analyze_from_url`, `close`, and `send_request`.\n\nSupporting Models and Classes  \nA comprehensive set of models under the `azure.ai.vision.imageanalysis.models` namespace represents the structure of analysis results. Classes such as `CaptionResult`, `CropRegion`, `DenseCaption`, `DenseCaptionsResult`, `DetectedObject`, `detectedPerson`, `DetectedTag`, `DetectedTextBlock`, `DetectedTextLine`, `DetectedTextWord`, `ImageAnalysisResult`, `ImageBoundingBox`, `ImageMetadata`, `ImagePoint`, `ObjectsResult`, `PeopleResult`, `ReadResult`, `SmartCropsResult`, and `TagsResult` model the output of various image analysis tasks. In addition, the `VisualFeatures` enumeration defines the visual features that can be requested.\n\nOverall Structure  \nThe API is structured to support both synchronous and asynchronous use cases with dedicated client classes and a rich set of result models. It is designed to operate in Azure\u2019s vision ecosystem, emphasizing flexibility through parameters such as the `api_version` and distributed tracing integration while handling credentials appropriately.",
+                    "source": "summary"
+                },
+                {
                     "rule_ids": [
                         "python_design.html#python-client-connection-string"
                     ],
                     "line_no": 10,
                     "bad_code": "connection_string: Optional[str] = None,",
-                    "suggestion": "Remove the connection_string parameter from __init__ and instead implement a separate from_connection_string factory method.",
-                    "comment": "The synchronous client constructor accepts a connection_string, which violates the guideline that the constructor must not take a connection string.",
+                    "suggestion": null,
+                    "comment": "The constructor should not accept a connection_string parameter. Instead, a separate from_connection_string factory method should be provided.",
                     "source": "guideline"
                 },
                 {
                     "rule_ids": [
-                        "python_design.html#python-client-optional-arguments-keyword-only"
+                        "python_implementation.html#python-codestyle-kwargs"
                     ],
-                    "line_no": 34,
-                    "bad_code": "gender_neutral_caption: Optional[bool] = ...,",
-                    "suggestion": "Insert a '*' before the optional parameters so that they become keyword-only, for example:\n\n def analyze_from_url(self, image_url: str, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., ...)",
-                    "comment": "Optional operation-specific arguments in analyze_from_url are not forced to be keyword-only. This violates the guideline that optional arguments should be keyword-only.",
-                    "source": "guideline"
-                },
-                {
-                    "rule_ids": [
-                        "python_design.html#python-client-same-name-sync-async"
-                    ],
-                    "line_no": 53,
-                    "bad_code": "class azure.ai.vision.imageanalysis.aio.AsyncImageAnalysisClient(ImageAnalysisClient): implements AsyncContextManager",
-                    "suggestion": "Rename the async client to ImageAnalysisClient so that the synchronous and asynchronous clients share the same name, with async located in the .aio subpackage.",
-                    "comment": "The async client is named AsyncImageAnalysisClient instead of using the same client name as the sync version, which violates naming guidelines.",
+                    "line_no": 30,
+                    "bad_code": "def analyze_from_url(",
+                    "suggestion": "def analyze_from_url(self, image_url: str, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
+                    "comment": "Optional parameters must be keyword-only. Insert a '*' after the required positional parameters to enforce this.",
                     "source": "guideline"
                 },
                 {
                     "rule_ids": [],
-                    "line_no": 168,
-                    "bad_code": "ivar list: List[DenseCaption]",
-                    "suggestion": "ivar items: List[DenseCaption]",
-                    "comment": "Using the name 'list' shadows the built\u2010in list type. Choose a more descriptive name such as 'items' to avoid potential conflicts.",
+                    "line_no": 90,
+                    "bad_code": "        self,",
+                    "suggestion": null,
+                    "comment": "Remove the 'self' parameter from a static method.",
                     "source": "generic"
+                },
+                {
+                    "rule_ids": [
+                        "python_implementation.html#python-codestyle-type-naming"
+                    ],
+                    "line_no": 209,
+                    "bad_code": "class azure.ai.vision.imageanalysis.models.detectedPerson(MutableMapping[str, Any]):",
+                    "suggestion": "class azure.ai.vision.imageanalysis.models.DetectedPerson(MutableMapping[str, Any]):",
+                    "comment": "Class names should use PascalCase. Rename 'detectedPerson' to 'DetectedPerson' to follow naming conventions.",
+                    "source": "merged"
                 },
                 {
                     "rule_ids": [
                         "python_implementation.html#python-codestyle-properties"
                     ],
                     "line_no": 411,
-                    "bad_code": "    def get_result(self) -> ObjectsResult",
-                    "suggestion": "Replace the get_result (and corresponding set_result) methods with a property, for example using @property and @<name>.setter decorators.",
-                    "comment": "Simple getter and setter methods are used in ObjectsResult, which violates the guideline that properties should be used instead.",
+                    "bad_code": "def get_result(self) -> ObjectsResult",
+                    "suggestion": null,
+                    "comment": "Replace explicit getter methods with a property to provide more Pythonic and idiomatic access to values.",
+                    "source": "merged"
+                },
+                {
+                    "rule_ids": [
+                        "python_implementation.html#python-codestyle-properties"
+                    ],
+                    "line_no": 413,
+                    "bad_code": "def set_result(self, obj) -> None",
+                    "suggestion": null,
+                    "comment": "Simple setter methods should be replaced by properties to expose modifiable attributes in a more Pythonic manner.",
                     "source": "guideline"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 492,
+                    "bad_code": "ivar list: List[DetectedTag]",
+                    "suggestion": "ivar detected_tags: List[DetectedTag]",
+                    "comment": "Avoid using 'list' as an attribute name because it shadows the built-in type; use a more descriptive name such as 'detected_tags'.",
+                    "source": "generic"
                 },
                 {
                     "rule_ids": [
@@ -249,33 +307,25 @@
                     ],
                     "line_no": 517,
                     "bad_code": "tags = 'tags'",
-                    "suggestion": "Rename the enum member to TAGS (i.e. use uppercase) to comply with the guideline.",
-                    "comment": "Enum members should be uppercase to follow standard Python conventions. Change 'tags' to 'TAGS' to be consistent with the other enum members. Enum member names should be in UPPERCASE. The 'tags' member violates this naming standard.",
-                    "source": "generic"
+                    "suggestion": "TAGS = 'tags'",
+                    "comment": "Enum member names should be uppercase to follow standard conventions and maintain consistency.",
+                    "source": "merged"
                 }
             ]
         },
         "expected_comments": 10,
-        "comments_found": 6,
-        "valid_generic_comments": 1,
-        "true_positives": 4,
+        "comments_found": 8,
+        "valid_generic_comments": 3,
+        "true_positives": 5,
         "false_positives": 0,
         "false_negatives": 5,
-        "percent_coverage": 40,
-        "rule_matches_wrong_line": 1,
-        "wrong_line_details": [
-            [
-                [
-                    "python_design.html#python-client-optional-arguments-keyword-only"
-                ],
-                30,
-                34
-            ]
-        ],
-        "similarity": 4,
+        "percent_coverage": 50,
+        "rule_matches_wrong_line": 0,
+        "wrong_line_details": [],
+        "similarity": 3,
         "groundedness": 5,
-        "groundedness_reason": "The RESPONSE accurately reflects the guidelines provided in the CONTEXT without introducing unsupported information or omitting critical details, making it fully grounded and complete.",
-        "overall_score": 59
+        "groundedness_reason": "The RESPONSE accurately and thoroughly reflects the guidelines in the CONTEXT, with no unsupported additions or omissions.",
+        "overall_score": 60
     },
     {
         "testcase": "no_violations",
@@ -286,17 +336,57 @@
             "comments": [
                 {
                     "rule_ids": [],
+                    "line_no": 1,
+                    "bad_code": "",
+                    "suggestion": null,
+                    "comment": "Here is a summary of the service described by this APIView:\n\nThis API provides image analysis capabilities. It is designed to process images\u2014whether in binary form or via a URL\u2014to extract insights such as captions, dense captions, object and people detection, text extraction, smart crop suggestions, and tags. The service supports custom configuration options such as selecting visual features, preferred language, and model versions, and it makes use of distributed tracing.\n\nThe API version is specified through the optional parameter `api_version` in the client constructors. Although no standalone API version object is provided, users can set this parameter when initializing the clients.\n\nThe primary entry points for the API are the `ImageAnalysisClient` classes. The synchronous client (`azure.ai.vision.imageanalysis.ImageAnalysisClient`) exposes the methods `analyze`, `analyze_from_url`, `close`, and `send_request`. Its asynchronous counterpart (`azure.ai.vision.imageanalysis.aio.ImageAnalysisClient`) offers the methods `analyze`, `analyze_from_url`, `close`, and `send_request` with asynchronous semantics.\n\nAdditional classes in the API include models that represent the analysis results and related data structures. The models encompass classes such as `CaptionResult`, `CropRegion`, `DenseCaption`, `DenseCaptionsResult`, `DetectedTextBlock`, `DetectedTextLine`, `DetectedTextWord`, `ImageAnalysisResult`, `ImageBoundingBox`, `ImageMetadata`, `ImagePoint`, `ObjectsResult`, `PeopleResult`, `ReadResult`, `SmartCropsResult`, and `TagsResult`. There is also the `VisualFeatures` enumeration, which defines the types of visual features that can be requested.\n\nThe API structure, with its context manager support and dedicated synchronous and asynchronous clients, is suitable for integrating image analysis into various Python applications while providing flexibility in how images are processed and results interpreted.",
+                    "source": "summary"
+                },
+                {
+                    "rule_ids": [],
                     "line_no": 170,
-                    "bad_code": "ivar list: List[DenseCaption]",
-                    "suggestion": "ivar captions: List[DenseCaption]",
-                    "comment": "Using 'list' as an attribute name shadows the built-in type. A more descriptive name like 'captions' improves clarity and avoids potential conflicts.",
+                    "bad_code": "    ivar list: List[DenseCaption]",
+                    "suggestion": "    ivar captions: List[DenseCaption]",
+                    "comment": "Avoid using the built\u2010in name 'list' as an attribute. Rename it to something descriptive like 'captions'.",
+                    "source": "generic"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 362,
+                    "bad_code": "    ivar list: List[DetectedObject]",
+                    "suggestion": "    ivar objects: List[DetectedObject]",
+                    "comment": "Rename 'list' to 'objects' to prevent shadowing the built\u2010in and enhance clarity.",
+                    "source": "generic"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 382,
+                    "bad_code": "    ivar list: List[DetectedPerson]",
+                    "suggestion": "    ivar people: List[DetectedPerson]",
+                    "comment": "Rename 'list' to 'people' to avoid conflicts with the built\u2010in type and improve readability.",
+                    "source": "generic"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 422,
+                    "bad_code": "    ivar list: List[CropRegion]",
+                    "suggestion": "    ivar crops: List[CropRegion]",
+                    "comment": "Rename 'list' to 'crops' to avoid using a built\u2010in name and to better express the attribute's intent.",
+                    "source": "generic"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 441,
+                    "bad_code": "    ivar list: List[DetectedTag]",
+                    "suggestion": "    ivar tags: List[DetectedTag]",
+                    "comment": "Rename 'list' to 'tags' to avoid conflict with the built\u2010in and to provide clearer semantics.",
                     "source": "generic"
                 }
             ]
         },
         "expected_comments": 0,
-        "comments_found": 1,
-        "valid_generic_comments": 1,
+        "comments_found": 5,
+        "valid_generic_comments": 5,
         "true_positives": 0,
         "false_positives": 0,
         "false_negatives": 0,
@@ -365,100 +455,111 @@
         "actual": {
             "comments": [
                 {
+                    "rule_ids": [],
+                    "line_no": 1,
+                    "bad_code": "",
+                    "suggestion": null,
+                    "comment": "Here is a summary of the service described by this APIView:\n\nService Purpose  \nThis API provides image analysis capabilities. It enables clients to process images either as raw bytes or via URLs and extract multiple visual features such as captions, dense captions, object and people detection, text recognition, smart cropping, and tagging.\n\nAPI Version  \nThe clients accept an `api_version` parameter during initialization. No dedicated API Version object is defined, so the specific version is supplied by the user or the consuming framework.\n\nClient Classes  \nThe synchronous `ImageAnalysisClient` exposes these methods: `__init__`, `analyze`, `analyze_from_url`, `close`, and `send_request`. Its asynchronous counterpart in the `aio` namespace also offers `__init__`, `analyze`, `analyze_from_url`, `close`, and `send_request`.\n\nAdditional Models and Classes  \nThe API includes various model classes that represent the response structure and image components. These include data models such as `CaptionResult`, `DenseCaption`, and `DenseCaptionsResult` for captioning; classes like `DetectedTextBlock`, `DetectedTextLine`, and `DetectedTextWord` for text detection; as well as `ImageAnalysisResult`, `ImageBoundingBox`, `ImageMetadata`, and `ImagePoint` for spatial data. There are also result containers such as `ObjectsResult`, `PeopleResult`, `ReadResult`, `SmartCropsResult`, and `TagsResult` along with the `VisualFeatures` enumeration for specifying the desired analysis features.",
+                    "source": "summary"
+                },
+                {
                     "rule_ids": [
-                        "python_design.html#python-client-optional-arguments-keyword-only"
+                        "python_implementation.html#python-codestyle-optional-args"
                     ],
-                    "line_no": 20,
-                    "bad_code": "    gender_neutral_caption: Optional[bool] = ...",
-                    "suggestion": "Add a '*' after 'visual_features: List[VisualFeatures]' so that all optional parameters become keyword-only, e.g.:\n\ndef analyze(self, image_data: bytes, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
-                    "comment": "Optional parameters in the synchronous 'analyze' method should be declared as keyword-only according to the guideline (python_design.html#python-client-optional-arguments-keyword-only).",
+                    "line_no": 16,
+                    "bad_code": "def analyze(",
+                    "suggestion": "def analyze(self, image_data: bytes, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
+                    "comment": "Optional parameters in the sync 'analyze' method should be keyword-only by inserting a '*' before them.",
                     "source": "guideline"
                 },
                 {
                     "rule_ids": [
-                        "python_design.html#python-client-optional-arguments-keyword-only"
+                        "python_implementation.html#python-codestyle-optional-args"
                     ],
-                    "line_no": 32,
-                    "bad_code": "    gender_neutral_caption: Optional[bool] = ...",
-                    "suggestion": "Insert a '*' delimiter before the optional parameters in the method signature, for example:\n\ndef analyze_from_url(self, image_url: str, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
-                    "comment": "Optional parameters in the synchronous 'analyze_from_url' method should be keyword-only as per the guideline (python_design.html#python-client-optional-arguments-keyword-only).",
+                    "line_no": 28,
+                    "bad_code": "def analyze_from_url(",
+                    "suggestion": "def analyze_from_url(self, image_url: str, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
+                    "comment": "Optional parameters in the sync 'analyze_from_url' method should be keyword-only by inserting a '*' before them.",
                     "source": "guideline"
                 },
                 {
                     "rule_ids": [
-                        "python_design.html#python-client-optional-arguments-keyword-only"
+                        "python_implementation.html#python-codestyle-optional-args"
                     ],
-                    "line_no": 66,
-                    "bad_code": "    gender_neutral_caption: Optional[bool] = ...",
-                    "suggestion": "Add a '*' separator after the required parameters in the async method signature, for example:\n\nasync def analyze(self, image_data: bytes, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
-                    "comment": "Optional parameters in the asynchronous 'analyze' method should be keyword-only (see python_design.html#python-client-optional-arguments-keyword-only).",
+                    "line_no": 62,
+                    "bad_code": "async def analyze(",
+                    "suggestion": "async def analyze(self, image_data: bytes, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
+                    "comment": "Optional parameters in the async 'analyze' method should be keyword-only by inserting a '*' before them.",
                     "source": "guideline"
                 },
                 {
                     "rule_ids": [
-                        "python_design.html#python-client-optional-arguments-keyword-only"
+                        "python_implementation.html#python-codestyle-optional-args"
                     ],
-                    "line_no": 78,
-                    "bad_code": "    gender_neutral_caption: Optional[bool] = ...",
-                    "suggestion": "Insert a '*' before the optional parameters in the async 'analyze_from_url' method, for example:\n\nasync def analyze_from_url(self, image_url: str, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
-                    "comment": "Optional parameters in the asynchronous 'analyze_from_url' method must be declared as keyword-only in compliance with python_design.html#python-client-optional-arguments-keyword-only.",
+                    "line_no": 74,
+                    "bad_code": "async def analyze_from_url(",
+                    "suggestion": "async def analyze_from_url(self, image_url: str, visual_features: List[VisualFeatures], *, gender_neutral_caption: Optional[bool] = ..., language: Optional[str] = ..., model_version: Optional[str] = ..., smart_crops_aspect_ratios: Optional[List[float]] = ..., **kwargs: Any) -> ImageAnalysisResult",
+                    "comment": "Optional parameters in the async 'analyze_from_url' method should be keyword-only by inserting a '*' before them.",
                     "source": "guideline"
                 },
                 {
                     "rule_ids": [],
                     "line_no": 166,
                     "bad_code": "ivar list: List[DenseCaption]",
-                    "suggestion": "ivar captions: List[DenseCaption]",
-                    "comment": "Naming an attribute 'list' shadows the built-in list type. Choose a more descriptive name (such as 'captions' or 'items') to avoid potential conflicts and improve readability.",
+                    "suggestion": "ivar dense_captions: List[DenseCaption]",
+                    "comment": "Rename 'list' to 'dense_captions' to avoid shadowing the built-in and improve clarity.",
+                    "source": "generic"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 358,
+                    "bad_code": "ivar list: List[DetectedObject]",
+                    "suggestion": "ivar objects: List[DetectedObject]",
+                    "comment": "Rename 'list' to 'objects' for clarity and to prevent conflict with the built-in type.",
+                    "source": "generic"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 378,
+                    "bad_code": "ivar list: List[DetectedPerson]",
+                    "suggestion": "ivar people: List[DetectedPerson]",
+                    "comment": "Rename 'list' to 'people' to better express the contained elements and avoid built-in shadowing.",
+                    "source": "generic"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 418,
+                    "bad_code": "ivar list: List[CropRegion]",
+                    "suggestion": "ivar smart_crops: List[CropRegion]",
+                    "comment": "Rename 'list' to 'smart_crops' to provide a more descriptive attribute name.",
+                    "source": "generic"
+                },
+                {
+                    "rule_ids": [],
+                    "line_no": 437,
+                    "bad_code": "ivar list: List[DetectedTag]",
+                    "suggestion": "ivar tags: List[DetectedTag]",
+                    "comment": "Rename 'list' to 'tags' to match the content and avoid clashing with the built-in 'list'.",
                     "source": "generic"
                 }
             ]
         },
         "expected_comments": 4,
-        "comments_found": 5,
-        "valid_generic_comments": 1,
+        "comments_found": 9,
+        "valid_generic_comments": 9,
         "true_positives": 0,
         "false_positives": 0,
-        "false_negatives": 0,
+        "false_negatives": 4,
         "percent_coverage": 0,
-        "rule_matches_wrong_line": 4,
-        "wrong_line_details": [
-            [
-                [
-                    "python_design.html#python-client-optional-arguments-keyword-only"
-                ],
-                28,
-                32
-            ],
-            [
-                [
-                    "python_design.html#python-client-optional-arguments-keyword-only"
-                ],
-                74,
-                78
-            ],
-            [
-                [
-                    "python_design.html#python-client-optional-arguments-keyword-only"
-                ],
-                16,
-                20
-            ],
-            [
-                [
-                    "python_design.html#python-client-optional-arguments-keyword-only"
-                ],
-                62,
-                66
-            ]
-        ],
+        "rule_matches_wrong_line": 0,
+        "wrong_line_details": [],
         "similarity": 4,
         "groundedness": 5,
-        "groundedness_reason": "The RESPONSE is fully grounded in the CONTEXT, accurately conveying the guideline without introducing unsupported information or omitting any critical details.",
-        "overall_score": 48
+        "groundedness_reason": "The RESPONSE is fully grounded, complete, and directly reflects all the information in the CONTEXT without any additions or omissions.",
+        "overall_score": 28
     },
     {
-        "average_score": 76.75,
+        "average_score": 71.25,
         "total_evals": 4
     }
 ]

--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -170,7 +170,7 @@ def review_apiview(query: str, language: str):
         ApiViewReview,
     )
 
-    reviewer = ApiViewReview(target=query, language=language)
+    reviewer = ApiViewReview(target=query, base=None, language=language)
     review = reviewer.run()
     reviewer.close()
     return {"response": review.model_dump_json()}

--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -19,13 +19,13 @@ dotenv.load_dotenv()
 
 NUM_RUNS: int = 3
 # for best results, this should always be a different model from the one we are evaluating
-MODEL_JUDGE = "gpt-4o"
+MODEL_JUDGE = "gpt-4.1"
 
 model_config: dict[str, str] = {
     "azure_endpoint": os.environ["AZURE_OPENAI_ENDPOINT"],
     "api_key": os.environ["AZURE_OPENAI_API_KEY"],
     "azure_deployment": MODEL_JUDGE,
-    "api_version": "2025-01-01-preview",
+    "api_version": "2025-03-01-preview",
 }
 
 
@@ -85,7 +85,7 @@ class CustomAPIViewEvaluator:
             end_idx = min(len(query), line_no + 10)
             context = query[start_idx:end_idx]
             response = client.responses.create(
-                model=MODEL_JUDGE,
+                **model_config,
                 input=f"Given the following code snippet, comment, and exceptions, state 'true' or 'false' whether the comment is a fair {language} review of the code and doesn't mention topics in the exceptions:\n CODE:\n{context}\nEXCEPTIONS:{exceptions}\nCOMMENT:\n{comment['comment']}",
             )
             comment["valid"] = "true" in response.output_text.lower()

--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -3,6 +3,8 @@ import json
 import pathlib
 import argparse
 from typing import Set, Tuple, Any
+import prompty
+import prompty.azure_beta
 import copy
 import sys
 import yaml
@@ -10,7 +12,6 @@ import yaml
 # set before azure.ai.evaluation import to make PF output less noisy
 os.environ["PF_LOGGING_LEVEL"] = "CRITICAL"
 
-import openai
 import dotenv
 from tabulate import tabulate
 from azure.ai.evaluation import evaluate, SimilarityEvaluator, GroundednessEvaluator
@@ -78,17 +79,24 @@ class CustomAPIViewEvaluator:
             exceptions = filter_data["exceptions"].strip().split("\n")
             exceptions = [e.split(". ", 1)[1] for e in exceptions]
 
-        client = openai.AzureOpenAI()
         for comment in generic_comments:
             line_no = comment["line_no"]
             start_idx = max(0, line_no - 10)
             end_idx = min(len(query), line_no + 10)
             context = query[start_idx:end_idx]
-            response = client.responses.create(
-                **model_config,
-                input=f"Given the following code snippet, comment, and exceptions, state 'true' or 'false' whether the comment is a fair {language} review of the code and doesn't mention topics in the exceptions:\n CODE:\n{context}\nEXCEPTIONS:{exceptions}\nCOMMENT:\n{comment['comment']}",
+            prompt_path = os.path.abspath(
+                os.path.join(os.path.dirname(__file__), "..", "prompts", "eval_judge_prompt.prompty")
             )
-            comment["valid"] = "true" in response.output_text.lower()
+            response = prompty.execute(
+                prompt_path,
+                inputs={
+                    "code": context,
+                    "comment": comment["comment"],
+                    "exceptions": exceptions,
+                    "language": language,
+                },
+            )
+            comment["valid"] = "true" in response.lower()
 
     def __call__(self, *, response: str, query: str, language: str, output: str, **kwargs):
         expected = json.loads(response)

--- a/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
@@ -1,6 +1,6 @@
 exceptions: |
   1. Comment on the `send_request` method
-  2. Suggest changes to class inheritance patterns
+  2. Suggest changes to class inheritance patterns (i.e. base‑class relationships only)
   3. Comment on `implements ContextManager` pseudocode
   4. Comment on ellipsis (...) usage in optional parameters
   5. Comment on __init__ overloads in model classes or MutableMapping inheritance
@@ -16,7 +16,7 @@ exceptions: |
   15. Comment about methods ending with :
   16. Comment on namespaces unless they are violating guidelines
   17. Comment on the overuse of **kwargs
-  18. Comment on class names being prefixed by the full module name
+  18. Comment that the *syntax* of including a module path in the *definition* is wrong (e.g. flagging `class azure.foo.FooClient:` itself as illegal)
 sample: |
   - description: "Should filter out docstring suggestions"
     initial_results: |

--- a/packages/python-packages/apiview-copilot/prompts/code_to_text.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/code_to_text.prompty
@@ -8,7 +8,7 @@ model:
   api: chat
   configuration:
     type: azure_openai
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: gpt-4o-mini
   parameters:

--- a/packages/python-packages/apiview-copilot/prompts/eval_judge_prompt.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/eval_judge_prompt.prompty
@@ -1,0 +1,42 @@
+---
+name: Evaluate Generic Comment
+description: A prompt that judges a generic comment in the evals framework.
+authors:
+  - kristapratico
+version: 1.0.0
+model:
+  api: chat
+  configuration:
+    type: azure_openai
+    api_version: 2025-03-01-preview
+    azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
+    azure_deployment: gpt-4.1
+  parameters:
+    temperature: 0
+    top_p: 1
+    stop: []
+    frequency_penalty: 0
+    presence_penalty: 0
+    max_tokens: 16384
+sample:
+  language: python
+  code: |
+    class BigReallyLongNameForWidgetClass:
+  exceptions: |
+    - Comment about class inheritance structure
+    - Comment about the send_request method
+  comment: |
+    This class name is too long and verbose. It should be shortened to `Widget` for better readability.
+---
+
+system:
+Given a code snippet, comment, and exceptions, state 'true' or 'false' whether the comment is a fair {{language}} review of the code and doesn't mention topics in the exceptions.
+user:
+ # CODE
+ {{context}}
+ 
+ # EXCEPTIONS
+ {{exceptions}}
+ 
+ # COMMENT
+ {{comment}}

--- a/packages/python-packages/apiview-copilot/prompts/final_comment_filter_single.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/final_comment_filter_single.prompty
@@ -13,8 +13,8 @@ model:
     azure_deployment: gpt-4.1
     api_version: 2025-01-01-preview
   parameters:
-    temperature: 0.7
-    top_p: 0.95
+    temperature: 0
+    top_p: 1
     stop: []
     frequency_penalty: 0
     presence_penalty: 0
@@ -24,7 +24,7 @@ sample:
   language: Python
   exceptions: |
     1. Comment on the `send_request` method
-    2. Suggest changes to class inheritance patterns
+    2. Suggest changes to class inheritance patterns (i.e. base‑class relationships only)
     3. Comment on `implements ContextManager` pseudocode
     4. Comment on ellipsis (...) usage in optional parameters
     5. Comment on __init__ overloads in model classes or MutableMapping inheritance
@@ -40,25 +40,52 @@ sample:
     15. Comment about methods ending with :
     16. Comments about not using the non-standard namespace declaration
     17. Comment on the overuse of **kwargs
-    18. Comment on class names being prefixed by the full module name
+    18. Comment that the *syntax* of including a module path in the *definition* is wrong (e.g. flagging `class azure.foo.FooClient:` itself as illegal)
+  outline: |
+    ## namespace azure.widget
+    - WidgetClient
+      - get
+      - create
+      - update
+      - delete
+      - list
+    
+    ## namespace azure.widget.aio
+    - WidgetClient
+      - get
+      - create
+      - update
+      - delete
+      - list
+
+    ## namespace azure.widget.models
+    - Widget
+    - WidgetPart
   content: |
     {
-      "line_no": 2,
-      "bad_code": "def method1(self, arg1: str) -> None",
+      "line_no": 4,
+      "bad_code": "class azure.widget.WidgetClient():",
       "suggestion": "",
-      "comment": "Methods should have descriptive docstrings",
-      "source": "generic"
+      "comment": "You must have an async client named `WidgetClient` in the azure.widget.aio namespace.",
+      "source": "guideline"
     }
 ---
 system:
   You are a helpful AI that reviews {{language}} API design comments from another AI. Your role is to filter out any comments that violate a set of known exceptions. You will receive:
   1. A proposed comment to review
   2. The exceptions that must be followed
+  3. An outline overview of the APIView.
 
   # EXCEPTIONS
   
   You MUST remove any comment that:
   {{exceptions}}
+
+  # ADDITIONAL EXCEPTIONS
+
+  
+  - You MUST remove any comment that explicitly asserts that a class, method, property, or parameter is *absent*, *not defined*, or *missing* when that element is present in the outline.
+  - DO NOT remove comments about naming mismatches or other design concerns—even if the outline shows an element exists—unless they literally say “this element doesn’t exist.”
 
   # OUTPUT REQUIREMENTS
   
@@ -69,27 +96,12 @@ system:
   - For properties that are in the input schema AND the output schema, the value in the output must be the same as the input.
 
 user:
-  Please validate the following comment against the exceptions:
+  Please validate the following comment against the exceptions and APIView outline.
 
-  Proposed Comment:
+  # OUTLINE
+  {{outline}}
+
+  # PROPOSED COMMENT
   ```json
   {{content}}
   ```
-
-assistant: |
-  I will analyze this comment and:
-
-  1. Check if it violates any of the validation rules by focusing on the content in the `comment` field, not other fields.
-  2. Flag the comment's `status` field as "REMOVE" if it violates the exceptions
-  3. Flag the comment's `status` field as "KEEP" if it enhances API design
-  4. For properties that are in the input schema AND the output schema, the value in the output must be the same as the input.
-
-  For this comment I will:
-  - Verify it doesn't comment on excluded aspects
-  - Ensure it focuses on API design quality
-  - Validate it improves developer experience
-  - Confirm it aligns with {{language}} best practices
-
-  The response will maintain the schema structure with:
-  - The comment will contain `line_no`, `bad_code`, `suggestion`, and `comment` identical to the original
-  - The comment will include new fields `status` and `status_reason` to indicate whether it was kept or removed and the reason for that decision.

--- a/packages/python-packages/apiview-copilot/prompts/final_comment_filter_single.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/final_comment_filter_single.prompty
@@ -11,7 +11,7 @@ model:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: gpt-4.1
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
   parameters:
     temperature: 0
     top_p: 1

--- a/packages/python-packages/apiview-copilot/prompts/final_comments_filter.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/final_comments_filter.prompty
@@ -11,7 +11,7 @@ model:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: o3-mini
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
   parameters:
     stop: []
     frequency_penalty: 0

--- a/packages/python-packages/apiview-copilot/prompts/final_comments_filter.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/final_comments_filter.prompty
@@ -89,28 +89,7 @@ system:
 user:
   Please validate the following review against the exceptions:
 
-  Proposed Review Comments:
+  # PROPOSED COMMENTS
   ```json
   {{comments}}
   ```
-
-assistant: |
-  I will analyze each comment in the review results and:
-
-  1. Check if it violates any of the validation rules by focusing on the content in the `comment` field, not other fields.
-  2. Flag any comments' `status` field as "REMOVE" that violate the exceptions
-  3. Flag any comments' `status` field as "KEEP" that enhance API design
-  4. For properties that are in the input schema AND the output schema, the value in the output must be the same as the input.
-
-  For each comment I will:
-  - Verify it doesn't comment on excluded aspects
-  - Ensure it focuses on API design quality
-  - Validate it improves developer experience
-  - Confirm it aligns with {{language}} best practices
-
-  The response will maintain the schema structure with:
-  - A list of comments
-  - Each comment containing line_no, bad_code, suggestion, and comment identical to the original
-  - Each comment will include new fields `status` and `status_reason` to indicate whether it was kept or removed and the reason for that decision.
-
-{{sample}}

--- a/packages/python-packages/apiview-copilot/prompts/generate_outline.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/generate_outline.prompty
@@ -1,0 +1,572 @@
+---
+name: Generate APIView Outline
+description: A prompt that generates a metadata outline for an APIView.
+authors:
+  - tjprescott
+version: 1.0.0
+model:
+  api: chat
+  configuration:
+    type: azure_openai
+    azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
+    azure_deployment: o3-mini
+    api_version: 2025-01-01-preview
+  parameters:
+    frequency_penalty: 0
+    presence_penalty: 0
+    max_completion_tokens: 80000
+    reasoning_effort: "high"
+sample:
+  content: |
+    # Package is parsed using apiview-stub-generator(version:0.3.18), Python version: 3.10.16
+
+
+    namespace azure.ai.vision.imageanalysis
+      
+      class azure.ai.vision.imageanalysis.ImageAnalysisClient(ImageAnalysisClient): implements ContextManager 
+        
+        def __init__(
+              self, 
+              endpoint: str, 
+              credential: Union[AzureKeyCredential, TokenCredential], 
+              *, 
+              api_version: str = ..., 
+              **kwargs: Any
+          ) -> None
+        
+        @distributed_trace
+        def analyze(
+              self, 
+              image_data: bytes, 
+              visual_features: List[VisualFeatures], 
+              *, 
+              gender_neutral_caption: Optional[bool] = ..., 
+              language: Optional[str] = ..., 
+              model_version: Optional[str] = ..., 
+              smart_crops_aspect_ratios: Optional[List[float]] = ..., 
+              **kwargs: Any
+          ) -> ImageAnalysisResult
+        
+        @distributed_trace
+        def analyze_from_url(
+              self, 
+              image_url: str, 
+              visual_features: List[VisualFeatures], 
+              *, 
+              gender_neutral_caption: Optional[bool] = ..., 
+              language: Optional[str] = ..., 
+              model_version: Optional[str] = ..., 
+              smart_crops_aspect_ratios: Optional[List[float]] = ..., 
+              **kwargs: Any
+          ) -> ImageAnalysisResult
+        
+        def close(self) -> None
+        
+        def send_request(
+              self, 
+              request: HttpRequest, 
+              *, 
+              stream: bool = False, 
+              **kwargs: Any
+          ) -> HttpResponse
+        
+        
+    namespace azure.ai.vision.imageanalysis.aio
+      
+      class azure.ai.vision.imageanalysis.aio.ImageAnalysisClient(ImageAnalysisClient): implements AsyncContextManager 
+        
+        def __init__(
+              self, 
+              endpoint: str, 
+              credential: Union[AzureKeyCredential, AsyncTokenCredential], 
+              *, 
+              api_version: str = ..., 
+              **kwargs: Any
+          ) -> None
+        
+        @distributed_trace_async
+        async def analyze(
+              self, 
+              image_data: bytes, 
+              visual_features: List[VisualFeatures], 
+              *, 
+              gender_neutral_caption: Optional[bool] = ..., 
+              language: Optional[str] = ..., 
+              model_version: Optional[str] = ..., 
+              smart_crops_aspect_ratios: Optional[List[float]] = ..., 
+              **kwargs: Any
+          ) -> ImageAnalysisResult
+        
+        @distributed_trace_async
+        async def analyze_from_url(
+              self, 
+              image_url: str, 
+              visual_features: List[VisualFeatures], 
+              *, 
+              gender_neutral_caption: Optional[bool] = ..., 
+              language: Optional[str] = ..., 
+              model_version: Optional[str] = ..., 
+              smart_crops_aspect_ratios: Optional[List[float]] = ..., 
+              **kwargs: Any
+          ) -> ImageAnalysisResult
+        
+        async def close(self) -> None
+        
+        def send_request(
+              self, 
+              request: HttpRequest, 
+              *, 
+              stream: bool = False, 
+              **kwargs: Any
+          ) -> Awaitable[AsyncHttpResponse]
+        
+        
+    namespace azure.ai.vision.imageanalysis.models
+      
+      class azure.ai.vision.imageanalysis.models.CaptionResult(MutableMapping[str, Any]):
+        ivar confidence: float
+        ivar text: str
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              confidence: float, 
+              text: str
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.CropRegion(MutableMapping[str, Any]):
+        ivar aspect_ratio: float
+        ivar bounding_box: ImageBoundingBox
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              aspect_ratio: float, 
+              bounding_box: ImageBoundingBox
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.DenseCaption(MutableMapping[str, Any]):
+        ivar bounding_box: ImageBoundingBox
+        ivar confidence: float
+        ivar text: str
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              bounding_box: ImageBoundingBox, 
+              confidence: float, 
+              text: str
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.DenseCaptionsResult(MutableMapping[str, Any]):
+        ivar list: List[DenseCaption]
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              list: List[DenseCaption]
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.DetectedObject(MutableMapping[str, Any]):
+        ivar bounding_box: ImageBoundingBox
+        ivar tags: List[DetectedTag]
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              bounding_box: ImageBoundingBox, 
+              tags: List[DetectedTag]
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.DetectedPerson(MutableMapping[str, Any]):
+        ivar bounding_box: ImageBoundingBox
+        ivar confidence: float
+        
+        
+      class azure.ai.vision.imageanalysis.models.DetectedTag(MutableMapping[str, Any]):
+        ivar confidence: float
+        ivar name: str
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              confidence: float, 
+              name: str
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.DetectedTextBlock(MutableMapping[str, Any]):
+        ivar lines: List[DetectedTextLine]
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              lines: List[DetectedTextLine]
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.DetectedTextLine(MutableMapping[str, Any]):
+        ivar bounding_polygon: List[ImagePoint]
+        ivar text: str
+        ivar words: List[DetectedTextWord]
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              bounding_polygon: List[ImagePoint], 
+              text: str, 
+              words: List[DetectedTextWord]
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.DetectedTextWord(MutableMapping[str, Any]):
+        ivar bounding_polygon: List[ImagePoint]
+        ivar confidence: float
+        ivar text: str
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              bounding_polygon: List[ImagePoint], 
+              confidence: float, 
+              text: str
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.ImageAnalysisResult(MutableMapping[str, Any]):
+        ivar caption: Optional[CaptionResult]
+        ivar dense_captions: Optional[DenseCaptionsResult]
+        ivar metadata: ImageMetadata
+        ivar model_version: str
+        ivar objects: Optional[ObjectsResult]
+        ivar people: Optional[PeopleResult]
+        ivar read: Optional[ReadResult]
+        ivar smart_crops: Optional[SmartCropsResult]
+        ivar tags: Optional[TagsResult]
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              caption: Optional[CaptionResult] = ..., 
+              dense_captions: Optional[DenseCaptionsResult] = ..., 
+              metadata: ImageMetadata, 
+              model_version: str, 
+              objects: Optional[ObjectsResult] = ..., 
+              people: Optional[PeopleResult] = ..., 
+              read: Optional[ReadResult] = ..., 
+              smart_crops: Optional[SmartCropsResult] = ..., 
+              tags: Optional[TagsResult] = ...
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.ImageBoundingBox(MutableMapping[str, Any]):
+        ivar height: int
+        ivar width: int
+        ivar x: int
+        ivar y: int
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              height: int, 
+              width: int, 
+              x: int, 
+              y: int
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.ImageMetadata(MutableMapping[str, Any]):
+        ivar height: int
+        ivar width: int
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              height: int, 
+              width: int
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.ImagePoint(MutableMapping[str, Any]):
+        ivar x: int
+        ivar y: int
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              x: int, 
+              y: int
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.ObjectsResult(MutableMapping[str, Any]):
+        ivar list: List[DetectedObject]
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              list: List[DetectedObject]
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.PeopleResult(MutableMapping[str, Any]):
+        ivar list: List[DetectedPerson]
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              list: List[DetectedPerson]
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.ReadResult(MutableMapping[str, Any]):
+        ivar blocks: List[DetectedTextBlock]
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              blocks: List[DetectedTextBlock]
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.SmartCropsResult(MutableMapping[str, Any]):
+        ivar list: List[CropRegion]
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              list: List[CropRegion]
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.TagsResult(MutableMapping[str, Any]):
+        ivar list: List[DetectedTag]
+        
+        @overload
+        def __init__(
+              self, 
+              *, 
+              list: List[DetectedTag]
+          )
+        
+        @overload
+        def __init__(self, mapping: Mapping[str, Any])
+        
+        def __init__(
+              self, 
+              *args: Any, 
+              **kwargs: Any
+          ) -> None
+        
+        
+      class azure.ai.vision.imageanalysis.models.VisualFeatures(str, Enum):
+        CAPTION = "caption"
+        DENSE_CAPTIONS = "denseCaptions"
+        OBJECTS = "objects"
+        PEOPLE = "people"
+        READ = "read"
+        SMART_CROPS = "smartCrops"
+        TAGS = "tags"        
+---
+system:
+You are an API‐view outline generator. Your job is to produce a **language‑agnostic**, hierarchical outline of an APIView that includes **only** the names of:
+
+  - namespaces (or modules/packages)
+  - classes, interfaces, structs, enums, etc.
+  - methods, functions, operations
+
+You MUST NOT include:
+
+  - method signatures or parameters
+  - methods that begin with `_` (underscore)
+  - class properties or fields
+  - enum member values or names beyond the enum itself
+  - any descriptions, types, default values, examples, or documentation text
+  - any full-qualified names or paths - just the simple names
+
+RULES:
+1. Preserve the exact names and nesting relationships.
+2. Represent each namespace/package as a second‑level heading (`## Namespace: ...`).
+3. Under each namespace, list classes/types as bullet points.
+4. Under each class, list methods/functions as nested bullets.
+5. Do not output any other details.
+
+Output in Markdown.
+
+user: |
+  {{content}}

--- a/packages/python-packages/apiview-copilot/prompts/generate_outline.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/generate_outline.prompty
@@ -10,7 +10,7 @@ model:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: o3-mini
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0

--- a/packages/python-packages/apiview-copilot/prompts/generic_diff_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/generic_diff_review.prompty
@@ -134,12 +134,3 @@ user:
   ```{{language}}
   {{content}}
   ```
-assistant: |
-  Based on the evaluation criteria, analyze how delightful this API is and how well it adheres to {{language}} best practices. Consider:
-
-  1. Whether method and parameter names are clear and intuitive
-  2. If the complexity level is appropriate
-  3. If naming is consistent and follows conventions  
-  4. How well it adheres to {{language}} best practices
-
-  Provide specific suggestions for improvement where the API could be more delightful or more idiomatic in {{language}}.

--- a/packages/python-packages/apiview-copilot/prompts/generic_diff_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/generic_diff_review.prompty
@@ -11,7 +11,7 @@ model:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: o3-mini
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0

--- a/packages/python-packages/apiview-copilot/prompts/generic_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/generic_review.prompty
@@ -100,12 +100,3 @@ user:
   ```{{language}}
   {{content}}
   ```
-assistant: |
-  Based on the evaluation criteria, analyze how delightful this API is and how well it adheres to {{language}} best practices. Consider:
-
-  1. Whether method and parameter names are clear and intuitive
-  2. If the complexity level is appropriate
-  3. If naming is consistent and follows conventions  
-  4. How well it adheres to {{language}} best practices
-
-  Provide specific suggestions for improvement where the API could be more delightful or more idiomatic in {{language}}.

--- a/packages/python-packages/apiview-copilot/prompts/generic_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/generic_review.prompty
@@ -11,7 +11,7 @@ model:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: o3-mini
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0

--- a/packages/python-packages/apiview-copilot/prompts/guidelines_diff_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/guidelines_diff_review.prompty
@@ -10,7 +10,7 @@ model:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: o3-mini
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0

--- a/packages/python-packages/apiview-copilot/prompts/guidelines_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/guidelines_review.prompty
@@ -11,7 +11,7 @@ model:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: o3-mini
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0

--- a/packages/python-packages/apiview-copilot/prompts/merge_comments.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/merge_comments.prompty
@@ -12,8 +12,8 @@ model:
     azure_deployment: gpt-4.1
     api_version: 2025-01-01-preview
   parameters:
-    temperature: 0.7
-    top_p: 0.95
+    temperature: 0
+    top_p: 1
     stop: []
     frequency_penalty: 0
     presence_penalty: 0
@@ -56,10 +56,10 @@ system:
   Regardless of the number of input comments, the output should always be an array of one comment.
 
 user:
-  Given this context:
+  # CONTEXT
   {{context}}
 
-  And these comments:
+  # COMMENTS
   {{comments}}
 
   Generate a single merged comment that summarizes the key points from all the comments.

--- a/packages/python-packages/apiview-copilot/prompts/merge_comments.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/merge_comments.prompty
@@ -10,7 +10,7 @@ model:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: gpt-4.1
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
   parameters:
     temperature: 0
     top_p: 1

--- a/packages/python-packages/apiview-copilot/prompts/summarize_api.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/summarize_api.prompty
@@ -10,7 +10,7 @@ model:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: o3-mini
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0

--- a/packages/python-packages/apiview-copilot/prompts/summarize_diff.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/summarize_diff.prompty
@@ -10,7 +10,7 @@ model:
     type: azure_openai
     azure_endpoint: ${env:AZURE_OPENAI_ENDPOINT}
     azure_deployment: o3-mini
-    api_version: 2025-01-01-preview
+    api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0

--- a/packages/python-packages/apiview-copilot/scratch/output/python/content_understanding.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/python/content_understanding.json
@@ -1,130 +1,145 @@
 {
     "comments": [
         {
-            "rule_ids": [
-                "python_design.html#python-client-sync-async-separate-clients"
-            ],
-            "line_no": 7,
-            "bad_code": "ivar analyzers: AnalyzersOperations",
-            "suggestion": "Use a synchronous operations type (for example, azure.ai.contentunderstanding.operations.AnalyzersOperations)",
-            "comment": "The synchronous ContentUnderstandingClient exposes an 'analyzers' property typed as AnalyzersOperations, but the only provided definition of AnalyzersOperations (in namespace azure.ai.contentunderstanding.aio.operations) defines asynchronous methods. Synchronous clients should use a corresponding synchronous operations type so that sync and async APIs remain clearly separated.. Suggest: Use a synchronous operations type (for example, azure.ai.contentunderstanding.operations.AnalyzersOperations) that provides synchronous method signatures in the synchronous client.",
-            "source": "guideline"
+            "rule_ids": [],
+            "line_no": 1,
+            "bad_code": "",
+            "suggestion": null,
+            "comment": "Here is a summary of the service described by this APIView:\n\nOverview  \nThis API provides a service for analyzing and understanding various content types within Azure. The service exposes both synchronous and asynchronous clients that enable users to interact with analyzers for content evaluation, management, and transformation. It facilitates operations that accept different input formats and supports long‐running tasks with poller objects.\n\nAPI Version  \nThe clients accept an `api_version` parameter during initialization. Although an explicit version object is not defined in the APIView, users can specify the desired version within the client constructors.\n\n*Client Classes  \nThe synchronous client, `azure.ai.contentunderstanding.ContentUnderstandingClient`, exposes the methods `__init__`, `close`, and `send_request`. Its asynchronous counterpart, `azure.ai.contentunderstanding.aio.ContentUnderstandingClient`, similarly provides `__init__`, `close`, and `send_request`.\n\nIn addition, the service includes analyzer operation clients in both synchronous and asynchronous variants. The asynchronous operations class, `azure.ai.contentunderstanding.aio.operations.AnalyzersOperations`, offers methods named `begin_analyze`, `begin_analyze_binary`, `begin_create_or_replace`, `delete`, `get`, `get_operation_status`, `get_result`, `get_result_image`, `list`, and `update`. The synchronous operations provided in `azure.ai.contentunderstanding.operations.AnalyzersOperations` include the same set of method names.\n\nOther Classes and Methods  \nA wide range of models under `azure.ai.contentunderstanding.models` encapsulate the data structures necessary for content analysis. Key models include `AnalyzeResult`, `ContentAnalyzer`, `ContentAnalyzerConfig`, `ContentField`, and `ContentSpan`. The APIView also defines specialized field models such as `ArrayField`, `BooleanField`, `DateField`, `IntegerField`, `NumberField`, `ObjectField`, `StringField`, and `TimeField` to represent various extracted data types. Enumerations and supporting classes like `DataSourceKind`, `DocumentBarcodeKind`, `DocumentFormulaKind`, `ParagraphRole`, and others further detail the structure and metadata for document and media content, including types for audio-visual and document content.\n\nRelevant API Functionality and Structure  \nThe design of the API centers around content analyzers, enabling users to create, update, delete, and retrieve analyzer resources. It supports both context-managed synchronous and asynchronous client patterns and includes methods to send HTTP requests as well as to manage long-running operations via pollers. Overloads in methods such as those in the analyzers operations classes support different input types (for example, JSON or byte streams) to accommodate diverse use cases in content extraction and analysis.",
+            "source": "summary"
         },
         {
             "rule_ids": [],
             "line_no": 110,
-            "bad_code": "input: bytes",
-            "suggestion": "binary_data: bytes",
-            "comment": "The parameter name 'input' shadows the built-in function. Renaming it to something like 'binary_data' avoids this shadowing and improves clarity.. Suggest: binary_data: bytes",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 167,
-            "bad_code": "def get_operation_status(...): -> ResourceOperationStatusContentAnalyzerContentAnalyzerError",
-            "suggestion": "/* Consider defining a type alias (e.g., OperationStatusError) to simplify the long return type name */ (general comment)",
-            "comment": "$The verbose return type name reduces readability. Using a type alias to encapsulate 'ResourceOperationStatusContentAnalyzerContentAnalyzerError' would make the signature cleaner and more approachable.. Suggest: /* Consider defining a type alias (e.g., OperationStatusError) to simplify the long return type name */ (general comment)",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 266,
-            "bad_code": "ivar spans: list[ContentSpan]",
-            "suggestion": "ivar spans: List[ContentSpan]",
-            "comment": "The API inconsistently uses built-in generics (list[...]) and typing generics (List[...]). For consistency and clarity, choose one style across the API.. Suggest: ivar spans: List[ContentSpan]",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 284,
-            "bad_code": "def __init__(self, *, confidence: Optional[float] = ..., source: Optional[str] = ..., spans: Optional[List[ContentSpan]] = ..., type: str) -> None",
-            "suggestion": "def __init__(self, *, confidence: Optional[float] = None, source: Optional[str] = None, spans: Optional[List[ContentSpan]] = None, field_type: str) -> None",
-            "comment": "Using 'type' as a parameter name can overshadow the built-in type() function. Renaming it to 'field_type' (or similar) avoids this conflict and improves code clarity.. Suggest: def __init__(self, *, confidence: Optional[float] = None, source: Optional[str] = None, spans: Optional[List[ContentSpan]] = None, field_type: str) -> None",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 736,
-            "bad_code": "ivar footnotes: Optional[List[ForwardRef('DocumentFootnote')]]",
-            "suggestion": "ivar footnotes: Optional[List['DocumentFootnote']]",
-            "comment": "Prefer using string literals for forward references in type annotations. This approach is more idiomatic and improves readability.. Suggest: ivar footnotes: Optional[List['DocumentFootnote']]",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 1139,
-            "bad_code": "ivar type: Literal[INTEGER]",
-            "suggestion": "ivar type: Literal['INTEGER']",
-            "comment": "When using Literal with string values, enclose the literal value in quotes to correctly indicate it is a string.. Suggest: ivar type: Literal['INTEGER']",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 1212,
-            "bad_code": "ivar spans: list[ContentSpan]",
-            "suggestion": "ivar spans: List[ContentSpan]",
-            "comment": "There is an inconsistency in type annotations for list types (using both 'list' and 'List'). Choose one style (preferably using the typing import for broader compatibility) to maintain consistency.. Suggest: ivar spans: List[ContentSpan]",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 1213,
-            "bad_code": "ivar type: Literal[NUMBER]",
-            "suggestion": "ivar field_type: Literal[NUMBER]",
-            "comment": "Using the attribute name 'type' shadows the built-in type() function. Renaming it to something like 'field_type' will prevent potential confusion and improve clarity.. Suggest: ivar field_type: Literal[NUMBER]",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [
-                "python_design.html#python-client-constructor-form"
-            ],
-            "line_no": 1510,
-            "bad_code": "def __init__(",
-            "suggestion": "def __init__(self, client: Any, endpoint: str, **kwargs) -> None:",
-            "comment": "The constructor is defined using generic *args and **kwargs rather than explicitly declaring the required binding parameters (for example, a service client or endpoint). For a public operations class, the constructor should clearly list its required positional parameters per python_design.html#python-client-constructor-form.. Suggest: def __init__(self, client: Any, endpoint: str, **kwargs) -> None:",
-            "source": "guideline"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 1547,
-            "bad_code": "def begin_analyze(self, analyzer_id: str, body: Union[JSON, IO[bytes]] = _Unset, *, url: Optional[str] = ..., **kwargs: Any) -> LROPoller[AnalyzeResult]",
-            "suggestion": "def begin_analyze(self, analyzer_id: str, *, body: Optional[Union[JSON, IO[bytes]]] = None, url: Optional[str] = None, **kwargs: Any) -> LROPoller[AnalyzeResult]:",
-            "comment": "The begin_analyze method accepts both 'body' and 'url', which may confuse developers about their mutual exclusivity. Making them keyword-only with a default of None clarifies usage and improves the API's intuitiveness.. Suggest: def begin_analyze(self, analyzer_id: str, *, body: Optional[Union[JSON, IO[bytes]]] = None, url: Optional[str] = None, **kwargs: Any) -> LROPoller[AnalyzeResult]:",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 1557,
-            "bad_code": "def begin_analyze_binary(self, analyzer_id: str, input: bytes, **kwargs: Any) -> LROPoller[AnalyzeResult]",
-            "suggestion": "def begin_analyze_binary(self, analyzer_id: str, data: bytes, **kwargs: Any) -> LROPoller[AnalyzeResult]",
-            "comment": "Avoid using 'input' as a parameter name since it shadows the built-in Python function. Renaming it to 'data' (or 'content') will prevent potential confusion.. Suggest: def begin_analyze_binary(self, analyzer_id: str, data: bytes, **kwargs: Any) -> LROPoller[AnalyzeResult]",
-            "source": "generic"
-        },
-        {
-            "rule_ids": [],
-            "line_no": 1617,
-            "bad_code": "def get_operation_status(self, analyzer_id: str, operation_id: str, **kwargs: Any) -> ResourceOperationStatusContentAnalyzerContentAnalyzerError",
-            "suggestion": "/* Consider using a type alias or simplifying the return type name if possible */",
-            "comment": "The return type is very verbose. Simplifying or aliasing complex type names can make the API more approachable and reduce friction for developers.. Suggest: /* Consider using a type alias or simplifying the return type name if possible */",
+            "bad_code": "input: bytes,",
+            "suggestion": "binary_data: bytes,",
+            "comment": "Avoid using 'input' as a parameter name as it shadows a built-in function.",
             "source": "generic"
         },
         {
             "rule_ids": [
                 "python_design.html#python-paged-prefix"
             ],
-            "line_no": 1642,
-            "bad_code": "def list(self, **kwargs: Any) -> Iterable[ContentAnalyzer]",
-            "suggestion": "def list_analyzers(self, **kwargs: Any) -> Iterable[ContentAnalyzer]",
-            "comment": "Methods that enumerate resources should be prefixed with 'list_'. Renaming the 'list' method to something like 'list_analyzers' would better align with python_design.html#python-paged-prefix.. Suggest: def list_analyzers(self, **kwargs: Any) -> Iterable[ContentAnalyzer]",
+            "line_no": 192,
+            "bad_code": "def list(self, **kwargs: Any) -> AsyncIterable[ContentAnalyzer]",
+            "suggestion": "def list_analyzers(self, **kwargs: Any) -> AsyncIterable[ContentAnalyzer]",
+            "comment": "Listing methods should be prefixed with 'list_' to clearly indicate resource enumeration.",
             "source": "guideline"
         },
         {
             "rule_ids": [],
-            "line_no": 1675,
-            "bad_code": "def update(self, analyzer_id: str, resource: Union[ContentAnalyzer, JSON, IO[bytes]], **kwargs: Any) -> ContentAnalyzer",
-            "suggestion": "def update(self, analyzer_id: str, resource: Union[ContentAnalyzer, JSON, IO[bytes]], *, content_type: str = 'application/merge-patch+json', **kwargs: Any) -> ContentAnalyzer",
-            "comment": "The overloads for update include an explicit content_type parameter, but the final implementation defers it into **kwargs. Including it explicitly aligns the implementation with its overloads and improves clarity for users.. Suggest: def update(self, analyzer_id: str, resource: Union[ContentAnalyzer, JSON, IO[bytes]], *, content_type: str = 'application/merge-patch+json', **kwargs: Any) -> ContentAnalyzer",
+            "line_no": 266,
+            "bad_code": "ivar spans: list[ContentSpan]",
+            "suggestion": "ivar spans: List[ContentSpan]",
+            "comment": "Use consistent type annotations by preferring List from the typing module over the built-in list.",
             "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 267,
+            "bad_code": "ivar type: Literal[ARRAY]",
+            "suggestion": "ivar field_type: Literal[ARRAY]",
+            "comment": "Avoid shadowing the built-in name 'type' by renaming the attribute to something like 'field_type'.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 306,
+            "bad_code": "ivar fields: dict[str, ContentField]",
+            "suggestion": "ivar fields: Dict[str, ContentField]",
+            "comment": "For consistency with other type hints, use Dict from the typing module instead of the built-in dict.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1138,
+            "bad_code": "ivar spans: list[ContentSpan]",
+            "suggestion": "ivar spans: Optional[List[ContentSpan]]",
+            "comment": "Use a consistent type annotation style and align the attribute’s type with its constructor signature.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1139,
+            "bad_code": "ivar type: Literal[INTEGER]",
+            "suggestion": "ivar type: Literal['integer']",
+            "comment": "Use a string literal for the literal value to avoid relying on an undefined constant.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1212,
+            "bad_code": "        ivar spans: list[ContentSpan]",
+            "suggestion": "        ivar spans: List[ContentSpan]",
+            "comment": "Use consistent type annotation style for collections; align with overloads by using 'List' from the typing module.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1236,
+            "bad_code": "                type: str",
+            "suggestion": "                field_type: str",
+            "comment": "Avoid shadowing the built-in 'type' by renaming the parameter to 'field_type' for clarity.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1242,
+            "bad_code": "        def __init__(",
+            "suggestion": null,
+            "comment": "Consider providing an explicit __init__ signature rather than using *args and **kwargs for better discoverability and type safety.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1276,
+            "bad_code": "                type: str",
+            "suggestion": "                field_type: str",
+            "comment": "Rename the 'type' parameter to 'field_type' to prevent confusion with the built-in and improve clarity.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1333,
+            "bad_code": "    class azure.ai.contentunderstanding.models.ResourceOperationStatusContentAnalyzerContentAnalyzerError(MutableMapping[str, Any]):",
+            "suggestion": "    class azure.ai.contentunderstanding.models.ResourceOperationStatusContentAnalyzerError(MutableMapping[str, Any]):",
+            "comment": "Shorten the class name to eliminate redundant segments and improve readability.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1393,
+            "bad_code": "                type: str",
+            "suggestion": "                field_type: str",
+            "comment": "Use a more descriptive name like 'field_type' instead of 'type' to avoid shadowing the built-in.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1433,
+            "bad_code": "                type: str",
+            "suggestion": "                field_type: str",
+            "comment": "Change 'type' to 'field_type' to avoid clashing with Python’s built-in name.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 1560,
+            "bad_code": "input: bytes,",
+            "suggestion": "data: bytes,",
+            "comment": "Avoid using 'input', a built-in function name; rename the parameter (e.g. to 'data') for clarity.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [
+                "python_design.html#python-paged-prefix",
+                "python_design.html#python-response-paged-protocol"
+            ],
+            "line_no": 1642,
+            "bad_code": "def list(self, **kwargs: Any) -> Iterable[ContentAnalyzer]",
+            "suggestion": "def list_analyzers(self, **kwargs: Any) -> ItemPaged[ContentAnalyzer]",
+            "comment": "The method should be renamed with a 'list_' prefix to clearly indicate it enumerates resources, and its name should be more descriptive to avoid shadowing the built-in list type. Additionally, it should return an ItemPaged object to properly support paging of results.",
+            "source": "merged"
         }
     ]
 }

--- a/packages/python-packages/apiview-copilot/scratch/output/python/image_analysis.json
+++ b/packages/python-packages/apiview-copilot/scratch/output/python/image_analysis.json
@@ -5,18 +5,154 @@
             "line_no": 1,
             "bad_code": "",
             "suggestion": null,
-            "comment": "Here is a summary of the service described by this APIView:\n\nOverview  \nThis API provides image analysis capabilities that enable the extraction and interpretation of various visual features from images provided as byte streams or via URLs. The service supports a range of analysis types including caption generation, dense captioning, object and person detection, optical character recognition, smart cropping, and tagging. It is designed with distributed tracing support and leverages context management for resource handling.\n\nAPI Version  \nThe API clients accept an `api_version` parameter during initialization. Although no dedicated API version object is defined in this view, the version is configurable through the client.\n\nPrimary Client Classes  \nThe API exposes a synchronous client class, `ImageAnalysisClient`, and an asynchronous client class, `AsyncImageAnalysisClient`. The `ImageAnalysisClient` offers the following methods: `__init__`, `analyze`, `analyze_from_url`, `close`, and `send_request`. The `AsyncImageAnalysisClient` provides analogous methods: `__init__`, `analyze`, `analyze_from_url`, `close`, and a static `send_request`.\n\nOther Classes and Models  \nSupporting models are organized under the `models` namespace and represent the structure of analysis results and image components. These include classes such as `CaptionResult`, `CropRegion`, `DenseCaption`, `DenseCaptionsResult`, `DetectedObject`, `detectedPerson`, `DetectedTag`, `DetectedTextBlock`, `DetectedTextLine`, `DetectedTextWord`, `ImageAnalysisResult`, `ImageBoundingBox`, `ImageMetadata`, `ImagePoint`, `ObjectsResult`, `PeopleResult`, `ReadResult`, `SmartCropsResult`, and `TagsResult`. Additionally, the `VisualFeatures` enumeration lists available visual feature types including `CAPTION`, `DENSE_CAPTIONS`, `OBJECTS`, `PEOPLE`, `READ`, `SMART_CROPS`, and `tags`.\n\nAdditional Details  \nThe clients implement context management protocols (with `ImageAnalysisClient` as a `ContextManager` and `AsyncImageAnalysisClient` as an `AsyncContextManager`) to manage resource lifecycles. Decorators for distributed tracing (`@distributed_trace` and `@distributed_trace_async`) are used to support observability within distributed environments. The model classes inherit from `MutableMapping`, offering flexible access to their properties, and support multiple construction patterns either via explicit parameters or mappings.",
+            "comment": "Here is a summary of the service described by this APIView:\n\nPurpose  \nThis API provides image analysis capabilities by allowing users to process images either through raw byte data or via URLs. It extracts various visual features such as captions, dense captions, object detection, people recognition, text (read), and smart crop suggestions. The service supports both synchronous and asynchronous workflows and is designed for use within managed context environments.\n\nAPI Version  \nThe API accepts an API version through the `api_version` parameter in the client initializer. No dedicated API Version object is exported, and explicit details regarding the latest version are not provided within the stub.\n\nClient Classes  \nThe primary client classes are `ImageAnalysisClient` and `AsyncImageAnalysisClient`. The `ImageAnalysisClient` exposes the methods `analyze`, `analyze_from_url`, `close`, and `send_request`. Similarly, `AsyncImageAnalysisClient` offers the methods `analyze`, `analyze_from_url`, `close`, and `send_request`.\n\nData Models and Additional Classes  \nA comprehensive set of models is defined under the `azure.ai.vision.imageanalysis.models` namespace. These include types such as `CaptionResult`, `CropRegion`, `DenseCaption`, `DenseCaptionsResult`, `DetectedObject`, `detectedPerson`, `DetectedTag`, `DetectedTextBlock`, `DetectedTextLine`, `DetectedTextWord`, `ImageAnalysisResult`, `ImageBoundingBox`, `ImageMetadata`, and `ImagePoint`. Additionally, `ObjectsResult` comes with methods `get_result` and `set_result`, while `SmartCropsResult`, `ReadResult`, and `TagsResult` capture specialized aspects of the analysis. An enumeration named `VisualFeatures` lists available features such as `CAPTION`, `DENSE_CAPTIONS`, `OBJECTS`, `PEOPLE`, `READ`, `SMART_CROPS`, and `tags`. There is also an asynchronous model, `PeopleResult`, provided under the `azure.ai.vision.imageanalysis.models.aio` namespace.\n\nAdditional Details  \nThe API methods are enhanced with distributed tracing features through the decorators `distributed_trace` and `distributed_trace_async` for synchronous and asynchronous operations respectively. Many of the model classes implement `MutableMapping`, supporting flexible, dictionary-like interactions with the image analysis results.",
             "source": "summary"
+        },
+        {
+            "rule_ids": [
+                "python_design.html#python-client-connection-string"
+            ],
+            "line_no": 10,
+            "bad_code": "connection_string: Optional[str] = None",
+            "suggestion": null,
+            "comment": "The constructor should not accept a connection_string parameter; instead, a separate from_connection_string factory method should be provided.",
+            "source": "guideline"
         },
         {
             "rule_ids": [
                 "python_implementation.html#python-codestyle-kwargs"
             ],
             "line_no": 34,
-            "bad_code": "         gender_neutral_caption: Optional[bool] = ...,",
-            "suggestion": "         *, gender_neutral_caption: Optional[bool] = ...,",
-            "comment": "Optional parameters should be keyword-only; insert a '*' to separate positional from keyword-only arguments.",
+            "bad_code": "gender_neutral_caption: Optional[bool] = ...",
+            "suggestion": "        *,",
+            "comment": "Optional parameters must be declared as keyword-only; insert a '*' before them in the method signature.",
             "source": "guideline"
+        },
+        {
+            "rule_ids": [
+                "python_design.html#python-client-same-name-sync-async"
+            ],
+            "line_no": 53,
+            "bad_code": "class azure.ai.vision.imageanalysis.aio.AsyncImageAnalysisClient(ImageAnalysisClient): implements AsyncContextManager",
+            "suggestion": "class azure.ai.vision.imageanalysis.aio.ImageAnalysisClient(ImageAnalysisClient): implements AsyncContextManager",
+            "comment": "Async clients should share the same class name as their sync counterparts; the async version is distinguished by its namespace, not by an 'Async' prefix.",
+            "source": "guideline"
+        },
+        {
+            "rule_ids": [
+                "python_design.html#python-client-constructor-api-version-argument-1"
+            ],
+            "line_no": 54,
+            "bad_code": "def __init__(self,",
+            "suggestion": "def __init__(self, endpoint: str, credential: Union[AzureKeyCredential, AsyncTokenCredential], *, api_version: str = ..., **kwargs: Any) -> None",
+            "comment": "Async client constructors must accept an optional api_version keyword-only argument to allow version specification.",
+            "source": "guideline"
+        },
+        {
+            "rule_ids": [
+                "python_implementation.html#python-codestyle-static-methods"
+            ],
+            "line_no": 88,
+            "bad_code": "@staticmethod",
+            "suggestion": null,
+            "comment": "Static methods should be avoided in client types; remove the staticmethod decorator and use an instance method instead.",
+            "source": "guideline"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 90,
+            "bad_code": "        self,",
+            "suggestion": null,
+            "comment": "Remove the 'self' parameter from a static method’s signature.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 168,
+            "bad_code": "    ivar list: List[DenseCaption]",
+            "suggestion": "    ivar items: List[DenseCaption]",
+            "comment": "Avoid using the built‐in name 'list' as an attribute; consider renaming it (e.g. to 'items').",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [
+                "python_implementation.html#python-codestyle-type-naming"
+            ],
+            "line_no": 209,
+            "bad_code": "class azure.ai.vision.imageanalysis.models.detectedPerson(MutableMapping[str, Any]):",
+            "suggestion": "class azure.ai.vision.imageanalysis.models.DetectedPerson(MutableMapping[str, Any]):",
+            "comment": "Class names should use PascalCase; rename 'detectedPerson' to 'DetectedPerson' to follow naming conventions.",
+            "source": "merged"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 409,
+            "bad_code": "    ivar list: List[DetectedObject]",
+            "suggestion": "    ivar items: List[DetectedObject]",
+            "comment": "Rename the attribute to avoid shadowing the built‐in 'list'.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [
+                "python_implementation.html#python-codestyle-properties"
+            ],
+            "line_no": 411,
+            "bad_code": "def get_result(self) -> ObjectsResult",
+            "suggestion": "def result(self) -> ObjectsResult",
+            "comment": "Replace the explicit getter method with a property by renaming the method to 'result' for a more idiomatic and Pythonic API.",
+            "source": "merged"
+        },
+        {
+            "rule_ids": [
+                "python_implementation.html#python-codestyle-properties"
+            ],
+            "line_no": 413,
+            "bad_code": "def set_result(self, obj) -> None",
+            "suggestion": null,
+            "comment": "Avoid using explicit set_ methods for setting values. Instead, implement setter functionality using properties for a more Pythonic and maintainable design.",
+            "source": "merged"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 433,
+            "bad_code": "    ivar list: List[detectedPerson]",
+            "suggestion": "    ivar items: List[DetectedPerson]",
+            "comment": "Rename the attribute to avoid shadowing 'list' and update the type to use proper PascalCase.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 473,
+            "bad_code": "    ivar list: List[CropRegion]",
+            "suggestion": "    ivar items: List[CropRegion]",
+            "comment": "Rename the attribute to avoid conflict with the built‐in 'list'.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 492,
+            "bad_code": "ivar list: List[DetectedTag]",
+            "suggestion": "ivar tags: List[DetectedTag]",
+            "comment": "Avoid using the built-in name 'list' as an attribute; 'tags' is more descriptive and avoids shadowing.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [],
+            "line_no": 498,
+            "bad_code": "list: List[DetectedTag]",
+            "suggestion": "tags: List[DetectedTag]",
+            "comment": "Rename the parameter from 'list' to 'tags' to prevent conflicts with Python built-ins and improve clarity.",
+            "source": "generic"
+        },
+        {
+            "rule_ids": [
+                "python_design.html#python-models-enum-name-uppercase"
+            ],
+            "line_no": 517,
+            "bad_code": "tags = 'tags'",
+            "suggestion": "TAGS = 'tags'",
+            "comment": "Enum member names should be written in uppercase for consistency and to follow naming conventions.",
+            "source": "merged"
         }
     ]
 }


### PR DESCRIPTION
- This PR adds an outline prompt that generates an API skeleton as a placeholder until we can get a deterministic one passed in. 
- It then uses this outline in the filter to filter out comments that result from chunking that can be verified invalid by referencing the outline. 
- Tunes the gpt4.x prompts to be deterministic (unfortunately this isn't really possible with the reasoning models!)
- Updates evals to use a prompty file for the generic comment judge instead of a direct openAI call

**TODO**
- [x] Run `small.jsonl` eval to validate change