### PR TITLE
fix(script): update clone:ts to use pnpm

### DIFF
--- a/tools/sdk-sample-generator/package.json
+++ b/tools/sdk-sample-generator/package.json
@@ -9,7 +9,7 @@
     "clean": "npm run clean:clones && rimraf *.tsbuildinfo",
     "clean:clones": "rimraf .artifacts",
     "clone:rest": "mkdir -p .artifacts && git clone --depth=1 --filter=blob:none --sparse https://github.com/Azure/azure-rest-api-specs.git .artifacts/azure-rest-api-specs && cd .artifacts/azure-rest-api-specs && git sparse-checkout set specification/cognitiveservices/Language.AnalyzeText",
-    "clone:ts": "mkdir -p .artifacts && git clone --depth=1 --filter=blob:none https://github.com/Azure/azure-sdk-for-js.git .artifacts/azure-sdk-for-js && cd .artifacts/azure-sdk-for-js/sdk/cognitivelanguage/ai-language-text && rush update && rush build -t . && npm pack",
+    "clone:ts": "mkdir -p .artifacts && git clone --depth=1 --filter=blob:none https://github.com/Azure/azure-sdk-for-js.git .artifacts/azure-sdk-for-js && cd .artifacts/azure-sdk-for-js && pnpm install && cd sdk/cognitivelanguage/ai-language-text && pnpm run build && pnpm pack",
     "clone:py": "mkdir -p .artifacts && git clone --depth=1 --filter=blob:none https://github.com/Azure/azure-sdk-for-python.git .artifacts/azure-sdk-for-python && cd .artifacts/azure-sdk-for-python/sdk/textanalytics/azure-ai-textanalytics",
     "clone:go": "mkdir -p .artifacts && git clone --depth=1 --filter=blob:none https://github.com/Azure/azure-sdk-for-go.git .artifacts/azure-sdk-for-go && cd .artifacts/azure-sdk-for-go/sdk/storage/azblob",
     "check-format": "prettier --check package.json tsconfig*.json 'genaisrc/**/*.{ts,mts}' 'test/**/*.{ts,mts}' '!**/*.d.ts'",


### PR DESCRIPTION
The `clone:ts` script was still using Rush commands, but the Azure SDK for JavaScript repo has switched to pnpm and Turbo for builds.

This update changes the script to use `pnpm install` and the new build commands.