### PR TITLE
Enable PullRequestTriage for auto-labeling

### DIFF
--- a/.github/event-processor.config
+++ b/.github/event-processor.config
@@ -11,7 +11,7 @@
   "ReopenIssue": "Off",
   "DeclineToReopenIssue": "Off",
   "IssueAddressedCommands": "Off",
-  "PullRequestTriage": "Off",
+  "PullRequestTriage": "On",
   "ResetApprovalsForUntrustedChanges": "On",
   "ReopenPullRequest": "On",
   "ResetIssueActivity": "Off",


### PR DESCRIPTION
Enable PullRequestTriage for auto-labeling, follow-on to https://github.com/Azure/azure-sdk-tools/pull/11499 which was incomplete.

@weshaggard I missed a spot.