### PR TITLE
Assigned language value while constructing packageData obj

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-05-06 - 0.6.1
+
+- Assigned value to language while constructing PackageData object
+
 ## 2025-05-02 - 0.6.0
 
 - Normalize the log message with prefixes

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/types/PackageData.ts
+++ b/tools/spec-gen-sdk/src/types/PackageData.ts
@@ -221,6 +221,7 @@ export const getPackageData = (context: WorkflowContext, result: PackageResult, 
     breakingChangeItems,
     version: result.version,
     readmeMd: result.readmeMd,
-    typespecProject: result.typespecProject
+    typespecProject: result.typespecProject,
+    language: result.language,
   };
 };


### PR DESCRIPTION
This pull request introduces a minor version update (`0.6.1`) to the `@azure-tools/spec-gen-sdk` package, which includes a new feature for assigning the `language` property in the `PackageData` object and updates related metadata files accordingly.

### Feature Addition:
* [`tools/spec-gen-sdk/src/types/PackageData.ts`](diffhunk://#diff-bcc41d61e2d95321aabb2c9f516e642a62f100a7224bdc7ad4fc836ecd010899L224-R225): Added the `language` property to the `PackageData` object initialization to include language information.

### Metadata Updates:
* [`tools/spec-gen-sdk/CHANGELOG.md`](diffhunk://#diff-968fa3cf4ab010d5256c9bccd3cbc8894339bc3ba128556e293522107994a821R3-R6): Added a changelog entry for version `0.6.1`, documenting the addition of the `language` property.
* [`tools/spec-gen-sdk/package.json`](diffhunk://#diff-5532e95511ec7c2d2c5fdbb91be5dab5521875c1e5d0206b4fc66ee25e0596eaL8-R8): Updated the package version to `0.6.1`.
* [`tools/spec-gen-sdk/package-lock.json`](diffhunk://#diff-30b3cfc1be35ebe8a8195d3a7a14e21d9a2dea21becb4fc9efb9fa3d276b064fL3-R9): Updated the package-lock version to `0.6.1`.