### PR TITLE
[azsdk-cli] Use 'all' by default when doing package checks

### DIFF
--- a/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageCheckTool.cs
+++ b/tools/azsdk-cli/Azure.Sdk.Tools.Cli/Tools/Package/PackageCheckTool.cs
@@ -39,6 +39,7 @@ namespace Azure.Sdk.Tools.Cli.Tools
 
             var checkTypeOption = new Option<PackageCheckName>(
                 "--check-type",
+                () => PackageCheckName.All,
                 "The type of check to run")
             {
                 IsRequired = true


### PR DESCRIPTION
- To simplify, just use 'All' as the type for package checks, which seems like a reasonable default.
- Moved the PackageTool under a `Package` folder, as `CheckAllTool` doesn't seem to match any name we're using for it.
