### PR TITLE
Ensure that `test-proxy` can actually release

### DIFF
--- a/tools/test-proxy/ci.yml
+++ b/tools/test-proxy/ci.yml
@@ -26,6 +26,7 @@ extends:
   parameters:
     ToolDirectory: tools/test-proxy
     ReleaseBinaries: true
+    SkipReleaseStage: false
     StandaloneExeMatrix:
     - rid: osx-arm64
       framework: net8.0


### PR DESCRIPTION
At some point there was a change to make a parameter named `SkipReleaseStage` default to `true`. There are other conditions that will prevent that stage showing up on public builds, so I'm just setting this parameter to unblock shipping the test-proxy.

[test run](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5180939&view=results) 