### PR TITLE
[SDK Release Agent] Changed CreatePullRequest MCP to support all repos

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/GitHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Helpers/GitHelper.cs
@@ -13,6 +13,7 @@ namespace Azure.Sdk.Tools.Cli.Helpers
         public Uri GetRepoRemoteUri(string path);
         public string GetBranchName(string path);
         public string GetMergeBaseCommitSha(string path, string targetBranch);
+        public string DiscoverRepoRoot(string path);
     }
     public class GitHelper(IGitHubService gitHubService, ILogger<GitHelper> logger) : IGitHelper
     {
@@ -86,5 +87,19 @@ namespace Azure.Sdk.Tools.Cli.Helpers
 
             throw new InvalidOperationException("Unable to determine repository owner.");
         }        
+
+        public string DiscoverRepoRoot(string path)
+        {
+            var repoPath = Repository.Discover(path);
+            if (string.IsNullOrEmpty(repoPath))
+            {
+                throw new InvalidOperationException($"No git repository found at or above the path: {path}");
+            }
+            
+            // Repository.Discover returns the path to .git directory
+            // The repository root is the parent directory of .git
+            var gitDir = new DirectoryInfo(repoPath);
+            return gitDir.Parent?.FullName ?? throw new InvalidOperationException("Unable to determine repository root");
+        }
     }
 }


### PR DESCRIPTION
## Summary
`CreatePullRequest` Tool could only be used in azure-rest-api-specs repository since it was using `TypeSpecProject` path to find repo root. Find repo root through `Repository.Discover` instead and added repo root parameter.

Resolves #10985