### PR TITLE
Ignore failures when new package isn't indexed yet.

### DIFF
--- a/eng/common/pipelines/templates/jobs/npm-publish.yml
+++ b/eng/common/pipelines/templates/jobs/npm-publish.yml
@@ -99,6 +99,7 @@ jobs:
                 $packageTags = npm view $packageJson.name "dist-tags" -json -silent | ConvertFrom-Json
                 if ($LASTEXITCODE -ne 0 -or !$packageTags) {
                   Write-Warning "Failed to retrieve dist-tags for $packageJson.name. It is possible the package hasn't been indexed yet so ignoring."
+                  $global:LASTEXITCODE = 0
                   continue
                 }
 


### PR DESCRIPTION
Fixes https://github.com/Azure/azure-sdk-tools/issues/10756

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5141388&view=logs&j=9f30ca4a-cbc5-590b-53b7-43f2804f0970&t=4fc0eabc-c9c4-5517-57a1-808bcd9cf283&s=cb72e075-ba37-5856-1fe8-5c8159c853b7
<img width="1068" height="148" alt="image" src="https://github.com/user-attachments/assets/a2d3eb28-0a72-4119-bfc5-3fc3b5d9b4d0" />

Even though we try to ignore this the last exit code was still non-zero so the step failed.