### PR TITLE
[azsdk-cli] Adding in tests for the ReadMeGeneratorTool

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Azure.Sdk.Tools.Cli.Tests.csproj
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Azure.Sdk.Tools.Cli.Tests.csproj
@@ -35,6 +35,12 @@
   </ItemGroup>
 
   <ItemGroup>
+    <None Include="..\Azure.Sdk.Tools.Cli\Templates\ReadMeGenerator\README-template.go.md" Link="TestAssets\README-template.go.md">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
     <None Update="TypeSpecTestData\specification\testcontoso\Contoso.Management\employee.tsp">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/MockServices/MockOutputService.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/MockServices/MockOutputService.cs
@@ -1,0 +1,75 @@
+using Azure.Sdk.Tools.Cli.Services;
+
+namespace Azure.Sdk.Tools.Cli.Tests.MockServices
+{
+    /// <summary>
+    /// A really simple mock that just accumulates all the outputs into a List, which you can assert on
+    /// after the test is complete.
+    /// </summary>
+    internal class MockOutputService : IOutputService
+    {
+        /// <summary>
+        /// All the collected outputs, in the order they were added.
+        /// The Method is the actual name of the method in the OutputService
+        /// </summary>
+        public IEnumerable<(string Method, object OutputValue)> Outputs => outputs;
+        private readonly List<(string Method, object OutputValue)> outputs;
+
+        public MockOutputService()
+        {
+            outputs = [];
+        }
+
+        public string Format(object response)
+        {
+            lock (outputs)
+            {
+                outputs.Add((nameof(Format), response));
+            }
+
+            return response?.ToString() ?? string.Empty;
+        }
+
+        public void Output(object output)
+        {
+            lock (outputs)
+            {
+                outputs.Add((nameof(Output), output));
+            }
+        }
+
+        public void Output(string output)
+        {
+            lock (outputs)
+            {
+                outputs.Add((nameof(Output), output));
+            }
+        }
+
+        public void OutputError(object output)
+        {
+            lock (outputs)
+            {
+                outputs.Add((nameof(OutputError), output));
+            }
+        }
+
+        public void OutputError(string output)
+        {
+            lock (outputs)
+            {
+                outputs.Add((nameof(OutputError), output));
+            }
+        }
+
+        public string ValidateAndFormat<T>(string response)
+        {
+            lock (outputs)
+            {
+                outputs.Add((nameof(ValidateAndFormat), response));
+            }
+
+            return response ?? string.Empty;
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/OpenAIMockHelper.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/TestHelpers/OpenAIMockHelper.cs
@@ -1,0 +1,26 @@
+using Azure.AI.OpenAI;
+using Moq;
+using OpenAI.Chat;
+
+namespace Azure.Sdk.Tools.Cli.Tests.TestHelpers
+{
+    internal class OpenAIMockHelper
+    {
+        /// <summary>
+        /// Creates a mock that will return a mock ChatClient when GetChatClient is called with the expected deployment name.
+        /// </summary>
+        /// <param name="expectedDeploymentName">The expected deployment name</param>
+        /// <returns></returns>
+        public static (Mock<AzureOpenAIClient> OpenAIClient, Mock<ChatClient> ChatClient) Create(string expectedDeploymentName)
+        {
+            Mock<AzureOpenAIClient> openAIClientMock = new();
+            Mock<ChatClient> chatClient = new();
+
+            openAIClientMock
+                .Setup(client => client.GetChatClient(It.Is<string>(s => s == expectedDeploymentName)))
+                .Returns(chatClient.Object);
+
+            return (openAIClientMock, chatClient);
+        }
+    }
+}

--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests/Tools/Generators/ReadMeGeneratorToolTests.cs
@@ -1,0 +1,162 @@
+using System.ClientModel;
+using System.ClientModel.Primitives;
+using System.CommandLine;
+using System.CommandLine.Parsing;
+using Azure.AI.OpenAI;
+using Azure.Sdk.Tools.Cli.Services;
+using Azure.Sdk.Tools.Cli.Tests.MockServices;
+using Azure.Sdk.Tools.Cli.Tests.TestHelpers;
+using Azure.Sdk.Tools.Cli.Tools;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Moq;
+using OpenAI.Chat;
+
+namespace Azure.Sdk.Tools.Cli.Tests.Tools.Generators
+{
+    internal class ReadMeGeneratorToolTests
+    {
+        [Test]
+        public async Task TestReadmeGeneratorTool()
+        {
+            var testClients = SetupOpenAIMocks();
+            (DirectoryInfo root, string packagePath) = await CreateFakeLanguageRepo();
+
+            var readmeOutputPath = Path.GetTempFileName();
+            var readmeTemplatePath = Path.Combine(AppContext.BaseDirectory, "TestAssets", "README-template.go.md");
+
+            try
+            {
+                var tool = ActivatorUtilities.CreateInstance<ReadMeGeneratorTool>(testClients.ServiceProvider);
+                var command = tool.GetCommand();
+
+                int exitCode = command.Invoke($"--output-path \"{readmeOutputPath}\" --service-url \"https://learn.microsoft.com/azure/service-bus-messaging\" --template-path {readmeTemplatePath} --package-path {packagePath}");
+
+                Assert.Multiple(() =>
+                {
+                    Assert.That(exitCode, Is.EqualTo(0), "Command should execute successfully");
+                    Assert.That(testClients.OutputService.Outputs.First().Method, Is.EqualTo("Output"));
+                    Assert.That(testClients.OutputService.Outputs.First().OutputValue, Is.EqualTo($"Readme written to {readmeOutputPath}"));
+                });
+
+                Assert.That(File.Exists(readmeOutputPath), Is.True, "Readme output file should be created");
+            }
+            finally
+            {
+                Directory.Delete(root.FullName, true);
+            }
+        }
+
+        [Test]
+        public void TestReadmeGeneratorToolLive()
+        {
+            var endpoint = Environment.GetEnvironmentVariable("AZURE_OPENAI_ENDPOINT");
+
+            if (endpoint == null)
+            {
+                Assert.Ignore("Skipping test as AZURE_OPENAI_ENDPOINT is not set");
+            }
+
+            var languageRepo = Environment.GetEnvironmentVariable("AZURE_SDK_FOR_GO_PATH");
+
+            if (languageRepo == null)
+            {
+                Assert.Ignore("Skipping test as AZURE_SDK_FOR_GO_PATH is not set");
+            }
+
+            var (sp, outputServiceMock) = CreateServiceProvider();
+
+            var tool = ActivatorUtilities.CreateInstance<ReadMeGeneratorTool>(sp);
+            var command = tool.GetCommand();
+            var readmeOutputPath = Path.GetTempFileName();
+            var readmeTemplatePath = Path.Combine(AppContext.BaseDirectory, "TestAssets", "README-template.go.md");
+
+            int exitCode = command.Invoke($"--output-path \"{readmeOutputPath}\" --service-url \"https://learn.microsoft.com/azure/service-bus-messaging\" --template-path {readmeTemplatePath} --package-path {Path.Join(languageRepo, "sdk", "messaging", "azservicebus")}");
+            Assert.That(exitCode, Is.EqualTo(0), "Command should execute successfully");
+
+            Assert.That(File.Exists(readmeOutputPath), Is.True, "Readme output file should be created");
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(outputServiceMock.Outputs.First().Method, Is.EqualTo("Output"));
+                Assert.That(outputServiceMock.Outputs.First().OutputValue, Is.EqualTo($"Readme written to {readmeOutputPath}"));
+            });
+        }
+
+        /// <summary>
+        /// Creates a service provider in the same way as the normal program. Can be used to instantiate real clients.
+        /// </summary>
+        /// <param name="customizeServices">Optional Action you can use to register your own client instances</param>
+        /// <returns></returns>
+        private static (ServiceProvider, MockOutputService) CreateServiceProvider(Action<ServiceCollection>? customizeServices = default)
+        {
+            var serviceCollection = new ServiceCollection();
+            var outputService = new MockOutputService();
+
+            
+            serviceCollection.AddLogging();     // so our ILogger<T>'s will be available.
+
+            
+            ServiceRegistrations.RegisterCommonServices(serviceCollection);
+            serviceCollection.AddSingleton<IOutputService>(outputService);
+
+            customizeServices?.Invoke(serviceCollection);
+
+            var sp = serviceCollection.BuildServiceProvider();
+            return (sp, outputService);
+        }
+        
+        private static TestClients SetupOpenAIMocks()
+        {
+            var (openAIClientMock, chatClientMock) = OpenAIMockHelper.Create("gpt-4.1");
+
+            // basically - create a model using the appropriate OpenAI*ModelFactory
+            // then return it, wrapped in a ClientResult. This is really similar to the online samples
+            // except it's ClientResult (instead of Response).
+            var chatCompletion = OpenAIChatModelFactory.ChatCompletion(
+                content: new ChatMessageContent("This is a test response for the readme generation.")
+            );
+
+            chatClientMock
+                .Setup(ccm => ccm.CompleteChatAsync(It.IsAny<ChatMessage[]>()))     // NOTE: I'm not checking the chat message input - I already know what I'm sending.
+                .Returns(() =>
+                {
+                    return Task.FromResult(
+                        ClientResult.FromValue(chatCompletion, Mock.Of<PipelineResponse>())
+                    );
+                });
+
+            var (serviceProvider, outputService) = CreateServiceProvider((sc) =>
+            {
+                sc.AddLogging((lb) => lb.AddConsole());
+                sc.AddSingleton(openAIClientMock.Object);
+
+                // register the mocks too, if you want to grab them later.
+                sc.AddSingleton(chatClientMock);
+                sc.AddSingleton(openAIClientMock);
+            });
+
+            return new TestClients(openAIClientMock, chatClientMock, serviceProvider, outputService);
+        }
+        
+        private static async Task<(DirectoryInfo root, string packagePath)> CreateFakeLanguageRepo()
+        {
+            var root = Directory.CreateTempSubdirectory("readme-generator-tool-test");
+            var scriptsDir = Path.Combine(root.FullName, "eng", "common", "scripts");
+            var packagePath = Path.Combine(root.FullName, "sdk", "messaging", "azservicebus");
+
+            Directory.CreateDirectory(packagePath);
+            Directory.CreateDirectory(scriptsDir);
+
+            await File.WriteAllTextAsync(Path.Join(scriptsDir, "Verify-Links.ps1"), "Write-Host 'passed'");
+            return (root, packagePath);
+        }
+
+        private record TestClients(
+            Mock<AzureOpenAIClient> OpenAIClient,
+            Mock<ChatClient> ChatClient,
+            ServiceProvider ServiceProvider,
+            MockOutputService OutputService
+        );
+    }
+}


### PR DESCRIPTION
Adding in some simple testing for ReadMeGenerator.

One is a unit test - pretty simple, mocks OpenAIClient and returns a faux response.

The second one is a live test, which will only run if the proper environment variables are defined. We need to get a pipeline going before that'll run anywhere else but on my local machine.

Both of these tests use a ServiceCollection and invoke the command through the command line framework. So it's as real as I can get it.

I also added in some other utilities:
- MockOutputService, if you want to just accumulate all the Output/OutputError calls into a single list and assert on it
- OpenAIMockHelper, just to make it simple to create and wire up a chat client.