### PR TITLE
Fallback to interactive credentials when chained token cred fail

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Services/DevOpsService.cs
@@ -40,8 +40,17 @@ namespace Azure.Sdk.Tools.Cli.Services
             }
 
             var credential = azureService.GetCredential();
-            _token = credential.GetToken(new TokenRequestContext([Constants.AZURE_DEVOPS_TOKEN_SCOPE]), CancellationToken.None);
-
+            try
+            {
+                _token = credential.GetToken(new TokenRequestContext([Constants.AZURE_DEVOPS_TOKEN_SCOPE]), CancellationToken.None);
+            }
+            catch
+            {
+                credential = new InteractiveBrowserCredential(new InteractiveBrowserCredentialOptions { TenantId = null });
+                // Retry with interactive browser credential if the initial credential fails
+                _token = credential.GetToken(new TokenRequestContext([Constants.AZURE_DEVOPS_TOKEN_SCOPE]), CancellationToken.None);
+            }
+            // If we still don't have a token, throw an exception
             if (_token == null)
             {
                 throw new Exception("Failed to get devops access token. " +


### PR DESCRIPTION
Azure CLI token chain fails with a time out error when using chained token credentials when running in MCP context. Adding Interactive browser credentials as a fallback mechanism to fix auth issue. Adding this interactive token into chained token credentials is not resolving this issue and credential is not attempting all the types in the chain.