### PR TITLE
Start MCP server using available port instead of 5000

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Program.cs
@@ -75,6 +75,12 @@ public class Program
             throw new ArgumentException($"Invalid output format '{outputFormat}'. Supported formats are: plain, json");
         }
 
+
+        builder.WebHost.ConfigureKestrel(options =>
+        {
+            options.Listen(System.Net.IPAddress.Loopback, 0); // 0 = dynamic port
+        });
+
         var toolTypes = SharedOptions.GetFilteredToolTypes(args);
 
         builder.Services


### PR DESCRIPTION
Azure SDK MCP server cannot be started on two vs code instances because both instances are trying to use port 5000. If user has Azure SDK MCP configured in more than one repo, then it's throwing exception when starting MCP server.

This change will use available port instead of 5000 to start MCP server.