### PR TITLE
Rename methods to include 'Async' suffix

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/GitHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/GitHelper.cs
@@ -9,7 +9,7 @@ namespace Azure.Sdk.Tools.Cli.Helpers
     public interface IGitHelper
     {
         // Get the owner 
-        public Task<string> GetRepoOwnerName(string path, bool findForkParent = true);
+        public Task<string> GetRepoOwnerNameAsync(string path, bool findForkParent = true);
         public Uri GetRepoRemoteUri(string path);
         public string GetBranchName(string path);
         public string GetMergeBaseCommitSha(string path, string targetBranch);
@@ -53,7 +53,7 @@ namespace Azure.Sdk.Tools.Cli.Helpers
             throw new InvalidOperationException("Unable to determine remote URL.");
         }
 
-        public async Task<string> GetRepoOwnerName(string path, bool findForkParent = true)
+        public async Task<string> GetRepoOwnerNameAsync(string path, bool findForkParent = true)
         {
             var uri = GetRepoRemoteUri(path);
             var segments = uri.Segments;
@@ -67,7 +67,7 @@ namespace Azure.Sdk.Tools.Cli.Helpers
 
             if(findForkParent) {
                 // Check if the repo is a fork and get the parent repo
-                var parentRepoUrl = await gitHubService.GetGitHubParentRepoUrl(repoOwner, repoName);
+                var parentRepoUrl = await gitHubService.GetGitHubParentRepoUrlAsync(repoOwner, repoName);
                 logger.LogInformation($"Parent repo URL: {parentRepoUrl}");
                 if (!string.IsNullOrEmpty(parentRepoUrl))
                 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
@@ -9,11 +9,11 @@ namespace Azure.Sdk.Tools.Cli.Services
 {
     public interface IGitHubService
     {
-        public Task<User> GetGitUserDetails();
-        public Task<List<String>> GetPullRequestChecks(int pullRequestNumber, string repoName, string repoOwner);
+        public Task<User> GetGitUserDetailsAsync();
+        public Task<List<String>> GetPullRequestChecksAsync(int pullRequestNumber, string repoName, string repoOwner);
         public Task<PullRequest> GetPullRequestAsync(string repoOwner, string repoName, int pullRequestNumber);
-        public Task<string> GetGitHubParentRepoUrl(string owner, string repoName);
-        public Task<List<string>> CreatePullRequest(string repoName, string repoOwner, string baseBranch, string headBranch, string title, string body);
+        public Task<string> GetGitHubParentRepoUrlAsync(string owner, string repoName);
+        public Task<List<string>> CreatePullRequestAsync(string repoName, string repoOwner, string baseBranch, string headBranch, string title, string body);
         public Task<List<string>> GetPullRequestCommentsAsync(string repoOwner, string repoName, int pullRequestNumber);
         public Task<PullRequest?> GetPullRequestForBranchAsync(string repoOwner, string repoName, string remoteBranch);
         public Task<Issue> GetIssueAsync(string repoOwner, string repoName, int issueNumber);
@@ -36,7 +36,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             };
         }
 
-        public async Task<User> GetGitUserDetails()
+        public async Task<User> GetGitUserDetailsAsync()
         {
             var user = await gitHubClient.User.Current();
             return user;
@@ -78,7 +78,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             }
         }
 
-        public async Task<string> GetGitHubParentRepoUrl(string owner, string repoName)
+        public async Task<string> GetGitHubParentRepoUrlAsync(string owner, string repoName)
         {
             var repository = await gitHubClient.Repository.Get(owner, repoName);
             if (repository == null)
@@ -96,7 +96,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             return pullRequests?.FirstOrDefault(pr => pr.Head?.Label != null && pr.Head.Label.Equals(remoteBranch, StringComparison.InvariantCultureIgnoreCase));
         }
 
-        private async Task<bool> IsDiffMergeable(string targetRepoOwner, string repoName, string baseBranch, string headBranch)
+        private async Task<bool> IsDiffMergeableAsync(string targetRepoOwner, string repoName, string baseBranch, string headBranch)
         {
             logger.LogInformation("Comparing the head branch against target branch");
             var comparison = await gitHubClient.Repository.Commit.Compare(targetRepoOwner, repoName, baseBranch, headBranch);
@@ -104,7 +104,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             return comparison?.MergeBaseCommit != null;
         }
 
-        public async Task<List<string>> CreatePullRequest(string repoName, string repoOwner, string baseBranch, string headBranch, string title, string body)
+        public async Task<List<string>> CreatePullRequestAsync(string repoName, string repoOwner, string baseBranch, string headBranch, string title, string body)
         {
             var responseList = new List<string>();
             // Check if a pull request already exists for the branch
@@ -129,7 +129,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             try
             {
                 responseList.Add($"Checking if changes are mergeable to {baseBranch} branch in repository [{repoOwner}/{repoName}]...");
-                var isMergeable = await IsDiffMergeable(repoOwner, repoName, baseBranch, headBranch);
+                var isMergeable = await IsDiffMergeableAsync(repoOwner, repoName, baseBranch, headBranch);
                 if (!isMergeable)
                 {
                     responseList.Add($"Changes from [{repoOwner}] are not mergeable to {baseBranch} branch in repository [{repoOwner}/{repoName}]. Please resolve the conflicts and try again.");
@@ -203,7 +203,7 @@ namespace Azure.Sdk.Tools.Cli.Services
             }
         }
 
-        public async Task<List<String>> GetPullRequestChecks(int pullRequestNumber, string repoName, string repoOwner)
+        public async Task<List<String>> GetPullRequestChecksAsync(int pullRequestNumber, string repoName, string repoOwner)
         {
             var checkResults = new List<string>();
             try

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
@@ -51,7 +51,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
 
 
         [McpServerTool, Description("Get release plan for API spec pull request. This tool should be used only if work item Id is unknown.")]
-        public async Task<string> GetReleasePlanForPullRequest(string pullRequestLink)
+        public async Task<string> GetReleasePlanForPullRequestAsync(string pullRequestLink)
         {
             try
             {
@@ -109,7 +109,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     var sdkReleaseType = commandParser.GetValueForOption(sdkReleaseTypeOpt);
                     var isTestReleasePlan = commandParser.GetValueForOption(isTestReleasePlanOpt);
                     var userEmail = commandParser.GetValueForOption(userEmailOpt);
-                    var releasePlan = await CreateReleasePlan(typeSpecProjectPath, targetReleaseMonthYear, serviceTreeId, productTreeId, specApiVersion, specPullRequestUrl, sdkReleaseType, userEmail: userEmail, isTestReleasePlan: isTestReleasePlan);
+                    var releasePlan = await CreateReleasePlanAsync(typeSpecProjectPath, targetReleaseMonthYear, serviceTreeId, productTreeId, specApiVersion, specPullRequestUrl, sdkReleaseType, userEmail: userEmail, isTestReleasePlan: isTestReleasePlan);
                     output.Output($"Release plan created: {releasePlan}");
                     return;
 
@@ -147,7 +147,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Create Release Plan work item.")]
-        public async Task<string> CreateReleasePlan(string typeSpecProjectPath, string targetReleaseMonthYear, string serviceTreeId, string productTreeId, string specApiVersion, string specPullRequestUrl, string sdkReleaseType, string userEmail = "", bool isTestReleasePlan = false)
+        public async Task<string> CreateReleasePlanAsync(string typeSpecProjectPath, string targetReleaseMonthYear, string serviceTreeId, string productTreeId, string specApiVersion, string specPullRequestUrl, string sdkReleaseType, string userEmail = "", bool isTestReleasePlan = false)
         {
             try
             {
@@ -219,7 +219,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
 
         [McpServerTool, Description("Update the SDK details in the release plan work item. This tool is called to update SDK language and package name in the release plan work item." +
             " sdkDetails parameter is a JSON of list of SDKInfo and each SDKInfo contains Language and PackageName as properties.")]
-        public async Task<string> UpdateSDKDetailsInReleasePlan(int releasePlanWorkItemId, string sdkDetails)
+        public async Task<string> UpdateSDKDetailsInReleasePlanAsync(int releasePlanWorkItemId, string sdkDetails)
         {
             try
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
@@ -56,7 +56,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
             try
             {
                 List<string> releasePlanList = [];
-                var releasePlan = await devOpsService.GetReleasePlan(pullRequestLink);
+                var releasePlan = await devOpsService.GetReleasePlanAsync(pullRequestLink);
                 var _out = releasePlan == null ? "Failed to get release plan details." :
                     $"Release Plan: {JsonSerializer.Serialize(releasePlan)}";
                 return output.Format(_out);
@@ -95,7 +95,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 case getReleasePlanDetailsCommandName:
                     var workItemId = commandParser.GetValueForOption(workItemIdOpt);
                     var releasePlanNumber = commandParser.GetValueForOption(releasePlanNumberOpt);
-                    var releasePlanDetails = await GetReleasePlan(workItem: workItemId, releasePlanId: releasePlanNumber);
+                    var releasePlanDetails = await GetReleasePlanAsync(workItem: workItemId, releasePlanId: releasePlanNumber);
                     output.Output($"Release plan details: {releasePlanDetails}");
                     return;
 
@@ -114,7 +114,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     return;
 
                 case linkNamespaceApprovalIssueCommandName:
-                    var linkResponse = await LinkNameSpaceApprovalIssue(commandParser.GetValueForOption(workItemIdOpt), commandParser.GetValueForOption(namespaceApprovalIssueOpt));
+                    var linkResponse = await LinkNamespaceApprovalIssueAsync(commandParser.GetValueForOption(workItemIdOpt), commandParser.GetValueForOption(namespaceApprovalIssueOpt));
                     output.Output($"Link namespace approval issue response: {linkResponse}");
                     return;
 
@@ -126,7 +126,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Get Release Plan: Get release plan work item details for a given work item id or release plan Id.")]
-        public async Task<string> GetReleasePlan(int workItem = 0, int releasePlanId = 0)
+        public async Task<string> GetReleasePlanAsync(int workItem = 0, int releasePlanId = 0)
         {
             try
             {
@@ -134,7 +134,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 {
                     return "Either work item ID or release plan number must be provided.";
                 }
-                var releasePlan = workItem != 0 ? await devOpsService.GetReleasePlanForWorkItem(workItem) : await devOpsService.GetReleasePlan(releasePlanId);
+                var releasePlan = workItem != 0 ? await devOpsService.GetReleasePlanForWorkItemAsync(workItem) : await devOpsService.GetReleasePlanAsync(releasePlanId);
                 var releasePlanText = releasePlan != null ? JsonSerializer.Serialize(releasePlan) :
                        "Failed to get release plan details.";
                 return releasePlanText;
@@ -199,7 +199,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     IsCreatedByAgent = true,
                     ReleasePlanSubmittedByEmail = userEmail
                 };
-                var workItem = await devOpsService.CreateReleasePlanWorkItem(releasePlan);
+                var workItem = await devOpsService.CreateReleasePlanWorkItemAsync(releasePlan);
                 if (workItem == null)
                 {
                     SetFailure();
@@ -246,7 +246,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     return $"Unsupported SDK language found. Supported languages are: {string.Join(", ", supportedLanguages)}";
                 }
 
-                var updated = await devOpsService.UpdateReleasePlanSDKDetails(releasePlanWorkItemId, SdkInfos);
+                var updated = await devOpsService.UpdateReleasePlanSDKDetailsAsync(releasePlanWorkItemId, SdkInfos);
                 if (!updated)
                 {
                     SetFailure();
@@ -271,7 +271,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Link package namespace approval issue to release plan(required only for management plan). This requires GitHub issue URL for the namespace approval request and release plan work item id.")]
-        public async Task<string> LinkNameSpaceApprovalIssue(int releasePlanWorkItemId, string namespaceApprovalIssue)
+        public async Task<string> LinkNamespaceApprovalIssueAsync(int releasePlanWorkItemId, string namespaceApprovalIssue)
         {
             try
             {
@@ -281,7 +281,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 }
 
                 // Get release plan and verify if it is a management plane release plan before linking namespace approval issue
-                var releasePlan = await devOpsService.GetReleasePlanForWorkItem(releasePlanWorkItemId);
+                var releasePlan = await devOpsService.GetReleasePlanForWorkItemAsync(releasePlanWorkItemId);
                 if (releasePlan == null)
                 {
                     return $"Release plan with ID {releasePlanWorkItemId} not found.";
@@ -323,7 +323,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     response.Append($"Package namespace has been approved.");
                 }
 
-                var updated = await devOpsService.LinkNamespaceApprovalIssue(releasePlanWorkItemId, issue.HtmlUrl);
+                var updated = await devOpsService.LinkNamespaceApprovalIssueAsync(releasePlanWorkItemId, issue.HtmlUrl);
                 if (!updated)
                 {
                     SetFailure();

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
@@ -51,7 +51,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
 
 
         [McpServerTool, Description("Get release plan for API spec pull request. This tool should be used only if work item Id is unknown.")]
-        public async Task<string> GetReleasePlanForPullRequestAsync(string pullRequestLink)
+        public async Task<string> GetReleasePlanForPullRequest(string pullRequestLink)
         {
             try
             {
@@ -95,7 +95,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 case getReleasePlanDetailsCommandName:
                     var workItemId = commandParser.GetValueForOption(workItemIdOpt);
                     var releasePlanNumber = commandParser.GetValueForOption(releasePlanNumberOpt);
-                    var releasePlanDetails = await GetReleasePlanAsync(workItem: workItemId, releasePlanId: releasePlanNumber);
+                    var releasePlanDetails = await GetReleasePlan(workItem: workItemId, releasePlanId: releasePlanNumber);
                     output.Output($"Release plan details: {releasePlanDetails}");
                     return;
 
@@ -109,12 +109,12 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     var sdkReleaseType = commandParser.GetValueForOption(sdkReleaseTypeOpt);
                     var isTestReleasePlan = commandParser.GetValueForOption(isTestReleasePlanOpt);
                     var userEmail = commandParser.GetValueForOption(userEmailOpt);
-                    var releasePlan = await CreateReleasePlanAsync(typeSpecProjectPath, targetReleaseMonthYear, serviceTreeId, productTreeId, specApiVersion, specPullRequestUrl, sdkReleaseType, userEmail: userEmail, isTestReleasePlan: isTestReleasePlan);
+                    var releasePlan = await CreateReleasePlan(typeSpecProjectPath, targetReleaseMonthYear, serviceTreeId, productTreeId, specApiVersion, specPullRequestUrl, sdkReleaseType, userEmail: userEmail, isTestReleasePlan: isTestReleasePlan);
                     output.Output($"Release plan created: {releasePlan}");
                     return;
 
                 case linkNamespaceApprovalIssueCommandName:
-                    var linkResponse = await LinkNamespaceApprovalIssueAsync(commandParser.GetValueForOption(workItemIdOpt), commandParser.GetValueForOption(namespaceApprovalIssueOpt));
+                    var linkResponse = await LinkNamespaceApprovalIssue(commandParser.GetValueForOption(workItemIdOpt), commandParser.GetValueForOption(namespaceApprovalIssueOpt));
                     output.Output($"Link namespace approval issue response: {linkResponse}");
                     return;
 
@@ -126,7 +126,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Get Release Plan: Get release plan work item details for a given work item id or release plan Id.")]
-        public async Task<string> GetReleasePlanAsync(int workItem = 0, int releasePlanId = 0)
+        public async Task<string> GetReleasePlan(int workItem = 0, int releasePlanId = 0)
         {
             try
             {
@@ -147,7 +147,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Create Release Plan work item.")]
-        public async Task<string> CreateReleasePlanAsync(string typeSpecProjectPath, string targetReleaseMonthYear, string serviceTreeId, string productTreeId, string specApiVersion, string specPullRequestUrl, string sdkReleaseType, string userEmail = "", bool isTestReleasePlan = false)
+        public async Task<string> CreateReleasePlan(string typeSpecProjectPath, string targetReleaseMonthYear, string serviceTreeId, string productTreeId, string specApiVersion, string specPullRequestUrl, string sdkReleaseType, string userEmail = "", bool isTestReleasePlan = false)
         {
             try
             {
@@ -219,7 +219,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
 
         [McpServerTool, Description("Update the SDK details in the release plan work item. This tool is called to update SDK language and package name in the release plan work item." +
             " sdkDetails parameter is a JSON of list of SDKInfo and each SDKInfo contains Language and PackageName as properties.")]
-        public async Task<string> UpdateSDKDetailsInReleasePlanAsync(int releasePlanWorkItemId, string sdkDetails)
+        public async Task<string> UpdateSDKDetailsInReleasePlan(int releasePlanWorkItemId, string sdkDetails)
         {
             try
             {
@@ -271,7 +271,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Link package namespace approval issue to release plan(required only for management plan). This requires GitHub issue URL for the namespace approval request and release plan work item id.")]
-        public async Task<string> LinkNamespaceApprovalIssueAsync(int releasePlanWorkItemId, string namespaceApprovalIssue)
+        public async Task<string> LinkNamespaceApprovalIssue(int releasePlanWorkItemId, string namespaceApprovalIssue)
         {
             try
             {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecPullRequestTools/SpecPullRequestTools.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecPullRequestTools/SpecPullRequestTools.cs
@@ -42,7 +42,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
 
 
         [McpServerTool, Description("Connect to GitHub using personal access token.")]
-        public async Task<string> GetGitHubUserDetailsAsync()
+        public async Task<string> GetGitHubUserDetails()
         {
             try
             {
@@ -76,7 +76,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Get pull request link for current branch in the repo. Provide absolute path to TypeSpec project root as param. This tool call GetPullRequest to get pull request details.")]
-        public async Task<string> GetPullRequestForCurrentBranchAsync(string typeSpecProjectPath)
+        public async Task<string> GetPullRequestForCurrentBranch(string typeSpecProjectPath)
         {
             try
             {
@@ -103,7 +103,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 }
 
                 string response = $"Pull request found: {pullRequest.HtmlUrl}";
-                response += await GetPullRequestAsync(pullRequest.Number);
+                response += await GetPullRequest(pullRequest.Number);
                 return output.Format(response);
             }
             catch (Exception ex)
@@ -113,7 +113,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Create pull request for spec changes. Provide title, description and absolute path to TypeSpec project root as params. Creates a pull request for committed changes in the current branch.")]
-        public async Task<List<string>> CreatePullRequestAsync(string title, string description, string typeSpecProjectPath, string targetBranch = "main")
+        public async Task<List<string>> CreatePullRequest(string title, string description, string typeSpecProjectPath, string targetBranch = "main")
         {
             try
             {
@@ -167,7 +167,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
 
 
         [McpServerTool, Description("This tool gets pull request details, status, comments, checks, next action details, links to APIView reviews.")]
-        public async Task<string> GetPullRequestAsync(int pullRequestNumber, string repoOwner = "Azure", string repoName = "azure-rest-api-specs")
+        public async Task<string> GetPullRequest(int pullRequestNumber, string repoOwner = "Azure", string repoName = "azure-rest-api-specs")
         {
             try
             {
@@ -237,7 +237,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     logger.LogInformation("Is spec in public repo: {isPublic}", isPublic);
                     return 0;
                 case getPullRequestForCurrentBranchCommandName:
-                    var pullRequestLink = await GetPullRequestForCurrentBranchAsync(commandParser.GetValueForOption(typeSpecProjectPathOpt));
+                    var pullRequestLink = await GetPullRequestForCurrentBranch(commandParser.GetValueForOption(typeSpecProjectPathOpt));
                     logger.LogInformation("Pull request link: {pullRequestLink}", pullRequestLink);
                     return 0;
                 case createPullRequestCommandName:
@@ -245,14 +245,14 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     var description = commandParser.GetValueForOption(descriptionOpt);
                     var typeSpecProject = commandParser.GetValueForOption(typeSpecProjectPathOpt);
                     var targetBranch = commandParser.GetValueForOption(targetBranchOpt);
-                    var createPullRequestResponse = await CreatePullRequestAsync(title, description, typeSpecProject, targetBranch);
+                    var createPullRequestResponse = await CreatePullRequest(title, description, typeSpecProject, targetBranch);
                     logger.LogInformation("Create pull request response: {createPullRequestResponse}", createPullRequestResponse);
                     return 0;
                 case getPullRequestCommandName:
                     var pullRequestNumber = commandParser.GetValueForOption(pullRequestNumberOpt);
                     var repoOwner = commandParser.GetValueForOption(repoOwnerOpt);
                     var repoName = commandParser.GetValueForOption(repoNameOpt);
-                    var pullRequestDetails = await GetPullRequestAsync(pullRequestNumber, repoOwner, repoName);
+                    var pullRequestDetails = await GetPullRequest(pullRequestNumber, repoOwner, repoName);
                     logger.LogInformation("Pull request details: {pullRequestDetails}", pullRequestDetails);
                     return 0;
                 default:

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecWorkflowTool/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecWorkflowTool/SpecWorkFlowTool.cs
@@ -227,12 +227,12 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 // Spec readiness passed. So mark the spec status as approved if release plan exists.
                 if (workItemId != 0)
                 {
-                    await devopsService.UpdateApiSpecStatus(workItemId, "Approved");
+                    await devopsService.UpdateApiSpecStatusAsync(workItemId, "Approved");
                 }
 
                 string typeSpecProjectPath = typespecHelper.GetTypeSpecProjectRelativePath(typespecProjectRoot);
                 string branchRef = (pullRequest?.Merged ?? false) ? pullRequest.Base.Ref : $"refs/pull/{pullRequestNumber}/merge";
-                var pipelineRun = await devopsService.RunSDKGenerationPipeline(branchRef, typeSpecProjectPath, apiVersion, sdkReleaseType, language, workItemId);
+                var pipelineRun = await devopsService.RunSDKGenerationPipelineAsync(branchRef, typeSpecProjectPath, apiVersion, sdkReleaseType, language, workItemId);
                 response = new GenericResponse()
                 {
                     Status = "Success",
@@ -261,7 +261,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
             try
             {
                 var response = new GenericResponse();
-                var pipeline = await devopsService.GetPipelineRun(buildId);
+                var pipeline = await devopsService.GetPipelineRunAsync(buildId);
                 if (pipeline != null)
                 {
                     response.Status = pipeline.Result?.ToString() ?? "Not available";
@@ -301,7 +301,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 if (buildId == 0)
                 {
                     sb.AppendLine("Build Id is not available. Checking for SDK pull request details in release plan work item.");
-                    var releasePlan = await devopsService.GetReleasePlan(workItemId);
+                    var releasePlan = await devopsService.GetReleasePlanAsync(workItemId);
                     var sdkInfo = releasePlan?.SDKInfo.FirstOrDefault(s => string.Equals(s.Language, language, StringComparison.OrdinalIgnoreCase));
                     if (sdkInfo != null && !string.IsNullOrEmpty(sdkInfo.SdkPullRequestUrl))
                     {
@@ -316,7 +316,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 }
 
                 // Find SDK details from build pipeline run
-                var pipeline = await devopsService.GetPipelineRun(buildId);
+                var pipeline = await devopsService.GetPipelineRunAsync(buildId);
                 if (pipeline == null)
                 {
                     return $"Failed to get SDK generation pipeline run with build ID {buildId}";
@@ -332,7 +332,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     return $"SDK generation pipeline did not succeed. Status: {pipeline.Result?.ToString()}. For more details: {DevOpsService.GetPipelineUrl(buildId)}";
                 }
 
-                var data = await devopsService.GetSDKPullRequestFromPipelineRun(buildId, language, workItemId);
+                var data = await devopsService.GetSDKPullRequestFromPipelineRunAsync(buildId, language, workItemId);
                 return data;
             }
             catch (Exception ex)
@@ -388,13 +388,13 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 }
                 
                 // Add PR to release plan
-                var releasePlan = workItemId == 0 ? await devopsService.GetReleasePlan(releasePlanId) : await devopsService.GetReleasePlanForWorkItem(workItemId);
+                var releasePlan = workItemId == 0 ? await devopsService.GetReleasePlanAsync(releasePlanId) : await devopsService.GetReleasePlanForWorkItemAsync(workItemId);
                 if (releasePlan == null || releasePlan.WorkItemId == 0)
                 {
                     return $"Release plan with ID {releasePlanId} or work item ID {workItemId} is not found.";
                 }
 
-                await devopsService.AddSdkInfoInReleasePlan(releasePlan.WorkItemId, language, "", parsedLink);
+                await devopsService.AddSdkInfoInReleasePlanAsync(releasePlan.WorkItemId, language, "", parsedLink);
                 return $"Successfully linked pull request to release plan {releasePlan.ReleasePlanId}, work item id {releasePlan.WorkItemId}";
             }
             catch(Exception ex)

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecWorkflowTool/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecWorkflowTool/SpecWorkFlowTool.cs
@@ -59,14 +59,14 @@ namespace Azure.Sdk.Tools.Cli.Tools
         // disabling analyzer warning for MCP001 because the called function is in an entire try/catch block.
 #pragma warning disable MCP001
         [McpServerTool, Description("Checks whether a TypeSpec API spec is ready to generate SDK. Provide a pull request number and path to TypeSpec project json as params.")]
-        public async Task<string> CheckApiReadyForSDKGeneration(string typeSpecProjectRoot, int pullRequestNumber = 0)
+        public async Task<string> CheckApiReadyForSDKGenerationAsync(string typeSpecProjectRoot, int pullRequestNumber = 0)
 #pragma warning restore MCP001
         {
-            var response = await IsSpecReadyToGenerateSDK(typeSpecProjectRoot, pullRequestNumber);
+            var response = await IsSpecReadyToGenerateSDKAsync(typeSpecProjectRoot, pullRequestNumber);
             return output.Format(response);
         }
 
-        private async Task<GenericResponse> IsSpecReadyToGenerateSDK(string typeSpecProjectRoot, int pullRequestNumber)
+        private async Task<GenericResponse> IsSpecReadyToGenerateSDKAsync(string typeSpecProjectRoot, int pullRequestNumber)
         {
             var response = new GenericResponse()
             {
@@ -167,7 +167,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
 
 
         [McpServerTool, Description("This tool runs pipeline to generate SDK for a TypeSpec project. This tool calls IsSpecReadyForSDKGeneration to make sure Spec is ready to generate SDK.")]
-        public async Task<string> GenerateSDK(string typespecProjectRoot, string apiVersion, string sdkReleaseType, string language, int pullRequestNumber, int workItemId)
+        public async Task<string> GenerateSDKAsync(string typespecProjectRoot, string apiVersion, string sdkReleaseType, string language, int pullRequestNumber, int workItemId)
         {
             try
             {
@@ -203,7 +203,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 }
 
                 // Verify if spec is read to generate SDK
-                var readiness = await IsSpecReadyToGenerateSDK(typespecProjectRoot, pullRequestNumber);
+                var readiness = await IsSpecReadyToGenerateSDKAsync(typespecProjectRoot, pullRequestNumber);
                 if (!readiness.Status.Equals("Success"))
                 {
                     response.Details.AddRange(readiness.Details);
@@ -255,7 +255,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         /// <param name="buildId">Build ID for the pipeline run</param>
         /// <returns></returns>
         [McpServerTool, Description("Get SDK generation pipeline run details and status for a given pipeline build ID")]
-        public async Task<string> GetPipelineRunStatus(int buildId)
+        public async Task<string> GetPipelineRunStatusAsync(int buildId)
         {
                 
             try
@@ -286,7 +286,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         /// <param name="workItemId">Work item ID for the release plan</param>
         /// <returns></returns>
         [McpServerTool, Description("Get SDK pull request link from SDK generation pipeline run or from work item. Build ID of pipeline run is required to query pull request link from SDK generation pipeline. This tool can get SDK pull request details if present in a work item.")]
-        public async Task<string> GetSDKPullRequestDetails(string language, int workItemId, int buildId = 0)
+        public async Task<string> GetSDKPullRequestDetailsAsync(string language, int workItemId, int buildId = 0)
         {
             try
             {
@@ -358,7 +358,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Link SDK pull request to release plan work item")]
-        public async Task<string> LinkSdkPullRequestToReleasePlan(string language, string pullRequestUrl, int workItemId = 0, int releasePlanId = 0)
+        public async Task<string> LinkSdkPullRequestToReleasePlanAsync(string language, string pullRequestUrl, int workItemId = 0, int releasePlanId = 0)
         {
             try
             {
@@ -431,11 +431,11 @@ namespace Azure.Sdk.Tools.Cli.Tools
             switch (command)
             {
                 case checkApiReadinessCommandName:
-                    var isSpecReady = await CheckApiReadyForSDKGeneration(commandParser.GetValueForOption(typeSpecProjectPathOpt), commandParser.GetValueForOption(pullRequestNumberOpt));
+                    var isSpecReady = await CheckApiReadyForSDKGenerationAsync(commandParser.GetValueForOption(typeSpecProjectPathOpt), commandParser.GetValueForOption(pullRequestNumberOpt));
                     output.Output($"Is API spec ready for SDK generation: {isSpecReady}");
                     return;
                 case generateSdkCommandName:
-                    var sdkGenerationResponse = await GenerateSDK(commandParser.GetValueForOption(typeSpecProjectPathOpt),
+                    var sdkGenerationResponse = await GenerateSDKAsync(commandParser.GetValueForOption(typeSpecProjectPathOpt),
                         commandParser.GetValueForOption(apiVersionOpt),
                         commandParser.GetValueForOption(sdkReleaseTypeOpt),
                         commandParser.GetValueForOption(languageOpt),
@@ -444,15 +444,15 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     output.Output($"SDK generation response: {sdkGenerationResponse}");
                     return;
                 case getPipelineStatusCommandName:
-                    var pipelineRunStatus = await GetPipelineRunStatus(commandParser.GetValueForOption(pipelineRunIdOpt));
+                    var pipelineRunStatus = await GetPipelineRunStatusAsync(commandParser.GetValueForOption(pipelineRunIdOpt));
                     output.Output($"SDK generation pipeline run status: {pipelineRunStatus}");
                     return;
                 case getSdkPullRequestCommandName:
-                    var sdkPullRequestDetails = await GetSDKPullRequestDetails(commandParser.GetValueForOption(languageOpt), workItemId: commandParser.GetValueForOption(workItemIdOpt), buildId: commandParser.GetValueForOption(pipelineRunIdOpt));
+                    var sdkPullRequestDetails = await GetSDKPullRequestDetailsAsync(commandParser.GetValueForOption(languageOpt), workItemId: commandParser.GetValueForOption(workItemIdOpt), buildId: commandParser.GetValueForOption(pipelineRunIdOpt));
                     output.Output($"SDK pull request details: {sdkPullRequestDetails}");
                     return;
                 case linkSdkPrCommandName:
-                    var linkStatus = await LinkSdkPullRequestToReleasePlan(commandParser.GetValueForOption(languageOpt), commandParser.GetValueForOption(urlOpt), workItemId: commandParser.GetValueForOption(workItemOptionalIdOpt), releasePlanId: commandParser.GetValueForOption(releasePlanIdOpt));
+                    var linkStatus = await LinkSdkPullRequestToReleasePlanAsync(commandParser.GetValueForOption(languageOpt), commandParser.GetValueForOption(urlOpt), workItemId: commandParser.GetValueForOption(workItemOptionalIdOpt), releasePlanId: commandParser.GetValueForOption(releasePlanIdOpt));
                     output.Output($"Link status: {linkStatus}");
                     return;
                 default:

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecWorkflowTool/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecWorkflowTool/SpecWorkFlowTool.cs
@@ -59,7 +59,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         // disabling analyzer warning for MCP001 because the called function is in an entire try/catch block.
 #pragma warning disable MCP001
         [McpServerTool, Description("Checks whether a TypeSpec API spec is ready to generate SDK. Provide a pull request number and path to TypeSpec project json as params.")]
-        public async Task<string> CheckApiReadyForSDKGenerationAsync(string typeSpecProjectRoot, int pullRequestNumber = 0)
+        public async Task<string> CheckApiReadyForSDKGeneration(string typeSpecProjectRoot, int pullRequestNumber = 0)
 #pragma warning restore MCP001
         {
             var response = await IsSpecReadyToGenerateSDKAsync(typeSpecProjectRoot, pullRequestNumber);
@@ -167,7 +167,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
 
 
         [McpServerTool, Description("This tool runs pipeline to generate SDK for a TypeSpec project. This tool calls IsSpecReadyForSDKGeneration to make sure Spec is ready to generate SDK.")]
-        public async Task<string> GenerateSDKAsync(string typespecProjectRoot, string apiVersion, string sdkReleaseType, string language, int pullRequestNumber, int workItemId)
+        public async Task<string> GenerateSDK(string typespecProjectRoot, string apiVersion, string sdkReleaseType, string language, int pullRequestNumber, int workItemId)
         {
             try
             {
@@ -255,7 +255,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         /// <param name="buildId">Build ID for the pipeline run</param>
         /// <returns></returns>
         [McpServerTool, Description("Get SDK generation pipeline run details and status for a given pipeline build ID")]
-        public async Task<string> GetPipelineRunStatusAsync(int buildId)
+        public async Task<string> GetPipelineRunStatus(int buildId)
         {
                 
             try
@@ -286,7 +286,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         /// <param name="workItemId">Work item ID for the release plan</param>
         /// <returns></returns>
         [McpServerTool, Description("Get SDK pull request link from SDK generation pipeline run or from work item. Build ID of pipeline run is required to query pull request link from SDK generation pipeline. This tool can get SDK pull request details if present in a work item.")]
-        public async Task<string> GetSDKPullRequestDetailsAsync(string language, int workItemId, int buildId = 0)
+        public async Task<string> GetSDKPullRequestDetails(string language, int workItemId, int buildId = 0)
         {
             try
             {
@@ -358,7 +358,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
         [McpServerTool, Description("Link SDK pull request to release plan work item")]
-        public async Task<string> LinkSdkPullRequestToReleasePlanAsync(string language, string pullRequestUrl, int workItemId = 0, int releasePlanId = 0)
+        public async Task<string> LinkSdkPullRequestToReleasePlan(string language, string pullRequestUrl, int workItemId = 0, int releasePlanId = 0)
         {
             try
             {
@@ -431,11 +431,11 @@ namespace Azure.Sdk.Tools.Cli.Tools
             switch (command)
             {
                 case checkApiReadinessCommandName:
-                    var isSpecReady = await CheckApiReadyForSDKGenerationAsync(commandParser.GetValueForOption(typeSpecProjectPathOpt), commandParser.GetValueForOption(pullRequestNumberOpt));
+                    var isSpecReady = await CheckApiReadyForSDKGeneration(commandParser.GetValueForOption(typeSpecProjectPathOpt), commandParser.GetValueForOption(pullRequestNumberOpt));
                     output.Output($"Is API spec ready for SDK generation: {isSpecReady}");
                     return;
                 case generateSdkCommandName:
-                    var sdkGenerationResponse = await GenerateSDKAsync(commandParser.GetValueForOption(typeSpecProjectPathOpt),
+                    var sdkGenerationResponse = await GenerateSDK(commandParser.GetValueForOption(typeSpecProjectPathOpt),
                         commandParser.GetValueForOption(apiVersionOpt),
                         commandParser.GetValueForOption(sdkReleaseTypeOpt),
                         commandParser.GetValueForOption(languageOpt),
@@ -444,15 +444,15 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     output.Output($"SDK generation response: {sdkGenerationResponse}");
                     return;
                 case getPipelineStatusCommandName:
-                    var pipelineRunStatus = await GetPipelineRunStatusAsync(commandParser.GetValueForOption(pipelineRunIdOpt));
+                    var pipelineRunStatus = await GetPipelineRunStatus(commandParser.GetValueForOption(pipelineRunIdOpt));
                     output.Output($"SDK generation pipeline run status: {pipelineRunStatus}");
                     return;
                 case getSdkPullRequestCommandName:
-                    var sdkPullRequestDetails = await GetSDKPullRequestDetailsAsync(commandParser.GetValueForOption(languageOpt), workItemId: commandParser.GetValueForOption(workItemIdOpt), buildId: commandParser.GetValueForOption(pipelineRunIdOpt));
+                    var sdkPullRequestDetails = await GetSDKPullRequestDetails(commandParser.GetValueForOption(languageOpt), workItemId: commandParser.GetValueForOption(workItemIdOpt), buildId: commandParser.GetValueForOption(pipelineRunIdOpt));
                     output.Output($"SDK pull request details: {sdkPullRequestDetails}");
                     return;
                 case linkSdkPrCommandName:
-                    var linkStatus = await LinkSdkPullRequestToReleasePlanAsync(commandParser.GetValueForOption(languageOpt), commandParser.GetValueForOption(urlOpt), workItemId: commandParser.GetValueForOption(workItemOptionalIdOpt), releasePlanId: commandParser.GetValueForOption(releasePlanIdOpt));
+                    var linkStatus = await LinkSdkPullRequestToReleasePlan(commandParser.GetValueForOption(languageOpt), commandParser.GetValueForOption(urlOpt), workItemId: commandParser.GetValueForOption(workItemOptionalIdOpt), releasePlanId: commandParser.GetValueForOption(releasePlanIdOpt));
                     output.Output($"Link status: {linkStatus}");
                     return;
                 default:


### PR DESCRIPTION
This PR renames asynchronous methods to include the 'Async' suffix, following C# naming conventions.