### PR TITLE
[APIView] Change display of multiple guidelines

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/HostedServices/CopilotPollingBackgroundHostedService.cs
+++ b/src/dotnet/APIView/APIViewWeb/HostedServices/CopilotPollingBackgroundHostedService.cs
@@ -100,10 +100,17 @@ namespace APIViewWeb.HostedServices
                                     commentText.AppendLine();
                                     commentText.AppendLine();
                                 }
-                                foreach (var id in comment.RuleIds)
+
+                                if (comment.RuleIds.Count > 0)
                                 {
-                                    commentText.AppendLine($"See: https://azure.github.io/azure-sdk/{id}");
+                                    commentText.AppendLine("**Guidelines**");
+                                    foreach (var ruleId in comment.RuleIds)
+                                    {
+                                        commentText.AppendLine();
+                                        commentText.AppendLine($"https://azure.github.io/azure-sdk/{ruleId}");
+                                    }
                                 }
+
                                 commentModel.ResolutionLocked = false;
                                 commentModel.CreatedBy = "azure-sdk";
                                 commentModel.CommentText = commentText.ToString();


### PR DESCRIPTION
Issue: https://github.com/Azure/azure-sdk-tools/issues/11098

## Multiple guidelines
![image](https://github.com/user-attachments/assets/ad718c25-c115-4ff1-ad21-df359322b8cd)


## TODO
- [ ] Add couple of tests for scenarios in where there is none, one and multiples guidelines ids