### PR TITLE
[Evals] Default to multiple evaluation runs

### DIFF
--- a/packages/python-packages/apiview-copilot/evals/run.py
+++ b/packages/python-packages/apiview-copilot/evals/run.py
@@ -461,7 +461,7 @@ if __name__ == "__main__":
         "--num-runs",
         "-n",
         type=int,
-        default=1,
+        default=NUM_RUNS,
         help="The number of runs to perform, with the median of results kept. Defaults to 3.",
     )
     parser.add_argument(


### PR DESCRIPTION
While investigating our variance on evaluation runs, I noticed that the script was only running evals once in pipelines. It looks like the default number of runs was changed to 1, possibly for local testing, when it was originally `NUM_RUNS`. This reverts the change.