### PR TITLE
[testmodeler] export type

### DIFF
--- a/tools/sdk-testgen/src/index.ts
+++ b/tools/sdk-testgen/src/index.ts
@@ -14,3 +14,7 @@ const extension = new AutoRestExtension();
 extension.add('test-modeler', testModeler);
 
 extension.run();
+
+export * from './core/model';
+export * from './common/testConfig';
+export * from './util/helper';


### PR DESCRIPTION
autorest.go rely on this package. in order to upgrade to latest version, it needs to export some types used in autorest.go