### PR TITLE
[sdk-sample-generator] Add support for user prompts

### DIFF
--- a/tools/sdk-sample-generator/README.md
+++ b/tools/sdk-sample-generator/README.md
@@ -170,20 +170,52 @@ Select sample ideas interactively before code generation.
 
 You can customize the generation by passing any combination of the following parameters:
 
-- `--rest-api=<path>`: Path to REST API spec
-- `--client-api=<path>`: Path to client API spec
-- `--language=<TypeScript|Python|Go|curl>`
-- `--samples-count=<number>`
-- `--ideas-model=<model>`
-- `--coding-model=<model>`
-- `--reviewing-model=<model>`
-- `--skip-review=<true|false>`
-- `--out=<output-folder>`
-- `--client-dist=<path-to-client-dist>`
-- `--client-dist-name=<name>`
-- `--interactive=<true|false>`
-- `--use-ideas-cache=<true|false>`
-- `--extra-files=<comma-separated-list>`
+- `rest-api=<path>`: Path to REST API spec
+- `client-api=<path>`: Path to client API spec
+- `language=<TypeScript|Python|Go|curl>`
+- `samples-count=<number>`
+- `ideas-model=<model>`
+- `coding-model=<model>`
+- `reviewing-model=<model>`
+- `skip-review=<true|false>`
+- `out=<output-folder>`
+- `client-dist=<path-to-client-dist>`
+- `client-dist-name=<name>`
+- `interactive=<true|false>`
+- `use-ideas-cache=<true|false>`
+- `extra-files=<comma-separated-list>`
+- `user-prompt=<path-to-markdown-file>`
+
+### Using a Custom User Prompt
+
+You can skip the idea generation phase and provide your own sample requirements by using a markdown file:
+
+```sh
+npx genaiscript run generate --apply-edits --vars \
+  client-api=.artifacts/azure-sdk-for-js/sdk/storage/storage-blob/review \
+  language=TypeScript \
+  user-prompt=example-user-prompt.md \
+  out=.artifacts/generated-samples
+```
+
+Create a markdown file (e.g., `my-sample-idea.md`) with your requirements:
+
+```markdown
+# Azure Storage Blob Upload Sample
+
+Create a sample that demonstrates how to upload a file to Azure Blob Storage.
+
+The sample should:
+- Authenticate using DefaultAzureCredential
+- Create a blob container if it doesn't exist
+- Upload a local file to the blob container
+- Include proper error handling
+```
+
+When `--user-prompt` is provided, the tool will:
+- Skip the automatic idea generation phase
+- Use your markdown content as the sample specification
+- Generate code directly based on your requirements
 
 ---
 

--- a/tools/sdk-sample-generator/example-user-prompt.md
+++ b/tools/sdk-sample-generator/example-user-prompt.md
@@ -1,0 +1,17 @@
+# Azure Storage Blob Upload Sample
+
+Create a sample that demonstrates how to upload a file to Azure Blob Storage using the Azure Storage SDK.
+
+The sample should:
+- Authenticate using DefaultAzureCredential
+- Create a blob container if it doesn't exist
+- Upload a local file to the blob container
+- Include proper error handling
+- Show how to set blob metadata
+- Demonstrate how to check if the upload was successful
+
+Additional requirements:
+- Use environment variables for the storage account name
+- Include comments explaining each step
+- Handle cases where the file doesn't exist
+- Show best practices for resource cleanup

--- a/tools/sdk-sample-generator/genaisrc/generate.genai.mts
+++ b/tools/sdk-sample-generator/genaisrc/generate.genai.mts
@@ -161,15 +161,12 @@ const selectedLanguages = (
 
 const cacheFolder = path.join(appEnvPaths.cache, getUniqueDirName());
 
-// Generate or load sample ideas, or use user-provided prompt
 let selectedSampleIdeas;
 
 if (userPromptPath) {
-  // User provided a prompt file, skip idea generation
   const userSampleIdea = await parseUserPrompt(userPromptPath);
   selectedSampleIdeas = [userSampleIdea];
 } else {
-  // Standard flow: generate or load ideas, then select them
   const sampleIdeas = await generateOrLoadSampleIdeas({
     model: ideasModel,
     spec: restApiFiles.length > 0 ? restApiFiles : clientApiFiles,

--- a/tools/sdk-sample-generator/genaisrc/src/parseUserPrompt.ts
+++ b/tools/sdk-sample-generator/genaisrc/src/parseUserPrompt.ts
@@ -1,0 +1,51 @@
+import * as fs from "node:fs/promises";
+import type { SampleIdea } from "./types.ts";
+
+/**
+ * Parses a user prompt from a markdown file and converts it to a SampleIdea
+ * @param promptPath Path to the markdown file containing the user prompt
+ * @returns A SampleIdea object based on the user prompt
+ */
+export async function parseUserPrompt(promptPath: string): Promise<SampleIdea> {
+    try {
+        const content = await fs.readFile(promptPath, "utf-8");
+
+        // Extract title from first # heading or use filename
+        const titleMatch = content.match(/^#\s+(.+)/m);
+        const title = titleMatch
+            ? titleMatch[1].trim()
+            : "User Provided Sample";
+
+        // Use the entire content as description, cleaning up markdown
+        const description = content
+            .replace(/^#\s+.+$/gm, "") // Remove title heading
+            .trim();
+
+        // Generate a filename based on the title
+        const fileName =
+            title
+                .toLowerCase()
+                .replace(/[^a-z0-9\s]/g, "")
+                .replace(/\s+/g, "-")
+                .substring(0, 50) || "user-sample";
+
+        // Create a basic SampleIdea structure
+        // Since this is user-provided, we don't have specific API requests
+        // The actual sample generation will be based on the description
+        const sampleIdea: SampleIdea = {
+            name: title,
+            description,
+            fileName,
+            requests: [], // Will be populated during code generation based on the prompt
+            prerequisites: {
+                setup: "Follow the user's requirements as described in the prompt.",
+            },
+        };
+
+        return sampleIdea;
+    } catch (error) {
+        throw new Error(
+            `Failed to parse user prompt from ${promptPath}: ${error}`,
+        );
+    }
+}

--- a/tools/sdk-sample-generator/test/internal/utils/parseUserPrompt.spec.ts
+++ b/tools/sdk-sample-generator/test/internal/utils/parseUserPrompt.spec.ts
@@ -3,7 +3,6 @@ import { parseUserPrompt } from "../../../genaisrc/src/parseUserPrompt.ts";
 import { vol } from "memfs";
 import { vi } from "vitest";
 
-// Mock the fs module to use memfs
 vi.mock("node:fs/promises", async () => {
     const memfs = await import("memfs");
     return memfs.fs.promises;

--- a/tools/sdk-sample-generator/test/internal/utils/parseUserPrompt.spec.ts
+++ b/tools/sdk-sample-generator/test/internal/utils/parseUserPrompt.spec.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { parseUserPrompt } from "../../../genaisrc/src/parseUserPrompt.ts";
+import { vol } from "memfs";
+import { vi } from "vitest";
+
+// Mock the fs module to use memfs
+vi.mock("node:fs/promises", async () => {
+    const memfs = await import("memfs");
+    return memfs.fs.promises;
+});
+
+describe("parseUserPrompt", () => {
+    beforeEach(() => {
+        vol.reset();
+    });
+
+    afterEach(() => {
+        vol.reset();
+    });
+
+    it("should parse a markdown file with title and description", async () => {
+        const promptContent = `# Create a Storage Blob Sample
+
+This sample should demonstrate how to:
+- Connect to Azure Storage
+- Upload a blob
+- Download a blob
+- List blobs in a container`;
+
+        const promptPath = "/user-prompt.md";
+        vol.fromJSON({ [promptPath]: promptContent });
+
+        const result = await parseUserPrompt(promptPath);
+
+        expect(result.name).toBe("Create a Storage Blob Sample");
+        expect(result.fileName).toBe("create-a-storage-blob-sample");
+        expect(result.description).toContain("This sample should demonstrate");
+        expect(result.description).toContain("Upload a blob");
+        expect(result.requests).toEqual([]);
+        expect(result.prerequisites?.setup).toContain(
+            "Follow the user's requirements",
+        );
+    });
+
+    it("should handle markdown without title", async () => {
+        const promptContent = `This is a sample request without a title heading.
+
+It should still work and generate a proper sample idea.`;
+
+        const promptPath = "/no-title.md";
+        vol.fromJSON({ [promptPath]: promptContent });
+
+        const result = await parseUserPrompt(promptPath);
+
+        expect(result.name).toBe("User Provided Sample");
+        expect(result.fileName).toBe("user-provided-sample");
+        expect(result.description).toContain("This is a sample request");
+    });
+
+    it("should generate clean filenames from titles", async () => {
+        const promptContent = `# Create Azure Key Vault Secret (with special chars!)
+
+Sample description here.`;
+
+        const promptPath = "/special-chars.md";
+        vol.fromJSON({ [promptPath]: promptContent });
+
+        const result = await parseUserPrompt(promptPath);
+
+        expect(result.fileName).toBe(
+            "create-azure-key-vault-secret-with-special-chars",
+        );
+    });
+
+    it("should throw error for non-existent file", async () => {
+        const nonExistentPath = "/does-not-exist.md";
+
+        await expect(parseUserPrompt(nonExistentPath)).rejects.toThrow(
+            "Failed to parse user prompt",
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Adds support for supplying a user-authored prompt from a Markdown file to drive sample generation directly, bypassing the “idea generation” step when provided.

## Usage

- With client API docs (Storage example):
```bash
npx genaiscript run generate --apply-edits --vars \
  client-api=.artifacts/azure-sdk-for-js/sdk/storage/storage-blob/review \
  language=TypeScript \
  user-prompt=.artifacts/test/test-user-prompt.md \
  out=.artifacts/test/ts-output \
  skip-review=true
```