### PR TITLE
Type spec mcp changes

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ReleasePlan.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Models/ReleasePlan.cs
@@ -25,7 +25,7 @@ namespace Azure.Sdk.Tools.Cli.Models
         public bool IsTestReleasePlan { get; set; } = false;
         public int ReleasePlanId { get; set; }
         public string SDKReleaseType { get; set; } = string.Empty;
-        public List<SDKGenerationInfo> SDKGenerationInfos { get; set; } = [];
+        public List<SDKInfo> SDKInfo { get; set; } = [];
 
         public Microsoft.VisualStudio.Services.WebApi.Patch.Json.JsonPatchDocument GetPatchDocument()
         {
@@ -102,7 +102,7 @@ namespace Azure.Sdk.Tools.Cli.Models
         }
     }
 
-    public class SDKGenerationInfo
+    public class SDKInfo
     {
         public string Language { get; set; } = string.Empty;
         public string GenerationPipelineUrl { get; set; } = string.Empty;

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -107,7 +107,6 @@ namespace Azure.Sdk.Tools.Cli.Services
             var workItem = await _connection.GetWorkItemClient().GetWorkItemAsync(workItemId);
             if (workItem?.Id == null)
                 throw new InvalidOperationException($"Work item {workItemId} not found.");
-            _logger.LogInformation($"Release plan work item: [{JsonSerializer.Serialize(workItem)}]");
             var releasePlan = MapWorkItemToReleasePlan(workItem);
             releasePlan.WorkItemUrl = workItem.Url;
             releasePlan.WorkItemId = workItem?.Id ?? 0;


### PR DESCRIPTION
This PR has changes to add new MCP tool and CLI to `link SDK PR` to release plan to support generating SDK locally. this also ha changes to get release plan using the release planner Id in addition to work item Id. So a use who knows about release plan created in release planner can use it agent work flow.

- Bug fixes related to language name when agent decides to send values in different casing.
