### PR TITLE
user UseShellExecute and read output streams before callins waitforExit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -518,3 +518,6 @@ tools/apiview/emitters/typespec-apiview/temp/
 # Issue Labeler Deploy
 tools/issue-labeler/src/IssueLabeler/Properties/*Zip Deploy.json
 tools/issue-labeler/src/IssueLabeler/Properties/ServiceDependencies/
+
+# Go Parser
+apiviewgo.exe

--- a/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using ApiView;
 using Microsoft.ApplicationInsights;
@@ -52,9 +53,29 @@ namespace APIViewWeb
                 processStartInfo.WorkingDirectory = tempDirectory;
                 processStartInfo.RedirectStandardError = true;
                 processStartInfo.RedirectStandardOutput = true;
+                processStartInfo.UseShellExecute = false;
+                processStartInfo.CreateNoWindow = true;
 
-                using (var process = Process.Start(processStartInfo))
+                var output = new StringBuilder();
+                var error = new StringBuilder();
+
+                using (var process = new Process())
                 {
+                    process.StartInfo = processStartInfo;
+                    process.OutputDataReceived += (sender, args) =>
+                    {
+                        if (args.Data != null)
+                            output.AppendLine(args.Data);
+                    };
+
+                    process.ErrorDataReceived += (sender, args) =>
+                    {
+                        if (args.Data != null)
+                            error.AppendLine(args.Data);
+                    };
+                    process.Start();
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
                     process.WaitForExit();
                     if (process.ExitCode != 0)
                     {


### PR DESCRIPTION
- Use `UseShellExecute` and read output streams before calling `WaitForExit` to avoid deadlocks.