### PR TITLE
Api view sub processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -518,3 +518,6 @@ tools/apiview/emitters/typespec-apiview/temp/
 # Issue Labeler Deploy
 tools/issue-labeler/src/IssueLabeler/Properties/*Zip Deploy.json
 tools/issue-labeler/src/IssueLabeler/Properties/ServiceDependencies/
+
+# Go Parser
+apiviewgo.exe

--- a/src/dotnet/APIView/APIViewWeb/Languages/GoLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/GoLanguageService.cs
@@ -44,7 +44,8 @@ namespace APIViewWeb
             archive.ExtractToDirectory(tempDirectory);
             var packageRootDirectory = originalFilePath.Replace(Extensions[0], "");
 
-            return await RunParserProcess(packageRootDirectory, tempDirectory, jsonFilePath);
+            var arguments = GetProcessorArguments(packageRootDirectory, tempDirectory, tempDirectory);
+            return await RunParserProcess(packageRootDirectory, tempDirectory, jsonFilePath, arguments);
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Languages/GoLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/GoLanguageService.cs
@@ -44,61 +44,7 @@ namespace APIViewWeb
             archive.ExtractToDirectory(tempDirectory);
             var packageRootDirectory = originalFilePath.Replace(Extensions[0], "");
 
-            try
-            {
-                var arguments = GetProcessorArguments(packageRootDirectory, tempDirectory, tempDirectory);
-                var processStartInfo = new ProcessStartInfo(ProcessName, arguments);
-                processStartInfo.WorkingDirectory = tempDirectory;
-                processStartInfo.RedirectStandardError = true;
-                processStartInfo.RedirectStandardOutput = true;
-                processStartInfo.UseShellExecute = false;
-                processStartInfo.CreateNoWindow = true;
-
-                var output = new StringBuilder();
-                var error = new StringBuilder();
-
-                using (var process = new Process())
-                {
-                    process.StartInfo = processStartInfo;
-                    process.OutputDataReceived += (sender, args) =>
-                    {
-                        if (args.Data != null)
-                            output.AppendLine(args.Data);
-                    };
-
-                    process.ErrorDataReceived += (sender, args) =>
-                    {
-                        if (args.Data != null)
-                            error.AppendLine(args.Data);
-                    };
-
-                    process.Start();
-                    process.BeginOutputReadLine();
-                    process.BeginErrorReadLine();
-                    process.WaitForExit();
-                    if (process.ExitCode != 0)
-                    {
-                        throw new InvalidOperationException(
-                            "Processor failed: " + Environment.NewLine +
-                            "stdout: " + Environment.NewLine +
-                            output + Environment.NewLine +
-                            "stderr: " + Environment.NewLine +
-                            error + Environment.NewLine);
-                    }
-                }
-
-                using (var codeFileStream = File.OpenRead(jsonFilePath))
-                {
-                    var codeFile = await CodeFile.DeserializeAsync(codeFileStream);
-                    codeFile.VersionString = VersionString;
-                    codeFile.Language = Name;
-                    return codeFile;
-                }
-            }
-            finally
-            {
-                Directory.Delete(tempDirectory, true);
-            }
+            return await RunParserProcess(packageRootDirectory, tempDirectory, jsonFilePath);
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using ApiView;
 using Microsoft.ApplicationInsights;
 using Microsoft.VisualStudio.Services.Common.CommandLine;
+using ThirdParty.Json.LitJson;
 
 namespace APIViewWeb
 {
@@ -44,7 +45,8 @@ namespace APIViewWeb
             {
                 await stream.CopyToAsync(file);
             }
-            return await RunParserProcess(originalName, tempDirectory, jsonFilePath);
+            var arguments = GetProcessorArguments(originalName, tempDirectory, jsonFilePath);
+            return await RunParserProcess(originalName, tempDirectory, jsonFilePath, arguments);
         }
 
         public string RunProcess(string workingDirectory, string processName, string arguments)
@@ -93,11 +95,10 @@ namespace APIViewWeb
             return processErrors;
         }
 
-        public async Task<CodeFile> RunParserProcess(string originalName, string tempDirectory, string jsonPath)
+        public async Task<CodeFile> RunParserProcess(string originalName, string tempDirectory, string jsonPath, string arguments)
         {
             try
             {
-                var arguments = GetProcessorArguments(originalName, tempDirectory, jsonPath);
                 var processErrors = RunProcess(tempDirectory, ProcessName, arguments);
 
                 _telemetryClient.TrackEvent($"Completed {Name} process run to parse " + originalName);

--- a/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 using System.Threading.Tasks;
 using ApiView;
 using Microsoft.ApplicationInsights;
@@ -52,9 +53,29 @@ namespace APIViewWeb
                 processStartInfo.WorkingDirectory = tempDirectory;
                 processStartInfo.RedirectStandardError = true;
                 processStartInfo.RedirectStandardOutput = true;
+                processStartInfo.UseShellExecute = false;
+                processStartInfo.CreateNoWindow = true;
 
-                using (var process = Process.Start(processStartInfo))
+                var output = new StringBuilder();
+                var error = new StringBuilder();
+
+                using (var process = new Process())
                 {
+                    process.StartInfo = processStartInfo;
+                    process.OutputDataReceived += (sender, args) =>
+                    {
+                        if (args.Data != null)
+                            output.AppendLine(args.Data);
+                    };
+
+                    process.ErrorDataReceived += (sender, args) =>
+                    {
+                        if (args.Data != null)
+                            error.AppendLine(args.Data);
+                    };
+                    process.Start();
+                    process.BeginOutputReadLine();
+                    process.BeginErrorReadLine();
                     process.WaitForExit();
                     if (process.ExitCode != 0)
                     {

--- a/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/LanguageProcessor.cs
@@ -5,10 +5,11 @@ using System.Text;
 using System.Threading.Tasks;
 using ApiView;
 using Microsoft.ApplicationInsights;
+using Microsoft.VisualStudio.Services.Common.CommandLine;
 
 namespace APIViewWeb
 {
-    public abstract class LanguageProcessor: LanguageService
+    public abstract class LanguageProcessor : LanguageService
     {
         private readonly TelemetryClient _telemetryClient;
 
@@ -34,7 +35,7 @@ namespace APIViewWeb
             originalName = Path.GetFileName(originalName);
             // Replace spaces and parentheses in the file name to remove invalid file name in cosmos DB.
             // temporary work around. We need to make sure FileName is set for all requests.
-            originalName = originalName.Replace(" ", "_").Replace("(", "").Replace(")","");
+            originalName = originalName.Replace(" ", "_").Replace("(", "").Replace(")", "");
             var originalFilePath = Path.Combine(tempDirectory, originalName);
 
             var jsonFilePath = Path.ChangeExtension(originalFilePath, ".json");
@@ -43,54 +44,67 @@ namespace APIViewWeb
             {
                 await stream.CopyToAsync(file);
             }
+            return await RunParserProcess(originalName, tempDirectory, jsonFilePath);
+        }
 
+        public string RunProcess(string workingDirectory, string processName, string arguments)
+        {
+            var processStartInfo = new ProcessStartInfo(processName, arguments);
+            string processErrors = String.Empty;
+
+            processStartInfo.WorkingDirectory = workingDirectory;
+            processStartInfo.RedirectStandardError = true;
+            processStartInfo.RedirectStandardOutput = true;
+            processStartInfo.UseShellExecute = false;
+            processStartInfo.CreateNoWindow = true;
+
+            var output = new StringBuilder();
+            var error = new StringBuilder();
+
+            using (var process = new Process())
+            {
+                process.StartInfo = processStartInfo;
+                process.OutputDataReceived += (sender, args) =>
+                {
+                    if (args.Data != null)
+                        output.AppendLine(args.Data);
+                };
+
+                process.ErrorDataReceived += (sender, args) =>
+                {
+                    if (args.Data != null)
+                        error.AppendLine(args.Data);
+                };
+                process.Start();
+                process.BeginOutputReadLine();
+                process.BeginErrorReadLine();
+                process.WaitForExit(90000);
+
+                if (process.ExitCode != 0)
+                {
+                    processErrors = "Processor failed: " + Environment.NewLine +
+                        "stdout: " + Environment.NewLine +
+                        output + Environment.NewLine +
+                        "stderr: " + Environment.NewLine +
+                        error + Environment.NewLine;
+                    throw new InvalidOperationException(processErrors);
+                }
+            }
+            return processErrors;
+        }
+
+        public async Task<CodeFile> RunParserProcess(string originalName, string tempDirectory, string jsonPath)
+        {
             try
             {
-                var arguments = GetProcessorArguments(originalName, tempDirectory, jsonFilePath);
-                var processStartInfo = new ProcessStartInfo(ProcessName, arguments);
-                string processErrors = String.Empty;
+                var arguments = GetProcessorArguments(originalName, tempDirectory, jsonPath);
+                var processErrors = RunProcess(tempDirectory, ProcessName, arguments);
 
-                processStartInfo.WorkingDirectory = tempDirectory;
-                processStartInfo.RedirectStandardError = true;
-                processStartInfo.RedirectStandardOutput = true;
-                processStartInfo.UseShellExecute = false;
-                processStartInfo.CreateNoWindow = true;
+                _telemetryClient.TrackEvent($"Completed {Name} process run to parse " + originalName);
 
-                var output = new StringBuilder();
-                var error = new StringBuilder();
-
-                using (var process = new Process())
+                if (File.Exists(jsonPath))
                 {
-                    process.StartInfo = processStartInfo;
-                    process.OutputDataReceived += (sender, args) =>
-                    {
-                        if (args.Data != null)
-                            output.AppendLine(args.Data);
-                    };
-
-                    process.ErrorDataReceived += (sender, args) =>
-                    {
-                        if (args.Data != null)
-                            error.AppendLine(args.Data);
-                    };
-                    process.Start();
-                    process.BeginOutputReadLine();
-                    process.BeginErrorReadLine();
-                    process.WaitForExit();
-                    if (process.ExitCode != 0)
-                    {
-                        processErrors = "Processor failed: " + Environment.NewLine +
-                            "stdout: " + Environment.NewLine +
-                            process.StandardOutput.ReadToEnd() + Environment.NewLine +
-                            "stderr: " + Environment.NewLine +
-                            process.StandardError.ReadToEnd() + Environment.NewLine;
-                        throw new InvalidOperationException(processErrors);
-                    }
-                }
-
-                if (File.Exists(jsonFilePath))
-                {
-                    using (var codeFileStream = new FileStream(jsonFilePath, FileMode.Open, FileAccess.Read, FileShare.None))
+                    using (var codeFileStream = new FileStream(jsonPath, FileMode.Open, FileAccess.Read, FileShare.None))
                     {
                         CodeFile codeFile = await CodeFile.DeserializeAsync(stream: codeFileStream);
                         codeFile.VersionString = VersionString;
@@ -100,8 +114,8 @@ namespace APIViewWeb
                 }
                 else
                 {
-                    _telemetryClient.TrackTrace($"Processor failed to generate json file {jsonFilePath} with error {processErrors}");
-                    throw new InvalidOperationException($"Processor failed to generate json file {jsonFilePath}");
+                    _telemetryClient.TrackTrace($"Processor failed to generate json file {jsonPath} with error {processErrors}");
+                    throw new InvalidOperationException($"Processor failed to generate json file {jsonPath}");
                 }
             }
             finally

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -59,7 +59,8 @@ namespace APIViewWeb
                 await stream.CopyToAsync(file);
             }
             var pythonVenvPath = GetPythonVirtualEnv(tempDirectory);
-            return await RunParserProcess(originalName, pythonVenvPath, jsonFilePath);
+            var arguments = GetProcessorArguments(originalName, tempDirectory, jsonFilePath);
+            return await RunParserProcess(originalName, pythonVenvPath, jsonFilePath, arguments);
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
+++ b/src/dotnet/APIView/APIViewWeb/Languages/PythonLanguageService.cs
@@ -58,74 +58,8 @@ namespace APIViewWeb
             {
                 await stream.CopyToAsync(file);
             }
-            try
-            {
-                var pythonVenvPath = GetPythonVirtualEnv(tempDirectory);
-                var arguments = GetProcessorArguments(originalName, tempDirectory, jsonFilePath);
-                RunProcess(tempDirectory, pythonVenvPath, arguments);
-                _telemetryClient.TrackEvent("Completed Python process run to parse " + originalName);
-                using (var codeFileStream = File.OpenRead(jsonFilePath))
-                {
-                    var codeFile = await CodeFile.DeserializeAsync(codeFileStream);
-                    codeFile.VersionString = VersionString;
-                    codeFile.Language = Name;
-                    return codeFile;
-                }
-            }
-            catch(Exception ex)
-            {
-                _telemetryClient.TrackException(ex);
-                throw;
-            }
-            finally
-            {
-                Directory.Delete(tempDirectory, true);
-            }
-        }
-
-        private void RunProcess(string workingDirectory, string processName, string args)
-        {
-            var processStartInfo = new ProcessStartInfo(processName, args)
-            {
-                WorkingDirectory = workingDirectory,
-                RedirectStandardError = true,
-                RedirectStandardOutput = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            };
-
-            var output = new StringBuilder();
-            var error = new StringBuilder();
-
-            using (var process = new Process())
-            {
-                process.StartInfo = processStartInfo;
-                process.OutputDataReceived += (sender, args) =>
-                {
-                    if (args.Data != null)
-                        output.AppendLine(args.Data);
-                };
-
-                process.ErrorDataReceived += (sender, args) =>
-                {
-                    if (args.Data != null)
-                        error.AppendLine(args.Data);
-                };
-                process.Start();
-                process.BeginOutputReadLine();
-                process.BeginErrorReadLine();
-                process.WaitForExit(3 * 60 * 1000);
-                _telemetryClient.TrackEvent("Completed parsing python wheel. Exit code: " + process.ExitCode);
-                if (process.ExitCode != 0)
-                {
-                    throw new InvalidOperationException(
-                        "Processor failed: " + Environment.NewLine +
-                        "stdout: " + Environment.NewLine +
-                        process.StandardOutput.ReadToEnd() + Environment.NewLine +
-                        "stderr: " + Environment.NewLine +
-                        process.StandardError.ReadToEnd() + Environment.NewLine);
-                }
-            }
+            var pythonVenvPath = GetPythonVirtualEnv(tempDirectory);
+            return await RunParserProcess(originalName, pythonVenvPath, jsonFilePath);
         }
     }
 }


### PR DESCRIPTION
- Refactor methods for running child process
- Use `UseShellExecute = false` and read output streams before calling `WaitForExit` to avoid deadlocks.

Replaces https://github.com/Azure/azure-sdk-tools/pull/10676