### PR TITLE
Disable SBom generation for pull requests

### DIFF
--- a/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
+++ b/eng/common/pipelines/templates/steps/publish-1es-artifact.yml
@@ -31,8 +31,8 @@ steps:
     inputs:
       artifactName: '$(PublishArtifactName)'
       targetPath: '${{ parameters.ArtifactPath }}'
-      # Disable sbom generation by default for our public validation builds to avoid unnecessary work
-      ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      # Disable sbom generation by default for our public or pull request validation builds to avoid unnecessary work
+      ${{ if or(eq(variables['System.TeamProject'], 'public'), eq(variables['Build.Reason'], 'PullRequest') }}:
         sbomEnabled: false
       ${{ else }}:
         sbomEnabled: ${{ parameters.SbomEnabled }}


### PR DESCRIPTION
We do not publish any builds coming from pull requests so we also don't need to generate an SBom. It takes unnecessary time and also fails on any PRs from forks so we should just disable it for those scenarios.