### PR TITLE
Sort retrieved crosslanguage APIRevisions by createdOn date descending

### DIFF
--- a/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
+++ b/src/dotnet/APIView/APIViewWeb/LeanControllers/ReviewsController.cs
@@ -14,6 +14,7 @@ using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using APIViewWeb.DTOs;
+using APIViewWeb.Models;
 
 namespace APIViewWeb.LeanControllers
 {

--- a/src/dotnet/APIView/APIViewWeb/Repositories/CosmosAPIRevisionsRepository.cs
+++ b/src/dotnet/APIView/APIViewWeb/Repositories/CosmosAPIRevisionsRepository.cs
@@ -224,7 +224,7 @@ namespace APIViewWeb
             {
                 queryStringBuilder.Append(" AND c.APIRevisionType = @apiRevisionType");
             }
-            queryStringBuilder.Append(" ORDER BY c.CreatedOn ASC OFFSET 0 LIMIT 20");
+            queryStringBuilder.Append(" ORDER BY c.CreatedOn DESC OFFSET 0 LIMIT 20");
             var revisions = new List<APIRevisionListItemModel>();
             QueryDefinition queryDefinition = new QueryDefinition(queryStringBuilder.ToString())
                 .WithParameter("@apiRevisionType", apiRevisionType.ToString());


### PR DESCRIPTION
- Sort order should be descending