### PR TITLE
Fix unported `build-tools` changes to `reassemble-signed-package`

### DIFF
--- a/eng/pipelines/templates/scripts/assemble-signed-artifact.ps1
+++ b/eng/pipelines/templates/scripts/assemble-signed-artifact.ps1
@@ -84,8 +84,6 @@ try {
 
    if ($Rid.StartsWith("win")) {
       $unzippedArtifactName = (Split-Path $SignedFileDirectory -Leaf).ToString()
-
-      Write-Host "Unzipped artifact name: $unzippedArtifactName"
       $summaryDirectory = Join-Path -Path $BinariesDirectory -ChildPath (Join-Path -Path "CodeSignSummaries" -ChildPath $unzippedArtifactName)
       $destinationDirectory = Join-Path -Path $BinariesDirectory -ChildPath $unzippedArtifactName
 

--- a/tools/azsdk-cli/ci.yml
+++ b/tools/azsdk-cli/ci.yml
@@ -28,18 +28,18 @@ extends:
     ReleaseBinaries: true
     TestDirectory: tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests
     StandaloneExeMatrix:
-    # - rid: osx-x64
-    #   framework: net8.0
-    #   assembly: azsdk
-    # - rid: osx-arm64
-    #   framework: net8.0
-    #   assembly: azsdk
+    - rid: osx-x64
+      framework: net8.0
+      assembly: azsdk
+    - rid: osx-arm64
+      framework: net8.0
+      assembly: azsdk
     - rid: win-x64
       framework: net8.0
       assembly: azsdk
-    # - rid: linux-x64
-    #   framework: net8.0
-    #   assembly: azsdk
-    # - rid: linux-arm64
-    #   framework: net8.0
-    #   assembly: azsdk
+    - rid: linux-x64
+      framework: net8.0
+      assembly: azsdk
+    - rid: linux-arm64
+      framework: net8.0
+      assembly: azsdk


### PR DESCRIPTION
I resolved this in `main` in `azure-sdk-build-tools`, but I somehow didn't pull the newest version of this script across when I moved all the yml to `azure-sdk-tools`.