### PR TITLE
Add compile-time enforcement ensuring static ToolsList is correctly populated

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Analyzer/EnforceToolsExceptionHandling.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Analyzer/EnforceToolsExceptionHandling.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Azure.Sdk.Tools.Cli.Analyzer
 {
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
-    public class MCPAnalyzer : DiagnosticAnalyzer
+    public class EnforceToolsExceptionHandlingAnalyzer : DiagnosticAnalyzer
     {
         public const string Id = "MCP001";
         private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Analyzer/EnforceToolsList.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Analyzer/EnforceToolsList.cs
@@ -1,0 +1,99 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Azure.Sdk.Tools.Cli.Analyzer
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    public class EnforceToolsListAnalyzer : DiagnosticAnalyzer
+    {
+        public const string Id = "MCP002";
+        private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+            Id,
+            "Every MCPTool must be listed in SharedOptions.ToolsList",
+            "MCPTool implementation '{0}' is not included in SharedOptions.ToolsList",
+            "Reliability",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true,
+            customTags: new[] { WellKnownDiagnosticTags.CompilationEnd }
+        );
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
+            => ImmutableArray.Create(Rule);
+
+        public override void Initialize(AnalysisContext context)
+        {
+            context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+            context.EnableConcurrentExecution();
+
+            context.RegisterCompilationStartAction(startCtx =>
+            {
+                // These will be populated during the compilation
+                var listedTypes = new HashSet<INamedTypeSymbol>(SymbolEqualityComparer.Default);
+                var implementations = new List<INamedTypeSymbol>();
+
+                // 1) Collect every typeof(...) inside SharedOptions.ToolsList
+                startCtx.RegisterSyntaxNodeAction(syntaxCtx =>
+                {
+                    var tof = (TypeOfExpressionSyntax)syntaxCtx.Node;
+
+                    // Find the field symbol this typeof lives in
+                    var variable = tof.FirstAncestorOrSelf<VariableDeclaratorSyntax>();
+                    if (variable == null) return;
+
+                    var field = syntaxCtx.SemanticModel.GetDeclaredSymbol(variable) as IFieldSymbol;
+                    if (field == null) return;
+
+                    // Check it's the exact static List<Type> ToolsList on your SharedOptions
+                    if (field.ContainingType?.ToDisplayString() == "Azure.Sdk.Tools.Cli.Commands.SharedOptions"
+                     && field.Name == "ToolsList")
+                    {
+                        var sym = syntaxCtx.SemanticModel.GetTypeInfo(tof.Type).Type as INamedTypeSymbol;
+                        if (sym != null)
+                            listedTypes.Add(sym);
+                    }
+                }, SyntaxKind.TypeOfExpression);
+
+                // 2) Collect every non-abstract class inheriting MCPTool
+                startCtx.RegisterSymbolAction(symCtx =>
+                {
+                    var named = (INamedTypeSymbol)symCtx.Symbol;
+                    if (named.TypeKind != TypeKind.Class || named.IsAbstract)
+                        return;
+
+                    var baseTool = symCtx.Compilation.GetTypeByMetadataName("Azure.Sdk.Tools.Cli.Contract.MCPTool");
+                    if (baseTool != null && InheritsFrom(named, baseTool))
+                        implementations.Add(named);
+
+                }, SymbolKind.NamedType);
+
+                // 3) At compilation end, compare and report any missing ones
+                startCtx.RegisterCompilationEndAction(endCtx =>
+                {
+                    foreach (var impl in implementations)
+                    {
+                        if (!listedTypes.Contains(impl))
+                        {
+                            // Report on the location of the class declaration
+                            var loc = impl.Locations.FirstOrDefault() ?? Location.None;
+                            endCtx.ReportDiagnostic(Diagnostic.Create(Rule, loc, impl.Name));
+                        }
+                    }
+                });
+            });
+        }
+
+        private static bool InheritsFrom(INamedTypeSymbol type, INamedTypeSymbol baseType)
+        {
+            for (var t = type.BaseType; t != null; t = t.BaseType)
+                if (SymbolEqualityComparer.Default.Equals(t, baseType))
+                    return true;
+            return false;
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
@@ -6,6 +6,7 @@ using System.Reflection;
 using Azure.Sdk.Tools.Cli.Tools;
 using Azure.Sdk.Tools.Cli.Tools.HelloWorldTool;
 using Azure.Sdk.Tools.Cli.Tools.HostServer;
+using AzureSDKDevToolsMCP.Tools;
 
 namespace Azure.Sdk.Tools.Cli.Commands
 {
@@ -20,6 +21,7 @@ namespace Azure.Sdk.Tools.Cli.Commands
             typeof(SpecCommonTools),
             typeof(SpecPullRequestTools),
             typeof(SpecWorkflowTool),
+            typeof(SpecValidationTools),
             #if DEBUG
             // only add this tool in debug mode
             typeof(HelloWorldTool),

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Commands/SharedOptions.cs
@@ -1,12 +1,9 @@
 using System.CommandLine;
 using System.CommandLine.Parsing;
-using Azure.Sdk.Tools.Cli.Contract;
 using System.IO.Enumeration;
-using System.Reflection;
 using Azure.Sdk.Tools.Cli.Tools;
 using Azure.Sdk.Tools.Cli.Tools.HelloWorldTool;
 using Azure.Sdk.Tools.Cli.Tools.HostServer;
-using AzureSDKDevToolsMCP.Tools;
 
 namespace Azure.Sdk.Tools.Cli.Commands
 {

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecValidationTool/SpecValidationTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecValidationTool/SpecValidationTool.cs
@@ -10,7 +10,7 @@ using Azure.Sdk.Tools.Cli.Contract;
 using Azure.Sdk.Tools.Cli.Helpers;
 using ModelContextProtocol.Server;
 
-namespace AzureSDKDevToolsMCP.Tools
+namespace Azure.Sdk.Tools.Cli.Tools
 {
     /// <summary>
     /// This tool is used to validate the TypeSpec specification for Azure SDK service.


### PR DESCRIPTION
in the previous PR #10861  we removed reflection from `azsdk-cli` so that we could massively improve our startup times.

This PR adds a compilation-end analyzer that _checks_ this static ToolsList against the newly created assembly. If the toolslist doesn't match up, throw an error!

The actually hilarious part is that this immediately caught an issue with my previous PR:
<img width="1143" alt="image" src="https://github.com/user-attachments/assets/79b93020-6b6e-45b6-8e05-db782f2ed315" />

So this PR also resolves that issue.