### PR TITLE
Consider PackageVersion when Comparing APIRevision for Auto APIReviews

### DIFF
--- a/src/dotnet/APIView/APIViewUnitTests/AzureEngSemanticVersionTests.cs
+++ b/src/dotnet/APIView/APIViewUnitTests/AzureEngSemanticVersionTests.cs
@@ -1,0 +1,85 @@
+using System.Collections.Generic;
+using Xunit;
+
+namespace APIViewUnitTests
+{
+    public class AzureEngSemanticVersionTests
+    {
+        [Fact]
+        public void SortVersionStrings_ShouldSortCorrectly()
+        {
+            var versions = new List<string>
+        {
+            "1.0.1",
+            "2.0.0",
+            "2.0.0-alpha.20200920",
+            "2.0.0-alpha.20200920.1",
+            "2.0.0-beta.2",
+            "1.0.10",
+            "2.0.0-alpha.20201221.03",
+            "2.0.0-alpha.20201221.1",
+            "2.0.0-alpha.20201221.5",
+            "2.0.0-alpha.20201221.2",
+            "2.0.0-alpha.20201221.10",
+            "2.0.0-beta.1",
+            "2.0.0-beta.10",
+            "1.0.0",
+            "1.0.0b2",
+            "1.0.2"
+        };
+
+            var expectedSort = new List<string>
+        {
+            "2.0.0",
+            "2.0.0-beta.10",
+            "2.0.0-beta.2",
+            "2.0.0-beta.1",
+            "2.0.0-alpha.20201221.10",
+            "2.0.0-alpha.20201221.5",
+            "2.0.0-alpha.20201221.03",
+            "2.0.0-alpha.20201221.2",
+            "2.0.0-alpha.20201221.1",
+            "2.0.0-alpha.20200920.1",
+            "2.0.0-alpha.20200920",
+            "1.0.10",
+            "1.0.2",
+            "1.0.1",
+            "1.0.0",
+            "1.0.0b2"
+        };
+
+            var sortedVersions = AzureEngSemanticVersion.SortVersionStrings(versions);
+            Assert.Equal(expectedSort, sortedVersions);
+        }
+
+        [Fact]
+        public void ParseAlphaVersion_ShouldParseCorrectly()
+        {
+            var alphaVerString = "1.2.3-alpha.20200828.9";
+            var alphaVer = new AzureEngSemanticVersion(alphaVerString);
+            Assert.True(alphaVer.IsPrerelease);
+            Assert.Equal(1, alphaVer.Major);
+            Assert.Equal(2, alphaVer.Minor);
+            Assert.Equal(3, alphaVer.Patch);
+            Assert.Equal("alpha", alphaVer.PrereleaseLabel);
+            Assert.Equal(20200828, alphaVer.PrereleaseNumber);
+            Assert.Equal("9", alphaVer.BuildNumber);
+            Assert.Equal(alphaVerString, alphaVer.ToString());
+        }
+
+        [Fact]
+        public void ParsePythonAlphaVersion_ShouldParseCorrectly()
+        {
+            var pythonAlphaVerString = "1.2.3a20200828009";
+            var pythonAlphaVer = new AzureEngSemanticVersion(pythonAlphaVerString, "python");
+            Assert.True(pythonAlphaVer.IsPrerelease);
+            Assert.Equal(1, pythonAlphaVer.Major);
+            Assert.Equal(2, pythonAlphaVer.Minor);
+            Assert.Equal(3, pythonAlphaVer.Patch);
+            Assert.Equal("a", pythonAlphaVer.PrereleaseLabel);
+            Assert.Equal(20200828, pythonAlphaVer.PrereleaseNumber);
+            Assert.Equal("009", pythonAlphaVer.BuildNumber);
+            Assert.Equal(pythonAlphaVerString, pythonAlphaVer.ToString());
+        }
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
+++ b/src/dotnet/APIView/APIViewWeb/Controllers/AutoReviewController.cs
@@ -209,18 +209,21 @@ namespace APIViewWeb.Controllers
                         // But any manual pipeline run at release time should compare against all approved revisions to ensure hotfix release doesn't have API change
                         // If review surface doesn't match with any approved revisions then we will create new revision if it doesn't match pending latest revision
 
+                        var packageSemVer = new AzureEngSemanticVersion(codeFile.PackageVersion, codeFile.Language);
+                        var considerPackageVersion = (!packageSemVer.IsPrerelease) ? true : false;
+
                         if (compareAllRevisions)
                         {
                             foreach (var approvedAPIRevision in automaticRevisions.Where(r => r.IsApproved))
                             {
-                                if (await _apiRevisionsManager.AreAPIRevisionsTheSame(approvedAPIRevision, renderedCodeFile))
+                                if (await _apiRevisionsManager.AreAPIRevisionsTheSame(approvedAPIRevision, renderedCodeFile, considerPackageVersion))
                                 {
                                     return (review, approvedAPIRevision);
                                 }
                             }
                         }
 
-                        if (await _apiRevisionsManager.AreAPIRevisionsTheSame(latestAutomaticAPIRevision, renderedCodeFile))
+                        if (await _apiRevisionsManager.AreAPIRevisionsTheSame(latestAutomaticAPIRevision, renderedCodeFile, considerPackageVersion))
                         {
                             apiRevision = latestAutomaticAPIRevision;
                             createNewRevision = false;

--- a/src/dotnet/APIView/APIViewWeb/Helpers/AzureEngSemanticVersion.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/AzureEngSemanticVersion.cs
@@ -1,0 +1,166 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+// Ported from https://github.com/Azure/azure-sdk-tools/blob/main/eng/common/scripts/SemVer.ps1
+public class AzureEngSemanticVersion : IComparable<AzureEngSemanticVersion>
+{
+    private static readonly Regex SemVerRegex = new Regex(
+        @"^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)(?:(?<presep>-?)(?<prelabel>[a-zA-Z]+)(?:(?<prenumsep>\.?)(?<prenumber>[0-9]{1,8})(?:(?<buildnumsep>\.?)(?<buildnumber>\d{1,3}))?)?)?$",
+        RegexOptions.Compiled);
+
+    public int Major { get; private set; }
+    public int Minor { get; private set; }
+    public int Patch { get; private set; }
+    public string PrereleaseLabelSeparator { get; private set; } = string.Empty;
+    public string PrereleaseLabel { get; private set; } = string.Empty;
+    public string PrereleaseNumberSeparator { get; private set; } = string.Empty;
+    public string BuildNumberSeparator { get; private set; } = string.Empty;
+    public string BuildNumber { get; private set; } = string.Empty;
+    public int PrereleaseNumber { get; private set; }
+    public bool IsPrerelease { get; private set; }
+    public string VersionType { get; private set; } = string.Empty;
+    public string RawVersion { get; private set; }
+    public bool IsSemVerFormat { get; private set; }
+    public string DefaultPrereleaseLabel { get; private set; } = string.Empty;
+    public string DefaultAlphaReleaseLabel { get; private set; } = string.Empty;
+
+    public AzureEngSemanticVersion(string version, string language = null)
+    {
+        RawVersion = version;
+        var match = SemVerRegex.Match(version);
+
+        if (match.Success)
+        {
+            IsSemVerFormat = true;
+
+            Major = int.Parse(match.Groups["major"].Value);
+            Minor = int.Parse(match.Groups["minor"].Value);
+            Patch = int.Parse(match.Groups["patch"].Value);
+
+            if (language == "Python")
+            {
+                SetupPythonConventions();
+            }
+            else
+            {
+                SetupDefaultConventions();
+            }
+
+            if (match.Groups["prelabel"].Success)
+            {
+                PrereleaseLabel = match.Groups["prelabel"].Value;
+                PrereleaseLabelSeparator = match.Groups["presep"].Value;
+                PrereleaseNumber = match.Groups["prenumber"].Success ? int.Parse(match.Groups["prenumber"].Value) : 0;
+                PrereleaseNumberSeparator = match.Groups["prenumsep"].Value;
+                IsPrerelease = true;
+                VersionType = "Beta";
+                BuildNumberSeparator = match.Groups["buildnumsep"].Value;
+                BuildNumber = match.Groups["buildnumber"].Success ? match.Groups["buildnumber"].Value : string.Empty;
+            }
+            else
+            {
+                // Artificially provide these values for non-prereleases to enable easy sorting of them later than prereleases.
+                PrereleaseLabel = "zzz";
+                PrereleaseNumber = 99999999;
+                IsPrerelease = false;
+                VersionType = "GA";
+
+                if (Major == 0)
+                {
+                    // Treat initial 0 versions as prerelease beta's
+                    VersionType = "Beta";
+                    IsPrerelease = true;
+                }
+                else if (Patch != 0)
+                {
+                    VersionType = "Patch";
+                }
+            }
+        }
+        else
+        {
+            IsSemVerFormat = false;
+        }
+    }
+
+    private void SetupPythonConventions()
+    {
+        PrereleaseLabelSeparator = string.Empty;
+        PrereleaseNumberSeparator = string.Empty;
+        BuildNumberSeparator = string.Empty;
+        DefaultPrereleaseLabel = "b";
+        DefaultAlphaReleaseLabel = "a";
+    }
+
+    private void SetupDefaultConventions()
+    {
+        PrereleaseLabelSeparator = "-";
+        PrereleaseNumberSeparator = ".";
+        BuildNumberSeparator = ".";
+        DefaultPrereleaseLabel = "beta";
+        DefaultAlphaReleaseLabel = "alpha";
+    }
+
+    public override string ToString()
+    {
+        string versionString = $"{Major}.{Minor}.{Patch}";
+
+        if (!string.IsNullOrEmpty(PrereleaseLabel))
+        {
+            versionString += $"{PrereleaseLabelSeparator}{PrereleaseLabel}{PrereleaseNumberSeparator}{PrereleaseNumber}";
+            if (!string.IsNullOrEmpty(BuildNumber))
+            {
+                versionString += $"{BuildNumberSeparator}{BuildNumber}";
+            }
+        }
+
+        return versionString;
+    }
+
+    /// <summary>
+    /// Compares this version with another version. Implemented for descending order sorting.
+    /// </summary>
+    /// <param name="other"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public int CompareTo(AzureEngSemanticVersion other)
+    {
+        if (other == null)
+        {
+            throw new ArgumentNullException(nameof(other));
+        }
+
+        int ret = other.Major.CompareTo(this.Major);
+        if (ret != 0) return ret;
+
+        ret = other.Minor.CompareTo(this.Minor); 
+        if (ret != 0) return ret;
+
+        ret = other.Patch.CompareTo(this.Patch);
+        if (ret != 0) return ret;
+
+        string thisPrereleaseLabel = this.PrereleaseLabel ?? "zzz";
+        string otherPrereleaseLabel = other.PrereleaseLabel ?? "zzz";
+        ret = string.Compare(otherPrereleaseLabel, thisPrereleaseLabel, StringComparison.OrdinalIgnoreCase);
+        if (ret != 0) return ret;
+
+        ret = other.PrereleaseNumber.CompareTo(this.PrereleaseNumber);
+        if (ret != 0) return ret;
+
+        int thisBuildNumber = string.IsNullOrEmpty(this.BuildNumber) ? 0 : int.Parse(this.BuildNumber);
+        int otherBuildNumber = string.IsNullOrEmpty(other.BuildNumber) ? 0 : int.Parse(other.BuildNumber);
+        return otherBuildNumber.CompareTo(thisBuildNumber);
+    }
+
+    public static List<string> SortVersionStrings(IEnumerable<string> versionStrings)
+    {
+        var versions = versionStrings
+            .Select(v => new AzureEngSemanticVersion(v))
+            .Where(v => v != null)
+            .ToList();
+        versions.Sort();
+        return versions.Select(v => v.RawVersion).ToList();
+    }
+}

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -711,12 +711,18 @@ namespace APIViewWeb.Managers
         /// </summary>
         /// <param name="revision"></param>
         /// <param name="renderedCodeFile"></param>
+        /// <param name="considerPackageVersion"></param>
         /// <returns></returns>
-        public async Task<bool> AreAPIRevisionsTheSame(APIRevisionListItemModel revision, RenderedCodeFile renderedCodeFile)
+        public async Task<bool> AreAPIRevisionsTheSame(APIRevisionListItemModel revision, RenderedCodeFile renderedCodeFile, bool considerPackageVersion = false)
         {
             //This will compare and check if new code file content is same as revision in parameter
             var lastRevisionFile = await _codeFileRepository.GetCodeFileAsync(revision, false);
-            return _codeFileManager.AreAPICodeFilesTheSame(codeFileA: lastRevisionFile, codeFileB: renderedCodeFile);
+            var result = _codeFileManager.AreAPICodeFilesTheSame(codeFileA: lastRevisionFile, codeFileB: renderedCodeFile);
+            if (considerPackageVersion)
+            {
+                return result && lastRevisionFile.CodeFile.PackageVersion == renderedCodeFile.CodeFile.PackageVersion;
+            }
+            return result;
         }
 
         /// <summary>

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -31,7 +31,7 @@ namespace APIViewWeb.Managers.Interfaces
         public Task SoftDeleteAPIRevisionAsync(APIRevisionListItemModel apiRevision, string userName = "azure-sdk", string notes = "");
         public Task RestoreAPIRevisionAsync(ClaimsPrincipal user, string reviewId, string revisionId);
         public Task UpdateAPIRevisionLabelAsync(ClaimsPrincipal user, string revisionId, string label);
-        public Task<bool> AreAPIRevisionsTheSame(APIRevisionListItemModel apiRevision, RenderedCodeFile renderedCodeFile);
+        public Task<bool> AreAPIRevisionsTheSame(APIRevisionListItemModel apiRevision, RenderedCodeFile renderedCodeFile, bool considerPackageVersion = false);
         public Task UpdateAPIRevisionCodeFileAsync(string repoName, string buildId, string artifact, string project);
         public Task GetLineNumbersOfHeadingsOfSectionsWithDiff(string reviewId, APIRevisionListItemModel apiRevision, IEnumerable<APIRevisionListItemModel> apiRevisions = null);
         public TreeNode<InlineDiffLine<CodeLine>> ComputeSectionDiff(TreeNode<CodeLine> before, TreeNode<CodeLine> after, RenderedCodeFile beforeFile, RenderedCodeFile afterFile);


### PR DESCRIPTION
- Add `AzureEngSemanticVersion` for parsing packageVersions.
- Consider PackageVersion when comparing APIRevision in AutoReviewController when the incoming APIRevision is not PreRelease

Should resolve https://github.com/Azure/azure-sdk-tools/issues/9594