### PR TITLE
Update FAQ for handling `dotnet devcert` expiry

### DIFF
--- a/tools/test-proxy/documentation/test-proxy/faq.md
+++ b/tools/test-proxy/documentation/test-proxy/faq.md
@@ -101,3 +101,27 @@ In this case, the issue is likely due to an unhandled edge case when resolving a
 - Share the folder with `scbedd` over teams along with any details on the proxy-side error that you've found in your logs.
 - Delete your existing `.assets`
 - Re-run your tests. The proxy will download a fresh copy of the tag from your `assets.json` and re-init the `.assets` folder automatically.
+
+### I've been successfully using the test-proxy for a while, but I'm suddenly getting SSL cert validation errors and my tests won't start
+
+The test-proxy enables SSL by meeting in the middle with each language's test framework. The test-framework adds the test-proxy dev cert to its trusted cert bundle, and then the proxy is _started_ using that same certificate to secure its HTTPS port. The combination of running the proxy using the dev cert and trusting that same dev cert allows any localhost to communicate over HTTPS with the test-proxy.
+
+While it is very possible that local users may encounter errors due to misconfiguration of SSL variables or other minutae, users must ensure that the dev-cert being utilized is valid for their current date!
+
+To ensure that the appropriate dev-cert is being used:
+
+- Check validity of current certificate. The dev cert will always be located at `eng/common/testproxy/dotnet-devcert.pfx in each language repo.
+  - On `windows`: `certutil -dump eng/common/testproxy/dotnet-devcert.pfx`. Enter `password` for the password when asked.
+  - On `linux/mac`, you must have `openssl` installed, then: `openssl pkcs12 -in eng/common/testproxy/dotnet-devcert.pfx -nokeys -clcerts -passin pass:password | openssl x509 -noout -enddate`
+  - If the current date DOES NOT fall within the date range of the cert, **expiration is the problem**.
+  - Otherwise the issue causing your SSL verification errors is most likely system configuration related, and not specifically related to the utilized dev-cert.
+
+If the current date is outside of the valid date range of the certificate, then you need to do the following:
+
+- Pull latest `main` of your repo.
+- Check the validity of the certificate as you did in previous step. If not up to date, you do not have latest main.
+- Shut down **any** running proxy instances. They will be using the previous SSL certificate, which is invalid.
+  - `windows` check task manager
+  - `linux/mac` use `ps aux | grep TestProxy`. Kill any processes that match.
+- Delete any local copies of the certificate.
+- Follow any specific `import` directions in [trusting-cert-per-language](trusting-cert-per-language.md) for your current `language`.

--- a/tools/test-proxy/documentation/test-proxy/faq.md
+++ b/tools/test-proxy/documentation/test-proxy/faq.md
@@ -110,7 +110,7 @@ While it is very possible that local users may encounter errors due to misconfig
 
 To ensure that the appropriate dev-cert is being used:
 
-- Check validity of current certificate. The dev cert will always be located at `eng/common/testproxy/dotnet-devcert.pfx in each language repo.
+- Check validity of current certificate. The dev cert will always be located at `eng/common/testproxy/dotnet-devcert.pfx` in each language repo.
   - On `windows`: `certutil -dump eng/common/testproxy/dotnet-devcert.pfx`. Enter `password` for the password when asked.
   - On `linux/mac`, you must have `openssl` installed, then: `openssl pkcs12 -in eng/common/testproxy/dotnet-devcert.pfx -nokeys -clcerts -passin pass:password | openssl x509 -noout -enddate`
   - If the current date DOES NOT fall within the date range of the cert, **expiration is the problem**.

--- a/tools/test-proxy/documentation/test-proxy/trusting-cert-per-language.md
+++ b/tools/test-proxy/documentation/test-proxy/trusting-cert-per-language.md
@@ -81,32 +81,9 @@ After doing any setup described in the [general section](#generally), run the
 ```
 
 This will copy the [test proxy certificate](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/common/testproxy/dotnet-devcert.crt) and place the copy
-under `azure-sdk-for-python/.certificate` as a `pem` file.
+under `azure-sdk-for-python/.certificate` as a `pem` file. Take note, when pulling down a new version of the dev-cert to replace an expired SSL cert, **delete** the local `.certificate` folder at root before rerunning `trust_proxy_cert.py`.
 
-The only remaining step is to set two environment variables to point to this certificate. The script will output the environment variables and values that you'll
-need to set once it finishes running. For example where `YOUR DIRECTORY` specifies where you've cloned the repo:
-```cmd
-Set the following certificate paths:
-        SSL_CERT_DIR=C:\<YOUR DIRECTORY>\azure-sdk-for-python\.certificate
-        REQUESTS_CA_BUNDLE=C:\<YOUR DIRECTORY>\azure-sdk-for-python\.certificate\dotnet-devcert.pem
-```
-
-Persistently set these environment variables. In a Windows Powershell command prompt as an administrator, use the `SETX` command (not the `SET` command) to set these variables.
-Using the example above, you would run:
-```cmd
-SETX SSL_CERT_DIR "C:\<YOUR DIRECTORY>\azure-sdk-for-python\.certificate"
-SETX REQUESTS_CA_BUNDLE "C:\<YOUR DIRECTORY>\azure-sdk-for-python\.certificate\dotnet-devcert.pem"
-```
-
-_Disclaimer:_ __A new terminal__ should be started up to make these variables available. 
-To check if these variables are indeed in the environment,
-```powershell
-[Environment]::GetEnvironmentVariable('SSL_CERT_DIR')
-[Environment]::GetEnvironmentVariable('REQUESTS_CA_BUNDLE')
-```
-should output your SSL certificate directory and file location path in this new terminal.
-
-In this and subsequent terminals, with the variables in place, running tests with the test proxy should now work with HTTPS requests.
+The test-framework will take care of using the correct certificate bundle at runtime.
 
 ## Java
 


### PR DESCRIPTION
I will still update the dev cert every month (automation as recommended by @weshaggard), but this was a bit of my day yesterday helping debug various situations.