### PR TITLE
Fix Changelog Not Generated When There's No Breaking Changes Or New Features

### DIFF
--- a/tools/js-sdk-release-tools/package-lock.json
+++ b/tools/js-sdk-release-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.13.0",
+  "version": "2.13.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/js-sdk-release-tools",
-      "version": "2.13.0",
+      "version": "2.13.2",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/openapi-tools-common": "^1.2.2",

--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/src/changelog/v2/ChangelogGenerator.ts
+++ b/tools/js-sdk-release-tools/src/changelog/v2/ChangelogGenerator.ts
@@ -214,9 +214,10 @@ export class ChangelogGenerator {
   private generateContentCore() {
     let content = '';
     const featureItems = this.getItemsFromCategoryMap(this.changelogItems.features);
-    content += this.generateSection(featureItems, 'Features Added');
-
     const breakingChangeItems = this.getItemsFromCategoryMap(this.changelogItems.breakingChanges);
+
+    content += this.generateSection(featureItems, 'Features Added');
+    if (featureItems.length > 0 && breakingChangeItems.length > 0) content += '\n';
     content += this.generateSection(breakingChangeItems, 'Breaking Changes');
 
     return content;

--- a/tools/js-sdk-release-tools/src/common/changelog/modifyChangelogFileAndBumpVersion.ts
+++ b/tools/js-sdk-release-tools/src/common/changelog/modifyChangelogFileAndBumpVersion.ts
@@ -79,20 +79,14 @@ export async function makeChangesForReleasingTrack2(packageFolderPath: string, p
         pacakgeVersionDetail +=`\nCompared with version ${comparedVersion}`
     }
     const modifiedChangelogContent = `# Release History
-    
+
 ${pacakgeVersionDetail}
-    
+
 ${changeLog}
-    
 ${originalChangeLogContent.replace(/.*Release History[\n\r]*/g, '')}`;
 
     fs.writeFileSync(path.join(packageFolderPath, 'CHANGELOG.md'), modifiedChangelogContent, {encoding: 'utf-8'});
 
-    changePackageJSON(packageFolderPath, packageVersion);
-    await updateUserAgent(packageFolderPath, packageVersion);
-}
-
-export async function makeChangesForPatchReleasingTrack2(packageFolderPath: string, packageVersion: string) {
     changePackageJSON(packageFolderPath, packageVersion);
     await updateUserAgent(packageFolderPath, packageVersion);
 }


### PR DESCRIPTION
Issue: Release tool removes all content before generating sdk. When there's no breaking changes and new features, no new changelog will be generated, but we already delete the changelog before generating sdk, there will be no changelog eventually.

Fix: Generate changelog based on changelog in npm regardless breaking changes and new features.

Result:
Please note that:
- original unreleased version entry is added in js sdk repo, which is not in npm, changelog generator will not take that entry.
- new entry contains only `### Features Added`, since we need to add at least one entry, otherwise, pipeline will throw errors due to azure changelog policy
<img width="2016" height="628" alt="image" src="https://github.com/user-attachments/assets/35cdabd3-7005-49c0-be19-5435fff9cdb6" />
