### PR TITLE
Bump `twine` requirement used by `mirror-pypi-to-dev-feed`

### DIFF
--- a/eng/scripts/download_targeted_packages_requirements.txt
+++ b/eng/scripts/download_targeted_packages_requirements.txt
@@ -1,5 +1,5 @@
 beautifulsoup4>=4.11.1
 requests>=2.27.1
 urllib3<3
-twine==3.1.1
+twine==6.1.0
 pipgrip>=0.8.0


### PR DESCRIPTION
See title. [This is what the error looked like](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5189371&view=logs&j=e60f60ac-19f1-58f4-25c4-e0922cc9db5a&t=a7abd3c0-bbcb-558c-c16a-c6916ea0ce6e&l=4138)

[This is what it _should_ look like](https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5189467&view=logs&j=e60f60ac-19f1-58f4-25c4-e0922cc9db5a)