### PR TITLE
[Devex Agent] Default to finding user email for create release plan

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
@@ -215,7 +215,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                     userEmail = email;
                     logger.LogInformation("Using current user email to submit release plan: {userEmail}", userEmail);
                 }
-                else if(string.IsNullOrEmpty(userEmail))
+                else if (string.IsNullOrEmpty(userEmail))
                 {
                     throw new InvalidOperationException("Current user email is sdk bot, email is required to create a release plan.");
                 }

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/ReleasePlanTool/ReleasePlanTool.cs
@@ -217,7 +217,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
                 }
                 else if (string.IsNullOrEmpty(userEmail))
                 {
-                    throw new InvalidOperationException("Current user email is sdk bot, email is required to create a release plan.");
+                    throw new InvalidOperationException("Cannot create release plan using SDK bot email. Please provide a valid user email address.");
                 }
 
                 logger.LogInformation("User email for release plan submission: {userEmail}", userEmail);


### PR DESCRIPTION
## Summary 
- Currently if no email address is provided by copilot to the tool, we retrieve the users email address. Instead, we by default retrieve the users email address and fall back on email provided. 
- Make sure not to use the azure sdk bot email address. 
- Resolves #11331