### PR TITLE
Fix `get_prompt_path` call in `run.py`

### DIFF
--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -135,7 +135,7 @@ class CustomAPIViewEvaluator:
             start_idx = max(0, line_no - 10)
             end_idx = min(len(query), line_no + 10)
             context = query[start_idx:end_idx]
-            prompt_path = get_prompt_path("evals", "eval_judge_prompt.prompty")
+            prompt_path = get_prompt_path(folder="evals", filename="eval_judge_prompt.prompty")
             response = prompty.execute(
                 prompt_path,
                 inputs={


### PR DESCRIPTION
Evaluation has been [failing for about two weeks](https://dev.azure.com/azure-sdk/internal/_build?definitionId=7662&_a=summary) -- it looks like this is because `get_prompt_path` was updated to accept only named parameters, and `run.py` wasn't updated accordingly. Local evaluation runs now complete and appear in the Azure AI Foundry.