### PR TITLE
added logic for the Agent to fix error

### DIFF
--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/AgentResponseParser.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/AgentResponseParser.cs
@@ -1,0 +1,93 @@
+using System.Text.RegularExpressions;
+using Azure.Tools.GeneratorAgent.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Tools.GeneratorAgent
+{
+    /// <summary>
+    /// Service for parsing and processing AI agent responses from TypeSpec code blocks
+    /// </summary>
+    internal class AgentResponseParser
+    {
+        private readonly ILogger<AgentResponseParser> Logger;
+        private static readonly Regex TypeSpecCodeBlockRegex = new(@"```typespec\s*\n(.*?)\n```", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex TspCodeBlockRegex = new(@"```tsp\s*\n(.*?)\n```", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex TypeScriptCodeBlockRegex = new(@"```typescript\s*\n(.*?)\n```", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+        private static readonly Regex GenericCodeBlockRegex = new(@"```\s*\n(.*?)\n```", RegexOptions.Singleline | RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        public AgentResponseParser(ILogger<AgentResponseParser> logger)
+        {
+            ArgumentNullException.ThrowIfNull(logger);
+            Logger = logger;
+        }
+
+        /// <summary>
+        /// Parses the agent's response and extracts the updated client.tsp content from TypeSpec code blocks
+        /// </summary>
+        public AgentResponse ParseResponse(string rawResponse)
+        {
+            try
+            {
+                string updatedContent = ExtractTypeSpecCodeBlock(rawResponse);
+                
+                Logger.LogInformation("Successfully parsed agent response with {Length} characters of client.tsp content", 
+                    updatedContent.Length);
+                
+                return new AgentResponse
+                {
+                    UpdatedFileContent = updatedContent.Trim(),
+                    HasValidContent = true
+                };
+            }
+            catch (Exception ex) when (!(ex is OperationCanceledException))
+            {
+                Logger.LogError(ex, "Unexpected error while parsing agent response. Response length: {Length}", 
+                    rawResponse?.Length ?? 0);
+                throw;
+            }
+        }
+
+        /// <summary>
+        /// Extracts TypeSpec content from code blocks in the response
+        /// </summary>
+        private string ExtractTypeSpecCodeBlock(string response)
+        {
+            try
+            {
+                // Try pre-compiled regex patterns in order of preference
+                (Regex, string)[] regexPatterns = new[]
+                {
+                    (TypeSpecCodeBlockRegex, "typespec"),        // ```typespec ... ``` (primary - correct format)
+                    (TspCodeBlockRegex, "tsp"),                  // ```tsp ... ``` (file extension)
+                    (TypeScriptCodeBlockRegex, "typescript"),    // ```typescript ... ``` (legacy fallback)
+                    (GenericCodeBlockRegex, "generic")           // ``` ... ``` (no language)
+                };
+
+                foreach ((Regex regex, string patternName) in regexPatterns)
+                {
+                    MatchCollection matches = regex.Matches(response);
+                    
+                    if (matches.Count > 0)
+                    {
+                        Match lastMatch = matches[matches.Count - 1];
+                        string extractedContent = lastMatch.Groups[1].Value.Trim();
+                        
+                        if (!string.IsNullOrWhiteSpace(extractedContent))
+                        {
+                            Logger.LogDebug("Successfully extracted content using {PatternName} pattern", patternName);
+                            return extractedContent.Trim();
+                        }
+                    }
+                }
+
+                Logger.LogWarning("No code blocks found in response using any pattern");
+                throw new InvalidOperationException("No valid TypeSpec code blocks found in agent response");
+            }
+            catch (Exception ex) when (!(ex is OperationCanceledException))
+            {
+                Logger.LogError(ex, "Error extracting TypeSpec code block from response");
+                throw;
+            }
+        }
+    }
+}

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/BuildErrorAnalyzer.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/BuildErrorAnalyzer.cs
@@ -15,8 +15,7 @@ namespace Azure.Tools.GeneratorAgent
     {
         // Regular expression to match error patterns.
         // Matches strings like "error CS0103: The name 'InvalidVariable' does not exist in the current context [/path/to/file.cs]" into groups: "error (CS0103): (The name 'InvalidVariable' does not exist in the current context) [/path/to/file.cs]"
-
-        private static readonly Regex ErrorRegex = new(@"error\s+([A-Z]+\d+):\s*(.+?)(?=\s*\[|$)", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled);
+        private static readonly Regex ErrorRegex = new(@"error\s+([A-Z]+\d+):\s*(.+?)(?=\s*\[|$)", RegexOptions.IgnoreCase | RegexOptions.Multiline | RegexOptions.Compiled, TimeSpan.FromSeconds(1));
 
         private readonly ILogger<BuildErrorAnalyzer> Logger;
 
@@ -103,7 +102,7 @@ namespace Azure.Tools.GeneratorAgent
             // TODO: Implement LLM-based error message parsing as a fallback
 
             HashSet<(string type, string message)> seenErrors = new HashSet<(string type, string message)>();
-            List<RuleError> errors = new List<RuleError>();
+            List<RuleError> errors = new List<RuleError>(matches.Count);
 
             foreach (Match match in matches)
             {
@@ -112,17 +111,16 @@ namespace Azure.Tools.GeneratorAgent
                     string errorType = match.Groups[1].Value.Trim();
                     string errorMessage = match.Groups[2].Value.Trim();
 
-                    if (string.IsNullOrWhiteSpace(errorType) || string.IsNullOrWhiteSpace(errorMessage))
+                    if (errorType.AsSpan().IsWhiteSpace() || errorMessage.AsSpan().IsWhiteSpace())
                     {
                         continue;
                     }
 
                     (string type, string message) errorKey = (errorType, errorMessage);
-                    if (seenErrors.Contains(errorKey))
+                    if (!seenErrors.Add(errorKey)) // Add returns false if already exists
                     {
                         continue;
                     }
-                    seenErrors.Add(errorKey);
 
                     try
                     {
@@ -140,9 +138,6 @@ namespace Azure.Tools.GeneratorAgent
             return errors;
         }
         
-        /// <summary>
-        /// Takes IEnumerable&lt;RuleError&gt; and calls ErrorAnalyzers.GetFixes method
-        /// </summary>
         public IEnumerable<Fix> GetFixes(IEnumerable<RuleError> errors)
         {
             ArgumentNullException.ThrowIfNull(errors);

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Configuration/AppSettings.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Configuration/AppSettings.cs
@@ -44,6 +44,18 @@ namespace Azure.Tools.GeneratorAgent.Configuration
         public TimeSpan VectorStoreReadyWaitTime => TimeSpan.FromMilliseconds(
             int.Parse(Configuration.GetSection("AzureSettings:VectorStoreReadyWaitTimeMs").Value ?? "5000"));
         
+        // Agent run settings
+        public TimeSpan? AgentRunMaxWaitTime => Configuration.GetSection("AzureSettings:AgentRunMaxWaitTimeMinutes").Value != null 
+            ? TimeSpan.FromMinutes(int.Parse(Configuration.GetSection("AzureSettings:AgentRunMaxWaitTimeMinutes").Value!))
+            : null;
+        public TimeSpan? AgentRunPollingInterval => Configuration.GetSection("AzureSettings:AgentRunPollingIntervalSeconds").Value != null
+            ? TimeSpan.FromSeconds(int.Parse(Configuration.GetSection("AzureSettings:AgentRunPollingIntervalSeconds").Value!))
+            : null;
+        
+        // Fix processing settings
+        public int DelayBetweenFixesMs => 
+            int.Parse(Configuration.GetSection("AzureSettings:DelayBetweenFixesMs").Value ?? "500");
+        
         public string TypespecEmitterPackage => "@typespec/http-client-csharp";
         public string TypeSpecDirectoryName => "@typespec";
         public string HttpClientCSharpDirectoryName => "http-client-csharp";

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/FixPromptService.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/FixPromptService.cs
@@ -1,0 +1,131 @@
+using System.Text;
+using Azure.Tools.ErrorAnalyzers;
+using Microsoft.Extensions.Logging;
+
+namespace Azure.Tools.GeneratorAgent
+{
+    /// <summary>
+    /// Service for converting Fix objects into prompts for the AI agent
+    /// </summary>
+    internal class FixPromptService
+    {
+        private readonly ILogger<FixPromptService> Logger;
+
+        private const string HeaderTemplate = "🔧 **APPLY FIX TO CURRENT CLIENT.TSP**\n\n";
+        
+        private const string RequirementsTemplate = """
+            **CRITICAL Requirements:**
+            1. Apply this fix to the current state of client.tsp (from our conversation history)
+            2. {0}
+            3. {1}
+            4. Preserve ALL previous fixes that were applied in our conversation
+            5. **MUST return the COMPLETE, FULL client.tsp file** - never partial content
+            6. Include ALL imports, namespace, interfaces, models, and operations
+
+            **MANDATORY Response Format:**
+            1. Provide a brief explanation of the changes made
+            2. **Return the COMPLETE client.tsp file** (ready to save directly)
+            3. Validate that ALL previous fixes are still present before responding
+            4. **Use ONLY actual TypeSpec code in the code block - no template comments**
+
+            Expected format:
+            ```typespec
+            [Your complete client.tsp content here]
+            ```
+            """;
+
+        public FixPromptService(ILogger<FixPromptService> logger)
+        {
+            ArgumentNullException.ThrowIfNull(logger);
+            Logger = logger;
+        }
+
+        /// <summary>
+        /// Converts a single Fix into a formatted prompt for the AI agent
+        /// </summary>
+        public string ConvertFixToPrompt(Fix fix)
+        {
+            ArgumentNullException.ThrowIfNull(fix);
+
+            if (fix is AgentPromptFix promptFix)
+            {
+                return BuildAgentPromptFixMessage(promptFix);
+            }
+            else
+            {
+                return BuildGenericFixMessage(fix);
+            }
+        }
+
+        /// <summary>
+        /// Builds a formatted message for AgentPromptFix
+        /// </summary>
+        private string BuildAgentPromptFixMessage(AgentPromptFix promptFix)
+        {
+            return BuildFixMessage(
+                customContent: sb =>
+                {
+                    if (!string.IsNullOrEmpty(promptFix.Context))
+                    {
+                        sb.AppendLine("**Context:**");
+                        sb.AppendLine(promptFix.Context);
+                        sb.AppendLine();
+                    }
+                    
+                    sb.AppendLine("**Fix Instructions:**");
+                    sb.AppendLine(promptFix.Prompt);
+                    sb.AppendLine();
+                },
+                toolInstruction: "Use the FileSearchTool to reference other TypeSpec files as needed",
+                primaryGoal: "Ensure the fix resolves the AZC violation while maintaining compatibility"
+            );
+        }
+
+        /// <summary>
+        /// Builds a formatted message for generic Fix types
+        /// </summary>
+        private string BuildGenericFixMessage(Fix fix)
+        {
+            return BuildFixMessage(
+                customContent: sb =>
+                {
+                    sb.AppendLine("**Fix Type:**");
+                    string fixTypeName = fix switch
+                    {
+                        AgentPromptFix => nameof(AgentPromptFix),
+                        _ => fix.GetType().Name
+                    };
+                    sb.AppendLine(fixTypeName);
+                    sb.AppendLine();
+                    
+                    sb.AppendLine("**Action Required:**");
+                    sb.AppendLine(fix.Action.ToString());
+                    sb.AppendLine();
+                },
+                toolInstruction: "Use the FileSearchTool to analyze the TypeSpec files if needed",
+                primaryGoal: "Address the compilation error while maintaining existing functionality"
+            );
+        }
+
+        /// <summary>
+        /// Builds a fix message using a template with customizable parts
+        /// </summary>
+        private string BuildFixMessage(Action<StringBuilder> customContent, string toolInstruction, string primaryGoal)
+        {
+            ArgumentNullException.ThrowIfNull(customContent);
+            ArgumentNullException.ThrowIfNull(toolInstruction);
+            ArgumentNullException.ThrowIfNull(primaryGoal);
+            
+            StringBuilder messageBuilder = new StringBuilder(2048);
+            
+            messageBuilder.Append(HeaderTemplate);
+            
+            customContent(messageBuilder);
+            
+            string requirements = string.Format(RequirementsTemplate, toolInstruction, primaryGoal);
+            messageBuilder.Append(requirements);
+            
+            return messageBuilder.ToString();
+        }
+    }
+}

--- a/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Models/AgentResponse.cs
+++ b/src/dotnet/GeneratorAgent/src/Azure.Tools.GeneratorAgent/Models/AgentResponse.cs
@@ -1,0 +1,27 @@
+namespace Azure.Tools.GeneratorAgent.Models
+{
+    /// <summary>
+    /// Represents the parsed response from the AI agent containing updated TypeSpec content
+    /// </summary>
+    public class AgentResponse
+    {
+        /// <summary>
+        /// The complete updated client.tsp content extracted from TypeSpec code blocks
+        /// </summary>
+        public string UpdatedFileContent { get; set; } = string.Empty;
+        
+        /// <summary>
+        /// Indicates whether the response contained valid TypeSpec content
+        /// </summary>
+        public bool HasValidContent { get; set; } = false;
+        
+        /// <summary>
+        /// Legacy property for backward compatibility - maps to UpdatedFileContent
+        /// </summary>
+        public string UpdatedClientTsp 
+        { 
+            get => UpdatedFileContent; 
+            set => UpdatedFileContent = value; 
+        }
+    }
+}

--- a/src/dotnet/GeneratorAgent/tests/Azure.Tools.GeneratorAgent.Tests/ErrorFixerAgentTests.cs
+++ b/src/dotnet/GeneratorAgent/tests/Azure.Tools.GeneratorAgent.Tests/ErrorFixerAgentTests.cs
@@ -1,5 +1,5 @@
-using System.Reflection;
 using Azure.AI.Agents.Persistent;
+using Azure.Tools.ErrorAnalyzers;
 using Azure.Tools.GeneratorAgent.Configuration;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
@@ -10,61 +10,25 @@ using NUnit.Framework;
 namespace Azure.Tools.GeneratorAgent.Tests
 {
     [TestFixture]
-    public class ErrorFixerAgentTests
+    internal class ErrorFixerAgentTests
     {
-        private AppSettings CreateTestAppSettings(
-            string model = "test-model",
-            string agentName = "test-agent", 
-            string agentInstructions = "test instructions",
-            string projectEndpoint = "https://test.example.com")
-        {
-            var configMock = new Mock<IConfiguration>();
-            var mockLogger = new Mock<ILogger<AppSettings>>();
-            
-            var testId = Guid.NewGuid().ToString("N")[..8];
-            var uniqueModel = $"{model}-{testId}";
-            var uniqueAgentName = $"{agentName}-{testId}";
-            
-
-            var defaultSection = new Mock<IConfigurationSection>();
-            defaultSection.Setup(s => s.Value).Returns((string?)null);
-            configMock.Setup(c => c.GetSection(It.IsAny<string>())).Returns(defaultSection.Object);
-            
-            var modelSection = new Mock<IConfigurationSection>();
-            modelSection.Setup(s => s.Value).Returns(uniqueModel);
-            configMock.Setup(c => c.GetSection("AzureSettings:Model")).Returns(modelSection.Object);
-
-            var nameSection = new Mock<IConfigurationSection>();
-            nameSection.Setup(s => s.Value).Returns(uniqueAgentName);
-            configMock.Setup(c => c.GetSection("AzureSettings:AgentName")).Returns(nameSection.Object);
-
-            var instructionsSection = new Mock<IConfigurationSection>();
-            instructionsSection.Setup(s => s.Value).Returns(agentInstructions);
-            configMock.Setup(c => c.GetSection("AzureSettings:AgentInstructions")).Returns(instructionsSection.Object);
-
-            var endpointSection = new Mock<IConfigurationSection>();
-            endpointSection.Setup(s => s.Value).Returns(projectEndpoint);
-            configMock.Setup(c => c.GetSection("AzureSettings:ProjectEndpoint")).Returns(endpointSection.Object);
-
-            return new AppSettings(configMock.Object, mockLogger.Object);
-        }
-
         private class TestableErrorFixerAgent : ErrorFixerAgent
         {
             private readonly PersistentAgent MockAgent;
-            private readonly Mock<PersistentAgentsClient>? MockClient;
-            
-            public TestableErrorFixerAgent(AppSettings appSettings, ILogger<ErrorFixerAgent> logger, PersistentAgent mockAgent, Mock<PersistentAgentsClient>? mockClient = null) 
-                : base(appSettings, logger, mockClient?.Object ?? Mock.Of<PersistentAgentsClient>())
+
+            public TestableErrorFixerAgent(
+                AppSettings appSettings,
+                ILogger<ErrorFixerAgent> logger,
+                PersistentAgentsClient client,
+                FixPromptService fixPromptService,
+                AgentResponseParser responseParser,
+                PersistentAgent mockAgent)
+                : base(appSettings, logger, client, fixPromptService, responseParser)
             {
                 MockAgent = mockAgent;
-                MockClient = mockClient;
             }
-            
-            internal override PersistentAgent CreateAgent()
-            {
-                return MockAgent;
-            }
+
+            internal override PersistentAgent CreateAgent() => MockAgent;
 
             public async Task<string> TestInitializeAgentEnvironmentAsync(Dictionary<string, string> typeSpecFiles, CancellationToken ct = default)
                 => await InitializeAgentEnvironmentAsync(typeSpecFiles, ct);
@@ -72,295 +36,348 @@ namespace Azure.Tools.GeneratorAgent.Tests
             public async ValueTask TestDisposeAsync() => await DisposeAsync();
         }
 
-        private Mock<PersistentAgent> CreateAgentMock(string agentId = "test-agent-id")
-        {
-            var agentMock = new Mock<PersistentAgent>(MockBehavior.Loose);
-            agentMock.SetupAllProperties();
-            return agentMock;
-        }
-
-        private ErrorFixerAgent CreateErrorFixerAgent(
-            AppSettings? appSettings = null,
-            ILogger<ErrorFixerAgent>? logger = null,
-            PersistentAgentsClient? client = null)
-        {
-            var mockAgent = CreateAgentMock().Object;
-            return new TestableErrorFixerAgent(
-                appSettings ?? CreateTestAppSettings(),
-                logger ?? NullLogger<ErrorFixerAgent>.Instance,
-                mockAgent);
-        }
-
-        private TestableErrorFixerAgent CreateTestableErrorFixerAgent(
-            AppSettings? appSettings = null,
-            ILogger<ErrorFixerAgent>? logger = null,
-            Mock<PersistentAgentsClient>? mockClient = null)
-        {
-            var mockAgent = CreateAgentMock().Object;
-            return new TestableErrorFixerAgent(
-                appSettings ?? CreateTestAppSettings(),
-                logger ?? NullLogger<ErrorFixerAgent>.Instance,
-                mockAgent,
-                mockClient);
-        }
+        #region Constructor Tests
 
         [Test]
         public void Constructor_WithValidParameters_ShouldNotThrow()
         {
-            // Arrange
             var appSettings = CreateTestAppSettings();
             var logger = NullLogger<ErrorFixerAgent>.Instance;
-            var mockAgent = CreateAgentMock().Object;
+            var client = new Mock<PersistentAgentsClient>().Object;
+            var fixPromptService = CreateMockFixPromptService();
+            var responseParser = CreateMockResponseParser();
 
-            // Act & Assert
-            Assert.DoesNotThrow(() => new TestableErrorFixerAgent(appSettings, logger, mockAgent));
+            Assert.DoesNotThrow(() => new ErrorFixerAgent(appSettings, logger, client, fixPromptService, responseParser));
         }
 
         [Test]
         public void Constructor_WithNullAppSettings_ShouldThrowArgumentNullException()
         {
-            // Arrange
             var logger = NullLogger<ErrorFixerAgent>.Instance;
-            var mockAgent = CreateAgentMock().Object;
+            var client = new Mock<PersistentAgentsClient>().Object;
+            var fixPromptService = CreateMockFixPromptService();
+            var responseParser = CreateMockResponseParser();
 
-            // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => new TestableErrorFixerAgent(null!, logger, mockAgent));
+            var ex = Assert.Throws<ArgumentNullException>(() => new ErrorFixerAgent(null!, logger, client, fixPromptService, responseParser));
+            Assert.That(ex!.ParamName, Is.EqualTo("appSettings"));
         }
 
         [Test]
         public void Constructor_WithNullLogger_ShouldThrowArgumentNullException()
         {
-            // Arrange
             var appSettings = CreateTestAppSettings();
-            var mockAgent = CreateAgentMock().Object;
+            var client = new Mock<PersistentAgentsClient>().Object;
+            var fixPromptService = CreateMockFixPromptService();
+            var responseParser = CreateMockResponseParser();
 
-            // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => new TestableErrorFixerAgent(appSettings, null!, mockAgent));
+            var ex = Assert.Throws<ArgumentNullException>(() => new ErrorFixerAgent(appSettings, null!, client, fixPromptService, responseParser));
+            Assert.That(ex!.ParamName, Is.EqualTo("logger"));
         }
 
         [Test]
         public void Constructor_WithNullClient_ShouldThrowArgumentNullException()
         {
-            // Arrange
             var appSettings = CreateTestAppSettings();
             var logger = NullLogger<ErrorFixerAgent>.Instance;
+            var fixPromptService = CreateMockFixPromptService();
+            var responseParser = CreateMockResponseParser();
 
-            // Act & Assert
-            Assert.Throws<ArgumentNullException>(() => new ErrorFixerAgent(appSettings, logger, null!));
+            var ex = Assert.Throws<ArgumentNullException>(() => new ErrorFixerAgent(appSettings, logger, null!, fixPromptService, responseParser));
+            Assert.That(ex!.ParamName, Is.EqualTo("client"));
         }
 
         [Test]
-        public void FixCodeAsync_ShouldNotThrow()
+        public void Constructor_WithNullFixPromptService_ShouldThrowArgumentNullException()
         {
-            // Arrange
             var appSettings = CreateTestAppSettings();
-            var agent = CreateErrorFixerAgent(appSettings);
+            var logger = NullLogger<ErrorFixerAgent>.Instance;
+            var client = new Mock<PersistentAgentsClient>().Object;
+            var responseParser = CreateMockResponseParser();
 
-            // Act & Assert
-            Assert.DoesNotThrowAsync(async () => await agent.FixCodeAsync(CancellationToken.None));
+            var ex = Assert.Throws<ArgumentNullException>(() => new ErrorFixerAgent(appSettings, logger, client, null!, responseParser));
+            Assert.That(ex!.ParamName, Is.EqualTo("fixPromptService"));
         }
 
         [Test]
-        public async Task FixCodeAsync_WithCancellationToken_ShouldComplete()
+        public void Constructor_WithNullResponseParser_ShouldThrowArgumentNullException()
         {
-            // Arrange
             var appSettings = CreateTestAppSettings();
-            var agent = CreateErrorFixerAgent(appSettings);
-            var cts = new CancellationTokenSource();
+            var logger = NullLogger<ErrorFixerAgent>.Instance;
+            var client = new Mock<PersistentAgentsClient>().Object;
+            var fixPromptService = CreateMockFixPromptService();
 
-            // Act
-            await agent.FixCodeAsync(cts.Token);
+            var ex = Assert.Throws<ArgumentNullException>(() => new ErrorFixerAgent(appSettings, logger, client, fixPromptService, null!));
+            Assert.That(ex!.ParamName, Is.EqualTo("responseParser"));
+        }
 
-            // Assert - No exception should be thrown
-            Assert.Pass("FixCodeAsync completed successfully");
+        #endregion
+
+        #region CreateAgent Tests
+
+        [Test]
+        public void CreateAgent_WithValidConfiguration_ShouldCreateAgent()
+        {
+            var mockAgent = CreateMockAgent();
+            var agent = CreateTestableAgent(mockAgent.Object);
+
+            var createdAgent = agent.CreateAgent();
+
+            Assert.That(createdAgent, Is.Not.Null);
+            Assert.That(createdAgent, Is.EqualTo(mockAgent.Object));
+        }
+
+        #endregion
+
+        #region FixCodeAsync Tests
+
+        [Test]
+        public void FixCodeAsync_WithNullFixes_ShouldThrowNullReferenceException()
+        {
+            var agent = CreateTestableAgent();
+            var threadId = "test-thread-id";
+
+            var ex = Assert.ThrowsAsync<NullReferenceException>(
+                async () => await agent.FixCodeAsync(null!, threadId));
         }
 
         [Test]
-        public void InitializeAgentEnvironmentAsync_WithEmptyDictionary_ShouldThrowInvalidOperationException()
+        public void FixCodeAsync_WithNullThreadId_ShouldThrowNullReferenceException()
         {
-            // Arrange
-            var agent = CreateTestableErrorFixerAgent();
-            var emptyTypeSpecFiles = new Dictionary<string, string>();
+            var agent = CreateTestableAgent();
+            var fixes = CreateValidFixesList();
 
-            // Act & Assert
+            Assert.ThrowsAsync<NullReferenceException>(
+                async () => await agent.FixCodeAsync(fixes, null!));
+        }
+
+        [Test]
+        public void FixCodeAsync_WithEmptyThreadId_ShouldThrowNullReferenceException()
+        {
+            var agent = CreateTestableAgent();
+            var fixes = CreateValidFixesList();
+
+            Assert.ThrowsAsync<NullReferenceException>(
+                async () => await agent.FixCodeAsync(fixes, ""));
+        }
+
+        [Test]
+        public void FixCodeAsync_WithEmptyFixesList_ShouldThrowInvalidOperationException()
+        {
+            var agent = CreateTestableAgent();
+            var fixes = new List<Fix>();
+            var threadId = "test-thread-id";
+
             var ex = Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await agent.TestInitializeAgentEnvironmentAsync(emptyTypeSpecFiles));
-            
-            Assert.That(ex!.Message, Does.Contain("No TypeSpec files"));
+                async () => await agent.FixCodeAsync(fixes, threadId));
+
+            Assert.That(ex!.Message, Does.Contain("No fixes were successfully applied"));
+        }
+
+        [Test]
+        public void FixCodeAsync_WithCancelledToken_ShouldThrowSemaphoreFullException()
+        {
+            var agent = CreateTestableAgent();
+            var fixes = CreateValidFixesList();
+            var threadId = "test-thread-id";
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
+
+            Assert.ThrowsAsync<SemaphoreFullException>(
+                async () => await agent.FixCodeAsync(fixes, threadId, cts.Token));
+        }
+
+        #endregion
+
+        #region InitializeAgentEnvironmentAsync Tests
+
+        [Test]
+        public void InitializeAgentEnvironmentAsync_WithNullTypeSpecFiles_ShouldThrowArgumentNullException()
+        {
+            var agent = CreateTestableAgent();
+
+            var ex = Assert.ThrowsAsync<ArgumentNullException>(
+                async () => await agent.TestInitializeAgentEnvironmentAsync(null!));
+
+            Assert.That(ex!.ParamName, Is.EqualTo("source"));
+        }
+
+        [Test]
+        public void InitializeAgentEnvironmentAsync_WithEmptyTypeSpecFiles_ShouldThrowInvalidOperationException()
+        {
+            var agent = CreateTestableAgent();
+            var typeSpecFiles = new Dictionary<string, string>();
+
+            var ex = Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await agent.TestInitializeAgentEnvironmentAsync(typeSpecFiles));
+
+            Assert.That(ex!.Message, Does.Contain("No TypeSpec files provided"));
         }
 
         [Test]
         public void InitializeAgentEnvironmentAsync_WithNonTypeSpecFiles_ShouldThrowInvalidOperationException()
         {
-            // Arrange
-            var agent = CreateTestableErrorFixerAgent();
-            var nonTypeSpecFiles = new Dictionary<string, string>
+            var agent = CreateTestableAgent();
+            var typeSpecFiles = new Dictionary<string, string>
             {
                 { "readme.md", "# README" },
-                { "config.txt", "some config" }
+                { "config.json", "{ \"test\": true }" }
             };
 
-            // Act & Assert
             var ex = Assert.ThrowsAsync<InvalidOperationException>(
-                async () => await agent.TestInitializeAgentEnvironmentAsync(nonTypeSpecFiles));
-            
-            Assert.That(ex!.Message, Does.Contain("No TypeSpec files"));
+                async () => await agent.TestInitializeAgentEnvironmentAsync(typeSpecFiles));
+
+            Assert.That(ex!.Message, Does.Contain("No TypeSpec files provided"));
         }
 
         [Test]
-        public void CreateAgent_WithValidSettings_ShouldReturnAgent()
+        public void InitializeAgentEnvironmentAsync_WithCancelledToken_ShouldThrowInvalidOperationException()
         {
-            // Arrange
-            var appSettings = CreateTestAppSettings();
-            var mockClient = new Mock<PersistentAgentsClient>();
-            var mockAdministration = new Mock<PersistentAgentsAdministrationClient>();
-            var mockAgent = CreateAgentMock().Object;
-            
-            var agent = new TestableErrorFixerAgent(appSettings, NullLogger<ErrorFixerAgent>.Instance, mockAgent, mockClient);
+            var agent = CreateTestableAgent();
+            var typeSpecFiles = new Dictionary<string, string>
+            {
+                { "main.tsp", "model Test {}" }
+            };
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
 
-            // Act
-            var createdAgent = agent.GetType().GetMethod("CreateAgent", BindingFlags.NonPublic | BindingFlags.Instance)?.Invoke(agent, null);
-
-            // Assert
-            Assert.That(createdAgent, Is.Not.Null);
-            Assert.That(createdAgent, Is.EqualTo(mockAgent));
+            Assert.ThrowsAsync<InvalidOperationException>(
+                async () => await agent.TestInitializeAgentEnvironmentAsync(typeSpecFiles, cts.Token));
         }
 
-        [Test]
-        public async Task DisposeAsync_WhenAgentNotCreated_ShouldNotThrow()
-        {
-            // Arrange
-            var agent = CreateTestableErrorFixerAgent();
+        #endregion
 
-            // Act & Assert
+        #region DisposeAsync Tests
+
+        [Test]
+        public void DisposeAsync_WithoutInitialization_ShouldNotThrow()
+        {
+            var agent = CreateTestableAgent();
+
             Assert.DoesNotThrowAsync(async () => await agent.TestDisposeAsync());
         }
 
         [Test]
-        public async Task DisposeAsync_WhenCalledMultipleTimes_ShouldOnlyDisposeOnce()
+        public void DisposeAsync_CalledMultipleTimes_ShouldNotThrow()
         {
-            // Arrange
-            var agent = CreateTestableErrorFixerAgent();
+            var agent = CreateTestableAgent();
 
-            // Act
-            await agent.TestDisposeAsync();
-            await agent.TestDisposeAsync(); // Second call
-
-            // Assert - Should not throw and should handle multiple calls gracefully
-            Assert.Pass("Multiple dispose calls handled correctly");
-        }
-
-        [Test]
-        public async Task DisposeAsync_WithCreatedAgent_ShouldAttemptCleanup()
-        {
-            // Arrange
-            var mockLogger = new Mock<ILogger<ErrorFixerAgent>>();
-            var agent = CreateTestableErrorFixerAgent(logger: mockLogger.Object);
-            
-            _ = agent.GetType().GetMethod("CreateAgent", BindingFlags.NonPublic | BindingFlags.Instance)?.Invoke(agent, null);
-
-            // Act
-            await agent.TestDisposeAsync();
-
-            Assert.Pass("Dispose completed without exceptions");
-        }
-
-        [Test]
-        public void Agent_Property_WhenAccessedMultipleTimes_ShouldReturnSameInstance()
-        {
-            // Arrange
-            var agent = CreateTestableErrorFixerAgent();
-            
-            var agentProperty = agent.GetType().BaseType?.GetField("Agent", BindingFlags.NonPublic | BindingFlags.Instance);
-            var lazyAgent = agentProperty?.GetValue(agent) as Lazy<PersistentAgent>;
-
-            // Act
-            var firstAccess = lazyAgent?.Value;
-            var secondAccess = lazyAgent?.Value;
-
-            // Assert
-            Assert.That(firstAccess, Is.Not.Null);
-            Assert.That(secondAccess, Is.Not.Null);
-            Assert.That(firstAccess, Is.EqualTo(secondAccess), "Lazy<T> should return the same instance on multiple accesses");
-        }
-
-        [Test]
-        public void Constructor_InitializesAllFields()
-        {
-            // Arrange
-            var appSettings = CreateTestAppSettings();
-            var logger = new Mock<ILogger<ErrorFixerAgent>>();
-            var client = new Mock<PersistentAgentsClient>();
-            var mockAgent = CreateAgentMock().Object;
-
-            // Act
-            var agent = new TestableErrorFixerAgent(appSettings, logger.Object, mockAgent);
-
-            // Assert - Verify object was created successfully
-            Assert.That(agent, Is.Not.Null);
-            
-            // Verify that the agent can be accessed without throwing
-            Assert.DoesNotThrow(() => {
-                var agentProperty = agent.GetType().BaseType?.GetField("Agent", BindingFlags.NonPublic | BindingFlags.Instance);
-                var lazyAgent = agentProperty?.GetValue(agent) as Lazy<PersistentAgent>;
-                _ = lazyAgent?.Value;
+            Assert.DoesNotThrowAsync(async () =>
+            {
+                await agent.TestDisposeAsync();
+                await agent.TestDisposeAsync();
             });
         }
 
         [Test]
-        public void Constructor_WithDifferentAppSettings_ShouldUseCorrectValues()
+        public void DisposeAsync_AfterAgentCreation_ShouldNotThrow()
         {
-            // Arrange
-            var customSettings = CreateTestAppSettings(
-                model: "custom-model",
-                agentName: "custom-agent",
-                agentInstructions: "custom instructions",
-                projectEndpoint: "https://custom.endpoint.com"
-            );
-            var logger = NullLogger<ErrorFixerAgent>.Instance;
-            var mockAgent = CreateAgentMock().Object;
+            var agent = CreateTestableAgent();
+            agent.CreateAgent();
 
-            // Act
-            var agent = new TestableErrorFixerAgent(customSettings, logger, mockAgent);
-
-            // Assert
-            Assert.That(agent, Is.Not.Null);
-            
-            var appSettingsField = agent.GetType().BaseType?.GetField("AppSettings", BindingFlags.NonPublic | BindingFlags.Instance);
-            var retrievedSettings = appSettingsField?.GetValue(agent) as AppSettings;
-            
-            Assert.That(retrievedSettings, Is.Not.Null);
-            
-            // Check that the values contain our custom values (they will have unique ID appended)
-            Assert.That(retrievedSettings.Model, Does.StartWith("custom-model-"));
-            Assert.That(retrievedSettings.AgentName, Does.StartWith("custom-agent-"));
-            Assert.That(retrievedSettings.AgentInstructions, Is.EqualTo("custom instructions"));
+            Assert.DoesNotThrowAsync(async () => await agent.TestDisposeAsync());
         }
 
-        private void CleanupDirectory(string directoryPath)
+        [Test]
+        public void DisposeAsync_AfterFixCodeAsync_ShouldNotThrow()
         {
-            if (!Directory.Exists(directoryPath))
-                return;
+            var agent = CreateTestableAgent();
+            var fixes = CreateValidFixesList();
+            var threadId = "test-thread-id";
 
-            for (int attempt = 0; attempt < 3; attempt++)
+            Assert.DoesNotThrowAsync(async () =>
             {
                 try
                 {
-                    Directory.Delete(directoryPath, true);
-                    return;
+                    await agent.FixCodeAsync(fixes, threadId);
                 }
-                catch (IOException) when (attempt < 2)
+                catch
                 {
-                    // Wait and retry - file might be locked
-                    Thread.Sleep(50);
                 }
-                catch (UnauthorizedAccessException) when (attempt < 2)
-                {
-                    // Wait and retry - file might be locked
-                    Thread.Sleep(50);
-                }
-            }
+                await agent.TestDisposeAsync();
+            });
         }
 
+        #endregion
+
+        #region Helper Methods
+
+        private TestableErrorFixerAgent CreateTestableAgent(PersistentAgent? mockAgent = null)
+        {
+            var appSettings = CreateTestAppSettings();
+            var logger = NullLogger<ErrorFixerAgent>.Instance;
+            var client = new Mock<PersistentAgentsClient>().Object;
+            var fixPromptService = CreateMockFixPromptService();
+            var responseParser = CreateMockResponseParser();
+            var agent = mockAgent ?? CreateMockAgent().Object;
+
+            return new TestableErrorFixerAgent(
+                appSettings,
+                logger,
+                client,
+                fixPromptService,
+                responseParser,
+                agent);
+        }
+
+        private AppSettings CreateTestAppSettings()
+        {
+            var configMock = new Mock<IConfiguration>();
+            var mockLogger = new Mock<ILogger<AppSettings>>();
+
+            var testId = Guid.NewGuid().ToString("N")[..8];
+
+            var defaultSection = new Mock<IConfigurationSection>();
+            defaultSection.Setup(s => s.Value).Returns((string?)null);
+            configMock.Setup(c => c.GetSection(It.IsAny<string>())).Returns(defaultSection.Object);
+
+            var modelSection = new Mock<IConfigurationSection>();
+            modelSection.Setup(s => s.Value).Returns($"test-model-{testId}");
+            configMock.Setup(c => c.GetSection("AzureSettings:Model")).Returns(modelSection.Object);
+
+            var nameSection = new Mock<IConfigurationSection>();
+            nameSection.Setup(s => s.Value).Returns($"test-agent-{testId}");
+            configMock.Setup(c => c.GetSection("AzureSettings:AgentName")).Returns(nameSection.Object);
+
+            var instructionsSection = new Mock<IConfigurationSection>();
+            instructionsSection.Setup(s => s.Value).Returns("test instructions");
+            configMock.Setup(c => c.GetSection("AzureSettings:AgentInstructions")).Returns(instructionsSection.Object);
+
+            var endpointSection = new Mock<IConfigurationSection>();
+            endpointSection.Setup(s => s.Value).Returns("https://test.example.com");
+            configMock.Setup(c => c.GetSection("AzureSettings:ProjectEndpoint")).Returns(endpointSection.Object);
+
+            return new AppSettings(configMock.Object, mockLogger.Object);
+        }
+
+        private FixPromptService CreateMockFixPromptService()
+        {
+            var mockLogger = new Mock<ILogger<FixPromptService>>();
+            return new FixPromptService(mockLogger.Object);
+        }
+
+        private AgentResponseParser CreateMockResponseParser()
+        {
+            var mockLogger = new Mock<ILogger<AgentResponseParser>>();
+            return new AgentResponseParser(mockLogger.Object);
+        }
+
+        private Mock<PersistentAgent> CreateMockAgent()
+        {
+            var mockAgent = new Mock<PersistentAgent>();
+            return mockAgent;
+        }
+
+        private static List<Fix> CreateValidFixesList()
+        {
+            var mockErrors = new List<RuleError>
+            {
+                new RuleError("AZC0012", "Type name 'Client' is too generic")
+            };
+            
+            var analyzer = new BuildErrorAnalyzer(new Mock<ILogger<BuildErrorAnalyzer>>().Object);
+            return analyzer.GetFixes(mockErrors).ToList();
+        }
+
+        #endregion
     }
 }

--- a/src/dotnet/GeneratorAgent/tests/Azure.Tools.GeneratorAgent.Tests/FixPromptServiceTests.cs
+++ b/src/dotnet/GeneratorAgent/tests/Azure.Tools.GeneratorAgent.Tests/FixPromptServiceTests.cs
@@ -1,0 +1,227 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Azure.Tools.ErrorAnalyzers;
+using Azure.Tools.GeneratorAgent;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NUnit.Framework;
+
+namespace Azure.Tools.GeneratorAgent.Tests
+{
+    [TestFixture]
+    internal class FixPromptServiceTests
+    {
+        #region Constructor Tests
+
+        [Test]
+        public void Constructor_WithValidLogger_ShouldCreateInstance()
+        {
+            var mockLogger = new Mock<ILogger<FixPromptService>>();
+
+            var service = new FixPromptService(mockLogger.Object);
+
+            Assert.That(service, Is.Not.Null);
+        }
+
+        [Test]
+        public void Constructor_WithNullLogger_ShouldThrowArgumentNullException()
+        {
+            var ex = Assert.Throws<ArgumentNullException>(() => new FixPromptService(null!));
+            Assert.That(ex!.ParamName, Is.EqualTo("logger"));
+        }
+
+        #endregion
+
+        #region ConvertFixToPrompt Tests
+
+        [Test]
+        public void ConvertFixToPrompt_WithNullFix_ShouldThrowArgumentNullException()
+        {
+            var service = CreateFixPromptService();
+
+            var ex = Assert.Throws<ArgumentNullException>(() => service.ConvertFixToPrompt(null!));
+            Assert.That(ex!.ParamName, Is.EqualTo("fix"));
+        }
+
+        [Test]
+        public void ConvertFixToPrompt_WithAgentPromptFixFromAnalyzer_ShouldReturnValidPrompt()
+        {
+            var service = CreateFixPromptService();
+            var fix = CreateValidFixFromAnalyzer();
+
+            var result = service.ConvertFixToPrompt(fix);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result, Is.Not.Empty);
+                Assert.That(result, Does.Contain("🔧 **APPLY FIX TO CURRENT CLIENT.TSP**"));
+                Assert.That(result, Does.Contain("**Context:**"));
+                Assert.That(result, Does.Contain("**Fix Instructions:**"));
+                Assert.That(result, Does.Contain("**CRITICAL Requirements:**"));
+                Assert.That(result, Does.Contain("Use the FileSearchTool to reference other TypeSpec files as needed"));
+                Assert.That(result, Does.Contain("Ensure the fix resolves the AZC violation while maintaining compatibility"));
+            });
+        }
+
+        [Test]
+        public void ConvertFixToPrompt_WithAgentPromptFix_ShouldReturnValidPrompt()
+        {
+            var service = CreateFixPromptService();
+            var fix = CreateValidAgentPromptFix();
+
+            var result = service.ConvertFixToPrompt(fix);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result, Is.Not.Empty);
+                Assert.That(result, Does.Contain("🔧 **APPLY FIX TO CURRENT CLIENT.TSP**"));
+                Assert.That(result, Does.Contain("**Context:**"));
+                Assert.That(result, Does.Contain("**Fix Instructions:**"));
+                Assert.That(result, Does.Contain("**CRITICAL Requirements:**"));
+                Assert.That(result, Does.Contain("Use the FileSearchTool to reference other TypeSpec files as needed"));
+                Assert.That(result, Does.Contain("Ensure the fix resolves the AZC violation while maintaining compatibility"));
+            });
+        }
+
+        [Test]
+        public void ConvertFixToPrompt_WithAgentPromptFixWithoutContext_ShouldReturnValidPrompt()
+        {
+            var service = CreateFixPromptService();
+            var fix = CreateAgentPromptFixWithoutContext();
+
+            var result = service.ConvertFixToPrompt(fix);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.Not.Null);
+                Assert.That(result, Is.Not.Empty);
+                Assert.That(result, Does.Contain("🔧 **APPLY FIX TO CURRENT CLIENT.TSP**"));
+                Assert.That(result, Does.Not.Contain("**Context:**"));
+                Assert.That(result, Does.Contain("**Fix Instructions:**"));
+                Assert.That(result, Does.Contain("**CRITICAL Requirements:**"));
+            });
+        }
+
+        [Test]
+        public void ConvertFixToPrompt_WithDifferentFixTypes_ShouldProduceConsistentStructure()
+        {
+            var service = CreateFixPromptService();
+            var analyzerFix = CreateValidFixFromAnalyzer();
+            var agentPromptFix = CreateValidAgentPromptFix();
+
+            var analyzerResult = service.ConvertFixToPrompt(analyzerFix);
+            var agentPromptResult = service.ConvertFixToPrompt(agentPromptFix);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(analyzerResult, Does.Contain("🔧 **APPLY FIX TO CURRENT CLIENT.TSP**"));
+                Assert.That(agentPromptResult, Does.Contain("🔧 **APPLY FIX TO CURRENT CLIENT.TSP**"));
+                Assert.That(analyzerResult, Does.Contain("**CRITICAL Requirements:**"));
+                Assert.That(agentPromptResult, Does.Contain("**CRITICAL Requirements:**"));
+                Assert.That(analyzerResult, Does.Contain("```typespec"));
+                Assert.That(agentPromptResult, Does.Contain("```typespec"));
+            });
+        }
+
+        #endregion
+
+        #region Performance Tests
+
+        [Test]
+        public void ConvertFixToPrompt_MultipleCallsWithSameFix_ShouldProduceConsistentResults()
+        {
+            var service = CreateFixPromptService();
+            var fix = CreateValidFixFromAnalyzer();
+
+            var result1 = service.ConvertFixToPrompt(fix);
+            var result2 = service.ConvertFixToPrompt(fix);
+
+            Assert.That(result1, Is.EqualTo(result2));
+        }
+
+        [Test]
+        public void ConvertFixToPrompt_WithMultipleFixes_ShouldCompleteInReasonableTime()
+        {
+            var service = CreateFixPromptService();
+            var fixes = CreateMultipleValidFixes();
+
+            var startTime = DateTime.UtcNow;
+            foreach (var fix in fixes)
+            {
+                service.ConvertFixToPrompt(fix);
+            }
+            var endTime = DateTime.UtcNow;
+
+            var duration = endTime - startTime;
+            Assert.That(duration.TotalMilliseconds, Is.LessThan(1000), "Should complete 10 fixes in under 1 second");
+        }
+
+        #endregion
+
+        #region Helper Methods
+
+        private FixPromptService CreateFixPromptService()
+        {
+            var mockLogger = new Mock<ILogger<FixPromptService>>();
+            return new FixPromptService(mockLogger.Object);
+        }
+
+        private Fix CreateValidFixFromAnalyzer()
+        {
+            var mockErrors = new List<RuleError>
+            {
+                new RuleError("AZC0012", "Type name 'Client' is too generic")
+            };
+            
+            var analyzer = new BuildErrorAnalyzer(new Mock<ILogger<BuildErrorAnalyzer>>().Object);
+            return analyzer.GetFixes(mockErrors).First();
+        }
+
+        private AgentPromptFix CreateValidAgentPromptFix()
+        {
+            return new AgentPromptFix(
+                "Fix the generic type name by replacing 'Client' with a more specific name like 'ServiceClient'",
+                "Test context for agent prompt fix"
+            );
+        }
+
+        private AgentPromptFix CreateAgentPromptFixWithoutContext()
+        {
+            return new AgentPromptFix(
+                "Fix the generic type name by replacing 'Client' with a more specific name",
+                null
+            );
+        }
+
+        private List<Fix> CreateMultipleValidFixes()
+        {
+            var mockErrors = new List<RuleError>
+            {
+                new RuleError("AZC0012", "Type name 'Client' is too generic"),
+                new RuleError("AZC0015", "Methods should follow naming convention"),
+                new RuleError("AZC0018", "Missing required parameters"),
+                new RuleError("AZC0020", "Return type not compatible"),
+                new RuleError("AZC0025", "Missing documentation")
+            };
+            
+            var analyzer = new BuildErrorAnalyzer(new Mock<ILogger<BuildErrorAnalyzer>>().Object);
+            var analyzerFixes = analyzer.GetFixes(mockErrors).ToList();
+            
+            var agentPromptFixes = new List<Fix>
+            {
+                new AgentPromptFix("Fix prompt 1", "Context 1"),
+                new AgentPromptFix("Fix prompt 2", "Context 2"),
+                new AgentPromptFix("Fix prompt 3", null),
+                new AgentPromptFix("Fix prompt 4", "Context 4"),
+                new AgentPromptFix("Fix prompt 5", "Context 5")
+            };
+            
+            return analyzerFixes.Concat(agentPromptFixes).ToList();
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
1. Added `ErrorFixerAgent.FixCodeAsync `

- Sequential Fix Processing: Processes a list of Azure SDK code fixes one by one, maintaining conversation state so each fix builds upon previous changes
- Converts each fix to a prompt, sends it to the Azure AI agent, waits for completion, and extracts the updated TypeSpec content from the response
- Uses semaphore-based concurrency control and configurable delays between fixes to prevent API throttling
- Implements fail-fast strategy with comprehensive logging, stopping on first failure while tracking progress ({Current}/{Total}) (TODO)
- Returns the final updated client.tsp content after successfully applying all fixes in the conversation thread

2. Added `AgentResponseParser.cs`

- Uses pre-compiled regex patterns to extract TypeSpec content from various code block formats (typespec, tsp, typescript, generic) in priority order. we use typescript here because I have noticed that sometimes (rarely) agent response with typescript code block
- Selects the last matching code block when multiple are present, ensuring the most recent/final content is captured from AI agent responses
