### PR TITLE
Spec agent workflow MCP bug fixes

### DIFF
--- a/tools/mcp/dotnet/AzureSDKDevToolsMCP/Models/ReleasePlan.cs
+++ b/tools/mcp/dotnet/AzureSDKDevToolsMCP/Models/ReleasePlan.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using Microsoft.VisualStudio.Services.WebApi.Patch;
-using Microsoft.VisualStudio.Services.WebApi.Patch.Json;
+using DevOpsPatch = Microsoft.VisualStudio.Services.WebApi.Patch;
+using DevOpsPatchJson = Microsoft.VisualStudio.Services.WebApi.Patch.Json;
 
 namespace AzureSDKDSpecTools.Models
 {
@@ -27,49 +27,49 @@ namespace AzureSDKDSpecTools.Models
         public string SpecType {  get; set; } = string.Empty;
         public List<SDKGenerationInfo> SDKGenerationInfos { get; set; } = [];
 
-        public JsonPatchDocument GetPatchDocument()
+        public DevOpsPatchJson.JsonPatchDocument GetPatchDocument()
         {
-            var jsonDocument = new JsonPatchDocument()
+            var jsonDocument = new DevOpsPatchJson.JsonPatchDocument()
             {
-                new JsonPatchOperation
+                new DevOpsPatchJson.JsonPatchOperation
                 {
-                    Operation = Operation.Add,
+                    Operation = DevOpsPatch.Operation.Add,
                     Path = "/fields/Custom.ServiceTreeID",
                     Value = ServiceTreeId
                 },
-                new JsonPatchOperation
+                new DevOpsPatchJson.JsonPatchOperation
                 {
-                    Operation = Operation.Add,
+                    Operation = DevOpsPatch.Operation.Add,
                     Path = "/fields/Custom.ProductServiceTreeID",
                     Value = ProductTreeId
                 },
-                new JsonPatchOperation
+                new DevOpsPatchJson.JsonPatchOperation
                 {
-                    Operation = Operation.Add,
+                    Operation = DevOpsPatch.Operation.Add,
                     Path = "/fields/Custom.SDKReleaseMonth",
                     Value = SDKReleaseMonth
                 },
-                new JsonPatchOperation
+                new DevOpsPatchJson.JsonPatchOperation
                 {
-                    Operation = Operation.Add,
+                    Operation = DevOpsPatch.Operation.Add,
                     Path = "/fields/Custom.MgmtScope",
                     Value = IsManagementPlane ? "Yes" : "No"
                 },
-                new JsonPatchOperation
+                new DevOpsPatchJson.JsonPatchOperation
                 {
-                    Operation = Operation.Add,
+                    Operation = DevOpsPatch.Operation.Add,
                     Path = "/fields/Custom.DataScope",
                     Value = IsDataPlane ? "Yes" : "No"
                 },
-                new JsonPatchOperation
+                new DevOpsPatchJson.JsonPatchOperation
                 {
-                    Operation = Operation.Add,
+                    Operation = DevOpsPatch.Operation.Add,
                     Path = "/fields/Custom.APISpecDefinitionType",
                     Value = SpecType
                 },
-                new JsonPatchOperation
+                new DevOpsPatchJson.JsonPatchOperation
                 {
-                    Operation = Operation.Add,
+                    Operation = DevOpsPatch.Operation.Add,
                     Path = "/fields/Custom.APISpecversion",
                     Value = SpecAPIVersion
                 }

--- a/tools/mcp/dotnet/AzureSDKDevToolsMCP/Services/DevOpsService.cs
+++ b/tools/mcp/dotnet/AzureSDKDevToolsMCP/Services/DevOpsService.cs
@@ -310,18 +310,22 @@ namespace AzureSDKDSpecTools.Services
 
         private static string MapLanguageToId(string language)
         {
-            return language switch
+            var lang = language.ToLower();
+            return lang switch
             {
-                ".NET" => "Dotnet",
+                ".net" => "Dotnet",
+                "csharp" => "Dotnet",
+                "js" => "JavaScript",
                 _ => language
             };
         }
 
         private static string MapLanguageIdToName(string language)
         {
+            var lang = language.ToLower();
             return language switch
             {
-                "Dotnet" => ".NET",
+                "dotnet" => ".NET",
                 _ => language
             };
         }

--- a/tools/mcp/dotnet/AzureSDKDevToolsMCP/Tools/ReleasePlanTool.cs
+++ b/tools/mcp/dotnet/AzureSDKDevToolsMCP/Tools/ReleasePlanTool.cs
@@ -65,9 +65,9 @@ namespace AzureSDKDSpecTools.Tools
 
                 var specType = typeSpecHelper.IsValidTypeSpecProjectPath(typeSpecProjectPath)? "TypeSpec" : "OpenAPI";
                 var isMgmt = typeSpecHelper.IsTypeSpecProjectForMgmtPlane(typeSpecProjectPath);
-
+                var repoRootPath = typeSpecHelper.GetSpecRepoRootPath(typeSpecProjectPath);
                 // Ensure a release plan is created only if the API specs pull request is in a public repository.
-                if (!typeSpecHelper.IsRepoPathForPublicSpecRepo(typeSpecProjectPath))
+                if (!typeSpecHelper.IsRepoPathForPublicSpecRepo(repoRootPath))
                 {
                     return """
                         SDK generation and release require the API specs pull request to be in the public azure-rest-api-specs repository.

--- a/tools/mcp/dotnet/AzureSDKSpecToolTests/ReleasePlanTest.cs
+++ b/tools/mcp/dotnet/AzureSDKSpecToolTests/ReleasePlanTest.cs
@@ -19,17 +19,16 @@ namespace AzureSDKSpecToolTests
             devOpsService = new DevOpsService(logger, new DevOpsConnection());
         }
 
-        [Fact]
+        [Fact (Skip = "Disabled for default run.")]
         public async Task GetReleasePlanTest()
         {
             var releasePlan = await devOpsService.GetReleasePlan(26960);
-            await devOpsService.GetPipelineRun(4813417);
             Assert.NotNull(releasePlan);
             Assert.Equal(26960, releasePlan.WorkItemId);
             Assert.True(!string.IsNullOrEmpty(releasePlan.Title));
         }
 
-        [Fact]
+        [Fact (Skip = "Disabled for default run test since it uses an actual PR link")]
         public async Task GetReleasePlansForServicePrductTest()
         {
             var pr = "https://github.com/Azure/azure-rest-api-specs/pull/32282";


### PR DESCRIPTION
Bug fix to use correct repo root when check whether spec changes are in public or private repo and also  resolve namespace collision