### PR TITLE
Convert azure-sdk-tools to use `ubuntu-24.04` instead of `20.04`

### DIFF
--- a/eng/common-tests/matrix-generator/samples/matrix-test.yml
+++ b/eng/common-tests/matrix-generator/samples/matrix-test.yml
@@ -8,8 +8,8 @@ jobs:
     parameters:
       JobTemplatePath: /eng/common-tests/matrix-generator/samples/matrix-job-sample.yml
       AdditionalParameters: {}
-      Pool: Azure Pipelines
-      OsVmImage: ubuntu-20.04
+      Pool: azsdk-pool
+      OsVmImage: ubuntu-24.04
       CloudConfig:
         ServiceConnection: azure-sdk-tests-public
         Location: eastus2
@@ -18,7 +18,7 @@ jobs:
         # Exclusion example
         - OSVmImage=^(?!macOS).*
       MatrixReplace:
-        - OsVmImage=(ubuntu).*/$1-20.04
+        - OsVmImage=(ubuntu).*/$1-24.04
         - .*Framework.*=net5.0/net5.1
       MatrixConfigs:
         - Name: base_product_matrix

--- a/eng/common-tests/matrix-generator/samples/matrix.json
+++ b/eng/common-tests/matrix-generator/samples/matrix.json
@@ -4,7 +4,7 @@
   },
   "matrix": {
     "Agent": {
-      "ubuntu": { "OSVmImage": "ubuntu-20.04", "Pool": "Azure Pipelines" },
+      "ubuntu": { "OSVmImage": "ubuntu-24.04", "Pool": "Azure Pipelines" },
       "windows": { "OSVmImage": "windows-2022", "Pool": "Azure Pipelines" },
       "macOS": { "OSVmImage": "macos-latest", "Pool": "Azure Pipelines" }
     },

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -106,7 +106,9 @@ jobs:
   - job: assemble
     dependsOn:
       - inventory_azure_pipelines
-      - inventory_custom_agents_linux
+      - inventory_custom_agents_linux_22_hardcoded
+      - inventory_custom_agents_linux_22_hardcoded_variable
+      - inventory_custom_agents_linux_22_strategy_variable
       - inventory_custom_agents_windows
     condition: succeededOrFailed()
     pool:

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -52,16 +52,10 @@ jobs:
     - template: /eng/pipelines/templates/steps/inventory-steps.yml
 
   - job: inventory_custom_agents_windows
-    strategy:
-      matrix:
-        CustomWindows:
-          Pool: azsdk-pool
-          OSVmImage: windows-2022
-          Host: Windows
 
     pool:
-      name: $(Pool)
-      image: $(OSVmImage)
+      name: azsdk-pool
+      image: windows-2022
       os: windows
 
     steps:

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -47,7 +47,6 @@ jobs:
 
     pool:
       name: $(Pool)
-      image: $(OSVmImage)
       demands: $(Demands)
       os: linux
 

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -39,15 +39,15 @@ jobs:
           OSVmImage: ubuntu-22.04
           Demands: ImageOverride -equals ubuntu-22.04
           Host: Ubuntu
-        CustomLinux24:
-          Pool: azsdk-pool
-          OSVmImage: ubuntu-24.04
-          Demands: ImageOverride -equals ubuntu-24.04
-          Host: Ubuntu
+        # CustomLinux24:
+        #   Pool: azsdk-pool
+        #   OSVmImage: ubuntu-24.04
+        #   Demands: ImageOverride -equals ubuntu-24.04
+        #   Host: Ubuntu
 
     pool:
       name: $(Pool)
-      demands: $(Demands)
+      demands: ImageOverride -equals ubuntu-22.04
       os: linux
 
     steps:

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -22,17 +22,17 @@ jobs:
         Pool: Azure Pipelines
         OSVmImage: macOS-latest
         Host: MacOS
-      CustomLinux20:
-        Pool: azsdk-pool-mms-ubuntu-2004-general
-        OSVmImage: MMSUbuntu20.04
-        Host: Ubuntu
       CustomLinux22:
-        Pool: azsdk-pool-mms-ubuntu-2204-general
-        OSVmImage: MMSUbuntu22.04
+        Pool: azsdk-pool
+        OSVmImage: ubuntu-22.04
+        Host: Ubuntu
+      CustomLinux24:
+        Pool: azsdk-pool
+        OSVmImage: ubuntu-24.04
         Host: Ubuntu
       CustomWindows:
-        Pool: azsdk-pool-mms-win-2022-general
-        OSVmImage: MMS2022
+        Pool: azsdk-pool
+        OSVmImage: windows-2022
         Host: Windows
 
   pool:
@@ -122,7 +122,7 @@ jobs:
       } > powershell-inventory.csv
     displayName: PowerShell modules
     workingDirectory: $(Build.ArtifactStagingDirectory)
-  
+
   - pwsh: |
       Get-ChildItem "${env:ProgramFiles}" | ForEach-Object {
         "$(Host), $(OSVmImage), ProgramFiles, $($_.Name), , all"

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -57,10 +57,7 @@ jobs:
   - job: assemble
     dependsOn:
       - inventory_azure_pipelines
-      - inventory_custom_agents_linux_22_hardcoded
-      - inventory_custom_agents_linux_22_hardcoded_variable
-      - inventory_custom_agents_linux_22_strategy_variable
-      - inventory_custom_agents_windows
+      - inventory_1es_pipelines
     condition: succeededOrFailed()
     pool:
       vmImage: ubuntu-latest

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
     - template: /eng/pipelines/templates/steps/inventory-steps.yml
 
-  - job: inventory_custom_agents_linux
+  - job: inventory_custom_agents_linux_22_hardcoded
     strategy:
       matrix:
         CustomLinux22:
@@ -48,6 +48,41 @@ jobs:
     pool:
       name: $(Pool)
       demands: ImageOverride -equals ubuntu-22.04
+      os: linux
+
+    steps:
+    - template: /eng/pipelines/templates/steps/inventory-steps.yml
+
+
+  - job: inventory_custom_agents_linux_22_strategy_variable
+    strategy:
+      matrix:
+        CustomLinux24:
+          Pool: azsdk-pool
+          OSVmImage: ubuntu-22.04
+          Demands: ImageOverride -equals ubuntu-22.04
+          Host: Ubuntu
+
+    pool:
+      name: $(Pool)
+      demands: $(Demands)
+      os: linux
+
+    steps:
+    - template: /eng/pipelines/templates/steps/inventory-steps.yml
+
+
+  - job: inventory_custom_agents_linux_22_hardcoded_variable
+
+    variables:
+      Pool: azsdk-pool
+      OSVmImage: ubuntu-22.04
+      Demands: ImageOverride -equals ubuntu-22.04
+      Host: Ubuntu
+
+    pool:
+      name: $(Pool)
+      demands: $(Demands)
       os: linux
 
     steps:

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -64,7 +64,7 @@ jobs:
 
     pool:
       name: $(Pool)
-      demands: $(Demands)
+      demands: ImageOverride -equals $(OSVmImage)
 
     steps:
     - template: /eng/pipelines/templates/steps/inventory-steps.yml

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -31,70 +31,25 @@ jobs:
     steps:
     - template: /eng/pipelines/templates/steps/inventory-steps.yml
 
-  - job: inventory_custom_agents_linux_22_hardcoded
+  - job: inventory_1es_pipelines
     strategy:
       matrix:
         CustomLinux22:
           Pool: azsdk-pool
           OSVmImage: ubuntu-22.04
-          Demands: ImageOverride -equals ubuntu-22.04
           Host: Ubuntu
-        # CustomLinux24:
-        #   Pool: azsdk-pool
-        #   OSVmImage: ubuntu-24.04
-        #   Demands: ImageOverride -equals ubuntu-24.04
-        #   Host: Ubuntu
-
-    pool:
-      name: $(Pool)
-      demands: ImageOverride -equals ubuntu-22.04
-
-    steps:
-    - template: /eng/pipelines/templates/steps/inventory-steps.yml
-
-
-  - job: inventory_custom_agents_linux_22_strategy_variable
-    strategy:
-      matrix:
         CustomLinux24:
           Pool: azsdk-pool
-          OSVmImage: ubuntu-22.04
-          Demands: ImageOverride -equals ubuntu-22.04
+          OSVmImage: ubuntu-24.04
           Host: Ubuntu
+        CustomWindows:
+          Pool: azsdk-pool
+          OSVmImage: windows-2022
+          Host: Windows
 
     pool:
       name: $(Pool)
       demands: ImageOverride -equals $(OSVmImage)
-
-    steps:
-    - template: /eng/pipelines/templates/steps/inventory-steps.yml
-
-
-  - job: inventory_custom_agents_linux_22_hardcoded_variable
-
-    variables:
-      Pool: azsdk-pool
-      OSVmImage: ubuntu-22.04
-      Demands: ImageOverride -equals ubuntu-22.04
-      Host: Ubuntu
-
-    pool:
-      name: $(Pool)
-      demands: $(Demands)
-
-    steps:
-    - template: /eng/pipelines/templates/steps/inventory-steps.yml
-
-  - job: inventory_custom_agents_windows
-
-    variables:
-      Pool: azsdk-pool
-      OSVmImage: windows-2022
-      Host: Windows
-
-    pool:
-      name: azsdk-pool
-      demands: ImageOverride -equals windows-2022
 
     steps:
     - template: /eng/pipelines/templates/steps/inventory-steps.yml

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -7,7 +7,7 @@ pr:
     - eng/pipelines/agent-software-inventory.yml
 
 jobs:
-- job: inventory
+- job: inventory_azure_pipelines
   strategy:
     matrix:
       Linux:
@@ -22,6 +22,18 @@ jobs:
         Pool: Azure Pipelines
         OSVmImage: macOS-latest
         Host: MacOS
+
+
+  pool:
+    name: $(Pool)
+    vmImage: $(OSVmImage)
+
+  steps:
+  - template: /eng/pipelines/templates/steps/inventory-steps.yml
+
+- job: inventory_custom_agents
+  strategy:
+    matrix:
       CustomLinux22:
         Pool: azsdk-pool
         OSVmImage: ubuntu-22.04
@@ -37,133 +49,15 @@ jobs:
 
   pool:
     name: $(Pool)
-    vmImage: $(OSVmImage)
+    image: $(OSVmImage)
 
   steps:
-  - checkout: self
-
-  # Inventory files should be written without headers in the format:
-  # Host, VmImage, Package Manager, Package Name, Package Version, Package Architecture {unknown, x86, amd64, arm64, all}
-  - bash: sudo chown -R runner ~/.Azure
-    displayName: (MacOS) Grant access to ~/.Azure
-    condition: and(succeeded(), eq(variables.Host, 'MacOS'))
-
-  - bash: dpkg-query -Wf '$(Host), $(OSVmImage), dpkg, ${Package}, ${Version}, ${Architecture}\n' > dpkg-inventory.csv
-    displayName: (Ubuntu) dpkg inventory
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    condition: and(succeeded(), eq(variables.Host, 'Ubuntu'))
-
-  # powershell returns CIM/WMI objects faster via Get-WmiObject than Get-CimInstance on either powershell or pwsh.
-  - powershell: >
-      Get-WmiObject Win32_Product
-      | ForEach-Object { "$(Host), $(OSVmImage), MSI, $($_.Name), $($_.Version), unknown" }
-      > msi-inventory.csv
-    displayName: (Windows) Windows Installer products
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    condition: and(succeeded(), eq(variables.Host, 'Windows'))
-
-  - pwsh: |
-      filter Write-NonWindowsInstaller($arch) {
-        if ($_.DisplayName -and $_.WindowsInstaller -ne 1) {
-          "$(Host), $(OSVmImage), MSI, $($_.DisplayName), $($_.DisplayVersion), $arch"
-        }
-      }
-      Get-ChildItem HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\ -ea SilentlyContinue | Get-ItemProperty | Write-NonWindowsInstaller 'amd64' >> arp-inventory.csv
-      Get-ChildItem HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall -ea SilentlyContinue | Get-ItemProperty | Write-NonWindowsInstaller 'x86' >> arp-inventory.csv
-      Get-ChildItem HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\ -ea SilentlyContinue | Get-ItemProperty | Write-NonWindowsInstaller 'amd64' >> arp-inventory.csv
-      Get-ChildItem HKCU:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\ -ea SilentlyContinue | Get-ItemProperty | Write-NonWindowsInstaller 'x86' >> arp-inventory.csv
-    displayName: (Windows) Add/Remove Programs inventory
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    condition: and(succeeded(), eq(variables.Host, 'Windows'))
-
-  - pwsh: >
-      & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease -format json -utf8
-      | ConvertFrom-Json
-      | ForEach-Object {
-        $arch = if ([Version]$_.installationVersion -lt [Version]'17.0') { "x86" } else { "amd64" };
-        "$(Host), $(OSVmImage), VSSetup, $($_.displayName) ($($_.channelId)), $($_.installationVersion), $arch"
-      }
-      > vssetup-inventory.csv
-    displayName: (Windows) Visual Studio inventory
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    condition: and(succeeded(), eq(variables.Host, 'Windows'))
-
-  - pwsh: >
-      az extension list
-      | ConvertFrom-Json
-      | ForEach-Object { "$(Host), $(OSVmImage), az, $($_.name), $($_.version), all" }
-      > az-inventory.csv
-    displayName: Azure CLI extensions
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-
-  - pwsh: >
-      dotnet --list-runtimes
-      | ForEach-Object {
-        $tokens = $_ -split ' ', 3;
-        "$(Host), $(OSVmImage), dotnet-runtime, $($tokens[0]), $($tokens[1]), all"
-      }
-      >> dotnet-inventory.csv
-    displayName: .NET runtimes
-
-  - pwsh: >
-      dotnet --list-sdks
-      | ForEach-Object {
-        $tokens = $_ -split ' ', 2;
-        "$(Host), $(OSVmImage), dotnet-sdk, SDK, $($tokens[0]), all"
-      }
-      >> dotnet-inventory.csv
-    displayName: .NET SDKs
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-
-  - pwsh: |
-      & "${env:BUILD_SOURCESDIRECTORY}/eng/common/scripts/Import-AzModules.ps1"
-      Get-Module -List | ForEach-Object {
-        "$(Host), $(OSVmImage), PowerShell, $($_.Name), $($_.Version), all"
-      } > powershell-inventory.csv
-    displayName: PowerShell modules
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-
-  - pwsh: |
-      Get-ChildItem "${env:ProgramFiles}" | ForEach-Object {
-        "$(Host), $(OSVmImage), ProgramFiles, $($_.Name), , all"
-      } > programfiles-inventory.csv
-    displayName: (Windows) Program Files
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    condition: and(succeeded(), eq(variables.Host, 'Windows'))
-
-  - pwsh: |
-      Get-ChildItem "${env:ProgramFiles(x86)}" | ForEach-Object {
-        "$(Host), $(OSVmImage), ProgramFilesX86, $($_.Name), , all"
-      } >> programfiles-inventory.csv
-    displayName: (Windows) Program Files (x86)
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    condition: and(succeeded(), eq(variables.Host, 'Windows'))
-
-  # - pwsh: |
-  #     Get-ChildItem env: | ForEach-Object {
-  #       "$(Host), $(OSVmImage), Environment, $($_.Name), $($_.Value), all"
-  #     } >> env-inventory.csv
-  #   displayName: Environment Variables
-  #   workingDirectory: $(Build.ArtifactStagingDirectory)
-
-  - pwsh: |
-      $root = $env:VCPKG_INSTALLATION_ROOT
-      if (!$root) {
-        $root = 'C:\vcpkg'
-      }
-      Get-ChildItem "$root\packages" -ErrorAction Ignore | ForEach-Object {
-        "$(Host), $(OSVmImage), Environment, $($_.Name), $($_.Value), all"
-      } >> vcpkg-inventory.csv
-    displayName: (Windows) Vcpkg Packages
-    workingDirectory: $(Build.ArtifactStagingDirectory)
-    condition: and(succeeded(), eq(variables.Host, 'Windows'))
-
-  - publish: $(Build.ArtifactStagingDirectory)
-    displayName: Publish inventory-$(OSVmImage)
-    artifact: inventory-$(OSVmImage)
+  - template: /eng/pipelines/templates/steps/inventory-steps.yml
 
 - job: assemble
-  dependsOn: inventory
+  dependsOn:
+    - inventory_azure_pipelines
+    - inventory_custom_agents
   condition: succeededOrFailed()
   pool:
     vmImage: ubuntu-latest

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -7,77 +7,91 @@ pr:
     - eng/pipelines/agent-software-inventory.yml
 
 jobs:
-- job: inventory_azure_pipelines
-  strategy:
-    matrix:
-      Linux:
-        Pool: Azure Pipelines
-        OSVmImage: ubuntu-latest
-        Host: Ubuntu
-      Windows:
-        Pool: Azure Pipelines
-        OSVmImage: windows-latest
-        Host: Windows
-      MacOS:
-        Pool: Azure Pipelines
-        OSVmImage: macOS-latest
-        Host: MacOS
+  - job: inventory_azure_pipelines
+    strategy:
+      matrix:
+        Linux:
+          Pool: Azure Pipelines
+          OSVmImage: ubuntu-latest
+          Host: Ubuntu
+        Windows:
+          Pool: Azure Pipelines
+          OSVmImage: windows-latest
+          Host: Windows
+        MacOS:
+          Pool: Azure Pipelines
+          OSVmImage: macOS-latest
+          Host: MacOS
 
 
-  pool:
-    name: $(Pool)
-    vmImage: $(OSVmImage)
+    pool:
+      name: $(Pool)
+      vmImage: $(OSVmImage)
 
-  steps:
-  - template: /eng/pipelines/templates/steps/inventory-steps.yml
+    steps:
+    - template: /eng/pipelines/templates/steps/inventory-steps.yml
 
-- job: inventory_custom_agents
-  strategy:
-    matrix:
-      CustomLinux22:
-        Pool: azsdk-pool
-        OSVmImage: ubuntu-22.04
-        Host: Ubuntu
-      CustomLinux24:
-        Pool: azsdk-pool
-        OSVmImage: ubuntu-24.04
-        Host: Ubuntu
-      CustomWindows:
-        Pool: azsdk-pool
-        OSVmImage: windows-2022
-        Host: Windows
+  - job: inventory_custom_agents_linux
+    strategy:
+      matrix:
+        CustomLinux22:
+          Pool: azsdk-pool
+          OSVmImage: ubuntu-22.04
+          Host: Ubuntu
+        CustomLinux24:
+          Pool: azsdk-pool
+          OSVmImage: ubuntu-24.04
+          Host: Ubuntu
 
-  pool:
-    name: $(Pool)
-    image: $(OSVmImage)
+    pool:
+      name: $(Pool)
+      image: $(OSVmImage)
+      os: linux
 
-  steps:
-  - template: /eng/pipelines/templates/steps/inventory-steps.yml
+    steps:
+    - template: /eng/pipelines/templates/steps/inventory-steps.yml
 
-- job: assemble
-  dependsOn:
-    - inventory_azure_pipelines
-    - inventory_custom_agents
-  condition: succeededOrFailed()
-  pool:
-    vmImage: ubuntu-latest
-  steps:
-  - checkout: none
+  - job: inventory_custom_agents_windows
+    strategy:
+      matrix:
+        CustomWindows:
+          Pool: azsdk-pool
+          OSVmImage: windows-2022
+          Host: Windows
 
-  - download: current
-    displayName: Download artifacts
-    patterns: |
-      **/*.csv
+    pool:
+      name: $(Pool)
+      image: $(OSVmImage)
+      os: windows
 
-  - pwsh: >
-      Get-ChildItem -Filter *.csv -Recurse
-      | Get-Content
-      | ConvertFrom-Csv -Header Host, VmImage, Type, Name, Version, Architecture
-      | Sort-Object Host, VmImage, Type, Name, Version, Architecture
-      | ConvertTo-Csv
-      > inventory.csv
-    displayName: Combine and sort inventory
-    workingDirectory: $(Pipeline.Workspace)
+    steps:
+    - template: /eng/pipelines/templates/steps/inventory-steps.yml
 
-  - publish: $(Pipeline.Workspace)/inventory.csv
-    artifact: inventory
+  - job: assemble
+    dependsOn:
+      - inventory_azure_pipelines
+      - inventory_custom_agents_linux
+      - inventory_custom_agents_windows
+    condition: succeededOrFailed()
+    pool:
+      vmImage: ubuntu-latest
+    steps:
+    - checkout: none
+
+    - download: current
+      displayName: Download artifacts
+      patterns: |
+        **/*.csv
+
+    - pwsh: >
+        Get-ChildItem -Filter *.csv -Recurse
+        | Get-Content
+        | ConvertFrom-Csv -Header Host, VmImage, Type, Name, Version, Architecture
+        | Sort-Object Host, VmImage, Type, Name, Version, Architecture
+        | ConvertTo-Csv
+        > inventory.csv
+      displayName: Combine and sort inventory
+      workingDirectory: $(Pipeline.Workspace)
+
+    - publish: $(Pipeline.Workspace)/inventory.csv
+      artifact: inventory

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -48,7 +48,6 @@ jobs:
     pool:
       name: $(Pool)
       demands: ImageOverride -equals ubuntu-22.04
-      os: linux
 
     steps:
     - template: /eng/pipelines/templates/steps/inventory-steps.yml
@@ -66,7 +65,6 @@ jobs:
     pool:
       name: $(Pool)
       demands: $(Demands)
-      os: linux
 
     steps:
     - template: /eng/pipelines/templates/steps/inventory-steps.yml
@@ -83,7 +81,6 @@ jobs:
     pool:
       name: $(Pool)
       demands: $(Demands)
-      os: linux
 
     steps:
     - template: /eng/pipelines/templates/steps/inventory-steps.yml
@@ -97,7 +94,6 @@ jobs:
 
     pool:
       name: azsdk-pool
-      os: windows
       demands: ImageOverride -equals windows-2022
 
     steps:

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -37,15 +37,18 @@ jobs:
         CustomLinux22:
           Pool: azsdk-pool
           OSVmImage: ubuntu-22.04
+          Demands: ImageOverride -equals ubuntu-22.04
           Host: Ubuntu
         CustomLinux24:
           Pool: azsdk-pool
           OSVmImage: ubuntu-24.04
+          Demands: ImageOverride -equals ubuntu-24.04
           Host: Ubuntu
 
     pool:
       name: $(Pool)
       image: $(OSVmImage)
+      demands: $(Demands)
       os: linux
 
     steps:
@@ -53,10 +56,15 @@ jobs:
 
   - job: inventory_custom_agents_windows
 
+    variables:
+      Pool: azsdk-pool
+      OSVmImage: windows-2022
+      Host: Windows
+
     pool:
       name: azsdk-pool
-      image: windows-2022
       os: windows
+      demands: ImageOverride -equals windows-2022
 
     steps:
     - template: /eng/pipelines/templates/steps/inventory-steps.yml

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -47,7 +47,7 @@ jobs:
 
     pool:
       name: $(Pool)
-      demands: $(Demands)
+      image: $(OSVmImage)
       os: linux
 
     steps:

--- a/eng/pipelines/agent-software-inventory.yml
+++ b/eng/pipelines/agent-software-inventory.yml
@@ -47,7 +47,7 @@ jobs:
 
     pool:
       name: $(Pool)
-      image: $(OSVmImage)
+      demands: $(Demands)
       os: linux
 
     steps:

--- a/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-python.yml
@@ -31,8 +31,8 @@ extends:
           - job: 'Build'
 
             pool:
-              name: $(LINUXNEXTPOOL)
-              image: $(LINUXNEXTVMIMAGE)
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
               os: linux
 
             steps:
@@ -63,8 +63,8 @@ extends:
                 - 'Build'
 
               pool:
-                name: $(LINUXNEXTPOOL)
-                image: $(LINUXNEXTVMIMAGE)
+                name: $(LINUXPOOL)
+                image: $(LINUXVMIMAGE)
                 os: linux
 
               steps:
@@ -85,8 +85,8 @@ extends:
           - job: PublishPackage
             displayName: 'Publish ${{ parameters.PackageName }} package to devops feed'
             pool:
-              name: $(LINUXNEXTPOOL)
-              image: $(LINUXNEXTVMIMAGE)
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
               os: linux
             steps:
             - checkout: none

--- a/eng/pipelines/templates/steps/inventory-steps.yml
+++ b/eng/pipelines/templates/steps/inventory-steps.yml
@@ -1,0 +1,123 @@
+# this job assumes that variables $(Pool), $(OsVmImage), and $(Host) are populated by a strategy matrix
+steps:
+  - checkout: self
+
+  # Inventory files should be written without headers in the format:
+  # Host, VmImage, Package Manager, Package Name, Package Version, Package Architecture {unknown, x86, amd64, arm64, all}
+  - bash: sudo chown -R runner ~/.Azure
+    displayName: (MacOS) Grant access to ~/.Azure
+    condition: and(succeeded(), eq(variables.Host, 'MacOS'))
+
+  - bash: dpkg-query -Wf '$(Host), $(OSVmImage), dpkg, ${Package}, ${Version}, ${Architecture}\n' > dpkg-inventory.csv
+    displayName: (Ubuntu) dpkg inventory
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    condition: and(succeeded(), eq(variables.Host, 'Ubuntu'))
+
+  # powershell returns CIM/WMI objects faster via Get-WmiObject than Get-CimInstance on either powershell or pwsh.
+  - powershell: >
+      Get-WmiObject Win32_Product
+      | ForEach-Object { "$(Host), $(OSVmImage), MSI, $($_.Name), $($_.Version), unknown" }
+      > msi-inventory.csv
+    displayName: (Windows) Windows Installer products
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    condition: and(succeeded(), eq(variables.Host, 'Windows'))
+
+  - pwsh: |
+      filter Write-NonWindowsInstaller($arch) {
+        if ($_.DisplayName -and $_.WindowsInstaller -ne 1) {
+          "$(Host), $(OSVmImage), MSI, $($_.DisplayName), $($_.DisplayVersion), $arch"
+        }
+      }
+      Get-ChildItem HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\ -ea SilentlyContinue | Get-ItemProperty | Write-NonWindowsInstaller 'amd64' >> arp-inventory.csv
+      Get-ChildItem HKLM:\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\Uninstall -ea SilentlyContinue | Get-ItemProperty | Write-NonWindowsInstaller 'x86' >> arp-inventory.csv
+      Get-ChildItem HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\ -ea SilentlyContinue | Get-ItemProperty | Write-NonWindowsInstaller 'amd64' >> arp-inventory.csv
+      Get-ChildItem HKCU:\Software\Wow6432Node\Microsoft\Windows\CurrentVersion\Uninstall\ -ea SilentlyContinue | Get-ItemProperty | Write-NonWindowsInstaller 'x86' >> arp-inventory.csv
+    displayName: (Windows) Add/Remove Programs inventory
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    condition: and(succeeded(), eq(variables.Host, 'Windows'))
+
+  - pwsh: >
+      & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease -format json -utf8
+      | ConvertFrom-Json
+      | ForEach-Object {
+        $arch = if ([Version]$_.installationVersion -lt [Version]'17.0') { "x86" } else { "amd64" };
+        "$(Host), $(OSVmImage), VSSetup, $($_.displayName) ($($_.channelId)), $($_.installationVersion), $arch"
+      }
+      > vssetup-inventory.csv
+    displayName: (Windows) Visual Studio inventory
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    condition: and(succeeded(), eq(variables.Host, 'Windows'))
+
+  - pwsh: >
+      az extension list
+      | ConvertFrom-Json
+      | ForEach-Object { "$(Host), $(OSVmImage), az, $($_.name), $($_.version), all" }
+      > az-inventory.csv
+    displayName: Azure CLI extensions
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+
+  - pwsh: >
+      dotnet --list-runtimes
+      | ForEach-Object {
+        $tokens = $_ -split ' ', 3;
+        "$(Host), $(OSVmImage), dotnet-runtime, $($tokens[0]), $($tokens[1]), all"
+      }
+      >> dotnet-inventory.csv
+    displayName: .NET runtimes
+
+  - pwsh: >
+      dotnet --list-sdks
+      | ForEach-Object {
+        $tokens = $_ -split ' ', 2;
+        "$(Host), $(OSVmImage), dotnet-sdk, SDK, $($tokens[0]), all"
+      }
+      >> dotnet-inventory.csv
+    displayName: .NET SDKs
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+
+  - pwsh: |
+      & "${env:BUILD_SOURCESDIRECTORY}/eng/common/scripts/Import-AzModules.ps1"
+      Get-Module -List | ForEach-Object {
+        "$(Host), $(OSVmImage), PowerShell, $($_.Name), $($_.Version), all"
+      } > powershell-inventory.csv
+    displayName: PowerShell modules
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+
+  - pwsh: |
+      Get-ChildItem "${env:ProgramFiles}" | ForEach-Object {
+        "$(Host), $(OSVmImage), ProgramFiles, $($_.Name), , all"
+      } > programfiles-inventory.csv
+    displayName: (Windows) Program Files
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    condition: and(succeeded(), eq(variables.Host, 'Windows'))
+
+  - pwsh: |
+      Get-ChildItem "${env:ProgramFiles(x86)}" | ForEach-Object {
+        "$(Host), $(OSVmImage), ProgramFilesX86, $($_.Name), , all"
+      } >> programfiles-inventory.csv
+    displayName: (Windows) Program Files (x86)
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    condition: and(succeeded(), eq(variables.Host, 'Windows'))
+
+  # - pwsh: |
+  #     Get-ChildItem env: | ForEach-Object {
+  #       "$(Host), $(OSVmImage), Environment, $($_.Name), $($_.Value), all"
+  #     } >> env-inventory.csv
+  #   displayName: Environment Variables
+  #   workingDirectory: $(Build.ArtifactStagingDirectory)
+
+  - pwsh: |
+      $root = $env:VCPKG_INSTALLATION_ROOT
+      if (!$root) {
+        $root = 'C:\vcpkg'
+      }
+      Get-ChildItem "$root\packages" -ErrorAction Ignore | ForEach-Object {
+        "$(Host), $(OSVmImage), Environment, $($_.Name), $($_.Value), all"
+      } >> vcpkg-inventory.csv
+    displayName: (Windows) Vcpkg Packages
+    workingDirectory: $(Build.ArtifactStagingDirectory)
+    condition: and(succeeded(), eq(variables.Host, 'Windows'))
+
+  - publish: $(Build.ArtifactStagingDirectory)
+    displayName: Publish inventory-$(OSVmImage)
+    artifact: inventory-$(OSVmImage)

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -2,20 +2,20 @@
 
 variables:
   - name: LINUXPOOL
-    value: azsdk-pool-mms-ubuntu-2004-general
+    value: azsdk-pool
   - name: LINUXNEXTPOOL
-    value: azsdk-pool-mms-ubuntu-2204-general
+    value: azsdk-pool
   - name: WINDOWSPOOL
-    value: azsdk-pool-mms-win-2022-general
+    value: azsdk-pool
   - name: MACPOOL
     value: Azure Pipelines
 
   - name: LINUXVMIMAGE
-    value: azsdk-pool-mms-ubuntu-2004-1espt
+    value: ubuntu-24.04
   - name: LINUXNEXTVMIMAGE
-    value: azsdk-pool-mms-ubuntu-2204-1espt
+    value: ubuntu-24.04
   - name: WINDOWSVMIMAGE
-    value: azsdk-pool-mms-win-2022-1espt
+    value: windows-2022
   - name: MACVMIMAGE
     value: macos-latest
 

--- a/eng/pipelines/templates/variables/image.yml
+++ b/eng/pipelines/templates/variables/image.yml
@@ -3,16 +3,12 @@
 variables:
   - name: LINUXPOOL
     value: azsdk-pool
-  - name: LINUXNEXTPOOL
-    value: azsdk-pool
   - name: WINDOWSPOOL
     value: azsdk-pool
   - name: MACPOOL
     value: Azure Pipelines
 
   - name: LINUXVMIMAGE
-    value: ubuntu-24.04
-  - name: LINUXNEXTVMIMAGE
     value: ubuntu-24.04
   - name: WINDOWSVMIMAGE
     value: windows-2022

--- a/packages/python-packages/apiview-copilot/tests.yml
+++ b/packages/python-packages/apiview-copilot/tests.yml
@@ -16,8 +16,8 @@ extends:
           - job: 'Build'
 
             pool:
-              name: $(LINUXNEXTPOOL)
-              image: $(LINUXNEXTVMIMAGE)
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
               os: linux
 
             steps:
@@ -45,12 +45,12 @@ extends:
                   inlineScript: |
                     # Login using service principal (handled automatically by Azure DevOps)
                     az account set --subscription "faa080af-c1d8-40ad-9cce-e1a450ca5b57"
-                    
+
                     # Verify the context
                     az account show --query '{subscription:name,tenant:tenantId}'
-                    
+
                     python packages/python-packages/apiview-copilot/evals/run.py
-                    
+
                     exit $?
                 env:
                   AZURE_OPENAI_ENDPOINT: $(python-openai-endpoint)

--- a/tools/apiview/emitters/typespec-apiview/ci.yml
+++ b/tools/apiview/emitters/typespec-apiview/ci.yml
@@ -39,8 +39,8 @@ extends:
           - job: 'Build'
 
             pool:
-              name: $(LINUXNEXTPOOL)
-              image: $(LINUXNEXTVMIMAGE)
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
               os: linux
 
             steps:

--- a/tools/apiview/parsers/js-api-parser/ci.yml
+++ b/tools/apiview/parsers/js-api-parser/ci.yml
@@ -38,8 +38,8 @@ extends:
           - job: 'Build'
 
             pool:
-              name: $(LINUXNEXTPOOL)
-              image: $(LINUXNEXTVMIMAGE)
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
               os: linux
 
             steps:
@@ -87,8 +87,8 @@ extends:
           - job: PublishPackage
             displayName: 'Publish ts-genapi package to devops feed'
             pool:
-              name: $(LINUXNEXTPOOL)
-              image: $(LINUXNEXTVMIMAGE)
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
               os: linux
             steps:
             - download: current

--- a/tools/apiview/parsers/rust-api-parser/ci.yml
+++ b/tools/apiview/parsers/rust-api-parser/ci.yml
@@ -38,8 +38,8 @@ extends:
           - job: 'Build'
 
             pool:
-              name: $(LINUXNEXTPOOL)
-              image: $(LINUXNEXTVMIMAGE)
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
               os: linux
 
             steps:
@@ -86,8 +86,8 @@ extends:
           - job: PublishPackage
             displayName: 'Publish rust-genapi package to devops feed'
             pool:
-              name: $(LINUXNEXTPOOL)
-              image: $(LINUXNEXTVMIMAGE)
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
               os: linux
             steps:
             - download: current

--- a/tools/js-sdk-release-tools/ci.yml
+++ b/tools/js-sdk-release-tools/ci.yml
@@ -42,8 +42,8 @@ extends:
         jobs:
           - job: Build
             pool:
-              name: $(LINUXNEXTPOOL)
-              image: $(LINUXNEXTVMIMAGE)
+              name: $(LINUXPOOL)
+              image: $(LINUXVMIMAGE)
               os: linux
             steps:
             - task: NodeTool@0


### PR DESCRIPTION
As well as swapping on to `azsdk-pool` wherever I made this update.

Manually invoked:

- [x] [Inventory](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4989177&view=results)
  - ~~Discovered a failure in `windows` invocation. `Get-WmiObject` is crashing on `windows-2022` for some reason.~~
  - ~~It's not assigning to a windows machine. Trying to understand why.~~
  - Solved the windows machine conflict, now the same `demands` methodology that works for `windows` isn't properly assigning `ubuntu 22.04` instead of `ubuntu 24.04`.
- [x] [Common Tests](https://dev.azure.com/azure-sdk/public/_build/results?buildId=4989172&view=results)
- [x] [Test proxy invocation to check a standard build w/ signing etc on the new image version](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=4989210&view=results) (running)

As well as running a test run for `test-proxy` that should exercise the new platform.

