### PR TITLE
[Part 2] detect parameters.ts for model only

### DIFF
--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.11.0",
+  "version": "2.10.1",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/src/common/changelog/automaticGenerateChangeLogAndBumpVersion.ts
+++ b/tools/js-sdk-release-tools/src/common/changelog/automaticGenerateChangeLogAndBumpVersion.ts
@@ -38,7 +38,7 @@ export async function generateChangelogAndBumpVersion(packageFolderPath: string,
 
     if (!npmViewResult || (!!stableVersion && isBetaVersion(stableVersion) && isStableRelease)) {
         logger.info(`Package ${packageName} is first ${!npmViewResult ? ' ' : ' stable'} release, start to generate changelogs and set version for first ${!npmViewResult ? ' ' : ' stable'} release.`);
-        makeChangesForFirstRelease(packageFolderPath, isStableRelease);
+        await makeChangesForFirstRelease(packageFolderPath, isStableRelease);
         logger.info(`Generated changelogs and setting version for first${!npmViewResult ? ' ' : ' stable'} release successfully`);
     } else {
         if (!stableVersion) {
@@ -132,11 +132,11 @@ export async function generateChangelogAndBumpVersion(packageFolderPath: string,
                     if (oriVersionReleased) {
                         newVersion = isBetaVersion(oriVersion) ? bumpPreviewVersion(oriVersion, usedVersions) : bumpPatchVersion(oriVersion, usedVersions);
                     }
-                    makeChangesForPatchReleasingTrack2(packageFolderPath, newVersion);
+                    await makeChangesForPatchReleasingTrack2(packageFolderPath, newVersion);
                 } else {
                     await changelog.postProcess(npmPackageRoot, packageFolderPath, clientType)
                     const newVersion = getNewVersion(stableVersion, usedVersions, changelog.hasBreakingChange, isStableRelease);
-                    makeChangesForReleasingTrack2(packageFolderPath, newVersion, changelog, originalChangeLogContent, stableVersion);
+                    await makeChangesForReleasingTrack2(packageFolderPath, newVersion, changelog, originalChangeLogContent, stableVersion);
                     logger.info('Generated changelogs and set version for track2 release successfully.');
                     return changelog;
                 }
@@ -144,7 +144,7 @@ export async function generateChangelogAndBumpVersion(packageFolderPath: string,
                 logger.info(`Package ${packageName} released before is track1 sdk.`);
                 logger.info('Start to generate changelog of migrating track1 to track2 sdk.');
                 const newVersion = getNewVersion(stableVersion, usedVersions, true, isStableRelease);
-                makeChangesForMigrateTrack1ToTrack2(packageFolderPath, newVersion);
+                await makeChangesForMigrateTrack1ToTrack2(packageFolderPath, newVersion);
                 logger.info('Generated changelogs and setting version for migrating track1 to track2 successfully.');
             }
         } finally {

--- a/tools/js-sdk-release-tools/src/common/changelog/modifyChangelogFileAndBumpVersion.ts
+++ b/tools/js-sdk-release-tools/src/common/changelog/modifyChangelogFileAndBumpVersion.ts
@@ -30,7 +30,7 @@ export function getFirstReleaseContent(packageFolderPath: string, isStableReleas
     }
 }
 
-export function makeChangesForFirstRelease(packageFolderPath: string, isStableRelease: boolean) {
+export async function makeChangesForFirstRelease(packageFolderPath: string, isStableRelease: boolean) {
     const newVersion = isStableRelease? '1.0.0' : '1.0.0-beta.1';
     const contentLog = getFirstReleaseContent(packageFolderPath, isStableRelease);
     const content = `# Release History
@@ -43,10 +43,10 @@ ${contentLog}
 `;
     fs.writeFileSync(path.join(packageFolderPath, 'CHANGELOG.md'), content, 'utf8');
     changePackageJSON(packageFolderPath, newVersion);
-    updateUserAgent(packageFolderPath, newVersion);
+    await updateUserAgent(packageFolderPath, newVersion);
 }
 
-export function makeChangesForMigrateTrack1ToTrack2(packageFolderPath: string, nextPackageVersion: string) {
+export async function makeChangesForMigrateTrack1ToTrack2(packageFolderPath: string, nextPackageVersion: string) {
     const packageJsonData: any = JSON.parse(fs.readFileSync(path.join(packageFolderPath, 'package.json'), 'utf8'));
     const content = `# Release History
     
@@ -64,7 +64,7 @@ To learn more, please refer to our documentation [Quick Start](https://aka.ms/az
 `;
     fs.writeFileSync(path.join(packageFolderPath, 'CHANGELOG.md'), content, 'utf8');
     changePackageJSON(packageFolderPath, nextPackageVersion);
-    updateUserAgent(packageFolderPath, nextPackageVersion)
+    await updateUserAgent(packageFolderPath, nextPackageVersion)
 }
 
 function changePackageJSON(packageFolderPath: string, packageVersion: string) {
@@ -73,7 +73,7 @@ function changePackageJSON(packageFolderPath: string, packageVersion: string) {
     fs.writeFileSync(path.join(packageFolderPath, 'package.json'), result, 'utf8');
 }
 
-export function makeChangesForReleasingTrack2(packageFolderPath: string, packageVersion: string, changeLog: Changelog, originalChangeLogContent: string, comparedVersion:string) {
+export async function makeChangesForReleasingTrack2(packageFolderPath: string, packageVersion: string, changeLog: Changelog, originalChangeLogContent: string, comparedVersion:string) {
     let pacakgeVersionDetail = `## ${packageVersion} (${date})`;
     if(packageVersion.includes("beta")){
         pacakgeVersionDetail +=`\nCompared with version ${comparedVersion}`
@@ -89,10 +89,10 @@ ${originalChangeLogContent.replace(/.*Release History[\n\r]*/g, '')}`;
     fs.writeFileSync(path.join(packageFolderPath, 'CHANGELOG.md'), modifiedChangelogContent, {encoding: 'utf-8'});
 
     changePackageJSON(packageFolderPath, packageVersion);
-    updateUserAgent(packageFolderPath, packageVersion);
+    await updateUserAgent(packageFolderPath, packageVersion);
 }
 
-export function makeChangesForPatchReleasingTrack2(packageFolderPath: string, packageVersion: string) {
+export async function makeChangesForPatchReleasingTrack2(packageFolderPath: string, packageVersion: string) {
     changePackageJSON(packageFolderPath, packageVersion);
-    updateUserAgent(packageFolderPath, packageVersion);
+    await updateUserAgent(packageFolderPath, packageVersion);
 }

--- a/tools/js-sdk-release-tools/src/common/interfaces.ts
+++ b/tools/js-sdk-release-tools/src/common/interfaces.ts
@@ -3,3 +3,7 @@ import { ApiVersionType } from "./types.js";
 export interface IApiVersionTypeExtractor {
     (packageRoot: string): Promise<ApiVersionType>;
 }
+
+export interface IModelOnlyChecker {
+    (packageRoot: string): Promise<boolean>;
+}

--- a/tools/js-sdk-release-tools/src/llc/apiVersion/apiVersionTypeExtractor.ts
+++ b/tools/js-sdk-release-tools/src/llc/apiVersion/apiVersionTypeExtractor.ts
@@ -1,7 +1,7 @@
 import { getApiVersionTypeFromOperations, getApiVersionTypeFromRestClient, tryFindRestClientPath } from "../../xlc/apiVersion/utils.js";
 
 import { ApiVersionType } from "../../common/types.js";
-import { IApiVersionTypeExtractor } from "../../common/interfaces.js";
+import { IApiVersionTypeExtractor, IModelOnlyChecker } from "../../common/interfaces.js";
 import { join } from "path";
 import pkg from 'fs-extra';
 const { exists, readFile } = pkg;
@@ -57,17 +57,33 @@ export const getApiVersionType: IApiVersionTypeExtractor = async (
         if (typeFromClient !== ApiVersionType.None) return typeFromClient;
     }
 
+    const isModelOnlyPackage = await isModelOnly(packageRoot);
+    if (isModelOnlyPackage) {
+        logger.info('No operation found, fallback to get api version type from latest version in NPM');
+        const packageName = getNpmPackageName(packageRoot);
+        const npmViewResult = await tryGetNpmView(packageName);
+        const latestVersion = getVersion(npmViewResult, "latest");
+        const isBeta = isBetaVersion(latestVersion);
+        return isBeta ? ApiVersionType.Preview : ApiVersionType.Stable;
+    }
+    
     logger.info('Failed to find api version in client, fallback to get api version type in operation\'s parameter');
     const parametersPath = await resolveParameterPath(packageRoot);
-    if (await exists(parametersPath)) {
-        const typeFromOperations = getApiVersionTypeFromOperations(parametersPath);
-        if (typeFromOperations !== ApiVersionType.None) return typeFromOperations;
-    }
+    const typeFromOperations = getApiVersionTypeFromOperations(parametersPath);
+    if (typeFromOperations !== ApiVersionType.None) return typeFromOperations;
+    return ApiVersionType.Stable;
+};
 
-    logger.info('No operation found, fallback to get api version type from latest version in NPM');
-    const packageName = getNpmPackageName(packageRoot);
-    const npmViewResult = await tryGetNpmView(packageName);
-    const latestVersion = getVersion(npmViewResult, "latest");
-    const isBeta = isBetaVersion(latestVersion);
-    return isBeta ? ApiVersionType.Preview : ApiVersionType.Stable;
+export const isModelOnly: IModelOnlyChecker = async (packageRoot: string): Promise<boolean> => {
+    // For LLC, simply check for parameters.ts - its absence indicates a model-only service
+    const parametersPath = await resolveParameterPath(packageRoot);
+    const isParametersExists = await exists(parametersPath);
+    
+    if (!isParametersExists) {
+        logger.info(`No parameters.ts found in ${packageRoot}, this is a model-only service in LLC`);
+        return true;
+    }
+    
+    logger.info(`Found parameters.ts in ${packageRoot}, this is not a model-only service`);
+    return false;
 };

--- a/tools/js-sdk-release-tools/src/llc/apiVersion/apiVersionTypeExtractor.ts
+++ b/tools/js-sdk-release-tools/src/llc/apiVersion/apiVersionTypeExtractor.ts
@@ -72,7 +72,7 @@ export const isModelOnly: IModelOnlyChecker = async (packageRoot: string): Promi
     const isParametersExists = await exists(parametersPath);
     
     if (!isParametersExists) {
-        logger.info(`No parameters.ts found in ${packageRoot}, this is a model-only service in LLC`);
+        logger.warn(`No parameters.ts found in ${packageRoot}, this is a model-only service in LLC`);
         return true;
     }
     

--- a/tools/js-sdk-release-tools/src/mlc/apiVersion/apiVersionTypeExtractor.ts
+++ b/tools/js-sdk-release-tools/src/mlc/apiVersion/apiVersionTypeExtractor.ts
@@ -35,7 +35,7 @@ export const isModelOnly: IModelOnlyChecker = async (packageRoot: string): Promi
     const isParametersExists = await exists(parametersPath);
     
     if (!isParametersExists) {
-        logger.warn(`No parameters.ts found in ${packageRoot}, this is a model-only service in MLC`);
+        logger.warn(`No parameters.ts found in ${packageRoot}, this is a model-only service in Modular client`);
         return true;
     }
     

--- a/tools/js-sdk-release-tools/src/mlc/apiVersion/apiVersionTypeExtractor.ts
+++ b/tools/js-sdk-release-tools/src/mlc/apiVersion/apiVersionTypeExtractor.ts
@@ -35,7 +35,7 @@ export const isModelOnly: IModelOnlyChecker = async (packageRoot: string): Promi
     const isParametersExists = await exists(parametersPath);
     
     if (!isParametersExists) {
-        logger.info(`No parameters.ts found in ${packageRoot}, this is a model-only service in MLC`);
+        logger.warn(`No parameters.ts found in ${packageRoot}, this is a model-only service in MLC`);
         return true;
     }
     

--- a/tools/js-sdk-release-tools/src/xlc/apiVersion/apiVersionTypeExtractor.ts
+++ b/tools/js-sdk-release-tools/src/xlc/apiVersion/apiVersionTypeExtractor.ts
@@ -1,6 +1,6 @@
 import { getSDKType } from "../../common/utils.js";
 import { ApiVersionType, SDKType } from "../../common/types.js";
-import { IApiVersionTypeExtractor } from "../../common/interfaces.js";
+import { IApiVersionTypeExtractor, IModelOnlyChecker } from "../../common/interfaces.js";
 import * as mlcApi from '../../mlc/apiVersion/apiVersionTypeExtractor.js'
 import * as hlcApi from '../../hlc/apiVersion/apiVersionTypeExtractor.js'
 import * as rlcApi from '../../llc/apiVersion/apiVersionTypeExtractor.js'
@@ -18,5 +18,20 @@ export const getApiVersionType: IApiVersionTypeExtractor = async (packageRoot: s
         default:
             logger.warn(`Unsupported SDK type ${sdkType} to get detact api version`);
             return ApiVersionType.None;
+    }
+}
+
+export const isModelOnly: IModelOnlyChecker = async (packageRoot: string): Promise<boolean> => {
+    const sdkType = getSDKType(packageRoot);
+    switch (sdkType) {
+        case SDKType.ModularClient:
+            return await mlcApi.isModelOnly(packageRoot);
+        case SDKType.HighLevelClient:
+            return false;
+        case SDKType.RestLevelClient:
+            return await rlcApi.isModelOnly(packageRoot); 
+        default:
+            logger.warn(`Unsupported SDK type ${sdkType} to check if package is model-only`);
+            return false;
     }
 }

--- a/tools/js-sdk-release-tools/src/xlc/codeUpdate/updateUserAgent.ts
+++ b/tools/js-sdk-release-tools/src/xlc/codeUpdate/updateUserAgent.ts
@@ -27,7 +27,7 @@ export async function updateUserAgent(packageFolderPath: string, packageVersion:
             // Check if it's a model-only package for MLC
             const isMlcModelOnly = await isModelOnly(packageFolderPath);
             if (isMlcModelOnly) {
-                logger.info(`MLC package in ${packageFolderPath} is a model-only package, skipping user agent update`);
+                logger.info(`Modular client package in ${packageFolderPath} is a model-only package, skipping user agent update`);
                 break;
             }
 

--- a/tools/js-sdk-release-tools/src/xlc/codeUpdate/updateUserAgent.ts
+++ b/tools/js-sdk-release-tools/src/xlc/codeUpdate/updateUserAgent.ts
@@ -1,11 +1,19 @@
 import { ApiVersionType, SDKType } from "../../common/types.js";
 import { getSDKType } from "../../common/utils.js";
 import { logger } from "../../utils/logger.js";
+import { isModelOnly } from "../apiVersion/apiVersionTypeExtractor.js";
 
 import * as fs from "fs";
 import * as path from "path";
 
-export function updateUserAgent(packageFolderPath: string, packageVersion: string) {
+export async function updateUserAgent(packageFolderPath: string, packageVersion: string) {
+    // Skip updating user agent for model-only packages
+    const isModelOnlyPackage = await isModelOnly(packageFolderPath);
+    if (isModelOnlyPackage) {
+        logger.info(`Package in ${packageFolderPath} is a model-only package, skipping user agent update`);
+        return;
+    }
+
     const packageJsonData: any = JSON.parse(fs.readFileSync(path.join(packageFolderPath, 'package.json'), 'utf8'));
     const packageName = packageJsonData.name.replace("@azure/", "");
     const sdkType = getSDKType(packageFolderPath);

--- a/tools/js-sdk-release-tools/src/xlc/codeUpdate/updateUserAgent.ts
+++ b/tools/js-sdk-release-tools/src/xlc/codeUpdate/updateUserAgent.ts
@@ -25,9 +25,9 @@ export async function updateUserAgent(packageFolderPath: string, packageVersion:
             break;
         case SDKType.ModularClient:
             // Check if it's a model-only package for MLC
-            const isMlcModelOnly = await isModelOnly(packageFolderPath);
-            if (isMlcModelOnly) {
-                logger.info(`Modular client package in ${packageFolderPath} is a model-only package, skipping user agent update`);
+            const isModelOnlyForModularClient = await isModelOnly(packageFolderPath);
+            if (isModelOnlyForModularClient) {
+                logger.info(`Modular client package in ${packageFolderPath} is a model-only package, skipping user agent update.`);
                 break;
             }
 


### PR DESCRIPTION
https://github.com/Azure/azure-sdk-tools/issues/10798
simply check for parameters.ts - its absence indicates a model-only service
test: https://dev.azure.com/azure-sdk/public/_build/results?buildId=4943502&view=logs&j=83516c17-6666-5250-abde-63983ce72a49&t=00be4b52-4a63-5865-8e02-c61723ad0692&l=857