### PR TITLE
[AVC] Update models to GPT-5

### DIFF
--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -28,7 +28,7 @@ dotenv.load_dotenv()
 
 NUM_RUNS: int = 3
 # for best results, this should always be a different model from the one we are evaluating
-MODEL_JUDGE = "gpt-4.1-nano"
+MODEL_JUDGE = "gpt-5-mini"
 
 global settings
 settings = SettingsManager()

--- a/packages/python-packages/apiview-copilot/prompts/api_review/comment_filter.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/comment_filter.prompty
@@ -10,15 +10,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-4.1
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
-    temperature: 0
-    top_p: 1
-    stop: []
     frequency_penalty: 0
     presence_penalty: 0
-    max_tokens: 16384
+    max_completion_tokens: 80000
+    reasoning_effort: "minimal"
     response_format: ${file:filtered_result_schema.json}
 sample:
   language: Python

--- a/packages/python-packages/apiview-copilot/prompts/api_review/context_diff_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/context_diff_review.prompty
@@ -9,13 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: o3-mini
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0
     max_completion_tokens: 80000
-    reasoning_effort: "high"
+    reasoning_effort: "medium"
     response_format: ${file:guideline_result_schema.json}
 sample:
   language: python

--- a/packages/python-packages/apiview-copilot/prompts/api_review/context_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/context_review.prompty
@@ -9,13 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: o3-mini
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0
     max_completion_tokens: 80000
-    reasoning_effort: "high"
+    reasoning_effort: "medium"
     response_format: ${file:guideline_result_schema.json}
 sample:
   language: python

--- a/packages/python-packages/apiview-copilot/prompts/api_review/existing_comment_filter.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/existing_comment_filter.prompty
@@ -9,15 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-4.1
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
-    temperature: 0
-    top_p: 1
-    stop: []
     frequency_penalty: 0
     presence_penalty: 0
-    max_tokens: 16384
+    max_completion_tokens: 80000
+    reasoning_effort: "minimal"
     response_format: ${file:existing_comparison_result_schema.json}
 sample:
   language: Python

--- a/packages/python-packages/apiview-copilot/prompts/api_review/generic_comment_judge.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/generic_comment_judge.prompty
@@ -9,15 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-4.1
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
-    temperature: 0
-    top_p: 1
-    stop: []
     frequency_penalty: 0
     presence_penalty: 0
-    max_tokens: 16384
+    max_completion_tokens: 80000
+    reasoning_effort: "minimal"
 sample:
   language: Python
   content: |

--- a/packages/python-packages/apiview-copilot/prompts/api_review/generic_diff_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/generic_diff_review.prompty
@@ -10,13 +10,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: o3-mini
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0
     max_completion_tokens: 80000
-    reasoning_effort: "high"
+    reasoning_effort: "medium"
     response_format: ${file:generic_result_schema.json}
 sample:
   language: python

--- a/packages/python-packages/apiview-copilot/prompts/api_review/generic_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/generic_review.prompty
@@ -10,13 +10,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: o3-mini
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0
     max_completion_tokens: 80000
-    reasoning_effort: "high"
+    reasoning_effort: "medium"
     response_format: ${file:generic_result_schema.json}
 sample:
   language: python

--- a/packages/python-packages/apiview-copilot/prompts/api_review/guidelines_diff_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/guidelines_diff_review.prompty
@@ -9,13 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: o3-mini
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0
     max_completion_tokens: 80000
-    reasoning_effort: "high"
+    reasoning_effort: "medium"
     response_format: ${file:guideline_result_schema.json}
 sample:
   language: python

--- a/packages/python-packages/apiview-copilot/prompts/api_review/guidelines_review.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/guidelines_review.prompty
@@ -10,13 +10,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: o3-mini
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0
     max_completion_tokens: 80000
-    reasoning_effort: "high"
+    reasoning_effort: "medium"
     response_format: ${file:guideline_result_schema.json}
 sample:
   language: python

--- a/packages/python-packages/apiview-copilot/prompts/api_review/merge_comments.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/api_review/merge_comments.prompty
@@ -9,15 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-4.1
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
-    temperature: 0
-    top_p: 1
-    stop: []
     frequency_penalty: 0
     presence_penalty: 0
-    max_tokens: 16384
+    max_completion_tokens: 80000
+    reasoning_effort: "minimal"
     response_format: ${file:guideline_result_schema.json}
 sample:
   comments: |

--- a/packages/python-packages/apiview-copilot/prompts/evals/eval_judge_prompt.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/evals/eval_judge_prompt.prompty
@@ -10,14 +10,12 @@ model:
     type: azure_openai
     api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-4.1
+    azure_deployment: gpt-5
   parameters:
-    temperature: 0
-    top_p: 1
-    stop: []
     frequency_penalty: 0
     presence_penalty: 0
-    max_tokens: 16384
+    max_completion_tokens: 80000
+    reasoning_effort: "minimal"
 sample:
   language: python
   code: |

--- a/packages/python-packages/apiview-copilot/prompts/mention/parse_conversation_action.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/mention/parse_conversation_action.prompty
@@ -10,14 +10,12 @@ model:
     type: azure_openai
     api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-4.1
+    azure_deployment: gpt-5
   parameters:
-    temperature: 0.0
-    top_p: 1.0
-    stop: []
     frequency_penalty: 0
     presence_penalty: 0
-    max_tokens: 32768
+    max_completion_tokens: 80000
+    reasoning_effort: "minimal"
 sample:
   language: python
   package_name: azure.widget

--- a/packages/python-packages/apiview-copilot/prompts/mention/parse_conversation_to_memory.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/mention/parse_conversation_to_memory.prompty
@@ -10,14 +10,12 @@ model:
     type: azure_openai
     api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-4.1
+    azure_deployment: gpt-5
   parameters:
-    temperature: 0.0
-    top_p: 1.0
-    stop: []
     frequency_penalty: 0
     presence_penalty: 0
-    max_tokens: 32768
+    max_completion_tokens: 80000
+    reasoning_effort: "minimal"
     response_format: ${file:conversation_parsing_result_schema.json}
 sample:
   language: python

--- a/packages/python-packages/apiview-copilot/prompts/mention/summarize_parse_conversation_to_memory.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/mention/summarize_parse_conversation_to_memory.prompty
@@ -14,14 +14,12 @@ model:
     type: azure_openai
     api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-4.1
+    azure_deployment: gpt-5
   parameters:
-    temperature: 0.0
-    top_p: 1.0
-    stop: []
     frequency_penalty: 0
     presence_penalty: 0
-    max_tokens: 32768
+    max_completion_tokens: 80000
+    reasoning_effort: "minimal"
 sample:
   results: | 
     {

--- a/packages/python-packages/apiview-copilot/prompts/other/summarize_metrics.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/other/summarize_metrics.prompty
@@ -10,14 +10,12 @@ model:
     type: azure_openai
     api_version: 2025-03-01-preview
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: gpt-4.1
+    azure_deployment: gpt-5
   parameters:
-    temperature: 0.0
-    top_p: 1.0
-    stop: []
     frequency_penalty: 0
     presence_penalty: 0
-    max_tokens: 32768
+    max_completion_tokens: 80000
+    reasoning_effort: "medium"
 sample:
   data: | 
     {     

--- a/packages/python-packages/apiview-copilot/prompts/summarize/summarize_api.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/summarize/summarize_api.prompty
@@ -9,13 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: o3-mini
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0
     max_completion_tokens: 80000
-    reasoning_effort: "high"
+    reasoning_effort: "medium"
 sample:
   content: |
     ```python

--- a/packages/python-packages/apiview-copilot/prompts/summarize/summarize_diff.prompty
+++ b/packages/python-packages/apiview-copilot/prompts/summarize/summarize_diff.prompty
@@ -9,13 +9,13 @@ model:
   configuration:
     type: azure_openai
     azure_endpoint: ${env:OPENAI_ENDPOINT}
-    azure_deployment: o3-mini
+    azure_deployment: gpt-5
     api_version: 2025-03-01-preview
   parameters:
     frequency_penalty: 0
     presence_penalty: 0
     max_completion_tokens: 80000
-    reasoning_effort: "high"
+    reasoning_effort: "medium"
 sample:
   content: |
     ```python


### PR DESCRIPTION
Closes #11637.

Initial draft follows the guidance here: https://platform.openai.com/docs/guides/latest-model#migrating-from-other-models-to-gpt-5

> o3: gpt-5 with medium or high reasoning is a great replacement. Start with medium reasoning with prompt tuning, then increasing to high if you aren't getting the results you want.

Since we were using o3-mini, I converted that to gpt-5 with "medium" reasoning

> gpt-4.1: gpt-5 with minimal or low reasoning is a strong alternative. Start with minimal and tune your prompts; increase to low if you need better performance.

Converted to GPT-5 with "minimal" reasoning

For evals, I converted it to use GPT-5-mini