### PR TITLE
Disable codeql for linter pipeline

### DIFF
--- a/eng/common/pipelines/codeowners-linter.yml
+++ b/eng/common/pipelines/codeowners-linter.yml
@@ -19,6 +19,7 @@ pr:
 stages:
 - stage: Run
   variables:
+    Codeql.SkipTaskAutoInjection: true
     skipComponentGovernanceDetection: true
     nugetMultiFeedWarnLevel: 'none'
     baseBranchBaseline: ''


### PR DESCRIPTION
We don't need codeql running randomly on our linter pipelines as it isn't interesting there, so I'm skipping it.

See https://dev.azure.com/azure-sdk/public/_build/results?buildId=5071971&view=logs&j=a460d732-23aa-5493-a411-cc406067acf8&t=5348fcfc-3752-5d67-089f-bab4d1181c52

<img width="563" height="667" alt="image" src="https://github.com/user-attachments/assets/f95f52bd-cf01-43d3-87be-c9ec85f8581d" />
