### PR TITLE
Api view cache busting

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Startup.cs
+++ b/src/dotnet/APIView/APIViewWeb/Startup.cs
@@ -233,6 +233,7 @@ namespace APIViewWeb
                         .AllowAnyMethod()
                         .AllowAnyHeader()
                         .AllowCredentials()
+                        .WithExposedHeaders("location")
                         .SetPreflightMaxAge(TimeSpan.FromHours(20));
                 });
             });

--- a/src/dotnet/APIView/ClientSPA/workbox-config.js
+++ b/src/dotnet/APIView/ClientSPA/workbox-config.js
@@ -15,7 +15,15 @@ module.exports = {
   skipWaiting: true,
   clientsClaim: true,
   cleanupOutdatedCaches: true,
-  modifyURLPrefix: {
-    '': `?v=${version}`
-  }
+  manifestTransforms: [
+      async (manifestEntries) => {
+        return {
+          manifest: manifestEntries.map(entry => ({
+            ...entry,
+            url: entry.url + `?v=${version}`
+          })),
+          warnings: [],
+        };
+      }
+    ]
 };


### PR DESCRIPTION
- Improve APIView cache busting by using manifestTransforms for cache busting.
- Allow client to read location header.