### PR TITLE
Update approve script to work with both sync PR types

### DIFF
--- a/eng/scripts/Approve-Eng-Common-Sync-PRs.ps1
+++ b/eng/scripts/Approve-Eng-Common-Sync-PRs.ps1
@@ -3,7 +3,7 @@
 [CmdletBinding(SupportsShouldProcess = $true)]
 param(
   [Parameter(Mandatory = $true)]
-  [string] $engCommonSyncPRNumber
+  [string] $ToolsPRNumber
 )
 
 . "${PSScriptRoot}/../common/scripts/logging.ps1"
@@ -16,42 +16,45 @@ if ($LASTEXITCODE -ne 0) {
   exit 1
 }
 
+$ToolsRepo = "Azure/azure-sdk-tools"
+
 $ghloggedInUser = (gh api user -q .login)
-$engCommonToolsBranch = gh pr view $engCommonSyncPRNumber -R Azure/azure-sdk-tools --json "headRefName" --jq ".headRefName"
+# Get a temp access token from the logged in az cli user for azure devops resource
+$jwt_accessToken = (az account get-access-token --resource "499b84ac-1321-427f-aa17-267ca6975798" --query "accessToken" --output tsv)
+$headers = @{ Authorization = "Bearer $jwt_accessToken" }
 
-if (!$engCommonToolsBranch) {
-  Write-Error "Didn't find branch for PR $engCommonSyncPRNumber in Azure/azure-sdk-tools"
-  exit 1
+$checks = gh pr checks $ToolsPRNumber -R $ToolsRepo --json "name,link" | ConvertFrom-Json
+$syncChecks = $checks | Where-Object { $_.name -match "azure-sdk-tools - sync - [^(]*$" }
+$prList = @()
+
+foreach ($check in $syncChecks) {
+  Write-Host "Gathering PRs from check [$($check.name)]'$($check.link)'"
+
+  $devOpsBuild = $check.link -replace "_build/results\?buildId=(\d+)", "_apis/build/builds/`$1/artifacts?artifactName=pullrequestdata"
+  try {
+    $response = Invoke-RestMethod $devOpsBuild -Headers $headers
+    $artifactDownload = $response.resource.downloadUrl
+    $PrsCreatedContent = Invoke-RestMethod $artifactDownload.Replace("format=zip","format=file&subPath=/PRsCreated.txt") -headers $headers
+    if ($PrsCreatedContent) {
+      $PrsCreatedContent = $PrsCreatedContent.Split("`n") | Where-Object { $_ }
+      foreach ($line in $PrsCreatedContent) {
+        $repoOwner, $repoName, $Number = $line.Trim().Split(";")
+        $prList += @{ RepoOwner = $repoOwner; RepoName = $repoName; Number = $Number; Repo = "$repoOwner/$repoName" }
+      }
+    }
+  } catch {
+    Write-Host "Failed while processing '$devOpsBuild'. $_"
+    continue
+  }
 }
 
-# needs to remain in sync with \eng\pipelines\templates\stages\archetype-sdk-tool-repo-sync.yml
-$engCommonSyncBranch = "sync-eng/common-${engCommonToolsBranch}-${engCommonSyncPRNumber}"
-
-# needs to remain in sync with  \eng\pipelines\eng-common-sync.yml
-$repos = @(
-  "azure-sdk",
-  "azure-sdk-for-android",
-  "azure-sdk-for-c",
-  "azure-sdk-for-cpp",
-  "azure-sdk-for-go",
-  "azure-sdk-for-ios",
-  "azure-sdk-for-java",
-  "azure-sdk-for-js",
-  "azure-sdk-for-net",
-  "azure-sdk-for-python",
-  "azure-sdk-for-rust",
-  "azure-rest-api-specs"
-)
-
-$owner = "Azure"
-
-function getPRState([string]$owner, [string]$repo) {
+function getPRState($pr) {
   $prFields = "number,url,state,headRefOid,mergeable,mergeStateStatus,reviews"
-  return gh pr view $engCommonSyncBranch -R $owner/$repo --json $prFields | ConvertFrom-Json
+  return gh pr view $pr.Number -R $pr.Repo --json $prFields | ConvertFrom-Json
 }
 
-foreach ($repo in $repos) {
-  $prstate = getPRState $owner $repo
+foreach ($pr in $prList) {
+  $prstate = getPRState $pr
 
   Write-Host "$($prstate.url) - " -NoNewline
   if ($prstate.state -eq "MERGED") {
@@ -59,23 +62,23 @@ foreach ($repo in $repos) {
     continue
   }
 
-  $commitDateString = (gh pr view $engCommonSyncBranch -R "${owner}/${repo}" --json "commits" --jq ".commits[-1].committedDate")
+  $commitDateString = (gh pr view $ToolsPRNumber -R $ToolsRepo --json "commits" --jq ".commits[-1].committedDate")
   $latestCommitDate = ([datetime]$commitDateString).ToUniversalTime()
   $approvalAfterCommit = $prstate.reviews | Where-Object { $_.state -eq "APPROVED" -and $_.submittedAt -gt $latestCommitDate }
 
   if (!$approvalAfterCommit -or $prstate.reviews.author.login -notcontains $ghloggedInUser) {
-    gh pr review $engCommonSyncBranch -R "${owner}/${repo}" --approve
+    gh pr review $pr.Number -R $pr.Repo --approve
     # Refresh after re-approval
-    $prstate = getPRState $owner $repo
+    $prstate = getPRState $pr
   }
   else {
     Write-Host "Already approved"
   }
 
   if ($prstate.mergeStateStatus -eq "BLOCKED") {
-    $resolved = TryResolveAIReviewThreads -repoOwner $owner -repoName $repo -prNumber $prstate.number
+    $resolved = TryResolveAIReviewThreads -repoOwner $pr.RepoOwner -repoName $pr.RepoName -prNumber $prstate.number
     if ($resolved) {
-      $prstate = getPRState $owner $repo
+      $prstate = getPRState $pr
     }
   }
 

--- a/eng/scripts/Approve-Eng-Common-Sync-PRs.ps1
+++ b/eng/scripts/Approve-Eng-Common-Sync-PRs.ps1
@@ -6,6 +6,8 @@ param(
   [string] $ToolsPRNumber
 )
 
+$PSNativeCommandUseErrorActionPreference = $true
+
 . "${PSScriptRoot}/../common/scripts/logging.ps1"
 . "${PSScriptRoot}/../common/scripts/Helpers/git-helpers.ps1"
 


### PR DESCRIPTION
This updates the approval script to pull the sync PR data from the pipeline and then use that. This will enable us to use it for both eng/common and workflow syncs and even PRs that have both. 