### PR TITLE
[tsp-client] Misc fixes

### DIFF
--- a/tools/tsp-client/src/fs.ts
+++ b/tools/tsp-client/src/fs.ts
@@ -3,6 +3,7 @@ import { Logger } from "./log.js";
 import { parse as parseYaml } from "yaml";
 import { joinPaths, normalizePath, resolvePath } from "@typespec/compiler";
 import { TspLocation } from "./typespec.js";
+import { EMITTER_PREFIXES } from "./utils.js";
 
 export async function ensureDirectory(path: string) {
   await mkdir(path, { recursive: true });
@@ -59,8 +60,7 @@ export async function getEmitterFromRepoConfig(emitterPath: string): Promise<str
   if (!obj || !obj.dependencies) {
     throw new Error("Invalid emitter-package.json");
   }
-  const languages: string[] = ["@azure-tools/typespec-", "@typespec/http-", "@typespec/openapi3", "@azure-typespec/"];
-  for (const lang of languages) {
+  for (const lang of EMITTER_PREFIXES) {
     const emitter = Object.keys(obj.dependencies).find((dep: string) => dep.startsWith(lang));
     if (emitter) {
       Logger.info(`Found emitter package ${emitter}@${obj.dependencies[emitter]}`);

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -128,7 +128,7 @@ export async function compileTsp({
       if (typeof value === "object") {
         value = JSON.stringify(value);
       }
-      return `--option ${key}=${value}`;
+      return `--option ${emitterPackage}.${key}=${value}`;
     })
     .join(" ");
 

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -7,6 +7,7 @@ import {
 import { Logger } from "./log.js";
 import { readFile, readdir, realpath, stat } from "fs/promises";
 import { pathToFileURL } from "url";
+import { EMITTER_PREFIXES } from "./utils.js";
 
 export interface TspLocation {
   directory: string;
@@ -103,8 +104,11 @@ export async function compileTsp({
   }
   if (additionalEmitterOptions) {
     additionalEmitterOptions.split(";").forEach((option) => {
-      const [key, value] = option.split("=");
+      let [key, value] = option.split("=");
       if (key && value) {
+        if (EMITTER_PREFIXES.some((prefix) => key?.startsWith(prefix))) {
+          key = key.split(".")[1]!;
+        }
         emitterOverrideOptions[key] = value;
       }
     });

--- a/tools/tsp-client/src/utils.ts
+++ b/tools/tsp-client/src/utils.ts
@@ -7,6 +7,13 @@ import { Logger } from "./log.js";
 import { TspLocation } from "./typespec.js";
 import { normalizeDirectory } from "./fs.js";
 
+export const EMITTER_PREFIXES = [
+  "@azure-tools/typespec-",
+  "@typespec/http-",
+  "@typespec/openapi3",
+  "@azure-typespec/",
+];
+
 export function formatAdditionalDirectories(additionalDirectories?: string[]): string {
   let additionalDirOutput = "\n";
   for (const dir of additionalDirectories ?? []) {


### PR DESCRIPTION
- Correct example command printing
- Make prefixes a global var to reuse as necessary