### PR TITLE
Continue SDK generation even if having duplicated SDK config

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2025-05-06 - 0.6.1
 
+- Turned duplicated SDK config error into warning and continued SDK generation based on TypeSpecs
 - Assigned value to language while constructing PackageData object
 
 ## 2025-05-02 - 0.6.0

--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-05-06 - 0.6.1
+
+- Assigned value to language while constructing PackageData object
+
 ## 2025-05-02 - 0.6.0
 
 - Normalize the log message with prefixes

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.6.0",
+      "version": "0.6.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -102,6 +102,7 @@ export const generateReport = (context: WorkflowContext) => {
   executionReport = {
     packages: packageReports,
     executionResult: context.status,
+    isSdkConfigDuplicated: context.isSdkConfigDuplicated,
     fullLogPath: context.fullLogFileName,
     filteredLogPath: context.filteredLogFileName,
     stagedArtifactsFolder: context.stagedArtifactsFolder,

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -151,7 +151,7 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
       if (!twoConfigProvided) {
         context.status = 'notEnabled';
         message = configWarning(`Warning: 'swagger-to-sdk' section cannot be found in ${readmeMdPath} or ${context.config.sdkName} cannot be found in` +
-          `'swagger-to-sdk' section. Please add the section to the readme file according to this guidance https://aka.ms/azsdk/sample-readme-sdk-config`);
+          ` 'swagger-to-sdk' section. Please add the section to the readme file according to this guidance https://aka.ms/azsdk/sample-readme-sdk-config`);
         context.logger.warn(message);
         return;
       }

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -135,7 +135,8 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
         if (tspConfigPath.includes(".Management")) {
           sampleTspConfigUrl = "https://aka.ms/azsdk/tspconfig-sample-mpg"
         }
-        message = configWarning(`Warning: cannot find supported emitter in tspconfig.yaml for typespec project ${tspConfigPath}. This typespec project will be skipped from SDK generation. Refer to ${sampleTspConfigUrl} to add the right emitter config in the 'tspconfig.yaml' file`);
+        message = configWarning(`Warning: cannot find supported emitter in tspconfig.yaml for typespec project ${tspConfigPath}. ` +
+          `This typespec project will be skipped from SDK generation. Refer to ${sampleTspConfigUrl} to add the right emitter config in the 'tspconfig.yaml' file`);
         context.logger.warn(message);
         return;
       }
@@ -149,7 +150,8 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
     if (!config || config.repositories.length === 0 || !config.repositories.some(r => r.repo === context.config.sdkName)) {
       if (!twoConfigProvided) {
         context.status = 'notEnabled';
-        message = configWarning(`Warning: 'swagger-to-sdk' section cannot be found in ${readmeMdPath} or ${context.config.sdkName} cannot be found in 'swagger-to-sdk' section. Please add the section to the readme file according to this guidance https://aka.ms/azsdk/sample-readme-sdk-config`)
+        message = configWarning(`Warning: 'swagger-to-sdk' section cannot be found in ${readmeMdPath} or ${context.config.sdkName} cannot be found in 'swagger-to-sdk' section. ` +
+          `Please add the section to the readme file according to this guidance https://aka.ms/azsdk/sample-readme-sdk-config`);
         context.logger.warn(message);
         return;
       }
@@ -160,8 +162,11 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
   // only needs to check the two config provided case when both config enable the sdk generation or both config disable the sdk generation
   // the last case is the normal case, only one config enabled the sdk generation
   if (enabledSdkForTspConfig && enabledSdkForReadme) {
-    message = configError(`SDK generation configuration is enabled for both ${context.config.tspConfigPath} and ${context.config.readmePath}. Refer to https://aka.ms/azsdk/spec-gen-sdk-config to disable sdk configuration from one of them`);
-    throw new Error(message);
+    message = configWarning(`SDK generation configuration is enabled for both ${context.config.tspConfigPath} and ${context.config.readmePath}. ` +
+      `Refer to https://aka.ms/azsdk/spec-gen-sdk-config to disable sdk configuration from one of them. ` +
+      `Use ${context.config.tspConfigPath} to generate ${context.config.sdkName} SDK.`);
+    context.logger.warn(message);
+    context.specConfigPath = context.config.tspConfigPath;
   } else if (!enabledSdkForTspConfig && !enabledSdkForReadme) {
     context.status = 'notEnabled';
     message = configWarning("No SDKs are enabled for generation. Please enable them in either the corresponding tspconfig.yaml or readme.md file.");
@@ -196,7 +201,7 @@ const workflowGenerateSdk = async (context: WorkflowContext) => {
     return;
   }
 
-  context.logger.log('info', `Handle the following typespec project: ${context.specConfigPath}`);
+  context.logger.log('info', `Handle the following spec config: ${context.specConfigPath}`);
   if (fs.existsSync(suppressionFile)) {
     filterSuppressionFileMap.set(context.specConfigPath, suppressionFile);
   }

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -150,8 +150,8 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
     if (!config || config.repositories.length === 0 || !config.repositories.some(r => r.repo === context.config.sdkName)) {
       if (!twoConfigProvided) {
         context.status = 'notEnabled';
-        message = configWarning(`Warning: 'swagger-to-sdk' section cannot be found in ${readmeMdPath} or ${context.config.sdkName} cannot be found in` +
-          ` 'swagger-to-sdk' section. Please add the section to the readme file according to this guidance https://aka.ms/azsdk/sample-readme-sdk-config`);
+        message = configWarning(`Warning: 'swagger-to-sdk' section cannot be found in ${readmeMdPath} or ${context.config.sdkName} cannot be found in ` +
+          `'swagger-to-sdk' section. Please add the section to the readme file according to this guidance https://aka.ms/azsdk/sample-readme-sdk-config`);
         context.logger.warn(message);
         return;
       }

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -42,6 +42,7 @@ export type WorkflowContext = SdkAutoContext & {
   stagedArtifactsFolder?: string;
   sdkArtifactFolder?: string;
   sdkApiViewArtifactFolder?: string;
+  isSdkConfigDuplicated?: boolean;
   specConfigPath?: string;
   pendingPackages: PackageData[];
   handledPackages: PackageData[];
@@ -164,9 +165,11 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
   if (enabledSdkForTspConfig && enabledSdkForReadme) {
     message = configWarning(`SDK generation configuration is enabled for both ${context.config.tspConfigPath} and ${context.config.readmePath}. ` +
       `Refer to https://aka.ms/azsdk/spec-gen-sdk-config to disable sdk configuration from one of them. ` +
-      `This generation will be using ${context.config.tspConfigPath} to generate ${context.config.sdkName} SDK.`);
+      `This generation will be using TypeSpecs to generate the SDK.`);
     context.logger.warn(message);
+    context.logger.info(`SDK to generate:${context.config.sdkName}, configPath: ${context.config.tspConfigPath}`);
     context.specConfigPath = context.config.tspConfigPath;
+    context.isSdkConfigDuplicated = true;
   } else if (!enabledSdkForTspConfig && !enabledSdkForReadme) {
     context.status = 'notEnabled';
     message = configWarning("No SDKs are enabled for generation. Please enable them in either the corresponding tspconfig.yaml or readme.md file.");

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -164,7 +164,7 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
   if (enabledSdkForTspConfig && enabledSdkForReadme) {
     message = configWarning(`SDK generation configuration is enabled for both ${context.config.tspConfigPath} and ${context.config.readmePath}. ` +
       `Refer to https://aka.ms/azsdk/spec-gen-sdk-config to disable sdk configuration from one of them. ` +
-      `Use ${context.config.tspConfigPath} to generate ${context.config.sdkName} SDK.`);
+      `This generation will be using ${context.config.tspConfigPath} to generate ${context.config.sdkName} SDK.`);
     context.logger.warn(message);
     context.specConfigPath = context.config.tspConfigPath;
   } else if (!enabledSdkForTspConfig && !enabledSdkForReadme) {

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -150,8 +150,8 @@ export const workflowValidateSdkConfig = async (context: WorkflowContext) => {
     if (!config || config.repositories.length === 0 || !config.repositories.some(r => r.repo === context.config.sdkName)) {
       if (!twoConfigProvided) {
         context.status = 'notEnabled';
-        message = configWarning(`Warning: 'swagger-to-sdk' section cannot be found in ${readmeMdPath} or ${context.config.sdkName} cannot be found in 'swagger-to-sdk' section. ` +
-          `Please add the section to the readme file according to this guidance https://aka.ms/azsdk/sample-readme-sdk-config`);
+        message = configWarning(`Warning: 'swagger-to-sdk' section cannot be found in ${readmeMdPath} or ${context.config.sdkName} cannot be found in` +
+          `'swagger-to-sdk' section. Please add the section to the readme file according to this guidance https://aka.ms/azsdk/sample-readme-sdk-config`);
         context.logger.warn(message);
         return;
       }

--- a/tools/spec-gen-sdk/src/types/ExecutionReport.ts
+++ b/tools/spec-gen-sdk/src/types/ExecutionReport.ts
@@ -13,6 +13,7 @@ export type ExecutionReport = {
   stagedArtifactsFolder?: string;
   sdkArtifactFolder?: string;
   sdkApiViewArtifactFolder?: string;
+  isSdkConfigDuplicated?: boolean;
 };
 
 export type PackageReport = {

--- a/tools/spec-gen-sdk/src/types/PackageData.ts
+++ b/tools/spec-gen-sdk/src/types/PackageData.ts
@@ -221,6 +221,7 @@ export const getPackageData = (context: WorkflowContext, result: PackageResult, 
     breakingChangeItems,
     version: result.version,
     readmeMd: result.readmeMd,
-    typespecProject: result.typespecProject
+    typespecProject: result.typespecProject,
+    language: result.language,
   };
 };


### PR DESCRIPTION
This pull request introduces updates to the `spec-gen-sdk` tool, focusing on improving SDK generation workflows, enhancing error handling, and updating versioning. The most significant changes include turning certain errors into warnings to allow SDK generation to proceed, adding a new `language` field to the `PackageData` object, and updating version information to `0.6.1`.

### Workflow and Error Handling Improvements:
* Changed duplicated SDK configuration errors into warnings, enabling SDK generation to continue despite configuration issues.
* Updated warning messages for unsupported emitter configurations and missing `swagger-to-sdk` sections to improve clarity and guidance.

### Enhancements to SDK Generation:
* Added a `language` property to the `PackageData` object to capture the programming language of the SDK being generated.
