### PR TITLE
Check status on all PRs on retry not just the ones that failed.

### DIFF
--- a/eng/scripts/Verify-And-Merge-PRs.ps1
+++ b/eng/scripts/Verify-And-Merge-PRs.ps1
@@ -40,7 +40,7 @@ function ProcessPRMergeStatuses([array]$prData, [switch]$noMerge) {
   for ($retry = 1; $retry -le 5; $retry++) {
     $currPRSet = $prData
     $prData = @()
-    foreach ($pr in ($currPRSet | Where-Object { $_.Retry -ne $false })) {
+    foreach ($pr in $currPRSet) {
       $prData += GetOrSetMergeablePR -repoOwner $pr.RepoOwner -repoName $pr.RepoName -prNumber $pr.Number
     }
 


### PR DESCRIPTION
If one PR wasn't ready to merge then after a retry we lost all the other PRData so we only end up trying to merge the one.

See https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4866203&view=logs&j=f6a7114c-32c6-5cc4-d467-98fb1350225d&t=92d3002b-c214-53f7-faf6-6294b17e07f4&s=b0f91f5f-86bb-51b4-905a-b77da63d1728