### PR TITLE
Ensure debugging tool isn't visible to end users

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
@@ -76,21 +76,11 @@ public class Program
         }
 
         var toolTypes = SharedOptions.GetFilteredToolTypes(args);
-        if (toolTypes.Count == 0)
-        {
-            builder.Services
-                .AddMcpServer()
-                .WithStdioServerTransport()
-                .WithToolsFromAssembly();
-        }
-        else
-        {
 
-            builder.Services
-                .AddMcpServer()
-                .WithStdioServerTransport()
-                .WithTools(toolTypes);
-        }
+        builder.Services
+            .AddMcpServer()
+            .WithStdioServerTransport()
+            .WithTools(toolTypes);
 
         return builder;
     }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/HelloWorldTool/HelloWorldTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/HelloWorldTool/HelloWorldTool.cs
@@ -10,7 +10,7 @@ using Azure.Sdk.Tools.Cli.Models;
 
 namespace Azure.Sdk.Tools.Cli.Tools.HelloWorldTool
 {
-
+    #if DEBUG
     [McpServerToolType, Description("Echoes the message back to the client.")]
     public class HelloWorldTool(ILogger<HelloWorldTool> logger, IOutputService output) : MCPTool
     {
@@ -64,4 +64,5 @@ namespace Azure.Sdk.Tools.Cli.Tools.HelloWorldTool
             };
         }
     }
+    #endif
 }


### PR DESCRIPTION
And we have an extremely easy way to make this work. The only concern is if tests run in Debug or Release mode to have the tool available.