### PR TITLE
Update codeowner linter so it works on ubuntu24 and when there is root global.json

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -45,7 +45,7 @@ stages:
           useGlobalJson: true
           
       - pwsh: |
-          dotnet install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"
+          dotnet tool install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"
         displayName: Install CodeownersLinter
         workingDirectory: '$(Build.SourcesDirectory)/eng/common'
 

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -38,6 +38,12 @@ stages:
       UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
 
     steps:
+      - task: UseDotNet@2 # About UseDotNet@2 task: https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines
+        displayName: "Use .NET SDK from global.json"
+        retryCountOnTaskFailure: 3
+        inputs:
+          useGlobalJson: true
+          
       - pwsh: |
           dotnet install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"
         displayName: Install CodeownersLinter

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -38,13 +38,10 @@ stages:
       UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
 
     steps:
-      - task: DotNetCoreCLI@2
-        displayName: 'Install CodeownersLinter'
-        inputs:
-          command: custom
-          custom: 'tool'
-          arguments: 'install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"'
-          workingDirectory: '$(Build.SourcesDirectory)/eng/common'
+      - pwsh: |
+          dotnet install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"
+        displayName: Install CodeownersLinter
+        workingDirectory: '$(Build.SourcesDirectory)/eng/common'
 
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         - pwsh: |

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -37,7 +37,10 @@ stages:
       TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"
       UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
 
-    steps:         
+    steps:
+      - checkout: self
+        fetchDepth: 1
+
       - pwsh: |
           dotnet tool install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"
         displayName: Install CodeownersLinter

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -37,17 +37,11 @@ stages:
       TeamUserUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/azure-sdk-write-teams-blob"
       UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
 
-    steps:
-      - task: UseDotNet@2 # About UseDotNet@2 task: https://learn.microsoft.com/azure/devops/pipelines/tasks/reference/use-dotnet-v2?view=azure-pipelines
-        displayName: "Use .NET SDK from global.json"
-        retryCountOnTaskFailure: 3
-        inputs:
-          useGlobalJson: true
-          
+    steps:         
       - pwsh: |
           dotnet tool install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"
         displayName: Install CodeownersLinter
-        workingDirectory: '$(Build.SourcesDirectory)/eng/common'
+        workingDirectory: '$(Agent.WorkFolder)' # Some directory outside of the source clone to avoid hitting global.json files when any version of dotnet will work for this install
 
       - ${{ if eq(variables['Build.Reason'], 'PullRequest') }}:
         - pwsh: |

--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -38,9 +38,6 @@ stages:
       UserOrgUri: "https://azuresdkartifacts.blob.core.windows.net/azure-sdk-write-teams/user-org-visibility-blob"
 
     steps:
-      - checkout: self
-        fetchDepth: 1
-
       - pwsh: |
           dotnet tool install --global --add-source "$(DotNetDevOpsFeed)" --version "$(CodeownersLinterVersion)" "Azure.Sdk.Tools.CodeownersLinter"
         displayName: Install CodeownersLinter


### PR DESCRIPTION
For this common pipeline we can rely on the version of .NET installed on the agent as we are only installing and running an existing tool. 

There are some repositories that have a global.json file at the root of the repository (tools and .NET) that specifies a version of .NET SDK that conflicts with this command so in order to workaround we are running the install command outside of the source directory. 