### PR TITLE
Update changelog parsing to round-trip header

### DIFF
--- a/eng/common/scripts/ChangeLog-Operations.ps1
+++ b/eng/common/scripts/ChangeLog-Operations.ps1
@@ -52,6 +52,7 @@ function Get-ChangeLogEntriesFromContent {
   $sectionHeaderRegex = "^${initialAtxHeader}${SECTION_HEADER_REGEX_SUFFIX}"
   $changeLogEntries | Add-Member -NotePropertyName "InitialAtxHeader" -NotePropertyValue $initialAtxHeader
   $releaseTitleAtxHeader = $initialAtxHeader + "#"
+  $headerLines = @()
 
   try {
     # walk the document, finding where the version specifiers are and creating lists
@@ -83,6 +84,9 @@ function Get-ChangeLogEntriesFromContent {
 
           $changeLogEntry.ReleaseContent += $line
         }
+        else {
+          $headerLines += $line
+        }
       }
     }
   }
@@ -90,6 +94,8 @@ function Get-ChangeLogEntriesFromContent {
     Write-Error "Error parsing Changelog."
     Write-Error $_
   }
+
+  $changeLogEntries | Add-Member -NotePropertyName "HeaderBlock" -NotePropertyValue ($headerLines -Join [Environment]::NewLine)
   return $changeLogEntries
 }
 
@@ -265,8 +271,13 @@ function Set-ChangeLogContent {
   )
 
   $changeLogContent = @()
-  $changeLogContent += "$($ChangeLogEntries.InitialAtxHeader) Release History"
-  $changeLogContent += ""
+  if ($ChangeLogEntries.HeaderBlock) {
+    $changeLogContent += $ChangeLogEntries.HeaderBlock
+  }
+  else {
+    $changeLogContent += "$($ChangeLogEntries.InitialAtxHeader) Release History"
+    $changeLogContent += ""
+  }
 
   $ChangeLogEntries = Sort-ChangeLogEntries -changeLogEntries $ChangeLogEntries
 


### PR DESCRIPTION
This will enable some customization of the header section that some usages need like the mcp changlog.

See https://github.com/microsoft/mcp/pull/33