### PR TITLE
[tsp-client] Fix emitter-output-dir support bug

### DIFF
--- a/tools/tsp-client/CHANGELOG.md
+++ b/tools/tsp-client/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release
 
+## 2025-08-15 - 0.28.1
+
+- Fix bug when using `emitter-output-dir` in tspconfig.yaml, always pass the repo root path for the `{output-dir}` variable.
+
 ## 2025-08-13 - 0.28.0
 
 - Support `emitter-output-dir` when generating a client library. `emitter-output-dir` will be given preference over client library path parsing with the `package-dir` option under the emitter.

--- a/tools/tsp-client/package-lock.json
+++ b/tools/tsp-client/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/typespec-client-generator-cli",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "license": "MIT",
       "dependencies": {
         "@autorest/core": "^3.10.2",

--- a/tools/tsp-client/package.json
+++ b/tools/tsp-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-cli",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "A tool to generate Azure SDKs from TypeSpec",
   "main": "dist/index.js",
   "homepage": "https://github.com/Azure/azure-sdk-tools/tree/main/tools/tsp-client#readme",

--- a/tools/tsp-client/src/commands.ts
+++ b/tools/tsp-client/src/commands.ts
@@ -445,7 +445,7 @@ export async function generateCommand(argv: any) {
   }
   const result = await compileTsp({
     emitterPackage: emitter,
-    outputPath: outputDir,
+    outputPath: legacyPathResolution ? outputDir : await getRepoRoot(outputDir), // always use repo root when using emitter-output-dir
     resolvedMainFilePath,
     saveInputs: saveInputs,
     additionalEmitterOptions: emitterOptions,


### PR DESCRIPTION
always pass repo root when using emitter-output-dir. All specs that use the output-dir variable to build the absolute path with the emitter-output-dir variable will do so based off of the repo root.