### PR TITLE
Ensure that we log the actual `serviceDirectories` when tagging a PR build

### DIFF
--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -41,20 +41,6 @@ steps:
           pwsh: true
           workingDirectory: '${{ parameters.WorkingDirectory }}'
 
-      # When running in PR mode, we want the detected changed services to be attached to the build as tags.
-      # However, the public identity does not have the permissions to attach tags to the build.
-      # Instead, we will save the changed services to a file, attach it as an attachment for PiplineWitness to pick up and utilize.
-      - pwsh: |
-          $changedServices = (Get-Content -Path '${{ parameters.DiffDirectory }}/diff.json' -Raw | ConvertFrom-Json).ChangedServices
-
-          if ($changedServices) {
-            Write-Host "Attaching changed service names to the build for additional tag generation."
-            $changedServices | ConvertTo-Json -AsArray | Out-File -FilePath $(System.DefaultWorkingDirectory)/tags.json -Encoding utf8
-            Write-Host '##vso[task.addattachment type=AdditionalTags;name=AdditionalTags;]$(System.DefaultWorkingDirectory)/tags.json'
-          }
-        displayName: Upload tags.json with changed services
-        workingDirectory: '${{ parameters.WorkingDirectory }}'
-
       - task: Powershell@2
         displayName: Save package properties filtered for PR
         inputs:
@@ -64,6 +50,26 @@ steps:
             -OutDirectory '${{ parameters.PackageInfoDirectory }}'
           pwsh: true
           workingDirectory: '${{ parameters.WorkingDirectory }}'
+
+      # When running in PR mode, we want the detected changed services to be attached to the build as tags.
+      # However, the public identity does not have the permissions to attach tags to the build.
+      # Instead, we will save the changed services to a file, attach it as an attachment for PiplineWitness to pick up and utilize.
+      #
+      - pwsh: |
+          $changedPackages = Get-Content -R -Filter *.json "${{ parameters.PackageInfoDirectory }}" `
+            | ForEach-Object { Get-Content -Raw $_ | ConvertFrom-Json }
+
+          $changedServices = $changedPackages | Where-Object { $_.IncludedForValidation -eq $false } `
+            | Select-Object -ExpandProperty ServiceDirectory | Sort-Object -Unique
+
+          if ($changedServices) {
+            Write-Host "Attaching changed service names to the build for additional tag generation."
+            $changedServices | ConvertTo-Json -AsArray | Out-File -FilePath $(System.DefaultWorkingDirectory)/tags.json -Encoding utf8
+            Write-Host '##vso[task.addattachment type=AdditionalTags;name=AdditionalTags;]$(System.DefaultWorkingDirectory)/tags.json'
+          }
+        displayName: Upload tags.json with changed services
+        workingDirectory: '${{ parameters.WorkingDirectory }}'
+
   - ${{ else }}:
       - task: Powershell@2
         displayName: Save package properties

--- a/eng/common/pipelines/templates/steps/save-package-properties.yml
+++ b/eng/common/pipelines/templates/steps/save-package-properties.yml
@@ -56,7 +56,7 @@ steps:
       # Instead, we will save the changed services to a file, attach it as an attachment for PiplineWitness to pick up and utilize.
       #
       - pwsh: |
-          $changedPackages = Get-Content -R -Filter *.json "${{ parameters.PackageInfoDirectory }}" `
+          $changedPackages = Get-ChildItem -Recurse -Filter *.json "${{ parameters.PackageInfoDirectory }}" `
             | ForEach-Object { Get-Content -Raw $_ | ConvertFrom-Json }
 
           $changedServices = $changedPackages | Where-Object { $_.IncludedForValidation -eq $false } `


### PR DESCRIPTION
for `go` especially the `ServiceDirectory` of each package doesn't necessarily align with the `sdk/<X>` pattern that we currently fill for `ChangedServices`.

Just updating this to use the generated package props Service Directories, which WILL reflect this reality.

FYI @benbp doing the needful from our convo.