### PR TITLE
Force entrylock on `matcher` value

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/InfoTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/InfoTests.cs
@@ -79,7 +79,7 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
 
             await testRecordingHandler.RegisterSanitizer(new UriRegexSanitizer(regex: "ABC123"), recordingId);
             await testRecordingHandler.RegisterSanitizer(new BodyRegexSanitizer(regex: ".+?"), recordingId);
-            testRecordingHandler.SetMatcherForRecording(recordingId, new CustomDefaultMatcher(compareBodies: false, excludedHeaders: "an-excluded-header"));
+            await testRecordingHandler.SetMatcherForRecording(recordingId, new CustomDefaultMatcher(compareBodies: false, excludedHeaders: "an-excluded-header"));
 
             var model = new ActiveMetadataModel(testRecordingHandler, recordingId);
             var descriptions = model.Descriptions.ToList();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -197,7 +197,7 @@ namespace Azure.Sdk.Tools.TestProxy
 
             if (recordingId != null)
             {
-                _recordingHandler.SetMatcherForRecording(recordingId, m);
+                await _recordingHandler.SetMatcherForRecording(recordingId, m);
             }
             else
             {

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Admin.cs
@@ -201,7 +201,16 @@ namespace Azure.Sdk.Tools.TestProxy
             }
             else
             {
-                _recordingHandler.Matcher = m;
+                await _recordingHandler.SanitizerRegistry.SessionSanitizerLock.WaitAsync();
+
+                try
+                {
+                    _recordingHandler.Matcher = m;
+                }
+                finally
+                {
+                    _recordingHandler.SanitizerRegistry.SessionSanitizerLock.Release();
+                }
             }
         }
 

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/RecordingHandler.cs
@@ -1093,14 +1093,21 @@ namespace Azure.Sdk.Tools.TestProxy
         }
 
 
-        public void SetMatcherForRecording(string recordingId, RecordMatcher matcher)
+        public async Task SetMatcherForRecording(string recordingId, RecordMatcher matcher)
         {
             if (!PlaybackSessions.TryGetValue(recordingId, out var session))
             {
                 throw new HttpException(HttpStatusCode.BadRequest, $"{recordingId} is not an active playback session. Check the value being passed and try again.");
             }
 
-            session.CustomMatcher = matcher;
+            await session.Session.EntryLock.WaitAsync();
+            try {
+                session.CustomMatcher = matcher;
+            }
+            finally
+            {
+                session.Session.EntryLock.Release();
+            }
         }
 
         public async Task SetDefaultExtensions(string recordingId = null)


### PR DESCRIPTION
As soon as I saw the error I thought I had missed something.