### PR TITLE
Add service label: AAAtest1

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -1,3 +1,4 @@
+AAAtest1,,e99695
 AAD,,e99695
 ACS,,e99695
 AI Agents,,e99695


### PR DESCRIPTION
This PR adds the service label 'AAAtest1' to the repository. Documentation link: https://contoso.com/