### PR TITLE
Support SDK generation without release plan and pull request

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/SpecWorkFlowToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/SpecWorkFlowToolTests.cs
@@ -64,7 +64,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             mockDevOpsService.Setup(x => x.GetReleasePlanForWorkItemAsync(It.IsAny<int>()))
                            .ReturnsAsync(releasePlan);
 
-            var result = await specWorkflowTool.GenerateSDK(
+            var result = await specWorkflowTool.GenerateSdkAsync(
                 typespecProjectRoot: "valid/path",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -95,7 +95,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             mockDevOpsService.Setup(x => x.GetReleasePlanForWorkItemAsync(It.IsAny<int>()))
                            .ReturnsAsync(releasePlan);
 
-            var result = await specWorkflowTool.GenerateSDK(
+            var result = await specWorkflowTool.GenerateSdkAsync(
                 typespecProjectRoot: "valid/path",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -122,7 +122,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             mockDevOpsService.Setup(x => x.GetReleasePlanForWorkItemAsync(It.IsAny<int>()))
                            .ReturnsAsync(releasePlanWithEmptyLanguage);
 
-            var resultEmptyLanguage = await specWorkflowTool.GenerateSDK(
+            var resultEmptyLanguage = await specWorkflowTool.GenerateSdkAsync(
                 typespecProjectRoot: "valid/path",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -145,7 +145,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             mockDevOpsService.Setup(x => x.GetReleasePlanForWorkItemAsync(It.IsAny<int>()))
                            .ReturnsAsync(releasePlan);
 
-            var result = await specWorkflowTool.GenerateSDK(
+            var result = await specWorkflowTool.GenerateSdkAsync(
                 typespecProjectRoot: "valid/path",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -198,7 +198,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
                     Status = BuildStatus.InProgress,
                 });
 
-            var result = await specWorkflowTool.GenerateSDK(
+            var result = await specWorkflowTool.GenerateSdkAsync(
                 typespecProjectRoot: "TypeSpecTestData/specification/testcontoso/Contoso.Management",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -224,7 +224,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
                     Status = BuildStatus.InProgress,
                 });
 
-            var result = await specWorkflowTool.GenerateSDK(
+            var result = await specWorkflowTool.GenerateSdkAsync(
                 typespecProjectRoot: "TypeSpecTestData/specification/testcontoso/Contoso.Management",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -252,7 +252,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
                 new Octokit.PullRequest(123, null, null, null, null, null, null, null, 123, ItemState.Open, null, null, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, null, null, null, null, null, null, false, null, null, null, null, 0, 1, 1, 1, 1, null, false, null, null, null, null, null));
 
 
-            var result = await specWorkflowTool.GenerateSDK(
+            var result = await specWorkflowTool.GenerateSdkAsync(
                 typespecProjectRoot: "TypeSpecTestData/specification/testcontoso/Contoso.Management",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/SpecWorkFlowToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/SpecWorkFlowToolTests.cs
@@ -1,8 +1,10 @@
 using Azure.Sdk.Tools.Cli.Helpers;
 using Azure.Sdk.Tools.Cli.Models;
 using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
 using Azure.Sdk.Tools.Cli.Tools;
 using Microsoft.Azure.Pipelines.WebApi;
+using Microsoft.Extensions.Logging;
 using Microsoft.TeamFoundation.Build.WebApi;
 using Moq;
 using Octokit;
@@ -17,6 +19,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
         private Mock<IGitHubService> mockGitHubService;
         private Mock<IGitHelper> mockGitHelper;
         private Mock<ITypeSpecHelper> mockTypeSpecHelper;
+        private ILogger<SpecWorkflowTool> logger;
         private SpecWorkflowTool specWorkflowTool;
 
         [SetUp]
@@ -27,6 +30,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             mockGitHubService = new Mock<IGitHubService>();
             mockGitHelper = new Mock<IGitHelper>();
             mockTypeSpecHelper = new Mock<ITypeSpecHelper>();
+            logger = new TestLogger<SpecWorkflowTool>();
 
             mockOutputService.Setup(x => x.Format(It.IsAny<GenericResponse>()))
                            .Returns((GenericResponse r) => string.Join(", ", r.Details));
@@ -42,7 +46,8 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
                 mockDevOpsService.Object,
                 mockGitHelper.Object,
                 mockTypeSpecHelper.Object,
-                mockOutputService.Object
+                mockOutputService.Object,
+                logger
             );
         }
 
@@ -64,7 +69,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             mockDevOpsService.Setup(x => x.GetReleasePlanForWorkItemAsync(It.IsAny<int>()))
                            .ReturnsAsync(releasePlan);
 
-            var result = await specWorkflowTool.GenerateSdkAsync(
+            var result = await specWorkflowTool.RunGenerateSdkAsync(
                 typespecProjectRoot: "valid/path",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -95,7 +100,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             mockDevOpsService.Setup(x => x.GetReleasePlanForWorkItemAsync(It.IsAny<int>()))
                            .ReturnsAsync(releasePlan);
 
-            var result = await specWorkflowTool.GenerateSdkAsync(
+            var result = await specWorkflowTool.RunGenerateSdkAsync(
                 typespecProjectRoot: "valid/path",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -122,7 +127,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             mockDevOpsService.Setup(x => x.GetReleasePlanForWorkItemAsync(It.IsAny<int>()))
                            .ReturnsAsync(releasePlanWithEmptyLanguage);
 
-            var resultEmptyLanguage = await specWorkflowTool.GenerateSdkAsync(
+            var resultEmptyLanguage = await specWorkflowTool.RunGenerateSdkAsync(
                 typespecProjectRoot: "valid/path",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -145,7 +150,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
             mockDevOpsService.Setup(x => x.GetReleasePlanForWorkItemAsync(It.IsAny<int>()))
                            .ReturnsAsync(releasePlan);
 
-            var result = await specWorkflowTool.GenerateSdkAsync(
+            var result = await specWorkflowTool.RunGenerateSdkAsync(
                 typespecProjectRoot: "valid/path",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -198,7 +203,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
                     Status = BuildStatus.InProgress,
                 });
 
-            var result = await specWorkflowTool.GenerateSdkAsync(
+            var result = await specWorkflowTool.RunGenerateSdkAsync(
                 typespecProjectRoot: "TypeSpecTestData/specification/testcontoso/Contoso.Management",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -224,7 +229,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
                     Status = BuildStatus.InProgress,
                 });
 
-            var result = await specWorkflowTool.GenerateSdkAsync(
+            var result = await specWorkflowTool.RunGenerateSdkAsync(
                 typespecProjectRoot: "TypeSpecTestData/specification/testcontoso/Contoso.Management",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",
@@ -252,7 +257,7 @@ namespace Azure.Sdk.Tools.Cli.Tests.Tools
                 new Octokit.PullRequest(123, null, null, null, null, null, null, null, 123, ItemState.Open, null, null, DateTimeOffset.Now, DateTimeOffset.Now, DateTimeOffset.Now, null, null, null, null, null, null, false, null, null, null, null, 0, 1, 1, 1, 1, null, false, null, null, null, null, null));
 
 
-            var result = await specWorkflowTool.GenerateSdkAsync(
+            var result = await specWorkflowTool.RunGenerateSdkAsync(
                 typespecProjectRoot: "TypeSpecTestData/specification/testcontoso/Contoso.Management",
                 apiVersion: "2023-01-01",
                 sdkReleaseType: "beta",

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecWorkflowTool/SpecWorkFlowTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/SpecWorkflowTool/SpecWorkFlowTool.cs
@@ -13,7 +13,7 @@ using System.Text;
 
 namespace Azure.Sdk.Tools.Cli.Tools
 {
-    [Description("This Type contains a set of tools to help with TypeSpec to SDK generation work flow.")]
+    [Description("This type contains the MCP tool to run SDK generation using pipeline, check SDK generation pipeline status and to get generated SDK pull request details.")]
     [McpServerToolType]
     public class SpecWorkflowTool(IGitHubService githubService,
         IDevOpsService devopsService,
@@ -45,11 +45,11 @@ namespace Azure.Sdk.Tools.Cli.Tools
 
         // Options
         private readonly Option<string> typeSpecProjectPathOpt = new(["--typespec-project"], "Path to typespec project") { IsRequired = true };
-        private readonly Option<int> pullRequestNumberOpt = new(["--pr"], "Pull request number") { IsRequired = true };
+        private readonly Option<int> pullRequestNumberOpt = new(["--pr"], "Pull request number") { IsRequired = false };
         private readonly Option<string> apiVersionOpt = new(["--api-version"], "API version") { IsRequired = true };
         private readonly Option<string> sdkReleaseTypeOpt = new(["--release-type"], "SDK release type: beta or stable") { IsRequired = true };
         private readonly Option<string> languageOpt = new(["--language"], "SDK language, Options[Python, .NET, JavaScript, Java, go]") { IsRequired = true };
-        private readonly Option<int> workItemIdOpt = new(["--workitem-id"], "SDK release plan work item id") { IsRequired = true };
+        private readonly Option<int> workItemIdOpt = new(["--workitem-id"], "SDK release plan work item id") { IsRequired = false };
         private readonly Option<int> pipelineRunIdOpt = new(["--pipeline-run"], "SDK generation pipeline run id") { IsRequired = true };
         private readonly Option<string> urlOpt = new(["--url"], "Pull request url") { IsRequired = true };
         private readonly Option<int> releasePlanIdOpt = new(["--release-plan"], "SDK release plan id") { IsRequired = false };
@@ -108,10 +108,14 @@ namespace Azure.Sdk.Tools.Cli.Tools
         // disabling analyzer warning for MCP001 because the called function is in an entire try/catch block.
 #pragma warning disable MCP001
         [McpServerTool, Description("Checks whether a TypeSpec API spec is ready to generate SDK. Provide a pull request number and path to TypeSpec project json as params.")]
-        public async Task<string> CheckApiReadyForSDKGeneration(string typeSpecProjectRoot, int pullRequestNumber = 0)
+        public async Task<string> CheckApiReadyForSDKGeneration(string typeSpecProjectRoot, int pullRequestNumber, int workItemId = 0)
 #pragma warning restore MCP001
         {
             var response = await IsSpecReadyToGenerateSDKAsync(typeSpecProjectRoot, pullRequestNumber);
+            if (workItemId != 0 && response.Status == "Success")
+            {
+                await devopsService.UpdateApiSpecStatusAsync(workItemId, "Approved");
+            }
             return output.Format(response);
         }
 
@@ -215,8 +219,8 @@ namespace Azure.Sdk.Tools.Cli.Tools
         }
 
 
-        [McpServerTool, Description("This tool runs pipeline to generate SDK for a TypeSpec project. This tool calls IsSpecReadyForSDKGeneration to make sure Spec is ready to generate SDK.")]
-        public async Task<string> GenerateSDK(string typespecProjectRoot, string apiVersion, string sdkReleaseType, string language, int pullRequestNumber, int workItemId)
+        [McpServerTool(Name ="GenerateSdk"), Description("Generate SDK from a TypeSpec project using pipeline.")]
+        public async Task<string> GenerateSdkAsync(string typespecProjectRoot, string apiVersion, string sdkReleaseType, string language, int pullRequestNumber = 0, int workItemId = 0)
         {
             try
             {
@@ -224,13 +228,15 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 {
                     Status = "Success"
                 };
+
+                // Is language supported for SDK generation
                 if (!DevOpsService.IsSDKGenerationSupported(language))
                 {
                     response.Details.Add($"SDK generation is currently not supported by agent for {language}");
                     response.Status = "Failed";
                 }
 
-                // Verify input
+                // Is valid typespec project path
                 if (!TypeSpecProject.IsValidTypeSpecProjectPath(typespecProjectRoot))
                 {
                     response.Details.Add($"Invalid TypeSpec project root path [{typespecProjectRoot}].");
@@ -251,28 +257,15 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     response.Status = "Failed";
                 }
 
-                // Verify if release plan is ready to generate SDK
-                var readiness = await IsSdkDetailsPresentInReleasePlanAsync(workItemId, language);
-                if (!readiness.Status.Equals("Success"))
+                // Update SDK details in release plan if work item ID is provided
+                if (workItemId > 0)
                 {
-                    response.Details.AddRange(readiness.Details);
-                    response.Status = "Failed";
-                }
-
-                // Verify if spec is ready to generate SDK
-                readiness = await IsSpecReadyToGenerateSDKAsync(typespecProjectRoot, pullRequestNumber);
-                if (!readiness.Status.Equals("Success"))
-                {
-                    response.Details.AddRange(readiness.Details);
-                    response.Status = "Failed";
-                }
-
-                // Get Pull request details and check if pr is merged or not. if merged then run the pipeline against the target branch or against pr merge ref
-                var pullRequest = await githubService.GetPullRequestAsync(REPO_OWNER, PUBLIC_SPECS_REPO, pullRequestNumber);
-                if (pullRequest == null)
-                {
-                    response.Details.Add($"Failed to get pull request details for {pullRequestNumber} in {REPO_OWNER}/{PUBLIC_SPECS_REPO}");
-                    response.Status = "Failed";
+                    var readiness = await IsSdkDetailsPresentInReleasePlanAsync(workItemId, language);
+                    if (!readiness.Status.Equals("Success"))
+                    {
+                        response.Details.AddRange(readiness.Details);
+                        response.Status = "Failed";
+                    }
                 }
 
                 // Return failure details in case of any failure
@@ -281,14 +274,13 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     return output.Format(response);
                 }
 
-                // Spec readiness passed. So mark the spec status as approved if release plan exists.
-                if (workItemId != 0)
-                {
-                    await devopsService.UpdateApiSpecStatusAsync(workItemId, "Approved");
-                }
-
                 string typeSpecProjectPath = typespecHelper.GetTypeSpecProjectRelativePath(typespecProjectRoot);
-                string branchRef = (pullRequest?.Merged ?? false) ? pullRequest.Base.Ref : $"refs/pull/{pullRequestNumber}/merge";
+                string branchRef = "main";
+                if (pullRequestNumber > 0)
+                {
+                    var pullRequest = await githubService.GetPullRequestAsync(REPO_OWNER, PUBLIC_SPECS_REPO, pullRequestNumber);
+                    branchRef = (pullRequest?.Merged ?? false) ? pullRequest.Base.Ref : $"refs/pull/{pullRequestNumber}/merge";
+                }
                 var pipelineRun = await devopsService.RunSDKGenerationPipelineAsync(branchRef, typeSpecProjectPath, apiVersion, sdkReleaseType, language, workItemId);
                 response = new GenericResponse()
                 {
@@ -466,7 +458,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
             var command = new Command("spec-workflow", "Tools to help with the TypeSpec SDK generation.");
             var subCommands = new[]
             {
-                new Command(checkApiReadinessCommandName, "Check if API spec is ready to generate SDK") { typeSpecProjectPathOpt, pullRequestNumberOpt },
+                new Command(checkApiReadinessCommandName, "Check if API spec is ready to generate SDK") { typeSpecProjectPathOpt, pullRequestNumberOpt, workItemIdOpt },
                 new Command(generateSdkCommandName, "Generate SDK for a TypeSpec project") { typeSpecProjectPathOpt, apiVersionOpt, sdkReleaseTypeOpt, languageOpt, pullRequestNumberOpt, workItemIdOpt },
                 new Command(getPipelineStatusCommandName, "Get SDK generation pipeline run status") { pipelineRunIdOpt },
                 new Command(getSdkPullRequestCommandName, "Get SDK pull request link from SDK generation pipeline") { languageOpt, pipelineRunIdOpt, workItemIdOpt },
@@ -488,11 +480,11 @@ namespace Azure.Sdk.Tools.Cli.Tools
             switch (command)
             {
                 case checkApiReadinessCommandName:
-                    var isSpecReady = await CheckApiReadyForSDKGeneration(commandParser.GetValueForOption(typeSpecProjectPathOpt), commandParser.GetValueForOption(pullRequestNumberOpt));
+                    var isSpecReady = await CheckApiReadyForSDKGeneration(commandParser.GetValueForOption(typeSpecProjectPathOpt), pullRequestNumber: commandParser.GetValueForOption(pullRequestNumberOpt), workItemId: commandParser.GetValueForOption(workItemIdOpt));
                     output.Output($"Is API spec ready for SDK generation: {isSpecReady}");
                     return;
                 case generateSdkCommandName:
-                    var sdkGenerationResponse = await GenerateSDK(commandParser.GetValueForOption(typeSpecProjectPathOpt),
+                    var sdkGenerationResponse = await GenerateSdkAsync(commandParser.GetValueForOption(typeSpecProjectPathOpt),
                         commandParser.GetValueForOption(apiVersionOpt),
                         commandParser.GetValueForOption(sdkReleaseTypeOpt),
                         commandParser.GetValueForOption(languageOpt),


### PR DESCRIPTION
- Change pull request and release plan as optional when generating SDK
- Update API status as approved when checking API readiness
- Tests to verify SDK generation without release plan and spec pull request