### PR TITLE
improve rlc typespec generation

### DIFF
--- a/tools/js-sdk-release-tools/package-lock.json
+++ b/tools/js-sdk-release-tools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@azure-tools/js-sdk-release-tools",
-      "version": "2.14.1",
+      "version": "2.14.2",
       "license": "MIT",
       "dependencies": {
         "@azure-tools/openapi-tools-common": "^1.2.2",

--- a/tools/js-sdk-release-tools/package.json
+++ b/tools/js-sdk-release-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/js-sdk-release-tools",
-  "version": "2.14.1",
+  "version": "2.14.2",
   "description": "",
   "files": [
     "dist"

--- a/tools/js-sdk-release-tools/src/autoGenerateInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/autoGenerateInPipeline.ts
@@ -76,6 +76,7 @@ async function automationGenerateInPipeline(
                     gitCommitId: gitCommitId,
                     apiVersion: apiVersion,
                     sdkReleaseType: sdkReleaseType,
+                    runMode: runMode as RunMode,
                 });
                 break;
 

--- a/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -259,9 +259,6 @@ export async function generateRLCInPipeline(options: {
             }
         }
 
-        await formatSdk(packagePath)
-        await updateSnippets(packagePath);
-
         let buildStatus = `succeeded`;
         if (isRushRepo(options.sdkRepo)) {
             logger.info(`Start to update rush.`);
@@ -293,7 +290,10 @@ export async function generateRLCInPipeline(options: {
             logger.info(`Start to run command 'pnpm run --filter ${packageJson.name}... pack'.`);
             execSync(`pnpm run --filter ${packageJson.name}... pack`, {stdio: 'inherit'});
         }
-     
+        
+        await formatSdk(packagePath)
+        await updateSnippets(packagePath);
+
         if (!options.skipGeneration && buildStatus === 'succeeded') {
             const getChangelogItems = () => {
                 const categories = changelog?.changelogItems.breakingChanges.keys();

--- a/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -25,9 +25,6 @@ import { isRushRepo } from "../../common/rushUtils.js";
 import { formatSdk, updateSnippets } from "../../common/devToolUtils.js";
 import { RunMode } from "../../common/types.js";
 import { exists } from 'fs-extra';
-import { C } from "vitest/dist/chunks/reporters.d.BFLkQcL6.js";
-import { cat } from "shelljs";
-import { error } from "console";
 
 export async function generateRLCInPipeline(options: {
     sdkRepo: string;

--- a/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -17,12 +17,13 @@ import {
 } from '../utils/generateSampleReadmeMd.js';
 import { updateTypeSpecProjectYamlFile } from '../utils/updateTypeSpecProjectYamlFile.js';
 import { getRelativePackagePath } from "../utils/utils.js";
-import { defaultChildProcessTimeout, getGeneratedPackageDirectory, generateRepoDataInTspLocation, specifyApiVersionToGenerateSDKByTypeSpec } from "../../common/utils.js";
+import { defaultChildProcessTimeout, getGeneratedPackageDirectory, generateRepoDataInTspLocation, specifyApiVersionToGenerateSDKByTypeSpec, cleanUpPackageDirectory } from "../../common/utils.js";
 import { remove } from 'fs-extra';
 import { generateChangelogAndBumpVersion } from "../../common/changelog/automaticGenerateChangeLogAndBumpVersion.js";
 import { updateChangelogResult } from "../../common/packageResultUtils.js";
 import { isRushRepo } from "../../common/rushUtils.js";
 import { updateSnippets } from "../../common/devToolUtils.js";
+import { RunMode } from "../../common/types.js";
 
 export async function generateRLCInPipeline(options: {
     sdkRepo: string;
@@ -41,6 +42,7 @@ export async function generateRLCInPipeline(options: {
     runningEnvironment?: RunningEnvironment;
     apiVersion: string | undefined;
     sdkReleaseType: string | undefined;
+    runMode: RunMode;
 }) {
     let packagePath: string | undefined;
     let relativePackagePath: string | undefined;
@@ -48,7 +50,6 @@ export async function generateRLCInPipeline(options: {
     if (options.typespecProject) {
         const typespecProject = path.join(options.swaggerRepo, options.typespecProject); 
         const generatedPackageDir = await getGeneratedPackageDirectory(typespecProject, options.sdkRepo);
-        await remove(generatedPackageDir);
 
         if (!options.skipGeneration) {
             logger.info(`Start to generate rest level client SDK from '${options.typespecProject}'.`);
@@ -75,6 +76,8 @@ export async function generateRLCInPipeline(options: {
                 });
                 logger.info("End with TypeSpec command.");
             } else {
+                await cleanUpPackageDirectory(generatedPackageDir, options.runMode);
+
                 logger.info("Start to generate code by tsp-client.");
                 const tspDefDir = path.join(options.swaggerRepo, options.typespecProject);
                 if (options.apiVersion) {

--- a/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
+++ b/tools/js-sdk-release-tools/src/llc/generateRLCInPipeline/generateRLCInPipeline.ts
@@ -59,8 +59,10 @@ export async function generateRLCInPipeline(options: {
             }else if(await exists(path.join(generatedPackageDir, "src","generated"))) {
                 sourcePath = path.join("src", "generated");
             }
+            logger.info(`Should only remove ${sourcePath} for RLC generation in ${options.runMode} mode.`)
             await remove(path.join(generatedPackageDir, sourcePath));
         } else {
+            logger.info(`Should remove all for RLC generation in ${options.runMode} mode`)
             await remove(generatedPackageDir);
         }
         if (!options.skipGeneration) {


### PR DESCRIPTION
fixes https://github.com/Azure/azure-sdk-tools/issues/11721

test in pipeline, this fix works
https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5243274&view=logs&j=83516c17-6666-5250-abde-63983ce72a49

generated sdk pr doesn't remove any customized files: https://github.com/Azure/azure-sdk-for-js/pull/35647/files#diff-0111f42fe80149f65e9b3cc9e235d4c7136fa4fbcc2408c8a29aade634d775b2
