### PR TITLE
Refactor: Just pointing out to a single location for bot name 

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Account/AutoAPIRevisionModifierRequirementHandler.cs
+++ b/src/dotnet/APIView/APIViewWeb/Account/AutoAPIRevisionModifierRequirementHandler.cs
@@ -10,7 +10,7 @@ namespace APIViewWeb
 {
     public class AutoAPIRevisionModifierRequirementHandler : IAuthorizationHandler
     {
-        private static string _autoReviewOwner = ApiViewConstants.BotName;
+        private static string _autoReviewOwner = ApiViewConstants.AzureSdkBotName;
         public Task HandleAsync(AuthorizationHandlerContext context)
         {
             if (context.User != null)

--- a/src/dotnet/APIView/APIViewWeb/Account/AutoAPIRevisionModifierRequirementHandler.cs
+++ b/src/dotnet/APIView/APIViewWeb/Account/AutoAPIRevisionModifierRequirementHandler.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Threading.Tasks;
+using APIViewWeb.Helpers;
 using APIViewWeb.LeanModels;
 using Microsoft.AspNetCore.Authorization;
 
@@ -9,7 +10,7 @@ namespace APIViewWeb
 {
     public class AutoAPIRevisionModifierRequirementHandler : IAuthorizationHandler
     {
-        private static string _autoReviewOwner = "azure-sdk";
+        private static string _autoReviewOwner = ApiViewConstants.BotName;
         public Task HandleAsync(AuthorizationHandlerContext context)
         {
             if (context.User != null)

--- a/src/dotnet/APIView/APIViewWeb/Account/CommentOwnerRequirementHandler.cs
+++ b/src/dotnet/APIView/APIViewWeb/Account/CommentOwnerRequirementHandler.cs
@@ -28,7 +28,7 @@ namespace APIViewWeb
                     var approvers = _configuration["Approvers"].Split(',');
                     var loggedInUserName = context.User.GetGitHubLogin();
                     if (creator == loggedInUserName ||
-                        (approvers.Contains(loggedInUserName) && creator == ApiViewConstants.BotName))
+                        (approvers.Contains(loggedInUserName) && creator == ApiViewConstants.AzureSdkBotName))
                     {
                         context.Succeed(requirement);
                     }

--- a/src/dotnet/APIView/APIViewWeb/Account/CommentOwnerRequirementHandler.cs
+++ b/src/dotnet/APIView/APIViewWeb/Account/CommentOwnerRequirementHandler.cs
@@ -3,6 +3,7 @@
 
 using System.Linq;
 using System.Threading.Tasks;
+using APIViewWeb.Helpers;
 using APIViewWeb.LeanModels;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Configuration;
@@ -27,7 +28,7 @@ namespace APIViewWeb
                     var approvers = _configuration["Approvers"].Split(',');
                     var loggedInUserName = context.User.GetGitHubLogin();
                     if (creator == loggedInUserName ||
-                        (approvers.Contains(loggedInUserName) && creator == "azure-sdk"))
+                        (approvers.Contains(loggedInUserName) && creator == ApiViewConstants.BotName))
                     {
                         context.Succeed(requirement);
                     }

--- a/src/dotnet/APIView/APIViewWeb/Filters/ApiKeyAuthorizeAsyncFilter.cs
+++ b/src/dotnet/APIView/APIViewWeb/Filters/ApiKeyAuthorizeAsyncFilter.cs
@@ -1,20 +1,21 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Filters;
-using Microsoft.Extensions.Configuration;
 using System;
 using System.Collections.Generic;
 using System.Security.Claims;
 using System.Threading.Tasks;
+using APIViewWeb.Helpers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.Extensions.Configuration;
 
 namespace APIViewWeb.Filters
 {
     public class ApiKeyAuthorizeAsyncFilter : Attribute, IAsyncAuthorizationFilter
     {
         private static string _apiKeyHeader = "ApiKey";
-        private string _azure_sdk_bot = "azure-sdk";
+        private string _azure_sdk_bot = ApiViewConstants.BotName;
         private HashSet<string> _apiKeyValues = new HashSet<string>();
 
         public ApiKeyAuthorizeAsyncFilter(IConfiguration configuration)

--- a/src/dotnet/APIView/APIViewWeb/Filters/ApiKeyAuthorizeAsyncFilter.cs
+++ b/src/dotnet/APIView/APIViewWeb/Filters/ApiKeyAuthorizeAsyncFilter.cs
@@ -15,7 +15,7 @@ namespace APIViewWeb.Filters
     public class ApiKeyAuthorizeAsyncFilter : Attribute, IAsyncAuthorizationFilter
     {
         private static string _apiKeyHeader = "ApiKey";
-        private string _azure_sdk_bot = ApiViewConstants.BotName;
+        private string _azure_sdk_bot = ApiViewConstants.AzureSdkBotName;
         private HashSet<string> _apiKeyValues = new HashSet<string>();
 
         public ApiKeyAuthorizeAsyncFilter(IConfiguration configuration)

--- a/src/dotnet/APIView/APIViewWeb/Helpers/ApiViewConstants.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/ApiViewConstants.cs
@@ -1,0 +1,6 @@
+namespace APIViewWeb.Helpers;
+
+public static class ApiViewConstants
+{
+    public const string BotName = "azure-sdk";
+}

--- a/src/dotnet/APIView/APIViewWeb/Helpers/ApiViewConstants.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/ApiViewConstants.cs
@@ -2,5 +2,5 @@ namespace APIViewWeb.Helpers;
 
 public static class ApiViewConstants
 {
-    public const string BotName = "azure-sdk";
+    public const string AzureSdkBotName = "azure-sdk";
 }

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -184,7 +184,7 @@ namespace APIViewWeb.Managers
         /// <returns></returns>
         public APIRevisionListItemModel GetNewAPIRevisionAsync(APIRevisionType apiRevisionType,
             string reviewId = null, string packageName = null, string language = null,
-            string label = null, int? prNumber = null, string createdBy= ApiViewConstants.BotName)
+            string label = null, int? prNumber = null, string createdBy= ApiViewConstants.AzureSdkBotName)
         {
             var apiRevision = new APIRevisionListItemModel()
             {
@@ -626,7 +626,7 @@ namespace APIViewWeb.Managers
         /// <param name="apiRevision"></param>
         /// <param name="notes"></param>
         /// <returns></returns>
-        public async Task SoftDeleteAPIRevisionAsync(APIRevisionListItemModel apiRevision, string userName = ApiViewConstants.BotName, string notes = "")
+        public async Task SoftDeleteAPIRevisionAsync(APIRevisionListItemModel apiRevision, string userName = ApiViewConstants.AzureSdkBotName, string notes = "")
         {
             if (!apiRevision.IsDeleted)
             {

--- a/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/APIRevisionsManager.cs
@@ -184,7 +184,7 @@ namespace APIViewWeb.Managers
         /// <returns></returns>
         public APIRevisionListItemModel GetNewAPIRevisionAsync(APIRevisionType apiRevisionType,
             string reviewId = null, string packageName = null, string language = null,
-            string label = null, int? prNumber = null, string createdBy="azure-sdk")
+            string label = null, int? prNumber = null, string createdBy= ApiViewConstants.BotName)
         {
             var apiRevision = new APIRevisionListItemModel()
             {
@@ -626,7 +626,7 @@ namespace APIViewWeb.Managers
         /// <param name="apiRevision"></param>
         /// <param name="notes"></param>
         /// <returns></returns>
-        public async Task SoftDeleteAPIRevisionAsync(APIRevisionListItemModel apiRevision, string userName = "azure-sdk", string notes = "")
+        public async Task SoftDeleteAPIRevisionAsync(APIRevisionListItemModel apiRevision, string userName = ApiViewConstants.BotName, string notes = "")
         {
             if (!apiRevision.IsDeleted)
             {

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -20,7 +20,7 @@ namespace APIViewWeb.Managers.Interfaces
         public Task<APIRevisionListItemModel> GetAPIRevisionAsync(ClaimsPrincipal user, string apiRevisionId);
         public Task<APIRevisionListItemModel> GetAPIRevisionAsync(string apiRevisionId);
         public APIRevisionListItemModel GetNewAPIRevisionAsync(APIRevisionType apiRevisionType, string reviewId = null, string packageName = null, string language = null,
-            string label = null, int? prNumber = null, string createdBy = ApiViewConstants.BotName);
+            string label = null, int? prNumber = null, string createdBy = ApiViewConstants.AzureSdkBotName);
         public Task<(bool updateReview, APIRevisionListItemModel apiRevision)> ToggleAPIRevisionApprovalAsync(ClaimsPrincipal user, string id, string revisionId = null, APIRevisionListItemModel apiRevision = null, string notes = "", string approver = "");
         public Task<APIRevisionListItemModel> AddAPIRevisionAsync(ClaimsPrincipal user, string reviewId, APIRevisionType apiRevisionType, string name, string label, Stream fileStream, string language = "", bool awaitComputeDiff = false);
         public Task<APIRevisionListItemModel> CreateAPIRevisionAsync(ClaimsPrincipal user, ReviewListItemModel review, IFormFile file, string filePath, string language, string label);
@@ -28,7 +28,7 @@ namespace APIViewWeb.Managers.Interfaces
         public Task RunAPIRevisionGenerationPipeline(List<APIRevisionGenerationPipelineParamModel> reviewGenParams, string language);
         public Task SoftDeleteAPIRevisionAsync(ClaimsPrincipal user, string reviewId, string revisionId);
         public Task SoftDeleteAPIRevisionAsync(ClaimsPrincipal user, APIRevisionListItemModel apiRevision);
-        public Task SoftDeleteAPIRevisionAsync(APIRevisionListItemModel apiRevision, string userName = ApiViewConstants.BotName, string notes = "");
+        public Task SoftDeleteAPIRevisionAsync(APIRevisionListItemModel apiRevision, string userName = ApiViewConstants.AzureSdkBotName, string notes = "");
         public Task RestoreAPIRevisionAsync(ClaimsPrincipal user, string reviewId, string revisionId);
         public Task UpdateAPIRevisionLabelAsync(ClaimsPrincipal user, string revisionId, string label);
         public Task<bool> AreAPIRevisionsTheSame(APIRevisionListItemModel apiRevision, RenderedCodeFile renderedCodeFile, bool considerPackageVersion = false);

--- a/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/Interfaces/IAPIRevisionsManager.cs
@@ -20,7 +20,7 @@ namespace APIViewWeb.Managers.Interfaces
         public Task<APIRevisionListItemModel> GetAPIRevisionAsync(ClaimsPrincipal user, string apiRevisionId);
         public Task<APIRevisionListItemModel> GetAPIRevisionAsync(string apiRevisionId);
         public APIRevisionListItemModel GetNewAPIRevisionAsync(APIRevisionType apiRevisionType, string reviewId = null, string packageName = null, string language = null,
-            string label = null, int? prNumber = null, string createdBy = "azure-sdk");
+            string label = null, int? prNumber = null, string createdBy = ApiViewConstants.BotName);
         public Task<(bool updateReview, APIRevisionListItemModel apiRevision)> ToggleAPIRevisionApprovalAsync(ClaimsPrincipal user, string id, string revisionId = null, APIRevisionListItemModel apiRevision = null, string notes = "", string approver = "");
         public Task<APIRevisionListItemModel> AddAPIRevisionAsync(ClaimsPrincipal user, string reviewId, APIRevisionType apiRevisionType, string name, string label, Stream fileStream, string language = "", bool awaitComputeDiff = false);
         public Task<APIRevisionListItemModel> CreateAPIRevisionAsync(ClaimsPrincipal user, ReviewListItemModel review, IFormFile file, string filePath, string language, string label);
@@ -28,7 +28,7 @@ namespace APIViewWeb.Managers.Interfaces
         public Task RunAPIRevisionGenerationPipeline(List<APIRevisionGenerationPipelineParamModel> reviewGenParams, string language);
         public Task SoftDeleteAPIRevisionAsync(ClaimsPrincipal user, string reviewId, string revisionId);
         public Task SoftDeleteAPIRevisionAsync(ClaimsPrincipal user, APIRevisionListItemModel apiRevision);
-        public Task SoftDeleteAPIRevisionAsync(APIRevisionListItemModel apiRevision, string userName = "azure-sdk", string notes = "");
+        public Task SoftDeleteAPIRevisionAsync(APIRevisionListItemModel apiRevision, string userName = ApiViewConstants.BotName, string notes = "");
         public Task RestoreAPIRevisionAsync(ClaimsPrincipal user, string reviewId, string revisionId);
         public Task UpdateAPIRevisionLabelAsync(ClaimsPrincipal user, string revisionId, string label);
         public Task<bool> AreAPIRevisionsTheSame(APIRevisionListItemModel apiRevision, RenderedCodeFile renderedCodeFile, bool considerPackageVersion = false);

--- a/src/dotnet/APIView/APIViewWeb/Managers/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/PullRequestManager.cs
@@ -236,7 +236,7 @@ namespace APIViewWeb.Managers
                 var apiRevision = await _apiRevisionsRepository.GetAPIRevisionAsync(pullRequestModel.APIRevisionId);
                 if (apiRevision != null && !apiRevision.Approvers.Any())
                 {
-                    await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(userName: ApiViewConstants.BotName, apiRevision: apiRevision, notes: "Deleted by PullRequest CleanUp Automation");
+                    await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(userName: ApiViewConstants.AzureSdkBotName, apiRevision: apiRevision, notes: "Deleted by PullRequest CleanUp Automation");
                 }
             }
 

--- a/src/dotnet/APIView/APIViewWeb/Managers/PullRequestManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/PullRequestManager.cs
@@ -236,7 +236,7 @@ namespace APIViewWeb.Managers
                 var apiRevision = await _apiRevisionsRepository.GetAPIRevisionAsync(pullRequestModel.APIRevisionId);
                 if (apiRevision != null && !apiRevision.Approvers.Any())
                 {
-                    await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(userName: "azure-sdk", apiRevision: apiRevision, notes: "Deleted by PullRequest CleanUp Automation");
+                    await _apiRevisionsManager.SoftDeleteAPIRevisionAsync(userName: ApiViewConstants.BotName, apiRevision: apiRevision, notes: "Deleted by PullRequest CleanUp Automation");
                 }
             }
 

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -240,14 +240,14 @@ namespace APIViewWeb.Managers
                 PackageName = packageName,
                 Language = language,
                 CreatedOn = DateTime.UtcNow,
-                CreatedBy = ApiViewConstants.BotName,
+                CreatedBy = ApiViewConstants.AzureSdkBotName,
                 IsClosed = isClosed,
                 ChangeHistory = new List<ReviewChangeHistoryModel>()
                 {
                     new ReviewChangeHistoryModel()
                     {
                         ChangeAction = ReviewChangeAction.Created,
-                        ChangedBy = ApiViewConstants.BotName,
+                        ChangedBy = ApiViewConstants.AzureSdkBotName,
                         ChangedOn = DateTime.UtcNow
                     }
                 }
@@ -439,7 +439,7 @@ namespace APIViewWeb.Managers
                     commentText.AppendLine($"See: https://azure.github.io/azure-sdk/{id}");
                 }
                 commentModel.ResolutionLocked = false;
-                commentModel.CreatedBy = ApiViewConstants.BotName;
+                commentModel.CreatedBy = ApiViewConstants.AzureSdkBotName;
                 commentModel.CommentText = commentText.ToString();
             
                 await _commentsRepository.UpsertCommentAsync(commentModel);

--- a/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/ReviewManager.cs
@@ -240,14 +240,14 @@ namespace APIViewWeb.Managers
                 PackageName = packageName,
                 Language = language,
                 CreatedOn = DateTime.UtcNow,
-                CreatedBy = "azure-sdk",
+                CreatedBy = ApiViewConstants.BotName,
                 IsClosed = isClosed,
                 ChangeHistory = new List<ReviewChangeHistoryModel>()
                 {
                     new ReviewChangeHistoryModel()
                     {
                         ChangeAction = ReviewChangeAction.Created,
-                        ChangedBy = "azure-sdk",
+                        ChangedBy = ApiViewConstants.BotName,
                         ChangedOn = DateTime.UtcNow
                     }
                 }
@@ -439,7 +439,7 @@ namespace APIViewWeb.Managers
                     commentText.AppendLine($"See: https://azure.github.io/azure-sdk/{id}");
                 }
                 commentModel.ResolutionLocked = false;
-                commentModel.CreatedBy = "azure-sdk";
+                commentModel.CreatedBy = ApiViewConstants.BotName;
                 commentModel.CommentText = commentText.ToString();
             
                 await _commentsRepository.UpsertCommentAsync(commentModel);

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -160,7 +160,7 @@
                     }
                     else
                     {
-                        approver = ApiViewConstants.BotName;
+                        approver = ApiViewConstants.AzureSdkBotName;
                     }
                 }
 

--- a/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
+++ b/src/dotnet/APIView/APIViewWeb/Pages/Assemblies/Review.cshtml
@@ -160,7 +160,7 @@
                     }
                     else
                     {
-                        approver = "azure-sdk";
+                        approver = ApiViewConstants.BotName;
                     }
                 }
 


### PR DESCRIPTION
There are multiple places in where we have the string "azure-sdk" so replacing this, if we feel more comfortable having this on a cofig, also happy to do that change instead, I just think we need to have a place where this is defined 