### PR TITLE
Update apiViewArtifactPath to point to pubished artifact path, retire…

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Release
 
+## 2025-05-16 - 0.7.0
+
+- Update apiViewArtifact to point to staged artifact location
+- Retire sdkApiViewArtifactFolder
+
 ## 2025-05-06 - 0.6.1
 
 - Turned duplicated SDK config error into warning and continued SDK generation based on TypeSpecs

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/reportStatus.ts
+++ b/tools/spec-gen-sdk/src/automation/reportStatus.ts
@@ -107,7 +107,6 @@ export const generateReport = (context: WorkflowContext) => {
     filteredLogPath: context.filteredLogFileName,
     stagedArtifactsFolder: context.stagedArtifactsFolder,
     sdkArtifactFolder: context.sdkArtifactFolder,
-    sdkApiViewArtifactFolder: context.sdkApiViewArtifactFolder,
     ...(context.config.runEnv === 'azureDevOps' ? {vsoLogPath: context.vsoLogFileName} : {})
   };
 

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -41,7 +41,6 @@ export enum FailureType {
 export type WorkflowContext = SdkAutoContext & {
   stagedArtifactsFolder?: string;
   sdkArtifactFolder?: string;
-  sdkApiViewArtifactFolder?: string;
   isSdkConfigDuplicated?: boolean;
   specConfigPath?: string;
   pendingPackages: PackageData[];

--- a/tools/spec-gen-sdk/src/automation/workflowPackage.ts
+++ b/tools/spec-gen-sdk/src/automation/workflowPackage.ts
@@ -174,10 +174,11 @@ const workflowPkgSaveApiViewArtifact = async (context: WorkflowContext, pkg: Pac
   if (!existsSync(destination)) {
     fs.mkdirSync(destination, { recursive: true });
   }
-  context.sdkApiViewArtifactFolder = destination;
   const fileName = path.basename(pkg.apiViewArtifactPath);
-  context.logger.info(`Copy apiView artifact from ${path.join(context.config.localSdkRepoPath, pkg.apiViewArtifactPath)} to ${path.join(destination, fileName)}`);
-  copyFileSync(path.join(context.config.localSdkRepoPath, pkg.apiViewArtifactPath), path.join(destination, fileName));
+  const newApiViewArtifactPath = path.join(destination, fileName);
+  context.logger.info(`Copy apiView artifact from ${path.join(context.config.localSdkRepoPath, pkg.apiViewArtifactPath)} to ${newApiViewArtifactPath}`);
+  copyFileSync(path.join(context.config.localSdkRepoPath, pkg.apiViewArtifactPath), newApiViewArtifactPath);
+  pkg.apiViewArtifactPath = newApiViewArtifactPath;
 };
 
 const fileInstallInstructionInput = 'installInstructionInput.json';


### PR DESCRIPTION
Update `apiViewArtifactPath` to point to published artifact path, retire `sdkApiViewArtifactFolder`.
This resolves error caused by the fact that go package names are similar directory paths