### PR TITLE
Corrected the key when match the suppression file in the map

### DIFF
--- a/tools/spec-gen-sdk/CHANGELOG.md
+++ b/tools/spec-gen-sdk/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-05-20 - 0.7.2
+
+- Corrected the key in the suppression files map
+
 ## 2025-05-19 - 0.7.1
 
 - Fixed a bug in processing breaking change suppressions

--- a/tools/spec-gen-sdk/package-lock.json
+++ b/tools/spec-gen-sdk/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/spec-gen-sdk",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/spec-gen-sdk",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.6",

--- a/tools/spec-gen-sdk/package.json
+++ b/tools/spec-gen-sdk/package.json
@@ -5,7 +5,7 @@
     "email": "azsdkteam@microsoft.com",
     "url": "https://github.com/Azure/azure-sdk-tools"
   },
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "A TypeScript implementation of the API specification to SDK tool",
   "tags": [
     "spec-gen-sdk"

--- a/tools/spec-gen-sdk/src/types/PackageData.ts
+++ b/tools/spec-gen-sdk/src/types/PackageData.ts
@@ -177,7 +177,7 @@ export const getPackageData = (context: WorkflowContext, result: PackageResult, 
   let parseSuppressionLinesErrors: string[] = [];
   let sdkSuppressionFilePath: string | undefined = undefined;
 
-  const packageTSForReadmeMdKey = result.typespecProject ? `${result.typespecProject[0]}/tspconfig.yaml` : result.readmeMd ? `${context.config.sdkName == 'azure-sdk-for-go' ? 'specification/' : ''}${result.readmeMd[0]}` : null;
+  const packageTSForReadmeMdKey = result.typespecProject ? `${result.typespecProject[0]}/tspconfig.yaml` : result.readmeMd ? result.readmeMd[0] : null;
   const suppressionContent = packageTSForReadmeMdKey ? suppressionContentList?.get(packageTSForReadmeMdKey) : undefined;
   if ((suppressionContent !== undefined) && !isBetaMgmtSdk) {
     if (breakingChangeItems && breakingChangeItems.length > 0) {

--- a/tools/spec-gen-sdk/src/types/PackageData.ts
+++ b/tools/spec-gen-sdk/src/types/PackageData.ts
@@ -177,7 +177,7 @@ export const getPackageData = (context: WorkflowContext, result: PackageResult, 
   let parseSuppressionLinesErrors: string[] = [];
   let sdkSuppressionFilePath: string | undefined = undefined;
 
-  const packageTSForReadmeMdKey = result.typespecProject ? result.typespecProject[0] : result.readmeMd ? `${context.config.sdkName == 'azure-sdk-for-go' ? 'specification/' : ''}${result.readmeMd[0]}` : null;
+  const packageTSForReadmeMdKey = result.typespecProject ? `${result.typespecProject[0]}/tspconfig.yaml` : result.readmeMd ? `${context.config.sdkName == 'azure-sdk-for-go' ? 'specification/' : ''}${result.readmeMd[0]}` : null;
   const suppressionContent = packageTSForReadmeMdKey ? suppressionContentList?.get(packageTSForReadmeMdKey) : undefined;
   if ((suppressionContent !== undefined) && !isBetaMgmtSdk) {
     if (breakingChangeItems && breakingChangeItems.length > 0) {


### PR DESCRIPTION

* Corrected the key used in the suppression files map within the `getPackageData` function to include `/tspconfig.yaml` for `typespecProject` entries. Also removed special logic for Go for the suppression map key because now Go result returns the correct readme path with 'specification' prefix.