### PR TITLE
Fix scenario where elemendId, for comments, is null

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/Helpers/AgentHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/AgentHelpers.cs
@@ -16,7 +16,6 @@ public class AgentHelpers
         RenderedCodeFile codeFile)
     {
         var activeCodeLines = codeFile.CodeFile.GetApiLines(skipDocs: true);
-
         Dictionary<string, int> elementIdToLineNumber = activeCodeLines
             .Select((line, index) => new { line.lineId, lineNumber = index })
             .Where(x => !string.IsNullOrEmpty(x.lineId))

--- a/src/dotnet/APIView/APIViewWeb/Helpers/AgentHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/AgentHelpers.cs
@@ -17,24 +17,21 @@ public class AgentHelpers
     {
         var activeCodeLines = codeFile.CodeFile.GetApiLines(skipDocs: true);
         Dictionary<string, int> elementIdToLineNumber = activeCodeLines
-            .Select((line, index) => new { line.lineId, lineNumber = index })
+            .Select((elementId, lineNumber) => new { elementId.lineId, lineNumber })
             .Where(x => !string.IsNullOrEmpty(x.lineId))
             .ToDictionary(x => x.lineId, x => x.lineNumber + 1);
 
-        List<ApiViewAgentComment> commentsForAgent = comments
-            .Select(threadComment => new ApiViewAgentComment
+        return (from comment in comments
+            where comment.ElementId != null
+            select new ApiViewAgentComment
             {
-                LineNumber = threadComment.ElementId is not null && elementIdToLineNumber.TryGetValue(threadComment.ElementId, out int id) ? id : -1,
-                CreatedOn = threadComment.CreatedOn,
-                Upvotes = threadComment.Upvotes.Count,
-                Downvotes = threadComment.Downvotes.Count,
-                CreatedBy = threadComment.CreatedBy,
-                CommentText = threadComment.CommentText,
-                IsResolved = threadComment.IsResolved
-            })
-            .ToList();
-
-        return commentsForAgent;
+                LineNumber = elementIdToLineNumber.TryGetValue(comment.ElementId, out int id) ? id : -1,
+                CreatedOn = comment.CreatedOn,
+                Upvotes = comment.Upvotes.Count,
+                Downvotes = comment.Downvotes.Count,
+                CreatedBy = comment.CreatedBy,
+                CommentText = comment.CommentText,
+            }).ToList();
     }
 
     public static string GetCodeLineForElement(RenderedCodeFile codeFile, string elementId)

--- a/src/dotnet/APIView/APIViewWeb/Helpers/AgentHelpers.cs
+++ b/src/dotnet/APIView/APIViewWeb/Helpers/AgentHelpers.cs
@@ -16,16 +16,16 @@ public class AgentHelpers
         RenderedCodeFile codeFile)
     {
         var activeCodeLines = codeFile.CodeFile.GetApiLines(skipDocs: true);
-        
+
         Dictionary<string, int> elementIdToLineNumber = activeCodeLines
-            .Select((elementId, lineNumber) => new { elementId.lineId, lineNumber })
+            .Select((line, index) => new { line.lineId, lineNumber = index })
             .Where(x => !string.IsNullOrEmpty(x.lineId))
             .ToDictionary(x => x.lineId, x => x.lineNumber + 1);
 
         List<ApiViewAgentComment> commentsForAgent = comments
             .Select(threadComment => new ApiViewAgentComment
             {
-                LineNumber = elementIdToLineNumber.TryGetValue(threadComment.ElementId, out int id) ? id : -1,
+                LineNumber = threadComment.ElementId is not null && elementIdToLineNumber.TryGetValue(threadComment.ElementId, out int id) ? id : -1,
                 CreatedOn = threadComment.CreatedOn,
                 Upvotes = threadComment.Upvotes.Count,
                 Downvotes = threadComment.Downvotes.Count,

--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/APIRevisionsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/APIRevisionsController.cs
@@ -198,7 +198,7 @@ namespace APIViewWeb.LeanControllers
             }
             catch (Exception ex)
             {
-                _logger.LogError("Error generating AI review" + ex.Message);
+                _logger.LogError("Error generating AI review " + ex.Message);
                 return StatusCode(StatusCodes.Status500InternalServerError);
             }
         }

--- a/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
@@ -183,12 +183,17 @@ namespace APIViewWeb.Managers
 
         private string GetHtmlContent(CommentItemModel comment, ReviewListItemModel review)
         {
-            var uri = new Uri($"{_apiviewEndpoint}/Assemblies/Review/{review.Id}#{Uri.EscapeDataString(comment.ElementId)}");
             var sb = new StringBuilder();
             sb.Append(GetContentHeading(comment, true));
             sb.Append("<br><br>");
-            sb.Append($"In <a href='{uri.ToString()}'>{comment.ElementId}</a>:");
-            sb.Append("<br><br>");
+
+            if (comment.ElementId != null)
+            {
+                var uri = new Uri($"{_apiviewEndpoint}/Assemblies/Review/{review.Id}#{Uri.EscapeDataString(comment.ElementId)}");
+                sb.Append($"In <a href='{uri.ToString()}'>{comment.ElementId}</a>:");
+                sb.Append("<br><br>");
+            }
+
             sb.Append(CommentMarkdownExtensions.MarkdownAsHtml(comment.CommentText));
             return sb.ToString();
         }

--- a/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
+++ b/src/dotnet/APIView/APIViewWeb/Managers/NotificationManager.cs
@@ -190,7 +190,7 @@ namespace APIViewWeb.Managers
             if (comment.ElementId != null)
             {
                 var uri = new Uri($"{_apiviewEndpoint}/Assemblies/Review/{review.Id}#{Uri.EscapeDataString(comment.ElementId)}");
-                sb.Append($"In <a href='{uri.ToString()}'>{comment.ElementId}</a>:");
+                sb.Append($"In <a href='{uri.ToString()}'>{WebUtility.HtmlEncode(comment.ElementId)}</a>:");
                 sb.Append("<br><br>");
             }
 


### PR DESCRIPTION
Copilot is writing some comments when reviewing the API, and in some cases are written and not elementId is assigned to them.

issue: https://github.com/Azure/azure-sdk-tools/issues/11170
