### PR TITLE
[spec-gen-sdk] bugfix for sdk-suppressions content judgement

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 2025-05-19 - 0.7.1
 
-- Fix the judgment logic after reading sdk-suppressions
+- Fixed a bug in processing breaking change suppressions
 
 ## 2025-05-16 - 0.7.0
 

--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-05-19 - 0.7.1
+
+- Fix the judgment logic after reading sdk-suppressions
+
 ## 2025-05-16 - 0.7.0
 
 - Update apiViewArtifact to point to staged artifact location

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/automation/workflow.ts
+++ b/tools/spec-gen-sdk/src/automation/workflow.ts
@@ -274,7 +274,7 @@ export const workflowInitGetSdkSuppressionsYml = async (
       sdkSuppressionFilesParseErrorTotal.push(message);
       continue;
     }
-    if (suppressionFileParseResult) {
+    if (!suppressionFileParseResult) {
       message = configWarning(`Ignore the suppressions as the file at ${sdkSuppressionFilePath} is empty.`);
       context.logger.warn(message);
       sdkSuppressionFilesParseErrorTotal.push(message);


### PR DESCRIPTION
This pull request includes updates to the `spec-gen-sdk` tool, addressing a bug in suppression file parsing logic and incrementing the version to `0.7.1`. These changes ensure better handling of empty suppression files and align the versioning across relevant files.

### Bug Fix:
* [`tools/spec-gen-sdk/src/automation/workflow.ts`](diffhunk://#diff-8abb2fc1b35d9aa372c77e814cacaa598863a407057a1a79877222cb57ab9f0eL277-R277): Fixed the logic to correctly handle cases where suppression files are empty by updating the condition to check for a falsy `suppressionFileParseResult`.

### Version Update:
* [`tools/spec-gen-sdk/package.json`](diffhunk://#diff-5532e95511ec7c2d2c5fdbb91be5dab5521875c1e5d0206b4fc66ee25e0596eaL8-R8): Updated the version from `0.7.0` to `0.7.1`.
* [`tools/spec-gen-sdk/package-lock.json`](diffhunk://#diff-30b3cfc1be35ebe8a8195d3a7a14e21d9a2dea21becb4fc9efb9fa3d276b064fL3-R9): Updated the version from `0.7.0` to `0.7.1` in the lock file for consistency.
* [`tools/spec-gen-sdk/CHANGELOG.md`](diffhunk://#diff-968fa3cf4ab010d5256c9bccd3cbc8894339bc3ba128556e293522107994a821R3-R6): Added a new entry for version `0.7.1`, documenting the fix for the suppression file parsing logic.