### PR TITLE
[Analyzers] Fix ACZ0012 and ACZ0036

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0034Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0034Tests.cs
@@ -40,7 +40,7 @@ namespace Azure.Test
     public class BlobClient { }
 }";
 
-            var expected = Verifier.Diagnostic("AZC0034").WithSpan(4, 18, 4, 28).WithArguments("BlobClient", "Azure.Storage.Blobs.BlobClient (from Azure.Storage.Blobs)");
+            var expected = Verifier.Diagnostic("AZC0034").WithSpan(4, 18, 4, 28).WithArguments("BlobClient", "Azure.Storage.Blobs.BlobClient (from Azure.Storage.Blobs)", "Consider renaming to 'TestBlobClient' or 'TestServiceClient' to avoid confusion.");
             await Verifier.VerifyAnalyzerAsync(code, expected);
         }
 
@@ -129,7 +129,7 @@ namespace Azure
 {
     public abstract class Operation<T> { }
 }";
-            var expected = Verifier.Diagnostic("AZC0034").WithSpan(4, 27, 4, 36).WithArguments("Operation`1", "Azure.Operation`1 (from Azure.Core)");
+            var expected = Verifier.Diagnostic("AZC0034").WithSpan(4, 27, 4, 36).WithArguments("Operation`1", "Azure.Operation`1 (from Azure.Core)", "Consider renaming to 'CustomOperation' or 'CustomProcess' to avoid confusion.");
             await Verifier.VerifyAnalyzerAsync(code, expected);
         }
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AzureAnalyzerTest.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0030Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0030Tests.cs
@@ -36,7 +36,7 @@ namespace Azure.ResourceManager
         }
     }
 }";
-            var expectedMessage = $"Suggest to rename it to 'ResponseContent' or 'ResponsePatch' or any other appropriate name.";
+            var expectedMessage = $"We suggest renaming it to 'ResourceManagerResponseParametersContent' or 'ResourceManagerResponseParametersPatch' or another name with this suffix.";
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(4, 18, 4, 36).WithArguments("ResponseParameters", "Parameters", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
@@ -55,7 +55,7 @@ namespace Azure.ResourceManager.Models
         }
     }
 }";
-            var expectedMessage = $"Suggest to rename it to 'DiskConfig' or any other appropriate name.";
+            var expectedMessage = $"We suggest renaming it to 'ResourceManagerDiskOptionConfig' or another name with this suffix.";
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(4, 18, 4, 28).WithArguments("DiskOption", "Option", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
@@ -73,7 +73,7 @@ namespace Azure.ResourceManager.Models
         }
     }
 }";
-            var expectedMessage = $"Suggest to rename it to 'DiskConfig' or any other appropriate name.";
+            var expectedMessage = $"We suggest renaming it to 'SubTestDiskOptionConfig' or another name with this suffix.";
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(6, 22, 6, 32).WithArguments("DiskOption", "Option", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
@@ -95,7 +95,7 @@ namespace Azure.ResourceManager.Models
         }
     }
 }";
-            var expectedMessage = $"Suggest to rename it to 'CreationResults' or any other appropriate name.";
+            var expectedMessage = $"We suggest renaming it to 'SubTestCreationResponsesResults' or another name with this suffix.";
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(6, 22, 6, 39).WithArguments("CreationResponses", "Responses", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0033Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0033Tests.cs
@@ -77,8 +77,8 @@ namespace Azure.ResourceManager.Network
     }
 }";
             DiagnosticResult[] expected = {
-                VerifyCS.Diagnostic(diagnosticId).WithSpan(4, 18, 4, 30).WithArguments("DnsOperation", "Operation", "DnsData", "DnsInfo"),
-                VerifyCS.Diagnostic(diagnosticId).WithSpan(11, 18, 11, 33).WithArguments("DnsArmOperation", "Operation", "DnsArmData", "DnsArmInfo")
+                VerifyCS.Diagnostic(diagnosticId).WithSpan(4, 18, 4, 30).WithArguments("DnsOperation", "Operation", "We suggest renaming it to 'NetworkDnsOperationData' or 'NetworkDnsOperationInfo' or another name with these suffixes."),
+                VerifyCS.Diagnostic(diagnosticId).WithSpan(11, 18, 11, 33).WithArguments("DnsArmOperation", "Operation", "We suggest renaming it to 'NetworkDnsArmOperationData' or 'NetworkDnsArmOperationInfo' or another name with these suffixes.")
             };
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0036Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/AZC0036Tests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Xunit;
 
@@ -8,9 +9,9 @@ using VerifyCS = Azure.ClientSdk.Analyzers.Tests.AzureAnalyzerVerifier<
 // So need to skip property bags which do not have any serialization codes.
 namespace Azure.ClientSdk.Analyzers.Tests.ModelName
 {
-    public class AZC0030OptionsSuffixTests
+    public class AZC0036Tests
     {
-        private const string DiagnosticId = "AZC0030";
+        private const string DiagnosticId = "AZC0036";
 
         // This test validates that the analyzer is triggered when the model is in the Azure.ResourceManager namespace
         // and has serialization methods.
@@ -33,7 +34,7 @@ namespace " + ns + @"
         void IUtf8JsonSerializable.Write(Utf8JsonWriter writer) {}
     }
 }";
-            var expectedMessage = GetDiagnosticMessage("DiskOptions");
+            var expectedMessage = GetDiagnosticMessage("DiskOptions", ns);
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(9, 18, 9, 29).WithArguments("DiskOptions", "Options", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
@@ -58,7 +59,7 @@ namespace " + ns + @"
         }
     }
 }";
-            var expectedMessage = GetDiagnosticMessage("ResponseOptions");
+            var expectedMessage = GetDiagnosticMessage("ResponseOptions", ns);
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(4, 18, 4, 33).WithArguments("ResponseOptions", "Options", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
@@ -87,7 +88,7 @@ namespace " + ns + @"
         }
     }
 }";
-            var expectedMessage = GetDiagnosticMessage("ResponseOptions");
+            var expectedMessage = GetDiagnosticMessage("ResponseOptions", ns);
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(10, 18, 10, 33).WithArguments("ResponseOptions", "Options", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
@@ -114,7 +115,7 @@ namespace " + ns + @"
         }
     }
 }";
-            var expectedMessage = GetDiagnosticMessage("DiskOptions");
+            var expectedMessage = GetDiagnosticMessage("DiskOptions", ns + ".SubTest");
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(11, 22, 11, 33).WithArguments("DiskOptions", "Options", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
@@ -237,10 +238,80 @@ namespace " + ns + @"
             await VerifyCS.VerifyAnalyzerAsync(test);
         }
 
-        private static string GetDiagnosticMessage(string typeName)
+        private static string GetDiagnosticMessage(string typeName, string namespaceName)
         {
+            string namespacePrefix = GetNamespacePrefix(namespaceName);
+
+            // Generate suggestions based on the namespace prefix like the actual analyzer does
+            if (!string.IsNullOrEmpty(namespacePrefix))
+            {
+                // The actual analyzer does NOT remove the "Options" suffix - it keeps the full type name
+                string suggestionText = $"'{namespacePrefix}{typeName}Settings' or '{namespacePrefix}{typeName}Config'";
+                
+                return $"The `Options` suffix is reserved for input models described by https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-parameters. " +
+                    $"Please rename `{typeName}` to {suggestionText} or another suitable name according to our guidelines at https://azure.github.io/azure-sdk/general_design.html#model-types for output or roundtrip models.";
+            }
+            
+            // For non-ResourceManager namespaces, return generic message (though this shouldn't occur in our tests)
             return $"The `Options` suffix is reserved for input models described by https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-parameters. " +
                 $"Please rename `{typeName}` according to our guidelines at https://azure.github.io/azure-sdk/general_design.html#model-types for output or roundtrip models.";
+        }
+
+        private static string GetNamespacePrefix(string namespaceName)
+        {
+            // Match the logic from NamingSuggestionHelper.GetNamespacePrefix()
+            var namespaceParts = namespaceName.Split('.');
+            
+            // Skip generic parts that don't provide context and find the most specific meaningful part
+            for (int i = namespaceParts.Length - 1; i >= 0; i--)
+            {
+                var part = namespaceParts[i];
+                
+                // Skip generic parts that don't provide context
+                if (part.Equals("Models", System.StringComparison.OrdinalIgnoreCase) ||
+                    part.Equals("Internal", System.StringComparison.OrdinalIgnoreCase) ||
+                    part.Equals("Common", System.StringComparison.OrdinalIgnoreCase) ||
+                    part.Equals("Azure", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+                
+                // Convert to PascalCase and return the most specific part
+                return ConvertToPascalCase(part);
+            }
+            
+            // If we can't find a good namespace part, try to extract from the full namespace
+            // For example: Azure.Messaging.EventHubs -> EventHubs
+            if (namespaceParts.Length >= 3 && namespaceParts[0] == "Azure")
+            {
+                // Take the last meaningful part
+                var lastPart = namespaceParts[namespaceParts.Length - 1];
+                if (lastPart != "Models" && lastPart != "Internal" && lastPart != "Azure")
+                {
+                    return ConvertToPascalCase(lastPart);
+                }
+                
+                // If last part is generic, try second to last
+                if (namespaceParts.Length >= 4)
+                {
+                    return ConvertToPascalCase(namespaceParts[namespaceParts.Length - 2]);
+                }
+            }
+            
+            return ""; // For non-Azure namespaces or if we can't determine a good prefix
+        }
+
+        private static string ConvertToPascalCase(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return "";
+                
+            // Handle cases like "EventHubs" (already PascalCase)
+            if (char.IsUpper(input[0]))
+                return input;
+                
+            // Handle cases like "eventHubs" or "eventhubs"
+            return char.ToUpper(input[0]) + input.Substring(1);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/SuffixAnalyzerBaseTests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/ModelName/SuffixAnalyzerBaseTests.cs
@@ -39,7 +39,7 @@ public class MonitorParameter
 }")]
         public async Task ClassWithoutSerializationMethodsButInModelsNamespaceIsChecked(string test)
         {
-            var expectedMessage = $"Suggest to rename it to 'MonitorContent' or 'MonitorPatch' or any other appropriate name.";
+            var expectedMessage = $"We suggest renaming it to 'TestMonitorParameterContent' or 'TestMonitorParameterPatch' or another name with this suffix.";
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(3, 14, 3, 30).WithArguments("MonitorParameter", "Parameter", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
@@ -57,7 +57,7 @@ public class MonitorParameter
         return null;
     }
 }";
-            var expectedMessage = $"Suggest to rename it to 'MonitorContent' or 'MonitorPatch' or any other appropriate name.";
+            var expectedMessage = $"We suggest renaming it to 'NotModelsMonitorParameterContent' or 'NotModelsMonitorParameterPatch' or another name with this suffix.";
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(4, 14, 4, 30).WithArguments("MonitorParameter", "Parameter", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }
@@ -80,7 +80,7 @@ public class MonitorParameter : IUtf8JsonSerializable
         return;
     }
 }";
-            var expectedMessage = $"Suggest to rename it to 'MonitorContent' or 'MonitorPatch' or any other appropriate name.";
+            var expectedMessage = $"We suggest renaming it to 'NotModelsMonitorParameterContent' or 'NotModelsMonitorParameterPatch' or another name with this suffix.";
             var expected = VerifyCS.Diagnostic(DiagnosticId).WithSpan(9, 14, 9, 30).WithArguments("MonitorParameter", "Parameter", expectedMessage);
             await VerifyCS.VerifyAnalyzerAsync(test, expected);
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/NamingSuggestionHelperTests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/NamingSuggestionHelperTests.cs
@@ -1,0 +1,270 @@
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Xunit;
+
+namespace Azure.ClientSdk.Analyzers.Tests
+{
+    public class NamingSuggestionHelperTests
+    {
+        [Theory]
+        [InlineData("MyType", "Data", null, "'TestMyTypeData'")]
+        [InlineData("MyType", "Data", "Info", "'TestMyTypeData' or 'TestMyTypeInfo'")]
+        [InlineData("SomeClass", "Settings", "Config", "'TestSomeClassSettings' or 'TestSomeClassConfig'")]
+        public void GetNamespacedSuggestion_WithVariousSuffixes_ReturnsExpectedFormat(string typeName, string primarySuffix, string secondarySuffix, string expected)
+        {
+            // Arrange
+            var typeSymbol = CreateTestTypeSymbol(typeName, "Azure.Test");
+
+            // Act
+            var result = NamingSuggestionHelper.GetNamespacedSuggestion(typeName, typeSymbol, primarySuffix, secondarySuffix);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("Operation`1", "Data", null, "'TestOperationData'")]
+        [InlineData("IClient", "Service", null, "'TestClientService'")]
+        [InlineData("IOperation`2", "Data", "Info", "'TestOperationData' or 'TestOperationInfo'")]
+        public void GetNamespacedSuggestion_WithCleanedTypeNames_ReturnsExpectedFormat(string typeName, string primarySuffix, string secondarySuffix, string expected)
+        {
+            // Arrange
+            var typeSymbol = CreateTestTypeSymbol(typeName, "Azure.Test");
+
+            // Act
+            var result = NamingSuggestionHelper.GetNamespacedSuggestion(typeName, typeSymbol, primarySuffix, secondarySuffix);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("Client", "'TestClient' or 'TestServiceClient'")]
+        [InlineData("Service", "'TestService' or 'TestManager'")]
+        [InlineData("Response", "'TestResponse' or 'TestResult'")]
+        [InlineData("Operation", "'TestOperation' or 'TestProcess'")]
+        [InlineData("Data", "'TestData' or 'TestInfo'")]
+        [InlineData("Options", "'TestOptions' or 'TestSettings'")]
+        [InlineData("Settings", "'TestSettings' or 'TestConfig'")]
+        [InlineData("Config", "'TestConfig' or 'TestSettings'")]
+        [InlineData("Builder", "'TestBuilder' or 'TestFactory'")]
+        [InlineData("Manager", "'TestManager' or 'TestService'")]
+        [InlineData("Provider", "'TestProvider' or 'TestFactory'")]
+        [InlineData("Handler", "'TestHandler' or 'TestProcessor'")]
+        [InlineData("Helper", "'TestHelper' or 'TestUtil'")]
+        [InlineData("Util", "'TestUtil' or 'TestHelper'")]
+        [InlineData("Utils", "'TestUtil' or 'TestHelper'")]
+        [InlineData("Factory", "'TestFactory' or 'TestBuilder'")]
+        [InlineData("Info", "'TestInfo' or 'TestData'")]
+        [InlineData("Result", "'TestResult' or 'TestResponse'")]
+        [InlineData("Type", "'TestType' or 'TestKind'")]
+        [InlineData("Kind", "'TestKind' or 'TestType'")]
+        [InlineData("State", "'TestState' or 'TestStatus'")]
+        [InlineData("Status", "'TestStatus' or 'TestState'")]
+        public void GetCommonTypeSuggestion_WithCommonTypeNames_ReturnsExpectedSuggestions(string typeName, string expected)
+        {
+            // Arrange
+            var typeSymbol = CreateTestTypeSymbol(typeName, "Azure.Test");
+
+            // Act
+            var result = NamingSuggestionHelper.GetCommonTypeSuggestion(typeName, typeSymbol);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("BlobClient", "'TestBlobClient' or 'TestServiceClient'")]
+        [InlineData("TableClient", "'TestTableClient' or 'TestServiceClient'")]
+        [InlineData("QueueClient", "'TestQueueClient' or 'TestServiceClient'")]
+        public void GetCommonTypeSuggestion_WithCompositeClientNames_ReturnsExpectedSuggestions(string typeName, string expected)
+        {
+            // Arrange
+            var typeSymbol = CreateTestTypeSymbol(typeName, "Azure.Test");
+
+            // Act
+            var result = NamingSuggestionHelper.GetCommonTypeSuggestion(typeName, typeSymbol);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("UnknownType", "'TestUnknownTypeClient' or 'TestUnknownTypeService'")]
+        [InlineData("CustomClass", "'TestCustomClassClient' or 'TestCustomClassService'")]
+        public void GetCommonTypeSuggestion_WithUnknownTypeNames_ReturnsDefaultSuggestions(string typeName, string expected)
+        {
+            // Arrange
+            var typeSymbol = CreateTestTypeSymbol(typeName, "Azure.Test");
+
+            // Act
+            var result = NamingSuggestionHelper.GetCommonTypeSuggestion(typeName, typeSymbol);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("Azure.Storage.Blobs", "Blobs")]
+        [InlineData("Azure.Messaging.EventHubs", "EventHubs")]
+        [InlineData("Azure.ResourceManager.Compute", "Compute")]
+        [InlineData("Azure.ResourceManager.Models", "ResourceManager")]
+        [InlineData("Azure.Test.Models", "Test")]
+        [InlineData("Azure.Models.Test", "Test")]
+        [InlineData("Azure.Common.Internal", "Custom")]
+        [InlineData("Custom.Namespace", "Namespace")]
+        [InlineData("CompanyName.ProductName", "ProductName")]
+        public void GetNamespacePrefix_WithVariousNamespaces_ReturnsExpectedPrefix(string namespaceName, string expected)
+        {
+            // Arrange
+            var typeSymbol = CreateTestTypeSymbol("TestType", namespaceName);
+
+            // Act
+            var result = NamingSuggestionHelper.GetNamespacePrefix(typeSymbol);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void GetNamespacePrefix_WithGlobalNamespace_ReturnsCustomFallback()
+        {
+            // Arrange
+            var typeSymbol = CreateTestTypeSymbolInGlobalNamespace("TestType");
+
+            // Act
+            var result = NamingSuggestionHelper.GetNamespacePrefix(typeSymbol);
+
+            // Assert
+            Assert.Equal("Custom", result);
+        }
+
+        [Theory]
+        [InlineData("Operation`1", "Operation")]
+        [InlineData("Operation`2", "Operation")]
+        [InlineData("IClient", "Client")]
+        [InlineData("IAsyncEnumerable", "AsyncEnumerable")]
+        [InlineData("IOperation`1", "Operation")]
+        [InlineData("RegularClass", "RegularClass")]
+        [InlineData("I", "I")] // Edge case - single character
+        [InlineData("Ix", "Ix")] // Edge case - two characters starting with I
+        public void CleanTypeName_WithVariousInputs_ReturnsCleanedName(string input, string expected)
+        {
+            // Arrange & Act
+            var result = NamingSuggestionHelper.CleanTypeName(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("BlobClient", true)]
+        [InlineData("TableClient", true)]
+        [InlineData("QueueClient", true)]
+        [InlineData("Client", false)]
+        [InlineData("ServiceClient", true)]
+        [InlineData("client", false)] // lowercase
+        [InlineData("", false)]
+        [InlineData("NotAClient", true)]
+        public void IsCompositeClientName_WithVariousInputs_ReturnsExpectedResult(string input, bool expected)
+        {
+            // Arrange & Act
+            var result = NamingSuggestionHelper.IsCompositeClientName(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("", "Custom")]
+        [InlineData("test", "Test")]
+        [InlineData("Test", "Test")]
+        [InlineData("testName", "TestName")]
+        [InlineData("TestName", "TestName")]
+        [InlineData("eventHubs", "EventHubs")]
+        [InlineData("ALLCAPS", "ALLCAPS")]
+        [InlineData("a", "A")]
+        public void ConvertToPascalCase_WithVariousInputs_ReturnsExpectedResult(string input, string expected)
+        {
+            // Arrange & Act
+            var result = NamingSuggestionHelper.ConvertToPascalCase(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("Azure.Storage.Blobs", "Blobs")]
+        [InlineData("Azure.Messaging.EventHubs.Models", "EventHubs")]
+        [InlineData("Azure.ResourceManager.Storage.Models", "Storage")]
+        [InlineData("Azure.Test.Internal", "Test")]
+        [InlineData("Azure.Common", "Custom")]
+        [InlineData("Azure", "Custom")]
+        [InlineData("Azure.Models", "Custom")]
+        public void GetNamespacePrefix_WithAzureNamespaces_SkipsGenericParts(string namespaceName, string expected)
+        {
+            // Arrange
+            var typeSymbol = CreateTestTypeSymbol("TestType", namespaceName);
+
+            // Act
+            var result = NamingSuggestionHelper.GetNamespacePrefix(typeSymbol);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData("lowerCase", "LowerCase")]
+        [InlineData("snake_case", "Snake_case")]
+        [InlineData("kebab-case", "Kebab-case")]
+        [InlineData("MixedCASE", "MixedCASE")]
+        [InlineData("123number", "123number")]
+        public void ConvertToPascalCase_WithEdgeCases_HandlesCorrectly(string input, string expected)
+        {
+            // Arrange & Act
+            var result = NamingSuggestionHelper.ConvertToPascalCase(input);
+
+            // Assert
+            Assert.Equal(expected, result);
+        }
+
+        private static INamedTypeSymbol CreateTestTypeSymbol(string typeName, string namespaceName)
+        {
+            var source = $@"
+namespace {namespaceName}
+{{
+    public class {typeName.Replace("`", "")} {{ }}
+}}";
+
+            var compilation = CreateCompilation(source);
+            var tree = compilation.SyntaxTrees.First();
+            var semanticModel = compilation.GetSemanticModel(tree);
+
+            var classDeclaration = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+            return semanticModel.GetDeclaredSymbol(classDeclaration) as INamedTypeSymbol;
+        }
+
+        private static INamedTypeSymbol CreateTestTypeSymbolInGlobalNamespace(string typeName)
+        {
+            var source = $@"public class {typeName} {{ }}";
+
+            var compilation = CreateCompilation(source);
+            var tree = compilation.SyntaxTrees.First();
+            var semanticModel = compilation.GetSemanticModel(tree);
+
+            var classDeclaration = tree.GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+            return semanticModel.GetDeclaredSymbol(classDeclaration) as INamedTypeSymbol;
+        }
+
+        private static CSharpCompilation CreateCompilation(string source)
+        {
+            return CSharpCompilation.Create(
+                "TestAssembly",
+                new[] { CSharpSyntaxTree.ParseText(source) },
+                new[] { MetadataReference.CreateFromFile(typeof(object).Assembly.Location) },
+                new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/Descriptors.cs
@@ -73,10 +73,13 @@ namespace Azure.ClientSdk.Analyzers
             "Internal visible to product libraries effectively become public API and have to be versioned appropriately", DiagnosticCategory.Usage, DiagnosticSeverity.Warning, true);
 
         public static DiagnosticDescriptor AZC0012 = new DiagnosticDescriptor(
-            nameof(AZC0012), "Avoid single word type names",
-            "Single word class names are too generic and have high chance of collision with BCL types or types from other libraries",
+            nameof(AZC0012),
+            "Avoid single word type names",
+            "Type name '{0}' is too generic and has high chance of collision with BCL types or types from other libraries. {1}",
             DiagnosticCategory.Usage,
-            DiagnosticSeverity.Warning, true);
+            DiagnosticSeverity.Warning,
+            true,
+            "Single word type names are too generic and have high chance of collision with BCL types or types from other libraries.");
 
         public static DiagnosticDescriptor AZC0013 = new DiagnosticDescriptor(
             nameof(AZC0013),
@@ -161,7 +164,7 @@ namespace Azure.ClientSdk.Analyzers
         public static readonly DiagnosticDescriptor AZC0033 = new DiagnosticDescriptor(
             nameof(AZC0033),
             "Improper model name suffix",
-            "Model name '{0}' ends with '{1}'. Suggest to rename it to '{2}' or '{3}', if an appropriate name could not be found.",
+            "Model name '{0}' ends with '{1}'. {2}.",
             DiagnosticCategory.Naming,
             DiagnosticSeverity.Warning,
             true,
@@ -170,7 +173,7 @@ namespace Azure.ClientSdk.Analyzers
         public static readonly DiagnosticDescriptor AZC0034 = new DiagnosticDescriptor(
             nameof(AZC0034),
             "Avoid duplicate type names",
-            "Type name '{0}' conflicts with '{1}'. Consider renaming to avoid confusion.",
+            "Type name '{0}' conflicts with '{1}'. {2}",
             DiagnosticCategory.Naming,
             DiagnosticSeverity.Error,
             true,
@@ -184,6 +187,15 @@ namespace Azure.ClientSdk.Analyzers
             DiagnosticSeverity.Warning,
             true,
             "Output model types returned from client methods should have corresponding model factory methods for mocking support.");
+
+        public static readonly DiagnosticDescriptor AZC0036 = new DiagnosticDescriptor(
+            nameof(AZC0036),
+            "Improper model name suffix",
+            "Model name '{0}' ends with '{1}'. {2}",
+            DiagnosticCategory.Naming,
+            DiagnosticSeverity.Warning,
+            true,
+            "Suffix is not recommended. Consider to remove or modify it.");
         #endregion
 
         #region General

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/DataSuffixAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/DataSuffixAnalyzer.cs
@@ -29,8 +29,10 @@ namespace Azure.ClientSdk.Analyzers.ModelName
         protected override Diagnostic GetDiagnostic(INamedTypeSymbol typeSymbol, string suffix, SymbolAnalysisContext context)
         {
             var name = typeSymbol.Name;
+            var suggestedName = NamingSuggestionHelper.GetNamespacedSuggestion(name, typeSymbol, "Info", "Details");
+            var additionalMessage = $"Suggest to rename it to {suggestedName} or any other appropriate name.";
             return Diagnostic.Create(Descriptors.AZC0032, context.Symbol.Locations[0],
-                new Dictionary<string, string> { { "SuggestedName", name.Substring(0, name.Length - suffix.Length) } }.ToImmutableDictionary(), name, suffix);
+                new Dictionary<string, string> { { "SuggestedName", suggestedName } }.ToImmutableDictionary(), name, suffix, additionalMessage);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/DefinitionSuffixAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/DefinitionSuffixAnalyzer.cs
@@ -41,8 +41,10 @@ namespace Azure.ClientSdk.Analyzers.ModelName
         protected override Diagnostic GetDiagnostic(INamedTypeSymbol typeSymbol, string suffix, SymbolAnalysisContext context)
         {
             var name = typeSymbol.Name;
+            var suggestedName = NamingSuggestionHelper.GetNamespacedSuggestion(name, typeSymbol, "Template", "Schema");
+            var additionalMessage = $"Suggest to rename it to {suggestedName} or any other appropriate name.";
             return Diagnostic.Create(Descriptors.AZC0031, context.Symbol.Locations[0],
-                new Dictionary<string, string> { { "SuggestedName", name.Substring(0, name.Length - suffix.Length) } }.ToImmutableDictionary(), name, suffix);
+                new Dictionary<string, string> { { "SuggestedName", suggestedName } }.ToImmutableDictionary(), name, suffix, additionalMessage);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/GeneralSuffixAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/GeneralSuffixAnalyzer.cs
@@ -33,23 +33,23 @@ namespace Azure.ClientSdk.Analyzers.ModelName
         protected override Diagnostic GetDiagnostic(INamedTypeSymbol typeSymbol, string suffix, SymbolAnalysisContext context)
         {
             var name = typeSymbol.Name;
-            var suggestedName = GetSuggestedName(name, suffix);
-            var additionalMessage = $"Suggest to rename it to {suggestedName} or any other appropriate name.";
+            var suggestedName = GetSuggestedName(name, suffix, typeSymbol);
+            var additionalMessage = $"We suggest renaming it to {suggestedName} or another name with this suffix.";
             return Diagnostic.Create(Descriptors.AZC0030, context.Symbol.Locations[0],
                 new Dictionary<string, string> { { "SuggestedName", suggestedName } }.ToImmutableDictionary(), name, suffix, additionalMessage);
         }
 
-        private string GetSuggestedName(string originalName, string suffix)
+        private string GetSuggestedName(string originalName, string suffix, INamedTypeSymbol typeSymbol)
         {
             var nameWithoutSuffix = originalName.Substring(0, originalName.Length - suffix.Length);
             return suffix switch
             {
-                "Request" or "Requests" => $"'{nameWithoutSuffix}Content'",
-                "Parameter" or "Parameters" => $"'{nameWithoutSuffix}Content' or '{nameWithoutSuffix}Patch'",
-                "Option" => $"'{nameWithoutSuffix}Config'",
-                "Response" => $"'{nameWithoutSuffix}Result'",
-                "Responses" => $"'{nameWithoutSuffix}Results'",
-                "Collection" => $"'{nameWithoutSuffix}Group' or '{nameWithoutSuffix}List'",
+                "Request" or "Requests" => NamingSuggestionHelper.GetNamespacedSuggestion(originalName, typeSymbol, "Content"),
+                "Parameter" or "Parameters" => NamingSuggestionHelper.GetNamespacedSuggestion(originalName, typeSymbol, "Content", "Patch"),
+                "Option" => NamingSuggestionHelper.GetNamespacedSuggestion(originalName, typeSymbol, "Config"),
+                "Response" => NamingSuggestionHelper.GetNamespacedSuggestion(originalName, typeSymbol, "Result"),
+                "Responses" => NamingSuggestionHelper.GetNamespacedSuggestion(originalName, typeSymbol, "Results"),
+                "Collection" => NamingSuggestionHelper.GetNamespacedSuggestion(originalName, typeSymbol, "Group", "List"),
                 _ => nameWithoutSuffix,
             };
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/OperationSuffixAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/OperationSuffixAnalyzer.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Immutable;
-using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
@@ -25,9 +24,9 @@ namespace Azure.ClientSdk.Analyzers.ModelName
         protected override Diagnostic GetDiagnostic(INamedTypeSymbol typeSymbol, string suffix, SymbolAnalysisContext context)
         {
             var name = typeSymbol.Name;
-            var nameWithoutSuffix = name.Substring(0, name.Length - suffix.Length);
-            return Diagnostic.Create(Descriptors.AZC0033, context.Symbol.Locations[0],
-                name, suffix, $"{nameWithoutSuffix}Data", $"{nameWithoutSuffix}Info");
+            var suggestedName = NamingSuggestionHelper.GetNamespacedSuggestion(name, typeSymbol, "Data", "Info");
+            var additionalMessage = $"We suggest renaming it to {suggestedName} or another name with these suffixes.";
+            return Diagnostic.Create(Descriptors.AZC0033, context.Symbol.Locations[0], name, suffix, additionalMessage);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/OptionsSuffixAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/OptionsSuffixAnalyzer.cs
@@ -9,7 +9,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 namespace Azure.ClientSdk.Analyzers.ModelName
 {
     /// <summary>
-    /// Analyzer that checks model names ending with "Options". This analyzer shares the diagnostic ID with <see cref="GeneralSuffixAnalyzer"/>.
+    /// Analyzer that checks model names ending with "Options". This analyzer uses its own diagnostic ID AZC0036.
     /// </summary>
     [DiagnosticAnalyzer(LanguageNames.CSharp)]
     public class OptionsSuffixAnalyzer : SuffixAnalyzerBase
@@ -20,7 +20,7 @@ namespace Azure.ClientSdk.Analyzers.ModelName
         private const string JsonElement = "JsonElement";
         private static readonly string[] suffixes = new string[] { OptionsSuffix };
 
-        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptors.AZC0030);
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Descriptors.AZC0036);
 
         protected override bool ShouldSkip(INamedTypeSymbol symbol, SymbolAnalysisContext context)
         {
@@ -61,10 +61,12 @@ namespace Azure.ClientSdk.Analyzers.ModelName
         protected override string[] SuffixesToCatch => suffixes;
         protected override Diagnostic GetDiagnostic(INamedTypeSymbol typeSymbol, string suffix, SymbolAnalysisContext context)
         {
+            var suggestedName = NamingSuggestionHelper.GetNamespacedSuggestion(typeSymbol.Name, typeSymbol, "Settings", "Config");
             var additionalMessage = $"The `{suffix}` suffix is reserved for input models described by " +
                 $"https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-parameters. Please rename `{typeSymbol.Name}` " +
-                $"according to our guidelines at https://azure.github.io/azure-sdk/general_design.html#model-types for output or roundtrip models.";
-            return Diagnostic.Create(Descriptors.AZC0030, context.Symbol.Locations[0], typeSymbol.Name, suffix, additionalMessage);
+                $"to {suggestedName} or another suitable name according to our guidelines at " +
+                $"https://azure.github.io/azure-sdk/general_design.html#model-types for output or roundtrip models.";
+            return Diagnostic.Create(Descriptors.AZC0036, context.Symbol.Locations[0], typeSymbol.Name, suffix, additionalMessage);
         }
     }
 }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/SuffixAnalyzerBase.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelName/SuffixAnalyzerBase.cs
@@ -16,7 +16,6 @@ namespace Azure.ClientSdk.Analyzers.ModelName
     {
         protected static readonly string Title = "Improper model name suffix";
         protected static readonly string Description = "Suffix is not recommended. Consider to remove or modify it.";
-        protected static readonly string GeneralRenamingMessageFormat = "Model name '{0}' ends with '{1}'. Suggest to rename it to an appropriate name.";
 
         public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray<DiagnosticDescriptor>.Empty;
 

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/NamingSuggestionHelper.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/NamingSuggestionHelper.cs
@@ -1,0 +1,205 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.CodeAnalysis;
+
+namespace Azure.ClientSdk.Analyzers
+{
+    /// <summary>
+    /// Shared helper for generating consistent naming suggestions across all analyzers.
+    /// </summary>
+    public static class NamingSuggestionHelper
+    {
+        /// <summary>
+        /// Gets namespace-aware naming suggestions for a given type.
+        /// </summary>
+        /// <param name="typeName">The current type name</param>
+        /// <param name="typeSymbol">The type symbol for namespace context</param>
+        /// <param name="primarySuffix">Primary suggested suffix</param>
+        /// <param name="secondarySuffix">Secondary suggested suffix</param>
+        /// <returns>Formatted suggestion string</returns>
+        public static string GetNamespacedSuggestion(string typeName, INamedTypeSymbol typeSymbol, string primarySuffix, string secondarySuffix = null)
+        {
+            var namespacePrefix = GetNamespacePrefix(typeSymbol);
+            var cleanTypeName = CleanTypeName(typeName);
+
+            if (string.IsNullOrEmpty(secondarySuffix))
+            {
+                return $"'{namespacePrefix}{cleanTypeName}{primarySuffix}'";
+            }
+
+            return $"'{namespacePrefix}{cleanTypeName}{primarySuffix}' or '{namespacePrefix}{cleanTypeName}{secondarySuffix}'";
+        }
+
+        /// <summary>
+        /// Gets naming suggestions based on common type patterns.
+        /// </summary>
+        /// <param name="typeName">The current type name</param>
+        /// <param name="typeSymbol">The type symbol for namespace context</param>
+        /// <returns>Formatted suggestion string</returns>
+        public static string GetCommonTypeSuggestion(string typeName, INamedTypeSymbol typeSymbol)
+        {
+            var cleanTypeName = CleanTypeName(typeName);
+            var namespacePrefix = GetNamespacePrefix(typeSymbol);
+
+            // Handle composite names (e.g., "BlobClient" -> "TestBlobClient" or "TestServiceClient")
+            if (IsCompositeClientName(cleanTypeName))
+            {
+                var primaryName = $"{namespacePrefix}{cleanTypeName}";
+                var secondaryName = $"{namespacePrefix}ServiceClient";
+                return $"'{primaryName}' or '{secondaryName}'";
+            }
+
+            // Handle exact matches with simple replacement patterns
+            return cleanTypeName switch
+            {
+                "Client" => GetSimpleNamespacedSuggestion(namespacePrefix, "Client", "ServiceClient"),
+                "Service" => GetSimpleNamespacedSuggestion(namespacePrefix, "Service", "Manager"),
+                "Response" => GetSimpleNamespacedSuggestion(namespacePrefix, "Response", "Result"),
+                "Operation" => GetSimpleNamespacedSuggestion(namespacePrefix, "Operation", "Process"),
+                "Data" => GetSimpleNamespacedSuggestion(namespacePrefix, "Data", "Info"),
+                "Options" => GetSimpleNamespacedSuggestion(namespacePrefix, "Options", "Settings"),
+                "Settings" => GetSimpleNamespacedSuggestion(namespacePrefix, "Settings", "Config"),
+                "Config" => GetSimpleNamespacedSuggestion(namespacePrefix, "Config", "Settings"),
+                "Builder" => GetSimpleNamespacedSuggestion(namespacePrefix, "Builder", "Factory"),
+                "Manager" => GetSimpleNamespacedSuggestion(namespacePrefix, "Manager", "Service"),
+                "Provider" => GetSimpleNamespacedSuggestion(namespacePrefix, "Provider", "Factory"),
+                "Handler" => GetSimpleNamespacedSuggestion(namespacePrefix, "Handler", "Processor"),
+                "Helper" => GetSimpleNamespacedSuggestion(namespacePrefix, "Helper", "Util"),
+                "Util" or "Utils" => GetSimpleNamespacedSuggestion(namespacePrefix, "Util", "Helper"),
+                "Factory" => GetSimpleNamespacedSuggestion(namespacePrefix, "Factory", "Builder"),
+                "Info" => GetSimpleNamespacedSuggestion(namespacePrefix, "Info", "Data"),
+                "Result" => GetSimpleNamespacedSuggestion(namespacePrefix, "Result", "Response"),
+                "Type" => GetSimpleNamespacedSuggestion(namespacePrefix, "Type", "Kind"),
+                "Kind" => GetSimpleNamespacedSuggestion(namespacePrefix, "Kind", "Type"),
+                "State" => GetSimpleNamespacedSuggestion(namespacePrefix, "State", "Status"),
+                "Status" => GetSimpleNamespacedSuggestion(namespacePrefix, "Status", "State"),
+                _ => GetNamespacedSuggestion(typeName, typeSymbol, "Client", "Service")
+            };
+        }
+
+        /// <summary>
+        /// Gets simple namespace-based suggestions without adding redundant suffixes.
+        /// </summary>
+        /// <param name="namespacePrefix">The namespace prefix</param>
+        /// <param name="primaryName">Primary suggested name</param>
+        /// <param name="secondaryName">Secondary suggested name</param>
+        /// <returns>Formatted suggestion string</returns>
+        public static string GetSimpleNamespacedSuggestion(string namespacePrefix, string primaryName, string secondaryName)
+        {
+            return $"'{namespacePrefix}{primaryName}' or '{namespacePrefix}{secondaryName}'";
+        }
+
+        /// <summary>
+        /// Determines if a type name is a composite client name (e.g., "BlobClient", "TableClient").
+        /// </summary>
+        /// <param name="typeName">The clean type name</param>
+        /// <returns>True if the name appears to be a composite client name</returns>
+        public static bool IsCompositeClientName(string typeName)
+        {
+            return typeName.EndsWith("Client") &&
+                   typeName.Length > "Client".Length &&
+                   char.IsUpper(typeName[0]) &&
+                   typeName != "Client";
+        }
+
+        /// <summary>
+        /// Cleans type name by removing generic notation and interface prefixes.
+        /// </summary>
+        /// <param name="typeName">The type name to clean</param>
+        /// <returns>Clean type name</returns>
+        public static string CleanTypeName(string typeName)
+        {
+            var cleaned = typeName;
+
+            // Remove generic type notation (e.g., "Operation`1" becomes "Operation")
+            var backtickIndex = cleaned.IndexOf('`');
+            if (backtickIndex >= 0)
+            {
+                cleaned = cleaned.Substring(0, backtickIndex);
+            }
+
+            // Remove interface prefix if present (e.g., "IClient" becomes "Client")
+            if (cleaned.StartsWith("I") && cleaned.Length > 1 && char.IsUpper(cleaned[1]))
+            {
+                cleaned = cleaned.Substring(1);
+            }
+
+            return cleaned;
+        }
+
+        /// <summary>
+        /// Extracts meaningful namespace prefix for naming suggestions.
+        /// </summary>
+        /// <param name="typeSymbol">The type symbol</param>
+        /// <returns>Namespace prefix</returns>
+        public static string GetNamespacePrefix(INamedTypeSymbol typeSymbol)
+        {
+            if (typeSymbol.ContainingNamespace == null || typeSymbol.ContainingNamespace.IsGlobalNamespace)
+            {
+                return "Custom"; // Fallback for types without meaningful namespace
+            }
+
+            var fullNamespace = typeSymbol.ContainingNamespace.GetFullNamespaceName().ToString();
+
+            // Split the namespace and get meaningful segments
+            var namespaceParts = fullNamespace.Split('.');
+
+            // Skip common Azure prefixes and find the most specific meaningful part
+            for (int i = namespaceParts.Length - 1; i >= 0; i--)
+            {
+                var part = namespaceParts[i];
+
+                // Skip generic parts that don't provide context
+                if (part.Equals("Models", System.StringComparison.OrdinalIgnoreCase) ||
+                    part.Equals("Internal", System.StringComparison.OrdinalIgnoreCase) ||
+                    part.Equals("Common", System.StringComparison.OrdinalIgnoreCase) ||
+                    part.Equals("Azure", System.StringComparison.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                // Convert to PascalCase and return the most specific part
+                return ConvertToPascalCase(part);
+            }
+
+            // If we can't find a good namespace part, try to extract from the full namespace
+            // For example: Azure.Messaging.EventHubs -> EventHubs
+            if (namespaceParts.Length >= 3 && namespaceParts[0] == "Azure")
+            {
+                // Take the last meaningful part
+                var lastPart = namespaceParts[namespaceParts.Length - 1];
+                if (lastPart != "Models" && lastPart != "Internal" && lastPart != "Azure")
+                {
+                    return ConvertToPascalCase(lastPart);
+                }
+
+                // If last part is generic, try second to last
+                if (namespaceParts.Length >= 4)
+                {
+                    return ConvertToPascalCase(namespaceParts[namespaceParts.Length - 2]);
+                }
+            }
+
+            return "Custom"; // Final fallback
+        }
+
+        /// <summary>
+        /// Converts string to PascalCase.
+        /// </summary>
+        /// <param name="input">Input string</param>
+        /// <returns>PascalCase string</returns>
+        public static string ConvertToPascalCase(string input)
+        {
+            if (string.IsNullOrEmpty(input))
+                return "Custom";
+
+            // Handle cases like "EventHubs" (already PascalCase)
+            if (char.IsUpper(input[0]))
+                return input;
+
+            // Handle cases like "eventHubs" or "eventhubs"
+            return char.ToUpper(input[0]) + input.Substring(1);
+        }
+    }
+}

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/TypeNameAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/TypeNameAnalyzer.cs
@@ -1,6 +1,7 @@
-﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
@@ -17,23 +18,36 @@ namespace Azure.ClientSdk.Analyzers
         {
             var namedTypeSymbol = (INamedTypeSymbol)context.Symbol;
 
-            // Account for an `I` prefix in the interfaces.
-            var minimumWordCount = namedTypeSymbol.TypeKind == TypeKind.Interface ? 2 : 1;
+            // Count words in the type name
             if (namedTypeSymbol.DeclaredAccessibility == Accessibility.Public &&
                 namedTypeSymbol.ContainingType == null &&
-                CountWords(namedTypeSymbol.Name) <= minimumWordCount)
+                (namedTypeSymbol.TypeKind == TypeKind.Class || namedTypeSymbol.TypeKind == TypeKind.Interface) &&
+                CountWords(namedTypeSymbol.Name) <= 1)
             {
+                var typeName = namedTypeSymbol.Name;
+                var suggestedName = NamingSuggestionHelper.GetCommonTypeSuggestion(typeName, namedTypeSymbol);
+                var additionalMessage = $"Consider using a more descriptive multi-word name, such as {suggestedName}.";
+
                 foreach (var location in namedTypeSymbol.Locations)
                 {
-                    context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0012, location, context.Symbol), context.Symbol);
+                    context.ReportDiagnostic(Diagnostic.Create(Descriptors.AZC0012, location,
+                        new Dictionary<string, string> { { "SuggestedName", suggestedName } }.ToImmutableDictionary(),
+                        typeName, additionalMessage), context.Symbol);
                 }
             }
         }
 
         private int CountWords(string name)
         {
+            // For interfaces, ignore the 'I' prefix when counting words
+            string nameToCount = name;
+            if (name.Length > 1 && name.StartsWith("I") && char.IsUpper(name[1]))
+            {
+                nameToCount = name.Substring(1);
+            }
+
             int i = 0;
-            foreach (var c in name)
+            foreach (var c in nameToCount)
             {
                 if (char.IsUpper(c))
                 {


### PR DESCRIPTION
# Summary

The focus of these changes is to update the `Azure.ClientSdk.Analyzers` to ensure that they provide enough information for developers or the agent to understand the issue being reported and to suggest appropriate fixes.  In addition, naming suggestions have been extracted from individual analyzers and moved into a central helper to ensure consistency of the patterns used and better differentiate for multiple instances by including part of the namespace.