### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -35,7 +35,6 @@
 /tools/github-team-user-store/          @JimSuplizio @weshaggard
 /tools/issue-labeler/                   @jsquire @jeo02
 /tools/js-sdk-release-tools/            @qiaozha @MaryGao @wanlwanl
-/tools/mock-service-host/               @raych1 @tadelesh
 /tools/perf-automation/                 @mikeharder @benbp
 /tools/perf-automation/**/*Rust*.cs     @gearama @heaths @LarryOsterman @RickWinter
 /tools/pipeline-generator/              @weshaggard @benbp


### PR DESCRIPTION
Code removed with https://github.com/Azure/azure-sdk-tools/pull/10686 so removing codeowner entry as well