### PR TITLE
Add validation for serviceTreeId and productTreeId

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlanToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/ReleasePlanToolTests.cs
@@ -29,9 +29,19 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             logger = new TestLogger<ReleasePlanTool>();
             devOpsService = new MockDevOpsService();
             gitHubService = new Mock<IGitHubService>().Object;
-            typeSpecHelper = new Mock<ITypeSpecHelper>().Object;
-            userHelper = new Mock<IUserHelper>().Object;
-            outputService = new Mock<IOutputService>().Object;
+
+            var typeSpecHelperMock = new Mock<ITypeSpecHelper>();
+            typeSpecHelperMock.Setup(x => x.IsRepoPathForPublicSpecRepo(It.IsAny<string>())).Returns(true);
+            typeSpecHelper = typeSpecHelperMock.Object;
+
+            var userHelperMock = new Mock<IUserHelper>();
+            userHelperMock.Setup(x => x.GetUserEmail()).ReturnsAsync("test@example.com");
+            userHelper = userHelperMock.Object;
+
+            var outputServiceMock = new Mock<IOutputService>();
+            outputServiceMock.Setup(x => x.Format(It.IsAny<object>())).Returns<object>(obj  => obj?.ToString() ?? "");
+            outputService = outputServiceMock.Object;
+
             releasePlanTool = new ReleasePlanTool(
                 devOpsService,
                 typeSpecHelper,
@@ -45,8 +55,33 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
         public async Task Test_Create_releasePlan_with_invalid_SDK_type()
         {
             var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
-            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "TBD", "TBD", "Test version", "https://github.com/Azure/azure-rest-api-specs/pull/35446", "Preview", isTestReleasePlan: true);
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "12345678-1234-5678-9012-123456789012", "12345678-1234-5678-9012-123456789012", "Test version", "https://github.com/Azure/azure-rest-api-specs/pull/35446", "Preview", isTestReleasePlan: true);
             Assert.True(releaseplan.Contains("Invalid SDK release type"));
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_with_invalid_service_tree_id()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "InvalidServiceTreeId", "12345678-1234-5678-9012-123456789012", "Test version", "https://github.com/Azure/azure-rest-api-specs/pull/35446", "beta", isTestReleasePlan: true);
+            Assert.True(releaseplan.Contains("Service tree ID 'InvalidServiceTreeId' is not a valid GUID"));
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_with_invalid_product_tree_id()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "12345678-1234-5678-9012-123456789012", "InvalidProductTreeId", "Test version", "https://github.com/Azure/azure-rest-api-specs/pull/35446", "beta", isTestReleasePlan: true);
+            Assert.True(releaseplan.Contains("Product tree ID 'InvalidProductTreeId' is not a valid GUID"));
+        }
+
+        [Test]
+        public async Task Test_Create_releasePlan_with_valid_inputs()
+        {
+            var testCodeFilePath = "TypeSpecTestData/specification/testcontoso/Contoso.Management";
+            var releaseplan = await releasePlanTool.CreateReleasePlan(testCodeFilePath, "July 2025", "12345678-1234-5678-9012-123456789012", "12345678-1234-5678-9012-123456789012", "Test version", "https://github.com/Azure/azure-rest-api-specs/pull/35446", "beta", isTestReleasePlan: true);
+            Assert.IsNotNull(releaseplan);
+            Assert.True(releaseplan.Contains("Microsoft.TeamFoundation.WorkItemTracking.WebApi.Models.WorkItem"));
         }
     }
 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
@@ -146,49 +146,66 @@ namespace Azure.Sdk.Tools.Cli.Tools
             }
         }
 
+        private async Task ValidateCreateReleasePlanInputs(string typeSpecProjectPath, string serviceTreeId, string productTreeId, string specPullRequestUrl, string sdkReleaseType)
+        {
+            // Check for existing release plan for the given pull request URL.
+            if (string.IsNullOrEmpty(specPullRequestUrl))
+            {
+                throw new Exception("API spec pull request URL is required to create a release plan.");
+            }
+
+            logger.LogInformation("Checking for existing release plan for pull request URL: {specPullRequestUrl}", specPullRequestUrl);
+            var existingReleasePlan = await devOpsService.GetReleasePlanAsync(specPullRequestUrl);
+            if (existingReleasePlan != null && existingReleasePlan.WorkItemId > 0)
+            {
+                throw new Exception($"Release plan already exists for the pull request: {specPullRequestUrl}. Release Plan ID: {existingReleasePlan.ReleasePlanId}");
+            }
+
+            if (string.IsNullOrEmpty(typeSpecProjectPath))
+            {
+                throw new Exception("TypeSpec project path is empty. Cannot create a release plan without a TypeSpec project root path");
+            }
+
+            var supportedReleaseTypes = new[] { "beta", "stable" };
+            if (!supportedReleaseTypes.Contains(sdkReleaseType))
+            {
+                throw new Exception($"Invalid SDK release type. Supported release types are: {string.Join(", ", supportedReleaseTypes)}");
+            }
+
+            var repoRoot = typeSpecHelper.GetSpecRepoRootPath(typeSpecProjectPath);
+
+            // Ensure a release plan is created only if the API specs pull request is in a public repository.
+            if (!typeSpecHelper.IsRepoPathForPublicSpecRepo(repoRoot))
+            {
+                throw new Exception("""
+                    SDK generation and release require the API specs pull request to be in the public azure-rest-api-specs repository.
+                    Please create a pull request in the public Azure/azure-rest-api-specs repository to move your specs changes to public.
+                    A release plan cannot be created for SDK generation using a pull request in a private repository.
+                    """);
+            }
+
+            if (!Guid.TryParse(serviceTreeId, out _))
+            {
+                throw new Exception($"Service tree ID '{serviceTreeId}' is not a valid GUID.");
+            }
+
+            if (!Guid.TryParse(productTreeId, out _))
+            {
+                throw new Exception($"Product tree ID '{productTreeId}' is not a valid GUID.");
+            }
+        }
+
         [McpServerTool, Description("Create Release Plan work item.")]
         public async Task<string> CreateReleasePlan(string typeSpecProjectPath, string targetReleaseMonthYear, string serviceTreeId, string productTreeId, string specApiVersion, string specPullRequestUrl, string sdkReleaseType, string userEmail = "", bool isTestReleasePlan = false)
         {
             try
             {
-                // Check for existing release plan for the given pull request URL.
-                if (string.IsNullOrEmpty(specPullRequestUrl))
-                {
-                    return "API spec pull request URL is required to create a release plan.";
-                }
-                logger.LogInformation("Checking for existing release plan for pull request URL: {specPullRequestUrl}", specPullRequestUrl);
-                var existingReleasePlan = await devOpsService.GetReleasePlanAsync(specPullRequestUrl);
-                if (existingReleasePlan != null && existingReleasePlan.WorkItemId > 0)
-                {
-                    return $"Release plan already exists for the pull request: {specPullRequestUrl}. Release Plan ID: {existingReleasePlan.ReleasePlanId}";
-                }
-
-                if (string.IsNullOrEmpty(typeSpecProjectPath))
-                {
-                    throw new Exception("TypeSpec project path is empty. Cannot create a release plan without a TypeSpec project root path");
-                }
+                sdkReleaseType = sdkReleaseType?.ToLower() ?? "";
+                await ValidateCreateReleasePlanInputs(typeSpecProjectPath, serviceTreeId, productTreeId, specPullRequestUrl, sdkReleaseType);
 
                 var specType = typeSpecHelper.IsValidTypeSpecProjectPath(typeSpecProjectPath) ? "TypeSpec" : "OpenAPI";
                 var isMgmt = typeSpecHelper.IsTypeSpecProjectForMgmtPlane(typeSpecProjectPath);
-                var repoRoot = typeSpecHelper.GetSpecRepoRootPath(typeSpecProjectPath);
-
-                sdkReleaseType = sdkReleaseType?.ToLower() ?? "";
-                var supportedReleaseTypes = new[] { "beta", "stable" };
-                if (!supportedReleaseTypes.Contains(sdkReleaseType))
-                {
-                    return $"Invalid SDK release type. Supported release types are: {string.Join(", ", supportedReleaseTypes)}";
-                }
-
-                // Ensure a release plan is created only if the API specs pull request is in a public repository.
-                if (!typeSpecHelper.IsRepoPathForPublicSpecRepo(repoRoot))
-                {
-                    return """
-                        SDK generation and release require the API specs pull request to be in the public azure-rest-api-specs repository.
-                        Please create a pull request in the public Azure/azure-rest-api-specs repository to move your specs changes to public.
-                        A release plan cannot be created for SDK generation using a pull request in a private repository.
-                        """;
-                }
-
+                
                 if (string.IsNullOrEmpty(userEmail))
                 {
                     logger.LogInformation("User email not provided. Attempting to retrieve current user email.");


### PR DESCRIPTION
This PR adds GUID validation for serviceTreeId and productTreeId parameters in the ReleasePlanTool.

Changes include:
- Added GUID validation for serviceTreeId and productTreeId in ValidateCreateReleasePlanInputs method
- Added comprehensive unit tests covering:
  - Invalid SDK release type validation
  - Invalid service tree ID validation
  - Invalid product tree ID validation
  - Valid inputs scenario

The validation ensures that both serviceTreeId and productTreeId are valid GUIDs before proceeding with release plan creation.