### PR TITLE
PR for Issue [#32318](https://github.com/Azure/azure-sdk-for-python/issues/32318)

### DIFF
--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/pylint_guidelines_checker.py
@@ -1769,7 +1769,19 @@ class CheckDocstringParameters(BaseChecker):
             docstring = docstring.split(":")
         except AttributeError:
             return
-
+        no_return = False
+        if hasattr(node, "returns") and node.returns is not None:
+            try:
+                inferred = next(node.returns.infer())
+                if (
+                    getattr(inferred, "name", None) == "NoReturn"
+                    or getattr(inferred, "attrname", None) == "NoReturn"
+                ):
+                    no_return = True
+            except Exception:
+                pass
+        if no_return:
+            return 
         has_return, has_rtype = False, False
         for line in docstring:
             if line.startswith("return"):

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_parameters.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_files/docstring_parameters.py
@@ -44,7 +44,7 @@ class MyClass():  # @
         """
 
 
-from typing import Dict
+from typing import Dict, NoReturn
 
 
 # test_docstring_property_decorator

--- a/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
+++ b/tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py
@@ -3078,6 +3078,11 @@ class TestDocstringParameters(pylint.testutils.CheckerTestCase):
             ),
         ):
             self.checker.visit_functiondef(node)
+    def test_docstring_noreturn(self, setup):
+        # Should not raise docstring-missing-return or docstring-missing-rtype for NoReturn
+        node = setup.body[13]
+        with self.assertNoMessages():
+            self.checker.visit_functiondef(node)
 
 
 class TestDoNotImportLegacySix(pylint.testutils.CheckerTestCase):


### PR DESCRIPTION
# Description

**Issue:**    If a function is annotated with NoReturn (from typing), the Pylint guidelines checker should not raise warnings about missing :return: or :rtype: in the docstring.

**Solution:** In the Pylint guidelines checker (pylint_guidelines_checker.py), I added logic to skip docstring return/rtype checks for functions annotated with NoReturn and skip warnings.

**Test**:  I added a test to verify that NoReturn functions don't trigger docstring return/rtype warnings (tools/pylint-extensions/azure-pylint-guidelines-checker/tests/test_pylint_custom_plugins.py ).

# All SDK Contribution checklist:
- [x] **The pull request does not introduce [breaking changes]**
- [ ] **CHANGELOG is updated for new features, bug fixes or other significant changes.**
- [ ] **I have read the [contribution guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md).**

## General Guidelines and Best Practices
- [x] Title of the pull request is clear and informative.
- [ ] There are a small number of commits, each of which have an informative message. This means that previously merged commits do not appear in the history of the PR. For more information on cleaning up the commits in your PR, [see this page](https://github.com/Azure/azure-powershell/blob/master/documentation/development-docs/cleaning-up-commits.md).

### [Testing Guidelines](https://github.com/Azure/azure-sdk-for-python/blob/main/CONTRIBUTING.md##building-and-testing)
- [x] Pull request includes test coverage for the included changes.


