### PR TITLE
First iteration of perf improvements

### DIFF
--- a/src/java/apiview-java-processor/pom.xml
+++ b/src/java/apiview-java-processor/pom.xml
@@ -33,7 +33,7 @@
     <dependency>
       <groupId>com.networknt</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>1.5.2</version>
+      <version>1.5.6</version>
       <exclusions>
           <exclusion>
               <groupId>com.fasterxml.jackson.dataformat</groupId>

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
@@ -13,6 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.networknt.schema.*;
 
 import java.io.*;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.FileSystem;
@@ -87,7 +88,10 @@ public class Main {
                 System.out.println("  Validating the generated JSON file against the schema...");
                 try {
                     JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
-                    JsonSchema schema = factory.getSchema(new URL(Constants.APIVIEW_JSON_SCHEMA).toURI());
+                    // Load the schema from the classpath resource
+                    URL resource = Main.class.getResource(Constants.APIVIEW_JSON_SCHEMA_RESOURCE);
+                    URI localResourceUri = resource.toURI();
+                    JsonSchema schema = factory.getSchema(localResourceUri);
 
                     JsonNode jsonNode = new ObjectMapper().readTree(files[0]);
                     schema.initializeValidators();
@@ -98,9 +102,7 @@ public class Main {
                         System.out.println("    Validation failed. Errors:");
                         validationMessages.forEach(msg -> System.out.println("      " + msg.getMessage()));
                     }
-                } catch (IOException e) {
-                    throw new RuntimeException(e);
-                } catch (URISyntaxException e) {
+                } catch (IOException | URISyntaxException e) {
                     throw new RuntimeException(e);
                 }
             }

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/Main.java
@@ -90,6 +90,9 @@ public class Main {
                     JsonSchemaFactory factory = JsonSchemaFactory.getInstance(SpecVersion.VersionFlag.V7);
                     // Load the schema from the classpath resource
                     URL resource = Main.class.getResource(Constants.APIVIEW_JSON_SCHEMA_RESOURCE);
+                    if (resource == null) {
+                        throw new IllegalStateException("Resource not found: " + Constants.APIVIEW_JSON_SCHEMA_RESOURCE);
+                    }
                     URI localResourceUri = resource.toURI();
                     JsonSchema schema = factory.getSchema(localResourceUri);
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -228,7 +228,9 @@ public class JavaASTAnalyser implements Analyser {
             return Optional.of(new ScanElement(path, null, ScanElementType.POM));
         }
         try {
-            boolean isModuleInfo = path.endsWith("module-info.java");            CompilationUnit compilationUnit = isModuleInfo
+            boolean isModuleInfo = path.endsWith("module-info.java");
+
+            CompilationUnit compilationUnit = isModuleInfo
                 ? JAVA_11_PARSER.get().parse(Files.newBufferedReader(path))
                 : JAVA_8_PARSER.get().parse(Files.newBufferedReader(path));
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -48,7 +48,11 @@ public class JavaASTAnalyser implements Analyser {
      **********************************************************************************************/
 
     public static final String MAVEN_KEY = "Maven";
-    public static final String MODULE_INFO_KEY = "module-info";    private static final Map<String, AnnotationRule> ANNOTATION_RULE_MAP;
+    public static final String MODULE_INFO_KEY = "module-info";
+
+    private static final Map<String, AnnotationRule> ANNOTATION_RULE_MAP;
+
+    // JavaParser is not thread-safe, so we need to use a ThreadLocal to ensure that each thread has its own instance.
     private static final ThreadLocal<JavaParserAdapter> JAVA_8_PARSER = ThreadLocal.withInitial(() -> 
         JavaParserAdapter.of(new JavaParser(new ParserConfiguration()
             .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_8)

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/JavaASTAnalyser.java
@@ -48,11 +48,19 @@ public class JavaASTAnalyser implements Analyser {
      **********************************************************************************************/
 
     public static final String MAVEN_KEY = "Maven";
-    public static final String MODULE_INFO_KEY = "module-info";
-
-    private static final Map<String, AnnotationRule> ANNOTATION_RULE_MAP;
-    private static final JavaParserAdapter JAVA_8_PARSER;
-    private static final JavaParserAdapter JAVA_11_PARSER;
+    public static final String MODULE_INFO_KEY = "module-info";    private static final Map<String, AnnotationRule> ANNOTATION_RULE_MAP;
+    private static final ThreadLocal<JavaParserAdapter> JAVA_8_PARSER = ThreadLocal.withInitial(() -> 
+        JavaParserAdapter.of(new JavaParser(new ParserConfiguration()
+            .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_8)
+            .setDetectOriginalLineSeparator(false)))
+    );
+    
+    private static final ThreadLocal<JavaParserAdapter> JAVA_11_PARSER = ThreadLocal.withInitial(() -> 
+        JavaParserAdapter.of(new JavaParser(new ParserConfiguration()
+            .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_11)
+            .setDetectOriginalLineSeparator(false)))
+    );
+    
     static {
         /*
          For some annotations, we want to customise how they are displayed. Sometimes, we don't show them in any
@@ -70,15 +78,6 @@ public class JavaASTAnalyser implements Analyser {
 
         // we always want @Metadata annotations to be fully expanded, but in a condensed form
         ANNOTATION_RULE_MAP.put(ANNOTATION_METADATA, new AnnotationRule().setShowProperties(true).setCondensed(true));
-
-        // Configure JavaParser to use type resolution
-        JAVA_8_PARSER = JavaParserAdapter.of(new JavaParser(new ParserConfiguration()
-            .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_8)
-            .setDetectOriginalLineSeparator(false)));
-
-        JAVA_11_PARSER = JavaParserAdapter.of(new JavaParser(new ParserConfiguration()
-            .setLanguageLevel(ParserConfiguration.LanguageLevel.JAVA_11)
-            .setDetectOriginalLineSeparator(false)));
     }
 
 
@@ -125,7 +124,7 @@ public class JavaASTAnalyser implements Analyser {
          * Finally, tokenize each file.
          */
         // a set of all elements discovered before we begin processing them
-        Set<ScanElement> scanElements = allFiles.stream()
+        Set<ScanElement> scanElements = allFiles.parallelStream()
                 .filter(this::filterFilePaths)
                 .map(this::scanForTypes)
                 .filter(Optional::isPresent)
@@ -225,11 +224,9 @@ public class JavaASTAnalyser implements Analyser {
             return Optional.of(new ScanElement(path, null, ScanElementType.POM));
         }
         try {
-            boolean isModuleInfo = path.endsWith("module-info.java");
-
-            CompilationUnit compilationUnit = isModuleInfo
-                ? JAVA_11_PARSER.parse(Files.newBufferedReader(path))
-                : JAVA_8_PARSER.parse(Files.newBufferedReader(path));
+            boolean isModuleInfo = path.endsWith("module-info.java");            CompilationUnit compilationUnit = isModuleInfo
+                ? JAVA_11_PARSER.get().parse(Files.newBufferedReader(path))
+                : JAVA_8_PARSER.get().parse(Files.newBufferedReader(path));
 
             compilationUnit.setStorage(path, StandardCharsets.UTF_8);
 

--- a/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/models/Constants.java
+++ b/src/java/apiview-java-processor/src/main/java/com/azure/tools/apiview/processor/analysers/models/Constants.java
@@ -3,6 +3,7 @@ package com.azure.tools.apiview.processor.analysers.models;
 public class Constants {
 
     public static final String APIVIEW_JSON_SCHEMA = "https://raw.githubusercontent.com/Azure/azure-sdk-tools/00aacf7f4e224e008702c3e77ecde46d25434e44/tools/apiview/parsers/apiview-treestyle-parser-schema/CodeFile.json";
+    public static final String APIVIEW_JSON_SCHEMA_RESOURCE = "/CodeFile.json";
 
     /************************************************************************************
      * Mode Flags

--- a/src/java/apiview-java-processor/src/main/resources/CodeFile.json
+++ b/src/java/apiview-java-processor/src/main/resources/CodeFile.json
@@ -1,0 +1,293 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "CodeFile.json",
+    "type": "object",
+    "properties": {
+        "PackageName": {
+            "type": "string"
+        },
+        "PackageVersion": {
+            "type": "string"
+        },
+        "ParserVersion": {
+            "type": "string",
+            "description": "version of the APIview language parser used to create token file"
+        },
+        "Language": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "const": "C"
+                },
+                {
+                    "type": "string",
+                    "const": "C++"
+                },
+                {
+                    "type": "string",
+                    "const": "C#"
+                },
+                {
+                    "type": "string",
+                    "const": "Go"
+                },
+                {
+                    "type": "string",
+                    "const": "Java"
+                },
+                {
+                    "type": "string",
+                    "const": "JavaScript"
+                },
+                {
+                    "type": "string",
+                    "const": "Kotlin"
+                },
+                {
+                    "type": "string",
+                    "const": "Python"
+                },
+                {
+                    "type": "string",
+                    "const": "Swagger"
+                },
+                {
+                    "type": "string",
+                    "const": "Swift"
+                },
+                {
+                    "type": "string",
+                    "const": "TypeSpec"
+                }
+            ]
+        },
+        "LanguageVariant": {
+            "anyOf": [
+                {
+                    "type": "string",
+                    "const": "None"
+                },
+                {
+                    "type": "string",
+                    "const": "Spring"
+                },
+                {
+                    "type": "string",
+                    "const": "Android"
+                }
+            ],
+            "default": "None",
+            "description": "Language variant is applicable only for java variants"
+        },
+        "CrossLanguagePackageId": {
+            "type": "string"
+        },
+        "ReviewLines": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/ReviewLine"
+            }
+        },
+        "Diagnostics": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/CodeDiagnostic"
+            },
+            "description": "Add any system generated comments. Each comment is linked to review line ID"
+        },
+        "Navigation": {
+            "type": "array",
+            "items": {
+                "$ref": "#/$defs/NavigationItem"
+            },
+            "description": "Navigation items are used to create a tree view in the navigation panel. Each navigation item is linked to a review line ID. This is optional.\nIf navigation items are not provided then navigation panel will be automatically generated using the review lines. Navigation items should be provided only if you want to customize the navigation panel."
+        }
+    },
+    "required": [
+        "PackageName",
+        "PackageVersion",
+        "ParserVersion",
+        "Language",
+        "ReviewLines"
+    ],
+    "description": "ReviewFile represents entire API review object. This will be processed to render review lines.",
+    "$defs": {
+        "ReviewLine": {
+            "type": "object",
+            "properties": {
+                "LineId": {
+                    "type": "string",
+                    "description": "lineId is only required if we need to support commenting on a line that contains this token. \nUsually code line for documentation or just punctuation is not required to have lineId. lineId should be a unique value within \nthe review token file to use it assign to review comments as well as navigation Id within the review page.\nfor e.g Azure.Core.HttpHeader.Common, azure.template.template_main"
+                },
+                "CrossLanguageId": {
+                    "type": "string"
+                },
+                "Tokens": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ReviewToken"
+                    },
+                    "description": "list of tokens that constructs a line in API review"
+                },
+                "Children": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/ReviewLine"
+                    },
+                    "description": "Add any child lines as children. For e.g. all classes and namespace level methods are added as a children of namespace(module) level code line. \nSimilarly all method level code lines are added as children of it's class code line."
+                },
+                "IsHidden": {
+                    "type": "boolean",
+                    "description": "Set current line as hidden code line by default. .NET has hidden APIs and architects don't want to see them by default."
+                },
+                "IsContextEndLine": {
+                    "type": "boolean",
+                    "description": "Set current line as context end line. For e.g. line with token } or empty line after the class to mark end of context."
+                },
+                "RelatedToLine": {
+                    "type": "string",
+                    "description": "Set ID of related line to ensure current line is not visible when a related line is hidden.\nOne e.g. is a code line for class attribute should set class line's Line ID as related line ID."
+                }
+            },
+            "required": [
+                "Tokens"
+            ],
+            "description": "ReviewLine object corresponds to each line displayed on API review. If an empty line is required then add a code line object without any token."
+        },
+        "CodeDiagnostic": {
+            "type": "object",
+            "properties": {
+                "DiagnosticId": {
+                    "type": "string",
+                    "description": "Diagnostic ID is auto generated ID by CSharp analyzer."
+                },
+                "TargetId": {
+                    "type": "string",
+                    "description": "Id of ReviewLine object where this diagnostic needs to be displayed"
+                },
+                "Text": {
+                    "type": "string",
+                    "description": "Auto generated system comment to be displayed under targeted line."
+                },
+                "Level": {
+                    "$ref": "#/$defs/CodeDiagnosticLevel"
+                },
+                "HelpLinkUri": {
+                    "type": "string"
+                }
+            },
+            "required": [
+                "TargetId",
+                "Text",
+                "Level"
+            ],
+            "description": "System comment object is to add system generated comment. It can be one of the 4 different types of system comments."
+        },
+        "NavigationItem": {
+            "type": "object",
+            "properties": {
+                "Text": {
+                    "type": "string"
+                },
+                "NavigationId": {
+                    "type": "string"
+                },
+                "ChildItems": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/$defs/NavigationItem"
+                    }
+                },
+                "Tags": {
+                    "$ref": "#/$defs/RecordString"
+                }
+            },
+            "required": [
+                "Text",
+                "NavigationId",
+                "ChildItems",
+                "Tags"
+            ]
+        },
+        "ReviewToken": {
+            "type": "object",
+            "properties": {
+                "Kind": {
+                    "$ref": "#/$defs/TokenKind"
+                },
+                "Value": {
+                    "type": "string"
+                },
+                "NavigationDisplayName": {
+                    "type": "string",
+                    "description": "NavigationDisplayName is used to create a tree node in the navigation panel. Navigation nodes will be created only if token contains navigation display name."
+                },
+                "NavigateToId": {
+                    "type": "string",
+                    "description": "navigateToId should be set if the underlying token is required to be displayed as HREF to another type within the review.\nFor e.g. a param type which is class name in the same package"
+                },
+                "SkipDiff": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "set skipDiff to true if underlying token needs to be ignored from diff calculation. For e.g. package metadata or dependency versions \nare usually excluded when comparing two revisions to avoid reporting them as API changes"
+                },
+                "IsDeprecated": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "This is set if API is marked as deprecated"
+                },
+                "HasSuffixSpace": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Set this to false if there is no suffix space required before next token. For e.g, punctuation right after method name"
+                },
+                "IsDocumentation": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Set isDocumentation to true if current token is part of documentation"
+                },
+                "RenderClasses": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "description": "Language specific style css class names"
+                }
+            },
+            "required": [
+                "Kind",
+                "Value"
+            ],
+            "description": "Token corresponds to each component within a code line. A separate token is required for keyword, punctuation, type name, text etc."
+        },
+        "CodeDiagnosticLevel": {
+            "type": "number",
+            "enum": [
+                1,
+                2,
+                3,
+                4
+            ]
+        },
+        "RecordString": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": {
+                "type": "string"
+            }
+        },
+        "TokenKind": {
+            "type": "number",
+            "enum": [
+                0,
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7
+            ]
+        }
+    }
+}


### PR DESCRIPTION
This is the first iteration of improving perf for Java API view parser.

- Updated the JavaASTAnalyser to use parallelstream() for scanning types. 
- Using local schema file for validation instead of downloading the schema each time 

Used **ARM Compute library** for testing this as it has quite a large API surface.
**Before:**
Total time for 5 iterations: 27.283 seconds
Average time per iteration: 5.457 seconds

**After:**
Total time for 5 iterations: 19.043 seconds
Average time per iteration: 3.809 seconds
