### PR TITLE
Ensure all updates to user preference happens from the cache

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IUserProfileManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IUserProfileManager.cs
@@ -9,6 +9,5 @@ namespace APIViewWeb.Managers
         public Task<UserProfileModel> TryGetUserProfileAsync(ClaimsPrincipal User);
         public Task<UserProfileModel> TryGetUserProfileByNameAsync(string UserName, bool createIfNotExist = true);
         public Task UpdateUserProfile(string userName, UserProfileModel profile);
-        public Task SetUserEmailIfNullOrEmpty(ClaimsPrincipal User);
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/UserProfileManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/UserProfileManager.cs
@@ -5,7 +5,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
 using System.Threading.Tasks;
-using APIView.Identity;
 using APIViewWeb.Models;
 using APIViewWeb.Repositories;
 
@@ -33,22 +32,6 @@ namespace APIViewWeb.Managers
         public async Task UpdateUserProfile(string userName, UserProfileModel profile)
         {
             await _UserProfileRepository.UpsertUserProfileAsync(userName, profile);
-        }
-
-        public async Task SetUserEmailIfNullOrEmpty(ClaimsPrincipal User)
-        {
-            var userProfile = await TryGetUserProfileAsync(User);
-
-            if (string.IsNullOrWhiteSpace(userProfile.Email))
-            {
-                var microsoftEmail = User.Claims.FirstOrDefault(c => c.Type == ClaimConstants.Email)?.Value;
-
-                if (!string.IsNullOrWhiteSpace(microsoftEmail))
-                {
-                    userProfile.Email = microsoftEmail;
-                    await UpdateUserProfile(User.GetGitHubLogin(), userProfile);
-                }
-            }
         }
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Models/UserPreferenceModel.cs
+++ b/src/dotnet/APIView/APIViewWeb/Models/UserPreferenceModel.cs
@@ -37,7 +37,7 @@ namespace APIViewWeb.Models
         public bool ShowSystemComments { get; set; }
         public bool DisableCodeLinesLazyLoading { get; set; }
         public bool UseBetaIndexPage { get; set; }
-        public string Theme { get; set; }
+        public string Theme { get; set; } = "light-theme";
         public ScrollBarSizes ScrollBarSize { get; set; } = ScrollBarSizes.Small;
     }
 }

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml.cs
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Index.cshtml.cs
@@ -24,7 +24,6 @@ namespace APIViewWeb.Pages.Assemblies
         private readonly IAPIRevisionsManager _apiRevisionsManager;
         private readonly IHubContext<SignalRHub> _notificationHubContext;
         public readonly UserProfileCache _userProfileCache;
-        public readonly IUserProfileManager _userProfileManager;
         private readonly ICodeFileManager _codeFileManager;
 
         public const int _defaultPageSize = 50;
@@ -37,7 +36,6 @@ namespace APIViewWeb.Pages.Assemblies
             _reviewManager = reviewManager;
             _apiRevisionsManager = apiRevisionsManager;
             _userProfileCache = userProfileCache;
-            _userProfileManager = userProfileManager;
             _codeFileManager = codeFileManager;
         }
         [FromForm]
@@ -56,7 +54,7 @@ namespace APIViewWeb.Pages.Assemblies
             IEnumerable<string> search, IEnumerable<string> languages, IEnumerable<string> state,
             IEnumerable<string> status, int pageNo=1, int pageSize=_defaultPageSize, string sortField=_defaultSortField)
         {
-            await _userProfileManager.SetUserEmailIfNullOrEmpty(User);
+            await _userProfileCache.SetUserEmailIfNullOrEmpty(User);
             var userPreference = (await _userProfileCache.GetUserProfileAsync(User.GetGitHubLogin())).Preferences;
             var spaUrl = "https://spa." + Request.Host.ToString();
             if (userPreference.UseBetaIndexPage == true)

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosUserProfileRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosUserProfileRepository.cs
@@ -31,7 +31,9 @@ namespace APIViewWeb
             {
                 if (createIfNotExist)
                 {
-                    return new UserProfileModel(UserName);
+                    var profile = new UserProfileModel(UserName);
+                    profile.Preferences.UserName = UserName;
+                    return profile;
                 }
                 throw;
             }


### PR DESCRIPTION
This is a follow up on https://github.com/Azure/azure-sdk-tools/pull/10498
We need to have only one path for updating user preferences, which is through the cache.