### PR TITLE
Add a pipeline template to mark SDK package as released

### DIFF
--- a/eng/common/pipelines/templates/steps/mark-release-completion.yml
+++ b/eng/common/pipelines/templates/steps/mark-release-completion.yml
@@ -1,0 +1,16 @@
+parameters:
+  ConfigFileDir: ''
+  PackageArtifactName: ''
+
+steps:
+  - task: AzureCLI@2
+    inputs:
+      azureSubscription: opensource-api-connection
+      scriptType: pscore
+      scriptLocation: scriptPath
+      scriptPath: $(Build.SourcesDirectory)/eng/common/scripts/Mark-ReleasePlanCompletion.ps1
+      arguments: -PackageInfoFilePath '${{ parameters.ConfigFileDir }}/${{ parameters.PackageArtifactName }}.json'
+      workingDirectory: $(Pipeline.Workspace)
+    displayName: Mark package as released
+    continueOnError: true
+    condition: and(succeeded(), ne(variables['Skip.MarkReleaseCompletion'], 'true'))

--- a/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
+++ b/eng/common/scripts/Helpers/DevOps-WorkItem-Helpers.ps1
@@ -1052,6 +1052,7 @@ function Get-ReleasePlanForPackage($packageName)
     $query = "SELECT ${fieldList} FROM WorkItems WHERE [Work Item Type] = 'Release Plan' AND [${packageNameFieldName}] = '${packageName}'"
     $query += " AND [${prStatusFieldName}] = 'merged'"
     $query += " AND [System.State] IN ('In Progress') ORDER BY [System.CreatedDate]"
+    $query += " AND [System.Tags] NOT CONTAINS 'Release Planner App Test'"
     $workItems = Invoke-Query $fields $query
     return $workItems
 }


### PR DESCRIPTION
New template that will be plugged in release stage to mark package as released.

Tested this change for azure-python package.

https://dev.azure.com/azure-sdk/internal/_build/results?buildId=5241649&view=logs&j=fa3624e2-400d-536b-43d3-bbed08ab0689&t=8abdbc0f-57ac-57a8-011c-ba46c0035f42&l=61