### PR TITLE
[tsp-client] Allow emitter option of object type 

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release
 
-## 2025-06-12 - 0.22.0
+## 2025-06-13 - 0.22.0
 
 - Add support for emitter options of `object` type.
 

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-06-12 - 0.22.0
+
+- Add support for emitter options of `object` type.
+
 ## 2025-05-01 - 0.21.0
 
 - Update `@typespec/compiler` dependency to `"1.0.0-rc.1 || >=1.0.0 <2.0.0"`.

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.21.0",
+      "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
         "@autorest/core": "^3.10.2",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -105,7 +105,16 @@ export async function compileTsp({
     additionalEmitterOptions.split(";").forEach((option) => {
       const [key, value] = option.split("=");
       if (key && value) {
-        emitterOverrideOptions[key] = value;
+        try {
+          const obj = JSON.parse(value);
+          if (typeof obj === "object" && obj !== null && !Array.isArray(obj)) {
+            emitterOverrideOptions[key] = obj;
+          } else {
+            emitterOverrideOptions[key] = value;
+          }
+        } catch {
+          emitterOverrideOptions[key] = value;
+        }
       }
     });
   }

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -72,6 +72,18 @@ export async function discoverEntrypointFile(
   return entryTsp;
 }
 
+export function tryParseEmitterOptionAsObject(value: string): object | string {
+  try {
+    const obj = JSON.parse(value);
+    if (typeof obj === "object" && obj !== null && !Array.isArray(obj)) {
+      return obj;
+    }
+  } catch {
+    // no-op
+  }
+  return value;
+}
+
 export async function compileTsp({
   emitterPackage,
   outputPath,

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -117,16 +117,7 @@ export async function compileTsp({
     additionalEmitterOptions.split(";").forEach((option) => {
       const [key, value] = option.split("=");
       if (key && value) {
-        try {
-          const obj = JSON.parse(value);
-          if (typeof obj === "object" && obj !== null && !Array.isArray(obj)) {
-            emitterOverrideOptions[key] = obj;
-          } else {
-            emitterOverrideOptions[key] = value;
-          }
-        } catch {
-          emitterOverrideOptions[key] = value;
-        }
+        emitterOverrideOptions[key] = tryParseEmitterOptionAsObject(value);
       }
     });
   }

--- a/tools/tsp-client/test/typespec.spec.ts
+++ b/tools/tsp-client/test/typespec.spec.ts
@@ -1,6 +1,10 @@
 import { assert } from "chai";
 import { describe, it } from "vitest";
-import { compileTsp, discoverEntrypointFile } from "../src/typespec.js";
+import {
+  compileTsp,
+  discoverEntrypointFile,
+  tryParseEmitterOptionAsObject,
+} from "../src/typespec.js";
 import { joinPaths, resolvePath } from "@typespec/compiler";
 
 describe("Check diagnostic reporting", function () {
@@ -54,5 +58,58 @@ describe("Check diagnostic reporting", function () {
       ),
     );
     assert.equal(entrypointFile, "client.tsp");
+  });
+
+  describe("tryParseEmitterOptionAsObject", function () {
+    it("returns object for JSON object string", function () {
+      const str = `{"name":"@azure/eventgrid-namespaces-2","version":"1.0.3"}`;
+      const result = tryParseEmitterOptionAsObject(str);
+
+      assert.isObject(result);
+      assert.deepEqual(result, {
+        name: "@azure/eventgrid-namespaces-2",
+        version: "1.0.3",
+      });
+    });
+
+    it("returns string for string 'true'", function () {
+      const str = "true";
+      const result = tryParseEmitterOptionAsObject(str);
+
+      assert.isString(result);
+      assert.strictEqual(result, "true");
+    });
+
+    it("returns string for string 'null'", function () {
+      const str = "null";
+      const result = tryParseEmitterOptionAsObject(str);
+
+      assert.isString(result);
+      assert.strictEqual(result, "null");
+    });
+
+    it("returns string for string '[]'", function () {
+      const str = "[]";
+      const result = tryParseEmitterOptionAsObject(str);
+
+      assert.isString(result);
+      assert.strictEqual(result, "[]");
+    });
+
+    it("returns string for a normal string", function () {
+      const str = "azure";
+      const result = tryParseEmitterOptionAsObject(str);
+
+      assert.isString(result);
+      assert.strictEqual(result, "azure");
+    });
+
+    it("returns string for a path string", function () {
+      const str = "sdk/some/path/src/generated";
+      const result = tryParseEmitterOptionAsObject(str);
+
+      assert.isString(result);
+      assert.strictEqual(result, "sdk/some/path/src/generated");
+    });
   });
 });


### PR DESCRIPTION
tsp support options of object type but currently tsp-client only pass key/value string pairs as additional emitter options to tsp.  This PR tries to parse the value string first. If the result is a non-null and non-array object, pass the parsed object; otherwise pass the original string.

Resolves https://github.com/Azure/azure-sdk-tools/issues/10821