### PR TITLE
[APIView Copilot] Remove sample from metada and other Python tweaks

### DIFF
--- a/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
+++ b/packages/python-packages/apiview-copilot/metadata/python/filter.yaml
@@ -1,7 +1,7 @@
 exceptions: |
   1. Comment on the `send_request` method
   2. Suggest changes to class inheritance patterns (i.e. base‑class relationships only)
-  3. Comment on `implements ContextManager` pseudocode
+  3. Comment on using non-standard `implements` pseudocode
   4. Comment on ellipsis (...) usage in optional parameters
   5. Comment on __init__ overloads in model classes or MutableMapping inheritance
   6. Suggest adding docstrings
@@ -17,43 +17,3 @@ exceptions: |
   16. Comment about removing the non-Python 'namespace' declaration
   17. Comment on the overuse of **kwargs
   18. Comment that the *syntax* of including a module path in the *definition* is wrong (e.g. flagging `class azure.foo.FooClient:` itself as illegal)
-sample: |
-  - description: "Should filter out docstring suggestions"
-    initial_results: |
-      {
-        "comments": [
-          {
-            "line_no": 2,
-            "bad_code": "def method1(self, arg1: str) -> None",
-            "suggestion": "Add docstring explaining method purpose",
-            "comment": "Methods should have descriptive docstrings"
-          },
-          {
-            "line_no": 2,
-            "bad_code": "def method1(self, arg1: str) -> None",
-            "suggestion": "def get_something(self, name: str) -> None",
-            "comment": "Method name should be more descriptive"
-          }
-        ]
-      }
-    expected_results: |
-      {
-        "comments": [
-          {
-            "line_no": 2,
-            "bad_code": "def method1(self, arg1: str) -> None",
-            "suggestion": "Add docstring explaining method purpose",
-            "comment": "Methods should have descriptive docstrings"
-            "status": "REMOVE",
-            "status_reason": "Comment on docstring suggestion violates exceptions"
-          },
-          {
-            "line_no": 2,
-            "bad_code": "def method1(self, arg1: str) -> None",
-            "suggestion": "def get_something(self, name: str) -> None",
-            "comment": "Method name should be more descriptive"
-            "status": "KEEP",
-            "status_reason": "Comment enhances API design"
-          }
-        ]
-      }

--- a/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
+++ b/packages/python-packages/apiview-copilot/src/_apiview_reviewer.py
@@ -775,27 +775,25 @@ class ApiViewReview:
 
         # Return defaults if the file doesn't exist
         if not os.path.exists(yaml_file):
-            return {"exceptions": "None", "sample": ""}
+            return {"exceptions": "None"}
 
         # Load the YAML file
         with open(yaml_file, "r") as f:
             yaml_data = yaml.safe_load(f)
 
-        sample_yaml = yaml_data.get("sample", None)
         exceptions_yaml = yaml_data.get("exceptions", None)
         metadata = {
-            "sample": "",
             "exceptions": exceptions_yaml or "None",
         }
-        # format the sample string if there's a value
-        if sample_yaml:
-            metadata[
-                "sample"
-            ] = f"""
-            sample:
-              {sample_yaml}
-            """
         return metadata
+
+    def _unescape(self, text: str) -> str:
+        return str(bytes(text, "utf-8").decode("unicode_escape"))
+
+    def close(self):
+        """Close resources used by this ApiViewReview instance."""
+        if hasattr(self, "executor"):
+            self.executor.shutdown(wait=True)
 
     def _unescape(self, text: str) -> str:
         return str(bytes(text, "utf-8").decode("unicode_escape"))


### PR DESCRIPTION
No other language uses "sample" and it's not necessary, so we can remove it.

Also, some tweaks to Python filters based on feedback. 