### PR TITLE
Use Path.Combine for create directory

### DIFF
--- a/eng/common/TestResources/New-TestResources.ps1
+++ b/eng/common/TestResources/New-TestResources.ps1
@@ -163,7 +163,7 @@ try {
     $root = $repositoryRoot = "$PSScriptRoot/../../.." | Resolve-Path
 
     if($ServiceDirectory) {
-        $root = "$repositoryRoot/sdk/$ServiceDirectory" | Resolve-Path
+        $root = [System.IO.Path]::Combine($repositoryRoot, "sdk", $ServiceDirectory) | Resolve-Path
     }
 
     if ($TestResourcesDirectory) {


### PR DESCRIPTION
Path.Combine will allow for fully qualified paths to override the combination. For example `Path.Combine("a","b","c:\test")` will resolve to `c:\test'. We have depended on such behavior in a few places like https://github.com/Azure/azure-sdk-for-python/blob/d66b5160f2fb9a3ca03e833a65b1c429993b2bc2/eng/pipelines/templates/steps/smoke-test-steps.yml#L99 so I'm reverting back to Path.Combine.