### PR TITLE
Add richard-park to codeowners for azsdk-cli

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -50,7 +50,7 @@
 /tools/perf-regression-finder/          @sa7936 @m-redding @jsquire
 
 # PRLabel: %azsdk-cli
-/tools/azsdk-cli/                       @benbp @scbedd @praveenkuttappan @smw-ms @Jeo02 @maririos 
+/tools/azsdk-cli/                       @benbp @scbedd @praveenkuttappan @smw-ms @Jeo02 @maririos @richardpark-msft
 
 ###########
 # Stress


### PR DESCRIPTION
@richardpark-msft is helping a lot with tool implementation reviews and coordination and is pretty familiar with the core framework and conventions at this point.