### PR TITLE
Use correct leading slash in common.ps1 repo root resolution

### DIFF
--- a/eng/common/scripts/common.ps1
+++ b/eng/common/scripts/common.ps1
@@ -1,6 +1,6 @@
 # cSpell:ignore Apireview
 # cSpell:ignore Onboarded
-$RepoRoot = Resolve-Path "${PSScriptRoot}/../../../"
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot .. .. ..)
 $EngDir = Join-Path $RepoRoot "eng"
 $EngCommonDir = Join-Path $EngDir "common"
 $EngCommonScriptsDir = Join-Path $EngCommonDir "scripts"

--- a/eng/common/scripts/common.ps1
+++ b/eng/common/scripts/common.ps1
@@ -1,6 +1,6 @@
 # cSpell:ignore Apireview
 # cSpell:ignore Onboarded
-$RepoRoot = Resolve-Path "${PSScriptRoot}..\..\..\.."
+$RepoRoot = Resolve-Path "${PSScriptRoot}/../../../"
 $EngDir = Join-Path $RepoRoot "eng"
 $EngCommonDir = Join-Path $EngDir "common"
 $EngCommonScriptsDir = Join-Path $EngCommonDir "scripts"


### PR DESCRIPTION
Use correct leading slash in common.ps1 repo root resolution. You need a leading slash after $PSScriptRoot, hence why the current code has to use 4 `..` instead of 3 (the first ends up getting ignored).