### PR TITLE
Ensure that inheritors of `archetype-sdk-tool-dotnet` have to manually queue builds to release

### DIFF
--- a/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
+++ b/eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
@@ -213,7 +213,7 @@ extends:
                 Publish: false
                 ImageTag: "${{ parameters.DockerTagPrefix }}$(Build.BuildNumber)"
 
-      - ${{ if and(ne(parameters.SkipReleaseStage, true), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+      - ${{ if and(ne(parameters.SkipReleaseStage, true), eq(variables['Build.Reason'], 'Manual'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
         - template: /eng/pipelines/templates/stages/archetype-sdk-publish-net.yml
           parameters:
             Feed: 'public/azure-sdk-for-net'
@@ -225,7 +225,7 @@ extends:
               PublishEnvironment: ${{ parameters.PublishEnvironment }}
             dependsOn: BuildTestAndPackage
 
-      - ${{ if and(ne(parameters.SkipReleaseStage, true), not(eq(length(parameters.DockerDeployments), 0)), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
+      - ${{ if and(ne(parameters.SkipReleaseStage, true), not(eq(length(parameters.DockerDeployments), 0)), eq(variables['Build.Reason'], 'Manual'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['System.TeamProject'], 'internal'))}}:
         - stage: PublishDockerImages
           displayName: Publish Docker Images
           dependsOn: BuildTestAndPackage


### PR DESCRIPTION
`parameters.SkipReleaseStage` skips it by default, but I have release enabled on my `test-proxy` ci.yml and I want to force manual triggers only to release.