### PR TITLE
Fix 11009

### DIFF
--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy.Tests/RecordSessionTests.cs
@@ -747,6 +747,52 @@ namespace Azure.Sdk.Tools.TestProxy.Tests
             ContentLengthUpdatedCorrectlyOnEmptyBody(isHeadRequest: false);
         }
 
+        [Fact]
+        public void JsonBodyCompareReportsMissingRecordWithCorrectOrder()
+        {
+            string requestBody = "{\"a\": \"meep\"}";
+            string recordBody = "{\"b\": \"meep\"}";
+            var requestBytes = Encoding.UTF8.GetBytes(requestBody);
+            var recordBytes = Encoding.UTF8.GetBytes(recordBody);
+
+            var differences = JsonComparer.CompareJson(requestBytes, recordBytes);
+            Assert.Equal(2, differences.Count);
+            Assert.Equal(".a: Missing in record JSON", differences[0]);
+            Assert.Equal(".b: Missing in request JSON", differences[1]);
+
+            requestBody = "{\"b\": \"meep\"}";
+            recordBody = "{\"a\": \"meep\"}";
+            requestBytes = Encoding.UTF8.GetBytes(requestBody);
+            recordBytes = Encoding.UTF8.GetBytes(recordBody);
+
+            differences = JsonComparer.CompareJson(requestBytes, recordBytes);
+            Assert.Equal(2, differences.Count);
+            Assert.Equal(".b: Missing in record JSON", differences[0]);
+            Assert.Equal(".a: Missing in request JSON", differences[1]);
+        }
+
+        [Fact]
+        public void JsonBodyCompareReportsMissingArrayElementWithCorrectOrder()
+        {
+            string requestBody = "{\"a\": [\"meep\"]}";
+            string recordBody = "{\"a\": [\"meep\", \"moop\"]}";
+            var requestBytes = Encoding.UTF8.GetBytes(requestBody);
+            var recordBytes = Encoding.UTF8.GetBytes(recordBody);
+
+            var differences = JsonComparer.CompareJson(requestBytes, recordBytes);
+            Assert.Single(differences);
+            Assert.Equal(".a[1]: Extra element in record JSON", differences[0]);
+
+            requestBody = "{\"a\": [\"meep\", \"moop\"]}";
+            recordBody = "{\"a\": [\"meep\"]}";
+            requestBytes = Encoding.UTF8.GetBytes(requestBody);
+            recordBytes = Encoding.UTF8.GetBytes(recordBody);
+
+            var differences2 = JsonComparer.CompareJson(requestBytes, recordBytes);
+            Assert.Single(differences2);
+            Assert.Equal(".a[1]: Extra element in request JSON", differences2[0]);
+        }
+
         private void ContentLengthUpdatedCorrectlyOnEmptyBody(bool isHeadRequest)
         {
             var sanitizer = new RecordedTestSanitizer();

--- a/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/JsonComparer.cs
+++ b/tools/test-proxy/Azure.Sdk.Tools.TestProxy/Common/JsonComparer.cs
@@ -73,7 +73,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                             }
                             else
                             {
-                                differences.Add($"{path}.{key}: Missing in request JSON");
+                                differences.Add($"{path}.{key}: Missing in record JSON");
                             }
                         }
 
@@ -81,7 +81,7 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                         {
                             if (!propDict1.ContainsKey(key))
                             {
-                                differences.Add($"{path}.{key}: Missing in record JSON");
+                                differences.Add($"{path}.{key}: Missing in request JSON");
                             }
                         }
 
@@ -89,29 +89,24 @@ namespace Azure.Sdk.Tools.TestProxy.Common
                     }
                 case JsonValueKind.Array:
                     {
-                        var array1 = element1.EnumerateArray();
-                        var array2 = element2.EnumerateArray();
+                        // Use index-based iteration to avoid double-advancing enumerators
+                        int len1 = element1.GetArrayLength();
+                        int len2 = element2.GetArrayLength();
+                        int common = Math.Min(len1, len2);
 
-                        int index = 0;
-                        var enum1 = array1.GetEnumerator();
-                        var enum2 = array2.GetEnumerator();
-
-                        while (enum1.MoveNext() && enum2.MoveNext())
+                        for (int i = 0; i < common; i++)
                         {
-                            CompareElements(enum1.Current, enum2.Current, differences, $"{path}[{index}]");
-                            index++;
+                            CompareElements(element1[i], element2[i], differences, $"{path}[{i}]");
                         }
 
-                        while (enum1.MoveNext())
+                        for (int i = common; i < len1; i++)
                         {
-                            differences.Add($"{path}[{index}]: Extra element in request JSON");
-                            index++;
+                            differences.Add($"{path}[{i}]: Extra element in request JSON");
                         }
 
-                        while (enum2.MoveNext())
+                        for (int i = common; i < len2; i++)
                         {
-                            differences.Add($"{path}[{index}]: Extra element in record JSON");
-                            index++;
+                            differences.Add($"{path}[{i}]: Extra element in record JSON");
                         }
 
                         break;


### PR DESCRIPTION
I decided to do some due diligence and also confirm that array is returning proper error. I actually discovered a _new_ bug for array comparison because of that. If the `request` body has extra entries we don't catch it rn. This fixes that. Will do a FULL recorded test run on all languages before I merge this.