### PR TITLE
[CODEOWNERS] Add .NET team to tools paths

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,7 +34,7 @@
 /tools/github/                          @jsquire @ronniegeraghty
 /tools/github-event-processor/          @benbp @jsquire @ronniegeraghty
 /tools/github-team-user-store/          @weshaggard
-/tools/issue-labeler/                   @jsquire @jeo02
+/tools/issue-labeler/                   @jsquire @jeo02 @radhgupta
 /tools/js-sdk-release-tools/            @qiaozha @MaryGao @wanlwanl
 /tools/perf-automation/                 @mikeharder @benbp
 /tools/perf-automation/**/*Rust*.cs     @gearama @heaths @LarryOsterman @RickWinter
@@ -56,8 +56,10 @@
 ###########
 # .NET Client Tools
 ###########
-/src/dotnet/Azure.ClientSdk.Analyzers/  @jsquire @JoshLove-msft @christothes @annelo-msft @KrzysztofCwalina @tg-msft @m-nash
+/src/dotnet/                            @azure/azadknet @jsquire
 /src/dotnet/APIView/                    @chidozieononiwu @praveenkuttappan @helen229
+/tools/net-changelog-gen-mgmt           @ArthurMa1978 @ArcturusZhang @
+/tools/snippet-generator/               @azure/azadknet @jsquire
 
 ###########
 # APIView parsers
@@ -65,7 +67,7 @@
 /tools/apiview/                           @chidozieononiwu @praveenkuttappan @helen229
 /tools/apiview/emitters/typespec-apiview/ @tjprescott
 /tools/apiview/parsers/cpp-api-parser/    @LarryOsterman
-/tools/apiview/parsers/csharp-api-parser/ @christothes
+/tools/apiview/parsers/csharp-api-parser/ @azure/azadknet @jsquire
 /tools/apiview/parsers/js-api-parser/     @jeremymeng @maorleger
 /src/swift/                               @tjprescott
 /src/java/apiview-java-processor/         @JonathanGiles

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -56,7 +56,7 @@
 ###########
 # .NET Client Tools
 ###########
-/src/dotnet/                            @azure/azadknet @jsquire
+/src/dotnet/                            @azure/azsdknet @jsquire
 /src/dotnet/APIView/                    @chidozieononiwu @praveenkuttappan @helen229
 /tools/net-changelog-gen-mgmt           @ArthurMa1978 @ArcturusZhang
 /tools/snippet-generator/               @azure/azadknet @jsquire

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,7 +67,7 @@
 /tools/apiview/                           @chidozieononiwu @praveenkuttappan @helen229
 /tools/apiview/emitters/typespec-apiview/ @tjprescott
 /tools/apiview/parsers/cpp-api-parser/    @LarryOsterman
-/tools/apiview/parsers/csharp-api-parser/ @azure/azadknet @jsquire
+/tools/apiview/parsers/csharp-api-parser/ @azure/azsdknet @jsquire
 /tools/apiview/parsers/js-api-parser/     @jeremymeng @maorleger
 /src/swift/                               @tjprescott
 /src/java/apiview-java-processor/         @JonathanGiles

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -58,7 +58,7 @@
 ###########
 /src/dotnet/                            @azure/azadknet @jsquire
 /src/dotnet/APIView/                    @chidozieononiwu @praveenkuttappan @helen229
-/tools/net-changelog-gen-mgmt           @ArthurMa1978 @ArcturusZhang @
+/tools/net-changelog-gen-mgmt           @ArthurMa1978 @ArcturusZhang
 /tools/snippet-generator/               @azure/azadknet @jsquire
 
 ###########

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -59,7 +59,7 @@
 /src/dotnet/                            @azure/azsdknet @jsquire
 /src/dotnet/APIView/                    @chidozieononiwu @praveenkuttappan @helen229
 /tools/net-changelog-gen-mgmt           @ArthurMa1978 @ArcturusZhang
-/tools/snippet-generator/               @azure/azadknet @jsquire
+/tools/snippet-generator/               @Azure/azsdknet @jsquire
 
 ###########
 # APIView parsers


### PR DESCRIPTION
# Summary

The focus of these changes is to add the Azure SDK for .NET team to the paths associated with the .NET tooling and utilities.