### PR TITLE
Update response to include work item 

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/GitHubService.cs
@@ -29,6 +29,12 @@ public class GitConnection
 
         private static string GetGitHubAuthToken()
         {
+            var token = Environment.GetEnvironmentVariable("GITHUB_TOKEN");
+            if (!string.IsNullOrEmpty(token))
+            {
+                return token;
+            }
+            // If the GITHUB_TOKEN environment variable is not set, try to get the token using the 'gh' CLI command
             bool isWindows = RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
             string command = isWindows ? "cmd.exe" : "gh";
             string args = isWindows ? "/C gh auth token" : "auth token";

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
@@ -158,7 +158,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
             var existingReleasePlan = await devOpsService.GetReleasePlanAsync(specPullRequestUrl);
             if (existingReleasePlan != null && existingReleasePlan.WorkItemId > 0)
             {
-                throw new Exception($"Release plan already exists for the pull request: {specPullRequestUrl}. Release Plan ID: {existingReleasePlan.ReleasePlanId}");
+                throw new Exception($"Release plan already exists for the pull request: {specPullRequestUrl}. Work item Id: {existingReleasePlan.WorkItemId}");
             }
 
             if (string.IsNullOrEmpty(typeSpecProjectPath))


### PR DESCRIPTION
Return work item ID instead of release plan ID to provide unique value among the different env