### PR TITLE
[Branch Cleanup, main-to-live] Migrate docs repos

### DIFF
--- a/eng/pipelines/branch-cleanup.yml
+++ b/eng/pipelines/branch-cleanup.yml
@@ -46,10 +46,10 @@ parameters:
 - name: DailyBranchRepos
   type: object
   default:
-    - Azure/azure-docs-sdk-dotnet
-    - Azure/azure-docs-sdk-java
     - MicrosoftDocs/azure-docs-sdk-node
     - MicrosoftDocs/azure-docs-sdk-python
+    - MicrosoftDocs/azure-docs-sdk-java
+    - MicrosoftDocs/azure-docs-sdk-net
 
 - name: RestAPISpecsDocsRepos
   type: object

--- a/eng/pipelines/merge-docs-main-to-live.yml
+++ b/eng/pipelines/merge-docs-main-to-live.yml
@@ -7,10 +7,10 @@ parameters:
   type: object
   default:
     - RepoName: azure-docs-sdk-dotnet
-      RepoOwner: Azure
+      RepoOwner: MicrosoftDocs
       AllowlistPath: docsms-allowlist/dotnet-allowlist.txt
     - RepoName: azure-docs-sdk-java
-      RepoOwner: Azure
+      RepoOwner: MicrosoftDocs
       AllowlistPath: docsms-allowlist/java-allowlist.txt
     - RepoName: azure-docs-sdk-python
       RepoOwner: MicrosoftDocs


### PR DESCRIPTION
Fixes #10067
Fixes #10599

Original instructions say to keep Azure/* repos around but the whole repo is changing orgs so those repos would get redirected from Azure to MicrosoftDocs and the work would be duplicated