### PR TITLE
Global versioning for azsdk MCP tool

### DIFF
--- a/eng/common/mcp/README.md
+++ b/eng/common/mcp/README.md
@@ -18,7 +18,7 @@ To install the mcp server for use within vscode copilot agent mode, run the foll
 
 *When updating the config the script will not overwrite any other server configs.*
 
-The script will install the latest version of the azsdk cli executable from [tools releases](https://github.com/Azure/azure-sdk-tools/releases) and install it to `$HOME/.azure-sdk-mcp/azsdk`.
+The script will install the version established [here](https://github.com/Azure/azure-sdk-tools/releases/tag/azsdk_Latest) of the azsdk cli executable from [tools releases](https://github.com/Azure/azure-sdk-tools/releases) and install it to `$HOME/.azure-sdk-mcp/azsdk`.
 
 ## Authoring an MCP server
 

--- a/eng/common/mcp/README.md
+++ b/eng/common/mcp/README.md
@@ -18,7 +18,7 @@ To install the mcp server for use within vscode copilot agent mode, run the foll
 
 *When updating the config the script will not overwrite any other server configs.*
 
-The script will install the version established [here](https://github.com/Azure/azure-sdk-tools/releases/tag/azsdk_Latest) of the azsdk cli executable from [tools releases](https://github.com/Azure/azure-sdk-tools/releases) and install it to `$HOME/.azure-sdk-mcp/azsdk`.
+The script will install the version established [here](https://github.com/Azure/azure-sdk-tools/releases/tag/azsdk_version) of the azsdk cli executable from [tools releases](https://github.com/Azure/azure-sdk-tools/releases) and install it to `$HOME/.azure-sdk-mcp/azsdk`.
 
 ## Authoring an MCP server
 

--- a/eng/common/mcp/azure-sdk-mcp.ps1
+++ b/eng/common/mcp/azure-sdk-mcp.ps1
@@ -21,6 +21,19 @@ if (-not $InstallDirectory)
 }
 . (Join-Path $PSScriptRoot '..' 'scripts' 'Helpers' 'AzSdkTool-Helpers.ps1')
 
+# If version is not provided, look for the tag <package>_Latest and set the version to the tag's description
+if (-not $Version) {
+    try {
+        $versionTag = "${Package}_Latest"
+        $specificReleaseUrl = "https://api.github.com/repos/$Repository/releases/tags/$versionTag"
+        $latestRelease = Invoke-RestMethod -Uri $specificReleaseUrl
+        $Version = $latestRelease.body
+    }
+    catch {
+        Write-Warning "Could not fetch version from ${Package}_Latest tag. Will run the latest version."
+    }
+}
+
 if ($Clean) {
     Clear-Directory -Path $InstallDirectory
 }

--- a/eng/common/mcp/azure-sdk-mcp.ps1
+++ b/eng/common/mcp/azure-sdk-mcp.ps1
@@ -21,19 +21,6 @@ if (-not $InstallDirectory)
 }
 . (Join-Path $PSScriptRoot '..' 'scripts' 'Helpers' 'AzSdkTool-Helpers.ps1')
 
-# If version is not provided, look for the tag <package>_version and set the version to the tag's description
-if (-not $Version) {
-    try {
-        $versionTag = "${Package}_version"
-        $specificReleaseUrl = "https://api.github.com/repos/$Repository/releases/tags/$versionTag"
-        $latestRelease = Invoke-RestMethod -Uri $specificReleaseUrl
-        $Version = $latestRelease.body
-    }
-    catch {
-        Write-Warning "Could not fetch version from ${Package}_version tag. Will run the latest version."
-    }
-}
-
 if ($Clean) {
     Clear-Directory -Path $InstallDirectory
 }

--- a/eng/common/mcp/azure-sdk-mcp.ps1
+++ b/eng/common/mcp/azure-sdk-mcp.ps1
@@ -21,16 +21,16 @@ if (-not $InstallDirectory)
 }
 . (Join-Path $PSScriptRoot '..' 'scripts' 'Helpers' 'AzSdkTool-Helpers.ps1')
 
-# If version is not provided, look for the tag <package>_Latest and set the version to the tag's description
+# If version is not provided, look for the tag <package>_version and set the version to the tag's description
 if (-not $Version) {
     try {
-        $versionTag = "${Package}_Latest"
+        $versionTag = "${Package}_version"
         $specificReleaseUrl = "https://api.github.com/repos/$Repository/releases/tags/$versionTag"
         $latestRelease = Invoke-RestMethod -Uri $specificReleaseUrl
         $Version = $latestRelease.body
     }
     catch {
-        Write-Warning "Could not fetch version from ${Package}_Latest tag. Will run the latest version."
+        Write-Warning "Could not fetch version from ${Package}_version tag. Will run the latest version."
     }
 }
 


### PR DESCRIPTION
## Summary
- Updated the azure-sdk-mcp script to retrieve version from [azsdk_version tag](https://github.com/Azure/azure-sdk-tools/releases/tag/azsdk_version).
- Now to update the version you need to change the description inside of the azsdk_version tag (will default to latest if invalid). 