### PR TITLE
Removed broken link from README

### DIFF
--- a/eng/common/mcp/README.md
+++ b/eng/common/mcp/README.md
@@ -32,7 +32,5 @@ When running in copilot the default is stdio mode, but SSE is useful to support 
 
 See the [C# MCP SDK](https://github.com/modelcontextprotocol/csharp-sdk)
 
-Add an [SSE transport](https://github.com/modelcontextprotocol/csharp-sdk/tree/main/samples/AspNetCoreSseServer)
-
 TODO: Add the azsdk-cli project to pull in MCP server dependencies from the repo
 


### PR DESCRIPTION
The SSE protocol was removed from the MCP spec and it seems the link referring to it has also been removed from the spec docs.