### PR TITLE
[Service Label] Add service label: Widget Manager

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -250,6 +250,7 @@ Visual Studio,,e99695
 Web Apps,,e99695
 WebPubSub,,e99695
 Weights & Biases,,e99695
+Widget Manager,,e99695
 auto-close-exempt,Prevents the auto-close from closing based on max lifetime,ededed
 blocking-release,Blocks release,d73a49
 breaking-change,,d73a49


### PR DESCRIPTION
This PR adds the service label 'Widget Manager' to the repository. Documentation link: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/contosowidgetmanager