### PR TITLE
Speed up azsdk-cli CI checks by only testing linux and not producing executables

### DIFF
--- a/tools/azsdk-cli/ci.yml
+++ b/tools/azsdk-cli/ci.yml
@@ -18,25 +18,33 @@ pr:
 extends:
   template: /eng/pipelines/templates/stages/archetype-sdk-tool-dotnet.yml
   parameters:
-    ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
-      SkipReleaseStage: false
     PublishEnvironment: 'package-publish'
     ReleaseBinaries: true
     ToolDirectory: tools/azsdk-cli/Azure.Sdk.Tools.Cli
     TestDirectory: tools/azsdk-cli/Azure.Sdk.Tools.Cli.Tests
-    StandaloneExeMatrix:
-    - rid: osx-x64
-      framework: net8.0
-      assembly: azsdk
-    - rid: osx-arm64
-      framework: net8.0
-      assembly: azsdk
-    - rid: win-x64
-      framework: net8.0
-      assembly: azsdk
-    - rid: linux-x64
-      framework: net8.0
-      assembly: azsdk
-    - rid: linux-arm64
-      framework: net8.0
-      assembly: azsdk
+    # Make CI tests much faster, we do not have cross-platform
+    # tests that differ in pull request CI checks
+    ${{ if eq(variables['Build.Reason'],'PullRequest') }}:
+      TestMatrix:
+        - name: Linux
+          Pool: $(LINUXPOOL)
+          Image: $(LINUXVMIMAGE)
+          Os: linux
+    ${{ if eq(variables['Build.SourceBranchName'], 'main') }}:
+      SkipReleaseStage: false
+      StandaloneExeMatrix:
+        - rid: linux-x64
+          framework: net8.0
+          assembly: azsdk
+        - rid: linux-arm64
+          framework: net8.0
+          assembly: azsdk
+        - rid: osx-x64
+          framework: net8.0
+          assembly: azsdk
+        - rid: osx-arm64
+          framework: net8.0
+          assembly: azsdk
+        - rid: win-x64
+          framework: net8.0
+          assembly: azsdk


### PR DESCRIPTION
Speed up azsdk-cli CI checks by only testing linux and not producing executables. This brings CI times down from ~5-10 minutes to ~2-3 minutes.