### PR TITLE
Remove MAC from pwsh tools template

### DIFF
--- a/eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
+++ b/eng/common/pipelines/templates/stages/archetype-sdk-tool-pwsh.yml
@@ -30,9 +30,6 @@ stages:
             Linux:
               Pool: azsdk-pool
               Image: ubuntu-24.04
-            Mac:
-              Pool: Azure Pipelines
-              Image: macos-latest
 
         pool:
           name: $(Pool)


### PR DESCRIPTION
With the new pools we would have to split MAC into its own job matrix which I don't think is worth it for these tests so I'm just remove it from the list.

```
##[error]No agent found in pool Azure Pipelines which satisfies the following demand: ImageOverride. All demands: Agent.Version -gtVersion 2.144.0, ImageOverride -equals macos-latest
```