### PR TITLE
[Analyzers] No model factory for System types

### DIFF
--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0035Tests.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers.Tests/AZC0035Tests.cs
@@ -419,7 +419,8 @@ namespace Azure.Test
         {
             return null;
         }
-    }";
+    }
+}";
 
             await Verifier.CreateAnalyzer(code).RunAsync();
         }

--- a/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelFactoryAnalyzer.cs
+++ b/src/dotnet/Azure.ClientSdk.Analyzers/Azure.ClientSdk.Analyzers/ModelFactoryAnalyzer.cs
@@ -174,8 +174,9 @@ namespace Azure.ClientSdk.Analyzers
             // Filter out System types, unless defined in System.ClientModel
             var containingNamespace = typeSymbol.ContainingNamespace?.ToString() ?? string.Empty;
 
-            if (containingNamespace.StartsWith(SystemNamespace) &&
-                (!containingNamespace.StartsWith(SystemClientModelNamespace)))
+            if (containingNamespace == SystemNamespace || containingNamespace.StartsWith($"{SystemNamespace}.")
+                && containingNamespace != SystemClientModelNamespace
+                && (!containingNamespace.StartsWith($"{SystemClientModelNamespace}.")))
             {
                 return false;
             }


### PR DESCRIPTION
# Summary

The focus of these changes is to update the `ModelFactoryAnalyzer` to exclude violations for types in the `System` namespaces unless explicitly under `System.ClientModel`.  This change does not
impact generic type unwrapping, which remains consistent with previous behavior.   This fixes an issue in several libraries where `BinaryData` return types were being flagged as violations.

## References and resources

- [Analyzer update failures](https://dev.azure.com/azure-sdk/public/_build/results?buildId=5079580&view=logs&j=6a35bf62-79e1-5fa3-97e7-f99304f2a7ef&t=0d11b518-8a24-5ded-c079-29c53cd50406) _(Microsoft internal)_