### PR TITLE
[Python APIView] raise error on duplicate line ID

### DIFF
--- a/packages/python-packages/apiview-stub-generator/apistub/nodes/_function_node.py
+++ b/packages/python-packages/apiview-stub-generator/apistub/nodes/_function_node.py
@@ -382,7 +382,7 @@ class FunctionNode(NodeEntityBase):
 
         # after children are added, add the review line
         def_line.add_children(self.children)
-        def_line.line_id = self.namespace_id
+        def_line.add_line_marker(self.namespace_id)
         review_lines.append(def_line)
 
     def generate_tokens(self, review_lines):

--- a/packages/python-packages/apiview-stub-generator/tests/azure_tests/azure_test.py
+++ b/packages/python-packages/apiview-stub-generator/tests/azure_tests/azure_test.py
@@ -302,33 +302,3 @@ class TestApiViewAzure:
         provided_token_file = os.path.abspath(os.path.join(os.path.dirname(__file__), f"token_files/{outfile}"))
 
         self._diff_token_file(provided_token_file, generated_token_file)
-
-    def test_unique_line_ids(self):
-        """Test that all LineIds in token files are unique."""
-        token_files_dir = os.path.join(os.path.dirname(__file__), "token_files")
-        
-        # Check each JSON file in the token_files directory
-        for filename in os.listdir(token_files_dir):
-            filepath = os.path.join(token_files_dir, filename)
-            
-            with open(filepath, 'r') as f:
-                data = json.load(f)
-            
-            line_ids = set()
-            
-            def check_line_ids(review_lines):
-                """Recursively check LineIds in ReviewLines and their Children."""
-                for line in review_lines:
-                    if "LineId" in line and line["LineId"]:
-                        line_id = line["LineId"]
-                        assert line_id not in line_ids, f"File '{filename}' contains duplicate LineIds: {line_id}"
-                        line_ids.add(line_id)
-                    
-                    # Check children recursively
-                    if "Children" in line and line["Children"]:
-                        check_line_ids(line["Children"])
-            
-            # Check ReviewLines
-            if "ReviewLines" in data:
-                check_line_ids(data["ReviewLines"])
-                


### PR DESCRIPTION
Python AI ML is showing a duplicated arg "kwargs" due to [incorrect docstring](https://github.com/Azure/azure-sdk-for-python/blob/4df650d2ce4c292942009ed648cae21eb9c2121d/sdk/ml/azure-ai-ml/azure/ai/ml/entities/_job/automl/image/image_instance_segmentation_job.py#L31) + the explicit "kwargs" in the method. This should've been caught earlier.

<img width="1790" height="1406" alt="image" src="https://github.com/user-attachments/assets/a5639ab8-a41d-44bc-a325-7501ff9daf8a" />

Adding a check in the parser so that duplicate line IDs will raise an error.

Related to #11591