### PR TITLE
[tsp-client] Fix entrypoint check

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-07-22 - 0.26.0
+
+- Fix bug when discovering entrypoint files to only accept `main.tsp` or `client.tsp` unless otherwise specified in tsp-location.yaml.
+
 ## 2025-07-09 - 0.25.0
 
 - Extend dependency retention in `generate-config-files` command to include regular dependencies, not just devDependencies.

--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Release
 
-## 2025-07-22 - 0.26.0
+## 2025-07-21 - 0.26.0
 
 - Fix bug when discovering entrypoint files to only accept `main.tsp` or `client.tsp` unless otherwise specified in tsp-location.yaml.
 

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.25.0",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@autorest/core": "^3.10.2",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.25.0",
+  "version": "0.26.0",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/typespec.ts
+++ b/tools/tsp-client/src/typespec.ts
@@ -53,7 +53,7 @@ export async function discoverEntrypointFile(
   const files = await readdir(srcDir, { recursive: true });
 
   function findEntrypoint(name: string): string | undefined {
-    return files.find((file) => file.endsWith(name)) ?? undefined;
+    return files.find((file) => file === name) ?? undefined;
   }
   if (specifiedEntrypointFile) {
     entryTsp = findEntrypoint(specifiedEntrypointFile);

--- a/tools/tsp-client/test/examples/specification/unexpected-entrypoint-name/fooclient.tsp
+++ b/tools/tsp-client/test/examples/specification/unexpected-entrypoint-name/fooclient.tsp
@@ -1,0 +1,1 @@
+// placeholder

--- a/tools/tsp-client/test/examples/specification/unexpected-entrypoint-name/foomain.tsp
+++ b/tools/tsp-client/test/examples/specification/unexpected-entrypoint-name/foomain.tsp
@@ -1,0 +1,1 @@
+// placeholder

--- a/tools/tsp-client/test/typespec.spec.ts
+++ b/tools/tsp-client/test/typespec.spec.ts
@@ -60,6 +60,16 @@ describe("Check diagnostic reporting", function () {
     assert.equal(entrypointFile, "client.tsp");
   });
 
+  it("Check discoverEntrypointFile() with unexpected entrypoint name", async function () {
+    try {
+        await discoverEntrypointFile(
+            joinPaths(process.cwd(), "test", "examples", "specification", "unexpected-entrypoint-name"),
+        );
+    } catch (e) {
+      assert.equal(e.message, "No main.tsp or client.tsp found");
+    }
+  });
+
   describe("tryParseEmitterOptionAsObject", function () {
     it("returns object for JSON object string", function () {
       const str = `{"name":"@azure/eventgrid-namespaces-2","version":"1.0.3"}`;


### PR DESCRIPTION
Bug fix so that the tool doesnt take into account names aside from main.tsp and client.tsp. We already have support for alternate entrypoints through tsp-location.yaml

Fixes #11225 