### PR TITLE
[Service Label] Add service label: Contoso WidgetManager

### DIFF
--- a/tools/github/data/common-labels.csv
+++ b/tools/github/data/common-labels.csv
@@ -95,6 +95,7 @@ Container Instances,,e99695
 Container Orchestrator Runtime,,e99695
 Container Registry,,e99695
 Container Service,,e99695
+Contoso WidgetManager,,e99695
 Cosmos,,e99695
 Cost Management - Billing,All issues in cost management where billing/price-related data is shown.,e99695
 Cost Management - Budget,"All issues in cost management for Budgets API, Alert API and other Notification scenarios.",e99695


### PR DESCRIPTION
This PR adds the service label 'Contoso WidgetManager' to the repository. Documentation link: https://github.com/Azure/azure-rest-api-specs/tree/main/specification/contosowidgetmanager