### PR TITLE
HtmlDecode hrefs in Verify-Links.ps1

### DIFF
--- a/eng/common/scripts/Verify-Links.ps1
+++ b/eng/common/scripts/Verify-Links.ps1
@@ -263,14 +263,14 @@ function ParseLinks([string]$baseUri, [string]$htmlContent)
   $hrefRegex = "<a[^>]+href\s*=\s*[""']?(?<href>[^""']*)[""']?"
   $regexOptions = [System.Text.RegularExpressions.RegexOptions]"Singleline, IgnoreCase";
 
-  $hrefs = [RegEx]::Matches($htmlContent, $hrefRegex, $regexOptions);
+  $matches = [RegEx]::Matches($htmlContent, $hrefRegex, $regexOptions);
 
-  #$hrefs | Foreach-Object { Write-Host $_ }
+  Write-Verbose "Found $($matches.Count) raw href's in page $baseUri";
 
-  Write-Verbose "Found $($hrefs.Count) raw href's in page $baseUri";
-  [string[]] $links = $hrefs | ForEach-Object { ResolveUri $baseUri $_.Groups["href"].Value }
+  # Html encoded urls in anchor hrefs need to be decoded
+  $urls = $matches | ForEach-Object { [System.Web.HttpUtility]::HtmlDecode($_.Groups["href"].Value) }
 
-  #$links | Foreach-Object { Write-Host $_ }
+  [string[]] $links = $urls | ForEach-Object { ResolveUri $baseUri $_ }
 
   if ($null -eq $links) {
     $links = @()


### PR DESCRIPTION
fixes #10601

In html, attribute values are encoded and should be decoded before use.  If not decoded using `[HttpUtility]::HtmlDecode()`, the url is incorrect and the server should not be expected to process it correctly.

In powershell, the markdown

```md
[example](https://dev.azure.com/azure-sdk/public/_build?view=branches&definitionId=7050)
```

is converted to the html

```html
<a href="https://dev.azure.com/azure-sdk/public/_build?view=branches&amp;definitionId=7050">Example</a>
```

which is regex parsed to 

```
https://dev.azure.com/azure-sdk/public/_build?view=branches&amp;definitionId=7050
```

and needs to be HtmlDecoded to

```
https://dev.azure.com/azure-sdk/public/_build?view=branches&definitionId=7050
```
