### PR TITLE
[sdk-sample-generator] Update the Go side of the fence to match expectations

### DIFF
--- a/tools/sdk-sample-generator/genaisrc/src/generateSamples.ts
+++ b/tools/sdk-sample-generator/genaisrc/src/generateSamples.ts
@@ -1,7 +1,7 @@
 import { getFileExtension, getToolNames } from "./languages.ts";
 import { sampleGuidelines } from "./sampleGuidelines.ts";
+import type { Language, Sample, SampleIdea } from "./types.ts";
 import { verifySample } from "./verifySample.ts";
-import type { Language, SampleIdea, Sample } from "./types.ts";
 
 function generateCurlSample(sampleIdea: SampleIdea): Sample {
     let curlCmds: string[] = [];
@@ -95,6 +95,11 @@ async function generateSampleCode(inputs: {
             tools: getToolNames(language),
         },
     );
+
+    if (res.error) {
+        throw res.error;
+    }
+
     return {
         fileName: `${sampleIdea.fileName}.${getFileExtension(language)}`,
         content: res.text,

--- a/tools/sdk-sample-generator/genaisrc/system.go.genai.mts
+++ b/tools/sdk-sample-generator/genaisrc/system.go.genai.mts
@@ -5,10 +5,18 @@ system({
 export default function (ctx: ChatGenerationContext) {
   const { $ } = ctx;
 
-  $`You are an expert Go programmer and reviewer. 
-You write idiomatic, well-documented, and production-quality Go code that follows best practices for error handling, concurrency, and modularity. 
-You use clear naming conventions, proper package structure, and always include necessary imports. 
-You avoid global variables, prefer context-aware APIs, and use Go modules for dependency management. 
-You are familiar with the latest Go features (up to Go 1.21+), including generics, slices, and error wrapping. 
-Your code is formatted with gofmt, passes go vet and golint, and is easy for other Go developers to understand and maintain.`;
+  $`You are an expert Go programmer who is writing example_test.go files.
+- You write idiomatic, well-documented, and production-quality Go code that follows best practices for error handling, concurrency, and modularity. 
+- You use clear naming conventions, proper package structure, and always include necessary imports. 
+- You avoid global variables, prefer context-aware APIs, and use Go modules for dependency management. 
+- You are familiar with the latest Go features (up to Go 1.23+), including generics, slices, and error wrapping. 
+- Your code is formatted with gofmt, passes golangci-lint, and is easy for other Go developers to understand and maintain.
+- Use context.TODO(), if a call needs a context.
+- Check all errors that come back from functions and use this block to check and report the error:
+  \`\`\`go
+  if err != nil {
+    // TODO: Update the following line with your application specific error handling logic
+    log.Fatalf(\"ERROR: %s\", err)
+    }
+  \`\`\`
 }


### PR DESCRIPTION
- generateSamples needs to throw an exception if one comes back, otherwise you can run this program a bunch of times and not realize what's failing. Err...so I've heard.
- Updating the typecheck part to do checks the way we do in the pipelines (at least, some of it)
- adding some stuff to the system prompt for Go. I'm unsure if it's overriding the standard declaration that's already in the genaiscript package or not though.