### PR TITLE
[APIView Copilot] Add outline and target_id to request payload

### DIFF
--- a/packages/python-packages/apiview-copilot/app.py
+++ b/packages/python-packages/apiview-copilot/app.py
@@ -43,7 +43,9 @@ def api_reviewer(language: str):
         data = request.get_json()
 
         target_apiview = data.get("target", None)
+        target_id = data.get("target_id", None)
         base_apiview = data.get("base", None)
+        outline = data.get("outline", None)
 
         if not target_apiview:
             logger.warning("No API content provided in the request")
@@ -52,7 +54,7 @@ def api_reviewer(language: str):
         logger.info(f"Processing {language} API review")
 
         # Create reviewer and get response
-        reviewer = ApiViewReview(language=language, target=target_apiview, base=base_apiview)
+        reviewer = ApiViewReview(language=language, target=target_apiview, base=base_apiview, outline=outline)
         result = reviewer.run()
         reviewer.close()
 
@@ -63,6 +65,9 @@ def api_reviewer(language: str):
                 logger.error(f"Error log contents:\n{error_message}")
 
         logger.info("API review completed successfully")
+
+        # TODO: Add logic to post comments to the target_id, if provided
+
         return jsonify(json.loads(result.model_dump_json()))
 
     except Exception as e:

--- a/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
@@ -85,6 +85,7 @@ class ApiViewReview:
         base: Optional[str],
         *,
         language: str,
+        outline: Optional[str] = None,
         use_rag: bool = DEFAULT_USE_RAG,
     ):
         self.target = self._unescape(target)
@@ -99,7 +100,7 @@ class ApiViewReview:
         static_guideline_ids = [x["id"] for x in self.search.static_guidelines]
         self.results = ReviewResult(guideline_ids=static_guideline_ids, comments=[])
         self.summary = None
-        self.outline = None
+        self.outline = outline
         self.executor = concurrent.futures.ThreadPoolExecutor()
 
     def __del__(self):


### PR DESCRIPTION
Closes #10623.

Adding "outline" will allow us to get rid of the workaround "generate_outline" prompt once it is being sent.

Adding "target_id" will allow us to post comments to APIView directly instead of returning a JSON payload that it uses to post the comments. This is desired because the APIView web side is sometimes failing when the Flask service is successful. 