### PR TITLE
Release plan mcp changes

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ReleasePlan.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ReleasePlan.cs
@@ -21,6 +21,10 @@ namespace Azure.Sdk.Tools.Cli.Models
         public bool IsDataPlane { get; set; } = false;
         public string SpecAPIVersion { get; set; } = string.Empty;
         public string SpecType {  get; set; } = string.Empty;
+        public string ReleasePlanLink { get; set; } = string.Empty;
+        public bool IsTestReleasePlan { get; set; } = false;
+        public int ReleasePlanId { get; set; }
+        public string SDKReleaseType { get; set; } = string.Empty;
         public List<SDKGenerationInfo> SDKGenerationInfos { get; set; } = [];
 
         public Microsoft.VisualStudio.Services.WebApi.Patch.Json.JsonPatchDocument GetPatchDocument()
@@ -69,8 +73,26 @@ namespace Azure.Sdk.Tools.Cli.Models
                     Operation = Microsoft.VisualStudio.Services.WebApi.Patch.Operation.Add,
                     Path = "/fields/Custom.APISpecversion",
                     Value = SpecAPIVersion
+                },
+                new JsonPatchOperation
+                {
+                    Operation = Microsoft.VisualStudio.Services.WebApi.Patch.Operation.Add,
+                    Path = "/fields/Custom.SDKtypetobereleased",
+                    Value = SDKReleaseType
                 }
             };
+
+            // Add release plan test tag if this is a test release plan
+            if (IsTestReleasePlan)
+            {
+                var tag = new JsonPatchOperation
+                {
+                    Operation = Microsoft.VisualStudio.Services.WebApi.Patch.Operation.Add,
+                    Path = "/fields/System.Tags",
+                    Value = "Release Planner App Test"
+                };
+                jsonDocument.Add(tag);
+            }
             return jsonDocument;
         }
 

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -116,7 +116,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         public async Task<ReleasePlan> GetReleasePlan(int releasePlanId)
         {
             // First find the API sepc work item
-            var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{RELEASE_PROJECT}' AND [Custom.ReleasePlanID] = '{releasePlanId}' AND [System.WorkItemType] = 'Release Plan' AND [System.State] NOT IN ('Closed','Duplicate','Abandoned') AND [System.Tags] Does Not Contain 'Release Planner App Test'";
+            var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{RELEASE_PROJECT}' AND [Custom.ReleasePlanID] = '{releasePlanId}' AND [System.WorkItemType] = 'Release Plan' AND [System.State] NOT IN ('Closed','Duplicate','Abandoned') AND [System.Tags] NOT CONTAINS 'Release Planner App Test'";
             var releasePlanWorkItems = await FetchWorkItems(query);
             if (releasePlanWorkItems.Count == 0)
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -115,7 +115,7 @@ namespace Azure.Sdk.Tools.Cli.Services
 
         public async Task<ReleasePlan> GetReleasePlan(int releasePlanId)
         {
-            // First find the API sepc work item
+            // First find the API spec work item
             var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{RELEASE_PROJECT}' AND [Custom.ReleasePlanID] = '{releasePlanId}' AND [System.WorkItemType] = 'Release Plan' AND [System.State] NOT IN ('Closed','Duplicate','Abandoned') AND [System.Tags] NOT CONTAINS 'Release Planner App Test'";
             var releasePlanWorkItems = await FetchWorkItems(query);
             if (releasePlanWorkItems.Count == 0)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -83,7 +83,8 @@ namespace Azure.Sdk.Tools.Cli.Services
 
     public interface IDevOpsService
     {
-        public Task<ReleasePlan> GetReleasePlan(int workItemId);
+        public Task<ReleasePlan> GetReleasePlan(int releasePlanId);
+        public Task<ReleasePlan> GetReleasePlanForWorkItem(int workItemId);
         public Task<ReleasePlan> GetReleasePlan(string pullRequestUrl);
         public Task<WorkItem> CreateReleasePlanWorkItem(ReleasePlan releasePlan);
         public Task<Build> RunSDKGenerationPipeline(string branchRef, string typespecProjectRoot, string apiVersion, string sdkReleaseType, string language, int workItemId);
@@ -99,7 +100,7 @@ namespace Azure.Sdk.Tools.Cli.Services
         private ILogger<DevOpsService> _logger = logger;
         private IDevOpsConnection _connection = connection;
 
-        public async Task<ReleasePlan> GetReleasePlan(int workItemId)
+        public async Task<ReleasePlan> GetReleasePlanForWorkItem(int workItemId)
         {
             _logger.LogInformation($"Fetching release plan work with id {workItemId}");
             var workItem = await _connection.GetWorkItemClient().GetWorkItemAsync(workItemId);
@@ -110,6 +111,18 @@ namespace Azure.Sdk.Tools.Cli.Services
             releasePlan.WorkItemUrl = workItem.Url;
             releasePlan.WorkItemId = workItem?.Id ?? 0;
             return releasePlan;
+        }
+
+        public async Task<ReleasePlan> GetReleasePlan(int releasePlanId)
+        {
+            // First find the API sepc work item
+            var query = $"SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = '{RELEASE_PROJECT}' AND [Custom.ReleasePlanID] = '{releasePlanId}' AND [System.WorkItemType] = 'Release Plan' AND [System.State] NOT IN ('Closed','Duplicate','Abandoned') AND [System.Tags] Does Not Contain 'Release Planner App Test'";
+            var releasePlanWorkItems = await FetchWorkItems(query);
+            if (releasePlanWorkItems.Count == 0)
+            {
+                throw new Exception($"Failed to find release plan work item with release plan Id {releasePlanId}");
+            }
+            return MapWorkItemToReleasePlan(releasePlanWorkItems[0]);
         }
 
         private static ReleasePlan MapWorkItemToReleasePlan(WorkItem workItem)
@@ -124,7 +137,10 @@ namespace Azure.Sdk.Tools.Cli.Services
                 ProductTreeId = workItem.Fields.TryGetValue("Custom.ProductServiceTreeID", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 SDKReleaseMonth = workItem.Fields.TryGetValue("Custom.SDKReleaseMonth", out value) ? value?.ToString() ?? string.Empty : string.Empty,
                 IsManagementPlane = workItem.Fields.TryGetValue("Custom.MgmtScope", out value) ? value?.ToString() == "Yes" : false,
-                IsDataPlane = workItem.Fields.TryGetValue("Custom.DataScope", out value) ? value?.ToString() == "Yes" : false
+                IsDataPlane = workItem.Fields.TryGetValue("Custom.DataScope", out value) ? value?.ToString() == "Yes" : false,
+                ReleasePlanLink = workItem.Fields.TryGetValue("Custom.ReleasePlanLink", out value) ? value?.ToString() ?? string.Empty : string.Empty,
+                ReleasePlanId = workItem.Fields.TryGetValue("Custom.ReleasePlanID", out value) ? int.Parse(value?.ToString() ?? "0") : 0,
+                SDKReleaseType = workItem.Fields.TryGetValue("Custom.SDKtypetobereleased", out value) ? value?.ToString() ?? string.Empty : string.Empty,
             };
 
             // Get sdk generation status if it was already run for current release plan

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
@@ -95,7 +95,7 @@ namespace Azure.Sdk.Tools.Cli.Services
 
         private async Task<bool> IsDiffMergeable(string targetRepoOwner, string repoName, string baseBranch, string headBranch)
         {
-            logger.LogInformation("Comparing the headbranch against target branch");
+            logger.LogInformation("Comparing the head branch against target branch");
             var comparison = await gitHubClient.Repository.Commit.Compare(targetRepoOwner, repoName, baseBranch, headBranch);
             logger.LogInformation($"Comparison: {comparison.Status}");
             return comparison?.MergeBaseCommit != null;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
@@ -17,21 +17,24 @@ namespace Azure.Sdk.Tools.Cli.Tools
     public class ReleasePlanTool(IDevOpsService devOpsService, ITypeSpecHelper typeSpecHelper, ILogger<ReleasePlanTool> logger, IOutputService output) : MCPTool
     {
         // Commands
-        private const string getReleasePlanDetailsCommandName = "get-details";
+        private const string getReleasePlanDetailsCommandName = "get";
         private const string createReleasePlanCommandName = "create";
 
         // Options
-        private readonly Option<int> workItemIdOpt = new(["--work-item-id", "-w"], "Work Item ID") { IsRequired = true };
+        private readonly Option<int> releasePlanNumberOpt = new(["--release-plan-id",], "Release Plan ID") { IsRequired = false };
+        private readonly Option<int> workItemIdOpt = new(["--work-item-id", "-w"], "Work Item ID") { IsRequired = false };
         private readonly Option<string> typeSpecProjectPathOpt = new(["--typespec-path"], "Path to TypeSpec project") { IsRequired = true };
         private readonly Option<string> targetReleaseOpt = new(["--release-month"], "SDK release target month(Month YYYY)");
         private readonly Option<string> serviceTreeIdOpt = new(["--service-tree"], "Service tree ID");
         private readonly Option<string> productTreeIdOpt = new(["--product"], "Product service tree ID");
         private readonly Option<string> apiVersionOpt = new(["--api-version"], "API version");
         private readonly Option<string> pullRequestOpt = new(["--pull-request"], "Api spec pull request URL");
+        private readonly Option<string> sdkReleaseTypeOpt = new(["--sdk-type"], "SDK release type: beta or preview");
+        private readonly Option<bool> isTestReleasePlanOpt = new(["--test-release"], () => false, "Create release plan in test environment") { IsRequired = false};
 
 
         [McpServerTool, Description("Get release plan for API spec pull request. This tool should be used only if work item Id is unknown.")]
-        public async Task<string> GetReleasePlan(string pullRequestLink)
+        public async Task<string> GetReleasePlanForPullRequest(string pullRequestLink)
         {
             List<string> releasePlanList = [];
             try
@@ -53,8 +56,8 @@ namespace Azure.Sdk.Tools.Cli.Tools
             Command command = new("release-plan");
             var subCommands = new[]
             {
-                new Command(getReleasePlanDetailsCommandName, "Get details of a release plan") {workItemIdOpt},
-                new Command(createReleasePlanCommandName, "Create a release plan") { typeSpecProjectPathOpt, targetReleaseOpt, serviceTreeIdOpt, productTreeIdOpt, apiVersionOpt, pullRequestOpt }
+                new Command(getReleasePlanDetailsCommandName, "Get release plan details") {workItemIdOpt, releasePlanNumberOpt},
+                new Command(createReleasePlanCommandName, "Create a release plan") { typeSpecProjectPathOpt, targetReleaseOpt, serviceTreeIdOpt, productTreeIdOpt, apiVersionOpt, pullRequestOpt, sdkReleaseTypeOpt, isTestReleasePlanOpt }
             };
 
             foreach (var subCommand in subCommands)
@@ -73,7 +76,8 @@ namespace Azure.Sdk.Tools.Cli.Tools
             {
                 case getReleasePlanDetailsCommandName:
                     var workItemId = commandParser.GetValueForOption(workItemIdOpt);
-                    var releasePlanDetails = await GetReleasePlanDetails(workItemId);
+                    var releasePlanNumber = commandParser.GetValueForOption(releasePlanNumberOpt);
+                    var releasePlanDetails = await GetReleasePlan(workItem: workItemId, releasePlanId: releasePlanNumber);
                     output.Output($"Release plan details: {releasePlanDetails}");
                     return;
 
@@ -84,7 +88,9 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     var productTreeId = commandParser.GetValueForOption(productTreeIdOpt);
                     var specApiVersion = commandParser.GetValueForOption(apiVersionOpt);
                     var specPullRequestUrl = commandParser.GetValueForOption(pullRequestOpt);
-                    var releasePlan = await CreateReleasePlan(typeSpecProjectPath, targetReleaseMonthYear, serviceTreeId, productTreeId, specApiVersion, specPullRequestUrl);
+                    var sdkReleaseType = commandParser.GetValueForOption(sdkReleaseTypeOpt);
+                    var isTestReleasePlan = commandParser.GetValueForOption(isTestReleasePlanOpt);
+                    var releasePlan = await CreateReleasePlan(typeSpecProjectPath, targetReleaseMonthYear, serviceTreeId, productTreeId, specApiVersion, specPullRequestUrl, sdkReleaseType, isTestReleasePlan);
                     output.Output($"Release plan created: {releasePlan}");
                     return;
                 default:
@@ -94,12 +100,16 @@ namespace Azure.Sdk.Tools.Cli.Tools
             }
         }
 
-        [McpServerTool, Description("Get Release Plan: Get release plan work item details for a given work item id.")]
-        public async Task<string> GetReleasePlanDetails(int workItemId)
+        [McpServerTool, Description("Get Release Plan: Get release plan work item details for a given work item id or release plan Id.")]
+        public async Task<string> GetReleasePlan(int workItem = 0, int releasePlanId = 0)
         {
             try
             {
-                var releasePlan = await devOpsService.GetReleasePlan(workItemId);
+                if (workItem == 0 && releasePlanId == 0)
+                {
+                    return "Either work item ID or release plan number must be provided.";
+                }
+                var releasePlan = workItem != 0 ? await devOpsService.GetReleasePlanForWorkItem(workItem) : await devOpsService.GetReleasePlan(releasePlanId);
                 var releasePlanText = releasePlan != null ? JsonSerializer.Serialize(releasePlan) :
                        "Failed to get release plan details.";
                 return releasePlanText;
@@ -112,7 +122,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Create Release Plan work item.")]
-        public async Task<string> CreateReleasePlan(string typeSpecProjectPath, string targetReleaseMonthYear, string serviceTreeId, string productTreeId, string specApiVersion, string specPullRequestUrl)
+        public async Task<string> CreateReleasePlan(string typeSpecProjectPath, string targetReleaseMonthYear, string serviceTreeId, string productTreeId, string specApiVersion, string specPullRequestUrl, string sdkReleaseType, bool isTestReleasePlan = false)
         {
             try
             {
@@ -135,6 +145,13 @@ namespace Azure.Sdk.Tools.Cli.Tools
                         """;
                 }
 
+                sdkReleaseType = sdkReleaseType?.ToLower() ?? "";
+                var supportedReleaseTypes = new[] { "beta", "stable" };
+                if (!supportedReleaseTypes.Contains(sdkReleaseType))
+                {
+                    return $"Invalid SDK release type. Supported release types are: {string.Join(", ", supportedReleaseTypes)}";
+                }
+
                 var releasePlan = new ReleasePlan
                 {
                     SDKReleaseMonth = targetReleaseMonthYear,
@@ -144,7 +161,9 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     SpecType = specType,
                     IsManagementPlane = isMgmt,
                     IsDataPlane = !isMgmt,
-                    SpecPullRequests = [specPullRequestUrl]
+                    SpecPullRequests = [specPullRequestUrl],
+                    IsTestReleasePlan = isTestReleasePlan,
+                    SDKReleaseType = sdkReleaseType,
                 };
                 var workItem = await devOpsService.CreateReleasePlanWorkItem(releasePlan);
                 if (workItem == null)


### PR DESCRIPTION
- Add support to create test release plan
- Include SDK release type in release plan
- Change TypeSpec validation to use call back to get output from process
- Get release plan using work item id or release plan number.